### PR TITLE
install: auto-disable global virtual store for packages known to break on it

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -336,6 +336,17 @@ impl Linker {
         self
     }
 
+    /// Override the global-virtual-store toggle set by `Linker::new`
+    /// (which looks at `CI`). Callers use this to force per-project
+    /// materialization when they've detected a consumer that breaks on
+    /// directory symlinks escaping the project root — e.g. Next.js /
+    /// Turbopack, which canonicalizes `node_modules/<pkg>` and rejects
+    /// anything that lands outside its declared filesystem root.
+    pub fn with_use_global_virtual_store(mut self, enabled: bool) -> Self {
+        self.use_global_virtual_store = enabled;
+        self
+    }
+
     fn link_parallelism(&self) -> usize {
         self.link_concurrency
             .unwrap_or_else(default_linker_parallelism)

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -28,6 +28,16 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub enable_global_virtual_store: Option<bool>,
 
+    /// Auto-disable the global virtual store when Next.js is detected
+    /// in the root package.json (default: true). Turbopack rejects
+    /// `node_modules/<pkg>` symlinks that canonicalize outside the
+    /// project's filesystem root, which trips on aube's default gvs
+    /// layout. Set `false` to keep gvs enabled even with Next.js
+    /// present. Declared here so `settings.toml`'s workspaceYaml
+    /// source stays in sync with the actual deserialize surface.
+    #[serde(default)]
+    pub auto_disable_global_virtual_store_for_nextjs: Option<bool>,
+
     /// Package import method: "auto", "hardlink", "copy", "clone", "clone-or-copy".
     #[serde(default)]
     pub package_import_method: Option<String>,

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -28,15 +28,17 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub enable_global_virtual_store: Option<bool>,
 
-    /// Auto-disable the global virtual store when Next.js is detected
-    /// in the root package.json (default: true). Turbopack rejects
-    /// `node_modules/<pkg>` symlinks that canonicalize outside the
-    /// project's filesystem root, which trips on aube's default gvs
-    /// layout. Set `false` to keep gvs enabled even with Next.js
-    /// present. Declared here so `settings.toml`'s workspaceYaml
-    /// source stays in sync with the actual deserialize surface.
+    /// Package names whose presence in any importer forces
+    /// per-project materialization (disabling the global virtual
+    /// store for that install). Defaults to `["next"]` — Turbopack
+    /// rejects `node_modules/<pkg>` symlinks that canonicalize
+    /// outside the project's filesystem root. Add more names as
+    /// you discover tools with the same restriction; set to `[]` to
+    /// disable the heuristic. Declared here so `settings.toml`'s
+    /// workspaceYaml source stays in sync with the actual
+    /// deserialize surface.
     #[serde(default)]
-    pub auto_disable_global_virtual_store_for_nextjs: Option<bool>,
+    pub disable_global_virtual_store_for_packages: Option<Vec<String>>,
 
     /// Package import method: "auto", "hardlink", "copy", "clone", "clone-or-copy".
     #[serde(default)]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -598,30 +598,30 @@ examples = []
 # `aube-linker`. The typed accessor would double up on that path.
 typedAccessorUnused = true
 
-[autoDisableGlobalVirtualStoreForNextjs]
-description = "Disable the global virtual store when a Next.js dependency is detected."
-type = "bool"
-default = "true"
+[disableGlobalVirtualStoreForPackages]
+description = "Package names whose presence in any importer forces per-project materialization."
+type = "list<string>"
+default = "[\"next\"]"
 docs = """
-Next.js's Turbopack canonicalizes every symlink under `node_modules/`
-and rejects any target that resolves outside the project's "filesystem
-root". aube's global virtual store makes `node_modules/.aube/<pkg>` an
-absolute symlink into `~/.cache/aube/virtual-store/`, which Turbopack
-then reports as `Symlink ... is invalid, it points out of the
-filesystem root`.
+aube's global virtual store makes `node_modules/.aube/<pkg>` an
+absolute symlink into `~/.cache/aube/virtual-store/`. Some tools —
+most notably Next.js's Turbopack — canonicalize every symlink under
+`node_modules/` and reject any target that resolves outside the
+project's "filesystem root", producing errors like `Symlink ... is
+invalid, it points out of the filesystem root`.
 
-When this setting is `true` (the default) and `aube install` detects
-`next` in the root `package.json`'s dependencies, aube forces
-per-project materialization for this install and prints a one-line
-warning explaining why. Set to `false` to keep the global virtual
-store enabled even when Next.js is present — useful if you're working
-around the Turbopack issue another way (e.g. `next dev --webpack`) and
-want the throughput win.
+When `aube install` finds one of these names in any importer's
+`dependencies`, `devDependencies`, or `optionalDependencies`, it
+forces per-project materialization for that install and prints a
+one-line warning naming the trigger. Defaults to `["next"]`; add
+other packages here as you discover them, or set the list to `[]` to
+disable the heuristic. `CI=1` already forces per-project mode, so the
+warning suppresses itself in that case.
 """
 sources.cli = []
 sources.env = []
-sources.npmrc = ["autoDisableGlobalVirtualStoreForNextjs"]
-sources.workspaceYaml = ["autoDisableGlobalVirtualStoreForNextjs"]
+sources.npmrc = ["disableGlobalVirtualStoreForPackages"]
+sources.workspaceYaml = ["disableGlobalVirtualStoreForPackages"]
 examples = []
 
 # ========================================= Store =========================================

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -598,6 +598,32 @@ examples = []
 # `aube-linker`. The typed accessor would double up on that path.
 typedAccessorUnused = true
 
+[autoDisableGlobalVirtualStoreForNextjs]
+description = "Disable the global virtual store when a Next.js dependency is detected."
+type = "bool"
+default = "true"
+docs = """
+Next.js's Turbopack canonicalizes every symlink under `node_modules/`
+and rejects any target that resolves outside the project's "filesystem
+root". aube's global virtual store makes `node_modules/.aube/<pkg>` an
+absolute symlink into `~/.cache/aube/virtual-store/`, which Turbopack
+then reports as `Symlink ... is invalid, it points out of the
+filesystem root`.
+
+When this setting is `true` (the default) and `aube install` detects
+`next` in the root `package.json`'s dependencies, aube forces
+per-project materialization for this install and prints a one-line
+warning explaining why. Set to `false` to keep the global virtual
+store enabled even when Next.js is present — useful if you're working
+around the Turbopack issue another way (e.g. `next dev --webpack`) and
+want the throughput win.
+"""
+sources.cli = []
+sources.env = []
+sources.npmrc = ["autoDisableGlobalVirtualStoreForNextjs"]
+sources.workspaceYaml = ["autoDisableGlobalVirtualStoreForNextjs"]
+examples = []
+
 # ========================================= Store =========================================
 
 [storeDir]

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -2132,6 +2132,24 @@ fn resolve_exclude_links_from_lockfile(ctx: &aube_settings::ResolveCtx<'_>) -> b
     aube_settings::resolved::exclude_links_from_lockfile(ctx)
 }
 
+/// Does the root / any workspace manifest declare a dependency on
+/// `next`? Next.js's Turbopack canonicalizes every `node_modules/<pkg>`
+/// symlink and rejects targets that escape the project's filesystem
+/// root — aube's global virtual store makes `.aube/<pkg>` an absolute
+/// symlink into `~/.cache/aube/virtual-store/`, which trips that
+/// check. Detection covers `dependencies`, `devDependencies`, and
+/// `optionalDependencies` on every importer in the install so a
+/// monorepo with a Next.js app under any workspace still opts out.
+/// `peerDependencies` intentionally doesn't count — a library that
+/// declares `next` as a peer isn't itself a Next.js app.
+fn manifests_depend_on_nextjs(manifests: &[(String, aube_manifest::PackageJson)]) -> bool {
+    manifests.iter().any(|(_, m)| {
+        m.dependencies.contains_key("next")
+            || m.dev_dependencies.contains_key("next")
+            || m.optional_dependencies.contains_key("next")
+    })
+}
+
 /// Honor `cleanupUnusedCatalogs` by pruning declared-but-unreferenced
 /// catalog entries from the workspace yaml. No-op when the setting is
 /// off, when there is no workspace yaml file on disk, or when every
@@ -3088,6 +3106,37 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             manifests.push((rel_path, pkg_manifest));
         }
     }
+
+    // Auto-disable the global virtual store when Next.js is present in
+    // the dep graph. Turbopack canonicalizes every `node_modules/<pkg>`
+    // symlink and rejects targets outside its "filesystem root" (the
+    // project dir); gvs makes `.aube/<pkg>` an absolute symlink into
+    // `~/.cache/aube/virtual-store/`, which trips that check.
+    // `autoDisableGlobalVirtualStoreForNextjs` (default `true`) is the
+    // escape hatch — flip it off and you keep gvs even with Next.js
+    // present. `CI=1` already forces per-project mode in `Linker::new`,
+    // so we don't warn in that case (the behavior wouldn't change and
+    // the message would just be noise). `virtualStoreOnly` installs
+    // skip the final top-level symlink pass, so Turbopack never sees
+    // the gvs path — the warning would be wrong, so suppress it too.
+    let use_global_virtual_store_override = {
+        let next_js_present = manifests_depend_on_nextjs(&manifests);
+        let auto_disable =
+            aube_settings::resolved::auto_disable_global_virtual_store_for_nextjs(&settings_ctx);
+        let ci_mode = opts
+            .env_snapshot
+            .iter()
+            .any(|(k, _)| k == "CI" || k == "npm_config_ci" || k == "NPM_CONFIG_CI");
+        let virtual_store_only_setting = aube_settings::resolved::virtual_store_only(&settings_ctx);
+        if next_js_present && auto_disable && !ci_mode && !virtual_store_only_setting {
+            tracing::warn!(
+                "Next.js detected in package.json; disabling global virtual store for this install to keep node_modules compatible with Turbopack. Set autoDisableGlobalVirtualStoreForNextjs=false in .npmrc to opt out."
+            );
+            Some(false)
+        } else {
+            None
+        }
+    };
 
     // Remember which lockfile format the project currently uses so
     // every downstream write site (the `--lockfile-only` short-circuit
@@ -4155,6 +4204,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         }
     };
     tracing::debug!("node-linker: {:?}", node_linker);
+
     let mut linker = aube_linker::Linker::new(store.as_ref(), strategy)
         .with_shamefully_hoist(shamefully_hoist)
         .with_public_hoist_pattern(&public_hoist_pattern)
@@ -4168,6 +4218,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         .with_virtual_store_only(virtual_store_only)
         .with_modules_dir_name(modules_dir_name.clone())
         .with_aube_dir_override(aube_dir.clone());
+    if let Some(enabled) = use_global_virtual_store_override {
+        linker = linker.with_use_global_virtual_store(enabled);
+    }
 
     // 6a. Pre-compute content-addressed virtual-store hashes.
     //     Only necessary when linking into the shared global virtual

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -3840,8 +3840,20 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 if !materialize_patches.is_empty() {
                     linker = linker.with_patches(materialize_patches);
                 }
+                // Carry the Next.js / `disableGlobalVirtualStoreForPackages`
+                // override the main linker got — without this the prewarm
+                // linker would still see `gvs = CI.is_err() = true`, spend
+                // the whole fetch phase materializing into
+                // `~/.cache/aube/virtual-store/`, and then throw all of that
+                // work away when link phase runs in per-project mode. The
+                // `!uses_global_virtual_store` short-circuit below depends
+                // on this being applied first.
+                if let Some(enabled) = use_global_virtual_store_override {
+                    linker = linker.with_use_global_virtual_store(enabled);
+                }
                 if !linker.uses_global_virtual_store() {
-                    // CI mode: `.aube/<dep_path>` is per-project so
+                    // Per-project mode (CI=1 or gvs-incompatible package
+                    // detected): `.aube/<dep_path>` is per-project so
                     // prewarming a shared store is pointless. Drain the
                     // channel to unblock the sender and return empty stats.
                     let mut rx = materialize_rx;

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -2132,22 +2132,33 @@ fn resolve_exclude_links_from_lockfile(ctx: &aube_settings::ResolveCtx<'_>) -> b
     aube_settings::resolved::exclude_links_from_lockfile(ctx)
 }
 
-/// Does the root / any workspace manifest declare a dependency on
-/// `next`? Next.js's Turbopack canonicalizes every `node_modules/<pkg>`
-/// symlink and rejects targets that escape the project's filesystem
-/// root — aube's global virtual store makes `.aube/<pkg>` an absolute
-/// symlink into `~/.cache/aube/virtual-store/`, which trips that
-/// check. Detection covers `dependencies`, `devDependencies`, and
-/// `optionalDependencies` on every importer in the install so a
-/// monorepo with a Next.js app under any workspace still opts out.
-/// `peerDependencies` intentionally doesn't count — a library that
-/// declares `next` as a peer isn't itself a Next.js app.
-fn manifests_depend_on_nextjs(manifests: &[(String, aube_manifest::PackageJson)]) -> bool {
-    manifests.iter().any(|(_, m)| {
-        m.dependencies.contains_key("next")
-            || m.dev_dependencies.contains_key("next")
-            || m.optional_dependencies.contains_key("next")
-    })
+/// Scan `manifests` for any `trigger` name that appears in an
+/// importer's `dependencies`, `devDependencies`, or
+/// `optionalDependencies`, and return the first match. Used to power
+/// `disableGlobalVirtualStoreForPackages` — some tools (Next.js's
+/// Turbopack is the canonical example) canonicalize every
+/// `node_modules/<pkg>` symlink and reject targets that escape the
+/// project's filesystem root, which aube's global virtual store
+/// produces by default. When a manifest declares one of those
+/// packages, the install driver falls back to per-project
+/// materialization. `peerDependencies` intentionally doesn't count —
+/// a library that declares `next` as a peer isn't itself a Next.js
+/// app.
+fn find_gvs_incompatible_trigger<'a>(
+    manifests: &[(String, aube_manifest::PackageJson)],
+    triggers: &'a [String],
+) -> Option<&'a str> {
+    for (_, m) in manifests {
+        for name in triggers {
+            if m.dependencies.contains_key(name)
+                || m.dev_dependencies.contains_key(name)
+                || m.optional_dependencies.contains_key(name)
+            {
+                return Some(name.as_str());
+            }
+        }
+    }
+    None
 }
 
 /// Honor `cleanupUnusedCatalogs` by pruning declared-but-unreferenced
@@ -3107,30 +3118,33 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         }
     }
 
-    // Auto-disable the global virtual store when Next.js is present in
-    // the dep graph. Turbopack canonicalizes every `node_modules/<pkg>`
-    // symlink and rejects targets outside its "filesystem root" (the
-    // project dir); gvs makes `.aube/<pkg>` an absolute symlink into
-    // `~/.cache/aube/virtual-store/`, which trips that check.
-    // `autoDisableGlobalVirtualStoreForNextjs` (default `true`) is the
-    // escape hatch — flip it off and you keep gvs even with Next.js
-    // present. `CI=1` already forces per-project mode in `Linker::new`,
-    // so we don't warn in that case (the behavior wouldn't change and
-    // the message would just be noise). `virtualStoreOnly` installs
-    // skip the final top-level symlink pass, so Turbopack never sees
-    // the gvs path — the warning would be wrong, so suppress it too.
+    // Auto-disable the global virtual store when any importer depends
+    // on a package listed in `disableGlobalVirtualStoreForPackages`
+    // (default `["next"]`). Turbopack canonicalizes every
+    // `node_modules/<pkg>` symlink and rejects targets outside the
+    // project dir; gvs makes `.aube/<pkg>` an absolute symlink into
+    // `~/.cache/aube/virtual-store/`, which trips that check. The
+    // list is the extension point — add other tools as they surface.
+    // `CI=1` already forces per-project mode in `Linker::new`, so we
+    // don't warn in that case (behavior wouldn't change and the
+    // message would just be noise). `virtualStoreOnly` installs skip
+    // the final top-level symlink pass, so Turbopack never sees the
+    // gvs path — suppress the warning there too.
+    let gvs_triggers =
+        aube_settings::resolved::disable_global_virtual_store_for_packages(&settings_ctx);
     let use_global_virtual_store_override = {
-        let next_js_present = manifests_depend_on_nextjs(&manifests);
-        let auto_disable =
-            aube_settings::resolved::auto_disable_global_virtual_store_for_nextjs(&settings_ctx);
+        let triggered_by = find_gvs_incompatible_trigger(&manifests, &gvs_triggers);
         let ci_mode = opts
             .env_snapshot
             .iter()
             .any(|(k, _)| k == "CI" || k == "npm_config_ci" || k == "NPM_CONFIG_CI");
         let virtual_store_only_setting = aube_settings::resolved::virtual_store_only(&settings_ctx);
-        if next_js_present && auto_disable && !ci_mode && !virtual_store_only_setting {
+        if let Some(name) = triggered_by
+            && !ci_mode
+            && !virtual_store_only_setting
+        {
             tracing::warn!(
-                "Next.js detected in package.json; disabling global virtual store for this install to keep node_modules compatible with Turbopack. Set autoDisableGlobalVirtualStoreForNextjs=false in .npmrc to opt out."
+                "disabling global virtual store: `{name}` is in disableGlobalVirtualStoreForPackages (packages in that list are known to be incompatible with gvs-linked node_modules, e.g. Next.js's Turbopack rejects symlinks that escape the project root). Set the list to `[]` in .npmrc to opt out."
             );
             Some(false)
         } else {

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -3134,10 +3134,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         aube_settings::resolved::disable_global_virtual_store_for_packages(&settings_ctx);
     let use_global_virtual_store_override = {
         let triggered_by = find_gvs_incompatible_trigger(&manifests, &gvs_triggers);
-        let ci_mode = opts
-            .env_snapshot
-            .iter()
-            .any(|(k, _)| k == "CI" || k == "npm_config_ci" || k == "NPM_CONFIG_CI");
+        // Match `Linker::new`'s exact gvs check — it keys off the `CI`
+        // env var alone, not `npm_config_ci` / `NPM_CONFIG_CI`. Using a
+        // broader set here would silently skip the override (and the
+        // warning) in a scenario where the linker still turns gvs on,
+        // leaving the Turbopack symlink error unmitigated. The snapshot
+        // is populated from `std::env` at `InstallOptions::from_cli`
+        // time, so it reflects the same environment the linker reads.
+        let ci_mode = opts.env_snapshot.iter().any(|(k, _)| k == "CI");
         let virtual_store_only_setting = aube_settings::resolved::virtual_store_only(&settings_ctx);
         if let Some(name) = triggered_by
             && !ci_mode

--- a/docs/settings/env.md
+++ b/docs/settings/env.md
@@ -50,7 +50,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
 | [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
 | [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`autoDisableGlobalVirtualStoreForNextjs`](#setting-autodisableglobalvirtualstorefornextjs) | `bool` | implemented | Disable the global virtual store when a Next.js dependency is detected. |
+| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | implemented | Package names whose presence in any importer forces per-project materialization. |
 | [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
 | [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
 | [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
@@ -677,30 +677,30 @@ It's enabled by default and disabled under CI (see `aube-linker`, which
 checks the `CI` env var). pnpm gained the same feature later; we expose
 it through `CI=1` rather than a dedicated config knob.
 
-### `autoDisableGlobalVirtualStoreForNextjs` {#setting-autodisableglobalvirtualstorefornextjs}
+### `disableGlobalVirtualStoreForPackages` {#setting-disableglobalvirtualstoreforpackages}
 
-Disable the global virtual store when a Next.js dependency is detected.
+Package names whose presence in any importer forces per-project materialization.
 
-- Type: `bool`
-- Default: `true`
+- Type: `list<string>`
+- Default: `["next"]`
 - Status: implemented
 - Added to registry: `2026-04-18`
-- Environment: `npm_config_auto_disable_global_virtual_store_for_nextjs`, `NPM_CONFIG_AUTO_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_NEXTJS`
+- Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
 
-Next.js's Turbopack canonicalizes every symlink under `node_modules/`
-and rejects any target that resolves outside the project's "filesystem
-root". aube's global virtual store makes `node_modules/.aube/<pkg>` an
-absolute symlink into `~/.cache/aube/virtual-store/`, which Turbopack
-then reports as `Symlink ... is invalid, it points out of the
-filesystem root`.
+aube's global virtual store makes `node_modules/.aube/<pkg>` an
+absolute symlink into `~/.cache/aube/virtual-store/`. Some tools —
+most notably Next.js's Turbopack — canonicalize every symlink under
+`node_modules/` and reject any target that resolves outside the
+project's "filesystem root", producing errors like `Symlink ... is
+invalid, it points out of the filesystem root`.
 
-When this setting is `true` (the default) and `aube install` detects
-`next` in the root `package.json`'s dependencies, aube forces
-per-project materialization for this install and prints a one-line
-warning explaining why. Set to `false` to keep the global virtual
-store enabled even when Next.js is present — useful if you're working
-around the Turbopack issue another way (e.g. `next dev --webpack`) and
-want the throughput win.
+When `aube install` finds one of these names in any importer's
+`dependencies`, `devDependencies`, or `optionalDependencies`, it
+forces per-project materialization for that install and prints a
+one-line warning naming the trigger. Defaults to `["next"]`; add
+other packages here as you discover them, or set the list to `[]` to
+disable the heuristic. `CI=1` already forces per-project mode, so the
+warning suppresses itself in that case.
 
 ## Store
 

--- a/docs/settings/env.md
+++ b/docs/settings/env.md
@@ -16,122 +16,123 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-112 settings are listed here.
+113 settings are listed here. 113 are currently implemented.
 
-| Setting | Type | Summary |
-| --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
-| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
-| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
-| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
-| [`symlink`](#setting-symlink) | `bool` | Create symlinks in the virtual store directory. |
-| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | Write files to the modules directory. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
-| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | Max length for virtual store directory names. |
-| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | Populate the virtual store without creating top-level symlinks. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
-| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | Minutes before orphan packages are removed from the virtual store. |
-| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | Minutes before the dlx cache is considered stale. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
-| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
-| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | Only allow installs when the store server is running. |
-| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | Validate package names and versions in the store. |
-| [`httpsProxy`](#setting-httpsproxy) | `url` | Proxy URL for outgoing HTTPS requests. |
-| [`httpProxy`](#setting-httpproxy) | `url` | Proxy URL for outgoing HTTP requests. |
-| [`noProxy`](#setting-noproxy) | `string` | Comma-separated list of domains that bypass the proxy. |
-| [`localAddress`](#setting-localaddress) | `string` | Local interface IP address to bind registry connections to. |
-| [`maxsockets`](#setting-maxsockets) | `int` | Maximum concurrent connections per origin. |
-| [`strictSsl`](#setting-strictssl) | `bool` | Validate SSL certificates for HTTPS requests. |
-| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | Hosts for which aube performs shallow git clones. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
-| [`fetchRetries`](#setting-fetchretries) | `int` | Number of retry attempts for failed registry fetches. |
-| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | Exponential backoff factor for fetch retries. |
-| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | Minimum retry timeout in milliseconds. |
-| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | Maximum retry timeout in milliseconds. |
-| [`fetchTimeout`](#setting-fetchtimeout) | `int` | Max time (ms) to wait for an HTTP request. |
-| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | Warn if a metadata request exceeds this threshold (ms). |
-| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | Warn if download speed falls below this threshold (KiB/s). |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
-| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | Control color output in aube's CLI. |
-| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | Minimum log level to display. |
-| [`useBetaCli`](#setting-usebetacli) | `bool` | Opt into experimental CLI features. |
-| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | Install on all workspace packages by default. |
-| [`engineStrict`](#setting-enginestrict) | `bool` | Fail if a package is incompatible with the current Node version. |
-| [`npmPath`](#setting-npmpath) | `path` | Path to the npm binary aube should shell out to when needed. |
-| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | Enforce the `packageManager` field in package.json. |
-| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | Enforce the exact `packageManager` version from package.json. |
-| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | Auto-download the specified pnpm version when mismatched. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
-| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | Only read from the side-effects cache; don't write. |
-| [`unsafePerm`](#setting-unsafeperm) | `bool` | Drop to a non-root user when running scripts as root. |
-| [`nodeOptions`](#setting-nodeoptions) | `string` | Options passed to Node.js via NODE_OPTIONS. |
-| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | Check dependencies before running scripts. |
-| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | Exit with an error if dependencies have unreviewed build scripts. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
-| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | Allow all dependency build scripts automatically. |
-| [`nodeVersion`](#setting-nodeversion) | `string` | Node.js version aube reports when evaluating `engines` checks. |
-| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | Custom Node.js download mirror URLs. |
-| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | Version prefix used when installing a package. |
-| [`tag`](#setting-tag) | `string` | Default dist-tag used by `aube add` without a version. |
-| [`globalDir`](#setting-globaldir) | `path` | Directory where globally installed packages live. |
-| [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
-| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
-| [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | Directory for package metadata and dlx cache. |
-| [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
-| [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
-| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | Create symlinks instead of shims for `.bin` entries. |
-| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | Disable pnpm's automatic dependency patching database. |
-| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | Dependency version resolution strategy. |
-| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | Whether the configured registry returns a `time` field in metadata. |
-| [`extendNodePath`](#setting-extendnodepath) | `bool` | Set NODE_PATH in command shims. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | Fast-path check before running a full install. |
-| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | Scripts that must be present in every workspace project. |
-| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | Run pre/post scripts automatically when a named script is invoked. |
-| [`scriptShell`](#setting-scriptshell) | `path` | Shell used to invoke package scripts. |
-| [`shellEmulator`](#setting-shellemulator) | `bool` | Use a JavaScript bash-like shell to run scripts cross-platform. |
-| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | How catalog references in package.json are handled by `add`. |
-| [`ci`](#setting-ci) | `bool` | Explicitly mark the environment as CI. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Status | Summary |
+| --- | --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
+| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | implemented | Specify architectures for optional dependency installation. |
+| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | implemented | Skip optional dependencies by name. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`registries`](#setting-registries) | `object` | implemented | Registry URLs, including scoped registry overrides. |
+| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
+| [`symlink`](#setting-symlink) | `bool` | implemented | Create symlinks in the virtual store directory. |
+| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | implemented | Write files to the modules directory. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
+| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | implemented | Max length for virtual store directory names. |
+| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | implemented | Populate the virtual store without creating top-level symlinks. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
+| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
+| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
+| [`autoDisableGlobalVirtualStoreForNextjs`](#setting-autodisableglobalvirtualstorefornextjs) | `bool` | implemented | Disable the global virtual store when a Next.js dependency is detected. |
+| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
+| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
+| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | implemented | Validate package names and versions in the store. |
+| [`httpsProxy`](#setting-httpsproxy) | `url` | implemented | Proxy URL for outgoing HTTPS requests. |
+| [`httpProxy`](#setting-httpproxy) | `url` | implemented | Proxy URL for outgoing HTTP requests. |
+| [`noProxy`](#setting-noproxy) | `string` | implemented | Comma-separated list of domains that bypass the proxy. |
+| [`localAddress`](#setting-localaddress) | `string` | implemented | Local interface IP address to bind registry connections to. |
+| [`maxsockets`](#setting-maxsockets) | `int` | implemented | Maximum concurrent connections per origin. |
+| [`strictSsl`](#setting-strictssl) | `bool` | implemented | Validate SSL certificates for HTTPS requests. |
+| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | implemented | Hosts for which aube performs shallow git clones. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
+| [`fetchRetries`](#setting-fetchretries) | `int` | implemented | Number of retry attempts for failed registry fetches. |
+| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | implemented | Exponential backoff factor for fetch retries. |
+| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | implemented | Minimum retry timeout in milliseconds. |
+| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | implemented | Maximum retry timeout in milliseconds. |
+| [`fetchTimeout`](#setting-fetchtimeout) | `int` | implemented | Max time (ms) to wait for an HTTP request. |
+| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | implemented | Warn if a metadata request exceeds this threshold (ms). |
+| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | implemented | Warn if download speed falls below this threshold (KiB/s). |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
+| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | implemented | Control color output in aube's CLI. |
+| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | implemented | Minimum log level to display. |
+| [`useBetaCli`](#setting-usebetacli) | `bool` | implemented | Opt into experimental CLI features. |
+| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | implemented | Install on all workspace packages by default. |
+| [`engineStrict`](#setting-enginestrict) | `bool` | implemented | Fail if a package is incompatible with the current Node version. |
+| [`npmPath`](#setting-npmpath) | `path` | implemented | Path to the npm binary aube should shell out to when needed. |
+| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | implemented | Enforce the `packageManager` field in package.json. |
+| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | implemented | Enforce the exact `packageManager` version from package.json. |
+| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | implemented | Auto-download the specified pnpm version when mismatched. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
+| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | implemented | Only read from the side-effects cache; don't write. |
+| [`unsafePerm`](#setting-unsafeperm) | `bool` | implemented | Drop to a non-root user when running scripts as root. |
+| [`nodeOptions`](#setting-nodeoptions) | `string` | implemented | Options passed to Node.js via NODE_OPTIONS. |
+| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | implemented | Check dependencies before running scripts. |
+| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | implemented | Exit with an error if dependencies have unreviewed build scripts. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
+| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | implemented | Allow all dependency build scripts automatically. |
+| [`nodeVersion`](#setting-nodeversion) | `string` | implemented | Node.js version aube reports when evaluating `engines` checks. |
+| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | implemented | Custom Node.js download mirror URLs. |
+| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | implemented | Version prefix used when installing a package. |
+| [`tag`](#setting-tag) | `string` | implemented | Default dist-tag used by `aube add` without a version. |
+| [`globalDir`](#setting-globaldir) | `path` | implemented | Directory where globally installed packages live. |
+| [`globalBinDir`](#setting-globalbindir) | `path` | implemented | Directory where global binaries are symlinked. |
+| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | implemented | Path to an additional .npmrc file consulted for registry authentication tokens. |
+| [`stateDir`](#setting-statedir) | `path` | implemented | Directory for aube install-state files. |
+| [`cacheDir`](#setting-cachedir) | `path` | implemented | Directory for package metadata and dlx cache. |
+| [`useStderr`](#setting-usestderr) | `bool` | implemented | Write all output to stderr instead of stdout. |
+| [`updateNotifier`](#setting-updatenotifier) | `bool` | implemented | Show an update notification when a newer aube is available. |
+| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | implemented | Create symlinks instead of shims for `.bin` entries. |
+| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | implemented | Disable pnpm's automatic dependency patching database. |
+| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | implemented | Dependency version resolution strategy. |
+| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | implemented | Whether the configured registry returns a `time` field in metadata. |
+| [`extendNodePath`](#setting-extendnodepath) | `bool` | implemented | Set NODE_PATH in command shims. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | implemented | Fast-path check before running a full install. |
+| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | implemented | Scripts that must be present in every workspace project. |
+| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | implemented | Run pre/post scripts automatically when a named script is invoked. |
+| [`scriptShell`](#setting-scriptshell) | `path` | implemented | Shell used to invoke package scripts. |
+| [`shellEmulator`](#setting-shellemulator) | `bool` | implemented | Use a JavaScript bash-like shell to run scripts cross-platform. |
+| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | implemented | How catalog references in package.json are handled by `add`. |
+| [`ci`](#setting-ci) | `bool` | implemented | Explicitly mark the environment as CI. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -141,6 +142,8 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_overrides`, `NPM_CONFIG_OVERRIDES`
 
 A root-level map of package specs to the versions aube should force them
@@ -154,6 +157,8 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_extensions`, `NPM_CONFIG_PACKAGE_EXTENSIONS`
 
 Patches a package's `dependencies`, `peerDependencies`, etc. at resolve
@@ -166,6 +171,8 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_allowed_deprecated_versions`, `NPM_CONFIG_ALLOWED_DEPRECATED_VERSIONS`
 
 Maps a package name to a semver range for which the deprecation warning
@@ -178,6 +185,8 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_update_config_ignore_dependencies`, `NPM_CONFIG_UPDATE_CONFIG_IGNORE_DEPENDENCIES`
 
 Packages in this list are never bumped by `aube update`, even when a
@@ -189,6 +198,8 @@ Specify architectures for optional dependency installation.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_supported_architectures`, `NPM_CONFIG_SUPPORTED_ARCHITECTURES`
 
 Override the current platform/arch/libc triple used to filter optional
@@ -201,6 +212,8 @@ Skip optional dependencies by name.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_ignored_optional_dependencies`, `NPM_CONFIG_IGNORED_OPTIONAL_DEPENDENCIES`
 
 Named entries are skipped even if their platform/arch matches. Distinct
@@ -212,6 +225,8 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_minimum_release_age`, `NPM_CONFIG_MINIMUM_RELEASE_AGE`
 
 Supply-chain attack mitigation: packages published within the last N
@@ -226,6 +241,8 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_minimum_release_age_exclude`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE`
 
 Use for trusted internal packages that need to be rolled out immediately
@@ -238,6 +255,8 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_minimum_release_age_strict`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_STRICT`
 
 By default the resolver falls back to the lowest satisfying version when
@@ -250,6 +269,8 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_trust_policy`, `NPM_CONFIG_TRUST_POLICY`
 
 When set to `no-downgrade`, aube accepts and preserves the policy in the
@@ -263,6 +284,8 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_trust_policy_exclude`, `NPM_CONFIG_TRUST_POLICY_EXCLUDE`
 
 Whitelist for `trustPolicy`. Entries skip the downgrade check.
@@ -273,6 +296,8 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_trust_policy_ignore_after`, `NPM_CONFIG_TRUST_POLICY_IGNORE_AFTER`
 
 Useful for pinning very old versions that predate signing infrastructure.
@@ -283,6 +308,8 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_block_exotic_subdeps`, `NPM_CONFIG_BLOCK_EXOTIC_SUBDEPS`
 
 When true, transitive deps referenced via `git+`, `file:`, or direct
@@ -295,6 +322,8 @@ Registry URLs, including scoped registry overrides.
 
 - Type: `object`
 - Default: `{ default = "https://registry.npmjs.org/" }`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_registries`, `NPM_CONFIG_REGISTRIES`
 
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
@@ -315,6 +344,8 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_hoist`, `NPM_CONFIG_HOIST`
 
 Controls whether aube populates `node_modules/.aube/node_modules/` —
@@ -343,6 +374,8 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_hoist_workspace_packages`, `NPM_CONFIG_HOIST_WORKSPACE_PACKAGES`
 
 Controls whether workspace packages get their own symlinks in each
@@ -359,6 +392,8 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_hoist_pattern`, `NPM_CONFIG_HOIST_PATTERN`
 
 Glob list matched against package names. Any non-local package
@@ -380,6 +415,8 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
+- Status: implemented
+- Added to registry: `2026-04-13`
 - Environment: `npm_config_public_hoist_pattern`, `NPM_CONFIG_PUBLIC_HOIST_PATTERN`
 
 Glob list matched against package names. Any non-local package in the
@@ -399,6 +436,8 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_shamefully_hoist`, `NPM_CONFIG_SHAMEFULLY_HOIST`
 
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
@@ -412,6 +451,8 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
+- Status: implemented
+- Added to registry: `2026-04-17`
 - Environment: `npm_config_modules_dir`, `NPM_CONFIG_MODULES_DIR`
 
 The project-level directory that holds the top-level `<name>` entries
@@ -436,6 +477,8 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_node_linker`, `NPM_CONFIG_NODE_LINKER`
 
 aube defaults to `isolated`, a strict symlink layout under
@@ -450,6 +493,8 @@ Create symlinks in the virtual store directory.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_symlink`, `NPM_CONFIG_SYMLINK`
 
 Accepted for pnpm parity. aube's isolated layout is structurally
@@ -478,6 +523,8 @@ Write files to the modules directory.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_enable_modules_dir`, `NPM_CONFIG_ENABLE_MODULES_DIR`
 
 When `false`, aube resolves the dependency graph and writes
@@ -493,6 +540,8 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_virtual_store_dir`, `NPM_CONFIG_VIRTUAL_STORE_DIR`
 
 Relocates the per-project `.aube/<dep>/node_modules/` tree that the
@@ -521,6 +570,8 @@ Max length for virtual store directory names.
 
 - Type: `int`
 - Default: `120 (Linux/macOS), 60 (Windows)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_virtual_store_dir_max_length`, `NPM_CONFIG_VIRTUAL_STORE_DIR_MAX_LENGTH`
 
 Caps the number of characters in a single `node_modules/.aube/<dep>`
@@ -538,6 +589,8 @@ Populate the virtual store without creating top-level symlinks.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_virtual_store_only`, `NPM_CONFIG_VIRTUAL_STORE_ONLY`
 
 When `true`, aube still materializes every package into
@@ -556,6 +609,8 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_import_method`, `NPM_CONFIG_PACKAGE_IMPORT_METHOD`
 
 Controls how aube materializes files from the global content-addressable
@@ -575,6 +630,8 @@ Minutes before orphan packages are removed from the virtual store.
 
 - Type: `int`
 - Default: `10080`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_modules_cache_max_age`, `NPM_CONFIG_MODULES_CACHE_MAX_AGE`
 
 After each successful install, aube sweeps the per-project
@@ -594,6 +651,8 @@ Minutes before the dlx cache is considered stale.
 
 - Type: `int`
 - Default: `1440`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_dlx_cache_max_age`, `NPM_CONFIG_DLX_CACHE_MAX_AGE`
 
 Accepted for pnpm parity. `aube dlx` currently installs into a fresh
@@ -609,12 +668,39 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `CI`, `npm_config_enable_global_virtual_store`, `NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
 It's enabled by default and disabled under CI (see `aube-linker`, which
 checks the `CI` env var). pnpm gained the same feature later; we expose
 it through `CI=1` rather than a dedicated config knob.
+
+### `autoDisableGlobalVirtualStoreForNextjs` {#setting-autodisableglobalvirtualstorefornextjs}
+
+Disable the global virtual store when a Next.js dependency is detected.
+
+- Type: `bool`
+- Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-18`
+- Environment: `npm_config_auto_disable_global_virtual_store_for_nextjs`, `NPM_CONFIG_AUTO_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_NEXTJS`
+
+Next.js's Turbopack canonicalizes every symlink under `node_modules/`
+and rejects any target that resolves outside the project's "filesystem
+root". aube's global virtual store makes `node_modules/.aube/<pkg>` an
+absolute symlink into `~/.cache/aube/virtual-store/`, which Turbopack
+then reports as `Symlink ... is invalid, it points out of the
+filesystem root`.
+
+When this setting is `true` (the default) and `aube install` detects
+`next` in the root `package.json`'s dependencies, aube forces
+per-project materialization for this install and prints a one-line
+warning explaining why. Set to `false` to keep the global virtual
+store enabled even when Next.js is present — useful if you're working
+around the Turbopack issue another way (e.g. `next dev --webpack`) and
+want the throughput win.
 
 ## Store
 
@@ -624,6 +710,8 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_store_dir`, `NPM_CONFIG_STORE_DIR`
 
 Defaults to aube's own store path (`~/.aube-store/v1/files/`). aube does not
@@ -651,6 +739,8 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_verify_store_integrity`, `NPM_CONFIG_VERIFY_STORE_INTEGRITY`
 
 aube verifies each package's `integrity` (SHA-512) against the tarball
@@ -670,6 +760,8 @@ Only allow installs when the store server is running.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_use_running_store_server`, `NPM_CONFIG_USE_RUNNING_STORE_SERVER`
 
 Accepted for pnpm parity. aube has no long-running store-daemon
@@ -685,6 +777,8 @@ Validate package names and versions in the store.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_store_pkg_content_check`, `NPM_CONFIG_STRICT_STORE_PKG_CONTENT_CHECK`
 
 After each registry tarball is imported, aube reads the freshly stored
@@ -711,6 +805,8 @@ Proxy URL for outgoing HTTPS requests.
 
 - Type: `url`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `HTTPS_PROXY`, `https_proxy`, `npm_config_https_proxy`, `NPM_CONFIG_HTTPS_PROXY`
 
 Forwards every HTTPS registry fetch through the given proxy URL.
@@ -724,6 +820,8 @@ Proxy URL for outgoing HTTP requests.
 
 - Type: `url`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `HTTP_PROXY`, `http_proxy`, `PROXY`, `proxy`, `npm_config_http_proxy`, `NPM_CONFIG_HTTP_PROXY`
 
 HTTP counterpart to `httpsProxy`. Resolution mirrors pnpm:
@@ -738,6 +836,8 @@ Comma-separated list of domains that bypass the proxy.
 
 - Type: `string`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `NO_PROXY`, `no_proxy`, `npm_config_no_proxy`, `NPM_CONFIG_NO_PROXY`
 
 Passed through to `reqwest::NoProxy::from_string` verbatim, so
@@ -751,6 +851,8 @@ Local interface IP address to bind registry connections to.
 
 - Type: `string`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_local_address`, `NPM_CONFIG_LOCAL_ADDRESS`
 
 Used on multi-homed hosts where outbound traffic must leave a
@@ -763,6 +865,8 @@ Maximum concurrent connections per origin.
 
 - Type: `int`
 - Default: `networkConcurrency x 3`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_maxsockets`, `NPM_CONFIG_MAXSOCKETS`
 
 Plumbed into reqwest's `pool_max_idle_per_host`. This is the
@@ -776,6 +880,8 @@ Validate SSL certificates for HTTPS requests.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_ssl`, `NPM_CONFIG_STRICT_SSL`
 
 Defaults to `true`. Setting `strict-ssl=false` disables TLS
@@ -792,6 +898,8 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_lockfile`, `NPM_CONFIG_LOCKFILE`
 
 Controls whether aube reads and writes a lockfile during install. When
@@ -816,6 +924,8 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_prefer_frozen_lockfile`, `NPM_CONFIG_PREFER_FROZEN_LOCKFILE`
 
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
@@ -832,6 +942,8 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_lockfile_include_tarball_url`, `NPM_CONFIG_LOCKFILE_INCLUDE_TARBALL_URL`
 
 When true, aube's lockfile writer records the registry tarball URL in
@@ -859,6 +971,8 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-13`
 - Environment: `npm_config_exclude_links_from_lockfile`, `NPM_CONFIG_EXCLUDE_LINKS_FROM_LOCKFILE`
 
 When true, `link:` dependencies are omitted from the lockfile's
@@ -879,6 +993,8 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_git_branch_lockfile`, `NPM_CONFIG_GIT_BRANCH_LOCKFILE`
 
 When enabled, aube writes the lockfile to `aube-lock.<branch>.yaml`
@@ -906,6 +1022,8 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_merge_git_branch_lockfiles_branch_pattern`, `NPM_CONFIG_MERGE_GIT_BRANCH_LOCKFILES_BRANCH_PATTERN`
 
 Complements `gitBranchLockfile`. Accepts a list of glob patterns. When
@@ -936,6 +1054,8 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_peers_suffix_max_length`, `NPM_CONFIG_PEERS_SUFFIX_MAX_LENGTH`
 
 Caps the length of the peer-ID suffix appended to a `dep_path` in the
@@ -956,6 +1076,8 @@ Hosts for which aube performs shallow git clones.
 
 - Type: `list<string>`
 - Default: `["github.com", "gist.github.com", "gitlab.com", "bitbucket.com", "bitbucket.org"]`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_git_shallow_hosts`, `NPM_CONFIG_GIT_SHALLOW_HOSTS`
 
 Consulted by `aube-store::git_shallow_clone` when cloning a git
@@ -979,6 +1101,8 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_network_concurrency`, `NPM_CONFIG_NETWORK_CONCURRENCY`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
@@ -1000,6 +1124,8 @@ Number of retry attempts for failed registry fetches.
 
 - Type: `int`
 - Default: `2`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retries`, `NPM_CONFIG_FETCH_RETRIES`
 
 Number of *additional* attempts the registry client makes after a
@@ -1018,6 +1144,8 @@ Exponential backoff factor for fetch retries.
 
 - Type: `int`
 - Default: `10`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retry_factor`, `NPM_CONFIG_FETCH_RETRY_FACTOR`
 
 Multiplier used between retry attempts. Attempt `n` waits
@@ -1031,6 +1159,8 @@ Minimum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `10000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retry_mintimeout`, `NPM_CONFIG_FETCH_RETRY_MINTIMEOUT`
 
 Lower bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1041,6 +1171,8 @@ Maximum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `60000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retry_maxtimeout`, `NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT`
 
 Upper bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1051,6 +1183,8 @@ Max time (ms) to wait for an HTTP request.
 
 - Type: `int`
 - Default: `60000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_timeout`, `NPM_CONFIG_FETCH_TIMEOUT`
 
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
@@ -1064,6 +1198,8 @@ Warn if a metadata request exceeds this threshold (ms).
 
 - Type: `int`
 - Default: `10000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_warn_timeout_ms`, `NPM_CONFIG_FETCH_WARN_TIMEOUT_MS`
 
 Observability threshold for registry *metadata* requests (packument,
@@ -1083,6 +1219,8 @@ Warn if download speed falls below this threshold (KiB/s).
 
 - Type: `int`
 - Default: `50`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_min_speed_ki_bps`, `NPM_CONFIG_FETCH_MIN_SPEED_KI_BPS`
 
 Observability threshold for *tarball* downloads. When a tarball
@@ -1104,6 +1242,8 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_auto_install_peers`, `NPM_CONFIG_AUTO_INSTALL_PEERS`
 
 When true (the default), missing peer dependencies are auto-installed
@@ -1117,6 +1257,8 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_dedupe_peer_dependents`, `NPM_CONFIG_DEDUPE_PEER_DEPENDENTS`
 
 When true (the default), aube collapses packages that landed at
@@ -1133,6 +1275,8 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_dedupe_peers`, `NPM_CONFIG_DEDUPE_PEERS`
 
 When true, lockfile peer suffixes emit `(18.2.0)` instead of the
@@ -1147,6 +1291,8 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_peer_dependencies`, `NPM_CONFIG_STRICT_PEER_DEPENDENCIES`
 
 When true, any unmet peer dependency (missing, or resolved to a version
@@ -1163,6 +1309,8 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_resolve_peers_from_workspace_root`, `NPM_CONFIG_RESOLVE_PEERS_FROM_WORKSPACE_ROOT`
 
 When true (the default), an unresolved peer falls back to the root
@@ -1178,6 +1326,8 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_peer_dependency_rules_ignore_missing`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_IGNORE_MISSING`
 
 Glob list of peer dependency names whose "missing required peer" warning
@@ -1194,6 +1344,8 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_peer_dependency_rules_allowed_versions`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOWED_VERSIONS`
 
 Map of peer selector to an additional semver range. Keys are either a
@@ -1211,6 +1363,8 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_peer_dependency_rules_allow_any`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOW_ANY`
 
 Glob list of peer dependency names whose semver check should be
@@ -1228,6 +1382,8 @@ Control color output in aube's CLI.
 
 - Type: `"auto" | "always" | "never"`
 - Default: `"auto"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_color`, `NPM_CONFIG_COLOR`
 
 `--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree.
@@ -1238,6 +1394,8 @@ Minimum log level to display.
 
 - Type: `"debug" | "info" | "warn" | "error" | "silent"`
 - Default: `"warn"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_loglevel`, `NPM_CONFIG_LOGLEVEL`
 
 Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`.
@@ -1248,6 +1406,8 @@ Opt into experimental CLI features.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_use_beta_cli`, `NPM_CONFIG_USE_BETA_CLI`
 
 Accepted from env and `.npmrc` for pnpm parity. aube currently has no beta-gated commands, so the setting is a no-op after validation.
@@ -1258,6 +1418,8 @@ Install on all workspace packages by default.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_recursive_install`, `NPM_CONFIG_RECURSIVE_INSTALL`
 
 When true, workspace installs resolve and link all importers by default. Set to false to opt out of implicit workspace-wide install behavior; explicit `--filter` / `--recursive` still wins.
@@ -1268,6 +1430,8 @@ Fail if a package is incompatible with the current Node version.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_engine_strict`, `NPM_CONFIG_ENGINE_STRICT`
 
 When on, an `engines.node` mismatch on the root project or any dependency fails the install. When off, mismatches are warnings only.
@@ -1278,6 +1442,8 @@ Path to the npm binary aube should shell out to when needed.
 
 - Type: `path`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_npm_path`, `NPM_CONFIG_NPM_PATH`
 
 Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`, `token`, `whoami`) when configured. Without it, aube keeps the explicit `use npm` error.
@@ -1288,6 +1454,8 @@ Enforce the `packageManager` field in package.json.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_manager_strict`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT`
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
@@ -1298,6 +1466,8 @@ Enforce the exact `packageManager` version from package.json.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_manager_strict_version`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION`
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
@@ -1308,6 +1478,8 @@ Auto-download the specified pnpm version when mismatched.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_manage_package_manager_versions`, `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS`
 
 Accepted for pnpm parity. aube does not download or re-exec other package-manager versions; when exact version enforcement is enabled, mismatches are reported instead.
@@ -1320,6 +1492,8 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_ignore_scripts`, `NPM_CONFIG_IGNORE_SCRIPTS`
 
 aube already skips dependency install scripts by default (security-first).
@@ -1338,6 +1512,8 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_child_concurrency`, `NPM_CONFIG_CHILD_CONCURRENCY`
 
 Caps how many dependency lifecycle scripts run in parallel during the
@@ -1357,6 +1533,8 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_side_effects_cache`, `NPM_CONFIG_SIDE_EFFECTS_CACHE`
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
@@ -1378,6 +1556,8 @@ Only read from the side-effects cache; don't write.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_side_effects_cache_readonly`, `NPM_CONFIG_SIDE_EFFECTS_CACHE_READONLY`
 
 When true, aube may restore allowlisted dependency build output from the
@@ -1389,6 +1569,8 @@ Drop to a non-root user when running scripts as root.
 
 - Type: `bool`
 - Default: `false (as root), true (otherwise)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_unsafe_perm`, `NPM_CONFIG_UNSAFE_PERM`
 
 aube exports the resolved value to lifecycle and `run` scripts as
@@ -1401,6 +1583,8 @@ Options passed to Node.js via NODE_OPTIONS.
 
 - Type: `string`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `NODE_OPTIONS`, `npm_config_node_options`, `NPM_CONFIG_NODE_OPTIONS`
 
 When set in `.npmrc`, aube exports the value as `NODE_OPTIONS` for
@@ -1413,6 +1597,8 @@ Check dependencies before running scripts.
 
 - Type: `"install" | "warn" | "error" | "prompt" | false`
 - Default: `"install"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_verify_deps_before_run`, `NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN`
 
 Controls `run`, lifecycle shortcuts, `exec`, and implicit script commands.
@@ -1426,6 +1612,8 @@ Exit with an error if dependencies have unreviewed build scripts.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_dep_builds`, `NPM_CONFIG_STRICT_DEP_BUILDS`
 
 aube never runs dependency lifecycle scripts unless the package is
@@ -1442,6 +1630,8 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_allow_builds`, `NPM_CONFIG_ALLOW_BUILDS`
 
 Per-package allowlist for dependency lifecycle scripts. Read from
@@ -1461,6 +1651,8 @@ Allow all dependency build scripts automatically.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_dangerously_allow_all_builds`, `NPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS`
 
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
@@ -1481,6 +1673,8 @@ Node.js version aube reports when evaluating `engines` checks.
 
 - Type: `string`
 - Default: `` output of `node -v` with the leading `v` stripped ``
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_node_version`, `NPM_CONFIG_NODE_VERSION`
 
 Paired with `engineStrict`. Set this in .npmrc to pin the Node version engines checks validate against, rather than probing `node --version` at install time.
@@ -1491,6 +1685,8 @@ Custom Node.js download mirror URLs.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_node_download_mirrors`, `NPM_CONFIG_NODE_DOWNLOAD_MIRRORS`
 
 Accepted for pnpm config parity. aube does not download Node.js itself,
@@ -1505,6 +1701,8 @@ Version prefix used when installing a package.
 
 - Type: `"^" | "~" | ""`
 - Default: `"^"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_save_prefix`, `NPM_CONFIG_SAVE_PREFIX`
 
 Resolved from `.npmrc`. `--save-exact` overrides to empty prefix.
@@ -1515,6 +1713,8 @@ Default dist-tag used by `aube add` without a version.
 
 - Type: `string`
 - Default: `"latest"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_tag`, `NPM_CONFIG_TAG`
 
 Resolved from `.npmrc`. Used by `aube add` when no version or dist-tag is specified.
@@ -1525,6 +1725,8 @@ Directory where globally installed packages live.
 
 - Type: `path`
 - Default: `platform-specific`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_global_dir`, `NPM_CONFIG_GLOBAL_DIR`
 
 Overrides the directory where globally installed packages live. Falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1535,6 +1737,8 @@ Directory where global binaries are symlinked.
 
 - Type: `path`
 - Default: `platform-specific`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_global_bin_dir`, `NPM_CONFIG_GLOBAL_BIN_DIR`
 
 Overrides the directory where global binaries are symlinked. Independent of `globalDir`; falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1545,6 +1749,8 @@ Path to an additional .npmrc file consulted for registry authentication tokens.
 
 - Type: `path`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_npmrc_auth_file`, `NPM_CONFIG_NPMRC_AUTH_FILE`
 
 Points at an extra `.npmrc`-formatted file that aube reads *after*
@@ -1572,6 +1778,8 @@ Directory for aube install-state files.
 
 - Type: `path`
 - Default: `.aube/.state`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_state_dir`, `NPM_CONFIG_STATE_DIR`
 
 Overrides the directory for install state tracking. Defaults to `.aube/.state` relative to the project root.
@@ -1582,6 +1790,8 @@ Directory for package metadata and dlx cache.
 
 - Type: `path`
 - Default: `~/.cache/aube`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_cache_dir`, `NPM_CONFIG_CACHE_DIR`
 
 Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path.
@@ -1592,6 +1802,8 @@ Write all output to stderr instead of stdout.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_use_stderr`, `NPM_CONFIG_USE_STDERR`
 
 Redirects stdout to stderr for the process lifetime. Resolved from `.npmrc` or the `--use-stderr` CLI flag.
@@ -1602,6 +1814,8 @@ Show an update notification when a newer aube is available.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_update_notifier`, `NPM_CONFIG_UPDATE_NOTIFIER`
 
 After a successful `install`, `add`, or `update`, aube fetches
@@ -1621,6 +1835,8 @@ Create symlinks instead of shims for `.bin` entries.
 
 - Type: `bool`
 - Default: `true (POSIX hoisted)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_prefer_symlinked_executables`, `NPM_CONFIG_PREFER_SYMLINKED_EXECUTABLES`
 
 POSIX only. Default (unset or `true`) creates a plain symlink from
@@ -1638,6 +1854,8 @@ Disable pnpm's automatic dependency patching database.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_ignore_compatibility_db`, `NPM_CONFIG_IGNORE_COMPATIBILITY_DB`
 
 Accepted for pnpm config parity. pnpm ships a built-in compatibility
@@ -1651,6 +1869,8 @@ Dependency version resolution strategy.
 
 - Type: `"highest" | "time-based" | "lowest-direct"`
 - Default: `"highest"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_resolution_mode`, `NPM_CONFIG_RESOLUTION_MODE`
 
 Controls how aube chooses versions during resolution. `highest` picks
@@ -1665,6 +1885,8 @@ Whether the configured registry returns a `time` field in metadata.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_registry_supports_time_field`, `NPM_CONFIG_REGISTRY_SUPPORTS_TIME_FIELD`
 
 When `false` (the default, matching pnpm and npmjs.org's behavior),
@@ -1690,6 +1912,8 @@ Set NODE_PATH in command shims.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_extend_node_path`, `NPM_CONFIG_EXTEND_NODE_PATH`
 
 When `true` (default), aube-generated `.bin` shims export
@@ -1707,6 +1931,8 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_deploy_all_files`, `NPM_CONFIG_DEPLOY_ALL_FILES`
 
 When true, `aube deploy` copies every file in the source workspace
@@ -1725,6 +1951,8 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_dedupe_direct_deps`, `NPM_CONFIG_DEDUPE_DIRECT_DEPS`
 
 When true, the linker skips creating a `node_modules/<name>` symlink in a
@@ -1743,6 +1971,8 @@ Fast-path check before running a full install.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_optimistic_repeat_install`, `NPM_CONFIG_OPTIMISTIC_REPEAT_INSTALL`
 
 When `true` (default), `aube run` / `aube exec` / `aube start` /
@@ -1760,6 +1990,8 @@ Scripts that must be present in every workspace project.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_required_scripts`, `NPM_CONFIG_REQUIRED_SCRIPTS`
 
 During install, aube verifies that the root package and every discovered
@@ -1771,6 +2003,8 @@ Run pre/post scripts automatically when a named script is invoked.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_enable_pre_post_scripts`, `NPM_CONFIG_ENABLE_PRE_POST_SCRIPTS`
 
 Controls whether `aube run build` also runs `prebuild` before `build`
@@ -1782,6 +2016,8 @@ Shell used to invoke package scripts.
 
 - Type: `path`
 - Default: `null (uses /bin/sh on Unix, cmd on Windows)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_script_shell`, `NPM_CONFIG_SCRIPT_SHELL`
 
 Overrides the shell executable used for lifecycle and `aube run`
@@ -1793,6 +2029,8 @@ Use a JavaScript bash-like shell to run scripts cross-platform.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_shell_emulator`, `NPM_CONFIG_SHELL_EMULATOR`
 
 Accepted for pnpm config parity. aube does not embed pnpm's JavaScript
@@ -1805,6 +2043,8 @@ How catalog references in package.json are handled by `add`.
 
 - Type: `"manual" | "strict" | "prefer"`
 - Default: `"manual"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_catalog_mode`, `NPM_CONFIG_CATALOG_MODE`
 
 `manual` (the default) writes whatever range `aube add` resolved, even
@@ -1828,6 +2068,8 @@ Explicitly mark the environment as CI.
 
 - Type: `bool`
 - Default: `auto-detected`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `CI`, `npm_config_ci`, `NPM_CONFIG_CI`
 
 aube detects CI via `env::var("CI").is_ok()` in two places:
@@ -1844,6 +2086,8 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `npm_config_cleanup_unused_catalogs`, `NPM_CONFIG_CLEANUP_UNUSED_CATALOGS`
 
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
@@ -1862,6 +2106,8 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
+- Status: implemented
+- Added to registry: `2026-04-17`
 - Environment: `AUBE_LINK_CONCURRENCY`, `npm_config_link_concurrency`, `NPM_CONFIG_LINK_CONCURRENCY`
 
 Caps the dedicated linker worker pool used for filesystem-heavy
@@ -1884,6 +2130,8 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `AUBE_NO_LOCK`, `npm_config_aube_no_lock`, `NPM_CONFIG_AUBE_NO_LOCK`
 
 aube takes an advisory lock on `node_modules/` at the start of every
@@ -1914,6 +2162,8 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Environment: `AUBE_NO_AUTO_INSTALL`, `npm_config_aube_no_auto_install`, `NPM_CONFIG_AUBE_NO_AUTO_INSTALL`
 
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs

--- a/docs/settings/env.md
+++ b/docs/settings/env.md
@@ -16,123 +16,123 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-113 settings are listed here. 113 are currently implemented.
+113 settings are listed here.
 
-| Setting | Type | Status | Summary |
-| --- | --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
-| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | implemented | Specify architectures for optional dependency installation. |
-| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | implemented | Skip optional dependencies by name. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`registries`](#setting-registries) | `object` | implemented | Registry URLs, including scoped registry overrides. |
-| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
-| [`symlink`](#setting-symlink) | `bool` | implemented | Create symlinks in the virtual store directory. |
-| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | implemented | Write files to the modules directory. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
-| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | implemented | Max length for virtual store directory names. |
-| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | implemented | Populate the virtual store without creating top-level symlinks. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
-| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
-| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | implemented | Package names whose presence in any importer forces per-project materialization. |
-| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
-| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
-| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | implemented | Validate package names and versions in the store. |
-| [`httpsProxy`](#setting-httpsproxy) | `url` | implemented | Proxy URL for outgoing HTTPS requests. |
-| [`httpProxy`](#setting-httpproxy) | `url` | implemented | Proxy URL for outgoing HTTP requests. |
-| [`noProxy`](#setting-noproxy) | `string` | implemented | Comma-separated list of domains that bypass the proxy. |
-| [`localAddress`](#setting-localaddress) | `string` | implemented | Local interface IP address to bind registry connections to. |
-| [`maxsockets`](#setting-maxsockets) | `int` | implemented | Maximum concurrent connections per origin. |
-| [`strictSsl`](#setting-strictssl) | `bool` | implemented | Validate SSL certificates for HTTPS requests. |
-| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | implemented | Hosts for which aube performs shallow git clones. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
-| [`fetchRetries`](#setting-fetchretries) | `int` | implemented | Number of retry attempts for failed registry fetches. |
-| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | implemented | Exponential backoff factor for fetch retries. |
-| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | implemented | Minimum retry timeout in milliseconds. |
-| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | implemented | Maximum retry timeout in milliseconds. |
-| [`fetchTimeout`](#setting-fetchtimeout) | `int` | implemented | Max time (ms) to wait for an HTTP request. |
-| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | implemented | Warn if a metadata request exceeds this threshold (ms). |
-| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | implemented | Warn if download speed falls below this threshold (KiB/s). |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
-| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | implemented | Control color output in aube's CLI. |
-| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | implemented | Minimum log level to display. |
-| [`useBetaCli`](#setting-usebetacli) | `bool` | implemented | Opt into experimental CLI features. |
-| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | implemented | Install on all workspace packages by default. |
-| [`engineStrict`](#setting-enginestrict) | `bool` | implemented | Fail if a package is incompatible with the current Node version. |
-| [`npmPath`](#setting-npmpath) | `path` | implemented | Path to the npm binary aube should shell out to when needed. |
-| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | implemented | Enforce the `packageManager` field in package.json. |
-| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | implemented | Enforce the exact `packageManager` version from package.json. |
-| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | implemented | Auto-download the specified pnpm version when mismatched. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
-| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | implemented | Only read from the side-effects cache; don't write. |
-| [`unsafePerm`](#setting-unsafeperm) | `bool` | implemented | Drop to a non-root user when running scripts as root. |
-| [`nodeOptions`](#setting-nodeoptions) | `string` | implemented | Options passed to Node.js via NODE_OPTIONS. |
-| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | implemented | Check dependencies before running scripts. |
-| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | implemented | Exit with an error if dependencies have unreviewed build scripts. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
-| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | implemented | Allow all dependency build scripts automatically. |
-| [`nodeVersion`](#setting-nodeversion) | `string` | implemented | Node.js version aube reports when evaluating `engines` checks. |
-| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | implemented | Custom Node.js download mirror URLs. |
-| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | implemented | Version prefix used when installing a package. |
-| [`tag`](#setting-tag) | `string` | implemented | Default dist-tag used by `aube add` without a version. |
-| [`globalDir`](#setting-globaldir) | `path` | implemented | Directory where globally installed packages live. |
-| [`globalBinDir`](#setting-globalbindir) | `path` | implemented | Directory where global binaries are symlinked. |
-| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | implemented | Path to an additional .npmrc file consulted for registry authentication tokens. |
-| [`stateDir`](#setting-statedir) | `path` | implemented | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | implemented | Directory for package metadata and dlx cache. |
-| [`useStderr`](#setting-usestderr) | `bool` | implemented | Write all output to stderr instead of stdout. |
-| [`updateNotifier`](#setting-updatenotifier) | `bool` | implemented | Show an update notification when a newer aube is available. |
-| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | implemented | Create symlinks instead of shims for `.bin` entries. |
-| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | implemented | Disable pnpm's automatic dependency patching database. |
-| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | implemented | Dependency version resolution strategy. |
-| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | implemented | Whether the configured registry returns a `time` field in metadata. |
-| [`extendNodePath`](#setting-extendnodepath) | `bool` | implemented | Set NODE_PATH in command shims. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | implemented | Fast-path check before running a full install. |
-| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | implemented | Scripts that must be present in every workspace project. |
-| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | implemented | Run pre/post scripts automatically when a named script is invoked. |
-| [`scriptShell`](#setting-scriptshell) | `path` | implemented | Shell used to invoke package scripts. |
-| [`shellEmulator`](#setting-shellemulator) | `bool` | implemented | Use a JavaScript bash-like shell to run scripts cross-platform. |
-| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | implemented | How catalog references in package.json are handled by `add`. |
-| [`ci`](#setting-ci) | `bool` | implemented | Explicitly mark the environment as CI. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Summary |
+| --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
+| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
+| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
+| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
+| [`symlink`](#setting-symlink) | `bool` | Create symlinks in the virtual store directory. |
+| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | Write files to the modules directory. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
+| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | Max length for virtual store directory names. |
+| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | Populate the virtual store without creating top-level symlinks. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
+| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | Minutes before orphan packages are removed from the virtual store. |
+| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | Minutes before the dlx cache is considered stale. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
+| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | Package names whose presence in any importer forces per-project materialization. |
+| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
+| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | Only allow installs when the store server is running. |
+| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | Validate package names and versions in the store. |
+| [`httpsProxy`](#setting-httpsproxy) | `url` | Proxy URL for outgoing HTTPS requests. |
+| [`httpProxy`](#setting-httpproxy) | `url` | Proxy URL for outgoing HTTP requests. |
+| [`noProxy`](#setting-noproxy) | `string` | Comma-separated list of domains that bypass the proxy. |
+| [`localAddress`](#setting-localaddress) | `string` | Local interface IP address to bind registry connections to. |
+| [`maxsockets`](#setting-maxsockets) | `int` | Maximum concurrent connections per origin. |
+| [`strictSsl`](#setting-strictssl) | `bool` | Validate SSL certificates for HTTPS requests. |
+| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | Hosts for which aube performs shallow git clones. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
+| [`fetchRetries`](#setting-fetchretries) | `int` | Number of retry attempts for failed registry fetches. |
+| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | Exponential backoff factor for fetch retries. |
+| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | Minimum retry timeout in milliseconds. |
+| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | Maximum retry timeout in milliseconds. |
+| [`fetchTimeout`](#setting-fetchtimeout) | `int` | Max time (ms) to wait for an HTTP request. |
+| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | Warn if a metadata request exceeds this threshold (ms). |
+| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | Warn if download speed falls below this threshold (KiB/s). |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
+| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | Control color output in aube's CLI. |
+| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | Minimum log level to display. |
+| [`useBetaCli`](#setting-usebetacli) | `bool` | Opt into experimental CLI features. |
+| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | Install on all workspace packages by default. |
+| [`engineStrict`](#setting-enginestrict) | `bool` | Fail if a package is incompatible with the current Node version. |
+| [`npmPath`](#setting-npmpath) | `path` | Path to the npm binary aube should shell out to when needed. |
+| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | Enforce the `packageManager` field in package.json. |
+| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | Enforce the exact `packageManager` version from package.json. |
+| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | Auto-download the specified pnpm version when mismatched. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
+| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | Only read from the side-effects cache; don't write. |
+| [`unsafePerm`](#setting-unsafeperm) | `bool` | Drop to a non-root user when running scripts as root. |
+| [`nodeOptions`](#setting-nodeoptions) | `string` | Options passed to Node.js via NODE_OPTIONS. |
+| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | Check dependencies before running scripts. |
+| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | Exit with an error if dependencies have unreviewed build scripts. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
+| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | Allow all dependency build scripts automatically. |
+| [`nodeVersion`](#setting-nodeversion) | `string` | Node.js version aube reports when evaluating `engines` checks. |
+| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | Custom Node.js download mirror URLs. |
+| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | Version prefix used when installing a package. |
+| [`tag`](#setting-tag) | `string` | Default dist-tag used by `aube add` without a version. |
+| [`globalDir`](#setting-globaldir) | `path` | Directory where globally installed packages live. |
+| [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
+| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
+| [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
+| [`cacheDir`](#setting-cachedir) | `path` | Directory for package metadata and dlx cache. |
+| [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
+| [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
+| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | Create symlinks instead of shims for `.bin` entries. |
+| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | Disable pnpm's automatic dependency patching database. |
+| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | Dependency version resolution strategy. |
+| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | Whether the configured registry returns a `time` field in metadata. |
+| [`extendNodePath`](#setting-extendnodepath) | `bool` | Set NODE_PATH in command shims. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | Fast-path check before running a full install. |
+| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | Scripts that must be present in every workspace project. |
+| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | Run pre/post scripts automatically when a named script is invoked. |
+| [`scriptShell`](#setting-scriptshell) | `path` | Shell used to invoke package scripts. |
+| [`shellEmulator`](#setting-shellemulator) | `bool` | Use a JavaScript bash-like shell to run scripts cross-platform. |
+| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | How catalog references in package.json are handled by `add`. |
+| [`ci`](#setting-ci) | `bool` | Explicitly mark the environment as CI. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -142,8 +142,6 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_overrides`, `NPM_CONFIG_OVERRIDES`
 
 A root-level map of package specs to the versions aube should force them
@@ -157,8 +155,6 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_extensions`, `NPM_CONFIG_PACKAGE_EXTENSIONS`
 
 Patches a package's `dependencies`, `peerDependencies`, etc. at resolve
@@ -171,8 +167,6 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_allowed_deprecated_versions`, `NPM_CONFIG_ALLOWED_DEPRECATED_VERSIONS`
 
 Maps a package name to a semver range for which the deprecation warning
@@ -185,8 +179,6 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_update_config_ignore_dependencies`, `NPM_CONFIG_UPDATE_CONFIG_IGNORE_DEPENDENCIES`
 
 Packages in this list are never bumped by `aube update`, even when a
@@ -198,8 +190,6 @@ Specify architectures for optional dependency installation.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_supported_architectures`, `NPM_CONFIG_SUPPORTED_ARCHITECTURES`
 
 Override the current platform/arch/libc triple used to filter optional
@@ -212,8 +202,6 @@ Skip optional dependencies by name.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_ignored_optional_dependencies`, `NPM_CONFIG_IGNORED_OPTIONAL_DEPENDENCIES`
 
 Named entries are skipped even if their platform/arch matches. Distinct
@@ -225,8 +213,6 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_minimum_release_age`, `NPM_CONFIG_MINIMUM_RELEASE_AGE`
 
 Supply-chain attack mitigation: packages published within the last N
@@ -241,8 +227,6 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_minimum_release_age_exclude`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE`
 
 Use for trusted internal packages that need to be rolled out immediately
@@ -255,8 +239,6 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_minimum_release_age_strict`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_STRICT`
 
 By default the resolver falls back to the lowest satisfying version when
@@ -269,8 +251,6 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_trust_policy`, `NPM_CONFIG_TRUST_POLICY`
 
 When set to `no-downgrade`, aube accepts and preserves the policy in the
@@ -284,8 +264,6 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_trust_policy_exclude`, `NPM_CONFIG_TRUST_POLICY_EXCLUDE`
 
 Whitelist for `trustPolicy`. Entries skip the downgrade check.
@@ -296,8 +274,6 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_trust_policy_ignore_after`, `NPM_CONFIG_TRUST_POLICY_IGNORE_AFTER`
 
 Useful for pinning very old versions that predate signing infrastructure.
@@ -308,8 +284,6 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_block_exotic_subdeps`, `NPM_CONFIG_BLOCK_EXOTIC_SUBDEPS`
 
 When true, transitive deps referenced via `git+`, `file:`, or direct
@@ -322,8 +296,6 @@ Registry URLs, including scoped registry overrides.
 
 - Type: `object`
 - Default: `{ default = "https://registry.npmjs.org/" }`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_registries`, `NPM_CONFIG_REGISTRIES`
 
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
@@ -344,8 +316,6 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_hoist`, `NPM_CONFIG_HOIST`
 
 Controls whether aube populates `node_modules/.aube/node_modules/` —
@@ -374,8 +344,6 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_hoist_workspace_packages`, `NPM_CONFIG_HOIST_WORKSPACE_PACKAGES`
 
 Controls whether workspace packages get their own symlinks in each
@@ -392,8 +360,6 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_hoist_pattern`, `NPM_CONFIG_HOIST_PATTERN`
 
 Glob list matched against package names. Any non-local package
@@ -415,8 +381,6 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - Environment: `npm_config_public_hoist_pattern`, `NPM_CONFIG_PUBLIC_HOIST_PATTERN`
 
 Glob list matched against package names. Any non-local package in the
@@ -436,8 +400,6 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_shamefully_hoist`, `NPM_CONFIG_SHAMEFULLY_HOIST`
 
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
@@ -451,8 +413,6 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - Environment: `npm_config_modules_dir`, `NPM_CONFIG_MODULES_DIR`
 
 The project-level directory that holds the top-level `<name>` entries
@@ -477,8 +437,6 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_node_linker`, `NPM_CONFIG_NODE_LINKER`
 
 aube defaults to `isolated`, a strict symlink layout under
@@ -493,8 +451,6 @@ Create symlinks in the virtual store directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_symlink`, `NPM_CONFIG_SYMLINK`
 
 Accepted for pnpm parity. aube's isolated layout is structurally
@@ -523,8 +479,6 @@ Write files to the modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_enable_modules_dir`, `NPM_CONFIG_ENABLE_MODULES_DIR`
 
 When `false`, aube resolves the dependency graph and writes
@@ -540,8 +494,6 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_virtual_store_dir`, `NPM_CONFIG_VIRTUAL_STORE_DIR`
 
 Relocates the per-project `.aube/<dep>/node_modules/` tree that the
@@ -570,8 +522,6 @@ Max length for virtual store directory names.
 
 - Type: `int`
 - Default: `120 (Linux/macOS), 60 (Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_virtual_store_dir_max_length`, `NPM_CONFIG_VIRTUAL_STORE_DIR_MAX_LENGTH`
 
 Caps the number of characters in a single `node_modules/.aube/<dep>`
@@ -589,8 +539,6 @@ Populate the virtual store without creating top-level symlinks.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_virtual_store_only`, `NPM_CONFIG_VIRTUAL_STORE_ONLY`
 
 When `true`, aube still materializes every package into
@@ -609,8 +557,6 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_import_method`, `NPM_CONFIG_PACKAGE_IMPORT_METHOD`
 
 Controls how aube materializes files from the global content-addressable
@@ -630,8 +576,6 @@ Minutes before orphan packages are removed from the virtual store.
 
 - Type: `int`
 - Default: `10080`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_modules_cache_max_age`, `NPM_CONFIG_MODULES_CACHE_MAX_AGE`
 
 After each successful install, aube sweeps the per-project
@@ -651,8 +595,6 @@ Minutes before the dlx cache is considered stale.
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_dlx_cache_max_age`, `NPM_CONFIG_DLX_CACHE_MAX_AGE`
 
 Accepted for pnpm parity. `aube dlx` currently installs into a fresh
@@ -668,8 +610,6 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `CI`, `npm_config_enable_global_virtual_store`, `NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
@@ -683,8 +623,6 @@ Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
 - Default: `["next"]`
-- Status: implemented
-- Added to registry: `2026-04-18`
 - Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
 
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
@@ -710,8 +648,6 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_store_dir`, `NPM_CONFIG_STORE_DIR`
 
 Defaults to aube's own store path (`~/.aube-store/v1/files/`). aube does not
@@ -739,8 +675,6 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_verify_store_integrity`, `NPM_CONFIG_VERIFY_STORE_INTEGRITY`
 
 aube verifies each package's `integrity` (SHA-512) against the tarball
@@ -760,8 +694,6 @@ Only allow installs when the store server is running.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_use_running_store_server`, `NPM_CONFIG_USE_RUNNING_STORE_SERVER`
 
 Accepted for pnpm parity. aube has no long-running store-daemon
@@ -777,8 +709,6 @@ Validate package names and versions in the store.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_store_pkg_content_check`, `NPM_CONFIG_STRICT_STORE_PKG_CONTENT_CHECK`
 
 After each registry tarball is imported, aube reads the freshly stored
@@ -805,8 +735,6 @@ Proxy URL for outgoing HTTPS requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `HTTPS_PROXY`, `https_proxy`, `npm_config_https_proxy`, `NPM_CONFIG_HTTPS_PROXY`
 
 Forwards every HTTPS registry fetch through the given proxy URL.
@@ -820,8 +748,6 @@ Proxy URL for outgoing HTTP requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `HTTP_PROXY`, `http_proxy`, `PROXY`, `proxy`, `npm_config_http_proxy`, `NPM_CONFIG_HTTP_PROXY`
 
 HTTP counterpart to `httpsProxy`. Resolution mirrors pnpm:
@@ -836,8 +762,6 @@ Comma-separated list of domains that bypass the proxy.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `NO_PROXY`, `no_proxy`, `npm_config_no_proxy`, `NPM_CONFIG_NO_PROXY`
 
 Passed through to `reqwest::NoProxy::from_string` verbatim, so
@@ -851,8 +775,6 @@ Local interface IP address to bind registry connections to.
 
 - Type: `string`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_local_address`, `NPM_CONFIG_LOCAL_ADDRESS`
 
 Used on multi-homed hosts where outbound traffic must leave a
@@ -865,8 +787,6 @@ Maximum concurrent connections per origin.
 
 - Type: `int`
 - Default: `networkConcurrency x 3`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_maxsockets`, `NPM_CONFIG_MAXSOCKETS`
 
 Plumbed into reqwest's `pool_max_idle_per_host`. This is the
@@ -880,8 +800,6 @@ Validate SSL certificates for HTTPS requests.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_ssl`, `NPM_CONFIG_STRICT_SSL`
 
 Defaults to `true`. Setting `strict-ssl=false` disables TLS
@@ -898,8 +816,6 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_lockfile`, `NPM_CONFIG_LOCKFILE`
 
 Controls whether aube reads and writes a lockfile during install. When
@@ -924,8 +840,6 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_prefer_frozen_lockfile`, `NPM_CONFIG_PREFER_FROZEN_LOCKFILE`
 
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
@@ -942,8 +856,6 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_lockfile_include_tarball_url`, `NPM_CONFIG_LOCKFILE_INCLUDE_TARBALL_URL`
 
 When true, aube's lockfile writer records the registry tarball URL in
@@ -971,8 +883,6 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - Environment: `npm_config_exclude_links_from_lockfile`, `NPM_CONFIG_EXCLUDE_LINKS_FROM_LOCKFILE`
 
 When true, `link:` dependencies are omitted from the lockfile's
@@ -993,8 +903,6 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_git_branch_lockfile`, `NPM_CONFIG_GIT_BRANCH_LOCKFILE`
 
 When enabled, aube writes the lockfile to `aube-lock.<branch>.yaml`
@@ -1022,8 +930,6 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_merge_git_branch_lockfiles_branch_pattern`, `NPM_CONFIG_MERGE_GIT_BRANCH_LOCKFILES_BRANCH_PATTERN`
 
 Complements `gitBranchLockfile`. Accepts a list of glob patterns. When
@@ -1054,8 +960,6 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_peers_suffix_max_length`, `NPM_CONFIG_PEERS_SUFFIX_MAX_LENGTH`
 
 Caps the length of the peer-ID suffix appended to a `dep_path` in the
@@ -1076,8 +980,6 @@ Hosts for which aube performs shallow git clones.
 
 - Type: `list<string>`
 - Default: `["github.com", "gist.github.com", "gitlab.com", "bitbucket.com", "bitbucket.org"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_git_shallow_hosts`, `NPM_CONFIG_GIT_SHALLOW_HOSTS`
 
 Consulted by `aube-store::git_shallow_clone` when cloning a git
@@ -1101,8 +1003,6 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_network_concurrency`, `NPM_CONFIG_NETWORK_CONCURRENCY`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
@@ -1124,8 +1024,6 @@ Number of retry attempts for failed registry fetches.
 
 - Type: `int`
 - Default: `2`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retries`, `NPM_CONFIG_FETCH_RETRIES`
 
 Number of *additional* attempts the registry client makes after a
@@ -1144,8 +1042,6 @@ Exponential backoff factor for fetch retries.
 
 - Type: `int`
 - Default: `10`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retry_factor`, `NPM_CONFIG_FETCH_RETRY_FACTOR`
 
 Multiplier used between retry attempts. Attempt `n` waits
@@ -1159,8 +1055,6 @@ Minimum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retry_mintimeout`, `NPM_CONFIG_FETCH_RETRY_MINTIMEOUT`
 
 Lower bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1171,8 +1065,6 @@ Maximum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retry_maxtimeout`, `NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT`
 
 Upper bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1183,8 +1075,6 @@ Max time (ms) to wait for an HTTP request.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_timeout`, `NPM_CONFIG_FETCH_TIMEOUT`
 
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
@@ -1198,8 +1088,6 @@ Warn if a metadata request exceeds this threshold (ms).
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_warn_timeout_ms`, `NPM_CONFIG_FETCH_WARN_TIMEOUT_MS`
 
 Observability threshold for registry *metadata* requests (packument,
@@ -1219,8 +1107,6 @@ Warn if download speed falls below this threshold (KiB/s).
 
 - Type: `int`
 - Default: `50`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_min_speed_ki_bps`, `NPM_CONFIG_FETCH_MIN_SPEED_KI_BPS`
 
 Observability threshold for *tarball* downloads. When a tarball
@@ -1242,8 +1128,6 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_auto_install_peers`, `NPM_CONFIG_AUTO_INSTALL_PEERS`
 
 When true (the default), missing peer dependencies are auto-installed
@@ -1257,8 +1141,6 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_dedupe_peer_dependents`, `NPM_CONFIG_DEDUPE_PEER_DEPENDENTS`
 
 When true (the default), aube collapses packages that landed at
@@ -1275,8 +1157,6 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_dedupe_peers`, `NPM_CONFIG_DEDUPE_PEERS`
 
 When true, lockfile peer suffixes emit `(18.2.0)` instead of the
@@ -1291,8 +1171,6 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_peer_dependencies`, `NPM_CONFIG_STRICT_PEER_DEPENDENCIES`
 
 When true, any unmet peer dependency (missing, or resolved to a version
@@ -1309,8 +1187,6 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_resolve_peers_from_workspace_root`, `NPM_CONFIG_RESOLVE_PEERS_FROM_WORKSPACE_ROOT`
 
 When true (the default), an unresolved peer falls back to the root
@@ -1326,8 +1202,6 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_peer_dependency_rules_ignore_missing`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_IGNORE_MISSING`
 
 Glob list of peer dependency names whose "missing required peer" warning
@@ -1344,8 +1218,6 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_peer_dependency_rules_allowed_versions`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOWED_VERSIONS`
 
 Map of peer selector to an additional semver range. Keys are either a
@@ -1363,8 +1235,6 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_peer_dependency_rules_allow_any`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOW_ANY`
 
 Glob list of peer dependency names whose semver check should be
@@ -1382,8 +1252,6 @@ Control color output in aube's CLI.
 
 - Type: `"auto" | "always" | "never"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_color`, `NPM_CONFIG_COLOR`
 
 `--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree.
@@ -1394,8 +1262,6 @@ Minimum log level to display.
 
 - Type: `"debug" | "info" | "warn" | "error" | "silent"`
 - Default: `"warn"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_loglevel`, `NPM_CONFIG_LOGLEVEL`
 
 Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`.
@@ -1406,8 +1272,6 @@ Opt into experimental CLI features.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_use_beta_cli`, `NPM_CONFIG_USE_BETA_CLI`
 
 Accepted from env and `.npmrc` for pnpm parity. aube currently has no beta-gated commands, so the setting is a no-op after validation.
@@ -1418,8 +1282,6 @@ Install on all workspace packages by default.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_recursive_install`, `NPM_CONFIG_RECURSIVE_INSTALL`
 
 When true, workspace installs resolve and link all importers by default. Set to false to opt out of implicit workspace-wide install behavior; explicit `--filter` / `--recursive` still wins.
@@ -1430,8 +1292,6 @@ Fail if a package is incompatible with the current Node version.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_engine_strict`, `NPM_CONFIG_ENGINE_STRICT`
 
 When on, an `engines.node` mismatch on the root project or any dependency fails the install. When off, mismatches are warnings only.
@@ -1442,8 +1302,6 @@ Path to the npm binary aube should shell out to when needed.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_npm_path`, `NPM_CONFIG_NPM_PATH`
 
 Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`, `token`, `whoami`) when configured. Without it, aube keeps the explicit `use npm` error.
@@ -1454,8 +1312,6 @@ Enforce the `packageManager` field in package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_manager_strict`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT`
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
@@ -1466,8 +1322,6 @@ Enforce the exact `packageManager` version from package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_manager_strict_version`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION`
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
@@ -1478,8 +1332,6 @@ Auto-download the specified pnpm version when mismatched.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_manage_package_manager_versions`, `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS`
 
 Accepted for pnpm parity. aube does not download or re-exec other package-manager versions; when exact version enforcement is enabled, mismatches are reported instead.
@@ -1492,8 +1344,6 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_ignore_scripts`, `NPM_CONFIG_IGNORE_SCRIPTS`
 
 aube already skips dependency install scripts by default (security-first).
@@ -1512,8 +1362,6 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_child_concurrency`, `NPM_CONFIG_CHILD_CONCURRENCY`
 
 Caps how many dependency lifecycle scripts run in parallel during the
@@ -1533,8 +1381,6 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_side_effects_cache`, `NPM_CONFIG_SIDE_EFFECTS_CACHE`
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
@@ -1556,8 +1402,6 @@ Only read from the side-effects cache; don't write.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_side_effects_cache_readonly`, `NPM_CONFIG_SIDE_EFFECTS_CACHE_READONLY`
 
 When true, aube may restore allowlisted dependency build output from the
@@ -1569,8 +1413,6 @@ Drop to a non-root user when running scripts as root.
 
 - Type: `bool`
 - Default: `false (as root), true (otherwise)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_unsafe_perm`, `NPM_CONFIG_UNSAFE_PERM`
 
 aube exports the resolved value to lifecycle and `run` scripts as
@@ -1583,8 +1425,6 @@ Options passed to Node.js via NODE_OPTIONS.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `NODE_OPTIONS`, `npm_config_node_options`, `NPM_CONFIG_NODE_OPTIONS`
 
 When set in `.npmrc`, aube exports the value as `NODE_OPTIONS` for
@@ -1597,8 +1437,6 @@ Check dependencies before running scripts.
 
 - Type: `"install" | "warn" | "error" | "prompt" | false`
 - Default: `"install"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_verify_deps_before_run`, `NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN`
 
 Controls `run`, lifecycle shortcuts, `exec`, and implicit script commands.
@@ -1612,8 +1450,6 @@ Exit with an error if dependencies have unreviewed build scripts.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_dep_builds`, `NPM_CONFIG_STRICT_DEP_BUILDS`
 
 aube never runs dependency lifecycle scripts unless the package is
@@ -1630,8 +1466,6 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_allow_builds`, `NPM_CONFIG_ALLOW_BUILDS`
 
 Per-package allowlist for dependency lifecycle scripts. Read from
@@ -1651,8 +1485,6 @@ Allow all dependency build scripts automatically.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_dangerously_allow_all_builds`, `NPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS`
 
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
@@ -1673,8 +1505,6 @@ Node.js version aube reports when evaluating `engines` checks.
 
 - Type: `string`
 - Default: `` output of `node -v` with the leading `v` stripped ``
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_node_version`, `NPM_CONFIG_NODE_VERSION`
 
 Paired with `engineStrict`. Set this in .npmrc to pin the Node version engines checks validate against, rather than probing `node --version` at install time.
@@ -1685,8 +1515,6 @@ Custom Node.js download mirror URLs.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_node_download_mirrors`, `NPM_CONFIG_NODE_DOWNLOAD_MIRRORS`
 
 Accepted for pnpm config parity. aube does not download Node.js itself,
@@ -1701,8 +1529,6 @@ Version prefix used when installing a package.
 
 - Type: `"^" | "~" | ""`
 - Default: `"^"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_save_prefix`, `NPM_CONFIG_SAVE_PREFIX`
 
 Resolved from `.npmrc`. `--save-exact` overrides to empty prefix.
@@ -1713,8 +1539,6 @@ Default dist-tag used by `aube add` without a version.
 
 - Type: `string`
 - Default: `"latest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_tag`, `NPM_CONFIG_TAG`
 
 Resolved from `.npmrc`. Used by `aube add` when no version or dist-tag is specified.
@@ -1725,8 +1549,6 @@ Directory where globally installed packages live.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_global_dir`, `NPM_CONFIG_GLOBAL_DIR`
 
 Overrides the directory where globally installed packages live. Falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1737,8 +1559,6 @@ Directory where global binaries are symlinked.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_global_bin_dir`, `NPM_CONFIG_GLOBAL_BIN_DIR`
 
 Overrides the directory where global binaries are symlinked. Independent of `globalDir`; falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1749,8 +1569,6 @@ Path to an additional .npmrc file consulted for registry authentication tokens.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_npmrc_auth_file`, `NPM_CONFIG_NPMRC_AUTH_FILE`
 
 Points at an extra `.npmrc`-formatted file that aube reads *after*
@@ -1778,8 +1596,6 @@ Directory for aube install-state files.
 
 - Type: `path`
 - Default: `.aube/.state`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_state_dir`, `NPM_CONFIG_STATE_DIR`
 
 Overrides the directory for install state tracking. Defaults to `.aube/.state` relative to the project root.
@@ -1790,8 +1606,6 @@ Directory for package metadata and dlx cache.
 
 - Type: `path`
 - Default: `~/.cache/aube`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_cache_dir`, `NPM_CONFIG_CACHE_DIR`
 
 Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path.
@@ -1802,8 +1616,6 @@ Write all output to stderr instead of stdout.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_use_stderr`, `NPM_CONFIG_USE_STDERR`
 
 Redirects stdout to stderr for the process lifetime. Resolved from `.npmrc` or the `--use-stderr` CLI flag.
@@ -1814,8 +1626,6 @@ Show an update notification when a newer aube is available.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_update_notifier`, `NPM_CONFIG_UPDATE_NOTIFIER`
 
 After a successful `install`, `add`, or `update`, aube fetches
@@ -1835,8 +1645,6 @@ Create symlinks instead of shims for `.bin` entries.
 
 - Type: `bool`
 - Default: `true (POSIX hoisted)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_prefer_symlinked_executables`, `NPM_CONFIG_PREFER_SYMLINKED_EXECUTABLES`
 
 POSIX only. Default (unset or `true`) creates a plain symlink from
@@ -1854,8 +1662,6 @@ Disable pnpm's automatic dependency patching database.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_ignore_compatibility_db`, `NPM_CONFIG_IGNORE_COMPATIBILITY_DB`
 
 Accepted for pnpm config parity. pnpm ships a built-in compatibility
@@ -1869,8 +1675,6 @@ Dependency version resolution strategy.
 
 - Type: `"highest" | "time-based" | "lowest-direct"`
 - Default: `"highest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_resolution_mode`, `NPM_CONFIG_RESOLUTION_MODE`
 
 Controls how aube chooses versions during resolution. `highest` picks
@@ -1885,8 +1689,6 @@ Whether the configured registry returns a `time` field in metadata.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_registry_supports_time_field`, `NPM_CONFIG_REGISTRY_SUPPORTS_TIME_FIELD`
 
 When `false` (the default, matching pnpm and npmjs.org's behavior),
@@ -1912,8 +1714,6 @@ Set NODE_PATH in command shims.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_extend_node_path`, `NPM_CONFIG_EXTEND_NODE_PATH`
 
 When `true` (default), aube-generated `.bin` shims export
@@ -1931,8 +1731,6 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_deploy_all_files`, `NPM_CONFIG_DEPLOY_ALL_FILES`
 
 When true, `aube deploy` copies every file in the source workspace
@@ -1951,8 +1749,6 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_dedupe_direct_deps`, `NPM_CONFIG_DEDUPE_DIRECT_DEPS`
 
 When true, the linker skips creating a `node_modules/<name>` symlink in a
@@ -1971,8 +1767,6 @@ Fast-path check before running a full install.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_optimistic_repeat_install`, `NPM_CONFIG_OPTIMISTIC_REPEAT_INSTALL`
 
 When `true` (default), `aube run` / `aube exec` / `aube start` /
@@ -1990,8 +1784,6 @@ Scripts that must be present in every workspace project.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_required_scripts`, `NPM_CONFIG_REQUIRED_SCRIPTS`
 
 During install, aube verifies that the root package and every discovered
@@ -2003,8 +1795,6 @@ Run pre/post scripts automatically when a named script is invoked.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_enable_pre_post_scripts`, `NPM_CONFIG_ENABLE_PRE_POST_SCRIPTS`
 
 Controls whether `aube run build` also runs `prebuild` before `build`
@@ -2016,8 +1806,6 @@ Shell used to invoke package scripts.
 
 - Type: `path`
 - Default: `null (uses /bin/sh on Unix, cmd on Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_script_shell`, `NPM_CONFIG_SCRIPT_SHELL`
 
 Overrides the shell executable used for lifecycle and `aube run`
@@ -2029,8 +1817,6 @@ Use a JavaScript bash-like shell to run scripts cross-platform.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_shell_emulator`, `NPM_CONFIG_SHELL_EMULATOR`
 
 Accepted for pnpm config parity. aube does not embed pnpm's JavaScript
@@ -2043,8 +1829,6 @@ How catalog references in package.json are handled by `add`.
 
 - Type: `"manual" | "strict" | "prefer"`
 - Default: `"manual"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_catalog_mode`, `NPM_CONFIG_CATALOG_MODE`
 
 `manual` (the default) writes whatever range `aube add` resolved, even
@@ -2068,8 +1852,6 @@ Explicitly mark the environment as CI.
 
 - Type: `bool`
 - Default: `auto-detected`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `CI`, `npm_config_ci`, `NPM_CONFIG_CI`
 
 aube detects CI via `env::var("CI").is_ok()` in two places:
@@ -2086,8 +1868,6 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_cleanup_unused_catalogs`, `NPM_CONFIG_CLEANUP_UNUSED_CATALOGS`
 
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
@@ -2106,8 +1886,6 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - Environment: `AUBE_LINK_CONCURRENCY`, `npm_config_link_concurrency`, `NPM_CONFIG_LINK_CONCURRENCY`
 
 Caps the dedicated linker worker pool used for filesystem-heavy
@@ -2130,8 +1908,6 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `AUBE_NO_LOCK`, `npm_config_aube_no_lock`, `NPM_CONFIG_AUBE_NO_LOCK`
 
 aube takes an advisory lock on `node_modules/` at the start of every
@@ -2162,8 +1938,6 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `AUBE_NO_AUTO_INSTALL`, `npm_config_aube_no_auto_install`, `NPM_CONFIG_AUBE_NO_AUTO_INSTALL`
 
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -16,123 +16,123 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-113 settings are listed here. 113 are currently implemented.
+113 settings are listed here.
 
-| Setting | Type | Status | Summary |
-| --- | --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
-| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | implemented | Specify architectures for optional dependency installation. |
-| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | implemented | Skip optional dependencies by name. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`registries`](#setting-registries) | `object` | implemented | Registry URLs, including scoped registry overrides. |
-| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
-| [`symlink`](#setting-symlink) | `bool` | implemented | Create symlinks in the virtual store directory. |
-| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | implemented | Write files to the modules directory. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
-| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | implemented | Max length for virtual store directory names. |
-| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | implemented | Populate the virtual store without creating top-level symlinks. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
-| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
-| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | implemented | Package names whose presence in any importer forces per-project materialization. |
-| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
-| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
-| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | implemented | Validate package names and versions in the store. |
-| [`httpsProxy`](#setting-httpsproxy) | `url` | implemented | Proxy URL for outgoing HTTPS requests. |
-| [`httpProxy`](#setting-httpproxy) | `url` | implemented | Proxy URL for outgoing HTTP requests. |
-| [`noProxy`](#setting-noproxy) | `string` | implemented | Comma-separated list of domains that bypass the proxy. |
-| [`localAddress`](#setting-localaddress) | `string` | implemented | Local interface IP address to bind registry connections to. |
-| [`maxsockets`](#setting-maxsockets) | `int` | implemented | Maximum concurrent connections per origin. |
-| [`strictSsl`](#setting-strictssl) | `bool` | implemented | Validate SSL certificates for HTTPS requests. |
-| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | implemented | Hosts for which aube performs shallow git clones. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
-| [`fetchRetries`](#setting-fetchretries) | `int` | implemented | Number of retry attempts for failed registry fetches. |
-| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | implemented | Exponential backoff factor for fetch retries. |
-| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | implemented | Minimum retry timeout in milliseconds. |
-| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | implemented | Maximum retry timeout in milliseconds. |
-| [`fetchTimeout`](#setting-fetchtimeout) | `int` | implemented | Max time (ms) to wait for an HTTP request. |
-| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | implemented | Warn if a metadata request exceeds this threshold (ms). |
-| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | implemented | Warn if download speed falls below this threshold (KiB/s). |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
-| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | implemented | Control color output in aube's CLI. |
-| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | implemented | Minimum log level to display. |
-| [`useBetaCli`](#setting-usebetacli) | `bool` | implemented | Opt into experimental CLI features. |
-| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | implemented | Install on all workspace packages by default. |
-| [`engineStrict`](#setting-enginestrict) | `bool` | implemented | Fail if a package is incompatible with the current Node version. |
-| [`npmPath`](#setting-npmpath) | `path` | implemented | Path to the npm binary aube should shell out to when needed. |
-| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | implemented | Enforce the `packageManager` field in package.json. |
-| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | implemented | Enforce the exact `packageManager` version from package.json. |
-| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | implemented | Auto-download the specified pnpm version when mismatched. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
-| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | implemented | Only read from the side-effects cache; don't write. |
-| [`unsafePerm`](#setting-unsafeperm) | `bool` | implemented | Drop to a non-root user when running scripts as root. |
-| [`nodeOptions`](#setting-nodeoptions) | `string` | implemented | Options passed to Node.js via NODE_OPTIONS. |
-| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | implemented | Check dependencies before running scripts. |
-| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | implemented | Exit with an error if dependencies have unreviewed build scripts. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
-| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | implemented | Allow all dependency build scripts automatically. |
-| [`nodeVersion`](#setting-nodeversion) | `string` | implemented | Node.js version aube reports when evaluating `engines` checks. |
-| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | implemented | Custom Node.js download mirror URLs. |
-| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | implemented | Version prefix used when installing a package. |
-| [`tag`](#setting-tag) | `string` | implemented | Default dist-tag used by `aube add` without a version. |
-| [`globalDir`](#setting-globaldir) | `path` | implemented | Directory where globally installed packages live. |
-| [`globalBinDir`](#setting-globalbindir) | `path` | implemented | Directory where global binaries are symlinked. |
-| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | implemented | Path to an additional .npmrc file consulted for registry authentication tokens. |
-| [`stateDir`](#setting-statedir) | `path` | implemented | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | implemented | Directory for package metadata and dlx cache. |
-| [`useStderr`](#setting-usestderr) | `bool` | implemented | Write all output to stderr instead of stdout. |
-| [`updateNotifier`](#setting-updatenotifier) | `bool` | implemented | Show an update notification when a newer aube is available. |
-| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | implemented | Create symlinks instead of shims for `.bin` entries. |
-| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | implemented | Disable pnpm's automatic dependency patching database. |
-| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | implemented | Dependency version resolution strategy. |
-| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | implemented | Whether the configured registry returns a `time` field in metadata. |
-| [`extendNodePath`](#setting-extendnodepath) | `bool` | implemented | Set NODE_PATH in command shims. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | implemented | Fast-path check before running a full install. |
-| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | implemented | Scripts that must be present in every workspace project. |
-| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | implemented | Run pre/post scripts automatically when a named script is invoked. |
-| [`scriptShell`](#setting-scriptshell) | `path` | implemented | Shell used to invoke package scripts. |
-| [`shellEmulator`](#setting-shellemulator) | `bool` | implemented | Use a JavaScript bash-like shell to run scripts cross-platform. |
-| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | implemented | How catalog references in package.json are handled by `add`. |
-| [`ci`](#setting-ci) | `bool` | implemented | Explicitly mark the environment as CI. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Summary |
+| --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
+| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
+| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
+| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
+| [`symlink`](#setting-symlink) | `bool` | Create symlinks in the virtual store directory. |
+| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | Write files to the modules directory. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
+| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | Max length for virtual store directory names. |
+| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | Populate the virtual store without creating top-level symlinks. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
+| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | Minutes before orphan packages are removed from the virtual store. |
+| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | Minutes before the dlx cache is considered stale. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
+| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | Package names whose presence in any importer forces per-project materialization. |
+| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
+| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | Only allow installs when the store server is running. |
+| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | Validate package names and versions in the store. |
+| [`httpsProxy`](#setting-httpsproxy) | `url` | Proxy URL for outgoing HTTPS requests. |
+| [`httpProxy`](#setting-httpproxy) | `url` | Proxy URL for outgoing HTTP requests. |
+| [`noProxy`](#setting-noproxy) | `string` | Comma-separated list of domains that bypass the proxy. |
+| [`localAddress`](#setting-localaddress) | `string` | Local interface IP address to bind registry connections to. |
+| [`maxsockets`](#setting-maxsockets) | `int` | Maximum concurrent connections per origin. |
+| [`strictSsl`](#setting-strictssl) | `bool` | Validate SSL certificates for HTTPS requests. |
+| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | Hosts for which aube performs shallow git clones. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
+| [`fetchRetries`](#setting-fetchretries) | `int` | Number of retry attempts for failed registry fetches. |
+| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | Exponential backoff factor for fetch retries. |
+| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | Minimum retry timeout in milliseconds. |
+| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | Maximum retry timeout in milliseconds. |
+| [`fetchTimeout`](#setting-fetchtimeout) | `int` | Max time (ms) to wait for an HTTP request. |
+| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | Warn if a metadata request exceeds this threshold (ms). |
+| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | Warn if download speed falls below this threshold (KiB/s). |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
+| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | Control color output in aube's CLI. |
+| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | Minimum log level to display. |
+| [`useBetaCli`](#setting-usebetacli) | `bool` | Opt into experimental CLI features. |
+| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | Install on all workspace packages by default. |
+| [`engineStrict`](#setting-enginestrict) | `bool` | Fail if a package is incompatible with the current Node version. |
+| [`npmPath`](#setting-npmpath) | `path` | Path to the npm binary aube should shell out to when needed. |
+| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | Enforce the `packageManager` field in package.json. |
+| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | Enforce the exact `packageManager` version from package.json. |
+| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | Auto-download the specified pnpm version when mismatched. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
+| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | Only read from the side-effects cache; don't write. |
+| [`unsafePerm`](#setting-unsafeperm) | `bool` | Drop to a non-root user when running scripts as root. |
+| [`nodeOptions`](#setting-nodeoptions) | `string` | Options passed to Node.js via NODE_OPTIONS. |
+| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | Check dependencies before running scripts. |
+| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | Exit with an error if dependencies have unreviewed build scripts. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
+| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | Allow all dependency build scripts automatically. |
+| [`nodeVersion`](#setting-nodeversion) | `string` | Node.js version aube reports when evaluating `engines` checks. |
+| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | Custom Node.js download mirror URLs. |
+| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | Version prefix used when installing a package. |
+| [`tag`](#setting-tag) | `string` | Default dist-tag used by `aube add` without a version. |
+| [`globalDir`](#setting-globaldir) | `path` | Directory where globally installed packages live. |
+| [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
+| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
+| [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
+| [`cacheDir`](#setting-cachedir) | `path` | Directory for package metadata and dlx cache. |
+| [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
+| [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
+| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | Create symlinks instead of shims for `.bin` entries. |
+| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | Disable pnpm's automatic dependency patching database. |
+| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | Dependency version resolution strategy. |
+| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | Whether the configured registry returns a `time` field in metadata. |
+| [`extendNodePath`](#setting-extendnodepath) | `bool` | Set NODE_PATH in command shims. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | Fast-path check before running a full install. |
+| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | Scripts that must be present in every workspace project. |
+| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | Run pre/post scripts automatically when a named script is invoked. |
+| [`scriptShell`](#setting-scriptshell) | `path` | Shell used to invoke package scripts. |
+| [`shellEmulator`](#setting-shellemulator) | `bool` | Use a JavaScript bash-like shell to run scripts cross-platform. |
+| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | How catalog references in package.json are handled by `add`. |
+| [`ci`](#setting-ci) | `bool` | Explicitly mark the environment as CI. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -142,9 +142,6 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_overrides`, `NPM_CONFIG_OVERRIDES`
 - .npmrc keys: `overrides`
 - Workspace YAML keys: `overrides`
@@ -160,9 +157,6 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_package_extensions`, `NPM_CONFIG_PACKAGE_EXTENSIONS`
 - .npmrc keys: `packageExtensions`
 - Workspace YAML keys: `packageExtensions`
@@ -177,9 +171,6 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_allowed_deprecated_versions`, `NPM_CONFIG_ALLOWED_DEPRECATED_VERSIONS`
 - .npmrc keys: `allowedDeprecatedVersions`
 - Workspace YAML keys: `allowedDeprecatedVersions`
@@ -194,9 +185,6 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_update_config_ignore_dependencies`, `NPM_CONFIG_UPDATE_CONFIG_IGNORE_DEPENDENCIES`
 - .npmrc keys: `updateConfig.ignoreDependencies`
 - Workspace YAML keys: `updateConfig.ignoreDependencies`
@@ -210,12 +198,8 @@ Specify architectures for optional dependency installation.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_supported_architectures`, `NPM_CONFIG_SUPPORTED_ARCHITECTURES`
 - .npmrc keys: `supportedArchitectures`
-- Workspace YAML keys: none
 
 Override the current platform/arch/libc triple used to filter optional
 dependencies. Useful when generating a lockfile for a target platform
@@ -227,12 +211,8 @@ Skip optional dependencies by name.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_ignored_optional_dependencies`, `NPM_CONFIG_IGNORED_OPTIONAL_DEPENDENCIES`
 - .npmrc keys: `ignoredOptionalDependencies`
-- Workspace YAML keys: none
 
 Named entries are skipped even if their platform/arch matches. Distinct
 from `--no-optional`, which drops *all* optional deps at install time.
@@ -243,9 +223,6 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_minimum_release_age`, `NPM_CONFIG_MINIMUM_RELEASE_AGE`
 - .npmrc keys: `minimumReleaseAge`
 - Workspace YAML keys: `minimumReleaseAge`
@@ -262,9 +239,6 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_minimum_release_age_exclude`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE`
 - .npmrc keys: `minimumReleaseAgeExclude`
 - Workspace YAML keys: `minimumReleaseAgeExclude`
@@ -279,9 +253,6 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_minimum_release_age_strict`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_STRICT`
 - .npmrc keys: `minimumReleaseAgeStrict`
 - Workspace YAML keys: `minimumReleaseAgeStrict`
@@ -296,9 +267,6 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_trust_policy`, `NPM_CONFIG_TRUST_POLICY`
 - .npmrc keys: `trustPolicy`
 - Workspace YAML keys: `trustPolicy`
@@ -314,9 +282,6 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_trust_policy_exclude`, `NPM_CONFIG_TRUST_POLICY_EXCLUDE`
 - .npmrc keys: `trustPolicyExclude`
 - Workspace YAML keys: `trustPolicyExclude`
@@ -329,9 +294,6 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_trust_policy_ignore_after`, `NPM_CONFIG_TRUST_POLICY_IGNORE_AFTER`
 - .npmrc keys: `trustPolicyIgnoreAfter`
 - Workspace YAML keys: `trustPolicyIgnoreAfter`
@@ -344,9 +306,6 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_block_exotic_subdeps`, `NPM_CONFIG_BLOCK_EXOTIC_SUBDEPS`
 - .npmrc keys: `blockExoticSubdeps`
 - Workspace YAML keys: `blockExoticSubdeps`
@@ -361,12 +320,8 @@ Registry URLs, including scoped registry overrides.
 
 - Type: `object`
 - Default: `{ default = "https://registry.npmjs.org/" }`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_registries`, `NPM_CONFIG_REGISTRIES`
 - .npmrc keys: `registry`, `@scope:registry`, `//host/:_authToken`, `//host/:_auth`
-- Workspace YAML keys: none
 
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
 `.npmrc` via `aube_registry::config::NpmConfig` (see
@@ -386,9 +341,6 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_hoist`, `NPM_CONFIG_HOIST`
 - .npmrc keys: `hoist`
 - Workspace YAML keys: `hoist`
@@ -419,9 +371,6 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_hoist_workspace_packages`, `NPM_CONFIG_HOIST_WORKSPACE_PACKAGES`
 - .npmrc keys: `hoist-workspace-packages`, `hoistWorkspacePackages`
 - Workspace YAML keys: `hoistWorkspacePackages`
@@ -440,9 +389,6 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_hoist_pattern`, `NPM_CONFIG_HOIST_PATTERN`
 - .npmrc keys: `hoist-pattern`, `hoistPattern`
 - Workspace YAML keys: `hoistPattern`
@@ -466,8 +412,6 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - CLI flags: `public-hoist-pattern`
 - Environment: `npm_config_public_hoist_pattern`, `NPM_CONFIG_PUBLIC_HOIST_PATTERN`
 - .npmrc keys: `public-hoist-pattern`, `publicHoistPattern`
@@ -490,8 +434,6 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `shamefully-hoist`
 - Environment: `npm_config_shamefully_hoist`, `NPM_CONFIG_SHAMEFULLY_HOIST`
 - .npmrc keys: `shamefully-hoist`, `shamefullyHoist`
@@ -508,9 +450,6 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
-- Status: implemented
-- Added to registry: `2026-04-17`
-- CLI flags: none
 - Environment: `npm_config_modules_dir`, `NPM_CONFIG_MODULES_DIR`
 - .npmrc keys: `modulesDir`, `modules-dir`
 - Workspace YAML keys: `modulesDir`
@@ -537,8 +476,6 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `node-linker`
 - Environment: `npm_config_node_linker`, `NPM_CONFIG_NODE_LINKER`
 - .npmrc keys: `nodeLinker`
@@ -556,12 +493,8 @@ Create symlinks in the virtual store directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_symlink`, `NPM_CONFIG_SYMLINK`
 - .npmrc keys: `symlink`
-- Workspace YAML keys: none
 
 Accepted for pnpm parity. aube's isolated layout is structurally
 defined by the symlink graph under `node_modules/.aube/` — each
@@ -589,12 +522,8 @@ Write files to the modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_enable_modules_dir`, `NPM_CONFIG_ENABLE_MODULES_DIR`
 - .npmrc keys: `enableModulesDir`
-- Workspace YAML keys: none
 
 When `false`, aube resolves the dependency graph and writes
 `aube-lock.yaml` but skips every `node_modules/` side effect: no
@@ -609,9 +538,6 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_virtual_store_dir`, `NPM_CONFIG_VIRTUAL_STORE_DIR`
 - .npmrc keys: `virtualStoreDir`, `virtual-store-dir`
 - Workspace YAML keys: `virtualStoreDir`
@@ -642,12 +568,8 @@ Max length for virtual store directory names.
 
 - Type: `int`
 - Default: `120 (Linux/macOS), 60 (Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_virtual_store_dir_max_length`, `NPM_CONFIG_VIRTUAL_STORE_DIR_MAX_LENGTH`
 - .npmrc keys: `virtualStoreDirMaxLength`
-- Workspace YAML keys: none
 
 Caps the number of characters in a single `node_modules/.aube/<dep>`
 directory name. `dep_path_to_filename` already truncates-and-hashes
@@ -664,12 +586,8 @@ Populate the virtual store without creating top-level symlinks.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_virtual_store_only`, `NPM_CONFIG_VIRTUAL_STORE_ONLY`
 - .npmrc keys: `virtualStoreOnly`
-- Workspace YAML keys: none
 
 When `true`, aube still materializes every package into
 `node_modules/.aube/<dep>/node_modules/<name>` (and, in global-store
@@ -687,8 +605,6 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `package-import-method`
 - Environment: `npm_config_package_import_method`, `NPM_CONFIG_PACKAGE_IMPORT_METHOD`
 - .npmrc keys: `packageImportMethod`, `package-import-method`
@@ -711,12 +627,8 @@ Minutes before orphan packages are removed from the virtual store.
 
 - Type: `int`
 - Default: `10080`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_modules_cache_max_age`, `NPM_CONFIG_MODULES_CACHE_MAX_AGE`
 - .npmrc keys: `modulesCacheMaxAge`
-- Workspace YAML keys: none
 
 After each successful install, aube sweeps the per-project
 `node_modules/.aube/` virtual store and removes entries whose
@@ -735,12 +647,8 @@ Minutes before the dlx cache is considered stale.
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_dlx_cache_max_age`, `NPM_CONFIG_DLX_CACHE_MAX_AGE`
 - .npmrc keys: `dlx-cache-max-age`, `dlxCacheMaxAge`
-- Workspace YAML keys: none
 
 Accepted for pnpm parity. `aube dlx` currently installs into a fresh
 `tempfile::TempDir` per invocation and removes it on exit, so there is
@@ -755,9 +663,6 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `CI`, `npm_config_enable_global_virtual_store`, `NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
 - .npmrc keys: `enableGlobalVirtualStore`
 - Workspace YAML keys: `enableGlobalVirtualStore`
@@ -773,9 +678,6 @@ Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
 - Default: `["next"]`
-- Status: implemented
-- Added to registry: `2026-04-18`
-- CLI flags: none
 - Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
 - .npmrc keys: `disableGlobalVirtualStoreForPackages`
 - Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
@@ -803,9 +705,6 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_store_dir`, `NPM_CONFIG_STORE_DIR`
 - .npmrc keys: `store-dir`, `storeDir`
 - Workspace YAML keys: `storeDir`
@@ -835,8 +734,6 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `verify-store-integrity`
 - Environment: `npm_config_verify_store_integrity`, `NPM_CONFIG_VERIFY_STORE_INTEGRITY`
 - .npmrc keys: `verify-store-integrity`, `verifyStoreIntegrity`
@@ -859,12 +756,8 @@ Only allow installs when the store server is running.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_use_running_store_server`, `NPM_CONFIG_USE_RUNNING_STORE_SERVER`
 - .npmrc keys: `use-running-store-server`, `useRunningStoreServer`
-- Workspace YAML keys: none
 
 Accepted for pnpm parity. aube has no long-running store-daemon
 component — every install talks directly to the on-disk CAS at
@@ -879,12 +772,8 @@ Validate package names and versions in the store.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_strict_store_pkg_content_check`, `NPM_CONFIG_STRICT_STORE_PKG_CONTENT_CHECK`
 - .npmrc keys: `strict-store-pkg-content-check`, `strictStorePkgContentCheck`
-- Workspace YAML keys: none
 
 After each registry tarball is imported, aube reads the freshly stored
 `package.json` and confirms its `name` and `version` match what the
@@ -910,12 +799,8 @@ Proxy URL for outgoing HTTPS requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `HTTPS_PROXY`, `https_proxy`, `npm_config_https_proxy`, `NPM_CONFIG_HTTPS_PROXY`
 - .npmrc keys: `https-proxy`, `httpsProxy`, `proxy`
-- Workspace YAML keys: none
 
 Forwards every HTTPS registry fetch through the given proxy URL.
 Honored by the `aube-registry` reqwest client. Resolution mirrors
@@ -928,12 +813,8 @@ Proxy URL for outgoing HTTP requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `HTTP_PROXY`, `http_proxy`, `PROXY`, `proxy`, `npm_config_http_proxy`, `NPM_CONFIG_HTTP_PROXY`
 - .npmrc keys: `http-proxy`, `httpProxy`
-- Workspace YAML keys: none
 
 HTTP counterpart to `httpsProxy`. Resolution mirrors pnpm:
 `.npmrc http-proxy` ?? resolved `httpsProxy` ?? `HTTP_PROXY` /
@@ -947,12 +828,8 @@ Comma-separated list of domains that bypass the proxy.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `NO_PROXY`, `no_proxy`, `npm_config_no_proxy`, `NPM_CONFIG_NO_PROXY`
 - .npmrc keys: `noproxy`, `noProxy`, `no-proxy`
-- Workspace YAML keys: none
 
 Passed through to `reqwest::NoProxy::from_string` verbatim, so
 wildcard and port-qualified hosts behave the same as curl / node.
@@ -965,12 +842,8 @@ Local interface IP address to bind registry connections to.
 
 - Type: `string`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_local_address`, `NPM_CONFIG_LOCAL_ADDRESS`
 - .npmrc keys: `local-address`, `localAddress`
-- Workspace YAML keys: none
 
 Used on multi-homed hosts where outbound traffic must leave a
 specific interface. Parsed as `IpAddr`; unparseable values are
@@ -982,12 +855,8 @@ Maximum concurrent connections per origin.
 
 - Type: `int`
 - Default: `networkConcurrency x 3`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_maxsockets`, `NPM_CONFIG_MAXSOCKETS`
 - .npmrc keys: `maxsockets`
-- Workspace YAML keys: none
 
 Plumbed into reqwest's `pool_max_idle_per_host`. This is the
 closest analogue to pnpm's per-origin socket cap — reqwest doesn't
@@ -1000,12 +869,8 @@ Validate SSL certificates for HTTPS requests.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_strict_ssl`, `NPM_CONFIG_STRICT_SSL`
 - .npmrc keys: `strict-ssl`, `strictSsl`
-- Workspace YAML keys: none
 
 Defaults to `true`. Setting `strict-ssl=false` disables TLS
 certificate verification entirely via
@@ -1021,9 +886,6 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_lockfile`, `NPM_CONFIG_LOCKFILE`
 - .npmrc keys: `lockfile`
 - Workspace YAML keys: `lockfile`
@@ -1050,8 +912,6 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `prefer-frozen-lockfile`
 - Environment: `npm_config_prefer_frozen_lockfile`, `NPM_CONFIG_PREFER_FROZEN_LOCKFILE`
 - .npmrc keys: `prefer-frozen-lockfile`
@@ -1071,9 +931,6 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_lockfile_include_tarball_url`, `NPM_CONFIG_LOCKFILE_INCLUDE_TARBALL_URL`
 - .npmrc keys: `lockfileIncludeTarballUrl`, `lockfile-include-tarball-url`
 - Workspace YAML keys: `lockfileIncludeTarballUrl`
@@ -1103,9 +960,6 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-13`
-- CLI flags: none
 - Environment: `npm_config_exclude_links_from_lockfile`, `NPM_CONFIG_EXCLUDE_LINKS_FROM_LOCKFILE`
 - .npmrc keys: `exclude-links-from-lockfile`, `excludeLinksFromLockfile`
 - Workspace YAML keys: `excludeLinksFromLockfile`
@@ -1128,9 +982,6 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_git_branch_lockfile`, `NPM_CONFIG_GIT_BRANCH_LOCKFILE`
 - .npmrc keys: `gitBranchLockfile`
 - Workspace YAML keys: `gitBranchLockfile`
@@ -1160,9 +1011,6 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_merge_git_branch_lockfiles_branch_pattern`, `NPM_CONFIG_MERGE_GIT_BRANCH_LOCKFILES_BRANCH_PATTERN`
 - .npmrc keys: `mergeGitBranchLockfilesBranchPattern`
 - Workspace YAML keys: `mergeGitBranchLockfilesBranchPattern`
@@ -1195,9 +1043,6 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_peers_suffix_max_length`, `NPM_CONFIG_PEERS_SUFFIX_MAX_LENGTH`
 - .npmrc keys: `peersSuffixMaxLength`
 - Workspace YAML keys: `peersSuffixMaxLength`
@@ -1220,12 +1065,8 @@ Hosts for which aube performs shallow git clones.
 
 - Type: `list<string>`
 - Default: `["github.com", "gist.github.com", "gitlab.com", "bitbucket.com", "bitbucket.org"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_git_shallow_hosts`, `NPM_CONFIG_GIT_SHALLOW_HOSTS`
 - .npmrc keys: `git-shallow-hosts`, `gitShallowHosts`
-- Workspace YAML keys: none
 
 Consulted by `aube-store::git_shallow_clone` when cloning a git
 dependency. When the URL's hostname matches an entry in this list
@@ -1248,8 +1089,6 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `network-concurrency`
 - Environment: `npm_config_network_concurrency`, `NPM_CONFIG_NETWORK_CONCURRENCY`
 - .npmrc keys: `network-concurrency`, `networkConcurrency`
@@ -1274,12 +1113,8 @@ Number of retry attempts for failed registry fetches.
 
 - Type: `int`
 - Default: `2`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_retries`, `NPM_CONFIG_FETCH_RETRIES`
 - .npmrc keys: `fetch-retries`, `fetchRetries`
-- Workspace YAML keys: none
 
 Number of *additional* attempts the registry client makes after a
 transient failure (5xx / 429 / connection error). `2` means up to 3
@@ -1297,12 +1132,8 @@ Exponential backoff factor for fetch retries.
 
 - Type: `int`
 - Default: `10`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_retry_factor`, `NPM_CONFIG_FETCH_RETRY_FACTOR`
 - .npmrc keys: `fetch-retry-factor`, `fetchRetryFactor`
-- Workspace YAML keys: none
 
 Multiplier used between retry attempts. Attempt `n` waits
 `min(fetchRetryMintimeout * fetchRetryFactor ^ (n-1), fetchRetryMaxtimeout)`
@@ -1315,12 +1146,8 @@ Minimum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_retry_mintimeout`, `NPM_CONFIG_FETCH_RETRY_MINTIMEOUT`
 - .npmrc keys: `fetch-retry-mintimeout`, `fetchRetryMintimeout`
-- Workspace YAML keys: none
 
 Lower bound on the computed retry backoff. See `fetchRetryFactor`.
 
@@ -1330,12 +1157,8 @@ Maximum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_retry_maxtimeout`, `NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT`
 - .npmrc keys: `fetch-retry-maxtimeout`, `fetchRetryMaxtimeout`
-- Workspace YAML keys: none
 
 Upper bound on the computed retry backoff. See `fetchRetryFactor`.
 
@@ -1345,12 +1168,8 @@ Max time (ms) to wait for an HTTP request.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_timeout`, `NPM_CONFIG_FETCH_TIMEOUT`
 - .npmrc keys: `fetchTimeout`
-- Workspace YAML keys: none
 
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
 `.timeout()` so it covers headers + body together. A request that
@@ -1363,12 +1182,8 @@ Warn if a metadata request exceeds this threshold (ms).
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_warn_timeout_ms`, `NPM_CONFIG_FETCH_WARN_TIMEOUT_MS`
 - .npmrc keys: `fetchWarnTimeoutMs`
-- Workspace YAML keys: none
 
 Observability threshold for registry *metadata* requests (packument,
 dist-tags). When a successful response takes longer than
@@ -1387,12 +1202,8 @@ Warn if download speed falls below this threshold (KiB/s).
 
 - Type: `int`
 - Default: `50`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_min_speed_ki_bps`, `NPM_CONFIG_FETCH_MIN_SPEED_KI_BPS`
 - .npmrc keys: `fetchMinSpeedKiBps`
-- Workspace YAML keys: none
 
 Observability threshold for *tarball* downloads. When a tarball
 finishes with an end-to-end average throughput below this many KiB/s,
@@ -1413,8 +1224,6 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `auto-install-peers`
 - Environment: `npm_config_auto_install_peers`, `NPM_CONFIG_AUTO_INSTALL_PEERS`
 - .npmrc keys: `auto-install-peers`, `autoInstallPeers`
@@ -1431,9 +1240,6 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_dedupe_peer_dependents`, `NPM_CONFIG_DEDUPE_PEER_DEPENDENTS`
 - .npmrc keys: `dedupePeerDependents`
 - Workspace YAML keys: `dedupePeerDependents`
@@ -1452,9 +1258,6 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_dedupe_peers`, `NPM_CONFIG_DEDUPE_PEERS`
 - .npmrc keys: `dedupePeers`
 - Workspace YAML keys: `dedupePeers`
@@ -1471,9 +1274,6 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_strict_peer_dependencies`, `NPM_CONFIG_STRICT_PEER_DEPENDENCIES`
 - .npmrc keys: `strict-peer-dependencies`, `strictPeerDependencies`
 - Workspace YAML keys: `strictPeerDependencies`
@@ -1492,9 +1292,6 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_resolve_peers_from_workspace_root`, `NPM_CONFIG_RESOLVE_PEERS_FROM_WORKSPACE_ROOT`
 - .npmrc keys: `resolvePeersFromWorkspaceRoot`
 - Workspace YAML keys: `resolvePeersFromWorkspaceRoot`
@@ -1512,9 +1309,6 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_peer_dependency_rules_ignore_missing`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_IGNORE_MISSING`
 - .npmrc keys: `peerDependencyRules.ignoreMissing`
 - Workspace YAML keys: `peerDependencyRules.ignoreMissing`
@@ -1533,9 +1327,6 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_peer_dependency_rules_allowed_versions`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOWED_VERSIONS`
 - .npmrc keys: `peerDependencyRules.allowedVersions`
 - Workspace YAML keys: `peerDependencyRules.allowedVersions`
@@ -1555,9 +1346,6 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_peer_dependency_rules_allow_any`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOW_ANY`
 - .npmrc keys: `peerDependencyRules.allowAny`
 - Workspace YAML keys: `peerDependencyRules.allowAny`
@@ -1577,12 +1365,9 @@ Control color output in aube's CLI.
 
 - Type: `"auto" | "always" | "never"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `color`, `no-color`
 - Environment: `npm_config_color`, `NPM_CONFIG_COLOR`
 - .npmrc keys: `color`
-- Workspace YAML keys: none
 
 `--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree.
 
@@ -1592,12 +1377,9 @@ Minimum log level to display.
 
 - Type: `"debug" | "info" | "warn" | "error" | "silent"`
 - Default: `"warn"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `loglevel`, `verbose`, `v`, `silent`
 - Environment: `npm_config_loglevel`, `NPM_CONFIG_LOGLEVEL`
 - .npmrc keys: `loglevel`
-- Workspace YAML keys: none
 
 Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`.
 
@@ -1607,12 +1389,8 @@ Opt into experimental CLI features.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_use_beta_cli`, `NPM_CONFIG_USE_BETA_CLI`
 - .npmrc keys: `useBetaCli`
-- Workspace YAML keys: none
 
 Accepted from env and `.npmrc` for pnpm parity. aube currently has no beta-gated commands, so the setting is a no-op after validation.
 
@@ -1622,12 +1400,8 @@ Install on all workspace packages by default.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_recursive_install`, `NPM_CONFIG_RECURSIVE_INSTALL`
 - .npmrc keys: `recursiveInstall`
-- Workspace YAML keys: none
 
 When true, workspace installs resolve and link all importers by default. Set to false to opt out of implicit workspace-wide install behavior; explicit `--filter` / `--recursive` still wins.
 
@@ -1637,12 +1411,8 @@ Fail if a package is incompatible with the current Node version.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_engine_strict`, `NPM_CONFIG_ENGINE_STRICT`
 - .npmrc keys: `engine-strict`, `engineStrict`
-- Workspace YAML keys: none
 
 When on, an `engines.node` mismatch on the root project or any dependency fails the install. When off, mismatches are warnings only.
 
@@ -1652,12 +1422,8 @@ Path to the npm binary aube should shell out to when needed.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_npm_path`, `NPM_CONFIG_NPM_PATH`
 - .npmrc keys: `npmPath`
-- Workspace YAML keys: none
 
 Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`, `token`, `whoami`) when configured. Without it, aube keeps the explicit `use npm` error.
 
@@ -1667,12 +1433,8 @@ Enforce the `packageManager` field in package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_package_manager_strict`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT`
 - .npmrc keys: `packageManagerStrict`
-- Workspace YAML keys: none
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
 
@@ -1682,12 +1444,8 @@ Enforce the exact `packageManager` version from package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_package_manager_strict_version`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION`
 - .npmrc keys: `packageManagerStrictVersion`
-- Workspace YAML keys: none
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
 
@@ -1697,12 +1455,8 @@ Auto-download the specified pnpm version when mismatched.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_manage_package_manager_versions`, `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS`
 - .npmrc keys: `managePackageManagerVersions`
-- Workspace YAML keys: none
 
 Accepted for pnpm parity. aube does not download or re-exec other package-manager versions; when exact version enforcement is enabled, mismatches are reported instead.
 
@@ -1714,8 +1468,6 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `ignore-scripts`
 - Environment: `npm_config_ignore_scripts`, `NPM_CONFIG_IGNORE_SCRIPTS`
 - .npmrc keys: `ignore-scripts`, `ignoreScripts`
@@ -1737,9 +1489,6 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_child_concurrency`, `NPM_CONFIG_CHILD_CONCURRENCY`
 - .npmrc keys: `child-concurrency`, `childConcurrency`
 - Workspace YAML keys: `childConcurrency`
@@ -1761,8 +1510,6 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `side-effects-cache`
 - Environment: `npm_config_side_effects_cache`, `NPM_CONFIG_SIDE_EFFECTS_CACHE`
 - .npmrc keys: `side-effects-cache`, `sideEffectsCache`
@@ -1787,12 +1534,8 @@ Only read from the side-effects cache; don't write.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_side_effects_cache_readonly`, `NPM_CONFIG_SIDE_EFFECTS_CACHE_READONLY`
 - .npmrc keys: `sideEffectsCacheReadonly`
-- Workspace YAML keys: none
 
 When true, aube may restore allowlisted dependency build output from the
 side-effects cache but will not write new cache entries after scripts run.
@@ -1803,12 +1546,8 @@ Drop to a non-root user when running scripts as root.
 
 - Type: `bool`
 - Default: `false (as root), true (otherwise)`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_unsafe_perm`, `NPM_CONFIG_UNSAFE_PERM`
 - .npmrc keys: `unsafePerm`
-- Workspace YAML keys: none
 
 aube exports the resolved value to lifecycle and `run` scripts as
 `npm_config_unsafe_perm`, matching the environment surface npm-style
@@ -1820,12 +1559,8 @@ Options passed to Node.js via NODE_OPTIONS.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `NODE_OPTIONS`, `npm_config_node_options`, `NPM_CONFIG_NODE_OPTIONS`
 - .npmrc keys: `nodeOptions`
-- Workspace YAML keys: none
 
 When set in `.npmrc`, aube exports the value as `NODE_OPTIONS` for
 lifecycle scripts and `aube run` scripts. An existing `NODE_OPTIONS`
@@ -1837,12 +1572,8 @@ Check dependencies before running scripts.
 
 - Type: `"install" | "warn" | "error" | "prompt" | false`
 - Default: `"install"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_verify_deps_before_run`, `NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN`
 - .npmrc keys: `verifyDepsBeforeRun`
-- Workspace YAML keys: none
 
 Controls `run`, lifecycle shortcuts, `exec`, and implicit script commands.
 `install` preserves aube's auto-install behavior, `warn` reports stale
@@ -1855,12 +1586,8 @@ Exit with an error if dependencies have unreviewed build scripts.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_strict_dep_builds`, `NPM_CONFIG_STRICT_DEP_BUILDS`
 - .npmrc keys: `strictDepBuilds`
-- Workspace YAML keys: none
 
 aube never runs dependency lifecycle scripts unless the package is
 listed in `allowBuilds` or `--dangerously-allow-all-builds` is set.
@@ -1876,9 +1603,6 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_allow_builds`, `NPM_CONFIG_ALLOW_BUILDS`
 - .npmrc keys: `allowBuilds`
 - Workspace YAML keys: `allowBuilds`
@@ -1900,12 +1624,9 @@ Allow all dependency build scripts automatically.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `dangerously-allow-all-builds`
 - Environment: `npm_config_dangerously_allow_all_builds`, `NPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS`
 - .npmrc keys: `dangerouslyAllowAllBuilds`
-- Workspace YAML keys: none
 
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
 dependency's `preinstall` / `install` / `postinstall` / `prepare`
@@ -1925,12 +1646,8 @@ Node.js version aube reports when evaluating `engines` checks.
 
 - Type: `string`
 - Default: `` output of `node -v` with the leading `v` stripped ``
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_node_version`, `NPM_CONFIG_NODE_VERSION`
 - .npmrc keys: `node-version`, `nodeVersion`
-- Workspace YAML keys: none
 
 Paired with `engineStrict`. Set this in .npmrc to pin the Node version engines checks validate against, rather than probing `node --version` at install time.
 
@@ -1940,12 +1657,8 @@ Custom Node.js download mirror URLs.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_node_download_mirrors`, `NPM_CONFIG_NODE_DOWNLOAD_MIRRORS`
 - .npmrc keys: `nodeDownloadMirrors`
-- Workspace YAML keys: none
 
 Accepted for pnpm config parity. aube does not download Node.js itself,
 so the parsed mirror map is preserved for config introspection but has
@@ -1959,12 +1672,8 @@ Version prefix used when installing a package.
 
 - Type: `"^" | "~" | ""`
 - Default: `"^"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_save_prefix`, `NPM_CONFIG_SAVE_PREFIX`
 - .npmrc keys: `save-prefix`, `savePrefix`
-- Workspace YAML keys: none
 
 Resolved from `.npmrc`. `--save-exact` overrides to empty prefix.
 
@@ -1974,12 +1683,8 @@ Default dist-tag used by `aube add` without a version.
 
 - Type: `string`
 - Default: `"latest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_tag`, `NPM_CONFIG_TAG`
 - .npmrc keys: `tag`
-- Workspace YAML keys: none
 
 Resolved from `.npmrc`. Used by `aube add` when no version or dist-tag is specified.
 
@@ -1989,12 +1694,8 @@ Directory where globally installed packages live.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_global_dir`, `NPM_CONFIG_GLOBAL_DIR`
 - .npmrc keys: `globalDir`
-- Workspace YAML keys: none
 
 Overrides the directory where globally installed packages live. Falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
 
@@ -2004,12 +1705,8 @@ Directory where global binaries are symlinked.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_global_bin_dir`, `NPM_CONFIG_GLOBAL_BIN_DIR`
 - .npmrc keys: `globalBinDir`
-- Workspace YAML keys: none
 
 Overrides the directory where global binaries are symlinked. Independent of `globalDir`; falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
 
@@ -2019,12 +1716,8 @@ Path to an additional .npmrc file consulted for registry authentication tokens.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_npmrc_auth_file`, `NPM_CONFIG_NPMRC_AUTH_FILE`
 - .npmrc keys: `npmrc-auth-file`, `npmrcAuthFile`
-- Workspace YAML keys: none
 
 Points at an extra `.npmrc`-formatted file that aube reads *after*
 the user and project `.npmrc` files when resolving registry auth.
@@ -2051,12 +1744,8 @@ Directory for aube install-state files.
 
 - Type: `path`
 - Default: `.aube/.state`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_state_dir`, `NPM_CONFIG_STATE_DIR`
 - .npmrc keys: `stateDir`
-- Workspace YAML keys: none
 
 Overrides the directory for install state tracking. Defaults to `.aube/.state` relative to the project root.
 
@@ -2066,12 +1755,8 @@ Directory for package metadata and dlx cache.
 
 - Type: `path`
 - Default: `~/.cache/aube`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_cache_dir`, `NPM_CONFIG_CACHE_DIR`
 - .npmrc keys: `cache-dir`, `cacheDir`
-- Workspace YAML keys: none
 
 Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path.
 
@@ -2081,12 +1766,8 @@ Write all output to stderr instead of stdout.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_use_stderr`, `NPM_CONFIG_USE_STDERR`
 - .npmrc keys: `useStderr`
-- Workspace YAML keys: none
 
 Redirects stdout to stderr for the process lifetime. Resolved from `.npmrc` or the `--use-stderr` CLI flag.
 
@@ -2096,12 +1777,8 @@ Show an update notification when a newer aube is available.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_update_notifier`, `NPM_CONFIG_UPDATE_NOTIFIER`
 - .npmrc keys: `updateNotifier`
-- Workspace YAML keys: none
 
 After a successful `install`, `add`, or `update`, aube fetches
 `https://aube.en.dev/VERSION` and prints a one-line notice if the
@@ -2120,12 +1797,8 @@ Create symlinks instead of shims for `.bin` entries.
 
 - Type: `bool`
 - Default: `true (POSIX hoisted)`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_prefer_symlinked_executables`, `NPM_CONFIG_PREFER_SYMLINKED_EXECUTABLES`
 - .npmrc keys: `preferSymlinkedExecutables`
-- Workspace YAML keys: none
 
 POSIX only. Default (unset or `true`) creates a plain symlink from
 `node_modules/.bin/<name>` straight to the package's executable file —
@@ -2142,12 +1815,8 @@ Disable pnpm's automatic dependency patching database.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_ignore_compatibility_db`, `NPM_CONFIG_IGNORE_COMPATIBILITY_DB`
 - .npmrc keys: `ignoreCompatibilityDb`
-- Workspace YAML keys: none
 
 Accepted for pnpm config parity. pnpm ships a built-in compatibility
 database of auto-patches for known-broken packages; aube has no such
@@ -2160,12 +1829,9 @@ Dependency version resolution strategy.
 
 - Type: `"highest" | "time-based" | "lowest-direct"`
 - Default: `"highest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `resolution-mode`
 - Environment: `npm_config_resolution_mode`, `NPM_CONFIG_RESOLUTION_MODE`
 - .npmrc keys: `resolution-mode`, `resolutionMode`
-- Workspace YAML keys: none
 
 Controls how aube chooses versions during resolution. `highest` picks
 the newest satisfying version. `time-based` filters candidates through
@@ -2179,12 +1845,8 @@ Whether the configured registry returns a `time` field in metadata.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_registry_supports_time_field`, `NPM_CONFIG_REGISTRY_SUPPORTS_TIME_FIELD`
 - .npmrc keys: `registry-supports-time-field`, `registrySupportsTimeField`
-- Workspace YAML keys: none
 
 When `false` (the default, matching pnpm and npmjs.org's behavior),
 aube fetches the full (non-corgi) packument to read the `time:` map
@@ -2209,12 +1871,8 @@ Set NODE_PATH in command shims.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_extend_node_path`, `NPM_CONFIG_EXTEND_NODE_PATH`
 - .npmrc keys: `extendNodePath`
-- Workspace YAML keys: none
 
 When `true` (default), aube-generated `.bin` shims export
 `NODE_PATH="$basedir/.."` so the shimmed binary can resolve modules
@@ -2231,9 +1889,6 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_deploy_all_files`, `NPM_CONFIG_DEPLOY_ALL_FILES`
 - .npmrc keys: `deploy-all-files`, `deployAllFiles`
 - Workspace YAML keys: `deployAllFiles`
@@ -2254,9 +1909,6 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_dedupe_direct_deps`, `NPM_CONFIG_DEDUPE_DIRECT_DEPS`
 - .npmrc keys: `dedupe-direct-deps`, `dedupeDirectDeps`
 - Workspace YAML keys: `dedupeDirectDeps`
@@ -2277,12 +1929,8 @@ Fast-path check before running a full install.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_optimistic_repeat_install`, `NPM_CONFIG_OPTIMISTIC_REPEAT_INSTALL`
 - .npmrc keys: `optimisticRepeatInstall`
-- Workspace YAML keys: none
 
 When `true` (default), `aube run` / `aube exec` / `aube start` /
 `aube test` / `aube restart` consult `.aube/.state/install-state.json`
@@ -2299,12 +1947,8 @@ Scripts that must be present in every workspace project.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_required_scripts`, `NPM_CONFIG_REQUIRED_SCRIPTS`
 - .npmrc keys: `requiredScripts`
-- Workspace YAML keys: none
 
 During install, aube verifies that the root package and every discovered
 workspace package define each required script in `package.json`.
@@ -2315,12 +1959,8 @@ Run pre/post scripts automatically when a named script is invoked.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_enable_pre_post_scripts`, `NPM_CONFIG_ENABLE_PRE_POST_SCRIPTS`
 - .npmrc keys: `enablePrePostScripts`
-- Workspace YAML keys: none
 
 Controls whether `aube run build` also runs `prebuild` before `build`
 and `postbuild` after it when those scripts exist.
@@ -2331,12 +1971,8 @@ Shell used to invoke package scripts.
 
 - Type: `path`
 - Default: `null (uses /bin/sh on Unix, cmd on Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_script_shell`, `NPM_CONFIG_SCRIPT_SHELL`
 - .npmrc keys: `scriptShell`
-- Workspace YAML keys: none
 
 Overrides the shell executable used for lifecycle and `aube run`
 scripts. On Unix, aube invokes the configured shell with `-c`.
@@ -2347,12 +1983,8 @@ Use a JavaScript bash-like shell to run scripts cross-platform.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_shell_emulator`, `NPM_CONFIG_SHELL_EMULATOR`
 - .npmrc keys: `shellEmulator`
-- Workspace YAML keys: none
 
 Accepted for pnpm config parity. aube does not embed pnpm's JavaScript
 shell emulator, but it exports `npm_config_shell_emulator=true` for
@@ -2364,12 +1996,8 @@ How catalog references in package.json are handled by `add`.
 
 - Type: `"manual" | "strict" | "prefer"`
 - Default: `"manual"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_catalog_mode`, `NPM_CONFIG_CATALOG_MODE`
 - .npmrc keys: `catalogMode`
-- Workspace YAML keys: none
 
 `manual` (the default) writes whatever range `aube add` resolved, even
 when the package is declared in the default catalog. `prefer` rewrites
@@ -2392,12 +2020,8 @@ Explicitly mark the environment as CI.
 
 - Type: `bool`
 - Default: `auto-detected`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `CI`, `npm_config_ci`, `NPM_CONFIG_CI`
 - .npmrc keys: `ci`
-- Workspace YAML keys: none
 
 aube detects CI via `env::var("CI").is_ok()` in two places:
 `aube-linker` (disables the global virtual store) and
@@ -2413,9 +2037,6 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_cleanup_unused_catalogs`, `NPM_CONFIG_CLEANUP_UNUSED_CATALOGS`
 - .npmrc keys: `cleanupUnusedCatalogs`
 - Workspace YAML keys: `cleanupUnusedCatalogs`
@@ -2436,9 +2057,6 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-17`
-- CLI flags: none
 - Environment: `AUBE_LINK_CONCURRENCY`, `npm_config_link_concurrency`, `NPM_CONFIG_LINK_CONCURRENCY`
 - .npmrc keys: `link-concurrency`, `linkConcurrency`
 - Workspace YAML keys: `linkConcurrency`
@@ -2463,9 +2081,6 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `AUBE_NO_LOCK`, `npm_config_aube_no_lock`, `NPM_CONFIG_AUBE_NO_LOCK`
 - .npmrc keys: `aubeNoLock`, `aube-no-lock`
 - Workspace YAML keys: `aubeNoLock`
@@ -2498,8 +2113,6 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `no-install`
 - Environment: `AUBE_NO_AUTO_INSTALL`, `npm_config_aube_no_auto_install`, `NPM_CONFIG_AUBE_NO_AUTO_INSTALL`
 - .npmrc keys: `aubeNoAutoInstall`, `aube-no-auto-install`

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -50,7 +50,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
 | [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
 | [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`autoDisableGlobalVirtualStoreForNextjs`](#setting-autodisableglobalvirtualstorefornextjs) | `bool` | implemented | Disable the global virtual store when a Next.js dependency is detected. |
+| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | implemented | Package names whose presence in any importer forces per-project materialization. |
 | [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
 | [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
 | [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
@@ -767,33 +767,33 @@ It's enabled by default and disabled under CI (see `aube-linker`, which
 checks the `CI` env var). pnpm gained the same feature later; we expose
 it through `CI=1` rather than a dedicated config knob.
 
-### `autoDisableGlobalVirtualStoreForNextjs` {#setting-autodisableglobalvirtualstorefornextjs}
+### `disableGlobalVirtualStoreForPackages` {#setting-disableglobalvirtualstoreforpackages}
 
-Disable the global virtual store when a Next.js dependency is detected.
+Package names whose presence in any importer forces per-project materialization.
 
-- Type: `bool`
-- Default: `true`
+- Type: `list<string>`
+- Default: `["next"]`
 - Status: implemented
 - Added to registry: `2026-04-18`
 - CLI flags: none
-- Environment: `npm_config_auto_disable_global_virtual_store_for_nextjs`, `NPM_CONFIG_AUTO_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_NEXTJS`
-- .npmrc keys: `autoDisableGlobalVirtualStoreForNextjs`
-- Workspace YAML keys: `autoDisableGlobalVirtualStoreForNextjs`
+- Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
+- .npmrc keys: `disableGlobalVirtualStoreForPackages`
+- Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
 
-Next.js's Turbopack canonicalizes every symlink under `node_modules/`
-and rejects any target that resolves outside the project's "filesystem
-root". aube's global virtual store makes `node_modules/.aube/<pkg>` an
-absolute symlink into `~/.cache/aube/virtual-store/`, which Turbopack
-then reports as `Symlink ... is invalid, it points out of the
-filesystem root`.
+aube's global virtual store makes `node_modules/.aube/<pkg>` an
+absolute symlink into `~/.cache/aube/virtual-store/`. Some tools —
+most notably Next.js's Turbopack — canonicalize every symlink under
+`node_modules/` and reject any target that resolves outside the
+project's "filesystem root", producing errors like `Symlink ... is
+invalid, it points out of the filesystem root`.
 
-When this setting is `true` (the default) and `aube install` detects
-`next` in the root `package.json`'s dependencies, aube forces
-per-project materialization for this install and prints a one-line
-warning explaining why. Set to `false` to keep the global virtual
-store enabled even when Next.js is present — useful if you're working
-around the Turbopack issue another way (e.g. `next dev --webpack`) and
-want the throughput win.
+When `aube install` finds one of these names in any importer's
+`dependencies`, `devDependencies`, or `optionalDependencies`, it
+forces per-project materialization for that install and prints a
+one-line warning naming the trigger. Defaults to `["next"]`; add
+other packages here as you discover them, or set the list to `[]` to
+disable the heuristic. `CI=1` already forces per-project mode, so the
+warning suppresses itself in that case.
 
 ## Store
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -16,122 +16,123 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-112 settings are listed here.
+113 settings are listed here. 113 are currently implemented.
 
-| Setting | Type | Summary |
-| --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
-| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
-| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
-| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
-| [`symlink`](#setting-symlink) | `bool` | Create symlinks in the virtual store directory. |
-| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | Write files to the modules directory. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
-| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | Max length for virtual store directory names. |
-| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | Populate the virtual store without creating top-level symlinks. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
-| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | Minutes before orphan packages are removed from the virtual store. |
-| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | Minutes before the dlx cache is considered stale. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
-| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
-| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | Only allow installs when the store server is running. |
-| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | Validate package names and versions in the store. |
-| [`httpsProxy`](#setting-httpsproxy) | `url` | Proxy URL for outgoing HTTPS requests. |
-| [`httpProxy`](#setting-httpproxy) | `url` | Proxy URL for outgoing HTTP requests. |
-| [`noProxy`](#setting-noproxy) | `string` | Comma-separated list of domains that bypass the proxy. |
-| [`localAddress`](#setting-localaddress) | `string` | Local interface IP address to bind registry connections to. |
-| [`maxsockets`](#setting-maxsockets) | `int` | Maximum concurrent connections per origin. |
-| [`strictSsl`](#setting-strictssl) | `bool` | Validate SSL certificates for HTTPS requests. |
-| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | Hosts for which aube performs shallow git clones. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
-| [`fetchRetries`](#setting-fetchretries) | `int` | Number of retry attempts for failed registry fetches. |
-| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | Exponential backoff factor for fetch retries. |
-| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | Minimum retry timeout in milliseconds. |
-| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | Maximum retry timeout in milliseconds. |
-| [`fetchTimeout`](#setting-fetchtimeout) | `int` | Max time (ms) to wait for an HTTP request. |
-| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | Warn if a metadata request exceeds this threshold (ms). |
-| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | Warn if download speed falls below this threshold (KiB/s). |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
-| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | Control color output in aube's CLI. |
-| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | Minimum log level to display. |
-| [`useBetaCli`](#setting-usebetacli) | `bool` | Opt into experimental CLI features. |
-| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | Install on all workspace packages by default. |
-| [`engineStrict`](#setting-enginestrict) | `bool` | Fail if a package is incompatible with the current Node version. |
-| [`npmPath`](#setting-npmpath) | `path` | Path to the npm binary aube should shell out to when needed. |
-| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | Enforce the `packageManager` field in package.json. |
-| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | Enforce the exact `packageManager` version from package.json. |
-| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | Auto-download the specified pnpm version when mismatched. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
-| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | Only read from the side-effects cache; don't write. |
-| [`unsafePerm`](#setting-unsafeperm) | `bool` | Drop to a non-root user when running scripts as root. |
-| [`nodeOptions`](#setting-nodeoptions) | `string` | Options passed to Node.js via NODE_OPTIONS. |
-| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | Check dependencies before running scripts. |
-| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | Exit with an error if dependencies have unreviewed build scripts. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
-| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | Allow all dependency build scripts automatically. |
-| [`nodeVersion`](#setting-nodeversion) | `string` | Node.js version aube reports when evaluating `engines` checks. |
-| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | Custom Node.js download mirror URLs. |
-| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | Version prefix used when installing a package. |
-| [`tag`](#setting-tag) | `string` | Default dist-tag used by `aube add` without a version. |
-| [`globalDir`](#setting-globaldir) | `path` | Directory where globally installed packages live. |
-| [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
-| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
-| [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | Directory for package metadata and dlx cache. |
-| [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
-| [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
-| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | Create symlinks instead of shims for `.bin` entries. |
-| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | Disable pnpm's automatic dependency patching database. |
-| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | Dependency version resolution strategy. |
-| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | Whether the configured registry returns a `time` field in metadata. |
-| [`extendNodePath`](#setting-extendnodepath) | `bool` | Set NODE_PATH in command shims. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | Fast-path check before running a full install. |
-| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | Scripts that must be present in every workspace project. |
-| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | Run pre/post scripts automatically when a named script is invoked. |
-| [`scriptShell`](#setting-scriptshell) | `path` | Shell used to invoke package scripts. |
-| [`shellEmulator`](#setting-shellemulator) | `bool` | Use a JavaScript bash-like shell to run scripts cross-platform. |
-| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | How catalog references in package.json are handled by `add`. |
-| [`ci`](#setting-ci) | `bool` | Explicitly mark the environment as CI. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Status | Summary |
+| --- | --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
+| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | implemented | Specify architectures for optional dependency installation. |
+| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | implemented | Skip optional dependencies by name. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`registries`](#setting-registries) | `object` | implemented | Registry URLs, including scoped registry overrides. |
+| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
+| [`symlink`](#setting-symlink) | `bool` | implemented | Create symlinks in the virtual store directory. |
+| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | implemented | Write files to the modules directory. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
+| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | implemented | Max length for virtual store directory names. |
+| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | implemented | Populate the virtual store without creating top-level symlinks. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
+| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
+| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
+| [`autoDisableGlobalVirtualStoreForNextjs`](#setting-autodisableglobalvirtualstorefornextjs) | `bool` | implemented | Disable the global virtual store when a Next.js dependency is detected. |
+| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
+| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
+| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | implemented | Validate package names and versions in the store. |
+| [`httpsProxy`](#setting-httpsproxy) | `url` | implemented | Proxy URL for outgoing HTTPS requests. |
+| [`httpProxy`](#setting-httpproxy) | `url` | implemented | Proxy URL for outgoing HTTP requests. |
+| [`noProxy`](#setting-noproxy) | `string` | implemented | Comma-separated list of domains that bypass the proxy. |
+| [`localAddress`](#setting-localaddress) | `string` | implemented | Local interface IP address to bind registry connections to. |
+| [`maxsockets`](#setting-maxsockets) | `int` | implemented | Maximum concurrent connections per origin. |
+| [`strictSsl`](#setting-strictssl) | `bool` | implemented | Validate SSL certificates for HTTPS requests. |
+| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | implemented | Hosts for which aube performs shallow git clones. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
+| [`fetchRetries`](#setting-fetchretries) | `int` | implemented | Number of retry attempts for failed registry fetches. |
+| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | implemented | Exponential backoff factor for fetch retries. |
+| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | implemented | Minimum retry timeout in milliseconds. |
+| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | implemented | Maximum retry timeout in milliseconds. |
+| [`fetchTimeout`](#setting-fetchtimeout) | `int` | implemented | Max time (ms) to wait for an HTTP request. |
+| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | implemented | Warn if a metadata request exceeds this threshold (ms). |
+| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | implemented | Warn if download speed falls below this threshold (KiB/s). |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
+| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | implemented | Control color output in aube's CLI. |
+| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | implemented | Minimum log level to display. |
+| [`useBetaCli`](#setting-usebetacli) | `bool` | implemented | Opt into experimental CLI features. |
+| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | implemented | Install on all workspace packages by default. |
+| [`engineStrict`](#setting-enginestrict) | `bool` | implemented | Fail if a package is incompatible with the current Node version. |
+| [`npmPath`](#setting-npmpath) | `path` | implemented | Path to the npm binary aube should shell out to when needed. |
+| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | implemented | Enforce the `packageManager` field in package.json. |
+| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | implemented | Enforce the exact `packageManager` version from package.json. |
+| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | implemented | Auto-download the specified pnpm version when mismatched. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
+| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | implemented | Only read from the side-effects cache; don't write. |
+| [`unsafePerm`](#setting-unsafeperm) | `bool` | implemented | Drop to a non-root user when running scripts as root. |
+| [`nodeOptions`](#setting-nodeoptions) | `string` | implemented | Options passed to Node.js via NODE_OPTIONS. |
+| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | implemented | Check dependencies before running scripts. |
+| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | implemented | Exit with an error if dependencies have unreviewed build scripts. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
+| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | implemented | Allow all dependency build scripts automatically. |
+| [`nodeVersion`](#setting-nodeversion) | `string` | implemented | Node.js version aube reports when evaluating `engines` checks. |
+| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | implemented | Custom Node.js download mirror URLs. |
+| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | implemented | Version prefix used when installing a package. |
+| [`tag`](#setting-tag) | `string` | implemented | Default dist-tag used by `aube add` without a version. |
+| [`globalDir`](#setting-globaldir) | `path` | implemented | Directory where globally installed packages live. |
+| [`globalBinDir`](#setting-globalbindir) | `path` | implemented | Directory where global binaries are symlinked. |
+| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | implemented | Path to an additional .npmrc file consulted for registry authentication tokens. |
+| [`stateDir`](#setting-statedir) | `path` | implemented | Directory for aube install-state files. |
+| [`cacheDir`](#setting-cachedir) | `path` | implemented | Directory for package metadata and dlx cache. |
+| [`useStderr`](#setting-usestderr) | `bool` | implemented | Write all output to stderr instead of stdout. |
+| [`updateNotifier`](#setting-updatenotifier) | `bool` | implemented | Show an update notification when a newer aube is available. |
+| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | implemented | Create symlinks instead of shims for `.bin` entries. |
+| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | implemented | Disable pnpm's automatic dependency patching database. |
+| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | implemented | Dependency version resolution strategy. |
+| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | implemented | Whether the configured registry returns a `time` field in metadata. |
+| [`extendNodePath`](#setting-extendnodepath) | `bool` | implemented | Set NODE_PATH in command shims. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | implemented | Fast-path check before running a full install. |
+| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | implemented | Scripts that must be present in every workspace project. |
+| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | implemented | Run pre/post scripts automatically when a named script is invoked. |
+| [`scriptShell`](#setting-scriptshell) | `path` | implemented | Shell used to invoke package scripts. |
+| [`shellEmulator`](#setting-shellemulator) | `bool` | implemented | Use a JavaScript bash-like shell to run scripts cross-platform. |
+| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | implemented | How catalog references in package.json are handled by `add`. |
+| [`ci`](#setting-ci) | `bool` | implemented | Explicitly mark the environment as CI. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -141,6 +142,9 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_overrides`, `NPM_CONFIG_OVERRIDES`
 - .npmrc keys: `overrides`
 - Workspace YAML keys: `overrides`
@@ -156,6 +160,9 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_package_extensions`, `NPM_CONFIG_PACKAGE_EXTENSIONS`
 - .npmrc keys: `packageExtensions`
 - Workspace YAML keys: `packageExtensions`
@@ -170,6 +177,9 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_allowed_deprecated_versions`, `NPM_CONFIG_ALLOWED_DEPRECATED_VERSIONS`
 - .npmrc keys: `allowedDeprecatedVersions`
 - Workspace YAML keys: `allowedDeprecatedVersions`
@@ -184,6 +194,9 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_update_config_ignore_dependencies`, `NPM_CONFIG_UPDATE_CONFIG_IGNORE_DEPENDENCIES`
 - .npmrc keys: `updateConfig.ignoreDependencies`
 - Workspace YAML keys: `updateConfig.ignoreDependencies`
@@ -197,8 +210,12 @@ Specify architectures for optional dependency installation.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_supported_architectures`, `NPM_CONFIG_SUPPORTED_ARCHITECTURES`
 - .npmrc keys: `supportedArchitectures`
+- Workspace YAML keys: none
 
 Override the current platform/arch/libc triple used to filter optional
 dependencies. Useful when generating a lockfile for a target platform
@@ -210,8 +227,12 @@ Skip optional dependencies by name.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_ignored_optional_dependencies`, `NPM_CONFIG_IGNORED_OPTIONAL_DEPENDENCIES`
 - .npmrc keys: `ignoredOptionalDependencies`
+- Workspace YAML keys: none
 
 Named entries are skipped even if their platform/arch matches. Distinct
 from `--no-optional`, which drops *all* optional deps at install time.
@@ -222,6 +243,9 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_minimum_release_age`, `NPM_CONFIG_MINIMUM_RELEASE_AGE`
 - .npmrc keys: `minimumReleaseAge`
 - Workspace YAML keys: `minimumReleaseAge`
@@ -238,6 +262,9 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_minimum_release_age_exclude`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE`
 - .npmrc keys: `minimumReleaseAgeExclude`
 - Workspace YAML keys: `minimumReleaseAgeExclude`
@@ -252,6 +279,9 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_minimum_release_age_strict`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_STRICT`
 - .npmrc keys: `minimumReleaseAgeStrict`
 - Workspace YAML keys: `minimumReleaseAgeStrict`
@@ -266,6 +296,9 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_trust_policy`, `NPM_CONFIG_TRUST_POLICY`
 - .npmrc keys: `trustPolicy`
 - Workspace YAML keys: `trustPolicy`
@@ -281,6 +314,9 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_trust_policy_exclude`, `NPM_CONFIG_TRUST_POLICY_EXCLUDE`
 - .npmrc keys: `trustPolicyExclude`
 - Workspace YAML keys: `trustPolicyExclude`
@@ -293,6 +329,9 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_trust_policy_ignore_after`, `NPM_CONFIG_TRUST_POLICY_IGNORE_AFTER`
 - .npmrc keys: `trustPolicyIgnoreAfter`
 - Workspace YAML keys: `trustPolicyIgnoreAfter`
@@ -305,6 +344,9 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_block_exotic_subdeps`, `NPM_CONFIG_BLOCK_EXOTIC_SUBDEPS`
 - .npmrc keys: `blockExoticSubdeps`
 - Workspace YAML keys: `blockExoticSubdeps`
@@ -319,8 +361,12 @@ Registry URLs, including scoped registry overrides.
 
 - Type: `object`
 - Default: `{ default = "https://registry.npmjs.org/" }`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_registries`, `NPM_CONFIG_REGISTRIES`
 - .npmrc keys: `registry`, `@scope:registry`, `//host/:_authToken`, `//host/:_auth`
+- Workspace YAML keys: none
 
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
 `.npmrc` via `aube_registry::config::NpmConfig` (see
@@ -340,6 +386,9 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_hoist`, `NPM_CONFIG_HOIST`
 - .npmrc keys: `hoist`
 - Workspace YAML keys: `hoist`
@@ -370,6 +419,9 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_hoist_workspace_packages`, `NPM_CONFIG_HOIST_WORKSPACE_PACKAGES`
 - .npmrc keys: `hoist-workspace-packages`, `hoistWorkspacePackages`
 - Workspace YAML keys: `hoistWorkspacePackages`
@@ -388,6 +440,9 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_hoist_pattern`, `NPM_CONFIG_HOIST_PATTERN`
 - .npmrc keys: `hoist-pattern`, `hoistPattern`
 - Workspace YAML keys: `hoistPattern`
@@ -411,6 +466,8 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
+- Status: implemented
+- Added to registry: `2026-04-13`
 - CLI flags: `public-hoist-pattern`
 - Environment: `npm_config_public_hoist_pattern`, `NPM_CONFIG_PUBLIC_HOIST_PATTERN`
 - .npmrc keys: `public-hoist-pattern`, `publicHoistPattern`
@@ -433,6 +490,8 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `shamefully-hoist`
 - Environment: `npm_config_shamefully_hoist`, `NPM_CONFIG_SHAMEFULLY_HOIST`
 - .npmrc keys: `shamefully-hoist`, `shamefullyHoist`
@@ -449,6 +508,9 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
+- Status: implemented
+- Added to registry: `2026-04-17`
+- CLI flags: none
 - Environment: `npm_config_modules_dir`, `NPM_CONFIG_MODULES_DIR`
 - .npmrc keys: `modulesDir`, `modules-dir`
 - Workspace YAML keys: `modulesDir`
@@ -475,6 +537,8 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `node-linker`
 - Environment: `npm_config_node_linker`, `NPM_CONFIG_NODE_LINKER`
 - .npmrc keys: `nodeLinker`
@@ -492,8 +556,12 @@ Create symlinks in the virtual store directory.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_symlink`, `NPM_CONFIG_SYMLINK`
 - .npmrc keys: `symlink`
+- Workspace YAML keys: none
 
 Accepted for pnpm parity. aube's isolated layout is structurally
 defined by the symlink graph under `node_modules/.aube/` — each
@@ -521,8 +589,12 @@ Write files to the modules directory.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_enable_modules_dir`, `NPM_CONFIG_ENABLE_MODULES_DIR`
 - .npmrc keys: `enableModulesDir`
+- Workspace YAML keys: none
 
 When `false`, aube resolves the dependency graph and writes
 `aube-lock.yaml` but skips every `node_modules/` side effect: no
@@ -537,6 +609,9 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_virtual_store_dir`, `NPM_CONFIG_VIRTUAL_STORE_DIR`
 - .npmrc keys: `virtualStoreDir`, `virtual-store-dir`
 - Workspace YAML keys: `virtualStoreDir`
@@ -567,8 +642,12 @@ Max length for virtual store directory names.
 
 - Type: `int`
 - Default: `120 (Linux/macOS), 60 (Windows)`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_virtual_store_dir_max_length`, `NPM_CONFIG_VIRTUAL_STORE_DIR_MAX_LENGTH`
 - .npmrc keys: `virtualStoreDirMaxLength`
+- Workspace YAML keys: none
 
 Caps the number of characters in a single `node_modules/.aube/<dep>`
 directory name. `dep_path_to_filename` already truncates-and-hashes
@@ -585,8 +664,12 @@ Populate the virtual store without creating top-level symlinks.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_virtual_store_only`, `NPM_CONFIG_VIRTUAL_STORE_ONLY`
 - .npmrc keys: `virtualStoreOnly`
+- Workspace YAML keys: none
 
 When `true`, aube still materializes every package into
 `node_modules/.aube/<dep>/node_modules/<name>` (and, in global-store
@@ -604,6 +687,8 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `package-import-method`
 - Environment: `npm_config_package_import_method`, `NPM_CONFIG_PACKAGE_IMPORT_METHOD`
 - .npmrc keys: `packageImportMethod`, `package-import-method`
@@ -626,8 +711,12 @@ Minutes before orphan packages are removed from the virtual store.
 
 - Type: `int`
 - Default: `10080`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_modules_cache_max_age`, `NPM_CONFIG_MODULES_CACHE_MAX_AGE`
 - .npmrc keys: `modulesCacheMaxAge`
+- Workspace YAML keys: none
 
 After each successful install, aube sweeps the per-project
 `node_modules/.aube/` virtual store and removes entries whose
@@ -646,8 +735,12 @@ Minutes before the dlx cache is considered stale.
 
 - Type: `int`
 - Default: `1440`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_dlx_cache_max_age`, `NPM_CONFIG_DLX_CACHE_MAX_AGE`
 - .npmrc keys: `dlx-cache-max-age`, `dlxCacheMaxAge`
+- Workspace YAML keys: none
 
 Accepted for pnpm parity. `aube dlx` currently installs into a fresh
 `tempfile::TempDir` per invocation and removes it on exit, so there is
@@ -662,6 +755,9 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `CI`, `npm_config_enable_global_virtual_store`, `NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
 - .npmrc keys: `enableGlobalVirtualStore`
 - Workspace YAML keys: `enableGlobalVirtualStore`
@@ -671,6 +767,34 @@ It's enabled by default and disabled under CI (see `aube-linker`, which
 checks the `CI` env var). pnpm gained the same feature later; we expose
 it through `CI=1` rather than a dedicated config knob.
 
+### `autoDisableGlobalVirtualStoreForNextjs` {#setting-autodisableglobalvirtualstorefornextjs}
+
+Disable the global virtual store when a Next.js dependency is detected.
+
+- Type: `bool`
+- Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-18`
+- CLI flags: none
+- Environment: `npm_config_auto_disable_global_virtual_store_for_nextjs`, `NPM_CONFIG_AUTO_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_NEXTJS`
+- .npmrc keys: `autoDisableGlobalVirtualStoreForNextjs`
+- Workspace YAML keys: `autoDisableGlobalVirtualStoreForNextjs`
+
+Next.js's Turbopack canonicalizes every symlink under `node_modules/`
+and rejects any target that resolves outside the project's "filesystem
+root". aube's global virtual store makes `node_modules/.aube/<pkg>` an
+absolute symlink into `~/.cache/aube/virtual-store/`, which Turbopack
+then reports as `Symlink ... is invalid, it points out of the
+filesystem root`.
+
+When this setting is `true` (the default) and `aube install` detects
+`next` in the root `package.json`'s dependencies, aube forces
+per-project materialization for this install and prints a one-line
+warning explaining why. Set to `false` to keep the global virtual
+store enabled even when Next.js is present — useful if you're working
+around the Turbopack issue another way (e.g. `next dev --webpack`) and
+want the throughput win.
+
 ## Store
 
 ### `storeDir` {#setting-storedir}
@@ -679,6 +803,9 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_store_dir`, `NPM_CONFIG_STORE_DIR`
 - .npmrc keys: `store-dir`, `storeDir`
 - Workspace YAML keys: `storeDir`
@@ -708,6 +835,8 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `verify-store-integrity`
 - Environment: `npm_config_verify_store_integrity`, `NPM_CONFIG_VERIFY_STORE_INTEGRITY`
 - .npmrc keys: `verify-store-integrity`, `verifyStoreIntegrity`
@@ -730,8 +859,12 @@ Only allow installs when the store server is running.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_use_running_store_server`, `NPM_CONFIG_USE_RUNNING_STORE_SERVER`
 - .npmrc keys: `use-running-store-server`, `useRunningStoreServer`
+- Workspace YAML keys: none
 
 Accepted for pnpm parity. aube has no long-running store-daemon
 component — every install talks directly to the on-disk CAS at
@@ -746,8 +879,12 @@ Validate package names and versions in the store.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_strict_store_pkg_content_check`, `NPM_CONFIG_STRICT_STORE_PKG_CONTENT_CHECK`
 - .npmrc keys: `strict-store-pkg-content-check`, `strictStorePkgContentCheck`
+- Workspace YAML keys: none
 
 After each registry tarball is imported, aube reads the freshly stored
 `package.json` and confirms its `name` and `version` match what the
@@ -773,8 +910,12 @@ Proxy URL for outgoing HTTPS requests.
 
 - Type: `url`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `HTTPS_PROXY`, `https_proxy`, `npm_config_https_proxy`, `NPM_CONFIG_HTTPS_PROXY`
 - .npmrc keys: `https-proxy`, `httpsProxy`, `proxy`
+- Workspace YAML keys: none
 
 Forwards every HTTPS registry fetch through the given proxy URL.
 Honored by the `aube-registry` reqwest client. Resolution mirrors
@@ -787,8 +928,12 @@ Proxy URL for outgoing HTTP requests.
 
 - Type: `url`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `HTTP_PROXY`, `http_proxy`, `PROXY`, `proxy`, `npm_config_http_proxy`, `NPM_CONFIG_HTTP_PROXY`
 - .npmrc keys: `http-proxy`, `httpProxy`
+- Workspace YAML keys: none
 
 HTTP counterpart to `httpsProxy`. Resolution mirrors pnpm:
 `.npmrc http-proxy` ?? resolved `httpsProxy` ?? `HTTP_PROXY` /
@@ -802,8 +947,12 @@ Comma-separated list of domains that bypass the proxy.
 
 - Type: `string`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `NO_PROXY`, `no_proxy`, `npm_config_no_proxy`, `NPM_CONFIG_NO_PROXY`
 - .npmrc keys: `noproxy`, `noProxy`, `no-proxy`
+- Workspace YAML keys: none
 
 Passed through to `reqwest::NoProxy::from_string` verbatim, so
 wildcard and port-qualified hosts behave the same as curl / node.
@@ -816,8 +965,12 @@ Local interface IP address to bind registry connections to.
 
 - Type: `string`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_local_address`, `NPM_CONFIG_LOCAL_ADDRESS`
 - .npmrc keys: `local-address`, `localAddress`
+- Workspace YAML keys: none
 
 Used on multi-homed hosts where outbound traffic must leave a
 specific interface. Parsed as `IpAddr`; unparseable values are
@@ -829,8 +982,12 @@ Maximum concurrent connections per origin.
 
 - Type: `int`
 - Default: `networkConcurrency x 3`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_maxsockets`, `NPM_CONFIG_MAXSOCKETS`
 - .npmrc keys: `maxsockets`
+- Workspace YAML keys: none
 
 Plumbed into reqwest's `pool_max_idle_per_host`. This is the
 closest analogue to pnpm's per-origin socket cap — reqwest doesn't
@@ -843,8 +1000,12 @@ Validate SSL certificates for HTTPS requests.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_strict_ssl`, `NPM_CONFIG_STRICT_SSL`
 - .npmrc keys: `strict-ssl`, `strictSsl`
+- Workspace YAML keys: none
 
 Defaults to `true`. Setting `strict-ssl=false` disables TLS
 certificate verification entirely via
@@ -860,6 +1021,9 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_lockfile`, `NPM_CONFIG_LOCKFILE`
 - .npmrc keys: `lockfile`
 - Workspace YAML keys: `lockfile`
@@ -886,6 +1050,8 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `prefer-frozen-lockfile`
 - Environment: `npm_config_prefer_frozen_lockfile`, `NPM_CONFIG_PREFER_FROZEN_LOCKFILE`
 - .npmrc keys: `prefer-frozen-lockfile`
@@ -905,6 +1071,9 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_lockfile_include_tarball_url`, `NPM_CONFIG_LOCKFILE_INCLUDE_TARBALL_URL`
 - .npmrc keys: `lockfileIncludeTarballUrl`, `lockfile-include-tarball-url`
 - Workspace YAML keys: `lockfileIncludeTarballUrl`
@@ -934,6 +1103,9 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-13`
+- CLI flags: none
 - Environment: `npm_config_exclude_links_from_lockfile`, `NPM_CONFIG_EXCLUDE_LINKS_FROM_LOCKFILE`
 - .npmrc keys: `exclude-links-from-lockfile`, `excludeLinksFromLockfile`
 - Workspace YAML keys: `excludeLinksFromLockfile`
@@ -956,6 +1128,9 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_git_branch_lockfile`, `NPM_CONFIG_GIT_BRANCH_LOCKFILE`
 - .npmrc keys: `gitBranchLockfile`
 - Workspace YAML keys: `gitBranchLockfile`
@@ -985,6 +1160,9 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_merge_git_branch_lockfiles_branch_pattern`, `NPM_CONFIG_MERGE_GIT_BRANCH_LOCKFILES_BRANCH_PATTERN`
 - .npmrc keys: `mergeGitBranchLockfilesBranchPattern`
 - Workspace YAML keys: `mergeGitBranchLockfilesBranchPattern`
@@ -1017,6 +1195,9 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_peers_suffix_max_length`, `NPM_CONFIG_PEERS_SUFFIX_MAX_LENGTH`
 - .npmrc keys: `peersSuffixMaxLength`
 - Workspace YAML keys: `peersSuffixMaxLength`
@@ -1039,8 +1220,12 @@ Hosts for which aube performs shallow git clones.
 
 - Type: `list<string>`
 - Default: `["github.com", "gist.github.com", "gitlab.com", "bitbucket.com", "bitbucket.org"]`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_git_shallow_hosts`, `NPM_CONFIG_GIT_SHALLOW_HOSTS`
 - .npmrc keys: `git-shallow-hosts`, `gitShallowHosts`
+- Workspace YAML keys: none
 
 Consulted by `aube-store::git_shallow_clone` when cloning a git
 dependency. When the URL's hostname matches an entry in this list
@@ -1063,6 +1248,8 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `network-concurrency`
 - Environment: `npm_config_network_concurrency`, `NPM_CONFIG_NETWORK_CONCURRENCY`
 - .npmrc keys: `network-concurrency`, `networkConcurrency`
@@ -1087,8 +1274,12 @@ Number of retry attempts for failed registry fetches.
 
 - Type: `int`
 - Default: `2`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_fetch_retries`, `NPM_CONFIG_FETCH_RETRIES`
 - .npmrc keys: `fetch-retries`, `fetchRetries`
+- Workspace YAML keys: none
 
 Number of *additional* attempts the registry client makes after a
 transient failure (5xx / 429 / connection error). `2` means up to 3
@@ -1106,8 +1297,12 @@ Exponential backoff factor for fetch retries.
 
 - Type: `int`
 - Default: `10`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_fetch_retry_factor`, `NPM_CONFIG_FETCH_RETRY_FACTOR`
 - .npmrc keys: `fetch-retry-factor`, `fetchRetryFactor`
+- Workspace YAML keys: none
 
 Multiplier used between retry attempts. Attempt `n` waits
 `min(fetchRetryMintimeout * fetchRetryFactor ^ (n-1), fetchRetryMaxtimeout)`
@@ -1120,8 +1315,12 @@ Minimum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `10000`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_fetch_retry_mintimeout`, `NPM_CONFIG_FETCH_RETRY_MINTIMEOUT`
 - .npmrc keys: `fetch-retry-mintimeout`, `fetchRetryMintimeout`
+- Workspace YAML keys: none
 
 Lower bound on the computed retry backoff. See `fetchRetryFactor`.
 
@@ -1131,8 +1330,12 @@ Maximum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `60000`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_fetch_retry_maxtimeout`, `NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT`
 - .npmrc keys: `fetch-retry-maxtimeout`, `fetchRetryMaxtimeout`
+- Workspace YAML keys: none
 
 Upper bound on the computed retry backoff. See `fetchRetryFactor`.
 
@@ -1142,8 +1345,12 @@ Max time (ms) to wait for an HTTP request.
 
 - Type: `int`
 - Default: `60000`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_fetch_timeout`, `NPM_CONFIG_FETCH_TIMEOUT`
 - .npmrc keys: `fetchTimeout`
+- Workspace YAML keys: none
 
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
 `.timeout()` so it covers headers + body together. A request that
@@ -1156,8 +1363,12 @@ Warn if a metadata request exceeds this threshold (ms).
 
 - Type: `int`
 - Default: `10000`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_fetch_warn_timeout_ms`, `NPM_CONFIG_FETCH_WARN_TIMEOUT_MS`
 - .npmrc keys: `fetchWarnTimeoutMs`
+- Workspace YAML keys: none
 
 Observability threshold for registry *metadata* requests (packument,
 dist-tags). When a successful response takes longer than
@@ -1176,8 +1387,12 @@ Warn if download speed falls below this threshold (KiB/s).
 
 - Type: `int`
 - Default: `50`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_fetch_min_speed_ki_bps`, `NPM_CONFIG_FETCH_MIN_SPEED_KI_BPS`
 - .npmrc keys: `fetchMinSpeedKiBps`
+- Workspace YAML keys: none
 
 Observability threshold for *tarball* downloads. When a tarball
 finishes with an end-to-end average throughput below this many KiB/s,
@@ -1198,6 +1413,8 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `auto-install-peers`
 - Environment: `npm_config_auto_install_peers`, `NPM_CONFIG_AUTO_INSTALL_PEERS`
 - .npmrc keys: `auto-install-peers`, `autoInstallPeers`
@@ -1214,6 +1431,9 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_dedupe_peer_dependents`, `NPM_CONFIG_DEDUPE_PEER_DEPENDENTS`
 - .npmrc keys: `dedupePeerDependents`
 - Workspace YAML keys: `dedupePeerDependents`
@@ -1232,6 +1452,9 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_dedupe_peers`, `NPM_CONFIG_DEDUPE_PEERS`
 - .npmrc keys: `dedupePeers`
 - Workspace YAML keys: `dedupePeers`
@@ -1248,6 +1471,9 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_strict_peer_dependencies`, `NPM_CONFIG_STRICT_PEER_DEPENDENCIES`
 - .npmrc keys: `strict-peer-dependencies`, `strictPeerDependencies`
 - Workspace YAML keys: `strictPeerDependencies`
@@ -1266,6 +1492,9 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_resolve_peers_from_workspace_root`, `NPM_CONFIG_RESOLVE_PEERS_FROM_WORKSPACE_ROOT`
 - .npmrc keys: `resolvePeersFromWorkspaceRoot`
 - Workspace YAML keys: `resolvePeersFromWorkspaceRoot`
@@ -1283,6 +1512,9 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_peer_dependency_rules_ignore_missing`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_IGNORE_MISSING`
 - .npmrc keys: `peerDependencyRules.ignoreMissing`
 - Workspace YAML keys: `peerDependencyRules.ignoreMissing`
@@ -1301,6 +1533,9 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_peer_dependency_rules_allowed_versions`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOWED_VERSIONS`
 - .npmrc keys: `peerDependencyRules.allowedVersions`
 - Workspace YAML keys: `peerDependencyRules.allowedVersions`
@@ -1320,6 +1555,9 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_peer_dependency_rules_allow_any`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOW_ANY`
 - .npmrc keys: `peerDependencyRules.allowAny`
 - Workspace YAML keys: `peerDependencyRules.allowAny`
@@ -1339,9 +1577,12 @@ Control color output in aube's CLI.
 
 - Type: `"auto" | "always" | "never"`
 - Default: `"auto"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `color`, `no-color`
 - Environment: `npm_config_color`, `NPM_CONFIG_COLOR`
 - .npmrc keys: `color`
+- Workspace YAML keys: none
 
 `--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree.
 
@@ -1351,9 +1592,12 @@ Minimum log level to display.
 
 - Type: `"debug" | "info" | "warn" | "error" | "silent"`
 - Default: `"warn"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `loglevel`, `verbose`, `v`, `silent`
 - Environment: `npm_config_loglevel`, `NPM_CONFIG_LOGLEVEL`
 - .npmrc keys: `loglevel`
+- Workspace YAML keys: none
 
 Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`.
 
@@ -1363,8 +1607,12 @@ Opt into experimental CLI features.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_use_beta_cli`, `NPM_CONFIG_USE_BETA_CLI`
 - .npmrc keys: `useBetaCli`
+- Workspace YAML keys: none
 
 Accepted from env and `.npmrc` for pnpm parity. aube currently has no beta-gated commands, so the setting is a no-op after validation.
 
@@ -1374,8 +1622,12 @@ Install on all workspace packages by default.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_recursive_install`, `NPM_CONFIG_RECURSIVE_INSTALL`
 - .npmrc keys: `recursiveInstall`
+- Workspace YAML keys: none
 
 When true, workspace installs resolve and link all importers by default. Set to false to opt out of implicit workspace-wide install behavior; explicit `--filter` / `--recursive` still wins.
 
@@ -1385,8 +1637,12 @@ Fail if a package is incompatible with the current Node version.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_engine_strict`, `NPM_CONFIG_ENGINE_STRICT`
 - .npmrc keys: `engine-strict`, `engineStrict`
+- Workspace YAML keys: none
 
 When on, an `engines.node` mismatch on the root project or any dependency fails the install. When off, mismatches are warnings only.
 
@@ -1396,8 +1652,12 @@ Path to the npm binary aube should shell out to when needed.
 
 - Type: `path`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_npm_path`, `NPM_CONFIG_NPM_PATH`
 - .npmrc keys: `npmPath`
+- Workspace YAML keys: none
 
 Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`, `token`, `whoami`) when configured. Without it, aube keeps the explicit `use npm` error.
 
@@ -1407,8 +1667,12 @@ Enforce the `packageManager` field in package.json.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_package_manager_strict`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT`
 - .npmrc keys: `packageManagerStrict`
+- Workspace YAML keys: none
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
 
@@ -1418,8 +1682,12 @@ Enforce the exact `packageManager` version from package.json.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_package_manager_strict_version`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION`
 - .npmrc keys: `packageManagerStrictVersion`
+- Workspace YAML keys: none
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
 
@@ -1429,8 +1697,12 @@ Auto-download the specified pnpm version when mismatched.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_manage_package_manager_versions`, `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS`
 - .npmrc keys: `managePackageManagerVersions`
+- Workspace YAML keys: none
 
 Accepted for pnpm parity. aube does not download or re-exec other package-manager versions; when exact version enforcement is enabled, mismatches are reported instead.
 
@@ -1442,6 +1714,8 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `ignore-scripts`
 - Environment: `npm_config_ignore_scripts`, `NPM_CONFIG_IGNORE_SCRIPTS`
 - .npmrc keys: `ignore-scripts`, `ignoreScripts`
@@ -1463,6 +1737,9 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_child_concurrency`, `NPM_CONFIG_CHILD_CONCURRENCY`
 - .npmrc keys: `child-concurrency`, `childConcurrency`
 - Workspace YAML keys: `childConcurrency`
@@ -1484,6 +1761,8 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `side-effects-cache`
 - Environment: `npm_config_side_effects_cache`, `NPM_CONFIG_SIDE_EFFECTS_CACHE`
 - .npmrc keys: `side-effects-cache`, `sideEffectsCache`
@@ -1508,8 +1787,12 @@ Only read from the side-effects cache; don't write.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_side_effects_cache_readonly`, `NPM_CONFIG_SIDE_EFFECTS_CACHE_READONLY`
 - .npmrc keys: `sideEffectsCacheReadonly`
+- Workspace YAML keys: none
 
 When true, aube may restore allowlisted dependency build output from the
 side-effects cache but will not write new cache entries after scripts run.
@@ -1520,8 +1803,12 @@ Drop to a non-root user when running scripts as root.
 
 - Type: `bool`
 - Default: `false (as root), true (otherwise)`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_unsafe_perm`, `NPM_CONFIG_UNSAFE_PERM`
 - .npmrc keys: `unsafePerm`
+- Workspace YAML keys: none
 
 aube exports the resolved value to lifecycle and `run` scripts as
 `npm_config_unsafe_perm`, matching the environment surface npm-style
@@ -1533,8 +1820,12 @@ Options passed to Node.js via NODE_OPTIONS.
 
 - Type: `string`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `NODE_OPTIONS`, `npm_config_node_options`, `NPM_CONFIG_NODE_OPTIONS`
 - .npmrc keys: `nodeOptions`
+- Workspace YAML keys: none
 
 When set in `.npmrc`, aube exports the value as `NODE_OPTIONS` for
 lifecycle scripts and `aube run` scripts. An existing `NODE_OPTIONS`
@@ -1546,8 +1837,12 @@ Check dependencies before running scripts.
 
 - Type: `"install" | "warn" | "error" | "prompt" | false`
 - Default: `"install"`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_verify_deps_before_run`, `NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN`
 - .npmrc keys: `verifyDepsBeforeRun`
+- Workspace YAML keys: none
 
 Controls `run`, lifecycle shortcuts, `exec`, and implicit script commands.
 `install` preserves aube's auto-install behavior, `warn` reports stale
@@ -1560,8 +1855,12 @@ Exit with an error if dependencies have unreviewed build scripts.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_strict_dep_builds`, `NPM_CONFIG_STRICT_DEP_BUILDS`
 - .npmrc keys: `strictDepBuilds`
+- Workspace YAML keys: none
 
 aube never runs dependency lifecycle scripts unless the package is
 listed in `allowBuilds` or `--dangerously-allow-all-builds` is set.
@@ -1577,6 +1876,9 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_allow_builds`, `NPM_CONFIG_ALLOW_BUILDS`
 - .npmrc keys: `allowBuilds`
 - Workspace YAML keys: `allowBuilds`
@@ -1598,9 +1900,12 @@ Allow all dependency build scripts automatically.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `dangerously-allow-all-builds`
 - Environment: `npm_config_dangerously_allow_all_builds`, `NPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS`
 - .npmrc keys: `dangerouslyAllowAllBuilds`
+- Workspace YAML keys: none
 
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
 dependency's `preinstall` / `install` / `postinstall` / `prepare`
@@ -1620,8 +1925,12 @@ Node.js version aube reports when evaluating `engines` checks.
 
 - Type: `string`
 - Default: `` output of `node -v` with the leading `v` stripped ``
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_node_version`, `NPM_CONFIG_NODE_VERSION`
 - .npmrc keys: `node-version`, `nodeVersion`
+- Workspace YAML keys: none
 
 Paired with `engineStrict`. Set this in .npmrc to pin the Node version engines checks validate against, rather than probing `node --version` at install time.
 
@@ -1631,8 +1940,12 @@ Custom Node.js download mirror URLs.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_node_download_mirrors`, `NPM_CONFIG_NODE_DOWNLOAD_MIRRORS`
 - .npmrc keys: `nodeDownloadMirrors`
+- Workspace YAML keys: none
 
 Accepted for pnpm config parity. aube does not download Node.js itself,
 so the parsed mirror map is preserved for config introspection but has
@@ -1646,8 +1959,12 @@ Version prefix used when installing a package.
 
 - Type: `"^" | "~" | ""`
 - Default: `"^"`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_save_prefix`, `NPM_CONFIG_SAVE_PREFIX`
 - .npmrc keys: `save-prefix`, `savePrefix`
+- Workspace YAML keys: none
 
 Resolved from `.npmrc`. `--save-exact` overrides to empty prefix.
 
@@ -1657,8 +1974,12 @@ Default dist-tag used by `aube add` without a version.
 
 - Type: `string`
 - Default: `"latest"`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_tag`, `NPM_CONFIG_TAG`
 - .npmrc keys: `tag`
+- Workspace YAML keys: none
 
 Resolved from `.npmrc`. Used by `aube add` when no version or dist-tag is specified.
 
@@ -1668,8 +1989,12 @@ Directory where globally installed packages live.
 
 - Type: `path`
 - Default: `platform-specific`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_global_dir`, `NPM_CONFIG_GLOBAL_DIR`
 - .npmrc keys: `globalDir`
+- Workspace YAML keys: none
 
 Overrides the directory where globally installed packages live. Falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
 
@@ -1679,8 +2004,12 @@ Directory where global binaries are symlinked.
 
 - Type: `path`
 - Default: `platform-specific`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_global_bin_dir`, `NPM_CONFIG_GLOBAL_BIN_DIR`
 - .npmrc keys: `globalBinDir`
+- Workspace YAML keys: none
 
 Overrides the directory where global binaries are symlinked. Independent of `globalDir`; falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
 
@@ -1690,8 +2019,12 @@ Path to an additional .npmrc file consulted for registry authentication tokens.
 
 - Type: `path`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_npmrc_auth_file`, `NPM_CONFIG_NPMRC_AUTH_FILE`
 - .npmrc keys: `npmrc-auth-file`, `npmrcAuthFile`
+- Workspace YAML keys: none
 
 Points at an extra `.npmrc`-formatted file that aube reads *after*
 the user and project `.npmrc` files when resolving registry auth.
@@ -1718,8 +2051,12 @@ Directory for aube install-state files.
 
 - Type: `path`
 - Default: `.aube/.state`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_state_dir`, `NPM_CONFIG_STATE_DIR`
 - .npmrc keys: `stateDir`
+- Workspace YAML keys: none
 
 Overrides the directory for install state tracking. Defaults to `.aube/.state` relative to the project root.
 
@@ -1729,8 +2066,12 @@ Directory for package metadata and dlx cache.
 
 - Type: `path`
 - Default: `~/.cache/aube`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_cache_dir`, `NPM_CONFIG_CACHE_DIR`
 - .npmrc keys: `cache-dir`, `cacheDir`
+- Workspace YAML keys: none
 
 Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path.
 
@@ -1740,8 +2081,12 @@ Write all output to stderr instead of stdout.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_use_stderr`, `NPM_CONFIG_USE_STDERR`
 - .npmrc keys: `useStderr`
+- Workspace YAML keys: none
 
 Redirects stdout to stderr for the process lifetime. Resolved from `.npmrc` or the `--use-stderr` CLI flag.
 
@@ -1751,8 +2096,12 @@ Show an update notification when a newer aube is available.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_update_notifier`, `NPM_CONFIG_UPDATE_NOTIFIER`
 - .npmrc keys: `updateNotifier`
+- Workspace YAML keys: none
 
 After a successful `install`, `add`, or `update`, aube fetches
 `https://aube.en.dev/VERSION` and prints a one-line notice if the
@@ -1771,8 +2120,12 @@ Create symlinks instead of shims for `.bin` entries.
 
 - Type: `bool`
 - Default: `true (POSIX hoisted)`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_prefer_symlinked_executables`, `NPM_CONFIG_PREFER_SYMLINKED_EXECUTABLES`
 - .npmrc keys: `preferSymlinkedExecutables`
+- Workspace YAML keys: none
 
 POSIX only. Default (unset or `true`) creates a plain symlink from
 `node_modules/.bin/<name>` straight to the package's executable file —
@@ -1789,8 +2142,12 @@ Disable pnpm's automatic dependency patching database.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_ignore_compatibility_db`, `NPM_CONFIG_IGNORE_COMPATIBILITY_DB`
 - .npmrc keys: `ignoreCompatibilityDb`
+- Workspace YAML keys: none
 
 Accepted for pnpm config parity. pnpm ships a built-in compatibility
 database of auto-patches for known-broken packages; aube has no such
@@ -1803,9 +2160,12 @@ Dependency version resolution strategy.
 
 - Type: `"highest" | "time-based" | "lowest-direct"`
 - Default: `"highest"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `resolution-mode`
 - Environment: `npm_config_resolution_mode`, `NPM_CONFIG_RESOLUTION_MODE`
 - .npmrc keys: `resolution-mode`, `resolutionMode`
+- Workspace YAML keys: none
 
 Controls how aube chooses versions during resolution. `highest` picks
 the newest satisfying version. `time-based` filters candidates through
@@ -1819,8 +2179,12 @@ Whether the configured registry returns a `time` field in metadata.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_registry_supports_time_field`, `NPM_CONFIG_REGISTRY_SUPPORTS_TIME_FIELD`
 - .npmrc keys: `registry-supports-time-field`, `registrySupportsTimeField`
+- Workspace YAML keys: none
 
 When `false` (the default, matching pnpm and npmjs.org's behavior),
 aube fetches the full (non-corgi) packument to read the `time:` map
@@ -1845,8 +2209,12 @@ Set NODE_PATH in command shims.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_extend_node_path`, `NPM_CONFIG_EXTEND_NODE_PATH`
 - .npmrc keys: `extendNodePath`
+- Workspace YAML keys: none
 
 When `true` (default), aube-generated `.bin` shims export
 `NODE_PATH="$basedir/.."` so the shimmed binary can resolve modules
@@ -1863,6 +2231,9 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_deploy_all_files`, `NPM_CONFIG_DEPLOY_ALL_FILES`
 - .npmrc keys: `deploy-all-files`, `deployAllFiles`
 - Workspace YAML keys: `deployAllFiles`
@@ -1883,6 +2254,9 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_dedupe_direct_deps`, `NPM_CONFIG_DEDUPE_DIRECT_DEPS`
 - .npmrc keys: `dedupe-direct-deps`, `dedupeDirectDeps`
 - Workspace YAML keys: `dedupeDirectDeps`
@@ -1903,8 +2277,12 @@ Fast-path check before running a full install.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_optimistic_repeat_install`, `NPM_CONFIG_OPTIMISTIC_REPEAT_INSTALL`
 - .npmrc keys: `optimisticRepeatInstall`
+- Workspace YAML keys: none
 
 When `true` (default), `aube run` / `aube exec` / `aube start` /
 `aube test` / `aube restart` consult `.aube/.state/install-state.json`
@@ -1921,8 +2299,12 @@ Scripts that must be present in every workspace project.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_required_scripts`, `NPM_CONFIG_REQUIRED_SCRIPTS`
 - .npmrc keys: `requiredScripts`
+- Workspace YAML keys: none
 
 During install, aube verifies that the root package and every discovered
 workspace package define each required script in `package.json`.
@@ -1933,8 +2315,12 @@ Run pre/post scripts automatically when a named script is invoked.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_enable_pre_post_scripts`, `NPM_CONFIG_ENABLE_PRE_POST_SCRIPTS`
 - .npmrc keys: `enablePrePostScripts`
+- Workspace YAML keys: none
 
 Controls whether `aube run build` also runs `prebuild` before `build`
 and `postbuild` after it when those scripts exist.
@@ -1945,8 +2331,12 @@ Shell used to invoke package scripts.
 
 - Type: `path`
 - Default: `null (uses /bin/sh on Unix, cmd on Windows)`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_script_shell`, `NPM_CONFIG_SCRIPT_SHELL`
 - .npmrc keys: `scriptShell`
+- Workspace YAML keys: none
 
 Overrides the shell executable used for lifecycle and `aube run`
 scripts. On Unix, aube invokes the configured shell with `-c`.
@@ -1957,8 +2347,12 @@ Use a JavaScript bash-like shell to run scripts cross-platform.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_shell_emulator`, `NPM_CONFIG_SHELL_EMULATOR`
 - .npmrc keys: `shellEmulator`
+- Workspace YAML keys: none
 
 Accepted for pnpm config parity. aube does not embed pnpm's JavaScript
 shell emulator, but it exports `npm_config_shell_emulator=true` for
@@ -1970,8 +2364,12 @@ How catalog references in package.json are handled by `add`.
 
 - Type: `"manual" | "strict" | "prefer"`
 - Default: `"manual"`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_catalog_mode`, `NPM_CONFIG_CATALOG_MODE`
 - .npmrc keys: `catalogMode`
+- Workspace YAML keys: none
 
 `manual` (the default) writes whatever range `aube add` resolved, even
 when the package is declared in the default catalog. `prefer` rewrites
@@ -1994,8 +2392,12 @@ Explicitly mark the environment as CI.
 
 - Type: `bool`
 - Default: `auto-detected`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `CI`, `npm_config_ci`, `NPM_CONFIG_CI`
 - .npmrc keys: `ci`
+- Workspace YAML keys: none
 
 aube detects CI via `env::var("CI").is_ok()` in two places:
 `aube-linker` (disables the global virtual store) and
@@ -2011,6 +2413,9 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `npm_config_cleanup_unused_catalogs`, `NPM_CONFIG_CLEANUP_UNUSED_CATALOGS`
 - .npmrc keys: `cleanupUnusedCatalogs`
 - Workspace YAML keys: `cleanupUnusedCatalogs`
@@ -2031,6 +2436,9 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
+- Status: implemented
+- Added to registry: `2026-04-17`
+- CLI flags: none
 - Environment: `AUBE_LINK_CONCURRENCY`, `npm_config_link_concurrency`, `NPM_CONFIG_LINK_CONCURRENCY`
 - .npmrc keys: `link-concurrency`, `linkConcurrency`
 - Workspace YAML keys: `linkConcurrency`
@@ -2055,6 +2463,9 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
+- CLI flags: none
 - Environment: `AUBE_NO_LOCK`, `npm_config_aube_no_lock`, `NPM_CONFIG_AUBE_NO_LOCK`
 - .npmrc keys: `aubeNoLock`, `aube-no-lock`
 - Workspace YAML keys: `aubeNoLock`
@@ -2087,6 +2498,8 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - CLI flags: `no-install`
 - Environment: `AUBE_NO_AUTO_INSTALL`, `npm_config_aube_no_auto_install`, `NPM_CONFIG_AUBE_NO_AUTO_INSTALL`
 - .npmrc keys: `aubeNoAutoInstall`, `aube-no-auto-install`

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -50,7 +50,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
 | [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
 | [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`autoDisableGlobalVirtualStoreForNextjs`](#setting-autodisableglobalvirtualstorefornextjs) | `bool` | implemented | Disable the global virtual store when a Next.js dependency is detected. |
+| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | implemented | Package names whose presence in any importer forces per-project materialization. |
 | [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
 | [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
 | [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
@@ -677,30 +677,30 @@ It's enabled by default and disabled under CI (see `aube-linker`, which
 checks the `CI` env var). pnpm gained the same feature later; we expose
 it through `CI=1` rather than a dedicated config knob.
 
-### `autoDisableGlobalVirtualStoreForNextjs` {#setting-autodisableglobalvirtualstorefornextjs}
+### `disableGlobalVirtualStoreForPackages` {#setting-disableglobalvirtualstoreforpackages}
 
-Disable the global virtual store when a Next.js dependency is detected.
+Package names whose presence in any importer forces per-project materialization.
 
-- Type: `bool`
-- Default: `true`
+- Type: `list<string>`
+- Default: `["next"]`
 - Status: implemented
 - Added to registry: `2026-04-18`
-- .npmrc keys: `autoDisableGlobalVirtualStoreForNextjs`
+- .npmrc keys: `disableGlobalVirtualStoreForPackages`
 
-Next.js's Turbopack canonicalizes every symlink under `node_modules/`
-and rejects any target that resolves outside the project's "filesystem
-root". aube's global virtual store makes `node_modules/.aube/<pkg>` an
-absolute symlink into `~/.cache/aube/virtual-store/`, which Turbopack
-then reports as `Symlink ... is invalid, it points out of the
-filesystem root`.
+aube's global virtual store makes `node_modules/.aube/<pkg>` an
+absolute symlink into `~/.cache/aube/virtual-store/`. Some tools —
+most notably Next.js's Turbopack — canonicalize every symlink under
+`node_modules/` and reject any target that resolves outside the
+project's "filesystem root", producing errors like `Symlink ... is
+invalid, it points out of the filesystem root`.
 
-When this setting is `true` (the default) and `aube install` detects
-`next` in the root `package.json`'s dependencies, aube forces
-per-project materialization for this install and prints a one-line
-warning explaining why. Set to `false` to keep the global virtual
-store enabled even when Next.js is present — useful if you're working
-around the Turbopack issue another way (e.g. `next dev --webpack`) and
-want the throughput win.
+When `aube install` finds one of these names in any importer's
+`dependencies`, `devDependencies`, or `optionalDependencies`, it
+forces per-project materialization for that install and prints a
+one-line warning naming the trigger. Defaults to `["next"]`; add
+other packages here as you discover them, or set the list to `[]` to
+disable the heuristic. `CI=1` already forces per-project mode, so the
+warning suppresses itself in that case.
 
 ## Store
 

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -16,123 +16,123 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-113 settings are listed here. 113 are currently implemented.
+113 settings are listed here.
 
-| Setting | Type | Status | Summary |
-| --- | --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
-| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | implemented | Specify architectures for optional dependency installation. |
-| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | implemented | Skip optional dependencies by name. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`registries`](#setting-registries) | `object` | implemented | Registry URLs, including scoped registry overrides. |
-| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
-| [`symlink`](#setting-symlink) | `bool` | implemented | Create symlinks in the virtual store directory. |
-| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | implemented | Write files to the modules directory. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
-| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | implemented | Max length for virtual store directory names. |
-| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | implemented | Populate the virtual store without creating top-level symlinks. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
-| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
-| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | implemented | Package names whose presence in any importer forces per-project materialization. |
-| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
-| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
-| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | implemented | Validate package names and versions in the store. |
-| [`httpsProxy`](#setting-httpsproxy) | `url` | implemented | Proxy URL for outgoing HTTPS requests. |
-| [`httpProxy`](#setting-httpproxy) | `url` | implemented | Proxy URL for outgoing HTTP requests. |
-| [`noProxy`](#setting-noproxy) | `string` | implemented | Comma-separated list of domains that bypass the proxy. |
-| [`localAddress`](#setting-localaddress) | `string` | implemented | Local interface IP address to bind registry connections to. |
-| [`maxsockets`](#setting-maxsockets) | `int` | implemented | Maximum concurrent connections per origin. |
-| [`strictSsl`](#setting-strictssl) | `bool` | implemented | Validate SSL certificates for HTTPS requests. |
-| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | implemented | Hosts for which aube performs shallow git clones. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
-| [`fetchRetries`](#setting-fetchretries) | `int` | implemented | Number of retry attempts for failed registry fetches. |
-| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | implemented | Exponential backoff factor for fetch retries. |
-| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | implemented | Minimum retry timeout in milliseconds. |
-| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | implemented | Maximum retry timeout in milliseconds. |
-| [`fetchTimeout`](#setting-fetchtimeout) | `int` | implemented | Max time (ms) to wait for an HTTP request. |
-| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | implemented | Warn if a metadata request exceeds this threshold (ms). |
-| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | implemented | Warn if download speed falls below this threshold (KiB/s). |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
-| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | implemented | Control color output in aube's CLI. |
-| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | implemented | Minimum log level to display. |
-| [`useBetaCli`](#setting-usebetacli) | `bool` | implemented | Opt into experimental CLI features. |
-| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | implemented | Install on all workspace packages by default. |
-| [`engineStrict`](#setting-enginestrict) | `bool` | implemented | Fail if a package is incompatible with the current Node version. |
-| [`npmPath`](#setting-npmpath) | `path` | implemented | Path to the npm binary aube should shell out to when needed. |
-| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | implemented | Enforce the `packageManager` field in package.json. |
-| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | implemented | Enforce the exact `packageManager` version from package.json. |
-| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | implemented | Auto-download the specified pnpm version when mismatched. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
-| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | implemented | Only read from the side-effects cache; don't write. |
-| [`unsafePerm`](#setting-unsafeperm) | `bool` | implemented | Drop to a non-root user when running scripts as root. |
-| [`nodeOptions`](#setting-nodeoptions) | `string` | implemented | Options passed to Node.js via NODE_OPTIONS. |
-| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | implemented | Check dependencies before running scripts. |
-| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | implemented | Exit with an error if dependencies have unreviewed build scripts. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
-| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | implemented | Allow all dependency build scripts automatically. |
-| [`nodeVersion`](#setting-nodeversion) | `string` | implemented | Node.js version aube reports when evaluating `engines` checks. |
-| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | implemented | Custom Node.js download mirror URLs. |
-| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | implemented | Version prefix used when installing a package. |
-| [`tag`](#setting-tag) | `string` | implemented | Default dist-tag used by `aube add` without a version. |
-| [`globalDir`](#setting-globaldir) | `path` | implemented | Directory where globally installed packages live. |
-| [`globalBinDir`](#setting-globalbindir) | `path` | implemented | Directory where global binaries are symlinked. |
-| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | implemented | Path to an additional .npmrc file consulted for registry authentication tokens. |
-| [`stateDir`](#setting-statedir) | `path` | implemented | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | implemented | Directory for package metadata and dlx cache. |
-| [`useStderr`](#setting-usestderr) | `bool` | implemented | Write all output to stderr instead of stdout. |
-| [`updateNotifier`](#setting-updatenotifier) | `bool` | implemented | Show an update notification when a newer aube is available. |
-| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | implemented | Create symlinks instead of shims for `.bin` entries. |
-| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | implemented | Disable pnpm's automatic dependency patching database. |
-| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | implemented | Dependency version resolution strategy. |
-| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | implemented | Whether the configured registry returns a `time` field in metadata. |
-| [`extendNodePath`](#setting-extendnodepath) | `bool` | implemented | Set NODE_PATH in command shims. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | implemented | Fast-path check before running a full install. |
-| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | implemented | Scripts that must be present in every workspace project. |
-| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | implemented | Run pre/post scripts automatically when a named script is invoked. |
-| [`scriptShell`](#setting-scriptshell) | `path` | implemented | Shell used to invoke package scripts. |
-| [`shellEmulator`](#setting-shellemulator) | `bool` | implemented | Use a JavaScript bash-like shell to run scripts cross-platform. |
-| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | implemented | How catalog references in package.json are handled by `add`. |
-| [`ci`](#setting-ci) | `bool` | implemented | Explicitly mark the environment as CI. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Summary |
+| --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
+| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
+| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
+| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
+| [`symlink`](#setting-symlink) | `bool` | Create symlinks in the virtual store directory. |
+| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | Write files to the modules directory. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
+| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | Max length for virtual store directory names. |
+| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | Populate the virtual store without creating top-level symlinks. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
+| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | Minutes before orphan packages are removed from the virtual store. |
+| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | Minutes before the dlx cache is considered stale. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
+| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | Package names whose presence in any importer forces per-project materialization. |
+| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
+| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | Only allow installs when the store server is running. |
+| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | Validate package names and versions in the store. |
+| [`httpsProxy`](#setting-httpsproxy) | `url` | Proxy URL for outgoing HTTPS requests. |
+| [`httpProxy`](#setting-httpproxy) | `url` | Proxy URL for outgoing HTTP requests. |
+| [`noProxy`](#setting-noproxy) | `string` | Comma-separated list of domains that bypass the proxy. |
+| [`localAddress`](#setting-localaddress) | `string` | Local interface IP address to bind registry connections to. |
+| [`maxsockets`](#setting-maxsockets) | `int` | Maximum concurrent connections per origin. |
+| [`strictSsl`](#setting-strictssl) | `bool` | Validate SSL certificates for HTTPS requests. |
+| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | Hosts for which aube performs shallow git clones. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
+| [`fetchRetries`](#setting-fetchretries) | `int` | Number of retry attempts for failed registry fetches. |
+| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | Exponential backoff factor for fetch retries. |
+| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | Minimum retry timeout in milliseconds. |
+| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | Maximum retry timeout in milliseconds. |
+| [`fetchTimeout`](#setting-fetchtimeout) | `int` | Max time (ms) to wait for an HTTP request. |
+| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | Warn if a metadata request exceeds this threshold (ms). |
+| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | Warn if download speed falls below this threshold (KiB/s). |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
+| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | Control color output in aube's CLI. |
+| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | Minimum log level to display. |
+| [`useBetaCli`](#setting-usebetacli) | `bool` | Opt into experimental CLI features. |
+| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | Install on all workspace packages by default. |
+| [`engineStrict`](#setting-enginestrict) | `bool` | Fail if a package is incompatible with the current Node version. |
+| [`npmPath`](#setting-npmpath) | `path` | Path to the npm binary aube should shell out to when needed. |
+| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | Enforce the `packageManager` field in package.json. |
+| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | Enforce the exact `packageManager` version from package.json. |
+| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | Auto-download the specified pnpm version when mismatched. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
+| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | Only read from the side-effects cache; don't write. |
+| [`unsafePerm`](#setting-unsafeperm) | `bool` | Drop to a non-root user when running scripts as root. |
+| [`nodeOptions`](#setting-nodeoptions) | `string` | Options passed to Node.js via NODE_OPTIONS. |
+| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | Check dependencies before running scripts. |
+| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | Exit with an error if dependencies have unreviewed build scripts. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
+| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | Allow all dependency build scripts automatically. |
+| [`nodeVersion`](#setting-nodeversion) | `string` | Node.js version aube reports when evaluating `engines` checks. |
+| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | Custom Node.js download mirror URLs. |
+| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | Version prefix used when installing a package. |
+| [`tag`](#setting-tag) | `string` | Default dist-tag used by `aube add` without a version. |
+| [`globalDir`](#setting-globaldir) | `path` | Directory where globally installed packages live. |
+| [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
+| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
+| [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
+| [`cacheDir`](#setting-cachedir) | `path` | Directory for package metadata and dlx cache. |
+| [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
+| [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
+| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | Create symlinks instead of shims for `.bin` entries. |
+| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | Disable pnpm's automatic dependency patching database. |
+| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | Dependency version resolution strategy. |
+| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | Whether the configured registry returns a `time` field in metadata. |
+| [`extendNodePath`](#setting-extendnodepath) | `bool` | Set NODE_PATH in command shims. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | Fast-path check before running a full install. |
+| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | Scripts that must be present in every workspace project. |
+| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | Run pre/post scripts automatically when a named script is invoked. |
+| [`scriptShell`](#setting-scriptshell) | `path` | Shell used to invoke package scripts. |
+| [`shellEmulator`](#setting-shellemulator) | `bool` | Use a JavaScript bash-like shell to run scripts cross-platform. |
+| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | How catalog references in package.json are handled by `add`. |
+| [`ci`](#setting-ci) | `bool` | Explicitly mark the environment as CI. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -142,8 +142,6 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `overrides`
 
 A root-level map of package specs to the versions aube should force them
@@ -157,8 +155,6 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `packageExtensions`
 
 Patches a package's `dependencies`, `peerDependencies`, etc. at resolve
@@ -171,8 +167,6 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `allowedDeprecatedVersions`
 
 Maps a package name to a semver range for which the deprecation warning
@@ -185,8 +179,6 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `updateConfig.ignoreDependencies`
 
 Packages in this list are never bumped by `aube update`, even when a
@@ -198,8 +190,6 @@ Specify architectures for optional dependency installation.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `supportedArchitectures`
 
 Override the current platform/arch/libc triple used to filter optional
@@ -212,8 +202,6 @@ Skip optional dependencies by name.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `ignoredOptionalDependencies`
 
 Named entries are skipped even if their platform/arch matches. Distinct
@@ -225,8 +213,6 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `minimumReleaseAge`
 
 Supply-chain attack mitigation: packages published within the last N
@@ -241,8 +227,6 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `minimumReleaseAgeExclude`
 
 Use for trusted internal packages that need to be rolled out immediately
@@ -255,8 +239,6 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `minimumReleaseAgeStrict`
 
 By default the resolver falls back to the lowest satisfying version when
@@ -269,8 +251,6 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `trustPolicy`
 
 When set to `no-downgrade`, aube accepts and preserves the policy in the
@@ -284,8 +264,6 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `trustPolicyExclude`
 
 Whitelist for `trustPolicy`. Entries skip the downgrade check.
@@ -296,8 +274,6 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `trustPolicyIgnoreAfter`
 
 Useful for pinning very old versions that predate signing infrastructure.
@@ -308,8 +284,6 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `blockExoticSubdeps`
 
 When true, transitive deps referenced via `git+`, `file:`, or direct
@@ -322,8 +296,6 @@ Registry URLs, including scoped registry overrides.
 
 - Type: `object`
 - Default: `{ default = "https://registry.npmjs.org/" }`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `registry`, `@scope:registry`, `//host/:_authToken`, `//host/:_auth`
 
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
@@ -344,8 +316,6 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `hoist`
 
 Controls whether aube populates `node_modules/.aube/node_modules/` —
@@ -374,8 +344,6 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `hoist-workspace-packages`, `hoistWorkspacePackages`
 
 Controls whether workspace packages get their own symlinks in each
@@ -392,8 +360,6 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `hoist-pattern`, `hoistPattern`
 
 Glob list matched against package names. Any non-local package
@@ -415,8 +381,6 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - .npmrc keys: `public-hoist-pattern`, `publicHoistPattern`
 
 Glob list matched against package names. Any non-local package in the
@@ -436,8 +400,6 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `shamefully-hoist`, `shamefullyHoist`
 
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
@@ -451,8 +413,6 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - .npmrc keys: `modulesDir`, `modules-dir`
 
 The project-level directory that holds the top-level `<name>` entries
@@ -477,8 +437,6 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `nodeLinker`
 
 aube defaults to `isolated`, a strict symlink layout under
@@ -493,8 +451,6 @@ Create symlinks in the virtual store directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `symlink`
 
 Accepted for pnpm parity. aube's isolated layout is structurally
@@ -523,8 +479,6 @@ Write files to the modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `enableModulesDir`
 
 When `false`, aube resolves the dependency graph and writes
@@ -540,8 +494,6 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `virtualStoreDir`, `virtual-store-dir`
 
 Relocates the per-project `.aube/<dep>/node_modules/` tree that the
@@ -570,8 +522,6 @@ Max length for virtual store directory names.
 
 - Type: `int`
 - Default: `120 (Linux/macOS), 60 (Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `virtualStoreDirMaxLength`
 
 Caps the number of characters in a single `node_modules/.aube/<dep>`
@@ -589,8 +539,6 @@ Populate the virtual store without creating top-level symlinks.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `virtualStoreOnly`
 
 When `true`, aube still materializes every package into
@@ -609,8 +557,6 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `packageImportMethod`, `package-import-method`
 
 Controls how aube materializes files from the global content-addressable
@@ -630,8 +576,6 @@ Minutes before orphan packages are removed from the virtual store.
 
 - Type: `int`
 - Default: `10080`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `modulesCacheMaxAge`
 
 After each successful install, aube sweeps the per-project
@@ -651,8 +595,6 @@ Minutes before the dlx cache is considered stale.
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `dlx-cache-max-age`, `dlxCacheMaxAge`
 
 Accepted for pnpm parity. `aube dlx` currently installs into a fresh
@@ -668,8 +610,6 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `enableGlobalVirtualStore`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
@@ -683,8 +623,6 @@ Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
 - Default: `["next"]`
-- Status: implemented
-- Added to registry: `2026-04-18`
 - .npmrc keys: `disableGlobalVirtualStoreForPackages`
 
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
@@ -710,8 +648,6 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `store-dir`, `storeDir`
 
 Defaults to aube's own store path (`~/.aube-store/v1/files/`). aube does not
@@ -739,8 +675,6 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `verify-store-integrity`, `verifyStoreIntegrity`
 
 aube verifies each package's `integrity` (SHA-512) against the tarball
@@ -760,8 +694,6 @@ Only allow installs when the store server is running.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `use-running-store-server`, `useRunningStoreServer`
 
 Accepted for pnpm parity. aube has no long-running store-daemon
@@ -777,8 +709,6 @@ Validate package names and versions in the store.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `strict-store-pkg-content-check`, `strictStorePkgContentCheck`
 
 After each registry tarball is imported, aube reads the freshly stored
@@ -805,8 +735,6 @@ Proxy URL for outgoing HTTPS requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `https-proxy`, `httpsProxy`, `proxy`
 
 Forwards every HTTPS registry fetch through the given proxy URL.
@@ -820,8 +748,6 @@ Proxy URL for outgoing HTTP requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `http-proxy`, `httpProxy`
 
 HTTP counterpart to `httpsProxy`. Resolution mirrors pnpm:
@@ -836,8 +762,6 @@ Comma-separated list of domains that bypass the proxy.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `noproxy`, `noProxy`, `no-proxy`
 
 Passed through to `reqwest::NoProxy::from_string` verbatim, so
@@ -851,8 +775,6 @@ Local interface IP address to bind registry connections to.
 
 - Type: `string`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `local-address`, `localAddress`
 
 Used on multi-homed hosts where outbound traffic must leave a
@@ -865,8 +787,6 @@ Maximum concurrent connections per origin.
 
 - Type: `int`
 - Default: `networkConcurrency x 3`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `maxsockets`
 
 Plumbed into reqwest's `pool_max_idle_per_host`. This is the
@@ -880,8 +800,6 @@ Validate SSL certificates for HTTPS requests.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `strict-ssl`, `strictSsl`
 
 Defaults to `true`. Setting `strict-ssl=false` disables TLS
@@ -898,8 +816,6 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `lockfile`
 
 Controls whether aube reads and writes a lockfile during install. When
@@ -924,8 +840,6 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `prefer-frozen-lockfile`
 
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
@@ -942,8 +856,6 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `lockfileIncludeTarballUrl`, `lockfile-include-tarball-url`
 
 When true, aube's lockfile writer records the registry tarball URL in
@@ -971,8 +883,6 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - .npmrc keys: `exclude-links-from-lockfile`, `excludeLinksFromLockfile`
 
 When true, `link:` dependencies are omitted from the lockfile's
@@ -993,8 +903,6 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `gitBranchLockfile`
 
 When enabled, aube writes the lockfile to `aube-lock.<branch>.yaml`
@@ -1022,8 +930,6 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `mergeGitBranchLockfilesBranchPattern`
 
 Complements `gitBranchLockfile`. Accepts a list of glob patterns. When
@@ -1054,8 +960,6 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `peersSuffixMaxLength`
 
 Caps the length of the peer-ID suffix appended to a `dep_path` in the
@@ -1076,8 +980,6 @@ Hosts for which aube performs shallow git clones.
 
 - Type: `list<string>`
 - Default: `["github.com", "gist.github.com", "gitlab.com", "bitbucket.com", "bitbucket.org"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `git-shallow-hosts`, `gitShallowHosts`
 
 Consulted by `aube-store::git_shallow_clone` when cloning a git
@@ -1101,8 +1003,6 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `network-concurrency`, `networkConcurrency`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
@@ -1124,8 +1024,6 @@ Number of retry attempts for failed registry fetches.
 
 - Type: `int`
 - Default: `2`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retries`, `fetchRetries`
 
 Number of *additional* attempts the registry client makes after a
@@ -1144,8 +1042,6 @@ Exponential backoff factor for fetch retries.
 
 - Type: `int`
 - Default: `10`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retry-factor`, `fetchRetryFactor`
 
 Multiplier used between retry attempts. Attempt `n` waits
@@ -1159,8 +1055,6 @@ Minimum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retry-mintimeout`, `fetchRetryMintimeout`
 
 Lower bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1171,8 +1065,6 @@ Maximum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retry-maxtimeout`, `fetchRetryMaxtimeout`
 
 Upper bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1183,8 +1075,6 @@ Max time (ms) to wait for an HTTP request.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetchTimeout`
 
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
@@ -1198,8 +1088,6 @@ Warn if a metadata request exceeds this threshold (ms).
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetchWarnTimeoutMs`
 
 Observability threshold for registry *metadata* requests (packument,
@@ -1219,8 +1107,6 @@ Warn if download speed falls below this threshold (KiB/s).
 
 - Type: `int`
 - Default: `50`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetchMinSpeedKiBps`
 
 Observability threshold for *tarball* downloads. When a tarball
@@ -1242,8 +1128,6 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `auto-install-peers`, `autoInstallPeers`
 
 When true (the default), missing peer dependencies are auto-installed
@@ -1257,8 +1141,6 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `dedupePeerDependents`
 
 When true (the default), aube collapses packages that landed at
@@ -1275,8 +1157,6 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `dedupePeers`
 
 When true, lockfile peer suffixes emit `(18.2.0)` instead of the
@@ -1291,8 +1171,6 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `strict-peer-dependencies`, `strictPeerDependencies`
 
 When true, any unmet peer dependency (missing, or resolved to a version
@@ -1309,8 +1187,6 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `resolvePeersFromWorkspaceRoot`
 
 When true (the default), an unresolved peer falls back to the root
@@ -1326,8 +1202,6 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `peerDependencyRules.ignoreMissing`
 
 Glob list of peer dependency names whose "missing required peer" warning
@@ -1344,8 +1218,6 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `peerDependencyRules.allowedVersions`
 
 Map of peer selector to an additional semver range. Keys are either a
@@ -1363,8 +1235,6 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `peerDependencyRules.allowAny`
 
 Glob list of peer dependency names whose semver check should be
@@ -1382,8 +1252,6 @@ Control color output in aube's CLI.
 
 - Type: `"auto" | "always" | "never"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `color`
 
 `--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree.
@@ -1394,8 +1262,6 @@ Minimum log level to display.
 
 - Type: `"debug" | "info" | "warn" | "error" | "silent"`
 - Default: `"warn"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `loglevel`
 
 Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`.
@@ -1406,8 +1272,6 @@ Opt into experimental CLI features.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `useBetaCli`
 
 Accepted from env and `.npmrc` for pnpm parity. aube currently has no beta-gated commands, so the setting is a no-op after validation.
@@ -1418,8 +1282,6 @@ Install on all workspace packages by default.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `recursiveInstall`
 
 When true, workspace installs resolve and link all importers by default. Set to false to opt out of implicit workspace-wide install behavior; explicit `--filter` / `--recursive` still wins.
@@ -1430,8 +1292,6 @@ Fail if a package is incompatible with the current Node version.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `engine-strict`, `engineStrict`
 
 When on, an `engines.node` mismatch on the root project or any dependency fails the install. When off, mismatches are warnings only.
@@ -1442,8 +1302,6 @@ Path to the npm binary aube should shell out to when needed.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `npmPath`
 
 Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`, `token`, `whoami`) when configured. Without it, aube keeps the explicit `use npm` error.
@@ -1454,8 +1312,6 @@ Enforce the `packageManager` field in package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `packageManagerStrict`
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
@@ -1466,8 +1322,6 @@ Enforce the exact `packageManager` version from package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `packageManagerStrictVersion`
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
@@ -1478,8 +1332,6 @@ Auto-download the specified pnpm version when mismatched.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `managePackageManagerVersions`
 
 Accepted for pnpm parity. aube does not download or re-exec other package-manager versions; when exact version enforcement is enabled, mismatches are reported instead.
@@ -1492,8 +1344,6 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `ignore-scripts`, `ignoreScripts`
 
 aube already skips dependency install scripts by default (security-first).
@@ -1512,8 +1362,6 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `child-concurrency`, `childConcurrency`
 
 Caps how many dependency lifecycle scripts run in parallel during the
@@ -1533,8 +1381,6 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `side-effects-cache`, `sideEffectsCache`
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
@@ -1556,8 +1402,6 @@ Only read from the side-effects cache; don't write.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `sideEffectsCacheReadonly`
 
 When true, aube may restore allowlisted dependency build output from the
@@ -1569,8 +1413,6 @@ Drop to a non-root user when running scripts as root.
 
 - Type: `bool`
 - Default: `false (as root), true (otherwise)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `unsafePerm`
 
 aube exports the resolved value to lifecycle and `run` scripts as
@@ -1583,8 +1425,6 @@ Options passed to Node.js via NODE_OPTIONS.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `nodeOptions`
 
 When set in `.npmrc`, aube exports the value as `NODE_OPTIONS` for
@@ -1597,8 +1437,6 @@ Check dependencies before running scripts.
 
 - Type: `"install" | "warn" | "error" | "prompt" | false`
 - Default: `"install"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `verifyDepsBeforeRun`
 
 Controls `run`, lifecycle shortcuts, `exec`, and implicit script commands.
@@ -1612,8 +1450,6 @@ Exit with an error if dependencies have unreviewed build scripts.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `strictDepBuilds`
 
 aube never runs dependency lifecycle scripts unless the package is
@@ -1630,8 +1466,6 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `allowBuilds`
 
 Per-package allowlist for dependency lifecycle scripts. Read from
@@ -1651,8 +1485,6 @@ Allow all dependency build scripts automatically.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `dangerouslyAllowAllBuilds`
 
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
@@ -1673,8 +1505,6 @@ Node.js version aube reports when evaluating `engines` checks.
 
 - Type: `string`
 - Default: `` output of `node -v` with the leading `v` stripped ``
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `node-version`, `nodeVersion`
 
 Paired with `engineStrict`. Set this in .npmrc to pin the Node version engines checks validate against, rather than probing `node --version` at install time.
@@ -1685,8 +1515,6 @@ Custom Node.js download mirror URLs.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `nodeDownloadMirrors`
 
 Accepted for pnpm config parity. aube does not download Node.js itself,
@@ -1701,8 +1529,6 @@ Version prefix used when installing a package.
 
 - Type: `"^" | "~" | ""`
 - Default: `"^"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `save-prefix`, `savePrefix`
 
 Resolved from `.npmrc`. `--save-exact` overrides to empty prefix.
@@ -1713,8 +1539,6 @@ Default dist-tag used by `aube add` without a version.
 
 - Type: `string`
 - Default: `"latest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `tag`
 
 Resolved from `.npmrc`. Used by `aube add` when no version or dist-tag is specified.
@@ -1725,8 +1549,6 @@ Directory where globally installed packages live.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `globalDir`
 
 Overrides the directory where globally installed packages live. Falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1737,8 +1559,6 @@ Directory where global binaries are symlinked.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `globalBinDir`
 
 Overrides the directory where global binaries are symlinked. Independent of `globalDir`; falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1749,8 +1569,6 @@ Path to an additional .npmrc file consulted for registry authentication tokens.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `npmrc-auth-file`, `npmrcAuthFile`
 
 Points at an extra `.npmrc`-formatted file that aube reads *after*
@@ -1778,8 +1596,6 @@ Directory for aube install-state files.
 
 - Type: `path`
 - Default: `.aube/.state`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `stateDir`
 
 Overrides the directory for install state tracking. Defaults to `.aube/.state` relative to the project root.
@@ -1790,8 +1606,6 @@ Directory for package metadata and dlx cache.
 
 - Type: `path`
 - Default: `~/.cache/aube`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `cache-dir`, `cacheDir`
 
 Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path.
@@ -1802,8 +1616,6 @@ Write all output to stderr instead of stdout.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `useStderr`
 
 Redirects stdout to stderr for the process lifetime. Resolved from `.npmrc` or the `--use-stderr` CLI flag.
@@ -1814,8 +1626,6 @@ Show an update notification when a newer aube is available.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `updateNotifier`
 
 After a successful `install`, `add`, or `update`, aube fetches
@@ -1835,8 +1645,6 @@ Create symlinks instead of shims for `.bin` entries.
 
 - Type: `bool`
 - Default: `true (POSIX hoisted)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `preferSymlinkedExecutables`
 
 POSIX only. Default (unset or `true`) creates a plain symlink from
@@ -1854,8 +1662,6 @@ Disable pnpm's automatic dependency patching database.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `ignoreCompatibilityDb`
 
 Accepted for pnpm config parity. pnpm ships a built-in compatibility
@@ -1869,8 +1675,6 @@ Dependency version resolution strategy.
 
 - Type: `"highest" | "time-based" | "lowest-direct"`
 - Default: `"highest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `resolution-mode`, `resolutionMode`
 
 Controls how aube chooses versions during resolution. `highest` picks
@@ -1885,8 +1689,6 @@ Whether the configured registry returns a `time` field in metadata.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `registry-supports-time-field`, `registrySupportsTimeField`
 
 When `false` (the default, matching pnpm and npmjs.org's behavior),
@@ -1912,8 +1714,6 @@ Set NODE_PATH in command shims.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `extendNodePath`
 
 When `true` (default), aube-generated `.bin` shims export
@@ -1931,8 +1731,6 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `deploy-all-files`, `deployAllFiles`
 
 When true, `aube deploy` copies every file in the source workspace
@@ -1951,8 +1749,6 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `dedupe-direct-deps`, `dedupeDirectDeps`
 
 When true, the linker skips creating a `node_modules/<name>` symlink in a
@@ -1971,8 +1767,6 @@ Fast-path check before running a full install.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `optimisticRepeatInstall`
 
 When `true` (default), `aube run` / `aube exec` / `aube start` /
@@ -1990,8 +1784,6 @@ Scripts that must be present in every workspace project.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `requiredScripts`
 
 During install, aube verifies that the root package and every discovered
@@ -2003,8 +1795,6 @@ Run pre/post scripts automatically when a named script is invoked.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `enablePrePostScripts`
 
 Controls whether `aube run build` also runs `prebuild` before `build`
@@ -2016,8 +1806,6 @@ Shell used to invoke package scripts.
 
 - Type: `path`
 - Default: `null (uses /bin/sh on Unix, cmd on Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `scriptShell`
 
 Overrides the shell executable used for lifecycle and `aube run`
@@ -2029,8 +1817,6 @@ Use a JavaScript bash-like shell to run scripts cross-platform.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `shellEmulator`
 
 Accepted for pnpm config parity. aube does not embed pnpm's JavaScript
@@ -2043,8 +1829,6 @@ How catalog references in package.json are handled by `add`.
 
 - Type: `"manual" | "strict" | "prefer"`
 - Default: `"manual"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `catalogMode`
 
 `manual` (the default) writes whatever range `aube add` resolved, even
@@ -2068,8 +1852,6 @@ Explicitly mark the environment as CI.
 
 - Type: `bool`
 - Default: `auto-detected`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `ci`
 
 aube detects CI via `env::var("CI").is_ok()` in two places:
@@ -2086,8 +1868,6 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `cleanupUnusedCatalogs`
 
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
@@ -2106,8 +1886,6 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - .npmrc keys: `link-concurrency`, `linkConcurrency`
 
 Caps the dedicated linker worker pool used for filesystem-heavy
@@ -2130,8 +1908,6 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `aubeNoLock`, `aube-no-lock`
 
 aube takes an advisory lock on `node_modules/` at the start of every
@@ -2162,8 +1938,6 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `aubeNoAutoInstall`, `aube-no-auto-install`
 
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -16,122 +16,123 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-112 settings are listed here.
+113 settings are listed here. 113 are currently implemented.
 
-| Setting | Type | Summary |
-| --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
-| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
-| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
-| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
-| [`symlink`](#setting-symlink) | `bool` | Create symlinks in the virtual store directory. |
-| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | Write files to the modules directory. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
-| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | Max length for virtual store directory names. |
-| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | Populate the virtual store without creating top-level symlinks. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
-| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | Minutes before orphan packages are removed from the virtual store. |
-| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | Minutes before the dlx cache is considered stale. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
-| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
-| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | Only allow installs when the store server is running. |
-| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | Validate package names and versions in the store. |
-| [`httpsProxy`](#setting-httpsproxy) | `url` | Proxy URL for outgoing HTTPS requests. |
-| [`httpProxy`](#setting-httpproxy) | `url` | Proxy URL for outgoing HTTP requests. |
-| [`noProxy`](#setting-noproxy) | `string` | Comma-separated list of domains that bypass the proxy. |
-| [`localAddress`](#setting-localaddress) | `string` | Local interface IP address to bind registry connections to. |
-| [`maxsockets`](#setting-maxsockets) | `int` | Maximum concurrent connections per origin. |
-| [`strictSsl`](#setting-strictssl) | `bool` | Validate SSL certificates for HTTPS requests. |
-| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | Hosts for which aube performs shallow git clones. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
-| [`fetchRetries`](#setting-fetchretries) | `int` | Number of retry attempts for failed registry fetches. |
-| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | Exponential backoff factor for fetch retries. |
-| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | Minimum retry timeout in milliseconds. |
-| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | Maximum retry timeout in milliseconds. |
-| [`fetchTimeout`](#setting-fetchtimeout) | `int` | Max time (ms) to wait for an HTTP request. |
-| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | Warn if a metadata request exceeds this threshold (ms). |
-| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | Warn if download speed falls below this threshold (KiB/s). |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
-| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | Control color output in aube's CLI. |
-| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | Minimum log level to display. |
-| [`useBetaCli`](#setting-usebetacli) | `bool` | Opt into experimental CLI features. |
-| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | Install on all workspace packages by default. |
-| [`engineStrict`](#setting-enginestrict) | `bool` | Fail if a package is incompatible with the current Node version. |
-| [`npmPath`](#setting-npmpath) | `path` | Path to the npm binary aube should shell out to when needed. |
-| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | Enforce the `packageManager` field in package.json. |
-| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | Enforce the exact `packageManager` version from package.json. |
-| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | Auto-download the specified pnpm version when mismatched. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
-| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | Only read from the side-effects cache; don't write. |
-| [`unsafePerm`](#setting-unsafeperm) | `bool` | Drop to a non-root user when running scripts as root. |
-| [`nodeOptions`](#setting-nodeoptions) | `string` | Options passed to Node.js via NODE_OPTIONS. |
-| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | Check dependencies before running scripts. |
-| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | Exit with an error if dependencies have unreviewed build scripts. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
-| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | Allow all dependency build scripts automatically. |
-| [`nodeVersion`](#setting-nodeversion) | `string` | Node.js version aube reports when evaluating `engines` checks. |
-| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | Custom Node.js download mirror URLs. |
-| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | Version prefix used when installing a package. |
-| [`tag`](#setting-tag) | `string` | Default dist-tag used by `aube add` without a version. |
-| [`globalDir`](#setting-globaldir) | `path` | Directory where globally installed packages live. |
-| [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
-| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
-| [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | Directory for package metadata and dlx cache. |
-| [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
-| [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
-| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | Create symlinks instead of shims for `.bin` entries. |
-| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | Disable pnpm's automatic dependency patching database. |
-| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | Dependency version resolution strategy. |
-| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | Whether the configured registry returns a `time` field in metadata. |
-| [`extendNodePath`](#setting-extendnodepath) | `bool` | Set NODE_PATH in command shims. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | Fast-path check before running a full install. |
-| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | Scripts that must be present in every workspace project. |
-| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | Run pre/post scripts automatically when a named script is invoked. |
-| [`scriptShell`](#setting-scriptshell) | `path` | Shell used to invoke package scripts. |
-| [`shellEmulator`](#setting-shellemulator) | `bool` | Use a JavaScript bash-like shell to run scripts cross-platform. |
-| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | How catalog references in package.json are handled by `add`. |
-| [`ci`](#setting-ci) | `bool` | Explicitly mark the environment as CI. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Status | Summary |
+| --- | --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
+| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | implemented | Specify architectures for optional dependency installation. |
+| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | implemented | Skip optional dependencies by name. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`registries`](#setting-registries) | `object` | implemented | Registry URLs, including scoped registry overrides. |
+| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
+| [`symlink`](#setting-symlink) | `bool` | implemented | Create symlinks in the virtual store directory. |
+| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | implemented | Write files to the modules directory. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
+| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | implemented | Max length for virtual store directory names. |
+| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | implemented | Populate the virtual store without creating top-level symlinks. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
+| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
+| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
+| [`autoDisableGlobalVirtualStoreForNextjs`](#setting-autodisableglobalvirtualstorefornextjs) | `bool` | implemented | Disable the global virtual store when a Next.js dependency is detected. |
+| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
+| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
+| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | implemented | Validate package names and versions in the store. |
+| [`httpsProxy`](#setting-httpsproxy) | `url` | implemented | Proxy URL for outgoing HTTPS requests. |
+| [`httpProxy`](#setting-httpproxy) | `url` | implemented | Proxy URL for outgoing HTTP requests. |
+| [`noProxy`](#setting-noproxy) | `string` | implemented | Comma-separated list of domains that bypass the proxy. |
+| [`localAddress`](#setting-localaddress) | `string` | implemented | Local interface IP address to bind registry connections to. |
+| [`maxsockets`](#setting-maxsockets) | `int` | implemented | Maximum concurrent connections per origin. |
+| [`strictSsl`](#setting-strictssl) | `bool` | implemented | Validate SSL certificates for HTTPS requests. |
+| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | implemented | Hosts for which aube performs shallow git clones. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
+| [`fetchRetries`](#setting-fetchretries) | `int` | implemented | Number of retry attempts for failed registry fetches. |
+| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | implemented | Exponential backoff factor for fetch retries. |
+| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | implemented | Minimum retry timeout in milliseconds. |
+| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | implemented | Maximum retry timeout in milliseconds. |
+| [`fetchTimeout`](#setting-fetchtimeout) | `int` | implemented | Max time (ms) to wait for an HTTP request. |
+| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | implemented | Warn if a metadata request exceeds this threshold (ms). |
+| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | implemented | Warn if download speed falls below this threshold (KiB/s). |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
+| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | implemented | Control color output in aube's CLI. |
+| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | implemented | Minimum log level to display. |
+| [`useBetaCli`](#setting-usebetacli) | `bool` | implemented | Opt into experimental CLI features. |
+| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | implemented | Install on all workspace packages by default. |
+| [`engineStrict`](#setting-enginestrict) | `bool` | implemented | Fail if a package is incompatible with the current Node version. |
+| [`npmPath`](#setting-npmpath) | `path` | implemented | Path to the npm binary aube should shell out to when needed. |
+| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | implemented | Enforce the `packageManager` field in package.json. |
+| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | implemented | Enforce the exact `packageManager` version from package.json. |
+| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | implemented | Auto-download the specified pnpm version when mismatched. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
+| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | implemented | Only read from the side-effects cache; don't write. |
+| [`unsafePerm`](#setting-unsafeperm) | `bool` | implemented | Drop to a non-root user when running scripts as root. |
+| [`nodeOptions`](#setting-nodeoptions) | `string` | implemented | Options passed to Node.js via NODE_OPTIONS. |
+| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | implemented | Check dependencies before running scripts. |
+| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | implemented | Exit with an error if dependencies have unreviewed build scripts. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
+| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | implemented | Allow all dependency build scripts automatically. |
+| [`nodeVersion`](#setting-nodeversion) | `string` | implemented | Node.js version aube reports when evaluating `engines` checks. |
+| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | implemented | Custom Node.js download mirror URLs. |
+| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | implemented | Version prefix used when installing a package. |
+| [`tag`](#setting-tag) | `string` | implemented | Default dist-tag used by `aube add` without a version. |
+| [`globalDir`](#setting-globaldir) | `path` | implemented | Directory where globally installed packages live. |
+| [`globalBinDir`](#setting-globalbindir) | `path` | implemented | Directory where global binaries are symlinked. |
+| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | implemented | Path to an additional .npmrc file consulted for registry authentication tokens. |
+| [`stateDir`](#setting-statedir) | `path` | implemented | Directory for aube install-state files. |
+| [`cacheDir`](#setting-cachedir) | `path` | implemented | Directory for package metadata and dlx cache. |
+| [`useStderr`](#setting-usestderr) | `bool` | implemented | Write all output to stderr instead of stdout. |
+| [`updateNotifier`](#setting-updatenotifier) | `bool` | implemented | Show an update notification when a newer aube is available. |
+| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | implemented | Create symlinks instead of shims for `.bin` entries. |
+| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | implemented | Disable pnpm's automatic dependency patching database. |
+| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | implemented | Dependency version resolution strategy. |
+| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | implemented | Whether the configured registry returns a `time` field in metadata. |
+| [`extendNodePath`](#setting-extendnodepath) | `bool` | implemented | Set NODE_PATH in command shims. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | implemented | Fast-path check before running a full install. |
+| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | implemented | Scripts that must be present in every workspace project. |
+| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | implemented | Run pre/post scripts automatically when a named script is invoked. |
+| [`scriptShell`](#setting-scriptshell) | `path` | implemented | Shell used to invoke package scripts. |
+| [`shellEmulator`](#setting-shellemulator) | `bool` | implemented | Use a JavaScript bash-like shell to run scripts cross-platform. |
+| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | implemented | How catalog references in package.json are handled by `add`. |
+| [`ci`](#setting-ci) | `bool` | implemented | Explicitly mark the environment as CI. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -141,6 +142,8 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `overrides`
 
 A root-level map of package specs to the versions aube should force them
@@ -154,6 +157,8 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `packageExtensions`
 
 Patches a package's `dependencies`, `peerDependencies`, etc. at resolve
@@ -166,6 +171,8 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `allowedDeprecatedVersions`
 
 Maps a package name to a semver range for which the deprecation warning
@@ -178,6 +185,8 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `updateConfig.ignoreDependencies`
 
 Packages in this list are never bumped by `aube update`, even when a
@@ -189,6 +198,8 @@ Specify architectures for optional dependency installation.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `supportedArchitectures`
 
 Override the current platform/arch/libc triple used to filter optional
@@ -201,6 +212,8 @@ Skip optional dependencies by name.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `ignoredOptionalDependencies`
 
 Named entries are skipped even if their platform/arch matches. Distinct
@@ -212,6 +225,8 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `minimumReleaseAge`
 
 Supply-chain attack mitigation: packages published within the last N
@@ -226,6 +241,8 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `minimumReleaseAgeExclude`
 
 Use for trusted internal packages that need to be rolled out immediately
@@ -238,6 +255,8 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `minimumReleaseAgeStrict`
 
 By default the resolver falls back to the lowest satisfying version when
@@ -250,6 +269,8 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `trustPolicy`
 
 When set to `no-downgrade`, aube accepts and preserves the policy in the
@@ -263,6 +284,8 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `trustPolicyExclude`
 
 Whitelist for `trustPolicy`. Entries skip the downgrade check.
@@ -273,6 +296,8 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `trustPolicyIgnoreAfter`
 
 Useful for pinning very old versions that predate signing infrastructure.
@@ -283,6 +308,8 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `blockExoticSubdeps`
 
 When true, transitive deps referenced via `git+`, `file:`, or direct
@@ -295,6 +322,8 @@ Registry URLs, including scoped registry overrides.
 
 - Type: `object`
 - Default: `{ default = "https://registry.npmjs.org/" }`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `registry`, `@scope:registry`, `//host/:_authToken`, `//host/:_auth`
 
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
@@ -315,6 +344,8 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `hoist`
 
 Controls whether aube populates `node_modules/.aube/node_modules/` —
@@ -343,6 +374,8 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `hoist-workspace-packages`, `hoistWorkspacePackages`
 
 Controls whether workspace packages get their own symlinks in each
@@ -359,6 +392,8 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `hoist-pattern`, `hoistPattern`
 
 Glob list matched against package names. Any non-local package
@@ -380,6 +415,8 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
+- Status: implemented
+- Added to registry: `2026-04-13`
 - .npmrc keys: `public-hoist-pattern`, `publicHoistPattern`
 
 Glob list matched against package names. Any non-local package in the
@@ -399,6 +436,8 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `shamefully-hoist`, `shamefullyHoist`
 
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
@@ -412,6 +451,8 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
+- Status: implemented
+- Added to registry: `2026-04-17`
 - .npmrc keys: `modulesDir`, `modules-dir`
 
 The project-level directory that holds the top-level `<name>` entries
@@ -436,6 +477,8 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `nodeLinker`
 
 aube defaults to `isolated`, a strict symlink layout under
@@ -450,6 +493,8 @@ Create symlinks in the virtual store directory.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `symlink`
 
 Accepted for pnpm parity. aube's isolated layout is structurally
@@ -478,6 +523,8 @@ Write files to the modules directory.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `enableModulesDir`
 
 When `false`, aube resolves the dependency graph and writes
@@ -493,6 +540,8 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `virtualStoreDir`, `virtual-store-dir`
 
 Relocates the per-project `.aube/<dep>/node_modules/` tree that the
@@ -521,6 +570,8 @@ Max length for virtual store directory names.
 
 - Type: `int`
 - Default: `120 (Linux/macOS), 60 (Windows)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `virtualStoreDirMaxLength`
 
 Caps the number of characters in a single `node_modules/.aube/<dep>`
@@ -538,6 +589,8 @@ Populate the virtual store without creating top-level symlinks.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `virtualStoreOnly`
 
 When `true`, aube still materializes every package into
@@ -556,6 +609,8 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `packageImportMethod`, `package-import-method`
 
 Controls how aube materializes files from the global content-addressable
@@ -575,6 +630,8 @@ Minutes before orphan packages are removed from the virtual store.
 
 - Type: `int`
 - Default: `10080`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `modulesCacheMaxAge`
 
 After each successful install, aube sweeps the per-project
@@ -594,6 +651,8 @@ Minutes before the dlx cache is considered stale.
 
 - Type: `int`
 - Default: `1440`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `dlx-cache-max-age`, `dlxCacheMaxAge`
 
 Accepted for pnpm parity. `aube dlx` currently installs into a fresh
@@ -609,12 +668,39 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `enableGlobalVirtualStore`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
 It's enabled by default and disabled under CI (see `aube-linker`, which
 checks the `CI` env var). pnpm gained the same feature later; we expose
 it through `CI=1` rather than a dedicated config knob.
+
+### `autoDisableGlobalVirtualStoreForNextjs` {#setting-autodisableglobalvirtualstorefornextjs}
+
+Disable the global virtual store when a Next.js dependency is detected.
+
+- Type: `bool`
+- Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-18`
+- .npmrc keys: `autoDisableGlobalVirtualStoreForNextjs`
+
+Next.js's Turbopack canonicalizes every symlink under `node_modules/`
+and rejects any target that resolves outside the project's "filesystem
+root". aube's global virtual store makes `node_modules/.aube/<pkg>` an
+absolute symlink into `~/.cache/aube/virtual-store/`, which Turbopack
+then reports as `Symlink ... is invalid, it points out of the
+filesystem root`.
+
+When this setting is `true` (the default) and `aube install` detects
+`next` in the root `package.json`'s dependencies, aube forces
+per-project materialization for this install and prints a one-line
+warning explaining why. Set to `false` to keep the global virtual
+store enabled even when Next.js is present — useful if you're working
+around the Turbopack issue another way (e.g. `next dev --webpack`) and
+want the throughput win.
 
 ## Store
 
@@ -624,6 +710,8 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `store-dir`, `storeDir`
 
 Defaults to aube's own store path (`~/.aube-store/v1/files/`). aube does not
@@ -651,6 +739,8 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `verify-store-integrity`, `verifyStoreIntegrity`
 
 aube verifies each package's `integrity` (SHA-512) against the tarball
@@ -670,6 +760,8 @@ Only allow installs when the store server is running.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `use-running-store-server`, `useRunningStoreServer`
 
 Accepted for pnpm parity. aube has no long-running store-daemon
@@ -685,6 +777,8 @@ Validate package names and versions in the store.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `strict-store-pkg-content-check`, `strictStorePkgContentCheck`
 
 After each registry tarball is imported, aube reads the freshly stored
@@ -711,6 +805,8 @@ Proxy URL for outgoing HTTPS requests.
 
 - Type: `url`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `https-proxy`, `httpsProxy`, `proxy`
 
 Forwards every HTTPS registry fetch through the given proxy URL.
@@ -724,6 +820,8 @@ Proxy URL for outgoing HTTP requests.
 
 - Type: `url`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `http-proxy`, `httpProxy`
 
 HTTP counterpart to `httpsProxy`. Resolution mirrors pnpm:
@@ -738,6 +836,8 @@ Comma-separated list of domains that bypass the proxy.
 
 - Type: `string`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `noproxy`, `noProxy`, `no-proxy`
 
 Passed through to `reqwest::NoProxy::from_string` verbatim, so
@@ -751,6 +851,8 @@ Local interface IP address to bind registry connections to.
 
 - Type: `string`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `local-address`, `localAddress`
 
 Used on multi-homed hosts where outbound traffic must leave a
@@ -763,6 +865,8 @@ Maximum concurrent connections per origin.
 
 - Type: `int`
 - Default: `networkConcurrency x 3`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `maxsockets`
 
 Plumbed into reqwest's `pool_max_idle_per_host`. This is the
@@ -776,6 +880,8 @@ Validate SSL certificates for HTTPS requests.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `strict-ssl`, `strictSsl`
 
 Defaults to `true`. Setting `strict-ssl=false` disables TLS
@@ -792,6 +898,8 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `lockfile`
 
 Controls whether aube reads and writes a lockfile during install. When
@@ -816,6 +924,8 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `prefer-frozen-lockfile`
 
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
@@ -832,6 +942,8 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `lockfileIncludeTarballUrl`, `lockfile-include-tarball-url`
 
 When true, aube's lockfile writer records the registry tarball URL in
@@ -859,6 +971,8 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-13`
 - .npmrc keys: `exclude-links-from-lockfile`, `excludeLinksFromLockfile`
 
 When true, `link:` dependencies are omitted from the lockfile's
@@ -879,6 +993,8 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `gitBranchLockfile`
 
 When enabled, aube writes the lockfile to `aube-lock.<branch>.yaml`
@@ -906,6 +1022,8 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `mergeGitBranchLockfilesBranchPattern`
 
 Complements `gitBranchLockfile`. Accepts a list of glob patterns. When
@@ -936,6 +1054,8 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `peersSuffixMaxLength`
 
 Caps the length of the peer-ID suffix appended to a `dep_path` in the
@@ -956,6 +1076,8 @@ Hosts for which aube performs shallow git clones.
 
 - Type: `list<string>`
 - Default: `["github.com", "gist.github.com", "gitlab.com", "bitbucket.com", "bitbucket.org"]`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `git-shallow-hosts`, `gitShallowHosts`
 
 Consulted by `aube-store::git_shallow_clone` when cloning a git
@@ -979,6 +1101,8 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `network-concurrency`, `networkConcurrency`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
@@ -1000,6 +1124,8 @@ Number of retry attempts for failed registry fetches.
 
 - Type: `int`
 - Default: `2`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retries`, `fetchRetries`
 
 Number of *additional* attempts the registry client makes after a
@@ -1018,6 +1144,8 @@ Exponential backoff factor for fetch retries.
 
 - Type: `int`
 - Default: `10`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retry-factor`, `fetchRetryFactor`
 
 Multiplier used between retry attempts. Attempt `n` waits
@@ -1031,6 +1159,8 @@ Minimum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `10000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retry-mintimeout`, `fetchRetryMintimeout`
 
 Lower bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1041,6 +1171,8 @@ Maximum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `60000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retry-maxtimeout`, `fetchRetryMaxtimeout`
 
 Upper bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1051,6 +1183,8 @@ Max time (ms) to wait for an HTTP request.
 
 - Type: `int`
 - Default: `60000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `fetchTimeout`
 
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
@@ -1064,6 +1198,8 @@ Warn if a metadata request exceeds this threshold (ms).
 
 - Type: `int`
 - Default: `10000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `fetchWarnTimeoutMs`
 
 Observability threshold for registry *metadata* requests (packument,
@@ -1083,6 +1219,8 @@ Warn if download speed falls below this threshold (KiB/s).
 
 - Type: `int`
 - Default: `50`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `fetchMinSpeedKiBps`
 
 Observability threshold for *tarball* downloads. When a tarball
@@ -1104,6 +1242,8 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `auto-install-peers`, `autoInstallPeers`
 
 When true (the default), missing peer dependencies are auto-installed
@@ -1117,6 +1257,8 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `dedupePeerDependents`
 
 When true (the default), aube collapses packages that landed at
@@ -1133,6 +1275,8 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `dedupePeers`
 
 When true, lockfile peer suffixes emit `(18.2.0)` instead of the
@@ -1147,6 +1291,8 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `strict-peer-dependencies`, `strictPeerDependencies`
 
 When true, any unmet peer dependency (missing, or resolved to a version
@@ -1163,6 +1309,8 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `resolvePeersFromWorkspaceRoot`
 
 When true (the default), an unresolved peer falls back to the root
@@ -1178,6 +1326,8 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `peerDependencyRules.ignoreMissing`
 
 Glob list of peer dependency names whose "missing required peer" warning
@@ -1194,6 +1344,8 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `peerDependencyRules.allowedVersions`
 
 Map of peer selector to an additional semver range. Keys are either a
@@ -1211,6 +1363,8 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `peerDependencyRules.allowAny`
 
 Glob list of peer dependency names whose semver check should be
@@ -1228,6 +1382,8 @@ Control color output in aube's CLI.
 
 - Type: `"auto" | "always" | "never"`
 - Default: `"auto"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `color`
 
 `--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree.
@@ -1238,6 +1394,8 @@ Minimum log level to display.
 
 - Type: `"debug" | "info" | "warn" | "error" | "silent"`
 - Default: `"warn"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `loglevel`
 
 Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`.
@@ -1248,6 +1406,8 @@ Opt into experimental CLI features.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `useBetaCli`
 
 Accepted from env and `.npmrc` for pnpm parity. aube currently has no beta-gated commands, so the setting is a no-op after validation.
@@ -1258,6 +1418,8 @@ Install on all workspace packages by default.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `recursiveInstall`
 
 When true, workspace installs resolve and link all importers by default. Set to false to opt out of implicit workspace-wide install behavior; explicit `--filter` / `--recursive` still wins.
@@ -1268,6 +1430,8 @@ Fail if a package is incompatible with the current Node version.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `engine-strict`, `engineStrict`
 
 When on, an `engines.node` mismatch on the root project or any dependency fails the install. When off, mismatches are warnings only.
@@ -1278,6 +1442,8 @@ Path to the npm binary aube should shell out to when needed.
 
 - Type: `path`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `npmPath`
 
 Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`, `token`, `whoami`) when configured. Without it, aube keeps the explicit `use npm` error.
@@ -1288,6 +1454,8 @@ Enforce the `packageManager` field in package.json.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `packageManagerStrict`
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
@@ -1298,6 +1466,8 @@ Enforce the exact `packageManager` version from package.json.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `packageManagerStrictVersion`
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
@@ -1308,6 +1478,8 @@ Auto-download the specified pnpm version when mismatched.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `managePackageManagerVersions`
 
 Accepted for pnpm parity. aube does not download or re-exec other package-manager versions; when exact version enforcement is enabled, mismatches are reported instead.
@@ -1320,6 +1492,8 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `ignore-scripts`, `ignoreScripts`
 
 aube already skips dependency install scripts by default (security-first).
@@ -1338,6 +1512,8 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `child-concurrency`, `childConcurrency`
 
 Caps how many dependency lifecycle scripts run in parallel during the
@@ -1357,6 +1533,8 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `side-effects-cache`, `sideEffectsCache`
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
@@ -1378,6 +1556,8 @@ Only read from the side-effects cache; don't write.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `sideEffectsCacheReadonly`
 
 When true, aube may restore allowlisted dependency build output from the
@@ -1389,6 +1569,8 @@ Drop to a non-root user when running scripts as root.
 
 - Type: `bool`
 - Default: `false (as root), true (otherwise)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `unsafePerm`
 
 aube exports the resolved value to lifecycle and `run` scripts as
@@ -1401,6 +1583,8 @@ Options passed to Node.js via NODE_OPTIONS.
 
 - Type: `string`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `nodeOptions`
 
 When set in `.npmrc`, aube exports the value as `NODE_OPTIONS` for
@@ -1413,6 +1597,8 @@ Check dependencies before running scripts.
 
 - Type: `"install" | "warn" | "error" | "prompt" | false`
 - Default: `"install"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `verifyDepsBeforeRun`
 
 Controls `run`, lifecycle shortcuts, `exec`, and implicit script commands.
@@ -1426,6 +1612,8 @@ Exit with an error if dependencies have unreviewed build scripts.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `strictDepBuilds`
 
 aube never runs dependency lifecycle scripts unless the package is
@@ -1442,6 +1630,8 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `allowBuilds`
 
 Per-package allowlist for dependency lifecycle scripts. Read from
@@ -1461,6 +1651,8 @@ Allow all dependency build scripts automatically.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `dangerouslyAllowAllBuilds`
 
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
@@ -1481,6 +1673,8 @@ Node.js version aube reports when evaluating `engines` checks.
 
 - Type: `string`
 - Default: `` output of `node -v` with the leading `v` stripped ``
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `node-version`, `nodeVersion`
 
 Paired with `engineStrict`. Set this in .npmrc to pin the Node version engines checks validate against, rather than probing `node --version` at install time.
@@ -1491,6 +1685,8 @@ Custom Node.js download mirror URLs.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `nodeDownloadMirrors`
 
 Accepted for pnpm config parity. aube does not download Node.js itself,
@@ -1505,6 +1701,8 @@ Version prefix used when installing a package.
 
 - Type: `"^" | "~" | ""`
 - Default: `"^"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `save-prefix`, `savePrefix`
 
 Resolved from `.npmrc`. `--save-exact` overrides to empty prefix.
@@ -1515,6 +1713,8 @@ Default dist-tag used by `aube add` without a version.
 
 - Type: `string`
 - Default: `"latest"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `tag`
 
 Resolved from `.npmrc`. Used by `aube add` when no version or dist-tag is specified.
@@ -1525,6 +1725,8 @@ Directory where globally installed packages live.
 
 - Type: `path`
 - Default: `platform-specific`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `globalDir`
 
 Overrides the directory where globally installed packages live. Falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1535,6 +1737,8 @@ Directory where global binaries are symlinked.
 
 - Type: `path`
 - Default: `platform-specific`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `globalBinDir`
 
 Overrides the directory where global binaries are symlinked. Independent of `globalDir`; falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1545,6 +1749,8 @@ Path to an additional .npmrc file consulted for registry authentication tokens.
 
 - Type: `path`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `npmrc-auth-file`, `npmrcAuthFile`
 
 Points at an extra `.npmrc`-formatted file that aube reads *after*
@@ -1572,6 +1778,8 @@ Directory for aube install-state files.
 
 - Type: `path`
 - Default: `.aube/.state`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `stateDir`
 
 Overrides the directory for install state tracking. Defaults to `.aube/.state` relative to the project root.
@@ -1582,6 +1790,8 @@ Directory for package metadata and dlx cache.
 
 - Type: `path`
 - Default: `~/.cache/aube`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `cache-dir`, `cacheDir`
 
 Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path.
@@ -1592,6 +1802,8 @@ Write all output to stderr instead of stdout.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `useStderr`
 
 Redirects stdout to stderr for the process lifetime. Resolved from `.npmrc` or the `--use-stderr` CLI flag.
@@ -1602,6 +1814,8 @@ Show an update notification when a newer aube is available.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `updateNotifier`
 
 After a successful `install`, `add`, or `update`, aube fetches
@@ -1621,6 +1835,8 @@ Create symlinks instead of shims for `.bin` entries.
 
 - Type: `bool`
 - Default: `true (POSIX hoisted)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `preferSymlinkedExecutables`
 
 POSIX only. Default (unset or `true`) creates a plain symlink from
@@ -1638,6 +1854,8 @@ Disable pnpm's automatic dependency patching database.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `ignoreCompatibilityDb`
 
 Accepted for pnpm config parity. pnpm ships a built-in compatibility
@@ -1651,6 +1869,8 @@ Dependency version resolution strategy.
 
 - Type: `"highest" | "time-based" | "lowest-direct"`
 - Default: `"highest"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `resolution-mode`, `resolutionMode`
 
 Controls how aube chooses versions during resolution. `highest` picks
@@ -1665,6 +1885,8 @@ Whether the configured registry returns a `time` field in metadata.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `registry-supports-time-field`, `registrySupportsTimeField`
 
 When `false` (the default, matching pnpm and npmjs.org's behavior),
@@ -1690,6 +1912,8 @@ Set NODE_PATH in command shims.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `extendNodePath`
 
 When `true` (default), aube-generated `.bin` shims export
@@ -1707,6 +1931,8 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `deploy-all-files`, `deployAllFiles`
 
 When true, `aube deploy` copies every file in the source workspace
@@ -1725,6 +1951,8 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `dedupe-direct-deps`, `dedupeDirectDeps`
 
 When true, the linker skips creating a `node_modules/<name>` symlink in a
@@ -1743,6 +1971,8 @@ Fast-path check before running a full install.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `optimisticRepeatInstall`
 
 When `true` (default), `aube run` / `aube exec` / `aube start` /
@@ -1760,6 +1990,8 @@ Scripts that must be present in every workspace project.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `requiredScripts`
 
 During install, aube verifies that the root package and every discovered
@@ -1771,6 +2003,8 @@ Run pre/post scripts automatically when a named script is invoked.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `enablePrePostScripts`
 
 Controls whether `aube run build` also runs `prebuild` before `build`
@@ -1782,6 +2016,8 @@ Shell used to invoke package scripts.
 
 - Type: `path`
 - Default: `null (uses /bin/sh on Unix, cmd on Windows)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `scriptShell`
 
 Overrides the shell executable used for lifecycle and `aube run`
@@ -1793,6 +2029,8 @@ Use a JavaScript bash-like shell to run scripts cross-platform.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `shellEmulator`
 
 Accepted for pnpm config parity. aube does not embed pnpm's JavaScript
@@ -1805,6 +2043,8 @@ How catalog references in package.json are handled by `add`.
 
 - Type: `"manual" | "strict" | "prefer"`
 - Default: `"manual"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `catalogMode`
 
 `manual` (the default) writes whatever range `aube add` resolved, even
@@ -1828,6 +2068,8 @@ Explicitly mark the environment as CI.
 
 - Type: `bool`
 - Default: `auto-detected`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `ci`
 
 aube detects CI via `env::var("CI").is_ok()` in two places:
@@ -1844,6 +2086,8 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `cleanupUnusedCatalogs`
 
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
@@ -1862,6 +2106,8 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
+- Status: implemented
+- Added to registry: `2026-04-17`
 - .npmrc keys: `link-concurrency`, `linkConcurrency`
 
 Caps the dedicated linker worker pool used for filesystem-heavy
@@ -1884,6 +2130,8 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `aubeNoLock`, `aube-no-lock`
 
 aube takes an advisory lock on `node_modules/` at the start of every
@@ -1914,6 +2162,8 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - .npmrc keys: `aubeNoAutoInstall`, `aube-no-auto-install`
 
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs

--- a/docs/settings/workspace-yaml.md
+++ b/docs/settings/workspace-yaml.md
@@ -16,59 +16,60 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-49 settings are listed here.
+50 settings are listed here. 50 are currently implemented.
 
-| Setting | Type | Summary |
-| --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
-| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
-| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Status | Summary |
+| --- | --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
+| [`autoDisableGlobalVirtualStoreForNextjs`](#setting-autodisableglobalvirtualstorefornextjs) | `bool` | implemented | Disable the global virtual store when a Next.js dependency is detected. |
+| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
+| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -78,6 +79,8 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `overrides`
 
 A root-level map of package specs to the versions aube should force them
@@ -91,6 +94,8 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `packageExtensions`
 
 Patches a package's `dependencies`, `peerDependencies`, etc. at resolve
@@ -103,6 +108,8 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `allowedDeprecatedVersions`
 
 Maps a package name to a semver range for which the deprecation warning
@@ -115,6 +122,8 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `updateConfig.ignoreDependencies`
 
 Packages in this list are never bumped by `aube update`, even when a
@@ -126,6 +135,8 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `minimumReleaseAge`
 
 Supply-chain attack mitigation: packages published within the last N
@@ -140,6 +151,8 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `minimumReleaseAgeExclude`
 
 Use for trusted internal packages that need to be rolled out immediately
@@ -152,6 +165,8 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `minimumReleaseAgeStrict`
 
 By default the resolver falls back to the lowest satisfying version when
@@ -164,6 +179,8 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `trustPolicy`
 
 When set to `no-downgrade`, aube accepts and preserves the policy in the
@@ -177,6 +194,8 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `trustPolicyExclude`
 
 Whitelist for `trustPolicy`. Entries skip the downgrade check.
@@ -187,6 +206,8 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `trustPolicyIgnoreAfter`
 
 Useful for pinning very old versions that predate signing infrastructure.
@@ -197,6 +218,8 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `blockExoticSubdeps`
 
 When true, transitive deps referenced via `git+`, `file:`, or direct
@@ -211,6 +234,8 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `hoist`
 
 Controls whether aube populates `node_modules/.aube/node_modules/` —
@@ -239,6 +264,8 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `hoistWorkspacePackages`
 
 Controls whether workspace packages get their own symlinks in each
@@ -255,6 +282,8 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `hoistPattern`
 
 Glob list matched against package names. Any non-local package
@@ -276,6 +305,8 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
+- Status: implemented
+- Added to registry: `2026-04-13`
 - Workspace YAML keys: `publicHoistPattern`
 
 Glob list matched against package names. Any non-local package in the
@@ -295,6 +326,8 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `shamefullyHoist`
 
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
@@ -308,6 +341,8 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
+- Status: implemented
+- Added to registry: `2026-04-17`
 - Workspace YAML keys: `modulesDir`
 
 The project-level directory that holds the top-level `<name>` entries
@@ -332,6 +367,8 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `nodeLinker`
 
 aube defaults to `isolated`, a strict symlink layout under
@@ -346,6 +383,8 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `virtualStoreDir`
 
 Relocates the per-project `.aube/<dep>/node_modules/` tree that the
@@ -374,6 +413,8 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `packageImportMethod`
 
 Controls how aube materializes files from the global content-addressable
@@ -393,12 +434,39 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `enableGlobalVirtualStore`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
 It's enabled by default and disabled under CI (see `aube-linker`, which
 checks the `CI` env var). pnpm gained the same feature later; we expose
 it through `CI=1` rather than a dedicated config knob.
+
+### `autoDisableGlobalVirtualStoreForNextjs` {#setting-autodisableglobalvirtualstorefornextjs}
+
+Disable the global virtual store when a Next.js dependency is detected.
+
+- Type: `bool`
+- Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-18`
+- Workspace YAML keys: `autoDisableGlobalVirtualStoreForNextjs`
+
+Next.js's Turbopack canonicalizes every symlink under `node_modules/`
+and rejects any target that resolves outside the project's "filesystem
+root". aube's global virtual store makes `node_modules/.aube/<pkg>` an
+absolute symlink into `~/.cache/aube/virtual-store/`, which Turbopack
+then reports as `Symlink ... is invalid, it points out of the
+filesystem root`.
+
+When this setting is `true` (the default) and `aube install` detects
+`next` in the root `package.json`'s dependencies, aube forces
+per-project materialization for this install and prints a one-line
+warning explaining why. Set to `false` to keep the global virtual
+store enabled even when Next.js is present — useful if you're working
+around the Turbopack issue another way (e.g. `next dev --webpack`) and
+want the throughput win.
 
 ## Store
 
@@ -408,6 +476,8 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `storeDir`
 
 Defaults to aube's own store path (`~/.aube-store/v1/files/`). aube does not
@@ -435,6 +505,8 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `verifyStoreIntegrity`
 
 aube verifies each package's `integrity` (SHA-512) against the tarball
@@ -456,6 +528,8 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `lockfile`
 
 Controls whether aube reads and writes a lockfile during install. When
@@ -480,6 +554,8 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `preferFrozenLockfile`
 
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
@@ -496,6 +572,8 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `lockfileIncludeTarballUrl`
 
 When true, aube's lockfile writer records the registry tarball URL in
@@ -523,6 +601,8 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-13`
 - Workspace YAML keys: `excludeLinksFromLockfile`
 
 When true, `link:` dependencies are omitted from the lockfile's
@@ -543,6 +623,8 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `gitBranchLockfile`
 
 When enabled, aube writes the lockfile to `aube-lock.<branch>.yaml`
@@ -570,6 +652,8 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `mergeGitBranchLockfilesBranchPattern`
 
 Complements `gitBranchLockfile`. Accepts a list of glob patterns. When
@@ -600,6 +684,8 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peersSuffixMaxLength`
 
 Caps the length of the peer-ID suffix appended to a `dep_path` in the
@@ -620,6 +706,8 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `networkConcurrency`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
@@ -643,6 +731,8 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `autoInstallPeers`
 
 When true (the default), missing peer dependencies are auto-installed
@@ -656,6 +746,8 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `dedupePeerDependents`
 
 When true (the default), aube collapses packages that landed at
@@ -672,6 +764,8 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `dedupePeers`
 
 When true, lockfile peer suffixes emit `(18.2.0)` instead of the
@@ -686,6 +780,8 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `strictPeerDependencies`
 
 When true, any unmet peer dependency (missing, or resolved to a version
@@ -702,6 +798,8 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `resolvePeersFromWorkspaceRoot`
 
 When true (the default), an unresolved peer falls back to the root
@@ -717,6 +815,8 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peerDependencyRules.ignoreMissing`
 
 Glob list of peer dependency names whose "missing required peer" warning
@@ -733,6 +833,8 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peerDependencyRules.allowedVersions`
 
 Map of peer selector to an additional semver range. Keys are either a
@@ -750,6 +852,8 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peerDependencyRules.allowAny`
 
 Glob list of peer dependency names whose semver check should be
@@ -767,6 +871,8 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `ignoreScripts`
 
 aube already skips dependency install scripts by default (security-first).
@@ -785,6 +891,8 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `childConcurrency`
 
 Caps how many dependency lifecycle scripts run in parallel during the
@@ -804,6 +912,8 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `sideEffectsCache`
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
@@ -825,6 +935,8 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `allowBuilds`
 
 Per-package allowlist for dependency lifecycle scripts. Read from
@@ -846,6 +958,8 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `deployAllFiles`
 
 When true, `aube deploy` copies every file in the source workspace
@@ -864,6 +978,8 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `dedupeDirectDeps`
 
 When true, the linker skips creating a `node_modules/<name>` symlink in a
@@ -882,6 +998,8 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `cleanupUnusedCatalogs`
 
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
@@ -900,6 +1018,8 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
+- Status: implemented
+- Added to registry: `2026-04-17`
 - Workspace YAML keys: `linkConcurrency`
 
 Caps the dedicated linker worker pool used for filesystem-heavy
@@ -922,6 +1042,8 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `aubeNoLock`
 
 aube takes an advisory lock on `node_modules/` at the start of every
@@ -952,6 +1074,8 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
+- Status: implemented
+- Added to registry: `2026-04-12`
 - Workspace YAML keys: `aubeNoAutoInstall`
 
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs

--- a/docs/settings/workspace-yaml.md
+++ b/docs/settings/workspace-yaml.md
@@ -41,7 +41,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
 | [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
 | [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`autoDisableGlobalVirtualStoreForNextjs`](#setting-autodisableglobalvirtualstorefornextjs) | `bool` | implemented | Disable the global virtual store when a Next.js dependency is detected. |
+| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | implemented | Package names whose presence in any importer forces per-project materialization. |
 | [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
 | [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
 | [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
@@ -443,30 +443,30 @@ It's enabled by default and disabled under CI (see `aube-linker`, which
 checks the `CI` env var). pnpm gained the same feature later; we expose
 it through `CI=1` rather than a dedicated config knob.
 
-### `autoDisableGlobalVirtualStoreForNextjs` {#setting-autodisableglobalvirtualstorefornextjs}
+### `disableGlobalVirtualStoreForPackages` {#setting-disableglobalvirtualstoreforpackages}
 
-Disable the global virtual store when a Next.js dependency is detected.
+Package names whose presence in any importer forces per-project materialization.
 
-- Type: `bool`
-- Default: `true`
+- Type: `list<string>`
+- Default: `["next"]`
 - Status: implemented
 - Added to registry: `2026-04-18`
-- Workspace YAML keys: `autoDisableGlobalVirtualStoreForNextjs`
+- Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
 
-Next.js's Turbopack canonicalizes every symlink under `node_modules/`
-and rejects any target that resolves outside the project's "filesystem
-root". aube's global virtual store makes `node_modules/.aube/<pkg>` an
-absolute symlink into `~/.cache/aube/virtual-store/`, which Turbopack
-then reports as `Symlink ... is invalid, it points out of the
-filesystem root`.
+aube's global virtual store makes `node_modules/.aube/<pkg>` an
+absolute symlink into `~/.cache/aube/virtual-store/`. Some tools —
+most notably Next.js's Turbopack — canonicalize every symlink under
+`node_modules/` and reject any target that resolves outside the
+project's "filesystem root", producing errors like `Symlink ... is
+invalid, it points out of the filesystem root`.
 
-When this setting is `true` (the default) and `aube install` detects
-`next` in the root `package.json`'s dependencies, aube forces
-per-project materialization for this install and prints a one-line
-warning explaining why. Set to `false` to keep the global virtual
-store enabled even when Next.js is present — useful if you're working
-around the Turbopack issue another way (e.g. `next dev --webpack`) and
-want the throughput win.
+When `aube install` finds one of these names in any importer's
+`dependencies`, `devDependencies`, or `optionalDependencies`, it
+forces per-project materialization for that install and prints a
+one-line warning naming the trigger. Defaults to `["next"]`; add
+other packages here as you discover them, or set the list to `[]` to
+disable the heuristic. `CI=1` already forces per-project mode, so the
+warning suppresses itself in that case.
 
 ## Store
 

--- a/docs/settings/workspace-yaml.md
+++ b/docs/settings/workspace-yaml.md
@@ -16,60 +16,60 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-50 settings are listed here. 50 are currently implemented.
+50 settings are listed here.
 
-| Setting | Type | Status | Summary |
-| --- | --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | implemented | Package names whose presence in any importer forces per-project materialization. |
-| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
-| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Summary |
+| --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
+| [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | Package names whose presence in any importer forces per-project materialization. |
+| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
+| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -79,8 +79,6 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `overrides`
 
 A root-level map of package specs to the versions aube should force them
@@ -94,8 +92,6 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `packageExtensions`
 
 Patches a package's `dependencies`, `peerDependencies`, etc. at resolve
@@ -108,8 +104,6 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `allowedDeprecatedVersions`
 
 Maps a package name to a semver range for which the deprecation warning
@@ -122,8 +116,6 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `updateConfig.ignoreDependencies`
 
 Packages in this list are never bumped by `aube update`, even when a
@@ -135,8 +127,6 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `minimumReleaseAge`
 
 Supply-chain attack mitigation: packages published within the last N
@@ -151,8 +141,6 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `minimumReleaseAgeExclude`
 
 Use for trusted internal packages that need to be rolled out immediately
@@ -165,8 +153,6 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `minimumReleaseAgeStrict`
 
 By default the resolver falls back to the lowest satisfying version when
@@ -179,8 +165,6 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `trustPolicy`
 
 When set to `no-downgrade`, aube accepts and preserves the policy in the
@@ -194,8 +178,6 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `trustPolicyExclude`
 
 Whitelist for `trustPolicy`. Entries skip the downgrade check.
@@ -206,8 +188,6 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `trustPolicyIgnoreAfter`
 
 Useful for pinning very old versions that predate signing infrastructure.
@@ -218,8 +198,6 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `blockExoticSubdeps`
 
 When true, transitive deps referenced via `git+`, `file:`, or direct
@@ -234,8 +212,6 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `hoist`
 
 Controls whether aube populates `node_modules/.aube/node_modules/` —
@@ -264,8 +240,6 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `hoistWorkspacePackages`
 
 Controls whether workspace packages get their own symlinks in each
@@ -282,8 +256,6 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `hoistPattern`
 
 Glob list matched against package names. Any non-local package
@@ -305,8 +277,6 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - Workspace YAML keys: `publicHoistPattern`
 
 Glob list matched against package names. Any non-local package in the
@@ -326,8 +296,6 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `shamefullyHoist`
 
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
@@ -341,8 +309,6 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - Workspace YAML keys: `modulesDir`
 
 The project-level directory that holds the top-level `<name>` entries
@@ -367,8 +333,6 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `nodeLinker`
 
 aube defaults to `isolated`, a strict symlink layout under
@@ -383,8 +347,6 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `virtualStoreDir`
 
 Relocates the per-project `.aube/<dep>/node_modules/` tree that the
@@ -413,8 +375,6 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `packageImportMethod`
 
 Controls how aube materializes files from the global content-addressable
@@ -434,8 +394,6 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `enableGlobalVirtualStore`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
@@ -449,8 +407,6 @@ Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
 - Default: `["next"]`
-- Status: implemented
-- Added to registry: `2026-04-18`
 - Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
 
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
@@ -476,8 +432,6 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `storeDir`
 
 Defaults to aube's own store path (`~/.aube-store/v1/files/`). aube does not
@@ -505,8 +459,6 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `verifyStoreIntegrity`
 
 aube verifies each package's `integrity` (SHA-512) against the tarball
@@ -528,8 +480,6 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `lockfile`
 
 Controls whether aube reads and writes a lockfile during install. When
@@ -554,8 +504,6 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `preferFrozenLockfile`
 
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
@@ -572,8 +520,6 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `lockfileIncludeTarballUrl`
 
 When true, aube's lockfile writer records the registry tarball URL in
@@ -601,8 +547,6 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - Workspace YAML keys: `excludeLinksFromLockfile`
 
 When true, `link:` dependencies are omitted from the lockfile's
@@ -623,8 +567,6 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `gitBranchLockfile`
 
 When enabled, aube writes the lockfile to `aube-lock.<branch>.yaml`
@@ -652,8 +594,6 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `mergeGitBranchLockfilesBranchPattern`
 
 Complements `gitBranchLockfile`. Accepts a list of glob patterns. When
@@ -684,8 +624,6 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peersSuffixMaxLength`
 
 Caps the length of the peer-ID suffix appended to a `dep_path` in the
@@ -706,8 +644,6 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `networkConcurrency`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
@@ -731,8 +667,6 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `autoInstallPeers`
 
 When true (the default), missing peer dependencies are auto-installed
@@ -746,8 +680,6 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `dedupePeerDependents`
 
 When true (the default), aube collapses packages that landed at
@@ -764,8 +696,6 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `dedupePeers`
 
 When true, lockfile peer suffixes emit `(18.2.0)` instead of the
@@ -780,8 +710,6 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `strictPeerDependencies`
 
 When true, any unmet peer dependency (missing, or resolved to a version
@@ -798,8 +726,6 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `resolvePeersFromWorkspaceRoot`
 
 When true (the default), an unresolved peer falls back to the root
@@ -815,8 +741,6 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peerDependencyRules.ignoreMissing`
 
 Glob list of peer dependency names whose "missing required peer" warning
@@ -833,8 +757,6 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peerDependencyRules.allowedVersions`
 
 Map of peer selector to an additional semver range. Keys are either a
@@ -852,8 +774,6 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peerDependencyRules.allowAny`
 
 Glob list of peer dependency names whose semver check should be
@@ -871,8 +791,6 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `ignoreScripts`
 
 aube already skips dependency install scripts by default (security-first).
@@ -891,8 +809,6 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `childConcurrency`
 
 Caps how many dependency lifecycle scripts run in parallel during the
@@ -912,8 +828,6 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `sideEffectsCache`
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
@@ -935,8 +849,6 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `allowBuilds`
 
 Per-package allowlist for dependency lifecycle scripts. Read from
@@ -958,8 +870,6 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `deployAllFiles`
 
 When true, `aube deploy` copies every file in the source workspace
@@ -978,8 +888,6 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `dedupeDirectDeps`
 
 When true, the linker skips creating a `node_modules/<name>` symlink in a
@@ -998,8 +906,6 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `cleanupUnusedCatalogs`
 
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
@@ -1018,8 +924,6 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - Workspace YAML keys: `linkConcurrency`
 
 Caps the dedicated linker worker pool used for filesystem-heavy
@@ -1042,8 +946,6 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `aubeNoLock`
 
 aube takes an advisory lock on `node_modules/` at the start of every
@@ -1074,8 +976,6 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `aubeNoAutoInstall`
 
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -119,6 +119,30 @@ JSON
 	refute_output --partial "disableGlobalVirtualStoreForPackages"
 }
 
+@test "npm_config_ci without CI does not skip the override" {
+	# Regression guard: an earlier version of this check treated
+	# `npm_config_ci` / `NPM_CONFIG_CI` as equivalent to `CI`, but
+	# `Linker::new` only reads `CI`. If the suppression set here drifts
+	# wider than the linker's set, the override is skipped while gvs
+	# stays on — the Turbopack bug resurfaces silently. Pin the exact
+	# match.
+	_make_fake_dep next
+	mkdir -p app
+	cd app
+	cat >package.json <<'JSON'
+{"name":"app","version":"0.0.0","dependencies":{"next":"link:../fake-next","is-odd":"3.0.1"}}
+JSON
+
+	npm_config_ci=true run aube install
+	assert_success
+	assert_output --partial "disableGlobalVirtualStoreForPackages"
+	# gvs must be off — `.aube/<pkg>` is a real directory, not a
+	# symlink. This is the only assertion that actually catches the
+	# original bug; the output check is just for the warning text.
+	[ -d node_modules/.aube/is-odd@3.0.1 ]
+	[ ! -L node_modules/.aube/is-odd@3.0.1 ]
+}
+
 @test "custom entry in disableGlobalVirtualStoreForPackages triggers the disable" {
 	# The whole point of making this a list: users can add packages
 	# they discover have the same filesystem-root problem. Use a

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+
+# Auto-disable of the global virtual store when Next.js is present in
+# the dep graph. Without this guard, `next dev` / `next build` fail
+# with "Symlink node_modules/<pkg> is invalid, it points out of the
+# filesystem root" because Turbopack canonicalizes every
+# `node_modules/` symlink and aube's gvs layout makes `.aube/<pkg>`
+# an absolute symlink into `~/.cache/aube/virtual-store/`.
+#
+# These tests use a `link:` local dep named `next` so the detection
+# fires without needing a real Next.js tarball from the registry —
+# detection only reads `dependencies` / `devDependencies` /
+# `optionalDependencies` keys, not the version specifier.
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+_make_fake_next() {
+	# Minimal local package named `next` so the detection's name-based
+	# match fires. Version is irrelevant — detection ignores the
+	# specifier.
+	mkdir -p fake-next
+	cat >fake-next/package.json <<'JSON'
+{"name":"next","version":"0.0.0-fake","main":"index.js"}
+JSON
+	cat >fake-next/index.js <<'JS'
+module.exports = "fake-next for bats";
+JS
+}
+
+@test "aube install warns and disables global virtual store when next is in dependencies" {
+	_make_fake_next
+	mkdir -p app
+	cd app
+	# Pair `next` (fake, local) with a real registry dep so the
+	# `.aube/<pkg>` layout assertion below has something to inspect —
+	# link: deps skip `.aube/` entirely.
+	cat >package.json <<'JSON'
+{"name":"app","version":"0.0.0","dependencies":{"next":"link:../fake-next","is-odd":"3.0.1"}}
+JSON
+
+	run aube install
+	assert_success
+	assert_output --partial "Next.js detected"
+	assert_output --partial "disabling global virtual store"
+
+	# The whole point of the auto-disable: `.aube/<pkg>` must be a
+	# real directory, not a symlink into
+	# `~/.cache/aube/virtual-store/`. A symlink here is what trips
+	# Turbopack's filesystem-root check.
+	[ -d node_modules/.aube/is-odd@3.0.1 ]
+	[ ! -L node_modules/.aube/is-odd@3.0.1 ]
+	[ -L node_modules/next ]
+}
+
+@test "aube install warns when next is in devDependencies" {
+	_make_fake_next
+	mkdir -p app
+	cd app
+	cat >package.json <<'JSON'
+{"name":"app","version":"0.0.0","devDependencies":{"next":"link:../fake-next"}}
+JSON
+
+	run aube install
+	assert_success
+	assert_output --partial "Next.js detected"
+}
+
+@test "aube install does not warn when next is absent" {
+	_setup_basic_fixture
+
+	run aube install
+	assert_success
+	refute_output --partial "Next.js detected"
+	refute_output --partial "disabling global virtual store"
+}
+
+@test "autoDisableGlobalVirtualStoreForNextjs=false opts out of the auto-disable" {
+	_make_fake_next
+	mkdir -p app
+	cd app
+	cat >.npmrc <<'RC'
+autoDisableGlobalVirtualStoreForNextjs=false
+RC
+	cat >package.json <<'JSON'
+{"name":"app","version":"0.0.0","dependencies":{"next":"link:../fake-next","is-odd":"3.0.1"}}
+JSON
+
+	run aube install
+	assert_success
+	refute_output --partial "Next.js detected"
+	refute_output --partial "disabling global virtual store"
+
+	# With the opt-out, gvs stays on — `.aube/<pkg>` should be a
+	# symlink into `~/.cache/aube/virtual-store/`. This is the
+	# inverse of the default-behavior test above and confirms the
+	# setting actually reaches the linker.
+	[ -L node_modules/.aube/is-odd@3.0.1 ]
+}
+
+@test "CI=1 suppresses the Next.js warning because gvs is already off" {
+	# Under CI, Linker::new already picks per-project materialization,
+	# so the warning would be noise. Detection is still correct —
+	# this test just pins the "no double-warn in CI" contract.
+	_make_fake_next
+	mkdir -p app
+	cd app
+	cat >package.json <<'JSON'
+{"name":"app","version":"0.0.0","dependencies":{"next":"link:../fake-next"}}
+JSON
+
+	CI=1 run aube install
+	assert_success
+	refute_output --partial "Next.js detected"
+}

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -56,6 +56,19 @@ JSON
 	[ -d node_modules/.aube/is-odd@3.0.1 ]
 	[ ! -L node_modules/.aube/is-odd@3.0.1 ]
 	[ -L node_modules/next ]
+
+	# Regression guard: the fetch-pipelined prewarm task builds its
+	# own Linker and used to miss this override, so it would spend
+	# the fetch phase materializing packages into
+	# `$XDG_CACHE_HOME/aube/virtual-store/` even though the main
+	# linker ran in per-project mode and threw all of that work
+	# away. HOME is isolated in setup, so the shared virtual store
+	# stays empty on a clean run — no per-dep_path subdir under
+	# `virtual-store/` means prewarm correctly skipped the pour.
+	if [ -d "$XDG_CACHE_HOME/aube/virtual-store" ]; then
+		run find "$XDG_CACHE_HOME/aube/virtual-store" -mindepth 1 -maxdepth 1 -type d
+		assert_output ""
+	fi
 }
 
 @test "aube install warns when next is in devDependencies" {

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -1,16 +1,16 @@
 #!/usr/bin/env bats
 
-# Auto-disable of the global virtual store when Next.js is present in
-# the dep graph. Without this guard, `next dev` / `next build` fail
-# with "Symlink node_modules/<pkg> is invalid, it points out of the
-# filesystem root" because Turbopack canonicalizes every
-# `node_modules/` symlink and aube's gvs layout makes `.aube/<pkg>`
-# an absolute symlink into `~/.cache/aube/virtual-store/`.
+# Auto-disable of the global virtual store when any package listed in
+# `disableGlobalVirtualStoreForPackages` is present in an importer's
+# deps. Default list is `["next"]` — Next.js's Turbopack canonicalizes
+# every `node_modules/<pkg>` symlink and rejects targets outside the
+# project root, which aube's gvs layout produces by default. The
+# setting is the extension point: add any tool with the same
+# restriction, or set to `[]` to disable the heuristic.
 #
-# These tests use a `link:` local dep named `next` so the detection
-# fires without needing a real Next.js tarball from the registry —
-# detection only reads `dependencies` / `devDependencies` /
-# `optionalDependencies` keys, not the version specifier.
+# These tests use a `link:` local dep so detection fires without
+# needing a real tarball — the scan only reads dependency names, not
+# versions.
 
 setup() {
 	load 'test_helper/common_setup'
@@ -21,21 +21,20 @@ teardown() {
 	_common_teardown
 }
 
-_make_fake_next() {
-	# Minimal local package named `next` so the detection's name-based
-	# match fires. Version is irrelevant — detection ignores the
-	# specifier.
-	mkdir -p fake-next
-	cat >fake-next/package.json <<'JSON'
-{"name":"next","version":"0.0.0-fake","main":"index.js"}
+_make_fake_dep() {
+	# $1 = name on disk (directory) and package name
+	local name="$1"
+	mkdir -p "fake-$name"
+	cat >"fake-$name/package.json" <<JSON
+{"name":"$name","version":"0.0.0-fake","main":"index.js"}
 JSON
-	cat >fake-next/index.js <<'JS'
-module.exports = "fake-next for bats";
+	cat >"fake-$name/index.js" <<JS
+module.exports = "fake-$name for bats";
 JS
 }
 
 @test "aube install warns and disables global virtual store when next is in dependencies" {
-	_make_fake_next
+	_make_fake_dep next
 	mkdir -p app
 	cd app
 	# Pair `next` (fake, local) with a real registry dep so the
@@ -47,8 +46,8 @@ JSON
 
 	run aube install
 	assert_success
-	assert_output --partial "Next.js detected"
-	assert_output --partial "disabling global virtual store"
+	assert_output --partial "disableGlobalVirtualStoreForPackages"
+	assert_output --partial "\`next\`"
 
 	# The whole point of the auto-disable: `.aube/<pkg>` must be a
 	# real directory, not a symlink into
@@ -60,7 +59,7 @@ JSON
 }
 
 @test "aube install warns when next is in devDependencies" {
-	_make_fake_next
+	_make_fake_dep next
 	mkdir -p app
 	cd app
 	cat >package.json <<'JSON'
@@ -69,24 +68,25 @@ JSON
 
 	run aube install
 	assert_success
-	assert_output --partial "Next.js detected"
+	assert_output --partial "disableGlobalVirtualStoreForPackages"
+	assert_output --partial "\`next\`"
 }
 
-@test "aube install does not warn when next is absent" {
+@test "aube install does not warn when no listed package is present" {
 	_setup_basic_fixture
 
 	run aube install
 	assert_success
-	refute_output --partial "Next.js detected"
+	refute_output --partial "disableGlobalVirtualStoreForPackages"
 	refute_output --partial "disabling global virtual store"
 }
 
-@test "autoDisableGlobalVirtualStoreForNextjs=false opts out of the auto-disable" {
-	_make_fake_next
+@test "disableGlobalVirtualStoreForPackages=[] opts out of the auto-disable" {
+	_make_fake_dep next
 	mkdir -p app
 	cd app
 	cat >.npmrc <<'RC'
-autoDisableGlobalVirtualStoreForNextjs=false
+disableGlobalVirtualStoreForPackages=[]
 RC
 	cat >package.json <<'JSON'
 {"name":"app","version":"0.0.0","dependencies":{"next":"link:../fake-next","is-odd":"3.0.1"}}
@@ -94,8 +94,7 @@ JSON
 
 	run aube install
 	assert_success
-	refute_output --partial "Next.js detected"
-	refute_output --partial "disabling global virtual store"
+	refute_output --partial "disableGlobalVirtualStoreForPackages"
 
 	# With the opt-out, gvs stays on — `.aube/<pkg>` should be a
 	# symlink into `~/.cache/aube/virtual-store/`. This is the
@@ -104,11 +103,11 @@ JSON
 	[ -L node_modules/.aube/is-odd@3.0.1 ]
 }
 
-@test "CI=1 suppresses the Next.js warning because gvs is already off" {
+@test "CI=1 suppresses the gvs-disable warning because gvs is already off" {
 	# Under CI, Linker::new already picks per-project materialization,
 	# so the warning would be noise. Detection is still correct —
 	# this test just pins the "no double-warn in CI" contract.
-	_make_fake_next
+	_make_fake_dep next
 	mkdir -p app
 	cd app
 	cat >package.json <<'JSON'
@@ -117,5 +116,26 @@ JSON
 
 	CI=1 run aube install
 	assert_success
-	refute_output --partial "Next.js detected"
+	refute_output --partial "disableGlobalVirtualStoreForPackages"
+}
+
+@test "custom entry in disableGlobalVirtualStoreForPackages triggers the disable" {
+	# The whole point of making this a list: users can add packages
+	# they discover have the same filesystem-root problem. Use a
+	# made-up name to prove the heuristic doesn't hardcode `next`.
+	_make_fake_dep turbo-clone
+	mkdir -p app
+	cd app
+	cat >.npmrc <<'RC'
+disableGlobalVirtualStoreForPackages=[next,turbo-clone]
+RC
+	cat >package.json <<'JSON'
+{"name":"app","version":"0.0.0","dependencies":{"turbo-clone":"link:../fake-turbo-clone","is-odd":"3.0.1"}}
+JSON
+
+	run aube install
+	assert_success
+	assert_output --partial "disableGlobalVirtualStoreForPackages"
+	assert_output --partial "\`turbo-clone\`"
+	[ ! -L node_modules/.aube/is-odd@3.0.1 ]
 }


### PR DESCRIPTION
## Summary

- Adds `disableGlobalVirtualStoreForPackages` (list<string>, default `["next"]`, readable from `.npmrc` and `aube-workspace.yaml`). When any name in the list appears in an importer's `dependencies` / `devDependencies` / `optionalDependencies`, `aube install` forces per-project materialization for that install and prints a one-line warning naming the trigger. The list is the extension point — add more tools as you discover them, set to `[]` to disable the heuristic.
- Adds `Linker::with_use_global_virtual_store(bool)` so the install driver can override the default that `Linker::new` picks from the `CI` env var.

## Why

Reported in-channel: `aube dev` on a freshly scaffolded `create-next-app` project fails with

```
Error [TurbopackInternalError]: Symlink [project]/node_modules/next is invalid, it points out of the filesystem root
```

Turbopack canonicalizes every `node_modules/<pkg>` symlink and rejects anything whose resolved target escapes the project dir. aube's default global virtual store makes `node_modules/.aube/<pkg>` an absolute symlink into `~/.cache/aube/virtual-store/`, so Turbopack's canonicalization lands outside the project and the tool bails.

pnpm doesn't hit this by default because pnpm's `enableGlobalVirtualStore` is off by default — `.pnpm/<pkg>/` is a real directory with file-level hardlinks into the CAS. aube inverts that default (gvs on, disabled only under `CI=1`), so we need an explicit guard for tools that break on directory-level symlinks escaping the project.

A bool-per-tool setting would stop scaling the moment the second tool shows up, so the setting is a list the user can extend without an aube release. `next` is the only known trigger today; the machinery is ready for the next one.

`CI=1` and `virtualStoreOnly` already bypass the gvs symlink path, so the warning suppresses itself in those cases to avoid noise.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p aube-linker -p aube-settings -p aube-manifest`
- [x] `mise run test:bats test/nextjs_gvs_autodisable.bats` — 6 tests: warn-on-`next`-in-deps (plus `.aube/<pkg>` is a real directory), warn-on-devDeps, no-warn-when-list-doesn't-match, `disableGlobalVirtualStoreForPackages=[]` opt-out (plus inverse layout check that `.aube/<pkg>` stays a symlink), `CI=1` suppression, and a custom package name added to the list to prove it's actually extensible.
- [x] `mise run test:bats test/install.bats` — all 52 existing tests still pass.
- [ ] Manual: reproduce the original `create-next-app` + `aube dev` failure, confirm it works on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time linking behavior by conditionally forcing per-project materialization based on dependency names, which can impact performance and disk usage across projects. Risk is bounded by being opt-out/overridable and covered by new bats regression tests.
> 
> **Overview**
> **`aube install` now auto-disables the global virtual store** when any importer depends on a package listed in new `disableGlobalVirtualStoreForPackages` (default `[`next`]`), and emits a one-line warning naming the trigger (suppressed under `CI=1` and `virtualStoreOnly`).
> 
> This introduces `Linker::with_use_global_virtual_store(bool)` so the install driver (including the fetch-phase prewarm linker) can explicitly force per-project materialization, wires the new setting through workspace deserialization and settings/docs, and adds bats coverage to pin the new behavior and regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 696a0933c193dcdd2ff7e871af18d692372e6e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->