### PR TITLE
test: add mise task for running BATS tests in parallel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,11 @@ cargo test                     # Run unit tests
 cargo clippy --all-targets -- -D warnings  # Lint (CI enforces zero warnings)
 cargo fmt --check              # Check formatting
 
-# Integration tests (BATS framework, requires Node.js 22)
-# First: cargo build, then:
-./test/bats/bin/bats test/     # Run all BATS tests
-./test/bats/bin/bats test/install.bats  # Run a single test file
+# BATS integration tests (requires Node.js 22 and GNU parallel).
+# `cargo build` first, then run the mise task — it shards across cores
+# via `bats --jobs`, so prefer it over raw `./test/bats/bin/bats`.
+mise run test:bats                       # Run the full suite in parallel
+mise run test:bats test/install.bats     # Run a single file (or several)
 ```
 
 ## Commit Messages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,13 @@ cargo test                                 # Unit tests
 cargo clippy --all-targets -- -D warnings  # Lint
 cargo fmt --check                          # Formatting
 
-# BATS integration tests (needs Node.js 22 and `verdaccio` on PATH;
-# the first run will `npm i -g verdaccio@6` if it isn't installed).
-./test/bats/bin/bats test/
-./test/bats/bin/bats test/install.bats     # single file
-./test/bats/bin/bats -f "<substring>" test/  # filter by test name
+# BATS integration tests (needs Node.js 22, GNU `parallel`, and
+# `verdaccio` on PATH; the first run will `npm i -g verdaccio@6` if it
+# isn't installed). The mise task shards files across cores via
+# `bats --jobs` — prefer it over the raw runner.
+mise run test:bats                            # full suite, in parallel
+mise run test:bats test/install.bats          # one or more files
+./test/bats/bin/bats -f "<substring>" test/   # filter by test name
 ```
 
 ## The offline Verdaccio test registry

--- a/mise-tasks/test/bats
+++ b/mise-tasks/test/bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#MISE description="Run BATS integration tests in parallel"
+#USAGE arg "[files]..." help="Specific .bats files or directories (defaults to test/)"
+set -euo pipefail
+
+if command -v nproc >/dev/null; then
+	jobs="$(nproc)"
+else
+	jobs="$(sysctl -n hw.ncpu)"
+fi
+
+if (($# > 0)); then
+	targets=("$@")
+else
+	targets=(test/)
+fi
+
+exec ./test/bats/bin/bats \
+	--jobs "$jobs" \
+	--parallel-binary-name parallel \
+	--no-parallelize-within-files \
+	"${targets[@]}"

--- a/mise-tasks/test/bats
+++ b/mise-tasks/test/bats
@@ -15,8 +15,22 @@ else
 	targets=(test/)
 fi
 
-exec ./test/bats/bin/bats \
+# Files tagged `# bats file_tags=serial` mutate shared state (Verdaccio
+# storage, `git checkout` in fixtures) and can't race against each
+# other or against the rest of the suite — mirror the CI split by
+# running non-serial files in parallel first, then serial files
+# sequentially. Both phases are scoped to the same targets, so
+# passing specific files still works.
+status=0
+./test/bats/bin/bats \
 	--jobs "$jobs" \
 	--parallel-binary-name parallel \
 	--no-parallelize-within-files \
-	"${targets[@]}"
+	--filter-tags "!serial" \
+	"${targets[@]}" || status=$?
+
+./test/bats/bin/bats \
+	--filter-tags "serial" \
+	"${targets[@]}" || status=$?
+
+exit "$status"


### PR DESCRIPTION
## Summary
- Adds `mise-tasks/test/bats`, a file-based task that runs the BATS suite with `bats --jobs $(nproc) --parallel-binary-name parallel --no-parallelize-within-files`.
- Takes variadic file args so `mise run test:bats test/install.bats` works; defaults to the full `test/` directory.
- Updates CLAUDE.md and CONTRIBUTING.md to point contributors at the task instead of `./test/bats/bin/bats test/`.

## Why
The raw `./test/bats/bin/bats test/` invocation is single-threaded — the CI pipeline already shards with `bats --jobs` for speed, but there was no equivalent for local dev. The new task mirrors the CI flags while staying safe for `# bats file_tags=serial` tests via `--no-parallelize-within-files`.

## Test plan
- [x] `mise tasks` lists `test:bats` with the new description
- [x] `mise run test:bats --help` shows the variadic `[files]...` argument
- [ ] `mise run test:bats` runs the full BATS suite in parallel (needs a build — verify in CI)
- [ ] `mise run test:bats test/install.bats` runs a single file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new developer test runner script and updates docs; no production code or build artifacts are affected, but the task assumes GNU `parallel` and could change how local test failures surface due to parallelization.
> 
> **Overview**
> Adds a new `mise` task (`mise-tasks/test/bats`) to run the BATS integration suite in parallel, auto-sizing `--jobs` to CPU count and supporting optional file/dir args.
> 
> The task mirrors CI behavior by running non-`serial` tests in parallel first, then re-running `serial`-tagged tests sequentially to avoid shared-state races. Docs in `CLAUDE.md` and `CONTRIBUTING.md` are updated to direct contributors to `mise run test:bats` instead of invoking `./test/bats/bin/bats` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0124c472f9948018e0ae6446677882dcb47b6b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->