### PR TITLE
ci(release-plz): grant contents:write to upload-assets caller

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -107,6 +107,8 @@ jobs:
     name: Upload assets
     needs: release-plz-release
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    permissions:
+      contents: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}


### PR DESCRIPTION
## Summary
- `release-plz.yml` declares top-level `permissions: contents: read`.
- The `upload-assets` job calls the reusable `release.yml` via `workflow_call` without overriding permissions, so it inherits `contents: read`.
- `release.yml` requests `contents: write`, which a called workflow cannot do unless the caller job has already granted that scope — so the workflow fails to even start.
- Fix: set `permissions: contents: write` on the calling job.

Fixes the error:

> `Error calling workflow '.../release.yml@…'. The workflow is requesting 'contents: write', but is only allowed 'contents: read'.`

## Test plan
- [ ] On next release-plz run after merge, `upload-assets` should transition out of "pending" and the release.yml matrix should start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts GitHub Actions job permissions to allow the reusable release workflow to run and upload release assets.
> 
> **Overview**
> Fixes the release pipeline by granting the `upload-assets` job in `release-plz.yml` `permissions: contents: write`, so the called reusable `release.yml` workflow (which requests `contents: write`) can start and upload binaries to the GitHub release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ab8141a3efc5bd2840f1aabd4a776e57d0578b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->