### PR TITLE
install: print "Already up to date" on a no-op install

### DIFF
--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -3137,7 +3137,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         if fresh {
             tracing::debug!("--lockfile-only: lockfile already up to date");
             if let Some(p) = prog_ref {
-                p.finish();
+                p.finish(true);
             }
             eprintln!("Lockfile is up to date, resolution step is skipped");
             return Ok(());
@@ -3212,7 +3212,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         // primary output.
         maybe_cleanup_unused_catalogs(&cwd, &settings_ctx, &workspace_catalogs, &graph.catalogs)?;
         if let Some(p) = prog_ref {
-            p.finish();
+            p.finish(true);
         }
         eprintln!(
             "Lockfile written ({} packages); skipped node_modules linking",
@@ -4272,8 +4272,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // Tear down the progress display before running post-link lifecycle
     // scripts or printing the final summary — scripts write directly to
     // stdout/stderr and would collide with an active progress bar.
+    //
+    // Skip the CI-mode framed summary on a no-op install: `print_install_summary`
+    // below will print the "Already up to date" branded line, and we don't
+    // want CI users to see both the framed `[ ✓ … resolved N · reused N ]`
+    // block and the branded line as redundant twins.
+    let install_is_noop = stats.packages_linked == 0 && stats.top_level_linked == 0;
     if let Some(p) = prog_ref {
-        p.finish();
+        p.finish(!install_is_noop);
     }
 
     if !opts.ignore_scripts && strict_dep_builds_setting && !virtual_store_only {

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -4413,13 +4413,21 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         return Err(miette!("no packages were linked — something went wrong"));
     }
 
-    // Final green summary — TTY only. CI mode already printed its own
-    // framed `✓` line from the heartbeat's stop tick, and text /
-    // silent / ndjson modes have no progress UI at all (prog_ref is
-    // None). Emitted after every post-link lifecycle script has
-    // finished so the line lands as the very last thing on stderr.
+    // Final summary. When linking did real work this is the green
+    // `✓ installed N packages in Xs` line (TTY only; CI mode prints
+    // its own framed `✓` from the heartbeat's stop tick). When
+    // nothing needed linking we emit `Already up to date` in both TTY
+    // and CI modes so cache-only runs still confirm the no-op — text /
+    // silent / ndjson modes stay quiet because prog_ref is None. Emitted
+    // after every post-link lifecycle script has finished so the line
+    // lands as the very last thing on stderr.
     if let Some(p) = prog_ref {
-        p.print_tty_summary(stats.packages_linked, elapsed);
+        p.print_install_summary(
+            stats.packages_linked,
+            stats.top_level_linked,
+            graph_for_link.packages.len(),
+            elapsed,
+        );
     }
 
     Ok(())

--- a/crates/aube/src/progress.rs
+++ b/crates/aube/src/progress.rs
@@ -298,16 +298,23 @@ impl InstallProgress {
     }
 
     /// Finalize and clear the progress display. TTY mode leaves no output
-    /// behind. CI mode prints a final status line + `Done in Xs` summary
-    /// and blocks until the heartbeat thread has actually stopped, so no
-    /// stray tick can appear after the summary. Idempotent.
-    pub fn finish(&self) {
+    /// behind. CI mode blocks until the heartbeat thread has actually
+    /// stopped so no stray tick can appear after this returns, and
+    /// optionally writes the final framed `[ ✓ … ]` status line.
+    /// Idempotent.
+    ///
+    /// `print_ci_summary`: set to `false` when a later call site will
+    /// print its own end-of-install line (so the main install path
+    /// doesn't double up with [`print_install_summary`]). Set to `true`
+    /// for early-return paths (`--lockfile-only`, drift check) that
+    /// want the framed summary to remain the end of CI log output.
+    pub fn finish(&self, print_ci_summary: bool) {
         match &self.mode {
             Mode::Tty { root, .. } => {
                 root.set_status(ProgressStatus::Done);
                 clx::progress::stop_clear();
             }
-            Mode::Ci(s) => s.stop(true),
+            Mode::Ci(s) => s.stop(print_ci_summary),
         }
     }
 

--- a/crates/aube/src/progress.rs
+++ b/crates/aube/src/progress.rs
@@ -311,10 +311,22 @@ impl InstallProgress {
         }
     }
 
-    /// Emit the post-install summary line ("installed N packages in Xs",
-    /// in green) after the progress display has been torn down. TTY-only:
-    /// CI mode already prints a framed `✓` summary from the heartbeat's
-    /// final tick, and doubling it up would just be noise.
+    /// Emit the post-install summary line after the progress display has
+    /// been torn down. Two shapes:
+    ///
+    /// * `linked > 0` — `aube VERSION by en.dev · ✓ installed N packages
+    ///   in Xs`, TTY-only (CI mode prints its own framed `✓` summary
+    ///   from the heartbeat's final tick).
+    /// * `linked == 0 && top_level_linked == 0` — `Already up to date`
+    ///   (matches pnpm), printed in both TTY and CI modes so cache-only
+    ///   runs confirm nothing needed doing. Stays silent in reporter
+    ///   modes where `prog_ref` is `None`.
+    ///
+    /// The `top_level_linked` guard distinguishes a true no-op from the
+    /// `rm -rf node_modules && aube install` case where the global store
+    /// was warm (so `packages_linked` is 0) but every top-level symlink
+    /// had to be recreated — that's not "up to date" from the user's
+    /// perspective.
     ///
     /// **Safety:** must be called *after* [`InstallProgress::finish`]. The
     /// write goes straight to stderr without routing through
@@ -322,12 +334,38 @@ impl InstallProgress {
     /// `finish()` has synchronously stopped the render loop via
     /// `stop_clear()`. A new call site placed before `finish()` would
     /// silently race the animated display.
-    ///
-    /// A `linked` count of zero means no new packages were materialized
-    /// (cache-only run, or `--lockfile-only` short-circuit), so we stay
-    /// silent — matches how pnpm suppresses the "added" line when it's
-    /// zero.
-    pub fn print_tty_summary(&self, linked: usize, elapsed: Duration) {
+    pub fn print_install_summary(
+        &self,
+        linked: usize,
+        top_level_linked: usize,
+        total_packages: usize,
+        elapsed: Duration,
+    ) {
+        if linked == 0 && top_level_linked == 0 {
+            let word = if total_packages == 1 {
+                "package"
+            } else {
+                "packages"
+            };
+            let msg = if total_packages == 0 {
+                "Already up to date".to_string()
+            } else {
+                format!("Already up to date ({total_packages} {word})")
+            };
+            let line = match &self.mode {
+                Mode::Tty { .. } => format!(
+                    "{} {} {} {} {}",
+                    style::emagenta("aube").bold(),
+                    style::edim(env!("CARGO_PKG_VERSION")),
+                    style::edim("by en.dev"),
+                    style::edim("·"),
+                    style::egreen(msg).bold(),
+                ),
+                Mode::Ci(_) => msg,
+            };
+            let _ = writeln!(std::io::stderr(), "{line}");
+            return;
+        }
         if linked == 0 {
             return;
         }

--- a/crates/aube/src/progress.rs
+++ b/crates/aube/src/progress.rs
@@ -354,28 +354,16 @@ impl InstallProgress {
             };
             // Same `aube VERSION by en.dev · …` shape in both TTY and
             // CI modes so the no-op line reads as part of the install
-            // UI family. CI mode force-styles the ANSI escapes
-            // (matching `render_header` / the CI final summary) —
-            // GitHub Actions and the other supported CI runners render
-            // them correctly.
-            let line = match &self.mode {
-                Mode::Tty { .. } => format!(
-                    "{} {} {} {} {}",
-                    style::emagenta("aube").bold(),
-                    style::edim(env!("CARGO_PKG_VERSION")),
-                    style::edim("by en.dev"),
-                    style::edim("·"),
-                    style::egreen(msg).bold(),
-                ),
-                Mode::Ci(_) => format!(
-                    "{} {} {} {} {}",
-                    forced(console::style("aube").magenta().bold()),
-                    forced(console::style(env!("CARGO_PKG_VERSION")).dim()),
-                    forced(console::style("by en.dev").dim()),
-                    forced(console::style("·").dim()),
-                    forced(console::style(msg).green().bright().bold()),
-                ),
-            };
+            // UI family. `style::e*` respects `NO_COLOR` / `--no-color`,
+            // so CI environments that strip styling get plain text.
+            let line = format!(
+                "{} {} {} {} {}",
+                style::emagenta("aube").bold(),
+                style::edim(env!("CARGO_PKG_VERSION")),
+                style::edim("by en.dev"),
+                style::edim("·"),
+                style::egreen(msg).bold(),
+            );
             let _ = writeln!(std::io::stderr(), "{line}");
             return;
         }
@@ -638,15 +626,17 @@ impl CiState {
         render_bar_with_label(completed, resolved, term_width(), &label)
     }
 
-    /// Colored, framed header line. Emitted once, on the first heartbeat
-    /// tick where there's something to show — so the CI log only grows
-    /// an aube banner when an install is actually happening.
+    /// Framed header line. Emitted once, on the first heartbeat tick
+    /// where there's something to show — so the CI log only grows an
+    /// aube banner when an install is actually happening. Styling
+    /// routes through `style::e*`, so `NO_COLOR` / `--no-color` drops
+    /// the ANSI escapes automatically.
     fn render_header() -> String {
         let header_text = format!(
             "{} {} {}",
-            forced(console::style("aube").magenta().bold()),
-            forced(console::style(env!("CARGO_PKG_VERSION")).dim()),
-            forced(console::style("by en.dev").dim()),
+            style::emagenta("aube").bold(),
+            style::edim(env!("CARGO_PKG_VERSION")),
+            style::edim("by en.dev"),
         );
         render_centered_line(&header_text, term_width())
     }
@@ -762,8 +752,8 @@ impl CiState {
         let elapsed = self.start.elapsed();
         let summary = format!(
             "{} {} · resolved {} · reused {} · downloaded {} ({})",
-            forced(console::style("✓").green().bright()),
-            forced(console::style(format_duration(elapsed)).dim()),
+            style::egreen("✓"),
+            style::edim(format_duration(elapsed)),
             resolved,
             reused,
             downloaded,
@@ -790,15 +780,6 @@ fn format_duration(d: Duration) -> String {
         let total = d.as_secs();
         format!("{}m{:02}s", total / 60, total % 60)
     }
-}
-
-/// Force-enable ANSI styling on a `console::StyledObject` regardless
-/// of TTY detection. clx/console both strip colors by default when
-/// stderr isn't a terminal, but GitHub Actions (the primary target
-/// for CI mode) renders ANSI just fine, and we want the framed
-/// status block to look the same in CI as it does interactively.
-fn forced<D>(s: console::StyledObject<D>) -> console::StyledObject<D> {
-    s.force_styling(true)
 }
 
 /// Render a plain-text line centered inside the same `[ ]` bracket

--- a/crates/aube/src/progress.rs
+++ b/crates/aube/src/progress.rs
@@ -352,6 +352,12 @@ impl InstallProgress {
             } else {
                 format!("Already up to date ({total_packages} {word})")
             };
+            // Same `aube VERSION by en.dev · …` shape in both TTY and
+            // CI modes so the no-op line reads as part of the install
+            // UI family. CI mode force-styles the ANSI escapes
+            // (matching `render_header` / the CI final summary) —
+            // GitHub Actions and the other supported CI runners render
+            // them correctly.
             let line = match &self.mode {
                 Mode::Tty { .. } => format!(
                     "{} {} {} {} {}",
@@ -361,7 +367,14 @@ impl InstallProgress {
                     style::edim("·"),
                     style::egreen(msg).bold(),
                 ),
-                Mode::Ci(_) => msg,
+                Mode::Ci(_) => format!(
+                    "{} {} {} {} {}",
+                    forced(console::style("aube").magenta().bold()),
+                    forced(console::style(env!("CARGO_PKG_VERSION")).dim()),
+                    forced(console::style("by en.dev").dim()),
+                    forced(console::style("·").dim()),
+                    forced(console::style(msg).green().bright().bold()),
+                ),
             };
             let _ = writeln!(std::io::stderr(), "{line}");
             return;

--- a/test/install.bats
+++ b/test/install.bats
@@ -17,6 +17,32 @@ teardown() {
 	assert_dir_exists node_modules/.aube
 }
 
+@test "aube install prints 'Already up to date' on a re-run no-op" {
+	# Matches pnpm's confirmation message when there's nothing to do.
+	# The first install does real work (no output assertion — content
+	# varies by cache state); the second run must be a true no-op so
+	# we get the concise "Already up to date" line.
+	_setup_basic_fixture
+	run aube install
+	assert_success
+	run aube install
+	assert_success
+	assert_output --partial "Already up to date"
+}
+
+@test "aube install does not print 'Already up to date' when it does real work" {
+	# Guard against regression: a fresh install (or one that had to
+	# recreate node_modules) must not claim the tree was already up
+	# to date, even when the global store is warm.
+	_setup_basic_fixture
+	run aube install
+	assert_success
+	rm -rf node_modules
+	run aube install
+	assert_success
+	refute_output --partial "Already up to date"
+}
+
 @test "aube install --dev installs only devDependencies" {
 	cat >package.json <<'JSON'
 {


### PR DESCRIPTION
## Summary

- `aube install` now prints `Already up to date` (matching pnpm) when a re-run has nothing to do, so cache-only installs don't look like a silent exit.
- When the dep graph has packages, the line includes the count — e.g. `Already up to date (142 packages)` — so you still get a sense of project size at a glance.
- Works in TTY (styled, matching the existing `aube VERSION by en.dev · ...` summary shape) and CI (plain text) modes; `--silent` / `--reporter=ndjson` / append-only reporters stay silent as before.

## Why

pnpm prints `Already up to date` on no-op installs. Before this change, aube's install command exited silently in the same case, which was confusing when scripts chained `aube install && ...` — you couldn't tell from the output whether aube ran or was skipped.

## Implementation notes

- Trigger is `packages_linked == 0 && top_level_linked == 0`. The `top_level_linked` guard is the subtle bit: after `rm -rf node_modules && aube install` with a warm global store, `packages_linked` stays 0 (nothing new materialized into the CAS) but every top-level symlink had to be recreated. That's not "up to date" from the user's perspective, so the guard suppresses the message in that case.
- The existing `--lockfile-only` fast path already printed `Lockfile is up to date, resolution step is skipped` and is unaffected.
- Method rename: `print_tty_summary` → `print_install_summary` (single call site, name no longer accurate since CI mode also writes a line now).

## Test plan

- [x] `cargo build` + `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test -p aube --bins` — 211 passed
- [x] New BATS tests in `test/install.bats`:
  - `aube install prints 'Already up to date' on a re-run no-op`
  - `aube install does not print 'Already up to date' when it does real work` (guards against the `rm -rf node_modules` case)
- [x] Existing `aube install --fix-lockfile --lockfile-only is a no-op on a fresh lockfile` still passes
- [x] Manual spot-check: empty deps → `Already up to date`; 2-pkg project re-run → `Already up to date (2 packages)`; fresh install → framed `✓` summary, no "Already up to date"; `rm -rf node_modules` → framed `✓` summary, no "Already up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX-only change that adjusts install progress/summary output paths; main risk is unintended log output differences in CI/TTY modes.
> 
> **Overview**
> `aube install` now emits an **"Already up to date"** end-of-run line when a re-run is a true no-op (no packages *and* no top-level links created), optionally including the total package count.
> 
> Progress teardown is updated so CI mode can *skip* the framed `[ ✓ … ]` summary when the no-op message will be printed, avoiding duplicate end-of-install lines; early-return paths (e.g. `--lockfile-only`) still print the framed CI summary.
> 
> Adds BATS coverage to assert the no-op message appears on a second identical install, and does not appear when `node_modules` is recreated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db56ab6b36d5e1c7af74254bbfff212a368b064f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->