### PR TITLE
fix(dlx): resolve bin from installed package when names differ

### DIFF
--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -80,6 +80,14 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
         .ok_or_else(|| miette!("dlx: missing command to run"))?;
     let bin_args: Vec<String> = params.iter().skip(1).cloned().collect();
 
+    // Remember whether `-p` was given. With `-p` the user has named the
+    // bin explicitly (`aube dlx -p which node-which`), so we run their
+    // command verbatim. Without `-p` the command doubles as the package
+    // name and we may need to cross-reference the installed package's
+    // `bin` map — e.g. `@tanstack/cli` ships its bin under the name
+    // `tanstack`, not `cli`.
+    let explicit_package = !package.is_empty();
+
     // Derive the packages to install. `-p` wins; otherwise the command name
     // is the package name (the common `pnpm dlx <pkg>` case). Under
     // `--shell-mode` the first positional is a shell line, not a bin name,
@@ -179,12 +187,21 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
             .into_diagnostic()
             .wrap_err("failed to execute dlx shell command")?
     } else {
-        let bin_path = super::project_modules_dir(&project_dir)
-            .join(".bin")
-            .join(&bin_name);
+        let bin_dir = super::project_modules_dir(&project_dir).join(".bin");
+        // If `-p` wasn't given, the command doubles as the package name
+        // and the bin is a best-guess derivation from it. Check the
+        // installed package's `bin` field and prefer the actual bin name
+        // it ships — e.g. `@tanstack/cli` ships `tanstack`, not `cli`.
+        let resolved_bin_name = if !explicit_package && !bin_dir.join(&bin_name).exists() {
+            resolve_bin_from_package(&project_dir, &install_specs[0])
+                .unwrap_or_else(|| bin_name.clone())
+        } else {
+            bin_name.clone()
+        };
+        let bin_path = bin_dir.join(&resolved_bin_name);
         if !bin_path.exists() {
             return Err(miette!(
-                "dlx: binary not found after install: {bin_name}\n\
+                "dlx: binary not found after install: {resolved_bin_name}\n\
                  help: the package may ship the binary under a different name — try `aube dlx -p <package> <bin>`"
             ));
         }
@@ -247,6 +264,45 @@ fn bin_name_for(command: &str) -> String {
     name.rsplit('/').next().unwrap_or(name).to_string()
 }
 
+/// When the bin derived from the package name doesn't match the installed
+/// package's actual bin, fall back to reading the package's `bin` field to
+/// find the right name. Matches `npx`/`pnpm dlx` behavior so e.g.
+/// `aube dlx @tanstack/cli create` works (ships its bin as `tanstack`, not
+/// `cli`) and `aube dlx which` works (ships `node-which`).
+///
+/// Returns `None` when we can't make a confident pick — caller keeps the
+/// original inference and lets the bin-missing error fire.
+fn resolve_bin_from_package(project_dir: &std::path::Path, install_spec: &str) -> Option<String> {
+    let (pkg_name, _) = split_spec(install_spec);
+    let pkg_json_path = project_dir
+        .join("node_modules")
+        .join(pkg_name)
+        .join("package.json");
+    let content = std::fs::read_to_string(&pkg_json_path).ok()?;
+    let pkg_json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let bin = pkg_json.get("bin")?;
+    let inferred = pkg_name.rsplit('/').next().unwrap_or(pkg_name);
+    match bin {
+        // String bin: npm always names it after the unscoped package name,
+        // so this matches what `bin_name_for` already derived. Returning
+        // it explicitly keeps the lookup path symmetric.
+        serde_json::Value::String(_) => Some(inferred.to_string()),
+        serde_json::Value::Object(bins) => {
+            if bins.contains_key(inferred) {
+                Some(inferred.to_string())
+            } else if bins.len() == 1 {
+                // Single bin under a different name — unambiguous pick.
+                bins.keys().next().cloned()
+            } else {
+                // Multiple bins, none matching the package name. We don't
+                // know which one the user wants; let them pick via `-p`.
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -276,5 +332,87 @@ mod tests {
         assert_eq!(bin_name_for("cowsay@1.5.0"), "cowsay");
         assert_eq!(bin_name_for("@scope/foo@2"), "foo");
         assert_eq!(bin_name_for("@scope/foo"), "foo");
+    }
+
+    fn write_pkg_json(project_dir: &std::path::Path, pkg_name: &str, pkg_json: serde_json::Value) {
+        let dir = project_dir.join("node_modules").join(pkg_name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("package.json"),
+            serde_json::to_string_pretty(&pkg_json).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn resolve_bin_single_object_bin_picks_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_pkg_json(
+            tmp.path(),
+            "@tanstack/cli",
+            serde_json::json!({
+                "name": "@tanstack/cli",
+                "bin": {"tanstack": "dist/bin.js"},
+            }),
+        );
+        assert_eq!(
+            resolve_bin_from_package(tmp.path(), "@tanstack/cli@latest"),
+            Some("tanstack".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_bin_object_with_matching_key_prefers_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_pkg_json(
+            tmp.path(),
+            "foo",
+            serde_json::json!({
+                "name": "foo",
+                "bin": {"foo": "x.js", "foo-helper": "y.js"},
+            }),
+        );
+        assert_eq!(
+            resolve_bin_from_package(tmp.path(), "foo"),
+            Some("foo".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_bin_object_multiple_no_match_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_pkg_json(
+            tmp.path(),
+            "foo",
+            serde_json::json!({
+                "name": "foo",
+                "bin": {"a": "a.js", "b": "b.js"},
+            }),
+        );
+        assert_eq!(resolve_bin_from_package(tmp.path(), "foo"), None);
+    }
+
+    #[test]
+    fn resolve_bin_string_bin_returns_package_tail() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_pkg_json(
+            tmp.path(),
+            "@scope/foo",
+            serde_json::json!({
+                "name": "@scope/foo",
+                "bin": "./x.js",
+            }),
+        );
+        assert_eq!(
+            resolve_bin_from_package(tmp.path(), "@scope/foo"),
+            Some("foo".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_bin_no_bin_field_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_pkg_json(tmp.path(), "foo", serde_json::json!({"name": "foo"}));
+        assert_eq!(resolve_bin_from_package(tmp.path(), "foo"), None);
     }
 }

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -187,13 +187,14 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
             .into_diagnostic()
             .wrap_err("failed to execute dlx shell command")?
     } else {
-        let bin_dir = super::project_modules_dir(&project_dir).join(".bin");
+        let modules_dir = super::project_modules_dir(&project_dir);
+        let bin_dir = modules_dir.join(".bin");
         // If `-p` wasn't given, the command doubles as the package name
         // and the bin is a best-guess derivation from it. Check the
         // installed package's `bin` field and prefer the actual bin name
         // it ships — e.g. `@tanstack/cli` ships `tanstack`, not `cli`.
         let resolved_bin_name = if !explicit_package && !bin_dir.join(&bin_name).exists() {
-            resolve_bin_from_package(&project_dir, &install_specs[0])
+            resolve_bin_from_package(&modules_dir, &install_specs[0])
                 .unwrap_or_else(|| bin_name.clone())
         } else {
             bin_name.clone()
@@ -270,14 +271,14 @@ fn bin_name_for(command: &str) -> String {
 /// `aube dlx @tanstack/cli create` works (ships its bin as `tanstack`, not
 /// `cli`) and `aube dlx which` works (ships `node-which`).
 ///
-/// Returns `None` when we can't make a confident pick — caller keeps the
-/// original inference and lets the bin-missing error fire.
-fn resolve_bin_from_package(project_dir: &std::path::Path, install_spec: &str) -> Option<String> {
+/// `modules_dir` is the project's resolved virtual-modules directory — the
+/// same one we derive the `.bin` path from, so a user with a custom
+/// `modulesDir` still sees the fallback work. Returns `None` when we can't
+/// make a confident pick; caller keeps the original inference and lets the
+/// bin-missing error fire.
+fn resolve_bin_from_package(modules_dir: &std::path::Path, install_spec: &str) -> Option<String> {
     let (pkg_name, _) = split_spec(install_spec);
-    let pkg_json_path = project_dir
-        .join("node_modules")
-        .join(pkg_name)
-        .join("package.json");
+    let pkg_json_path = modules_dir.join(pkg_name).join("package.json");
     let content = std::fs::read_to_string(&pkg_json_path).ok()?;
     let pkg_json: serde_json::Value = serde_json::from_str(&content).ok()?;
     let bin = pkg_json.get("bin")?;
@@ -334,8 +335,8 @@ mod tests {
         assert_eq!(bin_name_for("@scope/foo"), "foo");
     }
 
-    fn write_pkg_json(project_dir: &std::path::Path, pkg_name: &str, pkg_json: serde_json::Value) {
-        let dir = project_dir.join("node_modules").join(pkg_name);
+    fn write_pkg_json(modules_dir: &std::path::Path, pkg_name: &str, pkg_json: serde_json::Value) {
+        let dir = modules_dir.join(pkg_name);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             dir.join("package.json"),

--- a/test/dlx.bats
+++ b/test/dlx.bats
@@ -39,6 +39,17 @@ teardown() {
 	assert_output --partial "/node"
 }
 
+@test "aube dlx falls back to the package's single bin when names differ" {
+	# `which` ships its bin as `node-which`, so the naive
+	# "bin name == unscoped package name" inference would look for
+	# `.bin/which` and fail. With the installed-package fallback aube
+	# should pick `node-which` (the only bin) and run it — exactly
+	# what `npx which node` does.
+	run aube dlx which node
+	assert_success
+	assert_output --partial "/node"
+}
+
 @test "aube dlx accepts an @version suffix on the command" {
 	# semver@7.7.4 is what the fixture set has pinned. Run it against a
 	# prerelease version so the output is distinguishable from the default.


### PR DESCRIPTION
## Summary

- `aube dlx @tanstack/cli@latest create` (and `aube dlx which node`) failed with *binary not found after install*, even though `npx` and `pnpm dlx` handle both fine. The bin name was being derived by stripping the scope off the package name (`@tanstack/cli` → `cli`, `which` → `which`), but those packages actually ship their bin as `tanstack` and `node-which`.
- When `-p` wasn't given and the inferred bin is missing, read the installed package's `bin` field: pick the unambiguous single bin, prefer a name matching the package tail when there are multiple, and otherwise let the existing error fire so the user can disambiguate via `-p`.
- The `-p` path is unchanged — `aube dlx -p which node-which` still runs the user's command verbatim.

## Why

Matches `npx`/`pnpm dlx` behavior for the common "ships bin under a different name" case. Blocks TanStack Start's `aube dlx @tanstack/cli create` onboarding path today.

## Test plan

- [x] `cargo test -p aube -- commands::dlx` — 5 new unit tests for the four shapes of the `bin` field (single object bin, matching key preferred, ambiguous fallback returns `None`, string bin, missing `bin` field) plus the existing ones.
- [x] `./test/bats/bin/bats test/dlx.bats` — new case `aube dlx which node` exercises the fallback against the offline fixture registry; all six pass.
- [x] `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- [x] End-to-end against the live registry: `aube dlx @tanstack/cli@latest` now runs the `tanstack` CLI and prints its help, vs. the previous "binary not found: cli" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `aube dlx` execution-path selection by reading installed `package.json` to resolve the correct binary name when the inferred one is missing; mistakes here could cause regressions in which executable gets run or return a new error.
> 
> **Overview**
> Fixes `aube dlx <pkg> ...` for packages whose published binary name doesn’t match the unscoped package name by, when `-p` is *not* provided and the inferred `.bin/<name>` is missing, reading the installed package’s `package.json` `bin` field to pick an unambiguous executable name.
> 
> Adds focused unit tests for `resolve_bin_from_package` across `bin` shapes (string/object, single/multiple) and a new Bats E2E case (`aube dlx which node`) to validate the fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74e0dd6d6ee190d949c24321dd416b1ac5c359fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->