### PR TITLE
ci: allow release-plz to be triggered manually

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to `.github/workflows/release-plz.yml` so the workflow can be run manually from the Actions tab

## Test plan
- [ ] Verify the workflow shows a "Run workflow" button in the Actions UI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a `workflow_dispatch` trigger to an existing GitHub Actions workflow, without changing any release logic or permissions.
> 
> **Overview**
> Enables manually running the existing `release-plz` GitHub Actions workflow by adding a `workflow_dispatch` trigger to `.github/workflows/release-plz.yml`, while keeping the push-to-`main` trigger unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae755df7edc8aeaa08746bc7f278538e102691e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->