### PR TITLE
docs(installation): add `cargo install aube`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,6 +10,19 @@ mise use -g aube
 
 This installs `aube` on your PATH and lets mise manage future upgrades.
 
+## From crates.io
+
+If you already have a Rust toolchain installed, you can install the
+latest released `aube` from crates.io:
+
+```sh
+cargo install aube --locked
+```
+
+`--locked` makes cargo honor the committed `Cargo.lock` so you get the
+same dependency versions CI built against. The compiled binary lands in
+`~/.cargo/bin/aube`.
+
 ## From source
 
 If you want to build the current checkout yourself, use the standard source


### PR DESCRIPTION
## Summary

- Document `cargo install aube --locked` as an install method on the installation page, between the recommended mise path and the from-source build.
- README already defers to the docs page for "other install methods", so no README change.

## Dependency

The crates.io page for `aube` doesn't exist yet — it'll be published on the first release-plz cycle after [#7](https://github.com/endevco/aube/pull/7). **Don't merge this PR until that release has landed**, otherwise the docs page will link users to a 404.

## Test plan

- [ ] CI green (docs build + link check, if any).
- [ ] After merge, verify `cargo install aube --locked` actually pulls from crates.io on a clean machine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the main concern is user confusion if the crates.io package is not yet published when this ships.
> 
> **Overview**
> Adds a new *From crates.io* section to `docs/installation.md` documenting installation via `cargo install aube --locked`, including a brief explanation of `--locked` and where the binary is installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1faf18772981cf7b4d426f66045d9343e8154eb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->