### PR TITLE
ci(autofix): skip release-plz PRs to avoid racing their workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -17,7 +17,14 @@ env:
 
 jobs:
   autofix:
-    if: github.actor != 'renovate[bot]' && github.actor != 'mend[bot]'
+    # release-plz PRs regenerate derived files inside the release-plz
+    # workflow itself (`.github/workflows/release-plz.yml`), so skip
+    # autofix here — otherwise the two jobs race on the same branch
+    # and whichever loses gets a `--force-with-lease` rejection.
+    if: >-
+      github.actor != 'renovate[bot]'
+      && github.actor != 'mend[bot]'
+      && !startsWith(github.head_ref, 'release-plz-')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

Autofix and the release-plz workflow's `Update release PR` step were both trying to regenerate `aube.usage.kdl` / `docs/cli/*` on every release PR, and racing each other on the same branch. Autofix almost always won (the in-workflow step has to compile `./target/debug/aube` from scratch first), which left the release PR step hitting `! [rejected] ... (stale info)` on its `--force-with-lease` push — silently, because the step has `continue-on-error: true`.

Seen on [#22](https://github.com/endevco/aube/pull/22), where `5ca875df` is the autofix rescue commit and the in-workflow push died at 22:46:28 with stale lease info.

Skip autofix when `github.head_ref` starts with `release-plz-` so the in-workflow step is the sole owner of regenerated docs on release PRs.

## Why this is the right shape

- The in-workflow step already does the same work, and does it *as part of* the release-plz commit rather than as a second drive-by commit — which is what we actually want.
- If the in-workflow step ever genuinely fails, `cargo test -p aube` still runs on the PR and the `aube.usage.kdl` golden test will fail loudly. Losing autofix as a safety net on release PRs specifically is a feature, not a regression — it was masking the stale-lease bug for who knows how long.
- Guarding by `head_ref` (not `github.actor`) because release-plz uses a PAT, so the PR author shows up as `jdx`, not a bot.

## Test plan

- [ ] Next release-plz PR opens with the regenerated `aube.usage.kdl` / `docs/cli/*` in the initial release-plz commit (not in a follow-up autofix commit).
- [ ] No autofix workflow run appears on that PR.
- [ ] Non-release PRs still get autofix as normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes GitHub Actions job gating to avoid concurrent branch updates; no runtime/product code is affected.
> 
> **Overview**
> Prevents `autofix.ci` from running on `release-plz-*` pull requests by extending the job `if` condition to check `github.head_ref`.
> 
> This avoids racing the `release-plz` workflow’s own “Update release PR” step (which also regenerates derived docs) and reduces `--force-with-lease` push rejections on release PR branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5224ff9610403af502bb84f063a302582a87ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->