### PR TITLE
ci(release): drop x86_64-apple-darwin from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,6 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             build-tool: cargo
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            build-tool: cargo
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             build-tool: cross

--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Build and publish the @endevco/aube npm packages for a given tag.
 //
-// For each of the 6 release targets this:
+// For each of the 5 release targets this:
 //   1. downloads `aube-<tag>-<target>.{tar.gz,zip}` directly from the
 //      public GitHub release asset URL (no API, no auth token),
 //   2. extracts the three binaries (aube, aubr, aubx) into a staging
@@ -36,7 +36,6 @@ const stageRoot = resolve(npmDir, '.stage');
 
 const TARGETS = [
     { triple: 'aarch64-apple-darwin',       os: 'darwin', cpu: 'arm64', ext: '.tar.gz', exe: '' },
-    { triple: 'x86_64-apple-darwin',        os: 'darwin', cpu: 'x64',   ext: '.tar.gz', exe: '' },
     { triple: 'x86_64-unknown-linux-gnu',   os: 'linux',  cpu: 'x64',   ext: '.tar.gz', exe: '' },
     { triple: 'aarch64-unknown-linux-gnu',  os: 'linux',  cpu: 'arm64', ext: '.tar.gz', exe: '' },
     { triple: 'x86_64-pc-windows-msvc',     os: 'win32',  cpu: 'x64',   ext: '.zip',    exe: '.exe' },


### PR DESCRIPTION
## Summary
- Removes the `x86_64-apple-darwin` entry from the release workflow build matrix so we stop producing/signing Intel macOS archives. Apple Silicon (`aarch64-apple-darwin`) remains the only darwin target shipped.

## Test plan
- [ ] Next release run builds aarch64 macOS + both Linux targets + both Windows targets, with no Intel macOS job attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk CI/package-metadata change, but it will stop producing/publishing Intel macOS artifacts which could affect downstream users on x64 macOS.
> 
> **Overview**
> Stops shipping Intel macOS builds by removing `x86_64-apple-darwin` from the GitHub Actions release workflow matrix.
> 
> Updates the npm publish script’s `TARGETS` list (and comment) to match the new 5-target release set so it no longer expects/downloads an x64 darwin archive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c89a3b3adf7dd4489c1ad19b79742c1e12c4665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->