### PR TITLE
[codex] add Google Analytics tag

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -73,6 +73,22 @@ export default defineConfig({
     ],
     ["link", { rel: "manifest", href: "/site.webmanifest" }],
     ["meta", { name: "theme-color", content: "#FFB13B" }],
+    [
+      "script",
+      {
+        async: "",
+        src: "https://www.googletagmanager.com/gtag/js?id=G-WD1RRC0F8C",
+      },
+    ],
+    [
+      "script",
+      {},
+      `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'G-WD1RRC0F8C');`,
+    ],
   ],
   themeConfig: {
     logo: "/logo.svg",


### PR DESCRIPTION
## Summary

- Adds the Google tag manager script to the shared VitePress `head` configuration.
- Configures measurement ID `G-WD1RRC0F8C` so the docs site includes analytics on every page.

## Validation

- `npm run docs:build`

Note: the docs worktree did not have `node_modules`, so I installed the declared docs dependency with `npm install --no-save --no-package-lock` to run the build, then removed generated `docs/node_modules` and `docs/.vitepress/dist` before committing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-only change that injects third-party analytics scripts; main risk is privacy/compliance and any unintended script loading impact on the docs site.
> 
> **Overview**
> Adds Google Analytics tracking to the docs site by injecting the `gtag.js` loader and inline `gtag('config', 'G-WD1RRC0F8C')` initialization into the shared VitePress `head` config, enabling page-wide analytics on every docs page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3584219201918eebef67951187ef4f72394745ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->