### PR TITLE
Parse pnpm snapshot optional dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,23 @@ cargo fmt --check              # Check formatting
 ./test/bats/bin/bats test/install.bats  # Run a single test file
 ```
 
+## Commit Messages
+
+Match the existing history: short, imperative subjects with an optional
+lowercase area prefix.
+
+- Preferred shape: `area: do the thing`
+- Use a scoped area when it adds useful context, e.g.
+  `docs(installation): add cargo install aube` or
+  `ci(release-plz): grant contents:write to upload-assets caller`.
+- Good recent examples: `cli: add aubr/aubx multicall shims for run and dlx`,
+  `publish: ship aube on npm as @endevco/aube`, and
+  `release: use cross + rustls-tls for linux targets`.
+- Do not prefix commits or PR titles with `[codex]`, agent names, or tool
+  branding.
+- Do not include PR numbers in local commit messages; GitHub may add those
+  when squash-merging.
+
 ## Architecture
 
 Cargo workspace with 9 crates under `crates/`. The binary entry point is `crates/aube/src/main.rs`.

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -409,6 +409,11 @@ pub struct LockedPackage {
     pub integrity: Option<String>,
     /// Dependencies of this package (name -> dep_path tail, see struct docs)
     pub dependencies: BTreeMap<String, String>,
+    /// Optional dependency edges for this package. Active optional edges are
+    /// also mirrored in `dependencies` so graph walks and the linker continue
+    /// to see them; this separate map lets platform filtering prune optional
+    /// edges without touching regular dependencies.
+    pub optional_dependencies: BTreeMap<String, String>,
     /// Peer dependency ranges as *declared* by the package (from its
     /// package.json / packument). These are the constraints; the resolved
     /// versions live in `dependencies` after the peer-context pass runs.

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -141,6 +141,12 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             {
                 local_pkg.dependencies = deps;
             }
+            if let Some(snap) = raw.snapshots.get(&canonical)
+                && let Some(opt_deps) = snap.optional_dependencies.clone()
+            {
+                local_pkg.dependencies.extend(opt_deps.clone());
+                local_pkg.optional_dependencies = opt_deps;
+            }
             if let Some(pkg_info) = raw.packages.get(&canonical)
                 && let Some(ref res) = pkg_info.resolution
             {
@@ -246,6 +252,13 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             .get(&dep_path)
             .and_then(|s| s.dependencies.clone())
             .unwrap_or_default();
+        let optional_dependencies = raw
+            .snapshots
+            .get(&dep_path)
+            .and_then(|s| s.optional_dependencies.clone())
+            .unwrap_or_default();
+        let mut dependencies = dependencies;
+        dependencies.extend(optional_dependencies.clone());
 
         let bundled_dependencies = raw
             .snapshots
@@ -280,6 +293,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 version,
                 integrity,
                 dependencies,
+                optional_dependencies,
                 peer_dependencies,
                 peer_dependencies_meta,
                 dep_path,
@@ -590,10 +604,17 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         snapshots.insert(
             key,
             WritableSnapshot {
-                dependencies: if pkg.dependencies.is_empty() {
+                dependencies: {
+                    let mut deps = pkg.dependencies.clone();
+                    for name in pkg.optional_dependencies.keys() {
+                        deps.remove(name);
+                    }
+                    if deps.is_empty() { None } else { Some(deps) }
+                },
+                optional_dependencies: if pkg.optional_dependencies.is_empty() {
                     None
                 } else {
-                    Some(pkg.dependencies.clone())
+                    Some(pkg.optional_dependencies.clone())
                 },
                 bundled_dependencies: if pkg.bundled_dependencies.is_empty() {
                     None
@@ -842,6 +863,8 @@ struct WritableSnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     dependencies: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    optional_dependencies: Option<BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     bundled_dependencies: Option<Vec<String>>,
 }
 
@@ -943,6 +966,8 @@ struct Resolution {
 struct RawSnapshot {
     #[serde(default)]
     dependencies: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    optional_dependencies: Option<BTreeMap<String, String>>,
     #[serde(default)]
     bundled_dependencies: Option<Vec<String>>,
 }
@@ -1092,6 +1117,92 @@ mod tests {
 
         let kind_of = graph.packages.get("kind-of@3.2.2").unwrap();
         assert_eq!(kind_of.dependencies.get("is-buffer").unwrap(), "1.1.6");
+    }
+
+    #[test]
+    fn parse_snapshot_optional_dependencies_as_edges() {
+        let dir = tempfile::tempdir().unwrap();
+        let lockfile_path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &lockfile_path,
+            r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      host:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+  host@1.0.0:
+    resolution: {integrity: sha512-host}
+
+  native@1.0.0:
+    resolution: {integrity: sha512-native}
+    cpu: [arm64]
+    os: [darwin]
+
+snapshots:
+  host@1.0.0:
+    optionalDependencies:
+      native: 1.0.0
+
+  native@1.0.0: {}
+"#,
+        )
+        .unwrap();
+
+        let graph = parse(&lockfile_path).unwrap();
+        let host = graph.packages.get("host@1.0.0").unwrap();
+        assert_eq!(host.dependencies.get("native").unwrap(), "1.0.0");
+        assert_eq!(host.optional_dependencies.get("native").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn parse_local_snapshot_optional_dependencies_as_edges() {
+        let dir = tempfile::tempdir().unwrap();
+        let lockfile_path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &lockfile_path,
+            r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      local-host:
+        specifier: file:./local-host
+        version: file:./local-host
+
+packages:
+  local-host@file:./local-host:
+    resolution: {directory: ./local-host, type: directory}
+
+  native@1.0.0:
+    resolution: {integrity: sha512-native}
+    cpu: [arm64]
+    os: [darwin]
+
+snapshots:
+  local-host@file:./local-host:
+    optionalDependencies:
+      native: 1.0.0
+
+  native@1.0.0: {}
+"#,
+        )
+        .unwrap();
+
+        let graph = parse(&lockfile_path).unwrap();
+        let local = graph
+            .packages
+            .values()
+            .find(|pkg| pkg.name == "local-host")
+            .unwrap();
+        assert_eq!(local.dependencies.get("native").unwrap(), "1.0.0");
+        assert_eq!(local.optional_dependencies.get("native").unwrap(), "1.0.0");
     }
 
     #[test]

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1210,6 +1210,11 @@ impl Resolver {
                         parent_pkg
                             .dependencies
                             .insert(task.name.clone(), ws_version.clone());
+                        if task.dep_type == DepType::Optional {
+                            parent_pkg
+                                .optional_dependencies
+                                .insert(task.name.clone(), ws_version.clone());
+                        }
                     }
                     if task.is_root {
                         note_root_done!();
@@ -1247,7 +1252,12 @@ impl Resolver {
                     {
                         parent_pkg
                             .dependencies
-                            .insert(task.name.clone(), matched_ver);
+                            .insert(task.name.clone(), matched_ver.clone());
+                        if task.dep_type == DepType::Optional {
+                            parent_pkg
+                                .optional_dependencies
+                                .insert(task.name.clone(), matched_ver);
+                        }
                     }
                     if task.is_root {
                         note_root_done!();
@@ -1316,6 +1326,11 @@ impl Resolver {
                             parent_pkg
                                 .dependencies
                                 .insert(task.name.clone(), version.clone());
+                            if task.dep_type == DepType::Optional {
+                                parent_pkg
+                                    .optional_dependencies
+                                    .insert(task.name.clone(), version.clone());
+                            }
                         }
                         if !visited.contains(&dep_path) {
                             visited.insert(dep_path.clone());
@@ -1358,6 +1373,7 @@ impl Resolver {
                                     version: version.clone(),
                                     integrity: locked_pkg.integrity.clone(),
                                     dependencies: BTreeMap::new(),
+                                    optional_dependencies: BTreeMap::new(),
                                     peer_dependencies: locked_pkg.peer_dependencies.clone(),
                                     peer_dependencies_meta: locked_pkg
                                         .peer_dependencies_meta
@@ -1388,10 +1404,16 @@ impl Resolver {
                                     .next()
                                     .unwrap_or(dep_version)
                                     .to_string();
+                                let dep_type =
+                                    if locked_pkg.optional_dependencies.contains_key(dep_name) {
+                                        DepType::Optional
+                                    } else {
+                                        DepType::Production
+                                    };
                                 queue.push_back(ResolveTask {
                                     name: dep_name.clone(),
                                     range: canonical_version,
-                                    dep_type: DepType::Production,
+                                    dep_type,
                                     is_root: false,
                                     parent: Some(dep_path.clone()),
                                     importer: task.importer.clone(),
@@ -1685,6 +1707,11 @@ impl Resolver {
                     parent_pkg
                         .dependencies
                         .insert(task.name.clone(), version.clone());
+                    if task.dep_type == DepType::Optional {
+                        parent_pkg
+                            .optional_dependencies
+                            .insert(task.name.clone(), version.clone());
+                    }
                 }
 
                 // Skip if already fully processed this exact version
@@ -1780,6 +1807,7 @@ impl Resolver {
                         version: version.clone(),
                         integrity,
                         dependencies: BTreeMap::new(),
+                        optional_dependencies: BTreeMap::new(),
                         peer_dependencies: peer_deps,
                         peer_dependencies_meta: peer_meta,
                         dep_path: dep_path.clone(),
@@ -2876,6 +2904,14 @@ fn dedupe_peer_suffixes(graph: LockfileGraph) -> LockfileGraph {
                 (n, new_v)
             })
             .collect();
+        let new_optional_dependencies: BTreeMap<String, String> = pkg
+            .optional_dependencies
+            .into_iter()
+            .map(|(n, v)| {
+                let new_v = rewrite_tail(&n, &v);
+                (n, new_v)
+            })
+            .collect();
         new_packages.insert(
             new_key.clone(),
             LockedPackage {
@@ -2883,6 +2919,7 @@ fn dedupe_peer_suffixes(graph: LockfileGraph) -> LockfileGraph {
                 version: pkg.version,
                 integrity: pkg.integrity,
                 dependencies: new_dependencies,
+                optional_dependencies: new_optional_dependencies,
                 peer_dependencies: pkg.peer_dependencies,
                 peer_dependencies_meta: pkg.peer_dependencies_meta,
                 dep_path: new_key,
@@ -3260,6 +3297,15 @@ fn visit_peer_context(
     }
 
     visiting.remove(&contextualized);
+    let new_optional_dependencies: BTreeMap<String, String> = pkg
+        .optional_dependencies
+        .keys()
+        .filter_map(|name| {
+            new_dependencies
+                .get(name)
+                .map(|tail| (name.clone(), tail.clone()))
+        })
+        .collect();
 
     out_packages.insert(
         contextualized.clone(),
@@ -3268,6 +3314,7 @@ fn visit_peer_context(
             version: pkg.version.clone(),
             integrity: pkg.integrity.clone(),
             dependencies: new_dependencies,
+            optional_dependencies: new_optional_dependencies,
             peer_dependencies: pkg.peer_dependencies.clone(),
             peer_dependencies_meta: pkg.peer_dependencies_meta.clone(),
             dep_path: contextualized.clone(),
@@ -5799,6 +5846,64 @@ mod tests {
             "dep-a@2.0.0 missing (transitive fetch fell through the ensure_fetch guard)"
         );
         assert!(graph.packages.contains_key("other-a@2.0.0"));
+    }
+
+    #[tokio::test]
+    async fn lockfile_reuse_preserves_transitive_optional_edges() {
+        let client = Arc::new(aube_registry::client::RegistryClient::new(
+            "http://127.0.0.1:0",
+        ));
+        let mut resolver = Resolver::new(client);
+
+        let mut existing_pkgs: BTreeMap<String, LockedPackage> = BTreeMap::new();
+        existing_pkgs.insert(
+            "host@1.0.0".to_string(),
+            LockedPackage {
+                name: "host".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "host@1.0.0".to_string(),
+                dependencies: [("native".to_string(), "1.0.0".to_string())].into(),
+                optional_dependencies: [("native".to_string(), "1.0.0".to_string())].into(),
+                ..Default::default()
+            },
+        );
+        existing_pkgs.insert(
+            "native@1.0.0".to_string(),
+            LockedPackage {
+                name: "native".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "native@1.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+        let existing = LockfileGraph {
+            packages: existing_pkgs,
+            importers: BTreeMap::new(),
+            settings: Default::default(),
+            overrides: BTreeMap::new(),
+            ignored_optional_dependencies: BTreeSet::new(),
+            times: BTreeMap::new(),
+            skipped_optional_dependencies: BTreeMap::new(),
+            catalogs: BTreeMap::new(),
+        };
+
+        let mut manifest = PackageJson::default();
+        manifest
+            .dependencies
+            .insert("host".to_string(), "1.0.0".to_string());
+
+        let graph = resolver
+            .resolve(&manifest, Some(&existing))
+            .await
+            .expect("resolve failed");
+
+        let host = graph.packages.get("host@1.0.0").unwrap();
+        assert_eq!(host.dependencies.get("native").unwrap(), "1.0.0");
+        assert_eq!(
+            host.optional_dependencies.get("native").unwrap(),
+            "1.0.0",
+            "lockfile reuse must keep the optional edge metadata for write()"
+        );
     }
 
     // ===== peersSuffixMaxLength =====

--- a/crates/aube-resolver/src/platform.rs
+++ b/crates/aube-resolver/src/platform.rs
@@ -146,20 +146,16 @@ pub fn is_supported(
     false
 }
 
-/// Remove root-level optional dependencies that fail the platform
-/// check or appear in the ignore list from a parsed `LockfileGraph`,
-/// then garbage-collect any packages that become unreachable from the
-/// surviving importers.
+/// Remove optional dependencies that fail the platform check or appear in the
+/// ignore list from a parsed `LockfileGraph`, then garbage-collect any packages
+/// that become unreachable from the surviving importers.
 ///
 /// Used by the install-from-lockfile path, where the resolver's inline
 /// filter never runs: the lockfile carries os/cpu/libc per package so
 /// aube can re-check on every platform without reparsing packuments.
 ///
-/// Only *root* optional edges are inspected directly. Transitive
-/// optional edges are not stripped, because the lockfile does not
-/// record per-edge optionality in a form aube currently reads. Any
-/// transitive package that becomes unreachable after root-edge pruning
-/// is removed by the GC pass.
+/// Root and transitive optional edges are inspected directly. Any package that
+/// becomes unreachable after optional-edge pruning is removed by the GC pass.
 pub fn filter_graph(
     graph: &mut aube_lockfile::LockfileGraph,
     supported: &SupportedArchitectures,
@@ -183,7 +179,36 @@ pub fn filter_graph(
         });
     }
 
-    // 2. Garbage-collect unreachable packages by walking from the
+    // 2. Drop transitive optional deps by name or platform. The pnpm parser
+    // mirrors active optional edges into `dependencies`, so remove that edge
+    // whenever the optional edge is filtered.
+    let package_keys: std::collections::HashSet<String> = graph.packages.keys().cloned().collect();
+    let mismatched_packages: std::collections::HashSet<String> = graph
+        .packages
+        .iter()
+        .filter(|(_, pkg)| is_mismatched(pkg))
+        .map(|(dep_path, _)| dep_path.clone())
+        .collect();
+    for pkg in graph.packages.values_mut() {
+        let mut removed = Vec::new();
+        pkg.optional_dependencies.retain(|name, tail| {
+            let child_key = if package_keys.contains(tail) {
+                tail.clone()
+            } else {
+                format!("{name}@{tail}")
+            };
+            let keep = !ignored.contains(name) && !mismatched_packages.contains(&child_key);
+            if !keep {
+                removed.push(name.clone());
+            }
+            keep
+        });
+        for name in removed {
+            pkg.dependencies.remove(&name);
+        }
+    }
+
+    // 3. Garbage-collect unreachable packages by walking from the
     //    surviving roots.
     let mut reachable: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut stack: Vec<String> = Vec::new();
@@ -260,6 +285,74 @@ mod tests {
         };
         // A linux-only package passes regardless of host.
         assert!(is_supported(&s(&["linux"]), &[], &[], &sup));
+    }
+
+    #[test]
+    fn filter_graph_prunes_transitive_optional_platform_mismatches() {
+        let supported = SupportedArchitectures {
+            os: s(&["darwin"]),
+            cpu: s(&["arm64"]),
+            libc: vec![],
+        };
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.importers.insert(
+            ".".to_string(),
+            vec![aube_lockfile::DirectDep {
+                name: "host".to_string(),
+                dep_path: "host@1.0.0".to_string(),
+                dep_type: aube_lockfile::DepType::Production,
+                specifier: Some("1.0.0".to_string()),
+            }],
+        );
+        graph.packages.insert(
+            "host@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "host".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "host@1.0.0".to_string(),
+                dependencies: [
+                    ("native-darwin".to_string(), "1.0.0".to_string()),
+                    ("native-linux".to_string(), "1.0.0".to_string()),
+                ]
+                .into(),
+                optional_dependencies: [
+                    ("native-darwin".to_string(), "1.0.0".to_string()),
+                    ("native-linux".to_string(), "1.0.0".to_string()),
+                ]
+                .into(),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "native-darwin@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "native-darwin".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "native-darwin@1.0.0".to_string(),
+                os: s(&["darwin"]),
+                cpu: s(&["arm64"]),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "native-linux@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "native-linux".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "native-linux@1.0.0".to_string(),
+                os: s(&["linux"]),
+                cpu: s(&["x64"]),
+                ..Default::default()
+            },
+        );
+
+        filter_graph(&mut graph, &supported, &Default::default());
+
+        let host = graph.packages.get("host@1.0.0").unwrap();
+        assert!(host.dependencies.contains_key("native-darwin"));
+        assert!(!host.dependencies.contains_key("native-linux"));
+        assert!(graph.packages.contains_key("native-darwin@1.0.0"));
+        assert!(!graph.packages.contains_key("native-linux@1.0.0"));
     }
 
     #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
## Summary

- parse pnpm snapshot optionalDependencies into the lockfile graph
- preserve optional edge metadata through resolver reuse and peer-context rewrites
- prune transitive optional native packages by platform before linking

## Root cause

pnpm records packages like Rolldown native bindings under snapshots.*.optionalDependencies. aube parsed only snapshots.*.dependencies, so packages such as @rolldown/binding-darwin-arm64 were present in packages: but not reachable from rolldown during linking. SvelteKit prepare then failed with Rolldown’s native binding error.

## Validation

- cargo fmt --check
- cargo check
- cargo test -p aube-lockfile
- cargo test -p aube-resolver
- fresh Svelte repro: npx sv create my-app --template minimal --types ts --no-add-ons --install pnpm && cd my-app && target/debug/aube i
- follow-up smoke: target/debug/aube exec svelte-kit sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lockfile graph structure and resolver/platform filtering behavior for optional dependencies, which can affect install/link results across platforms. Risk is mitigated by added unit tests covering parse/write roundtrips, lockfile reuse, and transitive pruning.
> 
> **Overview**
> Fixes pnpm v9 optional dependency reachability by **parsing `snapshots.*.optionalDependencies` into the lockfile graph** and tracking those edges separately on `LockedPackage` via a new `optional_dependencies` map.
> 
> Updates pnpm lockfile read/write to **mirror optional edges into `dependencies` for graph walks/linking**, while still serializing them back under `optionalDependencies` and keeping regular `dependencies` clean.
> 
> Extends the resolver to **preserve optional-edge metadata** through workspace resolution, lockfile reuse, and peer-context rewrites, and enhances platform filtering to **prune transitive optional edges** (by ignore list or `os`/`cpu`/`libc`) before GC. Adds targeted tests for parsing, lockfile reuse, and transitive pruning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d61fad60d985bbc5005ff096567f28e76b88f96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->