### PR TITLE
publish: ship aube on npm as @endevco/aube

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -67,6 +67,5 @@ jobs:
         run: npm install -g npm@latest
       - name: Publish @endevco/aube and platform packages
         env:
-          GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
         run: node npm/scripts/publish.mjs

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,72 @@
+name: publish-npm
+
+# Fires on every published GitHub release (i.e. the moment the
+# release-plz flow flips the draft to non-draft and all prebuilt
+# binaries are already attached to the release). Downloads the
+# per-target archives that `release.yml` produced, then publishes
+# each `@endevco/aube-<os>-<arch>` followed by the root
+# `@endevco/aube`.
+#
+# Decoupled from `release-plz.yml` on purpose: a failed npm publish
+# doesn't block crates.io or the GitHub release, and re-runs can be
+# kicked off from the Actions UI for any existing tag.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish to npm (e.g. v1.0.0-beta.1)"
+        required: true
+        type: string
+
+concurrency:
+  # Serialize by tag so an accidental double-trigger (release event +
+  # manual re-run of the same tag) can't race two publish flights.
+  group: publish-npm-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for npm Trusted Publishing (OIDC). GitHub mints a
+      # short-lived OIDC token that npm exchanges for a one-shot
+      # publish token — no NPM_TOKEN secret to rotate or leak.
+      # Each @endevco/aube* package must have this repo + workflow
+      # configured as a Trusted Publisher on npmjs.com (org level
+      # default covers new packages under the scope).
+      id-token: write
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            echo "::error::no tag from release event or workflow_dispatch input"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ steps.tag.outputs.tag }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      # Trusted Publishing requires npm >= 11.5.1. Node 24 ships npm
+      # 11, but the exact minor varies — upgrade explicitly so the
+      # workflow doesn't break if Node's bundled npm drifts behind.
+      - name: Ensure npm supports Trusted Publishing
+        run: npm install -g npm@latest
+      - name: Publish @endevco/aube and platform packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: node npm/scripts/publish.mjs

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Inside a project, you can also pin aube with mise:
 mise use aube
 ```
 
-If you already have Node.js around, aube is also on npm:
+aube is also published on npm:
 
 ```sh
 npm install -g @endevco/aube

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Inside a project, you can also pin aube with mise:
 mise use aube
 ```
 
+If you already have Node.js around, aube is also on npm:
+
+```sh
+npm install -g @endevco/aube
+```
+
 See [other install methods](https://aube.en.dev/installation).
 
 ## First Install

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,8 +25,7 @@ same dependency versions CI built against. The compiled binary lands in
 
 ## From npm
 
-For users who already have Node.js around, aube is also published on
-npm as `@endevco/aube`:
+aube is also published on npm as `@endevco/aube`:
 
 ```sh
 npm install -g @endevco/aube

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,11 +33,6 @@ npm install -g @endevco/aube
 npx @endevco/aube --version
 ```
 
-No Rust toolchain required — the package's preinstall step downloads
-the matching prebuilt binary for your platform (Linux, macOS, Windows;
-x64 and arm64) from npm. `npm install -g` puts `aube`, `aubr`, and
-`aubx` on your PATH.
-
 Because the install happens via `preinstall`, this does not work with
 `--ignore-scripts` or in offline/air-gapped caches. Prefer mise or
 `cargo install` for those environments.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,6 +23,26 @@ cargo install aube --locked
 same dependency versions CI built against. The compiled binary lands in
 `~/.cargo/bin/aube`.
 
+## From npm
+
+For users who already have Node.js around, aube is also published on
+npm as `@endevco/aube`:
+
+```sh
+npm install -g @endevco/aube
+# or
+npx @endevco/aube --version
+```
+
+No Rust toolchain required — the package's preinstall step downloads
+the matching prebuilt binary for your platform (Linux, macOS, Windows;
+x64 and arm64) from npm. `npm install -g` puts `aube`, `aubr`, and
+`aubx` on your PATH.
+
+Because the install happens via `preinstall`, this does not work with
+`--ignore-scripts` or in offline/air-gapped caches. Prefer mise or
+`cargo install` for those environments.
+
 ## From source
 
 If you want to build the current checkout yourself, use the standard source

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,6 @@
+/bin
+/node_modules
+/.stage
+/*.tgz
+# Copied in from ../README.md by scripts/publish.mjs at publish time.
+/README.md

--- a/npm/installArchSpecificPackage.js
+++ b/npm/installArchSpecificPackage.js
@@ -1,0 +1,93 @@
+// Fetch the platform-matching @endevco/aube-<os>-<arch> sub-package at
+// install time and hardlink (or copy) its three binaries into ./bin so
+// npm's `bin` wrapper resolves directly to the native executable. This
+// mirrors https://www.npmjs.com/package/@jdxcode/mise — the preinstall
+// approach avoids the JS shim at runtime and keeps `package-lock.json`
+// free of six optional-dependency entries that are mostly skipped.
+//
+// Must stay CommonJS and use only the Node.js stdlib — it runs *before*
+// any dependency is installed, so nothing from node_modules is reachable.
+
+var spawn = require('child_process').spawn;
+var path = require('path');
+var fs = require('fs');
+
+function main() {
+    var pjson = require('./package.json');
+    var version = pjson.version;
+
+    // Nested `npm install` must stay local; otherwise it'd try to write
+    // into the global prefix when the user ran `npm i -g @endevco/aube`.
+    process.env.npm_config_global = 'false';
+
+    var platform = process.platform; // darwin | linux | win32
+    var arch = process.arch;         // arm64 | x64
+    var subpkgName = '@endevco/aube-' + platform + '-' + arch;
+
+    var npmCmd = platform === 'win32' ? 'npm.cmd' : 'npm';
+    var args = ['install', '--no-save', '--no-package-lock', subpkgName + '@' + version];
+
+    var cp = spawn(npmCmd, args, { stdio: 'inherit', shell: true });
+    cp.on('close', function(code) {
+        if (code !== 0) {
+            process.exit(code);
+            return;
+        }
+        try {
+            linkSubpkgBins(subpkgName, platform, pjson);
+            process.exit(0);
+        } catch (e) {
+            console.error('[@endevco/aube] preinstall failed: ' + (e && e.message ? e.message : e));
+            process.exit(1);
+        }
+    });
+}
+
+function linkSubpkgBins(subpkgName, platform, pjson) {
+    var subpkgJsonPath = require.resolve(subpkgName + '/package.json');
+    var subpkg = JSON.parse(fs.readFileSync(subpkgJsonPath, 'utf8'));
+    var subpkgDir = path.dirname(subpkgJsonPath);
+
+    var binDir = path.resolve(__dirname, 'bin');
+    try { fs.mkdirSync(binDir); } catch (e) { if (e.code !== 'EEXIST') throw e; }
+
+    var rootPkgJsonPath = path.resolve(__dirname, 'package.json');
+    var rootPkg = JSON.parse(fs.readFileSync(rootPkgJsonPath, 'utf8'));
+    var rootPkgChanged = false;
+
+    Object.keys(subpkg.bin).forEach(function(name) {
+        var srcRel = subpkg.bin[name];
+        var src = path.resolve(subpkgDir, srcRel);
+        var destBasename = path.basename(srcRel);
+        var dest = path.resolve(binDir, destBasename);
+
+        try { fs.unlinkSync(dest); } catch (e) { if (e.code !== 'ENOENT') throw e; }
+        try {
+            // Hardlink is cheapest (same inode, no extra disk). On some
+            // filesystems (cross-device, restricted sandboxes) hardlink
+            // fails — fall through to a copy.
+            fs.linkSync(src, dest);
+        } catch (e) {
+            fs.copyFileSync(src, dest);
+        }
+        if (platform !== 'win32') {
+            try { fs.chmodSync(dest, 0o755); } catch (_) {}
+        }
+
+        // Keep root package.json's `bin` entry aligned with the filename
+        // we actually wrote. Matters on Windows, where the sub-package's
+        // bin ends in `.exe` — the root's original `./bin/<name>` entry
+        // would leave the npm bin wrapper pointing at a missing file.
+        var desiredBin = './bin/' + destBasename;
+        if (rootPkg.bin[name] !== desiredBin) {
+            rootPkg.bin[name] = desiredBin;
+            rootPkgChanged = true;
+        }
+    });
+
+    if (rootPkgChanged) {
+        fs.writeFileSync(rootPkgJsonPath, JSON.stringify(rootPkg, null, 2) + '\n');
+    }
+}
+
+main();

--- a/npm/installArchSpecificPackage.js
+++ b/npm/installArchSpecificPackage.js
@@ -28,7 +28,15 @@ function main() {
     var args = ['install', '--no-save', '--no-package-lock', subpkgName + '@' + version];
 
     var cp = spawn(npmCmd, args, { stdio: 'inherit', shell: true });
-    cp.on('close', function(code) {
+    cp.on('close', function(code, signal) {
+        // `code` is null when the child was killed by a signal (e.g.
+        // OOM). `process.exit(null)` coerces to 0, which would tell
+        // npm the preinstall succeeded — surface it as failure.
+        if (signal || code === null) {
+            console.error('[@endevco/aube] preinstall: `npm install ' + subpkgName + '` killed by ' + (signal || 'signal'));
+            process.exit(1);
+            return;
+        }
         if (code !== 0) {
             process.exit(code);
             return;

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@endevco/aube",
+  "version": "0.0.0-placeholder",
+  "description": "A fast Node.js package manager that drops into existing projects.",
+  "homepage": "https://aube.en.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/endevco/aube"
+  },
+  "license": "MIT",
+  "files": [
+    "installArchSpecificPackage.js",
+    "README.md"
+  ],
+  "scripts": {
+    "prepack": "rm -rf bin",
+    "preinstall": "node installArchSpecificPackage.js"
+  },
+  "bin": {
+    "aube": "./bin/aube",
+    "aubr": "./bin/aubr",
+    "aubx": "./bin/aubx"
+  },
+  "engines": {
+    "node": ">=14"
+  }
+}

--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -144,7 +144,10 @@ async function buildPlatformPackage(repo, tag, version, target) {
 }
 
 function npmPublish(stageDir, npmTag, dryRun) {
-    const args = ['publish', '--access', 'public', '--tag', npmTag];
+    // `--provenance` is separate from Trusted Publishing: OIDC covers
+    // the auth handshake, but the provenance attestation is only
+    // attached when this flag is set explicitly.
+    const args = ['publish', '--access', 'public', '--tag', npmTag, '--provenance'];
     if (dryRun) args.push('--dry-run');
     run('npm', args, { cwd: stageDir });
 }

--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Build and publish the @endevco/aube npm packages for a given tag.
+//
+// For each of the 6 release targets this:
+//   1. downloads `aube-<tag>-<target>.{tar.gz,zip}` from the GitHub
+//      release (via `gh release download`),
+//   2. extracts the three binaries (aube, aubr, aubx) into a staging
+//      dir,
+//   3. generates a platform-scoped package.json and publishes it as
+//      `@endevco/aube-<os>-<arch>`.
+// Then rewrites the root `npm/package.json` version and publishes
+// `@endevco/aube` last, so the preinstall script can resolve every
+// sub-package it might want to install.
+//
+// Env:
+//   TAG           — release tag, with leading `v` (e.g. v1.0.0-beta.1)
+//   NPM_TAG       — npm dist-tag (optional; defaults to `next` for
+//                   pre-releases, `latest` otherwise)
+//   DRY_RUN=1     — stage + `npm pack` but don't publish
+//   SKIP_ROOT=1   — publish only the platform packages
+//   SKIP_PLATFORMS=1 — publish only the root package
+
+import { execSync, spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync, cpSync, rmSync, existsSync, chmodSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const npmDir = resolve(__dirname, '..');
+const stageRoot = resolve(npmDir, '.stage');
+
+const TARGETS = [
+    { triple: 'aarch64-apple-darwin',       os: 'darwin', cpu: 'arm64', ext: '.tar.gz', exe: '' },
+    { triple: 'x86_64-apple-darwin',        os: 'darwin', cpu: 'x64',   ext: '.tar.gz', exe: '' },
+    { triple: 'x86_64-unknown-linux-gnu',   os: 'linux',  cpu: 'x64',   ext: '.tar.gz', exe: '' },
+    { triple: 'aarch64-unknown-linux-gnu',  os: 'linux',  cpu: 'arm64', ext: '.tar.gz', exe: '' },
+    { triple: 'x86_64-pc-windows-msvc',     os: 'win32',  cpu: 'x64',   ext: '.zip',    exe: '.exe' },
+    { triple: 'aarch64-pc-windows-msvc',    os: 'win32',  cpu: 'arm64', ext: '.zip',    exe: '.exe' },
+];
+
+const BINS = ['aube', 'aubr', 'aubx'];
+
+function run(cmd, args, opts = {}) {
+    const result = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+    if (result.status !== 0) {
+        throw new Error(`${cmd} ${args.join(' ')} exited ${result.status}`);
+    }
+}
+
+function assertEnv(name) {
+    const v = process.env[name];
+    if (!v) throw new Error(`${name} env var is required`);
+    return v;
+}
+
+function versionFromTag(tag) {
+    if (!tag.startsWith('v')) throw new Error(`TAG must start with 'v': ${tag}`);
+    return tag.slice(1);
+}
+
+function defaultNpmTag(version) {
+    return version.includes('-') ? 'next' : 'latest';
+}
+
+function downloadArchive(tag, target, outDir) {
+    const archiveName = `aube-${tag}-${target.triple}${target.ext}`;
+    const archivePath = resolve(outDir, archiveName);
+    mkdirSync(outDir, { recursive: true });
+    run('gh', ['release', 'download', tag, '--pattern', archiveName, '--dir', outDir, '--clobber']);
+    return archivePath;
+}
+
+function extractArchive(archivePath, target, destDir) {
+    mkdirSync(destDir, { recursive: true });
+    if (target.ext === '.tar.gz') {
+        run('tar', ['-xzf', archivePath, '-C', destDir, '--strip-components=0']);
+    } else {
+        run('unzip', ['-o', archivePath, '-d', destDir]);
+    }
+    // taiki-e/upload-rust-binary-action packs each bin at the archive
+    // root (no containing directory). Verify each expected binary lands
+    // where we think, so a silent rename doesn't ship an empty package.
+    for (const bin of BINS) {
+        const binPath = resolve(destDir, bin + target.exe);
+        if (!existsSync(binPath)) {
+            throw new Error(`missing ${binPath} in extracted archive`);
+        }
+        if (target.os !== 'win32') chmodSync(binPath, 0o755);
+    }
+}
+
+function buildPlatformPackage(tag, version, target) {
+    const pkgName = `@endevco/aube-${target.os}-${target.cpu}`;
+    const stageDir = resolve(stageRoot, `${target.os}-${target.cpu}`);
+    rmSync(stageDir, { recursive: true, force: true });
+    const binDir = resolve(stageDir, 'bin');
+    mkdirSync(binDir, { recursive: true });
+
+    const dlDir = resolve(stageRoot, '_downloads');
+    const archivePath = downloadArchive(tag, target, dlDir);
+    const extractDir = resolve(stageRoot, `_extract-${target.os}-${target.cpu}`);
+    rmSync(extractDir, { recursive: true, force: true });
+    extractArchive(archivePath, target, extractDir);
+
+    const bins = {};
+    for (const bin of BINS) {
+        const src = resolve(extractDir, bin + target.exe);
+        const destName = bin + target.exe;
+        const dest = resolve(binDir, destName);
+        cpSync(src, dest);
+        if (target.os !== 'win32') chmodSync(dest, 0o755);
+        bins[bin] = `bin/${destName}`;
+    }
+
+    const pkgJson = {
+        name: pkgName,
+        version,
+        description: 'Platform binaries for aube — do not install directly, see @endevco/aube.',
+        homepage: 'https://aube.en.dev',
+        repository: { type: 'git', url: 'https://github.com/endevco/aube' },
+        license: 'MIT',
+        bin: bins,
+        files: ['bin', 'README.md'],
+        os: [target.os],
+        cpu: [target.cpu],
+    };
+    writeFileSync(resolve(stageDir, 'package.json'), JSON.stringify(pkgJson, null, 2) + '\n');
+
+    const rootReadme = resolve(npmDir, '..', 'README.md');
+    cpSync(rootReadme, resolve(stageDir, 'README.md'));
+
+    return { pkgName, stageDir };
+}
+
+function npmPublish(stageDir, npmTag, dryRun) {
+    const args = ['publish', '--access', 'public', '--tag', npmTag];
+    if (dryRun) args.push('--dry-run');
+    run('npm', args, { cwd: stageDir });
+}
+
+function main() {
+    const tag = assertEnv('TAG');
+    const version = versionFromTag(tag);
+    const npmTag = process.env.NPM_TAG || defaultNpmTag(version);
+    const dryRun = process.env.DRY_RUN === '1';
+    const skipPlatforms = process.env.SKIP_PLATFORMS === '1';
+    const skipRoot = process.env.SKIP_ROOT === '1';
+
+    console.log(`[publish] tag=${tag} version=${version} npmTag=${npmTag} dryRun=${dryRun}`);
+
+    if (!skipPlatforms) {
+        for (const target of TARGETS) {
+            console.log(`\n[publish] --- ${target.os}-${target.cpu} (${target.triple}) ---`);
+            const { pkgName, stageDir } = buildPlatformPackage(tag, version, target);
+            console.log(`[publish] staged ${pkgName} at ${stageDir}`);
+            npmPublish(stageDir, npmTag, dryRun);
+        }
+    }
+
+    if (!skipRoot) {
+        console.log(`\n[publish] --- @endevco/aube (root) ---`);
+        const rootPkgPath = resolve(npmDir, 'package.json');
+        const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf8'));
+        rootPkg.version = version;
+        writeFileSync(rootPkgPath, JSON.stringify(rootPkg, null, 2) + '\n');
+        // `npm pack` doesn't follow symlinks, so stage a real README
+        // copy next to package.json rather than linking ../README.md.
+        cpSync(resolve(npmDir, '..', 'README.md'), resolve(npmDir, 'README.md'));
+        npmPublish(npmDir, npmTag, dryRun);
+    }
+}
+
+main();

--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -2,8 +2,8 @@
 // Build and publish the @endevco/aube npm packages for a given tag.
 //
 // For each of the 6 release targets this:
-//   1. downloads `aube-<tag>-<target>.{tar.gz,zip}` from the GitHub
-//      release (via `gh release download`),
+//   1. downloads `aube-<tag>-<target>.{tar.gz,zip}` directly from the
+//      public GitHub release asset URL (no API, no auth token),
 //   2. extracts the three binaries (aube, aubr, aubx) into a staging
 //      dir,
 //   3. generates a platform-scoped package.json and publishes it as
@@ -14,15 +14,20 @@
 //
 // Env:
 //   TAG           — release tag, with leading `v` (e.g. v1.0.0-beta.1)
+//   REPO          — owner/repo for the release assets (optional;
+//                   defaults to $GITHUB_REPOSITORY or `endevco/aube`)
 //   NPM_TAG       — npm dist-tag (optional; defaults to `next` for
 //                   pre-releases, `latest` otherwise)
 //   DRY_RUN=1     — stage + `npm pack` but don't publish
 //   SKIP_ROOT=1   — publish only the platform packages
 //   SKIP_PLATFORMS=1 — publish only the root package
 
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
 import { mkdirSync, readFileSync, writeFileSync, cpSync, rmSync, existsSync, chmodSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -62,11 +67,17 @@ function defaultNpmTag(version) {
     return version.includes('-') ? 'next' : 'latest';
 }
 
-function downloadArchive(tag, target, outDir) {
+async function downloadArchive(repo, tag, target, outDir) {
     const archiveName = `aube-${tag}-${target.triple}${target.ext}`;
     const archivePath = resolve(outDir, archiveName);
     mkdirSync(outDir, { recursive: true });
-    run('gh', ['release', 'download', tag, '--pattern', archiveName, '--dir', outDir, '--clobber']);
+    // Public release assets redirect from /releases/download/<tag>/<asset>
+    // to a signed CDN URL — no auth, no API, fetch follows the redirect.
+    const url = `https://github.com/${repo}/releases/download/${tag}/${archiveName}`;
+    console.log(`[publish] downloading ${url}`);
+    const res = await fetch(url, { redirect: 'follow' });
+    if (!res.ok) throw new Error(`download ${url} failed: ${res.status} ${res.statusText}`);
+    await pipeline(Readable.fromWeb(res.body), createWriteStream(archivePath));
     return archivePath;
 }
 
@@ -89,7 +100,7 @@ function extractArchive(archivePath, target, destDir) {
     }
 }
 
-function buildPlatformPackage(tag, version, target) {
+async function buildPlatformPackage(repo, tag, version, target) {
     const pkgName = `@endevco/aube-${target.os}-${target.cpu}`;
     const stageDir = resolve(stageRoot, `${target.os}-${target.cpu}`);
     rmSync(stageDir, { recursive: true, force: true });
@@ -97,7 +108,7 @@ function buildPlatformPackage(tag, version, target) {
     mkdirSync(binDir, { recursive: true });
 
     const dlDir = resolve(stageRoot, '_downloads');
-    const archivePath = downloadArchive(tag, target, dlDir);
+    const archivePath = await downloadArchive(repo, tag, target, dlDir);
     const extractDir = resolve(stageRoot, `_extract-${target.os}-${target.cpu}`);
     rmSync(extractDir, { recursive: true, force: true });
     extractArchive(archivePath, target, extractDir);
@@ -138,20 +149,21 @@ function npmPublish(stageDir, npmTag, dryRun) {
     run('npm', args, { cwd: stageDir });
 }
 
-function main() {
+async function main() {
     const tag = assertEnv('TAG');
     const version = versionFromTag(tag);
+    const repo = process.env.REPO || process.env.GITHUB_REPOSITORY || 'endevco/aube';
     const npmTag = process.env.NPM_TAG || defaultNpmTag(version);
     const dryRun = process.env.DRY_RUN === '1';
     const skipPlatforms = process.env.SKIP_PLATFORMS === '1';
     const skipRoot = process.env.SKIP_ROOT === '1';
 
-    console.log(`[publish] tag=${tag} version=${version} npmTag=${npmTag} dryRun=${dryRun}`);
+    console.log(`[publish] repo=${repo} tag=${tag} version=${version} npmTag=${npmTag} dryRun=${dryRun}`);
 
     if (!skipPlatforms) {
         for (const target of TARGETS) {
             console.log(`\n[publish] --- ${target.os}-${target.cpu} (${target.triple}) ---`);
-            const { pkgName, stageDir } = buildPlatformPackage(tag, version, target);
+            const { pkgName, stageDir } = await buildPlatformPackage(repo, tag, version, target);
             console.log(`[publish] staged ${pkgName} at ${stageDir}`);
             npmPublish(stageDir, npmTag, dryRun);
         }
@@ -170,4 +182,7 @@ function main() {
     }
 }
 
-main();
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add a preinstall-based npm distribution alongside the existing mise/cargo/curl paths. Root package is `@endevco/aube`; six per-platform subs are `@endevco/aube-<os>-<arch>` (darwin-arm64, darwin-x64, linux-x64, linux-arm64, win32-x64, win32-arm64).
- New standalone workflow [`publish-npm.yml`](.github/workflows/publish-npm.yml) triggers on `release: published` (and `workflow_dispatch` for reruns). Decoupled from `release-plz.yml` so an npm hiccup never blocks crates.io or the GitHub release.
- Auth via npm **Trusted Publishing (OIDC)** — no `NPM_TOKEN` secret.

## How it works

At install time, `@endevco/aube`'s [`preinstall` script](npm/installArchSpecificPackage.js) spawns `npm install --no-save @endevco/aube-<os>-<arch>@<version>` and hardlinks (falling back to copy) the three binaries (`aube`, `aubr`, `aubx`) from the sub-package's `bin/` into the root's `./bin/`. Shape mirrors [`@jdxcode/mise`](https://www.npmjs.com/package/@jdxcode/mise) — no runtime JS shim and no `optionalDependencies` sprawl in `package-lock.json`. Note this means `--ignore-scripts` and fully offline caches won't work; those users keep the mise/cargo paths.

The multicall dispatch from [#6](https://github.com/endevco/aube/pull/6) works through npm because the preinstall creates three named files, so `aubr` invoked via npm's bin wrapper sees `argv[0]` ending in `aubr` and routes to `run`.

At release time, [`npm/scripts/publish.mjs`](npm/scripts/publish.mjs) downloads each `aube-<tag>-<target>.{tar.gz,zip}` from the just-published GitHub release, extracts the binaries, stages a platform-scoped `package.json` with correct `os`/`cpu`/`bin`, and `npm publish`es each sub-package. Root publishes last so its preinstall can resolve every sub. Auto-picks the `next` dist-tag for pre-releases (`1.0.0-beta.1` → `next`) and `latest` for stable. `DRY_RUN=1`, `SKIP_ROOT=1`, and `SKIP_PLATFORMS=1` env flags exist for manual recovery.

## Why OIDC

npm's Trusted Publishing (GA mid-2025) exchanges a short-lived GitHub OIDC token for a one-shot npm publish token. No long-lived secret to rotate or leak, and the publish is provenance-signed. Requires npm ≥ 11.5.1 — the workflow upgrades to `npm@latest` before publishing to avoid drift with the version Node 24 ships.

## Pre-merge setup

On [npmjs.com/org/endevco](https://www.npmjs.com/org/endevco) → Settings → Trusted Publishers, add an org-level trusted publisher:
- Repo: `endevco/aube`
- Workflow: `.github/workflows/publish-npm.yml`
- Environment: (blank)

Org-level config covers all new `@endevco/*` packages, so the first release auto-covers root + 6 subs.

## Limitations / follow-ups

- `aube` (unscoped) is taken on npm by a year-old placeholder (`estjs/aube`, 1 version, never updated). If you want the unscoped name, file an [npm dispute](https://docs.npmjs.com/policies/disputes) — unrelated to this PR.
- No Alpine / musl package yet. Linux users on glibc distros get `linux-<arch>`; muslc users will hit the glibc binary and fail. Adding `linux-x64-musl` / `linux-arm64-musl` needs corresponding Rust release targets first.
- Retrying after partial publish failure: same-version republishes return 403. Recovery is running the workflow manually with `SKIP_PLATFORMS=1` (or vice versa) to publish only what hasn't shipped.

## Test plan

- [x] Built `aube`, `aubr`, `aubx` locally; staged a fake `@endevco/aube-darwin-arm64` sub-package under `node_modules/`; ran the link logic and confirmed each bin dispatches to the right subcommand via `argv[0]` basename (`aubr --help` → `run`'s help, `aubx --help` → `dlx`'s help).
- [x] `npm pack --dry-run` on the root package — tarball contains only `installArchSpecificPackage.js` + `package.json` (README copied in by publish script at release time).
- [x] `npm pack --dry-run` on a hand-staged platform package — contains `bin/{aube,aubr,aubx}`, `package.json` with correct `os`/`cpu`, `README.md`.
- [ ] End-to-end first publish under `1.0.0-beta.X` with `next` dist-tag, then `npm install -g @endevco/aube@next` from a clean machine. Runs for real on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new release-triggered GitHub Actions workflow and `preinstall`-driven npm packaging/publishing logic, which can impact release automation and end-user installation behavior if misconfigured.
> 
> **Overview**
> Adds npm distribution for `aube` by introducing a root `@endevco/aube` package that installs a platform-specific `@endevco/aube-<os>-<arch>` subpackage at `preinstall` time and links/copies the native `aube`/`aubr`/`aubx` binaries into `./bin`.
> 
> Introduces a new `publish-npm` GitHub Actions workflow that runs on `release: published` (or manual tag input) and uses npm Trusted Publishing (OIDC) to download release artifacts, stage per-platform npm packages, and publish them before publishing the root package. Documentation is updated to mention `npm install -g @endevco/aube` as an install option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7125137c91a16f3e1a48059d2555017978b4e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->