### PR TITLE
v1.0.0-beta.2: npm distribution and improved Linux compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [Unreleased]
+
+## [v1.0.0-beta.2](https://github.com/endevco/aube/releases/tag/v1.0.0-beta.2) - 2026-04-18
+
+### Added
+- npm distribution: install aube globally via `npm install -g @endevco/aube` with platform-specific binary packages for macOS, Linux, and Windows (arm64 + x64) ([#12](https://github.com/endevco/aube/pull/12))
+
+### Changed
+- Switched TLS backend from system OpenSSL (`native-tls`) to pure-Rust `rustls-tls`, eliminating the OpenSSL system dependency and fixing cross-compilation failures on `aarch64-unknown-linux-gnu` ([#15](https://github.com/endevco/aube/pull/15))
+- Linux release binaries are now built with `cross`, providing broader glibc compatibility across Linux distributions ([#15](https://github.com/endevco/aube/pull/15))
+
+### Fixed
+- Fixed per-registry client certificate authentication to work with the rustls TLS backend by using combined PEM format (`Identity::from_pem`) instead of the native-tls-only `Identity::from_pkcs8_pem` ([#15](https://github.com/endevco/aube/pull/15))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -182,7 +182,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "base64",
  "flate2",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -375,9 +375,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -434,9 +434,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -523,7 +523,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1233,7 +1233,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1446,15 +1446,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1810,9 +1809,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -2283,7 +2282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2453,9 +2452,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2480,7 +2479,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2523,15 +2522,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2756,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2820,9 +2819,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3133,7 +3132,7 @@ dependencies = [
  "der",
  "digest 0.10.7",
  "pem",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "sha2 0.10.9",
  "signature",
  "sigstore-types",
@@ -3535,7 +3534,7 @@ dependencies = [
  "percent-encoding",
  "pest",
  "pest_derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "serde",
  "serde_json",
@@ -3675,9 +3674,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -4079,11 +4078,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4092,7 +4091,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -4219,9 +4218,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4753,6 +4752,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"
@@ -81,13 +81,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.1" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.1" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.1" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.1" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.1" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.1" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.1" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.1" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.1" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.1" }
+aube = { path = "crates/aube", version = "1.0.0-beta.2" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.2" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.2" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.2" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.2" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.2" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.2" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.2" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.2" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.2" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.1"
+version "1.0.0-beta.2"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.1...aube-linker-v1.0.0-beta.2) - 2026-04-18
+
+### Other
+
+- aube-cli crate -> aube ([#7](https://github.com/endevco/aube/pull/7))

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.1...aube-lockfile-v1.0.0-beta.2) - 2026-04-18
+
+### Other
+
+- aube-cli crate -> aube ([#7](https://github.com/endevco/aube/pull/7))

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.1...aube-manifest-v1.0.0-beta.2) - 2026-04-18
+
+### Other
+
+- aube-cli crate -> aube ([#7](https://github.com/endevco/aube/pull/7))
+- move settings.toml into aube-settings; pin per-crate include lists ([#4](https://github.com/endevco/aube/pull/4))

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.1...aube-registry-v1.0.0-beta.2) - 2026-04-18
+
+### Other
+
+- use cross + rustls-tls for linux targets ([#15](https://github.com/endevco/aube/pull/15))
+- aube-cli crate -> aube ([#7](https://github.com/endevco/aube/pull/7))

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.1...aube-resolver-v1.0.0-beta.2) - 2026-04-18
+
+### Other
+
+- aube-cli crate -> aube ([#7](https://github.com/endevco/aube/pull/7))

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0-beta.1...aube-scripts-v1.0.0-beta.2) - 2026-04-18
+
+### Other
+
+- aube-cli crate -> aube ([#7](https://github.com/endevco/aube/pull/7))

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.1...aube-settings-v1.0.0-beta.2) - 2026-04-18
+
+### Other
+
+- aube-cli crate -> aube ([#7](https://github.com/endevco/aube/pull/7))

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.1...aube-store-v1.0.0-beta.2) - 2026-04-18
+
+### Other
+
+- aube-cli crate -> aube ([#7](https://github.com/endevco/aube/pull/7))

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.1...aube-workspace-v1.0.0-beta.2) - 2026-04-18
+
+### Other
+
+- aube-cli crate -> aube ([#7](https://github.com/endevco/aube/pull/7))

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.2](https://github.com/endevco/aube/compare/v1.0.0-beta.1...v1.0.0-beta.2) - 2026-04-18
+
+### Other
+
+- update Cargo.toml dependencies

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5656,7 +5656,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.1
+**Version**: 1.0.0-beta.2
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
aube can now be installed via npm (`npm install -g @endevco/aube`), and Linux binaries have been rebuilt with broader glibc compatibility and a pure-Rust TLS stack — no more OpenSSL system dependency.

## Highlights

- **Install from npm** — `npm install -g @endevco/aube` ships native binaries for all six supported platforms (macOS, Linux, Windows × arm64/x64). The multicall shims `aubr` and `aubx` work out of the box.
- **Better Linux portability** — Linux targets are now built with `cross`, producing binaries that run on older glibc versions. The switch from OpenSSL to `rustls` removes the system OpenSSL dependency entirely.

## Added

- **npm distribution** — aube is now published on npm as `@endevco/aube`. At install time, a `preinstall` script fetches the correct `@endevco/aube-<os>-<arch>` sub-package and hardlinks the three binaries (`aube`, `aubr`, `aubx`) into place. No runtime JS shim — npm's bin wrapper calls the native binary directly. Pre-releases use the `next` dist-tag; stable releases use `latest`. ([#12](https://github.com/endevco/aube/pull/12) by @jdx)

  ```sh
  npm install -g @endevco/aube
  # or try it without installing
  npx @endevco/aube --version
  ```

  > **Note:** Because install relies on `preinstall`, the `--ignore-scripts` flag and fully offline caches are not supported. Use mise or `cargo install` in those environments.

## Changed

- **TLS backend switched to rustls** — HTTP requests now use the pure-Rust `rustls` TLS implementation instead of the system's OpenSSL via `native-tls`. This eliminates the need for OpenSSL headers at build time and removes the OpenSSL runtime dependency on Linux. ([#15](https://github.com/endevco/aube/pull/15) by @jdx)
- **Linux builds use `cross`** — Linux release binaries (x86_64 and aarch64) are now compiled inside `cross`'s Docker images, which target an older glibc baseline for broader distribution compatibility. ([#15](https://github.com/endevco/aube/pull/15) by @jdx)

## Fixed

- **Per-registry client certificate auth** — The mTLS client certificate path now concatenates cert and key into a single PEM buffer and calls `Identity::from_pem`, which works correctly under rustls. The previous `Identity::from_pkcs8_pem` was a `native-tls`-only API. ([#15](https://github.com/endevco/aube/pull/15) by @jdx)

**Full Changelog**: https://github.com/endevco/aube/compare/6587e37...16ded6f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This is primarily a release/versioning PR (changelogs, version bumps, and dependency lockfile updates) with no functional code changes shown in the diff, so runtime risk is low.
> 
> **Overview**
> Prepares the `v1.0.0-beta.2` release by adding a top-level `CHANGELOG.md` and per-crate changelogs, and bumping the workspace + internal crate versions from `1.0.0-beta.1` to `1.0.0-beta.2`.
> 
> Updates `Cargo.lock` for the release (dependency version/lock refresh) and syncs the reported CLI/docs version (`aube.usage.kdl`, `docs/cli/index.md`, `docs/cli/commands.json`) to `1.0.0-beta.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e5376250d252bcbd4ef756d09ddf3ad7f6ebeaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->