### PR TITLE
ci(autofix): drop no-op rm -rf .cargo step

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -23,7 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-      - run: rm -rf .cargo
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: autofix


### PR DESCRIPTION
## Summary

- Removes the `rm -rf .cargo` step from [.github/workflows/autofix.yml](.github/workflows/autofix.yml). It was copied verbatim from jdx/pitchfork's autofix workflow (see #196) but aube has no `.cargo/` dir tracked in-tree and nothing in the prior steps (checkout, mise-action) creates one, so the step was a no-op.

## Test plan

- [ ] autofix.ci runs green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow cleanup: it only removes a redundant `rm -rf .cargo` step and does not change build/lint commands or caching behavior.
> 
> **Overview**
> Simplifies the `autofix.ci` GitHub Actions workflow by removing the `rm -rf .cargo` step after `mise-action`, leaving the rest of the checkout, Rust cache, and `mise run ... lint-fix` flow unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a367fea5eee26090829da3c12cbb41dd5b088e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->