### PR TITLE
ci: drop dead depot-ubuntu-latest actionlint config

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,0 @@
-self-hosted-runner:
-  labels:
-    - depot-ubuntu-latest


### PR DESCRIPTION
## Summary
- All workflows already run on GitHub-hosted runners (`ubuntu-latest`, `macos-latest`, `windows-latest`) — no job still targets a depot runner.
- `.github/actionlint.yaml` existed only to register `depot-ubuntu-latest` as a valid self-hosted label. With nothing using that label, the file is dead; removing it.

## Test plan
- [ ] Confirm `grep -r depot` comes back empty across the tree.
- [ ] Next workflow run passes without actionlint flagging anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes an unused `actionlint` configuration entry; impact is limited to CI linting behavior and only if any workflow still referenced the old self-hosted label.
> 
> **Overview**
> Removes the `.github/actionlint.yaml` configuration that declared `depot-ubuntu-latest` as a valid self-hosted runner label, since it is no longer used anywhere in workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0217fb443368b087084d21050bea3d6e286a664a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->