### PR TITLE
lockfile(npm): support npm:<real>@<ver> aliases + fix dep_path tail

### DIFF
--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -391,9 +391,12 @@ pub(crate) fn link_hoisted_importer(
         let index = match package_indices.get(&dep_path) {
             Some(i) => i,
             None => {
+                // `registry_name()` is the lookup key for npm-aliased
+                // packages (`"h3-v2": "npm:h3@..."`), which saved the
+                // index under the real package name at fetch time.
                 let loaded = linker
                     .store
-                    .load_index(&pkg.name, &pkg.version)
+                    .load_index(pkg.registry_name(), &pkg.version)
                     .ok_or_else(|| Error::MissingPackageIndex(dep_path.clone()))?;
                 owned_index = loaded;
                 &owned_index

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -876,10 +876,12 @@ impl Linker {
                             let index = match package_indices.get(dep_path) {
                                 Some(idx) => idx,
                                 None => {
-                                    owned_index =
-                                        self.store.load_index(&pkg.name, &pkg.version).ok_or_else(
-                                            || Error::MissingPackageIndex(dep_path.to_string()),
-                                        )?;
+                                    owned_index = self
+                                        .store
+                                        .load_index(pkg.registry_name(), &pkg.version)
+                                        .ok_or_else(|| {
+                                            Error::MissingPackageIndex(dep_path.to_string())
+                                        })?;
                                     &owned_index
                                 }
                             };
@@ -944,7 +946,7 @@ impl Linker {
                     None => {
                         owned_index = self
                             .store
-                            .load_index(&pkg.name, &pkg.version)
+                            .load_index(pkg.registry_name(), &pkg.version)
                             .ok_or_else(|| Error::MissingPackageIndex(dep_path.to_string()))?;
                         &owned_index
                     }
@@ -1227,7 +1229,7 @@ impl Linker {
             let index = match package_indices.get(dep_path) {
                 Some(idx) => idx,
                 None => {
-                    let Some(idx) = self.store.load_index(&pkg.name, &pkg.version) else {
+                    let Some(idx) = self.store.load_index(pkg.registry_name(), &pkg.version) else {
                         return Err(Error::MissingPackageIndex(dep_path.to_string()));
                     };
                     owned_index = idx;

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -453,6 +453,32 @@ pub struct LockedPackage {
     /// remote tarball) already carry their own URL via `LocalSource`
     /// and don't populate this field.
     pub tarball_url: Option<String>,
+    /// For npm-alias deps (`"h3-v2": "npm:h3@2.0.1-rc.20"`): the real
+    /// package name on the registry (`"h3"`). `None` means the entry
+    /// is not aliased and `name` already holds the registry name.
+    ///
+    /// Install semantics when `Some(real)`:
+    /// - `name` is the *alias* — that's the folder under `node_modules/`,
+    ///   the symlink name for transitive deps, and the key every package
+    ///   that declares this dep refers to.
+    /// - `alias_of` is the real package name used for tarball URL lookup,
+    ///   store index keying, and packument fetches.
+    /// - `version` is the real resolved version.
+    ///
+    /// `registry_name()` returns the right name for registry IO; every
+    /// call site that talks to the registry or the CAS uses that helper.
+    pub alias_of: Option<String>,
+}
+
+impl LockedPackage {
+    /// The package name to use for registry / store operations — the real
+    /// name behind an npm-alias when aliased, otherwise just `name`. Used
+    /// at every site that derives a tarball URL, a packument URL, or a
+    /// `~/.aube-store/` cache key so aliased entries hit the actual
+    /// package instead of the alias-qualified name.
+    pub fn registry_name(&self) -> &str {
+        self.alias_of.as_deref().unwrap_or(&self.name)
+    }
 }
 
 /// Metadata about a single declared peer dependency. Matches the shape of

--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -30,12 +30,25 @@ struct RawNpmLockfile {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RawNpmPackage {
+    /// npm emits this field only when the entry is an npm-alias
+    /// (`"h3-v2": "npm:h3@..."` resolves to `node_modules/h3-v2` with
+    /// `name: "h3"`). For non-aliased packages the name is recoverable
+    /// from the install path and npm omits the field. We use the
+    /// presence of this field — combined with inequality against the
+    /// install-path segment — to detect aliases.
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
     version: Option<String>,
     #[serde(default)]
     integrity: Option<String>,
+    /// Full registry tarball URL npm wrote when it locked this entry.
+    /// We capture it so aliased packages (whose registry name differs
+    /// from the install-path-derived name used to key the graph) don't
+    /// need to re-derive the URL from the registry base — and so we
+    /// can round-trip `resolved:` faithfully when we write back.
+    #[serde(default)]
+    resolved: Option<String>,
     #[serde(default)]
     dependencies: BTreeMap<String, String>,
     #[serde(default)]
@@ -76,7 +89,14 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             continue; // root project, handled separately
         }
 
-        let name = package_name_from_install_path(install_path)
+        // The install-path segment is what every other package in the
+        // tree refers to. For non-aliased deps that's the real package
+        // name; for `"h3-v2": "npm:h3@..."` it's the alias `h3-v2`.
+        // Keep it as the LockedPackage.name so the linker drops the
+        // dep into `node_modules/<alias>/` and transitive symlinks
+        // resolve by the string that appears in consumers'
+        // `dependencies` maps.
+        let install_name = package_name_from_install_path(install_path)
             .or_else(|| entry.name.clone())
             .ok_or_else(|| {
                 Error::Parse(
@@ -84,15 +104,27 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                     format!("could not determine package name for '{install_path}'"),
                 )
             })?;
+        // npm writes `name:` only for aliases. If present and different
+        // from the install-path segment, this is `"<alias>": "npm:<real>@..."`
+        // and the real name is what we hit the registry with. If absent
+        // or equal, it's a regular dep.
+        let alias_of = entry
+            .name
+            .as_ref()
+            .filter(|real| real.as_str() != install_name.as_str())
+            .cloned();
         let version = entry.version.clone().ok_or_else(|| {
             Error::Parse(
                 path.to_path_buf(),
-                format!("package '{name}' has no version"),
+                format!("package '{install_name}' has no version"),
             )
         })?;
-        install_path_info.insert(install_path.clone(), (name.clone(), version.clone()));
+        install_path_info.insert(
+            install_path.clone(),
+            (install_name.clone(), version.clone()),
+        );
 
-        let dep_path = format!("{name}@{version}");
+        let dep_path = format!("{install_name}@{version}");
 
         // Same (name, version) may appear at multiple nest levels; keep the first occurrence.
         if graph.packages.contains_key(&dep_path) {
@@ -110,14 +142,31 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             deps.insert(dep_name.clone(), String::new());
         }
 
+        // Keep the `resolved` URL for aliased entries so the fetcher
+        // doesn't try to re-derive it from the alias-qualified name.
+        // For non-aliased entries the stock name-based derivation is
+        // what other paths already expect, so leave `tarball_url`
+        // unset and let the default code path handle it.
+        let tarball_url = if alias_of.is_some() {
+            entry
+                .resolved
+                .as_ref()
+                .filter(|u| u.starts_with("http://") || u.starts_with("https://"))
+                .cloned()
+        } else {
+            None
+        };
+
         graph.packages.insert(
             dep_path.clone(),
             LockedPackage {
-                name,
+                name: install_name,
                 version,
                 integrity: entry.integrity.clone(),
                 dependencies: deps,
                 dep_path,
+                alias_of,
+                tarball_url,
                 ..Default::default()
             },
         );
@@ -129,11 +178,18 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     // `node_modules/bar` exists — npm hoists shared versions to the root but
     // keeps conflicting versions nested.
     //
-    // We then write the resolved (name → dep_path) back onto the LockedPackage
-    // keyed by the *first* dep_path (name@version) we stored. This may lose
-    // fidelity if two entries share (name, version) but have different
-    // resolved transitives — npm.rs's data model doesn't express that, and
-    // in practice npm dedupes only when the transitives match anyway.
+    // We then write the resolved (name → dep_path tail) back onto the
+    // LockedPackage keyed by the *first* dep_path (name@version) we
+    // stored. The map value is the substring that follows `<name>@` in
+    // the target dep_path (just the version for simple packages), per
+    // `LockedPackage.dependencies` doc — the linker recombines the
+    // name and tail with an `@` separator when walking siblings.
+    // Emitting the full dep_path here doubled the name and produced
+    // broken sibling symlinks like `rolldown@rolldown@1.0.0` for every
+    // transitive dep. This may lose fidelity if two entries share
+    // (name, version) but have different resolved transitives —
+    // npm.rs's data model doesn't express that, and in practice npm
+    // dedupes only when the transitives match anyway.
     let mut resolved_by_dep_path: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     for (install_path, entry) in &raw.packages {
         if install_path.is_empty() {
@@ -158,9 +214,9 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         {
             if let Some(target_install_path) =
                 resolve_nested(install_path, dep_name, &install_path_info)
-                && let Some((dname, dver)) = install_path_info.get(&target_install_path)
+                && let Some((_, dver)) = install_path_info.get(&target_install_path)
             {
-                resolved.insert(dep_name.clone(), format!("{dname}@{dver}"));
+                resolved.insert(dep_name.clone(), dver.clone());
             }
         }
         resolved_by_dep_path.insert(dep_path, resolved);
@@ -330,11 +386,14 @@ struct WriteNpmPackage<'a> {
 /// Lossy areas (documented so callers know what to expect):
 ///  - Peer-contextualized variants of the same `name@version` collapse
 ///    to one entry. npm's layout can't represent per-context peers.
-///  - `resolved` tarball URLs are omitted — we don't persist the
-///    origin URL in [`LockedPackage`]. npm's own consumers tolerate
-///    missing `resolved` (they refetch from the registry); aube's own
-///    parser only needs `integrity`, so round-trip through the parser
-///    is lossless for the data it inspects.
+///  - `resolved` tarball URLs are omitted for non-aliased packages —
+///    we don't persist the origin URL in [`LockedPackage`]. npm's own
+///    consumers tolerate missing `resolved` (they refetch from the
+///    registry); aube's own parser only needs `integrity`, so round-trip
+///    through the parser is lossless for the data it inspects. Aliased
+///    entries always emit `resolved:` because the install-path name is
+///    the alias — without the URL the consumer can't recover the real
+///    registry location.
 ///  - `file:` / `link:` / git sources aren't emitted yet.
 ///  - Multiple workspace importers aren't emitted — only the root
 ///    importer's tree is walked. Workspace + npm-lockfile projects
@@ -438,10 +497,25 @@ pub fn write(
         let dev = is_dev && !dev_optional;
         let optional = is_opt && !dev_optional;
 
+        // Aliased deps (`"h3-v2": "npm:h3@..."` in package.json) round-trip
+        // as `node_modules/h3-v2` with an explicit `name: "h3"` and the
+        // captured `resolved:` URL. Without both fields npm (and aube's
+        // own reader on a subsequent install) has no way to recover
+        // the real package identity from an alias-qualified install
+        // path.
+        let alias_name = pkg.alias_of.as_deref();
+        let resolved = if alias_name.is_some() {
+            pkg.tarball_url.clone()
+        } else {
+            None
+        };
+
         packages.insert(
             install_path.clone(),
             WriteNpmPackage {
+                name: alias_name,
                 version: Some(pkg.version.as_str()),
+                resolved,
                 integrity: pkg.integrity.as_deref(),
                 dependencies: deps,
                 dev,
@@ -776,9 +850,12 @@ mod tests {
 
         let foo = &graph.packages["foo@1.2.3"];
         assert_eq!(foo.integrity.as_deref(), Some("sha512-aaa"));
+        // `LockedPackage.dependencies` values are dep_path *tails* (the
+        // substring after `<name>@`), not full dep_paths — matches the
+        // pnpm parser and the linker's sibling-symlink builder.
         assert_eq!(
             foo.dependencies.get("nested").map(String::as_str),
-            Some("nested@3.1.0")
+            Some("3.1.0")
         );
 
         let root = graph.importers.get(".").unwrap();
@@ -852,10 +929,11 @@ mod tests {
         assert!(graph.packages.contains_key("foo@1.0.0"));
 
         // foo's transitive dep must point to the nested (1.0.0), not the hoisted (2.0.0).
+        // Value is the dep_path tail (version) — see the `LockedPackage.dependencies` doc.
         let foo = &graph.packages["foo@1.0.0"];
         assert_eq!(
             foo.dependencies.get("bar").map(String::as_str),
-            Some("bar@1.0.0")
+            Some("1.0.0")
         );
 
         // Root's direct bar dep points to the hoisted 2.0.0.
@@ -1092,11 +1170,12 @@ mod tests {
         let reparsed = parse(out.path()).unwrap();
 
         // baz's transitive dep must resolve to bar@2.0.0, not the
-        // shadowing bar@1.0.0 under foo.
+        // shadowing bar@1.0.0 under foo. Value is the dep_path tail
+        // (version) so the linker can recombine it with the dep name.
         let baz = &reparsed.packages["baz@1.0.0"];
         assert_eq!(
             baz.dependencies.get("bar").map(String::as_str),
-            Some("bar@2.0.0"),
+            Some("2.0.0"),
             "baz's bar dep was shadowed by foo/bar@1.0.0 — shadow-nest fix regressed",
         );
     }
@@ -1187,13 +1266,13 @@ mod tests {
         );
         // foo's nested bar dep still resolves to 1.0.0, not the
         // hoisted 2.0.0. If the writer failed to nest, reparse would
-        // snap this to bar@2.0.0.
+        // snap this to bar@2.0.0. Value is the dep_path tail.
         assert_eq!(
             reparsed.packages["foo@1.0.0"]
                 .dependencies
                 .get("bar")
                 .map(String::as_str),
-            Some("bar@1.0.0")
+            Some("1.0.0")
         );
     }
 
@@ -1276,5 +1355,146 @@ mod tests {
 
         let err = parse(tmp.path()).unwrap_err();
         assert!(matches!(err, Error::Parse(_, msg) if msg.contains("lockfileVersion 1")));
+    }
+
+    /// npm writes `"h3-v2": "npm:h3@..."` aliases as a packages entry
+    /// at `node_modules/h3-v2` with `name: "h3"` and the real registry
+    /// `resolved:` URL. Aube keys the graph on the *alias* (so
+    /// `node_modules/h3-v2` ends up at `.aube/h3-v2@.../node_modules/h3-v2`)
+    /// but remembers the real package name in `alias_of` so fetches
+    /// and store-index lookups use the URL that actually exists.
+    #[test]
+    fn test_parse_npm_alias_dependency() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+            "name": "test",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "test",
+                    "version": "1.0.0",
+                    "dependencies": { "h3-v2": "npm:h3@2.0.1-rc.20" }
+                },
+                "node_modules/h3-v2": {
+                    "name": "h3",
+                    "version": "2.0.1-rc.20",
+                    "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.20.tgz",
+                    "integrity": "sha512-aliased"
+                }
+            }
+        }"#;
+        std::fs::write(tmp.path(), content).unwrap();
+
+        let graph = parse(tmp.path()).unwrap();
+        assert_eq!(graph.packages.len(), 1);
+        // Graph key and LockedPackage.name both carry the alias —
+        // that's what consumers (and the linker's folder-name logic)
+        // refer to when they say "h3-v2".
+        let pkg = graph
+            .packages
+            .get("h3-v2@2.0.1-rc.20")
+            .expect("aliased entry should be keyed by the alias dep_path");
+        assert_eq!(pkg.name, "h3-v2");
+        assert_eq!(pkg.version, "2.0.1-rc.20");
+        assert_eq!(pkg.alias_of.as_deref(), Some("h3"));
+        assert_eq!(pkg.registry_name(), "h3");
+        // `resolved:` round-trips into `tarball_url` so the fetcher
+        // skips re-deriving from the alias-qualified name (which
+        // would 404 the registry).
+        assert_eq!(
+            pkg.tarball_url.as_deref(),
+            Some("https://registry.npmjs.org/h3/-/h3-2.0.1-rc.20.tgz")
+        );
+
+        let root = graph.importers.get(".").unwrap();
+        assert_eq!(root.len(), 1);
+        assert_eq!(root[0].name, "h3-v2");
+        assert_eq!(root[0].dep_path, "h3-v2@2.0.1-rc.20");
+    }
+
+    /// Non-aliased entries (the common case) leave `alias_of` unset
+    /// and `registry_name()` degenerates to `name`. Regression guard
+    /// against over-aggressive alias detection that would flag every
+    /// entry carrying an explicit `name:` field (npm sometimes emits
+    /// one for non-aliased roots too).
+    #[test]
+    fn test_parse_non_alias_preserves_empty_alias_of() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+            "name": "test",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "test",
+                    "version": "1.0.0",
+                    "dependencies": { "foo": "^1.0.0" }
+                },
+                "node_modules/foo": {
+                    "name": "foo",
+                    "version": "1.2.3",
+                    "integrity": "sha512-foo"
+                }
+            }
+        }"#;
+        std::fs::write(tmp.path(), content).unwrap();
+
+        let graph = parse(tmp.path()).unwrap();
+        let pkg = &graph.packages["foo@1.2.3"];
+        assert_eq!(pkg.name, "foo");
+        assert!(pkg.alias_of.is_none());
+        assert_eq!(pkg.registry_name(), "foo");
+        assert!(pkg.tarball_url.is_none());
+    }
+
+    /// Round-trip: writer must emit `name:` and `resolved:` for the
+    /// aliased entry so a subsequent `parse()` still recognizes it as
+    /// an alias. Without both fields the re-parser would see
+    /// `node_modules/h3-v2` with no `name:` and treat it as a plain
+    /// package called `h3-v2` — which doesn't exist on the registry.
+    #[test]
+    fn test_write_roundtrip_npm_alias() {
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            "h3-v2@2.0.1-rc.20".to_string(),
+            LockedPackage {
+                name: "h3-v2".to_string(),
+                version: "2.0.1-rc.20".to_string(),
+                integrity: Some("sha512-aliased".to_string()),
+                dep_path: "h3-v2@2.0.1-rc.20".to_string(),
+                alias_of: Some("h3".to_string()),
+                tarball_url: Some("https://registry.npmjs.org/h3/-/h3-2.0.1-rc.20.tgz".to_string()),
+                ..Default::default()
+            },
+        );
+        graph.importers.insert(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "h3-v2".to_string(),
+                dep_path: "h3-v2@2.0.1-rc.20".to_string(),
+                dep_type: DepType::Production,
+                specifier: Some("npm:h3@2.0.1-rc.20".to_string()),
+            }],
+        );
+
+        let manifest = test_manifest();
+        let out = tempfile::NamedTempFile::new().unwrap();
+        write(out.path(), &graph, &manifest).unwrap();
+
+        let body = std::fs::read_to_string(out.path()).unwrap();
+        assert!(
+            body.contains("\"name\": \"h3\""),
+            "expected `name: h3` emitted for aliased entry; got:\n{body}"
+        );
+        assert!(
+            body.contains("\"resolved\": \"https://registry.npmjs.org/h3/-/h3-2.0.1-rc.20.tgz\""),
+            "expected `resolved:` URL emitted for aliased entry; got:\n{body}"
+        );
+
+        let reparsed = parse(out.path()).unwrap();
+        let pkg = &reparsed.packages["h3-v2@2.0.1-rc.20"];
+        assert_eq!(pkg.alias_of.as_deref(), Some("h3"));
+        assert_eq!(pkg.registry_name(), "h3");
     }
 }

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -303,6 +303,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 libc,
                 bundled_dependencies,
                 tarball_url,
+                alias_of: None,
             },
         );
     }

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1436,6 +1436,7 @@ impl Resolver {
                                     libc: locked_pkg.libc.clone(),
                                     bundled_dependencies: locked_pkg.bundled_dependencies.clone(),
                                     tarball_url: locked_pkg.tarball_url.clone(),
+                                    alias_of: locked_pkg.alias_of.clone(),
                                 },
                             );
 
@@ -1872,6 +1873,7 @@ impl Resolver {
                             v
                         },
                         tarball_url: None,
+                        alias_of: None,
                     },
                 );
 
@@ -2980,6 +2982,7 @@ fn dedupe_peer_suffixes(graph: LockfileGraph) -> LockfileGraph {
                 libc: pkg.libc,
                 bundled_dependencies: pkg.bundled_dependencies,
                 tarball_url: pkg.tarball_url,
+                alias_of: pkg.alias_of,
             },
         );
     }
@@ -3375,6 +3378,7 @@ fn visit_peer_context(
             libc: pkg.libc.clone(),
             bundled_dependencies: pkg.bundled_dependencies.clone(),
             tarball_url: pkg.tarball_url.clone(),
+            alias_of: pkg.alias_of.clone(),
         },
     );
     Some(contextualized)

--- a/crates/aube/src/commands/fetch.rs
+++ b/crates/aube/src/commands/fetch.rs
@@ -173,9 +173,16 @@ fn dep_closure(
         let Some(pkg) = graph.packages.get(&dep_path) else {
             continue;
         };
-        for child_path in pkg.dependencies.values() {
+        // `LockedPackage.dependencies` values are dep_path *tails* —
+        // the string that follows `<name>@` in the child's dep_path.
+        // Recombine with the child name to rebuild the key we'll look
+        // up in `graph.packages`. Skipping this recombine would search
+        // the graph by the tail alone (e.g. `"6.0.0"`), miss every
+        // transitive, and `fetch --prod` would underreport its count.
+        for (child_name, child_tail) in &pkg.dependencies {
+            let child_path = format!("{child_name}@{child_tail}");
             if seen.insert(child_path.clone()) {
-                queue.push_back(child_path.clone());
+                queue.push_back(child_path);
             }
         }
     }

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -1791,7 +1791,10 @@ where
                     return (dep_path.clone(), pkg, CheckResult::AlreadyLinked);
                 }
             }
-            match store.load_index(&pkg.name, &pkg.version) {
+            // Keyed by registry name so two npm-aliases of the same
+            // real package share one store index entry instead of
+            // wastefully double-fetching under the alias.
+            match store.load_index(pkg.registry_name(), &pkg.version) {
                 Some(index) => (dep_path.clone(), pkg, CheckResult::Cached(index)),
                 None => (dep_path.clone(), pkg, CheckResult::NeedsFetch),
             }
@@ -1864,10 +1867,19 @@ where
                 cached_count += 1;
             }
             CheckResult::NeedsFetch => {
+                // `registry_name` is the real package name on the
+                // registry — equal to `name` for the common case, and
+                // the aliased-real-name for npm-alias entries. The
+                // tarball URL override is only present for aliased
+                // entries where `client.tarball_url(&name, ...)` would
+                // 404 the alias-qualified name; the lockfile reader
+                // populated it from `resolved:` at parse time.
                 to_fetch.push((
                     dep_path,
                     pkg.name.clone(),
+                    pkg.registry_name().to_string(),
                     pkg.version.clone(),
+                    pkg.tarball_url.clone(),
                     pkg.integrity.clone(),
                 ));
             }
@@ -1910,11 +1922,13 @@ where
         let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(sem_permits));
         let mut handles = Vec::new();
 
-        for (dep_path, name, version, integrity) in to_fetch {
+        for (dep_path, display_name, registry_name, version, tarball_url_override, integrity) in
+            to_fetch
+        {
             let sem = semaphore.clone();
             let store = store.clone();
             let client = client.clone();
-            let row = progress.map(|p| p.start_fetch(&name, &version));
+            let row = progress.map(|p| p.start_fetch(&display_name, &version));
             let bytes_progress = progress.cloned();
 
             let handle = tokio::spawn(async move {
@@ -1922,13 +1936,20 @@ where
                 let task_start = std::time::Instant::now();
                 let permit = sem.acquire().await.unwrap();
                 let wait_time = task_start.elapsed();
-                let url = client.tarball_url(&name, &version);
+                // Aliased entries (`"h3-v2": "npm:h3@..."`) carry the
+                // resolved tarball URL verbatim from the lockfile so
+                // we skip re-deriving it from `registry_name` — the
+                // lockfile captured the exact URL at write time
+                // against whatever registry was active then.
+                let url = tarball_url_override
+                    .clone()
+                    .unwrap_or_else(|| client.tarball_url(&registry_name, &version));
 
                 let dl_start = std::time::Instant::now();
                 let bytes = client
                     .fetch_tarball_bytes(&url)
                     .await
-                    .map_err(|e| miette!("failed to fetch {name}@{version}: {e}"))?;
+                    .map_err(|e| miette!("failed to fetch {display_name}@{version}: {e}"))?;
                 let dl_time = dl_start.elapsed();
 
                 if let Some(p) = bytes_progress.as_ref() {
@@ -1953,17 +1974,18 @@ where
                 let bytes_len = bytes.len();
                 let (index, import_time) = tokio::task::spawn_blocking({
                     let store = store.clone();
-                    let name = name.clone();
+                    let display_name = display_name.clone();
+                    let registry_name = registry_name.clone();
                     let version = version.clone();
                     move || -> miette::Result<_> {
                         if verify_integrity && let Some(ref expected) = integrity {
                             aube_store::verify_integrity(&bytes, expected)
-                                .map_err(|e| miette!("{name}@{version}: {e}"))?;
+                                .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
                         }
                         let import_start = std::time::Instant::now();
-                        let index = store
-                            .import_tarball(&bytes)
-                            .map_err(|e| miette!("failed to import {name}@{version}: {e}"))?;
+                        let index = store.import_tarball(&bytes).map_err(|e| {
+                            miette!("failed to import {display_name}@{version}: {e}")
+                        })?;
                         let import_time = import_start.elapsed();
                         // strictStorePkgContentCheck: cross-check the
                         // freshly stored package.json against the
@@ -1974,12 +1996,23 @@ where
                         // read + JSON parse) but pnpm parity is to
                         // produce no error path at all when the user
                         // opted out.
+                        //
+                        // Validate against `registry_name` — the real
+                        // package name that appears in the tarball's
+                        // own `package.json` — not the alias, or this
+                        // would fail every npm-aliased entry.
                         if strict_pkg_content_check {
-                            aube_store::validate_pkg_content(&index, &name, &version)
-                                .map_err(|e| miette!("{name}@{version}: {e}"))?;
+                            aube_store::validate_pkg_content(&index, &registry_name, &version)
+                                .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
                         }
-                        if let Err(e) = store.save_index(&name, &version, &index) {
-                            tracing::warn!("Failed to cache index for {name}@{version}: {e}");
+                        // Cache under `registry_name` so two aliases
+                        // of the same real package hit the same
+                        // on-disk index file and avoid redundant
+                        // fetches.
+                        if let Err(e) = store.save_index(&registry_name, &version, &index) {
+                            tracing::warn!(
+                                "Failed to cache index for {display_name}@{version}: {e}"
+                            );
                         }
                         Ok((index, import_time))
                     }
@@ -1988,7 +2021,7 @@ where
                 .into_diagnostic()??;
 
                 tracing::trace!(
-                    "fetch {name}@{version}: wait={:.0?} dl={:.0?} ({} bytes) import={:.0?}",
+                    "fetch {display_name}@{version}: wait={:.0?} dl={:.0?} ({} bytes) import={:.0?}",
                     wait_time,
                     dl_time,
                     bytes_len,
@@ -3192,7 +3225,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 if pkg.local_source.is_some() {
                     continue;
                 }
-                pkg.tarball_url = Some(lo_client.tarball_url(&pkg.name, &pkg.version));
+                // Preserve any URL the parser already captured from an
+                // aliased `resolved:` field — deriving from
+                // `(registry_name, version)` would also work for
+                // aliases but skips a redundant allocation.
+                if pkg.tarball_url.is_none() {
+                    pkg.tarball_url =
+                        Some(lo_client.tarball_url(pkg.registry_name(), &pkg.version));
+                }
             }
         }
         let lo_write_kind = source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube);
@@ -3530,7 +3570,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         continue;
                     }
 
-                    // Check index cache first
+                    // Check index cache first. This path consumes
+                    // `ResolvedPackage` values streaming from the
+                    // resolver, which already rewrites `npm:` aliases
+                    // into the real package name before emission — so
+                    // `pkg.name` is always the registry name here.
+                    // (Aliased entries round-tripping *from* the
+                    // lockfile go through `fetch_packages`, which
+                    // handles aliases via `LockedPackage::alias_of`.)
                     if let Some(index) = fetch_store.load_index(&pkg.name, &pkg.version) {
                         let _ = materialize_tx.send((pkg.dep_path.clone(), index.clone()));
                         indices.insert(pkg.dep_path, index);
@@ -3891,8 +3938,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         if pkg.local_source.is_some() {
                             continue;
                         }
-                        pkg.tarball_url =
-                            Some(post_fetch_client.tarball_url(&pkg.name, &pkg.version));
+                        // Preserve any URL already present — the npm
+                        // lockfile reader stashes the `resolved:` URL
+                        // for aliased entries at parse time because
+                        // `(alias, version)` doesn't resolve against
+                        // the registry.
+                        if pkg.tarball_url.is_none() {
+                            pkg.tarball_url = Some(
+                                post_fetch_client.tarball_url(pkg.registry_name(), &pkg.version),
+                            );
+                        }
                     }
                 }
                 let write_kind = source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube);

--- a/test/package_lock_write.bats
+++ b/test/package_lock_write.bats
@@ -270,3 +270,79 @@ EOF
 	run grep -F "orphan-pkg" pnpm-lock.yaml
 	assert_failure
 }
+
+# Regression: `aube install` must handle npm-style aliases
+# (`"<alias>": "npm:<real>@..."`) captured in package-lock.json. npm
+# writes the entry at `node_modules/<alias>` with `name: "<real>"` and
+# a `resolved:` URL pointing at the *real* package; aube used to treat
+# the alias as the registry name and 404 on fetch. This verifies that
+# install from the captured lockfile completes and that the alias
+# lands as a distinct top-level folder, not as the real package name.
+#
+# Covers the lockfile-driven path (default / `--frozen-lockfile`).
+# A separate fresh-resolve path through the resolver does not yet
+# preserve the alias-as-folder-name — see the TODO in
+# `aube-resolver::task.name` rewriting for `npm:` specifiers.
+@test "aube install handles npm-alias in package-lock.json" {
+	cat >package.json <<'JSON'
+{
+  "name": "alias-via-npm-lock",
+  "version": "1.0.0",
+  "dependencies": {
+    "odd-alias": "npm:is-odd@3.0.1"
+  }
+}
+JSON
+
+	cat >package-lock.json <<'JSON'
+{
+  "name": "alias-via-npm-lock",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "alias-via-npm-lock",
+      "version": "1.0.0",
+      "dependencies": { "odd-alias": "npm:is-odd@3.0.1" }
+    },
+    "node_modules/is-number": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-6.0.0.tgz",
+      "integrity": "sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg=="
+    },
+    "node_modules/odd-alias": {
+      "name": "is-odd",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz",
+      "integrity": "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==",
+      "dependencies": { "is-number": "^6.0.0" }
+    }
+  }
+}
+JSON
+
+	run aube install
+	assert_success
+
+	# The alias is the folder name that node_modules walks see — not
+	# the real package name. A top-level `is-odd` here would mean the
+	# installer collapsed the alias back to the real name, breaking
+	# any `require("odd-alias")` callers.
+	assert_link_exists node_modules/odd-alias
+	assert_not_exists node_modules/is-odd
+
+	# Virtual store entry goes under the alias so transitive
+	# lookups (`require("odd-alias")` from anywhere in the tree)
+	# resolve via the same folder name declared in package.json.
+	assert_dir_exists node_modules/.aube
+
+	# The lockfile's `name:` + `resolved:` fields must survive the
+	# pass-through. Without them a reparse has no way to recover the
+	# real registry identity from the alias-qualified install path.
+	run grep -F '"name": "is-odd"' package-lock.json
+	assert_success
+	run grep -F 'https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz' package-lock.json
+	assert_success
+	assert [ ! -f aube-lock.yaml ]
+}


### PR DESCRIPTION
## Summary

- Fixes `aube install` on any `package-lock.json` that uses an npm alias (`"h3-v2": "npm:h3@..."`) — aube was fetching `registry.npmjs.org/h3-v2/...` and 404'ing. This blocks the TanStack Start starter's `aube i` after `npm install`.
- Adds `LockedPackage.alias_of: Option<String>` + a `registry_name()` helper. When set, `name` is the alias (folder in `node_modules/`), `alias_of` is the real registry name used for tarball fetch / store index / packument lookup, and `version` is the real version. Route every fetch/cache/linker site through the helper; two aliases of the same real package now share one store index entry.
- npm reader populates `alias_of` + captures `resolved:` into `tarball_url` when the install-path segment differs from `entry.name`. npm writer round-trips `name:` + `resolved:` for aliased entries so a reparse still recognizes the alias.
- Pre-existing bug surfaced by the fix: the npm reader was storing full dep_paths (`is-number@6.0.0`) as values in `LockedPackage.dependencies` instead of the tail (`6.0.0`) — both the struct docs and the pnpm reader agree it should be a tail. The linker's sibling-symlink builder recombines `{name}@{tail}`, silently producing broken links like `rolldown@rolldown@1.0.0-rc.15/node_modules/rolldown` on every non-alias npm-lockfile install (most installs "succeeded" with a broken virtual store). Fixed the parser to emit tails; fixed `dep_closure` in `fetch --prod` to recombine because it was compensating for the wrong shape.

## Out of scope (flagged for follow-up)

- `aube dev` on the TanStack Start starter still fails because the npm lockfile doesn't resolve peer deps (`vite` as a peer of `@tanstack/devtools-vite`), and aube's isolated layout needs those as siblings. Fresh-resolve handles peers correctly; lockfile-driven install skips peer resolution.
- Resolver-side alias handling is still broken for fresh resolves: when `task.range` starts with `npm:`, the resolver rewrites `task.name` to the real name and loses the alias, so `node_modules/h3-v2/` becomes `node_modules/h3/`. Separate path from this PR.

## Test plan

- [x] `cargo test -p aube-lockfile --lib` — 121 pass (3 new alias unit tests, 4 existing tests updated to the correct tail shape)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Full BATS suite — 836/836 pass (1 new alias regression test)
- [x] End-to-end: `npm install` + `aube i` on the TanStack Start React starter now succeeds; sibling symlinks under `.aube/` resolve correctly
- [x] Round-trip: `aube i` on an aliased `package-lock.json` preserves `name:` + `resolved:` fields, no surprise `aube-lock.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lockfile parsing/writing and install/fetch/linker cache keying, which can affect dependency resolution and on-disk layouts; risk is mitigated by added unit + integration tests but could still break edge-case npm lockfiles.
> 
> **Overview**
> Fixes npm `package-lock.json` handling for alias dependencies (`"<alias>": "npm:<real>@..."`) by recording the real registry name in a new `LockedPackage.alias_of` field and routing registry/store operations through `LockedPackage::registry_name()`.
> 
> Updates the npm lockfile reader/writer to detect aliases via `name` vs install-path, preserve `resolved` URLs for aliased entries, and round-trip `name`/`resolved` so reparsing still recognizes aliases; fetch/install/linker code now keys store index lookups and strict package-content validation by the registry name while keeping the alias as the `node_modules/` folder name.
> 
> Fixes a bug in npm lockfile parsing where `LockedPackage.dependencies` stored full dep_paths instead of dep-path tails, and updates dependent traversal (`fetch`’s dep-closure) accordingly; adds regression tests (Rust + BATS) covering alias installs and the corrected dependency encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc462f298c3f284188c0185cda9f9718d6634a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->