### PR TITLE
ci(release): gate Buildkite on render-done marker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,11 @@
 steps:
   - label: ":pipeline: upload"
     command: ".buildkite/pipeline.sh | buildkite-agent pipeline upload"
+    # Skip the build on `release-plz-*` branches until the release-plz
+    # GitHub Actions workflow has finished the render step — otherwise
+    # Buildkite races the workflow and reports a failure for the raw
+    # commit that release-plz force-pushes before `mise run render`
+    # regenerates `aube.usage.kdl`. The render step appends a
+    # `[render-done]` subject marker to its commit, so the final push to
+    # the PR branch runs CI normally.
+    if: build.branch !~ /^release-plz-/ || build.message =~ /\[render-done\]/

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -255,5 +255,14 @@ jobs:
           git add -A aube.usage.kdl docs CHANGELOG.md Cargo.toml Cargo.lock crates release.json
           MERGE_BASE=$(git merge-base HEAD origin/main)
           git reset --soft "$MERGE_BASE"
-          git commit -m "chore: release ${TAG}"
+          # The `[render-done]` subject marker is how Buildkite's
+          # pipeline filter (`.buildkite/pipeline.yml`) knows the render
+          # step has run. Without it, Buildkite skips builds on
+          # `release-plz-*` branches, so the raw commit release-plz
+          # force-pushes (which doesn't yet include the regenerated
+          # `aube.usage.kdl`) can't report a spurious golden-file
+          # failure. GitHub squashes the PR on merge using the PR title
+          # (which release-plz sets separately and never gets this
+          # marker), so the final commit on main is clean.
+          git commit -m "chore: release ${TAG} [render-done]"
           git push --force-with-lease


### PR DESCRIPTION
## Summary

Buildkite races the release-plz workflow. `release-plz/action@v0.5` force-pushes a raw commit (Cargo.toml + Cargo.lock + CHANGELOG bumps only) before the workflow's follow-up step runs `mise run render` and amends the commit. Buildkite webhooks on that intermediate commit and runs the full pipeline against it — the golden-file test `cli_spec_tests::usage_kdl_matches_committed_golden_file` fails because the binary built from the bumped `Cargo.toml` emits a different `aube.usage.kdl` than the one committed.

[Build 80](https://buildkite.com/endev/aube/builds/80) is the concrete example. Commit [`a4bf1bd`](https://github.com/endevco/aube/pull/22/commits/a4bf1bd0c9478a8d5b954984ee849419912b3bdd) (raw release-plz push, failed Buildkite) → [`acd48e4`](https://github.com/endevco/aube/pull/22/commits/acd48e40467cb0ad91aea55df431659bcd066eb8) (rendered, passes).

## Fix

- `.buildkite/pipeline.yml`: skip the upload step on `release-plz-*` branches unless the commit subject carries `[render-done]`. Non-release-plz branches are unaffected.
- `.github/workflows/release-plz.yml`: have the render step append `[render-done]` to its final commit subject. The raw release-plz push has no marker and is silently no-op'd by Buildkite; only the rendered push runs CI. GitHub squash-merges the PR using the release-plz PR title (not the commit subject), so main stays clean.

## Test plan

- [ ] Next release-plz run: first Buildkite build on the release-plz branch shows zero steps (skipped upload); second build runs the full pipeline and passes.
- [ ] Buildkite on this PR's own branch runs normally (branch isn't `release-plz-*`).
- [ ] Main branch after the next release-plz PR merges has a commit message without `[render-done]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating for `release-plz-*` branches; a misconfigured condition or missing commit marker could cause release PR builds to be skipped or delayed.
> 
> **Overview**
> Prevents Buildkite from running on intermediate `release-plz-*` force-pushes by adding a pipeline condition that only uploads/runs when the commit message includes `[render-done]`.
> 
> Updates the release-plz GitHub Actions workflow to append `[render-done]` to the squashed release PR commit after the `render` step, ensuring CI runs only on the final rendered commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a59c882a0705c4532cd5d146b72d431fe13834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->