### PR TITLE
chore: release v1.0.0-beta.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "base64",
  "blake3",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -82,13 +82,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.2" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.2" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.2" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.2" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.2" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.2" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.2" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.2" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.2" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.2" }
+aube = { path = "crates/aube", version = "1.0.0-beta.3" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.3" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.3" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.3" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.3" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.3" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.3" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.3" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.3" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.3" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.2"
+version "1.0.0-beta.3"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.2...aube-linker-v1.0.0-beta.3) - 2026-04-19
+
+### Other
+
+- auto-disable global virtual store for packages known to break on it ([#32](https://github.com/endevco/aube/pull/32))
+- *(npm)* support npm:<real>@<ver> aliases + fix dep_path tail ([#30](https://github.com/endevco/aube/pull/30))
+
 ## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.1...aube-linker-v1.0.0-beta.2) - 2026-04-18
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.2...aube-lockfile-v1.0.0-beta.3) - 2026-04-19
+
+### Other
+
+- *(bun)* handle github/git 3-tuple package entries ([#42](https://github.com/endevco/aube/pull/42))
+- preserve npm-alias as folder name on fresh resolve ([#37](https://github.com/endevco/aube/pull/37))
+- *(npm)* resolve peer deps when installing from package-lock.json ([#35](https://github.com/endevco/aube/pull/35))
+- *(npm)* support npm:<real>@<ver> aliases + fix dep_path tail ([#30](https://github.com/endevco/aube/pull/30))
+- Parse pnpm snapshot optional dependencies ([#18](https://github.com/endevco/aube/pull/18))
+
 ## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.1...aube-lockfile-v1.0.0-beta.2) - 2026-04-18
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.2...aube-manifest-v1.0.0-beta.3) - 2026-04-19
+
+### Other
+
+- discover from workspace root + package.json sources ([#44](https://github.com/endevco/aube/pull/44))
+- auto-disable global virtual store for packages known to break on it ([#32](https://github.com/endevco/aube/pull/32))
+
 ## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.1...aube-manifest-v1.0.0-beta.2) - 2026-04-18
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.2...aube-registry-v1.0.0-beta.3) - 2026-04-19
+
+### Added
+
+- *(cli)* support jsr: specifier protocol ([#19](https://github.com/endevco/aube/pull/19))
+
+### Other
+
+- honor npm_config_* env vars in NpmConfig::load ([#47](https://github.com/endevco/aube/pull/47))
+
 ## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.1...aube-registry-v1.0.0-beta.2) - 2026-04-18
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.2...aube-resolver-v1.0.0-beta.3) - 2026-04-19
+
+### Added
+
+- *(cli)* support jsr: specifier protocol ([#19](https://github.com/endevco/aube/pull/19))
+
+### Other
+
+- discover from workspace root + package.json sources ([#44](https://github.com/endevco/aube/pull/44))
+- preserve npm-alias as folder name on fresh resolve ([#37](https://github.com/endevco/aube/pull/37))
+- *(npm)* resolve peer deps when installing from package-lock.json ([#35](https://github.com/endevco/aube/pull/35))
+- *(npm)* support npm:<real>@<ver> aliases + fix dep_path tail ([#30](https://github.com/endevco/aube/pull/30))
+- Parse pnpm snapshot optional dependencies ([#18](https://github.com/endevco/aube/pull/18))
+
 ## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.1...aube-resolver-v1.0.0-beta.2) - 2026-04-18
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.2...aube-settings-v1.0.0-beta.3) - 2026-04-19
+
+### Other
+
+- auto-disable global virtual store for packages known to break on it ([#32](https://github.com/endevco/aube/pull/32))
+- drop transitional implemented/since fields ahead of 1.0 ([#33](https://github.com/endevco/aube/pull/33))
+
 ## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.1...aube-settings-v1.0.0-beta.2) - 2026-04-18
 
 ### Other

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.2...aube-store-v1.0.0-beta.3) - 2026-04-19
+
+### Other
+
+- swap CAS hash from SHA-512 to BLAKE3 ([#36](https://github.com/endevco/aube/pull/36))
+
 ## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.1...aube-store-v1.0.0-beta.2) - 2026-04-18
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.3](https://github.com/endevco/aube/compare/v1.0.0-beta.2...v1.0.0-beta.3) - 2026-04-19
+
+### Added
+
+- *(cli)* support jsr: specifier protocol ([#19](https://github.com/endevco/aube/pull/19))
+
+### Fixed
+
+- *(dlx)* resolve bin from installed package when names differ ([#25](https://github.com/endevco/aube/pull/25))
+- verifyDepsBeforeRun fires when node_modules is removed ([#23](https://github.com/endevco/aube/pull/23))
+
+### Other
+
+- discover from workspace root + package.json sources ([#44](https://github.com/endevco/aube/pull/44))
+- AUBE_DEBUG/AUBE_LOG replace RUST_LOG for log control ([#43](https://github.com/endevco/aube/pull/43))
+- preserve npm-alias as folder name on fresh resolve ([#37](https://github.com/endevco/aube/pull/37))
+- *(npm)* resolve peer deps when installing from package-lock.json ([#35](https://github.com/endevco/aube/pull/35))
+- clarify packageManagerStrict rejection message ([#40](https://github.com/endevco/aube/pull/40))
+- swap CAS hash from SHA-512 to BLAKE3 ([#36](https://github.com/endevco/aube/pull/36))
+- auto-disable global virtual store for packages known to break on it ([#32](https://github.com/endevco/aube/pull/32))
+- *(npm)* support npm:<real>@<ver> aliases + fix dep_path tail ([#30](https://github.com/endevco/aube/pull/30))
+- print "Already up to date" on a no-op install ([#17](https://github.com/endevco/aube/pull/17))
+
 ## [1.0.0-beta.2](https://github.com/endevco/aube/compare/v1.0.0-beta.1...v1.0.0-beta.2) - 2026-04-18
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5657,7 +5657,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.2
+**Version**: 1.0.0-beta.3
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.1",
-  "releasedAt": "2026-04-17T00:00:00-05:00"
+  "version": "1.0.0-beta.3",
+  "releasedAt": "2026-04-19T01:58:05Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.3`

This PR bumps the workspace to `v1.0.0-beta.3` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a version bump and regenerated release artifacts (lockfile, changelogs, and CLI docs) with no functional code changes in this diff. Low risk aside from any downstream impact of publishing the new crate versions.
> 
> **Overview**
> Updates the workspace and all internal crate versions from `1.0.0-beta.2` to `1.0.0-beta.3` in `Cargo.toml`/`Cargo.lock` and bumps the CLI spec/doc version (`aube.usage.kdl`, generated docs).
> 
> Regenerates per-crate `CHANGELOG.md` entries for the `1.0.0-beta.3` release and updates `release.json` timestamps/version to reflect the new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cbdc80c59367fda5494af61a3ee1e676d6dc35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->