### PR TITLE
ci(release): auto-bump release.json in the release PR

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -232,13 +232,27 @@ jobs:
             | jq -r '.packages[] | select(.name == "aube") | .version')
           TAG="v${VERSION}"
 
+          # Bump release.json so the docs homepage's "Released at" line
+          # tracks the new version. `releasedAt` is set to "now" on
+          # every PR regeneration, and since release-plz re-renders the
+          # PR on every push to main, the timestamp that actually lands
+          # is from the last run before merge — within one push-to-main
+          # of the real release, which is good enough for a display
+          # string. The vitepress config blanks the field when the
+          # version here doesn't match Cargo.toml, so an out-of-date
+          # release.json on a non-release branch can't render wrong.
+          RELEASED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          jq --arg v "$VERSION" --arg d "$RELEASED_AT" \
+            '.version = $v | .releasedAt = $d' release.json > release.json.tmp
+          mv release.json.tmp release.json
+
           # Squash any rendered-doc changes onto the release-plz commit
           # so the PR stays one commit. Use `-A` on the paths the
           # `render` task writes to, so NEW files (e.g.
           # docs/cli/<new-subcommand>.md after `docs/cli` is
           # regenerated from scratch) are picked up — `git add -u`
           # would silently omit them.
-          git add -A aube.usage.kdl docs CHANGELOG.md Cargo.toml Cargo.lock crates
+          git add -A aube.usage.kdl docs CHANGELOG.md Cargo.toml Cargo.lock crates release.json
           MERGE_BASE=$(git merge-base HEAD origin/main)
           git reset --soft "$MERGE_BASE"
           git commit -m "chore: release ${TAG}"


### PR DESCRIPTION
## Summary

- Wire `release.json` into the release-plz PR regeneration so its `version` + `releasedAt` stop going stale after every release.
- `releasedAt` is set to the UTC timestamp of the last PR render before merge — within one push-to-main of the real release, which is close enough for the docs homepage's display string. The existing vitepress guard at [docs/.vitepress/config.mts:39](https://github.com/endevco/aube/blob/main/docs/.vitepress/config.mts#L39) already hides the field when `release.json` drifts from `Cargo.toml`, so wrong data can't render.
- `release.json` is added to the existing `git add -A` list so it lands in the squashed release commit.

## Context

The docs build reads `release.json` at VitePress config time to show "Released at ..." on the homepage. Nothing in CI was writing the file, so on `main` today it still points at `1.0.0-beta.1` even though the workspace has shipped `1.0.0-beta.2`. With this change, the next release PR regenerates it automatically.

## Test plan

- [ ] Next release-plz PR (or a dry-run `workflow_dispatch`) shows `release.json` diffing both fields in the squashed commit.
- [ ] On merge, `docs/.vitepress/config.mts` reads the new version/date and the homepage renders a current `releasedAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the GitHub Actions release workflow to rewrite `release.json` and include it in the squashed release commit; no runtime or publishing logic changes beyond committing one more generated file.
> 
> **Overview**
> Ensures `release.json` is automatically updated as part of the `release-plz` PR regeneration so docs can display a current release version and timestamp.
> 
> The workflow now sets `release.json.version` from Cargo metadata and refreshes `release.json.releasedAt` to the current UTC time on each regeneration, and includes `release.json` in the existing `git add -A` list so the update is squashed into the single `chore: release vX.Y.Z` commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2801ade489f519466242a48ba9e4cfb6b4491082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->