### PR TITLE
docs: auto-redeploy on bench refresh and sync README ratios

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
       - "aube.usage.kdl"
       - "crates/**"
       - "Cargo.lock"
+      - "benchmarks/results.json"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,14 @@ flock /tmp/aube-bench.lock bench/run.sh
 but manual benchmark commands (hyperfine one-shots, ad-hoc
 `aube install` timing loops, etc.) must take the lock too.
 
+When `mise run bench:bump` rewrites [`benchmarks/results.json`](benchmarks/results.json),
+refresh the hardcoded ratios in [`README.md`](README.md) in the same
+commit. The docs site and landing page pull the numbers from
+`results.json` at VitePress build time, but the README is plain text —
+nothing regenerates it. The `Why Try It` section quotes both the
+warm-CI multiples (pnpm, bun) and the cross-fixture ranges; recompute
+them from the new JSON and update the sentence to match.
+
 ## Rust Configuration
 
 - Edition: 2024

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## Why Try It
 
-**[Fast installs](https://aube.en.dev/benchmarks).** Warm CI is about 9x faster than pnpm and 3x faster than Bun in the current benchmarks. Across the fixture set, aube runs roughly 2-21x faster than pnpm and 1-3x faster than Bun.
+**[Fast installs](https://aube.en.dev/benchmarks).** Warm CI is about 6x faster than pnpm and 2x faster than Bun in the current benchmarks. Across the fixture set, aube runs roughly 2-21x faster than pnpm and 1-2x faster than Bun.
 
 **[Existing lockfiles](https://aube.en.dev/package-manager/lockfiles).** Reads and writes `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock` in place.
 


### PR DESCRIPTION
## Summary

- Add `benchmarks/results.json` to the `docs.yml` push-trigger paths. The landing page (`HomeLanding.vue`) and benchmarks chart read this JSON at VitePress build time, so a bench bump should redeploy the site — previously it only did if the same commit also touched `docs/**`, `aube.usage.kdl`, `crates/**`, or `Cargo.lock`.
- Refresh the hardcoded ratios in `README.md` to match the latest `results.json` (post-`#28`): warm CI drops from ~9× to ~6× vs pnpm and from ~3× to ~2× vs bun; cross-fixture bun range tightens to 1-2×. The pnpm 2-21× range still holds (ci-cold ~2×, install-test ~21×).
- Add a note to `CLAUDE.md` under the Benchmarks section reminding future contributors to recompute the README figures whenever `mise run bench:bump` rewrites the JSON — nothing regenerates the README automatically.

## Test plan

- [ ] CI `docs` workflow triggers and deploys on this PR's merge (touches `.github/workflows/docs.yml` and `benchmarks/results.json` path wasn't added retroactively, but the workflow file change itself fires the trigger).
- [ ] Next bench-only commit to `main` fires the `docs` workflow and the landing page ratios update.
- [ ] Landing page multiples (`pnpmCiWarmMultiple`, `bunCiWarmMultiple`, ranges) continue to match the README after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/CI trigger tweaks with no runtime code changes; main risk is unintended extra docs deployments when `benchmarks/results.json` changes.
> 
> **Overview**
> Docs deployment now triggers when `benchmarks/results.json` changes, ensuring benchmark-only updates redeploy the VitePress site.
> 
> Updates the `README.md` benchmark speedup ratios to match the latest results, and adds a `CLAUDE.md` reminder to keep the README figures in sync whenever `bench:bump` rewrites the JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b539135a59b2b9510f91f554f6db6439570b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->