### PR TITLE
ci(diagnostic): log cache sizes before linux/test pre-exit

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -73,6 +73,15 @@ steps:
           - "set -o pipefail; mise run lint 2>&1 | cat"
           - "mise run render"
           - "mise run docs:build"
+          # Diagnostic: the cargo-linux-test cache has been mounting at 4.0K
+          # since build #23 even though this job passes most of the time.
+          # Print final sizes + free space right before pre-exit so we can
+          # tell whether the save step is dropping populated content
+          # (→ Buildkite-side issue: eviction, concurrent-save clobber, or
+          # silent save failure) or whether something in the commands above
+          # is wiping /tmp/aube-cache before the hook fires. Remove once
+          # diagnosed.
+          - "echo '--- final cache sizes ---'; du -sh /tmp/aube-cache/* 2>/dev/null || true; echo '--- df /tmp ---'; df -h /tmp || true"
 
       - label: "linux / bats 1/4"
         key: "linux-bats-0"


### PR DESCRIPTION
## Why

The `cargo-linux-test` Buildkite cache has been mounting at **4.0K** (empty) across every recent build I checked (#23 main, #38 branch, #42 branch) — even when the job passed. Meanwhile the same agent image restores `cargo-linux-build` at 328M + 2.3G and `cargo-macos-test` at 389M + 6.8G on the same builds. Only this one named cache is stuck empty.

Build #21 (main, earlier today) restored `cargo-linux-test` at 1006M cargo + 5.8G cargo-target, so the cache name has worked historically — it broke sometime after that.

## What this PR does

Adds one final diagnostic command to the `linux / test` step that runs just before Buildkite's pre-exit hook:

```bash
du -sh /tmp/aube-cache/*
df -h /tmp
```

The Linux hosted-agent pre-exit output is silent in job logs (macOS prints `Un mounted cache on …`, Linux doesn't), so this is the only place we can observe cache state right before save.

## What the result tells us

| Final `du` shows | Meaning |
|---|---|
| Big (GBs) | Content is there at pre-exit → save/upload is failing on Buildkite's side (eviction, concurrent-save clobber, silent upload failure) |
| Small (KBs) | Something in `mise run test` / `lint` / `render` / `docs:build` is wiping `/tmp/aube-cache` before the hook fires |

## Next steps

Once the next build on this branch runs, the answer will be in the `linux / test` log tail. Remove this diagnostic step in a follow-up PR and, if it points to Buildkite side, file with their support including the cache name and build numbers.

## Test plan

- [ ] Next build's `linux / test` step prints the new `--- final cache sizes ---` block at the end
- [ ] Sizes point us to whether save is failing (big) or something's wiping (small)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds extra logging in the Buildkite `linux / test` step only, with no effect on build artifacts or runtime behavior beyond a small amount of additional output.
> 
> **Overview**
> Adds a final diagnostic command to the Buildkite `linux / test` step to print `/tmp/aube-cache` directory sizes (`du -sh`) and available `/tmp` disk space (`df -h`) immediately before the job exits, to help debug why the `cargo-linux-test` cache is being saved/restored as empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 888fb155e982f9ccf79fb7aa343ab1f0f66b285f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->