### PR TITLE
fix: verifyDepsBeforeRun fires when node_modules is removed

### DIFF
--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -52,6 +52,17 @@ pub fn check_needs_install(project_dir: &Path) -> Option<String> {
         None => return Some("node_modules not found or never installed by aube".into()),
     };
 
+    // The state file lives outside `node_modules`, so a user who runs
+    // `rm -rf node_modules` leaves the state behind. Verify the tree is
+    // still on disk — otherwise the lockfile+manifest hashes match but
+    // the packages are gone, and `aube run` would execute the script
+    // against a missing tree. Zero-dep projects still get a
+    // `node_modules/` (with `.bin/`) from install, so checking for the
+    // directory itself covers both cases.
+    if !project_dir.join("node_modules").exists() {
+        return Some("node_modules is missing".into());
+    }
+
     // Check lockfile hash. Honor `gitBranchLockfile` so a branch-specific
     // lockfile is the freshness anchor when present, but fall back to the
     // base lockfile names so a freshly-enabled branch doesn't loop on

--- a/test/guardrails.bats
+++ b/test/guardrails.bats
@@ -198,6 +198,23 @@ _setup_workspace_fixture() {
 	[[ "$output" == *"dependencies need install before run"* ]]
 }
 
+@test "verifyDepsBeforeRun=error fails after node_modules is removed" {
+	_setup_basic_fixture
+	node -e 'let p=require("./package.json"); p.scripts={dev:"echo hello-dev"}; require("fs").writeFileSync("package.json", JSON.stringify(p))'
+
+	run aube install
+	assert_success
+	assert_dir_exists node_modules
+
+	rm -rf node_modules
+	echo "verifyDepsBeforeRun=error" >.npmrc
+
+	run aube dev
+	assert_failure
+	[[ "$output" == *"dependencies need install before run"* ]]
+	[[ "$output" != *"hello-dev"* ]]
+}
+
 @test "npmPath delegates npm-only fallback commands" {
 	fake_npm="$TEST_TEMP_DIR/fake-npm"
 	cat >"$fake_npm" <<-'SH'


### PR DESCRIPTION
## Summary

- `ensure_installed` was exiting early when someone ran `rm -rf node_modules`, because the install-state file lives at `.aube/.state/install-state.json` (outside `node_modules`). `check_needs_install` saw matching lockfile + `package.json` hashes and returned `None` (fresh), so `verifyDepsBeforeRun` was never consulted and `aube run <script>` executed against a missing tree.
- Fix: `check_needs_install` now also verifies `node_modules/` exists. Zero-dep projects still get a `node_modules/.bin/` from install, so they don't regress into a reinstall loop.
- Regression test in `test/guardrails.bats` covers: install → `rm -rf node_modules` → set `verifyDepsBeforeRun=error` → run script → expect failure, not silent success.

## Test plan

- [x] `./test/bats/bin/bats test/guardrails.bats` — 18/18 pass
- [x] Manual repro: `rm -rf node_modules` + `verifyDepsBeforeRun=error` + `aube dev` now errors with `node_modules is missing` instead of running the script
- [x] Manual repro: default mode auto-installs the missing tree with reason `node_modules is missing`
- [x] Manual repro: zero-dep project doesn't loop on reinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an extra filesystem existence check to the install staleness logic and a regression test; behavior change is limited to cases where `node_modules/` is deleted while the state file remains.
> 
> **Overview**
> Fixes a case where auto-install/`verifyDepsBeforeRun` could be skipped when `node_modules/` was deleted but the persisted install-state hashes still matched.
> 
> `check_needs_install` now treats a missing `node_modules/` directory as stale (reason: `node_modules is missing`), ensuring `ensure_installed` re-triggers install policy instead of running scripts against an absent dependency tree. Adds a `guardrails.bats` regression test covering install → delete `node_modules` → `verifyDepsBeforeRun=error` → script run must fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8f04949d447945038dd687007cf4b610d2228a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->