### PR TITLE
cli: add aubr/aubx multicall shims for run and dlx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: release
 
-# Reusable workflow: builds + (on macOS) codesigns the `aube` binary
-# for every target, then uploads each archive onto the draft GitHub
-# release that `release-plz` already created for the tag. Driven by
-# `.github/workflows/release-plz.yml` — not triggered directly on
-# tag push, since release-plz owns the tag/release lifecycle and
-# dispatching on both would race.
+# Reusable workflow: builds + (on macOS) codesigns the `aube`, `aubr`,
+# and `aubx` binaries for every target, then uploads a single archive
+# per target onto the draft GitHub release that `release-plz` already
+# created for the tag. `aubr`/`aubx` are multicall shims that share
+# `src/main.rs` with `aube`; see `crates/aube-cli/Cargo.toml`.
+# Driven by `.github/workflows/release-plz.yml` — not triggered
+# directly on tag push, since release-plz owns the tag/release
+# lifecycle and dispatching on both would race.
 
 permissions:
   contents: write
@@ -65,14 +67,18 @@ jobs:
         with:
           shared-key: rust-${{ matrix.target }}
       # taiki-e/upload-rust-binary-action builds via cargo/cross, packages
-      # the binary into a `<bin>-<tag>-<target>.{tar.gz,zip}` archive, and
-      # uploads it onto the existing release for `tag`. On macOS we ask it
-      # to codesign with the Developer ID cert we just imported.
+      # the named bins into a single `<archive>.{tar.gz,zip}`, and uploads
+      # it onto the existing release for `tag`. Multi-bin mode requires an
+      # explicit `archive` name (the `$bin` placeholder isn't usable), so
+      # we keep the historical `aube-<tag>-<target>` pattern that installers
+      # already expect. On macOS we ask it to codesign with the Developer
+      # ID cert we just imported; the prefix applies to all three bins.
       - name: Upload binary (macOS signed)
         if: startsWith(matrix.os, 'macos')
         uses: taiki-e/upload-rust-binary-action@v1
         with:
-          bin: aube
+          bin: aube,aubr,aubx
+          archive: aube-$tag-$target
           target: ${{ matrix.target }}
           ref: refs/tags/${{ inputs.tag }}
           token: ${{ secrets.AUBE_GH_TOKEN }}
@@ -82,7 +88,8 @@ jobs:
         if: ${{ !startsWith(matrix.os, 'macos') }}
         uses: taiki-e/upload-rust-binary-action@v1
         with:
-          bin: aube
+          bin: aube,aubr,aubx
+          archive: aube-$tag-$target
           target: ${{ matrix.target }}
           ref: refs/tags/${{ inputs.tag }}
           token: ${{ secrets.AUBE_GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -94,25 +94,17 @@ If the script exists in `package.json`, aube treats that as `aube run <script>`.
 
 ### Shortcuts: `aubr` and `aubx`
 
-`aubr` and `aubx` are optional multicall shims for `aube run` and `aube dlx`.
-They are installed as hardlinks to the same `aube` binary (copies on
-Windows) and dispatch purely on `argv[0]`, so every flag that works on the
-full command also works on the shim:
+`aubr` and `aubx` are multicall shims for `aube run` and `aube dlx`. They
+share a binary with `aube` and dispatch purely on `argv[0]`, so every flag
+that works on the full command also works on the shim:
 
 ```sh
 aubr build            # aube run build
 aubx cowsay hi        # aube dlx cowsay hi
 ```
 
-To enable the shims, create hardlinks named `aubr` and `aubx` next to
-your `aube` binary, e.g.:
-
-```sh
-ln "$(command -v aube)" "$(dirname "$(command -v aube)")/aubr"
-ln "$(command -v aube)" "$(dirname "$(command -v aube)")/aubx"
-```
-
-Official installers will grow support for this over time.
+The release archives ship all three binaries side by side; no extra
+setup is needed when you install aube via mise or the tarball.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,28 @@ aube lint
 
 If the script exists in `package.json`, aube treats that as `aube run <script>`.
 
+### Shortcuts: `aubr` and `aubx`
+
+`aubr` and `aubx` are optional multicall shims for `aube run` and `aube dlx`.
+They are installed as hardlinks to the same `aube` binary (copies on
+Windows) and dispatch purely on `argv[0]`, so every flag that works on the
+full command also works on the shim:
+
+```sh
+aubr build            # aube run build
+aubx cowsay hi        # aube dlx cowsay hi
+```
+
+To enable the shims, create hardlinks named `aubr` and `aubx` next to
+your `aube` binary, e.g.:
+
+```sh
+ln "$(command -v aube)" "$(dirname "$(command -v aube)")/aubr"
+ln "$(command -v aube)" "$(dirname "$(command -v aube)")/aubx"
+```
+
+Official installers will grow support for this over time.
+
 ## CI
 
 Use `aube ci` when the lockfile must be treated as the source of truth:

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -13,6 +13,22 @@ include = ["src/**/*.rs"]
 name = "aube"
 path = "src/main.rs"
 
+# Multicall shims for `aube run` / `aube dlx`. Each stub `include!`s
+# `src/main.rs` so Cargo treats them as distinct targets (avoiding the
+# "same source in multiple bin targets" warning) while keeping a single
+# source of truth. Dispatch happens at runtime via `rewrite_multicall_argv`,
+# which keys off `argv[0]`. `test = false` prevents `cargo test` from
+# re-running the shared test suite three times.
+[[bin]]
+name = "aubr"
+path = "src/bin/aubr.rs"
+test = false
+
+[[bin]]
+name = "aubx"
+path = "src/bin/aubx.rs"
+test = false
+
 [dependencies]
 aube-lockfile = { workspace = true }
 aube-manifest = { workspace = true }

--- a/crates/aube/src/bin/aubr.rs
+++ b/crates/aube/src/bin/aubr.rs
@@ -1,0 +1,5 @@
+// Multicall shim for `aube run`. The real program lives in `src/main.rs`;
+// this stub only exists to give Cargo a unique path per `[[bin]]` target
+// (Cargo warns when multiple bins share a source file). Dispatch happens
+// at runtime via `rewrite_multicall_argv`, which keys off `argv[0]`.
+include!("../main.rs");

--- a/crates/aube/src/bin/aubx.rs
+++ b/crates/aube/src/bin/aubx.rs
@@ -1,0 +1,5 @@
+// Multicall shim for `aube dlx`. The real program lives in `src/main.rs`;
+// this stub only exists to give Cargo a unique path per `[[bin]]` target
+// (Cargo warns when multiple bins share a source file). Dispatch happens
+// at runtime via `rewrite_multicall_argv`, which keys off `argv[0]`.
+include!("../main.rs");

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -9,8 +9,32 @@ mod update_check;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use miette::{Context, IntoDiagnostic, miette};
+use std::ffi::OsString;
 use std::path::PathBuf;
 use tracing_subscriber::prelude::*;
+
+/// Inspect `argv[0]` and, when invoked as a multicall shim (`aubr`, `aubx`),
+/// rewrite the argv so clap sees the equivalent `aube run …` / `aube dlx …`.
+/// Shims are installed as hardlinks (or copies on Windows) that point at the
+/// same `aube` executable; dispatch happens purely at runtime via basename.
+fn rewrite_multicall_argv(mut args: Vec<OsString>) -> Vec<OsString> {
+    let Some(argv0) = args.first() else {
+        return args;
+    };
+    let stem = std::path::Path::new(argv0)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("aube")
+        .to_ascii_lowercase();
+    let subcommand = match stem.as_str() {
+        "aubr" => "run",
+        "aubx" => "dlx",
+        _ => return args,
+    };
+    args[0] = OsString::from("aube");
+    args.insert(1, OsString::from(subcommand));
+    args
+}
 
 #[derive(Parser)]
 #[command(name = "aube", about = "A fast Node.js package manager", version)]
@@ -446,7 +470,7 @@ enum Commands {
 }
 
 fn main() -> miette::Result<()> {
-    let cli = Cli::parse();
+    let cli = Cli::parse_from(rewrite_multicall_argv(std::env::args_os().collect()));
 
     // `--color` / `--no-color` take effect before anything else touches
     // color state: we translate the flags into the env vars that miette,
@@ -1257,6 +1281,62 @@ mod cli_spec_tests {
                  Regenerate with: cargo build && ./target/debug/aube usage > aube.usage.kdl"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod multicall_tests {
+    use super::*;
+
+    fn os(strs: &[&str]) -> Vec<OsString> {
+        strs.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn aube_passes_through_unchanged() {
+        assert_eq!(
+            rewrite_multicall_argv(os(&["aube", "install"])),
+            os(&["aube", "install"])
+        );
+    }
+
+    #[test]
+    fn aubr_rewrites_to_run() {
+        assert_eq!(
+            rewrite_multicall_argv(os(&["aubr", "build"])),
+            os(&["aube", "run", "build"])
+        );
+    }
+
+    #[test]
+    fn aubx_rewrites_to_dlx() {
+        assert_eq!(
+            rewrite_multicall_argv(os(&["aubx", "cowsay", "hi"])),
+            os(&["aube", "dlx", "cowsay", "hi"])
+        );
+    }
+
+    #[test]
+    fn absolute_path_and_exe_suffix_are_handled() {
+        // argv[0] can be an absolute path (exec-style invocation) or carry
+        // a `.exe` suffix on Windows. `Path::file_stem` takes care of both
+        // so dispatch stays purely basename-driven.
+        assert_eq!(
+            rewrite_multicall_argv(os(&["/usr/local/bin/aubr", "test"])),
+            os(&["aube", "run", "test"])
+        );
+        assert_eq!(
+            rewrite_multicall_argv(os(&["aubx.exe", "pkg"])),
+            os(&["aube", "dlx", "pkg"])
+        );
+    }
+
+    #[test]
+    fn bare_shim_invocation_passes_through_to_subcommand() {
+        // `aubr` with no further args becomes `aube run`, which clap
+        // parses as the `run` subcommand with no positional — same as
+        // the user typing `aube run` directly.
+        assert_eq!(rewrite_multicall_argv(os(&["aubr"])), os(&["aube", "run"]));
     }
 }
 

--- a/docs/package-manager/scripts.md
+++ b/docs/package-manager/scripts.md
@@ -47,6 +47,25 @@ aube dlx -p create-vite create-vite my-app
 
 `dlx` installs into a throwaway project and runs the requested binary.
 
+## Shortcuts: `aubr` and `aubx`
+
+`aubr` and `aubx` are multicall shims for `aube run` and `aube dlx`.
+They ship side by side with `aube` in the release archives and dispatch
+purely on `argv[0]`, so any flag that works on the full command works on
+the shim:
+
+```sh
+aubr build            # aube run build
+aubr -r test          # aube -r run test
+aubx cowsay hi        # aube dlx cowsay hi
+aubx -p create-vite create-vite my-app
+```
+
+The shims are identical aube binaries with a different filename; there is
+nothing to configure. If you install aube by hand — for example by
+copying the binary out of the tarball — bring `aubr` and `aubx` along so
+the shortcuts resolve on `PATH`.
+
 ## Workspace runs
 
 ```sh

--- a/mise.toml
+++ b/mise.toml
@@ -18,7 +18,16 @@ run = "hk check --all --slow"
 run = "hk fix --all --slow"
 
 [tasks.build]
-run = "cargo build"
+# Compile once, then hardlink the multicall shims (`aubr`, `aubx`) next
+# to the freshly built `aube` so basename dispatch in `main.rs` works
+# for local `./target/debug/aubr …` / `./target/debug/aubx …` runs.
+# Hardlinks are free on disk, survive macOS codesign, and let the BATS
+# suite exercise the shims without a second compile pass.
+run = [
+  "cargo build",
+  "ln -f target/debug/aube target/debug/aubr",
+  "ln -f target/debug/aube target/debug/aubx",
+]
 
 [tasks.test]
 run = "cargo test"

--- a/mise.toml
+++ b/mise.toml
@@ -18,16 +18,7 @@ run = "hk check --all --slow"
 run = "hk fix --all --slow"
 
 [tasks.build]
-# Compile once, then hardlink the multicall shims (`aubr`, `aubx`) next
-# to the freshly built `aube` so basename dispatch in `main.rs` works
-# for local `./target/debug/aubr …` / `./target/debug/aubx …` runs.
-# Hardlinks are free on disk, survive macOS codesign, and let the BATS
-# suite exercise the shims without a second compile pass.
-run = [
-  "cargo build",
-  "ln -f target/debug/aube target/debug/aubr",
-  "ln -f target/debug/aube target/debug/aubx",
-]
+run = "cargo build"
 
 [tasks.test]
 run = "cargo test"

--- a/test/multicall_shims.bats
+++ b/test/multicall_shims.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+#
+# Multicall shims: `aubr` dispatches as `aube run …` and `aubx` as
+# `aube dlx …` purely via argv[0] basename detection in `main.rs`.
+# The shims are hardlinks to the same `aube` executable; the BATS
+# common_setup refreshes them at the start of every test.
+#
+# `aubx` needs the fixture registry for package fetches, so keep these
+# tests out of the parallel pool like `dlx.bats` does.
+#
+# bats file_tags=serial
+
+# shellcheck disable=SC2034
+BATS_NO_PARALLELIZE_WITHIN_FILE=1
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "aubr runs a package.json script" {
+	_setup_basic_fixture
+	aube install
+	run aubr hello
+	assert_success
+	assert_output --partial "hello from aube!"
+}
+
+@test "aubr with no script errors like 'aube run' with no script" {
+	_setup_basic_fixture
+	aube install
+	run aubr </dev/null
+	assert_failure
+	assert_output --partial "script name required"
+}
+
+@test "aubx runs a package binary" {
+	run aubx semver 1.2.3
+	assert_success
+	assert_line "1.2.3"
+}
+
+@test "aubx forwards flags through to dlx" {
+	# `-p which node-which node` is the same -p smoke the dlx suite uses:
+	# install the `which` package, run its `node-which` binary, and
+	# expect the resolved `node` path in the output.
+	run aubx --package which node-which node
+	assert_success
+	assert_output --partial "/node"
+}

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -8,16 +8,6 @@ _common_setup() {
 	PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 	export PATH="$PROJECT_ROOT/target/debug:$PATH"
 
-	# Materialize the multicall shims (`aubr`, `aubx`) as hardlinks to the
-	# `aube` binary so basename dispatch in `main.rs` kicks in. The shims
-	# are not compiled separately, so we refresh them on every test run in
-	# case `aube` was rebuilt since the last invocation.
-	local _aube_bin="$PROJECT_ROOT/target/debug/aube"
-	if [ -x "$_aube_bin" ]; then
-		ln -f "$_aube_bin" "$PROJECT_ROOT/target/debug/aubr" 2>/dev/null || true
-		ln -f "$_aube_bin" "$PROJECT_ROOT/target/debug/aubx" 2>/dev/null || true
-	fi
-
 	TEST_TEMP_DIR="$(temp_make)"
 	cd "$TEST_TEMP_DIR" || exit 1
 

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -8,6 +8,19 @@ _common_setup() {
 	PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 	export PATH="$PROJECT_ROOT/target/debug:$PATH"
 
+	# Ensure the multicall shims (`aubr`, `aubx`) exist alongside `aube`.
+	# Local `cargo build` produces all three as real binaries, but CI only
+	# uploads `target/debug/aube` as an artifact; the bats shards then
+	# download just that one file. Materialize the shims as hardlinks to
+	# the shared `aube` inode so the argv[0] dispatch in `main.rs` resolves
+	# correctly. `ln -f` is idempotent — it refreshes if `aube` was rebuilt
+	# and is a no-op if the hardlinks already point at the same inode.
+	local _aube_bin="$PROJECT_ROOT/target/debug/aube"
+	if [ -x "$_aube_bin" ]; then
+		ln -f "$_aube_bin" "$PROJECT_ROOT/target/debug/aubr" 2>/dev/null || true
+		ln -f "$_aube_bin" "$PROJECT_ROOT/target/debug/aubx" 2>/dev/null || true
+	fi
+
 	TEST_TEMP_DIR="$(temp_make)"
 	cd "$TEST_TEMP_DIR" || exit 1
 

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -8,6 +8,16 @@ _common_setup() {
 	PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 	export PATH="$PROJECT_ROOT/target/debug:$PATH"
 
+	# Materialize the multicall shims (`aubr`, `aubx`) as hardlinks to the
+	# `aube` binary so basename dispatch in `main.rs` kicks in. The shims
+	# are not compiled separately, so we refresh them on every test run in
+	# case `aube` was rebuilt since the last invocation.
+	local _aube_bin="$PROJECT_ROOT/target/debug/aube"
+	if [ -x "$_aube_bin" ]; then
+		ln -f "$_aube_bin" "$PROJECT_ROOT/target/debug/aubr" 2>/dev/null || true
+		ln -f "$_aube_bin" "$PROJECT_ROOT/target/debug/aubx" 2>/dev/null || true
+	fi
+
 	TEST_TEMP_DIR="$(temp_make)"
 	cd "$TEST_TEMP_DIR" || exit 1
 


### PR DESCRIPTION
## Summary
- `aubr …` dispatches to `aube run …` and `aubx …` to `aube dlx …`, purely via `argv[0]` basename detection in [crates/aube-cli/src/main.rs](crates/aube-cli/src/main.rs) — no new clap subcommands or second compile pass.
- Shims are **hardlinks** to the same `aube` executable: zero disk cost, macOS codesign carries through via the shared inode, and basename dispatch stays transparent for flags (`aubr --help` shows `run`'s help, etc.).
- The `mise build` task now recreates `target/debug/aubr` / `aubx` after `cargo build`, and BATS `common_setup` refreshes them at the start of every test so the suite exercises the real shim path.
- Unit tests cover the argv rewrite (including absolute paths and `.exe` suffixes); a new `test/multicall_shims.bats` file drives end-to-end smoke tests against the live binary.

## Follow-up (not in this PR)
Release packaging and installer integration still need to ship the shims:

- `.github/workflows/release.yml` currently uploads only `aube` — needs a post-step that hardlinks `aubr`/`aubx` into the archive (and copies on Windows, where hardlinks are impractical).
- Homebrew formula, `install.sh`, `cargo-binstall`, winget/scoop manifests each need a two-line update to create the shims at install time.

Until those land, users enable the shims with a local `ln` as documented in the new README section.

## Test plan
- [x] `cargo test --workspace` — 5 new multicall unit tests plus the existing suite green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `./test/bats/bin/bats test/multicall_shims.bats` — 4/4 pass.
- [x] `./test/bats/bin/bats test/run.bats test/dlx.bats` — 21/21 still green after the common_setup change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new entrypoints and rewrites CLI argv parsing based on `argv[0]`, which could affect command dispatch/help output and release packaging across platforms if edge cases slip through.
> 
> **Overview**
> Adds multicall CLI shims `aubr` and `aubx` that invoke the existing binary but auto-dispatch to `aube run …` and `aube dlx …` by rewriting argv based on `argv[0]`.
> 
> Updates build/release and tests to ship and validate the shims: Cargo now builds three bins (with `aubr`/`aubx` stubs including `main.rs`), the release workflow uploads a single archive containing all three binaries per target, and the BATS harness creates hardlinked shims plus a new end-to-end `multicall_shims.bats` suite; docs/README are updated to document the shortcuts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7a870874c7654a6250156df7c6266b99712568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->