### PR TITLE
settings: drop transitional implemented/since fields ahead of 1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,35 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Pre-1.0: pnpm parity
-
-Until aube ships 1.0 and hits drop-in parity with pnpm, this section
-calls out workflow rules that only apply during the parity push. Once
-we're done, delete the whole section.
-
-- **Every new CLI arg or flag must update two docs in the same PR**:
-  - [`README.md`](README.md) — the user-facing feature comparison table
-    (command row + any relevant flag row). If a command's notes column
-    is stale, fix it while you're there.
-  - [`CLI_SPEC.md`](CLI_SPEC.md) — the per-flag parity tracker. Flip
-    the status cell from ❌/🟡 to ✅ when you land the flag, and add
-    new rows for any pnpm flag the PR exposes for the first time.
-  Think of both docs as part of the CLI surface: a PR that skips them
-  leaves future contributors unsure whether a flag is shipped,
-  half-wired, or intentionally deferred.
-- **Keep `aube.usage.kdl` in sync**. Run `cargo build && ./target/debug/aube usage > aube.usage.kdl`
-  after any clap change. The golden test in `crates/aube/src/main.rs`
-  fails loudly if you forget.
-- **Hide aliases that aube makes redundant**. Commands we only keep for
-  pnpm muscle memory (e.g. `install-test`, `ll`, `la`) should be
-  `#[command(hide = true)]` so `aube --help` doesn't grow noise, and
-  the README row should explain *why* they're hidden. Feature-complete
-  commands stay visible.
-- **Every new command needs a BATS test.** The offline Verdaccio
-  fixture registry (`test/registry/`) exists so these tests can run
-  without network access; see the testing section below for the
-  recipe to add a fixture package.
-
 ## What is Aube?
 
 Aube is a fast Node.js package manager written in Rust. It mirrors pnpm's CLI surface and isolated symlink layout so users can swap it in, but it owns its own on-disk state: the global store lives in `~/.aube-store/`, the per-project virtual store is `node_modules/.aube/`, and the canonical lockfile is `aube-lock.yaml`. Aube reads and writes several lockfile formats — `aube-lock.yaml`, `pnpm-lock.yaml` (v9), `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock` — and preserves whatever kind is already on disk, so a project with only `pnpm-lock.yaml` keeps getting `pnpm-lock.yaml` updated. `aube-lock.yaml` is the default only when no lockfile exists yet. If a project already has a `node_modules` from another package manager, aube leaves it alone and installs into its own tree alongside — it never reaches into `.pnpm/` or `~/.pnpm-store/`. Lifecycle scripts are skipped by default for security.

--- a/crates/aube-settings/build.rs
+++ b/crates/aube-settings/build.rs
@@ -24,8 +24,6 @@ struct SettingDef {
     #[serde(rename = "type")]
     type_: String,
     default: String,
-    implemented: bool,
-    since: String,
     #[serde(default)]
     docs: String,
     #[serde(default)]
@@ -100,8 +98,6 @@ fn main() {
         writeln!(out, "        description: {},", lit(&def.description)).unwrap();
         writeln!(out, "        type_: {},", lit(&def.type_)).unwrap();
         writeln!(out, "        default: {},", lit(&def.default)).unwrap();
-        writeln!(out, "        implemented: {},", def.implemented).unwrap();
-        writeln!(out, "        since: {},", lit(&def.since)).unwrap();
         writeln!(out, "        docs: {},", lit(&def.docs)).unwrap();
         writeln!(out, "        cli_flags: {},", slice_lit(&def.sources.cli)).unwrap();
         // Env vars: always include the pnpm/npm-convention alias

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1,15 +1,11 @@
 # Aube Settings Registry
 #
-# Source of truth for every setting aube supports or plans to support.
-# Mirrors https://pnpm.io/next/settings exhaustively; the `implemented`
-# field marks which ones aube currently honors. When aube reaches v1
-# every setting will be implemented and this field will be removed.
+# Source of truth for every setting aube supports. Mirrors
+# https://pnpm.io/next/settings.
 #
 # Tooling consumes this file to generate:
 #   - docs/settings/*.md (pnpm-style reference pages)
 #   - Rust metadata/accessors in `aube-settings`
-#   - integration tests that verify each `implemented = true` setting
-#     actually affects observable behavior
 #
 # The `# ===== Category =====` separators below are intentionally
 # structured: the docs generator uses them for page grouping while
@@ -20,8 +16,6 @@
 #   type          = TOML-ish type spec ("bool", "string", "int",
 #                   "path", "url", "list<string>", "object", enum unions)
 #   default       = default value rendered as a string
-#   implemented   = whether aube currently honors this setting (dropped at v1)
-#   since         = ISO date the setting was added to this registry
 #   docs          = longer markdown explanation
 #   sources.cli   = CLI flags that set this setting (list, may be empty)
 #   sources.env   = env vars that set this setting (list, may be empty)
@@ -40,8 +34,6 @@
 description = "Instruct aube to override any dependency in the dependency graph, including peer dependencies."
 type = "object"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 A root-level map of package specs to the versions aube should force them
 to, regardless of what any package's `dependencies` field requests. The
@@ -58,8 +50,6 @@ examples = []
 description = "Extend existing package definitions with additional information."
 type = "object"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Patches a package's `dependencies`, `peerDependencies`, etc. at resolve
 time. Used to work around upstream packages that forget to declare their
@@ -75,8 +65,6 @@ examples = []
 description = "Mute deprecation warnings for specific package versions."
 type = "object"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Maps a package name to a semver range for which the deprecation warning
 should be suppressed. Useful when a deprecated version is still pinned
@@ -92,8 +80,6 @@ examples = []
 description = "List of packages to ignore during update checks."
 type = "list<string>"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Packages in this list are never bumped by `aube update`, even when a
 newer version matching their range exists.
@@ -108,8 +94,6 @@ examples = []
 description = "Specify architectures for optional dependency installation."
 type = "object"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Override the current platform/arch/libc triple used to filter optional
 dependencies. Useful when generating a lockfile for a target platform
@@ -124,8 +108,6 @@ examples = []
 description = "Skip optional dependencies by name."
 type = "list<string>"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Named entries are skipped even if their platform/arch matches. Distinct
 from `--no-optional`, which drops *all* optional deps at install time.
@@ -144,8 +126,6 @@ typedAccessorUnused = true
 description = "Delay installation of newly published versions (minutes)."
 type = "int"
 default = "1440"
-implemented = true
-since = "2026-04-12"
 docs = """
 Supply-chain attack mitigation: packages published within the last N
 minutes are skipped by the resolver. By default the resolver falls back
@@ -166,8 +146,6 @@ examples = []
 description = "Packages exempt from the minimumReleaseAge requirement."
 type = "list<string>"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Use for trusted internal packages that need to be rolled out immediately
 without waiting for the age gate. `pnpm audit --fix` (when implemented)
@@ -184,8 +162,6 @@ examples = []
 description = "Fail the install when no version satisfies the minimumReleaseAge cutoff."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 By default the resolver falls back to the lowest satisfying version when
 every candidate is younger than `minimumReleaseAge`. With this set, the
@@ -202,8 +178,6 @@ examples = []
 description = "Behavior when a package's trust level decreases between installs."
 type = '"no-downgrade" | "off"'
 default = "\"off\""
-implemented = true
-since = "2026-04-12"
 docs = """
 When set to `no-downgrade`, aube accepts and preserves the policy in the
 resolver configuration. Registry trust metadata is not exposed through
@@ -220,8 +194,6 @@ examples = []
 description = "Packages exempt from trust policy checks."
 type = "list<string>"
 default = "[]"
-implemented = true
-since = "2026-04-12"
 docs = "Whitelist for `trustPolicy`. Entries skip the downgrade check."
 sources.cli = []
 sources.env = []
@@ -233,8 +205,6 @@ examples = []
 description = "Ignore trust policy for packages older than this age (minutes)."
 type = "int"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Useful for pinning very old versions that predate signing infrastructure.
 """
@@ -248,8 +218,6 @@ examples = []
 description = "Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs)."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 When true, transitive deps referenced via `git+`, `file:`, or direct
 tarball URLs are rejected. Helps prevent supply-chain attacks via
@@ -265,8 +233,6 @@ examples = []
 description = "Registry URLs, including scoped registry overrides."
 type = "object"
 default = "{ default = \"https://registry.npmjs.org/\" }"
-implemented = true
-since = "2026-04-12"
 docs = """
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
 `.npmrc` via `aube_registry::config::NpmConfig` (see
@@ -287,8 +253,6 @@ examples = [
 description = "Hoist all dependencies to the hidden modules directory."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 Controls whether aube populates `node_modules/.aube/node_modules/` —
 the *hidden* hoist tree that lives inside the private virtual store.
@@ -318,8 +282,6 @@ examples = [
 description = "Symlink workspace packages into node_modules."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 Controls whether workspace packages get their own symlinks in each
 importer's `node_modules/`. When true (the default), every importer
@@ -339,8 +301,6 @@ examples = []
 description = "Packages to hoist to the hidden modules directory."
 type = "list<string>"
 default = "[\"*\"]"
-implemented = true
-since = "2026-04-12"
 docs = """
 Glob list matched against package names. Any non-local package
 whose name matches at least one positive pattern (and no
@@ -365,8 +325,6 @@ examples = []
 description = "Packages to hoist directly to the root node_modules."
 type = "list<string>"
 default = "[]"
-implemented = true
-since = "2026-04-13"
 docs = """
 Glob list matched against package names. Any non-local package in the
 resolved graph whose name matches at least one positive pattern (and
@@ -389,8 +347,6 @@ examples = []
 description = "Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=[\"*\"])."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
 design — only use as a last-resort compatibility knob.
@@ -407,8 +363,6 @@ examples = []
 description = "Directory to install dependencies into."
 type = "path"
 default = "\"node_modules\""
-implemented = true
-since = "2026-04-17"
 docs = """
 The project-level directory that holds the top-level `<name>` entries
 the user sees under the project root. Defaults to `"node_modules"`.
@@ -436,8 +390,6 @@ examples = []
 description = "Strategy for linking Node packages into node_modules."
 type = '"isolated" | "hoisted" | "pnp"'
 default = "\"isolated\""
-implemented = true
-since = "2026-04-12"
 docs = """
 aube defaults to `isolated`, a strict symlink layout under
 `node_modules/.aube/`. `hoisted` is also supported for projects that need an
@@ -455,8 +407,6 @@ examples = []
 description = "Create symlinks in the virtual store directory."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 Accepted for pnpm parity. aube's isolated layout is structurally
 defined by the symlink graph under `node_modules/.aube/` — each
@@ -485,8 +435,6 @@ examples = [
 description = "Write files to the modules directory."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 When `false`, aube resolves the dependency graph and writes
 `aube-lock.yaml` but skips every `node_modules/` side effect: no
@@ -504,8 +452,6 @@ examples = []
 description = "Directory with links to the store."
 type = "path"
 default = "\"node_modules/.aube\""
-implemented = true
-since = "2026-04-12"
 docs = """
 Relocates the per-project `.aube/<dep>/node_modules/` tree that the
 isolated linker writes into. Relative paths resolve against the project
@@ -537,8 +483,6 @@ examples = []
 description = "Max length for virtual store directory names."
 type = "int"
 default = "120 (Linux/macOS), 60 (Windows)"
-implemented = true
-since = "2026-04-12"
 docs = """
 Caps the number of characters in a single `node_modules/.aube/<dep>`
 directory name. `dep_path_to_filename` already truncates-and-hashes
@@ -558,8 +502,6 @@ examples = []
 description = "Populate the virtual store without creating top-level symlinks."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 When `true`, aube still materializes every package into
 `node_modules/.aube/<dep>/node_modules/<name>` (and, in global-store
@@ -580,8 +522,6 @@ examples = []
 description = "Method for importing packages from the store into node_modules."
 type = '"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"'
 default = "\"auto\""
-implemented = true
-since = "2026-04-12"
 docs = """
 Controls how aube materializes files from the global content-addressable
 store into the virtual store. `auto` (default) probes the destination
@@ -604,8 +544,6 @@ examples = []
 description = "Minutes before orphan packages are removed from the virtual store."
 type = "int"
 default = "10080"
-since = "2026-04-12"
-implemented = true
 docs = """
 After each successful install, aube sweeps the per-project
 `node_modules/.aube/` virtual store and removes entries whose
@@ -627,8 +565,6 @@ examples = []
 description = "Minutes before the dlx cache is considered stale."
 type = "int"
 default = "1440"
-implemented = true
-since = "2026-04-12"
 docs = """
 Accepted for pnpm parity. `aube dlx` currently installs into a fresh
 `tempfile::TempDir` per invocation and removes it on exit, so there is
@@ -646,8 +582,6 @@ examples = []
 description = "Use a per-user virtual store for all projects."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
 It's enabled by default and disabled under CI (see `aube-linker`, which
@@ -670,8 +604,6 @@ typedAccessorUnused = true
 description = "Location where packages are saved on disk (content-addressable store)."
 type = "path"
 default = "~/.aube-store/v1/files/"
-implemented = true
-since = "2026-04-12"
 docs = """
 Defaults to aube's own store path (`~/.aube-store/v1/files/`). aube does not
 read from or write to pnpm's `~/.pnpm-store/`. Set in `.npmrc` or
@@ -700,8 +632,6 @@ examples = [
 description = "Check store file integrity before linking."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 aube verifies each package's `integrity` (SHA-512) against the tarball
 bytes at import time in `aube_store::verify_integrity`, before extraction.
@@ -722,8 +652,6 @@ examples = [
 description = "Only allow installs when the store server is running."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 Accepted for pnpm parity. aube has no long-running store-daemon
 component — every install talks directly to the on-disk CAS at
@@ -741,8 +669,6 @@ examples = []
 description = "Validate package names and versions in the store."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 After each registry tarball is imported, aube reads the freshly stored
 `package.json` and confirms its `name` and `version` match what the
@@ -769,8 +695,6 @@ examples = [
 description = "Proxy URL for outgoing HTTPS requests."
 type = "url"
 default = "null"
-implemented = true
-since = "2026-04-12"
 docs = """
 Forwards every HTTPS registry fetch through the given proxy URL.
 Honored by the `aube-registry` reqwest client. Resolution mirrors
@@ -786,8 +710,6 @@ examples = []
 description = "Proxy URL for outgoing HTTP requests."
 type = "url"
 default = "null"
-implemented = true
-since = "2026-04-12"
 docs = """
 HTTP counterpart to `httpsProxy`. Resolution mirrors pnpm:
 `.npmrc http-proxy` ?? resolved `httpsProxy` ?? `HTTP_PROXY` /
@@ -804,8 +726,6 @@ examples = []
 description = "Comma-separated list of domains that bypass the proxy."
 type = "string"
 default = "null"
-implemented = true
-since = "2026-04-12"
 docs = """
 Passed through to `reqwest::NoProxy::from_string` verbatim, so
 wildcard and port-qualified hosts behave the same as curl / node.
@@ -826,8 +746,6 @@ typedAccessorUnused = true
 description = "Local interface IP address to bind registry connections to."
 type = "string"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Used on multi-homed hosts where outbound traffic must leave a
 specific interface. Parsed as `IpAddr`; unparseable values are
@@ -846,8 +764,6 @@ typedAccessorUnused = true
 description = "Maximum concurrent connections per origin."
 type = "int"
 default = "networkConcurrency x 3"
-implemented = true
-since = "2026-04-12"
 docs = """
 Plumbed into reqwest's `pool_max_idle_per_host`. This is the
 closest analogue to pnpm's per-origin socket cap — reqwest doesn't
@@ -867,8 +783,6 @@ typedAccessorUnused = true
 description = "Validate SSL certificates for HTTPS requests."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 Defaults to `true`. Setting `strict-ssl=false` disables TLS
 certificate verification entirely via
@@ -891,8 +805,6 @@ typedAccessorUnused = true
 description = "Read and generate aube-lock.yaml."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 Controls whether aube reads and writes a lockfile during install. When
 false (npm's `--no-package-lock` equivalent), every `aube install` runs
@@ -918,8 +830,6 @@ examples = [
 description = "Perform a headless install if the lockfile already satisfies package.json."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
 `crates/aube/src/commands/install.rs`. Inside CI the default flips
@@ -935,8 +845,6 @@ examples = ["aube install --prefer-frozen-lockfile"]
 description = "Add the full tarball URL to each lockfile entry."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 When true, aube's lockfile writer records the registry tarball URL in
 each package's `resolution:` block alongside the `integrity:` hash.
@@ -965,8 +873,6 @@ examples = [
 description = "Skip local `link:` dependencies when writing the lockfile."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-13"
 docs = """
 When true, `link:` dependencies are omitted from the lockfile's
 `importers.*.dependencies:` (and `devDependencies:` /
@@ -990,8 +896,6 @@ examples = []
 description = "Generate branch-specific lockfile names (aube-lock.<branch>.yaml)."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 When enabled, aube writes the lockfile to `aube-lock.<branch>.yaml`
 instead of `aube-lock.yaml`, where `<branch>` is the current git branch
@@ -1022,8 +926,6 @@ examples = []
 description = "Branch-name glob list for auto-merging branch lockfiles."
 type = "list<string>"
 default = "null"
-implemented = true
-since = "2026-04-12"
 docs = """
 Complements `gitBranchLockfile`. Accepts a list of glob patterns. When
 `aube install` runs on a branch whose name matches any pattern, aube
@@ -1057,8 +959,6 @@ examples = []
 description = "Max length of the peer-ID suffix in lockfile dep_paths."
 type = "int"
 default = "1000"
-implemented = true
-since = "2026-04-12"
 docs = """
 Caps the length of the peer-ID suffix appended to a `dep_path` in the
 lockfile (e.g. `react-dom@18.2.0(react@18.2.0)`). When the suffix would
@@ -1082,8 +982,6 @@ examples = []
 description = "Hosts for which aube performs shallow git clones."
 type = "list<string>"
 default = "[\"github.com\", \"gist.github.com\", \"gitlab.com\", \"bitbucket.com\", \"bitbucket.org\"]"
-implemented = true
-since = "2026-04-12"
 docs = """
 Consulted by `aube-store::git_shallow_clone` when cloning a git
 dependency. When the URL's hostname matches an entry in this list
@@ -1109,8 +1007,6 @@ examples = []
 description = "Maximum concurrent HTTP(S) requests."
 type = "int"
 default = "128 (tarballs), 64 (packuments)"
-implemented = true
-since = "2026-04-12"
 docs = """
 Caps the tokio semaphores that gate concurrent tarball downloads
 inside `crates/aube/src/commands/install.rs`. When set, both the
@@ -1133,8 +1029,6 @@ examples = [
 description = "Number of retry attempts for failed registry fetches."
 type = "int"
 default = "2"
-implemented = true
-since = "2026-04-12"
 docs = """
 Number of *additional* attempts the registry client makes after a
 transient failure (5xx / 429 / connection error). `2` means up to 3
@@ -1155,8 +1049,6 @@ examples = []
 description = "Exponential backoff factor for fetch retries."
 type = "int"
 default = "10"
-implemented = true
-since = "2026-04-12"
 docs = """
 Multiplier used between retry attempts. Attempt `n` waits
 `min(fetchRetryMintimeout * fetchRetryFactor ^ (n-1), fetchRetryMaxtimeout)`
@@ -1172,8 +1064,6 @@ examples = []
 description = "Minimum retry timeout in milliseconds."
 type = "int"
 default = "10000"
-implemented = true
-since = "2026-04-12"
 docs = "Lower bound on the computed retry backoff. See `fetchRetryFactor`."
 sources.cli = []
 sources.env = []
@@ -1184,8 +1074,6 @@ examples = []
 description = "Maximum retry timeout in milliseconds."
 type = "int"
 default = "60000"
-implemented = true
-since = "2026-04-12"
 docs = "Upper bound on the computed retry backoff. See `fetchRetryFactor`."
 sources.cli = []
 sources.env = []
@@ -1196,8 +1084,6 @@ examples = []
 description = "Max time (ms) to wait for an HTTP request."
 type = "int"
 default = "60000"
-implemented = true
-since = "2026-04-12"
 docs = """
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
 `.timeout()` so it covers headers + body together. A request that
@@ -1213,8 +1099,6 @@ examples = []
 description = "Warn if a metadata request exceeds this threshold (ms)."
 type = "int"
 default = "10000"
-implemented = true
-since = "2026-04-12"
 docs = """
 Observability threshold for registry *metadata* requests (packument,
 dist-tags). When a successful response takes longer than
@@ -1236,8 +1120,6 @@ examples = []
 description = "Warn if download speed falls below this threshold (KiB/s)."
 type = "int"
 default = "50"
-implemented = true
-since = "2026-04-12"
 docs = """
 Observability threshold for *tarball* downloads. When a tarball
 finishes with an end-to-end average throughput below this many KiB/s,
@@ -1261,8 +1143,6 @@ examples = []
 description = "Automatically install missing peer dependencies."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 When true (the default), missing peer dependencies are auto-installed
 during resolution and hoisted into the importer. Set to `false` to
@@ -1279,8 +1159,6 @@ examples = []
 description = "Deduplicate packages that have peer dependencies."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 When true (the default), aube collapses packages that landed at
 different peer-suffixed dep_paths but resolved every declared peer to
@@ -1300,8 +1178,6 @@ examples = []
 description = "Use version-only identifiers for peer suffixes in the lockfile."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 When true, lockfile peer suffixes emit `(18.2.0)` instead of the
 default `(react@18.2.0)`. Applied as a post-pass over the resolved
@@ -1319,8 +1195,6 @@ examples = []
 description = "Fail if peer dependencies are missing or invalid."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 When true, any unmet peer dependency (missing, or resolved to a version
 outside the declared range) fails the install with a miette diagnostic
@@ -1340,8 +1214,6 @@ examples = []
 description = "Use root workspace dependencies for peer resolution."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 When true (the default), an unresolved peer falls back to the root
 workspace importer's direct deps before the graph-wide scan tier.
@@ -1360,8 +1232,6 @@ examples = []
 description = "Suppress warnings for specific missing peer dependencies."
 type = "list<string>"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Glob list of peer dependency names whose "missing required peer" warning
 should be silenced. Only silences peers that are missing entirely — a peer
@@ -1381,8 +1251,6 @@ examples = []
 description = "Override the accepted semver range for specific peer dependencies."
 type = "object"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Map of peer selector to an additional semver range. Keys are either a
 bare peer name (e.g. `react`) which applies regardless of parent, or
@@ -1403,8 +1271,6 @@ examples = []
 description = "Allow any peer version to resolve, bypassing semver checks."
 type = "list<string>"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Glob list of peer dependency names whose semver check should be
 bypassed entirely — any resolved version counts as satisfying the
@@ -1425,8 +1291,6 @@ examples = []
 description = "Control color output in aube's CLI."
 type = '"auto" | "always" | "never"'
 default = "\"auto\""
-implemented = true
-since = "2026-04-12"
 docs = "`--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree."
 sources.cli = ["color", "no-color"]
 sources.env = []
@@ -1443,8 +1307,6 @@ typedAccessorUnused = true
 description = "Minimum log level to display."
 type = '"debug" | "info" | "warn" | "error" | "silent"'
 default = "\"warn\""
-implemented = true
-since = "2026-04-12"
 docs = "Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`."
 sources.cli = ["loglevel", "verbose", "v", "silent"]
 sources.env = []
@@ -1461,8 +1323,6 @@ typedAccessorUnused = true
 description = "Opt into experimental CLI features."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = "Accepted from env and `.npmrc` for pnpm parity. aube currently has no beta-gated commands, so the setting is a no-op after validation."
 sources.cli = []
 sources.env = []
@@ -1476,8 +1336,6 @@ typedAccessorUnused = true
 description = "Install on all workspace packages by default."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = "When true, workspace installs resolve and link all importers by default. Set to false to opt out of implicit workspace-wide install behavior; explicit `--filter` / `--recursive` still wins."
 sources.cli = []
 sources.env = []
@@ -1488,8 +1346,6 @@ examples = []
 description = "Fail if a package is incompatible with the current Node version."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = "When on, an `engines.node` mismatch on the root project or any dependency fails the install. When off, mismatches are warnings only."
 sources.cli = []
 sources.env = []
@@ -1500,8 +1356,6 @@ examples = []
 description = "Path to the npm binary aube should shell out to when needed."
 type = "path"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = "Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`, `token`, `whoami`) when configured. Without it, aube keeps the explicit `use npm` error."
 sources.cli = []
 sources.env = []
@@ -1512,8 +1366,6 @@ examples = []
 description = "Enforce the `packageManager` field in package.json."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = "When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard."
 sources.cli = []
 sources.env = []
@@ -1524,8 +1376,6 @@ examples = []
 description = "Enforce the exact `packageManager` version from package.json."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = "When enabled, `packageManager: \"aube@<version>\"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic."
 sources.cli = []
 sources.env = []
@@ -1536,8 +1386,6 @@ examples = []
 description = "Auto-download the specified pnpm version when mismatched."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = "Accepted for pnpm parity. aube does not download or re-exec other package-manager versions; when exact version enforcement is enabled, mismatches are reported instead."
 sources.cli = []
 sources.env = []
@@ -1553,8 +1401,6 @@ typedAccessorUnused = true
 description = "Skip all lifecycle scripts in package.json."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 aube already skips dependency install scripts by default (security-first).
 The `--ignore-scripts` flag additionally skips root lifecycle hooks
@@ -1580,8 +1426,6 @@ typedAccessorUnused = true
 description = "Maximum number of concurrent script-executing child processes."
 type = "int"
 default = "5"
-implemented = true
-since = "2026-04-12"
 docs = """
 Caps how many dependency lifecycle scripts run in parallel during the
 post-link `allowBuilds` phase. Inside a single package the
@@ -1602,8 +1446,6 @@ examples = [
 description = "Cache the results of install hooks."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
 the post-build package directory under the cache dir keyed by
@@ -1626,8 +1468,6 @@ examples = [
 description = "Only read from the side-effects cache; don't write."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 When true, aube may restore allowlisted dependency build output from the
 side-effects cache but will not write new cache entries after scripts run.
@@ -1641,8 +1481,6 @@ examples = []
 description = "Drop to a non-root user when running scripts as root."
 type = "bool"
 default = "false (as root), true (otherwise)"
-implemented = true
-since = "2026-04-12"
 docs = """
 aube exports the resolved value to lifecycle and `run` scripts as
 `npm_config_unsafe_perm`, matching the environment surface npm-style
@@ -1657,8 +1495,6 @@ examples = []
 description = "Options passed to Node.js via NODE_OPTIONS."
 type = "string"
 default = "null"
-implemented = true
-since = "2026-04-12"
 docs = """
 When set in `.npmrc`, aube exports the value as `NODE_OPTIONS` for
 lifecycle scripts and `aube run` scripts. An existing `NODE_OPTIONS`
@@ -1673,8 +1509,6 @@ examples = []
 description = "Check dependencies before running scripts."
 type = '"install" | "warn" | "error" | "prompt" | false'
 default = "\"install\""
-implemented = true
-since = "2026-04-12"
 docs = """
 Controls `run`, lifecycle shortcuts, `exec`, and implicit script commands.
 `install` preserves aube's auto-install behavior, `warn` reports stale
@@ -1690,8 +1524,6 @@ examples = []
 description = "Exit with an error if dependencies have unreviewed build scripts."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 aube never runs dependency lifecycle scripts unless the package is
 listed in `allowBuilds` or `--dangerously-allow-all-builds` is set.
@@ -1710,8 +1542,6 @@ examples = []
 description = "Explicitly allow or disallow script execution per package."
 type = "object"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Per-package allowlist for dependency lifecycle scripts. Read from
 `package.json`'s `pnpm.allowBuilds` field and `aube-workspace.yaml`'s
@@ -1730,8 +1560,6 @@ examples = ['pnpm.allowBuilds: { esbuild: true, "@some/pkg": false }']
 description = "Allow all dependency build scripts automatically."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
 dependency's `preinstall` / `install` / `postinstall` / `prepare`
@@ -1755,8 +1583,6 @@ typedAccessorUnused = true
 description = "Node.js version aube reports when evaluating `engines` checks."
 type = "string"
 default = "output of `node -v` with the leading `v` stripped"
-implemented = true
-since = "2026-04-12"
 docs = "Paired with `engineStrict`. Set this in .npmrc to pin the Node version engines checks validate against, rather than probing `node --version` at install time."
 sources.cli = []
 sources.env = []
@@ -1767,8 +1593,6 @@ examples = []
 description = "Custom Node.js download mirror URLs."
 type = "object"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Accepted for pnpm config parity. aube does not download Node.js itself,
 so the parsed mirror map is preserved for config introspection but has
@@ -1785,8 +1609,6 @@ examples = []
 description = "Version prefix used when installing a package."
 type = '"^" | "~" | ""'
 default = "\"^\""
-implemented = true
-since = "2026-04-12"
 docs = "Resolved from `.npmrc`. `--save-exact` overrides to empty prefix."
 sources.cli = []
 sources.env = []
@@ -1797,8 +1619,6 @@ examples = []
 description = "Default dist-tag used by `aube add` without a version."
 type = "string"
 default = "\"latest\""
-implemented = true
-since = "2026-04-12"
 docs = "Resolved from `.npmrc`. Used by `aube add` when no version or dist-tag is specified."
 sources.cli = []
 sources.env = []
@@ -1809,8 +1629,6 @@ examples = []
 description = "Directory where globally installed packages live."
 type = "path"
 default = "platform-specific"
-implemented = true
-since = "2026-04-12"
 docs = "Overrides the directory where globally installed packages live. Falls back to `AUBE_HOME` / `PNPM_HOME` / platform default."
 sources.cli = []
 sources.env = []
@@ -1821,8 +1639,6 @@ examples = []
 description = "Directory where global binaries are symlinked."
 type = "path"
 default = "platform-specific"
-implemented = true
-since = "2026-04-12"
 docs = "Overrides the directory where global binaries are symlinked. Independent of `globalDir`; falls back to `AUBE_HOME` / `PNPM_HOME` / platform default."
 sources.cli = []
 sources.env = []
@@ -1833,8 +1649,6 @@ examples = []
 description = "Path to an additional .npmrc file consulted for registry authentication tokens."
 type = "path"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 Points at an extra `.npmrc`-formatted file that aube reads *after*
 the user and project `.npmrc` files when resolving registry auth.
@@ -1867,8 +1681,6 @@ typedAccessorUnused = true
 description = "Directory for aube install-state files."
 type = "path"
 default = ".aube/.state"
-implemented = true
-since = "2026-04-12"
 docs = "Overrides the directory for install state tracking. Defaults to `.aube/.state` relative to the project root."
 sources.cli = []
 sources.env = []
@@ -1879,8 +1691,6 @@ examples = []
 description = "Directory for package metadata and dlx cache."
 type = "path"
 default = "~/.cache/aube"
-implemented = true
-since = "2026-04-12"
 docs = "Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path."
 sources.cli = []
 sources.env = []
@@ -1891,8 +1701,6 @@ examples = []
 description = "Write all output to stderr instead of stdout."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = "Redirects stdout to stderr for the process lifetime. Resolved from `.npmrc` or the `--use-stderr` CLI flag."
 sources.cli = []
 sources.env = []
@@ -1903,8 +1711,6 @@ examples = []
 description = "Show an update notification when a newer aube is available."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 After a successful `install`, `add`, or `update`, aube fetches
 `https://aube.en.dev/VERSION` and prints a one-line notice if the
@@ -1926,8 +1732,6 @@ examples = []
 description = "Create symlinks instead of shims for `.bin` entries."
 type = "bool"
 default = "true (POSIX hoisted)"
-implemented = true
-since = "2026-04-12"
 docs = """
 POSIX only. Default (unset or `true`) creates a plain symlink from
 `node_modules/.bin/<name>` straight to the package's executable file —
@@ -1947,8 +1751,6 @@ examples = []
 description = "Disable pnpm's automatic dependency patching database."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 Accepted for pnpm config parity. pnpm ships a built-in compatibility
 database of auto-patches for known-broken packages; aube has no such
@@ -1967,8 +1769,6 @@ typedAccessorUnused = true
 description = "Dependency version resolution strategy."
 type = '"highest" | "time-based" | "lowest-direct"'
 default = "\"highest\""
-implemented = true
-since = "2026-04-12"
 docs = """
 Controls how aube chooses versions during resolution. `highest` picks
 the newest satisfying version. `time-based` filters candidates through
@@ -1985,8 +1785,6 @@ examples = []
 description = "Whether the configured registry returns a `time` field in metadata."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 When `false` (the default, matching pnpm and npmjs.org's behavior),
 aube fetches the full (non-corgi) packument to read the `time:` map
@@ -2012,8 +1810,6 @@ examples = [
 description = "Set NODE_PATH in command shims."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 When `true` (default), aube-generated `.bin` shims export
 `NODE_PATH="$basedir/.."` so the shimmed binary can resolve modules
@@ -2033,8 +1829,6 @@ examples = []
 description = "Copy all files when deploying a workspace package."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 When true, `aube deploy` copies every file in the source workspace
 package into the target directory instead of running pack's selection
@@ -2056,8 +1850,6 @@ examples = []
 description = "Skip symlinking workspace-root dependencies if identical across packages."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 When true, the linker skips creating a `node_modules/<name>` symlink in a
 workspace package whose root importer already declares the same workspace
@@ -2079,8 +1871,6 @@ examples = []
 description = "Fast-path check before running a full install."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 When `true` (default), `aube run` / `aube exec` / `aube start` /
 `aube test` / `aube restart` consult `.aube/.state/install-state.json`
@@ -2100,8 +1890,6 @@ examples = []
 description = "Scripts that must be present in every workspace project."
 type = "list<string>"
 default = "undefined"
-implemented = true
-since = "2026-04-12"
 docs = """
 During install, aube verifies that the root package and every discovered
 workspace package define each required script in `package.json`.
@@ -2115,8 +1903,6 @@ examples = []
 description = "Run pre/post scripts automatically when a named script is invoked."
 type = "bool"
 default = "true"
-implemented = true
-since = "2026-04-12"
 docs = """
 Controls whether `aube run build` also runs `prebuild` before `build`
 and `postbuild` after it when those scripts exist.
@@ -2130,8 +1916,6 @@ examples = []
 description = "Shell used to invoke package scripts."
 type = "path"
 default = "null (uses /bin/sh on Unix, cmd on Windows)"
-implemented = true
-since = "2026-04-12"
 docs = """
 Overrides the shell executable used for lifecycle and `aube run`
 scripts. On Unix, aube invokes the configured shell with `-c`.
@@ -2145,8 +1929,6 @@ examples = []
 description = "Use a JavaScript bash-like shell to run scripts cross-platform."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 Accepted for pnpm config parity. aube does not embed pnpm's JavaScript
 shell emulator, but it exports `npm_config_shell_emulator=true` for
@@ -2161,8 +1943,6 @@ examples = []
 description = "How catalog references in package.json are handled by `add`."
 type = '"manual" | "strict" | "prefer"'
 default = "\"manual\""
-implemented = true
-since = "2026-04-12"
 docs = """
 `manual` (the default) writes whatever range `aube add` resolved, even
 when the package is declared in the default catalog. `prefer` rewrites
@@ -2188,8 +1968,6 @@ examples = []
 description = "Explicitly mark the environment as CI."
 type = "bool"
 default = "auto-detected"
-implemented = true
-since = "2026-04-12"
 docs = """
 aube detects CI via `env::var("CI").is_ok()` in two places:
 `aube-linker` (disables the global virtual store) and
@@ -2209,8 +1987,6 @@ typedAccessorUnused = true
 description = "Remove unused catalog entries during install."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
 `pnpm-workspace.yaml`, whichever is present) after resolution to drop
@@ -2235,8 +2011,6 @@ examples = []
 description = "Maximum concurrent package materialization/linking tasks."
 type = "int"
 default = "platform-specific"
-implemented = true
-since = "2026-04-17"
 docs = """
 Caps the dedicated linker worker pool used for filesystem-heavy
 materialization in `aube-linker`: creating package directories,
@@ -2260,8 +2034,6 @@ examples = [
 description = "Disable aube's project-level advisory lock."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 aube takes an advisory lock on `node_modules/` at the start of every
 mutating command (install, add, remove, etc.) so concurrent invocations
@@ -2293,8 +2065,6 @@ examples = [
 description = "Skip the auto-install staleness check in `aube run` / `aube exec`."
 type = "bool"
 default = "false"
-implemented = true
-since = "2026-04-12"
 docs = """
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs
 before running if package.json or the lockfile has drifted. Setting

--- a/crates/aube-settings/src/bin/generate_settings_docs.rs
+++ b/crates/aube-settings/src/bin/generate_settings_docs.rs
@@ -228,27 +228,19 @@ fn same_filter(a: SourceFilter, b: SourceFilter) -> bool {
 }
 
 fn render_summary(out: &mut String, settings: &[&SettingRef<'_>]) {
-    let implemented = settings.iter().filter(|s| s.meta.implemented).count();
     writeln!(out, "## Summary").unwrap();
     writeln!(out).unwrap();
-    writeln!(
-        out,
-        "{} settings are listed here. {} are currently implemented.",
-        settings.len(),
-        implemented
-    )
-    .unwrap();
+    writeln!(out, "{} settings are listed here.", settings.len()).unwrap();
     writeln!(out).unwrap();
-    writeln!(out, "| Setting | Type | Status | Summary |").unwrap();
-    writeln!(out, "| --- | --- | --- | --- |").unwrap();
+    writeln!(out, "| Setting | Type | Summary |").unwrap();
+    writeln!(out, "| --- | --- | --- |").unwrap();
     for setting in settings {
         writeln!(
             out,
-            "| [{}](#{}) | {} | {} | {} |",
+            "| [{}](#{}) | {} | {} |",
             code_span(setting.meta.name),
             setting_anchor(setting.meta.name),
             table_code_cell(setting.meta.type_),
-            status(setting.meta.implemented),
             table_text_cell(setting.meta.description),
         )
         .unwrap();
@@ -289,8 +281,6 @@ fn render_setting(out: &mut String, setting: &SettingMeta, filter: SourceFilter)
     writeln!(out).unwrap();
     writeln!(out, "- Type: {}", code_span(setting.type_)).unwrap();
     writeln!(out, "- Default: {}", code_span(setting.default)).unwrap();
-    writeln!(out, "- Status: {}", status(setting.implemented)).unwrap();
-    writeln!(out, "- Added to registry: {}", code_span(setting.since)).unwrap();
     render_sources(out, setting, filter);
     writeln!(out).unwrap();
 
@@ -328,19 +318,10 @@ fn render_sources(out: &mut String, setting: &SettingMeta, filter: SourceFilter)
 
 fn source_line(out: &mut String, label: &str, values: &[&str]) {
     if values.is_empty() {
-        writeln!(out, "- {label}: none").unwrap();
         return;
     }
     let values = values.iter().map(|v| code_span(v)).collect::<Vec<_>>();
     writeln!(out, "- {label}: {}", values.join(", ")).unwrap();
-}
-
-fn status(implemented: bool) -> &'static str {
-    if implemented {
-        "implemented"
-    } else {
-        "planned"
-    }
 }
 
 fn code_span(value: &str) -> String {

--- a/crates/aube-settings/src/meta.rs
+++ b/crates/aube-settings/src/meta.rs
@@ -8,9 +8,8 @@
 //! Use cases:
 //! - Future `aube settings` subcommand to render a CLI version of
 //!   pnpm's settings reference page
-//! - Sanity tests that verify every `implemented = true` entry still
-//!   maps to real behavior in the Rust source
-//! - A future docs generator that reads this and emits markdown
+//! - The docs generator that reads this and emits
+//!   `docs/settings/*.md`
 
 /// Metadata for one setting. Every field is `'static` because the
 /// containing `SETTINGS` slice is a `const` built from string
@@ -26,10 +25,6 @@ pub struct SettingMeta {
     pub type_: &'static str,
     /// Default value rendered as a string (e.g. `"true"`, `"undefined"`)
     pub default: &'static str,
-    /// Whether aube currently honors this setting. Transitional: removed at v1.
-    pub implemented: bool,
-    /// ISO date the setting was added to the registry (`YYYY-MM-DD`)
-    pub since: &'static str,
     /// Longer markdown docs body
     pub docs: &'static str,
     /// CLI flags that set this setting
@@ -50,10 +45,9 @@ pub struct SettingMeta {
     /// accessor" — e.g. read through `std::env::var` behind a
     /// hand-rolled `LazyLock`, looked up in `NpmConfig` by string
     /// key, or accepted for pnpm parity with no behavior wired.
-    /// Default `false`; the audit fails CI when an `implemented =
-    /// true` setting with a supported scalar type has no
-    /// `resolved::<name>` call site anywhere in the workspace and
-    /// this flag is not set.
+    /// Default `false`; the audit fails CI when a setting with a
+    /// supported scalar type has no `resolved::<name>` call site
+    /// anywhere in the workspace and this flag is not set.
     pub typed_accessor_unused: bool,
 }
 
@@ -89,7 +83,6 @@ mod tests {
             assert!(!s.name.is_empty(), "empty name in entry");
             assert!(!s.description.is_empty(), "{}: empty description", s.name);
             assert!(!s.type_.is_empty(), "{}: empty type", s.name);
-            assert!(!s.since.is_empty(), "{}: empty since", s.name);
         }
     }
 

--- a/crates/aube-settings/tests/accessor_audit.rs
+++ b/crates/aube-settings/tests/accessor_audit.rs
@@ -9,12 +9,12 @@
 //!
 //! This test recovers the intent (an unused setting should surface
 //! loudly) at `cargo test` time instead of compile time: for every
-//! `SettingMeta` with `implemented = true` and a supported scalar
-//! type, it verifies that *some* workspace `.rs` file outside
-//! `aube-settings` references the generated `resolved::<name>`
-//! accessor. Settings honored through other pathways (direct env
-//! reads, `NpmConfig` string lookups, accepted-for-parity no-ops)
-//! opt out with `typedAccessorUnused = true` in `settings.toml`.
+//! `SettingMeta` with a supported scalar type, it verifies that
+//! *some* workspace `.rs` file outside `aube-settings` references
+//! the generated `resolved::<name>` accessor. Settings honored
+//! through other pathways (direct env reads, `NpmConfig` string
+//! lookups, accepted-for-parity no-ops) opt out with
+//! `typedAccessorUnused = true` in `settings.toml`.
 //!
 //! Diagnostic on failure names the offending settings and suggests
 //! the two legal fixes: wire a `resolved::<name>(...)` caller, or
@@ -131,7 +131,7 @@ fn corpus_has_accessor_call(corpus: &str, accessor: &str) -> bool {
 }
 
 #[test]
-fn every_implemented_setting_has_a_typed_accessor_caller() {
+fn every_setting_has_a_typed_accessor_caller() {
     let root = workspace_root();
     let crates_dir = root.join("crates");
     let self_src = root.join("crates").join("aube-settings").join("src");
@@ -164,9 +164,6 @@ fn every_implemented_setting_has_a_typed_accessor_caller() {
     let mut reported: BTreeSet<String> = BTreeSet::new();
 
     for s in all() {
-        if !s.implemented {
-            continue;
-        }
         if s.typed_accessor_unused {
             continue;
         }
@@ -194,12 +191,11 @@ fn every_implemented_setting_has_a_typed_accessor_caller() {
     if !missing.is_empty() {
         panic!(
             "\n\
-             Settings marked `implemented = true` in settings.toml but with no call \
-             to their generated `resolved::<name>` accessor anywhere in the workspace \
-             ({n} total):\n\
+             Settings in settings.toml with no call to their generated \
+             `resolved::<name>` accessor anywhere in the workspace ({n} total):\n\
              {list}\n\n\
              Fix one of two ways:\n  \
-             1. Wire a real caller (typical path for a newly-implemented setting).\n  \
+             1. Wire a real caller (typical path for a newly-added setting).\n  \
              2. Set `typedAccessorUnused = true` in settings.toml with a comment \
              explaining how the setting *is* honored — e.g. read directly through \
              env at startup, looked up by string key in `NpmConfig`, or accepted \

--- a/docs/package-manager/configuration.md
+++ b/docs/package-manager/configuration.md
@@ -40,7 +40,7 @@ See [workspace YAML settings](/settings/workspace-yaml).
 
 ## Environment variables
 
-pnpm-compatible `NPM_CONFIG_*` aliases are supported for implemented settings:
+pnpm-compatible `NPM_CONFIG_*` aliases are supported:
 
 ```sh
 NPM_CONFIG_REGISTRY=https://registry.example.test aube install

--- a/docs/settings/cli.md
+++ b/docs/settings/cli.md
@@ -16,25 +16,25 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-15 settings are listed here. 15 are currently implemented.
+15 settings are listed here.
 
-| Setting | Type | Status | Summary |
-| --- | --- | --- | --- |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
-| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | implemented | Control color output in aube's CLI. |
-| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | implemented | Minimum log level to display. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
-| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | implemented | Allow all dependency build scripts automatically. |
-| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | implemented | Dependency version resolution strategy. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Summary |
+| --- | --- | --- |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
+| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | Control color output in aube's CLI. |
+| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | Minimum log level to display. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
+| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | Allow all dependency build scripts automatically. |
+| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | Dependency version resolution strategy. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Hoisting
 
@@ -44,8 +44,6 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - CLI flags: `public-hoist-pattern`
 
 Glob list matched against package names. Any non-local package in the
@@ -65,8 +63,6 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `shamefully-hoist`
 
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
@@ -80,8 +76,6 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `node-linker`
 
 aube defaults to `isolated`, a strict symlink layout under
@@ -96,8 +90,6 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `package-import-method`
 
 Controls how aube materializes files from the global content-addressable
@@ -119,8 +111,6 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `verify-store-integrity`
 
 aube verifies each package's `integrity` (SHA-512) against the tarball
@@ -142,8 +132,6 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `prefer-frozen-lockfile`
 
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
@@ -162,8 +150,6 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `network-concurrency`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
@@ -187,8 +173,6 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `auto-install-peers`
 
 When true (the default), missing peer dependencies are auto-installed
@@ -204,8 +188,6 @@ Control color output in aube's CLI.
 
 - Type: `"auto" | "always" | "never"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `color`, `no-color`
 
 `--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree.
@@ -216,8 +198,6 @@ Minimum log level to display.
 
 - Type: `"debug" | "info" | "warn" | "error" | "silent"`
 - Default: `"warn"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `loglevel`, `verbose`, `v`, `silent`
 
 Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`.
@@ -230,8 +210,6 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `ignore-scripts`
 
 aube already skips dependency install scripts by default (security-first).
@@ -250,8 +228,6 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `side-effects-cache`
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
@@ -273,8 +249,6 @@ Allow all dependency build scripts automatically.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `dangerously-allow-all-builds`
 
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
@@ -295,8 +269,6 @@ Dependency version resolution strategy.
 
 - Type: `"highest" | "time-based" | "lowest-direct"`
 - Default: `"highest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `resolution-mode`
 
 Controls how aube chooses versions during resolution. `highest` picks
@@ -313,8 +285,6 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `no-install`
 
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs

--- a/docs/settings/env.md
+++ b/docs/settings/env.md
@@ -16,122 +16,122 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-112 settings are listed here. 112 are currently implemented.
+112 settings are listed here.
 
-| Setting | Type | Status | Summary |
-| --- | --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
-| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | implemented | Specify architectures for optional dependency installation. |
-| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | implemented | Skip optional dependencies by name. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`registries`](#setting-registries) | `object` | implemented | Registry URLs, including scoped registry overrides. |
-| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
-| [`symlink`](#setting-symlink) | `bool` | implemented | Create symlinks in the virtual store directory. |
-| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | implemented | Write files to the modules directory. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
-| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | implemented | Max length for virtual store directory names. |
-| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | implemented | Populate the virtual store without creating top-level symlinks. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
-| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
-| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
-| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
-| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | implemented | Validate package names and versions in the store. |
-| [`httpsProxy`](#setting-httpsproxy) | `url` | implemented | Proxy URL for outgoing HTTPS requests. |
-| [`httpProxy`](#setting-httpproxy) | `url` | implemented | Proxy URL for outgoing HTTP requests. |
-| [`noProxy`](#setting-noproxy) | `string` | implemented | Comma-separated list of domains that bypass the proxy. |
-| [`localAddress`](#setting-localaddress) | `string` | implemented | Local interface IP address to bind registry connections to. |
-| [`maxsockets`](#setting-maxsockets) | `int` | implemented | Maximum concurrent connections per origin. |
-| [`strictSsl`](#setting-strictssl) | `bool` | implemented | Validate SSL certificates for HTTPS requests. |
-| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | implemented | Hosts for which aube performs shallow git clones. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
-| [`fetchRetries`](#setting-fetchretries) | `int` | implemented | Number of retry attempts for failed registry fetches. |
-| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | implemented | Exponential backoff factor for fetch retries. |
-| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | implemented | Minimum retry timeout in milliseconds. |
-| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | implemented | Maximum retry timeout in milliseconds. |
-| [`fetchTimeout`](#setting-fetchtimeout) | `int` | implemented | Max time (ms) to wait for an HTTP request. |
-| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | implemented | Warn if a metadata request exceeds this threshold (ms). |
-| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | implemented | Warn if download speed falls below this threshold (KiB/s). |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
-| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | implemented | Control color output in aube's CLI. |
-| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | implemented | Minimum log level to display. |
-| [`useBetaCli`](#setting-usebetacli) | `bool` | implemented | Opt into experimental CLI features. |
-| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | implemented | Install on all workspace packages by default. |
-| [`engineStrict`](#setting-enginestrict) | `bool` | implemented | Fail if a package is incompatible with the current Node version. |
-| [`npmPath`](#setting-npmpath) | `path` | implemented | Path to the npm binary aube should shell out to when needed. |
-| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | implemented | Enforce the `packageManager` field in package.json. |
-| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | implemented | Enforce the exact `packageManager` version from package.json. |
-| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | implemented | Auto-download the specified pnpm version when mismatched. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
-| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | implemented | Only read from the side-effects cache; don't write. |
-| [`unsafePerm`](#setting-unsafeperm) | `bool` | implemented | Drop to a non-root user when running scripts as root. |
-| [`nodeOptions`](#setting-nodeoptions) | `string` | implemented | Options passed to Node.js via NODE_OPTIONS. |
-| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | implemented | Check dependencies before running scripts. |
-| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | implemented | Exit with an error if dependencies have unreviewed build scripts. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
-| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | implemented | Allow all dependency build scripts automatically. |
-| [`nodeVersion`](#setting-nodeversion) | `string` | implemented | Node.js version aube reports when evaluating `engines` checks. |
-| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | implemented | Custom Node.js download mirror URLs. |
-| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | implemented | Version prefix used when installing a package. |
-| [`tag`](#setting-tag) | `string` | implemented | Default dist-tag used by `aube add` without a version. |
-| [`globalDir`](#setting-globaldir) | `path` | implemented | Directory where globally installed packages live. |
-| [`globalBinDir`](#setting-globalbindir) | `path` | implemented | Directory where global binaries are symlinked. |
-| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | implemented | Path to an additional .npmrc file consulted for registry authentication tokens. |
-| [`stateDir`](#setting-statedir) | `path` | implemented | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | implemented | Directory for package metadata and dlx cache. |
-| [`useStderr`](#setting-usestderr) | `bool` | implemented | Write all output to stderr instead of stdout. |
-| [`updateNotifier`](#setting-updatenotifier) | `bool` | implemented | Show an update notification when a newer aube is available. |
-| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | implemented | Create symlinks instead of shims for `.bin` entries. |
-| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | implemented | Disable pnpm's automatic dependency patching database. |
-| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | implemented | Dependency version resolution strategy. |
-| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | implemented | Whether the configured registry returns a `time` field in metadata. |
-| [`extendNodePath`](#setting-extendnodepath) | `bool` | implemented | Set NODE_PATH in command shims. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | implemented | Fast-path check before running a full install. |
-| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | implemented | Scripts that must be present in every workspace project. |
-| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | implemented | Run pre/post scripts automatically when a named script is invoked. |
-| [`scriptShell`](#setting-scriptshell) | `path` | implemented | Shell used to invoke package scripts. |
-| [`shellEmulator`](#setting-shellemulator) | `bool` | implemented | Use a JavaScript bash-like shell to run scripts cross-platform. |
-| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | implemented | How catalog references in package.json are handled by `add`. |
-| [`ci`](#setting-ci) | `bool` | implemented | Explicitly mark the environment as CI. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Summary |
+| --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
+| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
+| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
+| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
+| [`symlink`](#setting-symlink) | `bool` | Create symlinks in the virtual store directory. |
+| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | Write files to the modules directory. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
+| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | Max length for virtual store directory names. |
+| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | Populate the virtual store without creating top-level symlinks. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
+| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | Minutes before orphan packages are removed from the virtual store. |
+| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | Minutes before the dlx cache is considered stale. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
+| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
+| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | Only allow installs when the store server is running. |
+| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | Validate package names and versions in the store. |
+| [`httpsProxy`](#setting-httpsproxy) | `url` | Proxy URL for outgoing HTTPS requests. |
+| [`httpProxy`](#setting-httpproxy) | `url` | Proxy URL for outgoing HTTP requests. |
+| [`noProxy`](#setting-noproxy) | `string` | Comma-separated list of domains that bypass the proxy. |
+| [`localAddress`](#setting-localaddress) | `string` | Local interface IP address to bind registry connections to. |
+| [`maxsockets`](#setting-maxsockets) | `int` | Maximum concurrent connections per origin. |
+| [`strictSsl`](#setting-strictssl) | `bool` | Validate SSL certificates for HTTPS requests. |
+| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | Hosts for which aube performs shallow git clones. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
+| [`fetchRetries`](#setting-fetchretries) | `int` | Number of retry attempts for failed registry fetches. |
+| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | Exponential backoff factor for fetch retries. |
+| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | Minimum retry timeout in milliseconds. |
+| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | Maximum retry timeout in milliseconds. |
+| [`fetchTimeout`](#setting-fetchtimeout) | `int` | Max time (ms) to wait for an HTTP request. |
+| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | Warn if a metadata request exceeds this threshold (ms). |
+| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | Warn if download speed falls below this threshold (KiB/s). |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
+| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | Control color output in aube's CLI. |
+| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | Minimum log level to display. |
+| [`useBetaCli`](#setting-usebetacli) | `bool` | Opt into experimental CLI features. |
+| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | Install on all workspace packages by default. |
+| [`engineStrict`](#setting-enginestrict) | `bool` | Fail if a package is incompatible with the current Node version. |
+| [`npmPath`](#setting-npmpath) | `path` | Path to the npm binary aube should shell out to when needed. |
+| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | Enforce the `packageManager` field in package.json. |
+| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | Enforce the exact `packageManager` version from package.json. |
+| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | Auto-download the specified pnpm version when mismatched. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
+| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | Only read from the side-effects cache; don't write. |
+| [`unsafePerm`](#setting-unsafeperm) | `bool` | Drop to a non-root user when running scripts as root. |
+| [`nodeOptions`](#setting-nodeoptions) | `string` | Options passed to Node.js via NODE_OPTIONS. |
+| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | Check dependencies before running scripts. |
+| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | Exit with an error if dependencies have unreviewed build scripts. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
+| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | Allow all dependency build scripts automatically. |
+| [`nodeVersion`](#setting-nodeversion) | `string` | Node.js version aube reports when evaluating `engines` checks. |
+| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | Custom Node.js download mirror URLs. |
+| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | Version prefix used when installing a package. |
+| [`tag`](#setting-tag) | `string` | Default dist-tag used by `aube add` without a version. |
+| [`globalDir`](#setting-globaldir) | `path` | Directory where globally installed packages live. |
+| [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
+| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
+| [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
+| [`cacheDir`](#setting-cachedir) | `path` | Directory for package metadata and dlx cache. |
+| [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
+| [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
+| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | Create symlinks instead of shims for `.bin` entries. |
+| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | Disable pnpm's automatic dependency patching database. |
+| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | Dependency version resolution strategy. |
+| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | Whether the configured registry returns a `time` field in metadata. |
+| [`extendNodePath`](#setting-extendnodepath) | `bool` | Set NODE_PATH in command shims. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | Fast-path check before running a full install. |
+| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | Scripts that must be present in every workspace project. |
+| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | Run pre/post scripts automatically when a named script is invoked. |
+| [`scriptShell`](#setting-scriptshell) | `path` | Shell used to invoke package scripts. |
+| [`shellEmulator`](#setting-shellemulator) | `bool` | Use a JavaScript bash-like shell to run scripts cross-platform. |
+| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | How catalog references in package.json are handled by `add`. |
+| [`ci`](#setting-ci) | `bool` | Explicitly mark the environment as CI. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -141,8 +141,6 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_overrides`, `NPM_CONFIG_OVERRIDES`
 
 A root-level map of package specs to the versions aube should force them
@@ -156,8 +154,6 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_extensions`, `NPM_CONFIG_PACKAGE_EXTENSIONS`
 
 Patches a package's `dependencies`, `peerDependencies`, etc. at resolve
@@ -170,8 +166,6 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_allowed_deprecated_versions`, `NPM_CONFIG_ALLOWED_DEPRECATED_VERSIONS`
 
 Maps a package name to a semver range for which the deprecation warning
@@ -184,8 +178,6 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_update_config_ignore_dependencies`, `NPM_CONFIG_UPDATE_CONFIG_IGNORE_DEPENDENCIES`
 
 Packages in this list are never bumped by `aube update`, even when a
@@ -197,8 +189,6 @@ Specify architectures for optional dependency installation.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_supported_architectures`, `NPM_CONFIG_SUPPORTED_ARCHITECTURES`
 
 Override the current platform/arch/libc triple used to filter optional
@@ -211,8 +201,6 @@ Skip optional dependencies by name.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_ignored_optional_dependencies`, `NPM_CONFIG_IGNORED_OPTIONAL_DEPENDENCIES`
 
 Named entries are skipped even if their platform/arch matches. Distinct
@@ -224,8 +212,6 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_minimum_release_age`, `NPM_CONFIG_MINIMUM_RELEASE_AGE`
 
 Supply-chain attack mitigation: packages published within the last N
@@ -240,8 +226,6 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_minimum_release_age_exclude`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE`
 
 Use for trusted internal packages that need to be rolled out immediately
@@ -254,8 +238,6 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_minimum_release_age_strict`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_STRICT`
 
 By default the resolver falls back to the lowest satisfying version when
@@ -268,8 +250,6 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_trust_policy`, `NPM_CONFIG_TRUST_POLICY`
 
 When set to `no-downgrade`, aube accepts and preserves the policy in the
@@ -283,8 +263,6 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_trust_policy_exclude`, `NPM_CONFIG_TRUST_POLICY_EXCLUDE`
 
 Whitelist for `trustPolicy`. Entries skip the downgrade check.
@@ -295,8 +273,6 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_trust_policy_ignore_after`, `NPM_CONFIG_TRUST_POLICY_IGNORE_AFTER`
 
 Useful for pinning very old versions that predate signing infrastructure.
@@ -307,8 +283,6 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_block_exotic_subdeps`, `NPM_CONFIG_BLOCK_EXOTIC_SUBDEPS`
 
 When true, transitive deps referenced via `git+`, `file:`, or direct
@@ -321,8 +295,6 @@ Registry URLs, including scoped registry overrides.
 
 - Type: `object`
 - Default: `{ default = "https://registry.npmjs.org/" }`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_registries`, `NPM_CONFIG_REGISTRIES`
 
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
@@ -343,8 +315,6 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_hoist`, `NPM_CONFIG_HOIST`
 
 Controls whether aube populates `node_modules/.aube/node_modules/` —
@@ -373,8 +343,6 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_hoist_workspace_packages`, `NPM_CONFIG_HOIST_WORKSPACE_PACKAGES`
 
 Controls whether workspace packages get their own symlinks in each
@@ -391,8 +359,6 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_hoist_pattern`, `NPM_CONFIG_HOIST_PATTERN`
 
 Glob list matched against package names. Any non-local package
@@ -414,8 +380,6 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - Environment: `npm_config_public_hoist_pattern`, `NPM_CONFIG_PUBLIC_HOIST_PATTERN`
 
 Glob list matched against package names. Any non-local package in the
@@ -435,8 +399,6 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_shamefully_hoist`, `NPM_CONFIG_SHAMEFULLY_HOIST`
 
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
@@ -450,8 +412,6 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - Environment: `npm_config_modules_dir`, `NPM_CONFIG_MODULES_DIR`
 
 The project-level directory that holds the top-level `<name>` entries
@@ -476,8 +436,6 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_node_linker`, `NPM_CONFIG_NODE_LINKER`
 
 aube defaults to `isolated`, a strict symlink layout under
@@ -492,8 +450,6 @@ Create symlinks in the virtual store directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_symlink`, `NPM_CONFIG_SYMLINK`
 
 Accepted for pnpm parity. aube's isolated layout is structurally
@@ -522,8 +478,6 @@ Write files to the modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_enable_modules_dir`, `NPM_CONFIG_ENABLE_MODULES_DIR`
 
 When `false`, aube resolves the dependency graph and writes
@@ -539,8 +493,6 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_virtual_store_dir`, `NPM_CONFIG_VIRTUAL_STORE_DIR`
 
 Relocates the per-project `.aube/<dep>/node_modules/` tree that the
@@ -569,8 +521,6 @@ Max length for virtual store directory names.
 
 - Type: `int`
 - Default: `120 (Linux/macOS), 60 (Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_virtual_store_dir_max_length`, `NPM_CONFIG_VIRTUAL_STORE_DIR_MAX_LENGTH`
 
 Caps the number of characters in a single `node_modules/.aube/<dep>`
@@ -588,8 +538,6 @@ Populate the virtual store without creating top-level symlinks.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_virtual_store_only`, `NPM_CONFIG_VIRTUAL_STORE_ONLY`
 
 When `true`, aube still materializes every package into
@@ -608,8 +556,6 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_import_method`, `NPM_CONFIG_PACKAGE_IMPORT_METHOD`
 
 Controls how aube materializes files from the global content-addressable
@@ -629,8 +575,6 @@ Minutes before orphan packages are removed from the virtual store.
 
 - Type: `int`
 - Default: `10080`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_modules_cache_max_age`, `NPM_CONFIG_MODULES_CACHE_MAX_AGE`
 
 After each successful install, aube sweeps the per-project
@@ -650,8 +594,6 @@ Minutes before the dlx cache is considered stale.
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_dlx_cache_max_age`, `NPM_CONFIG_DLX_CACHE_MAX_AGE`
 
 Accepted for pnpm parity. `aube dlx` currently installs into a fresh
@@ -667,8 +609,6 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `CI`, `npm_config_enable_global_virtual_store`, `NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
@@ -684,8 +624,6 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_store_dir`, `NPM_CONFIG_STORE_DIR`
 
 Defaults to aube's own store path (`~/.aube-store/v1/files/`). aube does not
@@ -713,8 +651,6 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_verify_store_integrity`, `NPM_CONFIG_VERIFY_STORE_INTEGRITY`
 
 aube verifies each package's `integrity` (SHA-512) against the tarball
@@ -734,8 +670,6 @@ Only allow installs when the store server is running.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_use_running_store_server`, `NPM_CONFIG_USE_RUNNING_STORE_SERVER`
 
 Accepted for pnpm parity. aube has no long-running store-daemon
@@ -751,8 +685,6 @@ Validate package names and versions in the store.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_store_pkg_content_check`, `NPM_CONFIG_STRICT_STORE_PKG_CONTENT_CHECK`
 
 After each registry tarball is imported, aube reads the freshly stored
@@ -779,8 +711,6 @@ Proxy URL for outgoing HTTPS requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `HTTPS_PROXY`, `https_proxy`, `npm_config_https_proxy`, `NPM_CONFIG_HTTPS_PROXY`
 
 Forwards every HTTPS registry fetch through the given proxy URL.
@@ -794,8 +724,6 @@ Proxy URL for outgoing HTTP requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `HTTP_PROXY`, `http_proxy`, `PROXY`, `proxy`, `npm_config_http_proxy`, `NPM_CONFIG_HTTP_PROXY`
 
 HTTP counterpart to `httpsProxy`. Resolution mirrors pnpm:
@@ -810,8 +738,6 @@ Comma-separated list of domains that bypass the proxy.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `NO_PROXY`, `no_proxy`, `npm_config_no_proxy`, `NPM_CONFIG_NO_PROXY`
 
 Passed through to `reqwest::NoProxy::from_string` verbatim, so
@@ -825,8 +751,6 @@ Local interface IP address to bind registry connections to.
 
 - Type: `string`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_local_address`, `NPM_CONFIG_LOCAL_ADDRESS`
 
 Used on multi-homed hosts where outbound traffic must leave a
@@ -839,8 +763,6 @@ Maximum concurrent connections per origin.
 
 - Type: `int`
 - Default: `networkConcurrency x 3`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_maxsockets`, `NPM_CONFIG_MAXSOCKETS`
 
 Plumbed into reqwest's `pool_max_idle_per_host`. This is the
@@ -854,8 +776,6 @@ Validate SSL certificates for HTTPS requests.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_ssl`, `NPM_CONFIG_STRICT_SSL`
 
 Defaults to `true`. Setting `strict-ssl=false` disables TLS
@@ -872,8 +792,6 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_lockfile`, `NPM_CONFIG_LOCKFILE`
 
 Controls whether aube reads and writes a lockfile during install. When
@@ -898,8 +816,6 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_prefer_frozen_lockfile`, `NPM_CONFIG_PREFER_FROZEN_LOCKFILE`
 
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
@@ -916,8 +832,6 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_lockfile_include_tarball_url`, `NPM_CONFIG_LOCKFILE_INCLUDE_TARBALL_URL`
 
 When true, aube's lockfile writer records the registry tarball URL in
@@ -945,8 +859,6 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - Environment: `npm_config_exclude_links_from_lockfile`, `NPM_CONFIG_EXCLUDE_LINKS_FROM_LOCKFILE`
 
 When true, `link:` dependencies are omitted from the lockfile's
@@ -967,8 +879,6 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_git_branch_lockfile`, `NPM_CONFIG_GIT_BRANCH_LOCKFILE`
 
 When enabled, aube writes the lockfile to `aube-lock.<branch>.yaml`
@@ -996,8 +906,6 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_merge_git_branch_lockfiles_branch_pattern`, `NPM_CONFIG_MERGE_GIT_BRANCH_LOCKFILES_BRANCH_PATTERN`
 
 Complements `gitBranchLockfile`. Accepts a list of glob patterns. When
@@ -1028,8 +936,6 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_peers_suffix_max_length`, `NPM_CONFIG_PEERS_SUFFIX_MAX_LENGTH`
 
 Caps the length of the peer-ID suffix appended to a `dep_path` in the
@@ -1050,8 +956,6 @@ Hosts for which aube performs shallow git clones.
 
 - Type: `list<string>`
 - Default: `["github.com", "gist.github.com", "gitlab.com", "bitbucket.com", "bitbucket.org"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_git_shallow_hosts`, `NPM_CONFIG_GIT_SHALLOW_HOSTS`
 
 Consulted by `aube-store::git_shallow_clone` when cloning a git
@@ -1075,8 +979,6 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_network_concurrency`, `NPM_CONFIG_NETWORK_CONCURRENCY`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
@@ -1098,8 +1000,6 @@ Number of retry attempts for failed registry fetches.
 
 - Type: `int`
 - Default: `2`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retries`, `NPM_CONFIG_FETCH_RETRIES`
 
 Number of *additional* attempts the registry client makes after a
@@ -1118,8 +1018,6 @@ Exponential backoff factor for fetch retries.
 
 - Type: `int`
 - Default: `10`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retry_factor`, `NPM_CONFIG_FETCH_RETRY_FACTOR`
 
 Multiplier used between retry attempts. Attempt `n` waits
@@ -1133,8 +1031,6 @@ Minimum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retry_mintimeout`, `NPM_CONFIG_FETCH_RETRY_MINTIMEOUT`
 
 Lower bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1145,8 +1041,6 @@ Maximum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_retry_maxtimeout`, `NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT`
 
 Upper bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1157,8 +1051,6 @@ Max time (ms) to wait for an HTTP request.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_timeout`, `NPM_CONFIG_FETCH_TIMEOUT`
 
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
@@ -1172,8 +1064,6 @@ Warn if a metadata request exceeds this threshold (ms).
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_warn_timeout_ms`, `NPM_CONFIG_FETCH_WARN_TIMEOUT_MS`
 
 Observability threshold for registry *metadata* requests (packument,
@@ -1193,8 +1083,6 @@ Warn if download speed falls below this threshold (KiB/s).
 
 - Type: `int`
 - Default: `50`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_fetch_min_speed_ki_bps`, `NPM_CONFIG_FETCH_MIN_SPEED_KI_BPS`
 
 Observability threshold for *tarball* downloads. When a tarball
@@ -1216,8 +1104,6 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_auto_install_peers`, `NPM_CONFIG_AUTO_INSTALL_PEERS`
 
 When true (the default), missing peer dependencies are auto-installed
@@ -1231,8 +1117,6 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_dedupe_peer_dependents`, `NPM_CONFIG_DEDUPE_PEER_DEPENDENTS`
 
 When true (the default), aube collapses packages that landed at
@@ -1249,8 +1133,6 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_dedupe_peers`, `NPM_CONFIG_DEDUPE_PEERS`
 
 When true, lockfile peer suffixes emit `(18.2.0)` instead of the
@@ -1265,8 +1147,6 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_peer_dependencies`, `NPM_CONFIG_STRICT_PEER_DEPENDENCIES`
 
 When true, any unmet peer dependency (missing, or resolved to a version
@@ -1283,8 +1163,6 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_resolve_peers_from_workspace_root`, `NPM_CONFIG_RESOLVE_PEERS_FROM_WORKSPACE_ROOT`
 
 When true (the default), an unresolved peer falls back to the root
@@ -1300,8 +1178,6 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_peer_dependency_rules_ignore_missing`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_IGNORE_MISSING`
 
 Glob list of peer dependency names whose "missing required peer" warning
@@ -1318,8 +1194,6 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_peer_dependency_rules_allowed_versions`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOWED_VERSIONS`
 
 Map of peer selector to an additional semver range. Keys are either a
@@ -1337,8 +1211,6 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_peer_dependency_rules_allow_any`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOW_ANY`
 
 Glob list of peer dependency names whose semver check should be
@@ -1356,8 +1228,6 @@ Control color output in aube's CLI.
 
 - Type: `"auto" | "always" | "never"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_color`, `NPM_CONFIG_COLOR`
 
 `--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree.
@@ -1368,8 +1238,6 @@ Minimum log level to display.
 
 - Type: `"debug" | "info" | "warn" | "error" | "silent"`
 - Default: `"warn"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_loglevel`, `NPM_CONFIG_LOGLEVEL`
 
 Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`.
@@ -1380,8 +1248,6 @@ Opt into experimental CLI features.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_use_beta_cli`, `NPM_CONFIG_USE_BETA_CLI`
 
 Accepted from env and `.npmrc` for pnpm parity. aube currently has no beta-gated commands, so the setting is a no-op after validation.
@@ -1392,8 +1258,6 @@ Install on all workspace packages by default.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_recursive_install`, `NPM_CONFIG_RECURSIVE_INSTALL`
 
 When true, workspace installs resolve and link all importers by default. Set to false to opt out of implicit workspace-wide install behavior; explicit `--filter` / `--recursive` still wins.
@@ -1404,8 +1268,6 @@ Fail if a package is incompatible with the current Node version.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_engine_strict`, `NPM_CONFIG_ENGINE_STRICT`
 
 When on, an `engines.node` mismatch on the root project or any dependency fails the install. When off, mismatches are warnings only.
@@ -1416,8 +1278,6 @@ Path to the npm binary aube should shell out to when needed.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_npm_path`, `NPM_CONFIG_NPM_PATH`
 
 Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`, `token`, `whoami`) when configured. Without it, aube keeps the explicit `use npm` error.
@@ -1428,8 +1288,6 @@ Enforce the `packageManager` field in package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_manager_strict`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT`
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
@@ -1440,8 +1298,6 @@ Enforce the exact `packageManager` version from package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_package_manager_strict_version`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION`
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
@@ -1452,8 +1308,6 @@ Auto-download the specified pnpm version when mismatched.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_manage_package_manager_versions`, `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS`
 
 Accepted for pnpm parity. aube does not download or re-exec other package-manager versions; when exact version enforcement is enabled, mismatches are reported instead.
@@ -1466,8 +1320,6 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_ignore_scripts`, `NPM_CONFIG_IGNORE_SCRIPTS`
 
 aube already skips dependency install scripts by default (security-first).
@@ -1486,8 +1338,6 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_child_concurrency`, `NPM_CONFIG_CHILD_CONCURRENCY`
 
 Caps how many dependency lifecycle scripts run in parallel during the
@@ -1507,8 +1357,6 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_side_effects_cache`, `NPM_CONFIG_SIDE_EFFECTS_CACHE`
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
@@ -1530,8 +1378,6 @@ Only read from the side-effects cache; don't write.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_side_effects_cache_readonly`, `NPM_CONFIG_SIDE_EFFECTS_CACHE_READONLY`
 
 When true, aube may restore allowlisted dependency build output from the
@@ -1543,8 +1389,6 @@ Drop to a non-root user when running scripts as root.
 
 - Type: `bool`
 - Default: `false (as root), true (otherwise)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_unsafe_perm`, `NPM_CONFIG_UNSAFE_PERM`
 
 aube exports the resolved value to lifecycle and `run` scripts as
@@ -1557,8 +1401,6 @@ Options passed to Node.js via NODE_OPTIONS.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `NODE_OPTIONS`, `npm_config_node_options`, `NPM_CONFIG_NODE_OPTIONS`
 
 When set in `.npmrc`, aube exports the value as `NODE_OPTIONS` for
@@ -1571,8 +1413,6 @@ Check dependencies before running scripts.
 
 - Type: `"install" | "warn" | "error" | "prompt" | false`
 - Default: `"install"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_verify_deps_before_run`, `NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN`
 
 Controls `run`, lifecycle shortcuts, `exec`, and implicit script commands.
@@ -1586,8 +1426,6 @@ Exit with an error if dependencies have unreviewed build scripts.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_strict_dep_builds`, `NPM_CONFIG_STRICT_DEP_BUILDS`
 
 aube never runs dependency lifecycle scripts unless the package is
@@ -1604,8 +1442,6 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_allow_builds`, `NPM_CONFIG_ALLOW_BUILDS`
 
 Per-package allowlist for dependency lifecycle scripts. Read from
@@ -1625,8 +1461,6 @@ Allow all dependency build scripts automatically.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_dangerously_allow_all_builds`, `NPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS`
 
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
@@ -1647,8 +1481,6 @@ Node.js version aube reports when evaluating `engines` checks.
 
 - Type: `string`
 - Default: `` output of `node -v` with the leading `v` stripped ``
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_node_version`, `NPM_CONFIG_NODE_VERSION`
 
 Paired with `engineStrict`. Set this in .npmrc to pin the Node version engines checks validate against, rather than probing `node --version` at install time.
@@ -1659,8 +1491,6 @@ Custom Node.js download mirror URLs.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_node_download_mirrors`, `NPM_CONFIG_NODE_DOWNLOAD_MIRRORS`
 
 Accepted for pnpm config parity. aube does not download Node.js itself,
@@ -1675,8 +1505,6 @@ Version prefix used when installing a package.
 
 - Type: `"^" | "~" | ""`
 - Default: `"^"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_save_prefix`, `NPM_CONFIG_SAVE_PREFIX`
 
 Resolved from `.npmrc`. `--save-exact` overrides to empty prefix.
@@ -1687,8 +1515,6 @@ Default dist-tag used by `aube add` without a version.
 
 - Type: `string`
 - Default: `"latest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_tag`, `NPM_CONFIG_TAG`
 
 Resolved from `.npmrc`. Used by `aube add` when no version or dist-tag is specified.
@@ -1699,8 +1525,6 @@ Directory where globally installed packages live.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_global_dir`, `NPM_CONFIG_GLOBAL_DIR`
 
 Overrides the directory where globally installed packages live. Falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1711,8 +1535,6 @@ Directory where global binaries are symlinked.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_global_bin_dir`, `NPM_CONFIG_GLOBAL_BIN_DIR`
 
 Overrides the directory where global binaries are symlinked. Independent of `globalDir`; falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1723,8 +1545,6 @@ Path to an additional .npmrc file consulted for registry authentication tokens.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_npmrc_auth_file`, `NPM_CONFIG_NPMRC_AUTH_FILE`
 
 Points at an extra `.npmrc`-formatted file that aube reads *after*
@@ -1752,8 +1572,6 @@ Directory for aube install-state files.
 
 - Type: `path`
 - Default: `.aube/.state`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_state_dir`, `NPM_CONFIG_STATE_DIR`
 
 Overrides the directory for install state tracking. Defaults to `.aube/.state` relative to the project root.
@@ -1764,8 +1582,6 @@ Directory for package metadata and dlx cache.
 
 - Type: `path`
 - Default: `~/.cache/aube`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_cache_dir`, `NPM_CONFIG_CACHE_DIR`
 
 Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path.
@@ -1776,8 +1592,6 @@ Write all output to stderr instead of stdout.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_use_stderr`, `NPM_CONFIG_USE_STDERR`
 
 Redirects stdout to stderr for the process lifetime. Resolved from `.npmrc` or the `--use-stderr` CLI flag.
@@ -1788,8 +1602,6 @@ Show an update notification when a newer aube is available.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_update_notifier`, `NPM_CONFIG_UPDATE_NOTIFIER`
 
 After a successful `install`, `add`, or `update`, aube fetches
@@ -1809,8 +1621,6 @@ Create symlinks instead of shims for `.bin` entries.
 
 - Type: `bool`
 - Default: `true (POSIX hoisted)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_prefer_symlinked_executables`, `NPM_CONFIG_PREFER_SYMLINKED_EXECUTABLES`
 
 POSIX only. Default (unset or `true`) creates a plain symlink from
@@ -1828,8 +1638,6 @@ Disable pnpm's automatic dependency patching database.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_ignore_compatibility_db`, `NPM_CONFIG_IGNORE_COMPATIBILITY_DB`
 
 Accepted for pnpm config parity. pnpm ships a built-in compatibility
@@ -1843,8 +1651,6 @@ Dependency version resolution strategy.
 
 - Type: `"highest" | "time-based" | "lowest-direct"`
 - Default: `"highest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_resolution_mode`, `NPM_CONFIG_RESOLUTION_MODE`
 
 Controls how aube chooses versions during resolution. `highest` picks
@@ -1859,8 +1665,6 @@ Whether the configured registry returns a `time` field in metadata.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_registry_supports_time_field`, `NPM_CONFIG_REGISTRY_SUPPORTS_TIME_FIELD`
 
 When `false` (the default, matching pnpm and npmjs.org's behavior),
@@ -1886,8 +1690,6 @@ Set NODE_PATH in command shims.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_extend_node_path`, `NPM_CONFIG_EXTEND_NODE_PATH`
 
 When `true` (default), aube-generated `.bin` shims export
@@ -1905,8 +1707,6 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_deploy_all_files`, `NPM_CONFIG_DEPLOY_ALL_FILES`
 
 When true, `aube deploy` copies every file in the source workspace
@@ -1925,8 +1725,6 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_dedupe_direct_deps`, `NPM_CONFIG_DEDUPE_DIRECT_DEPS`
 
 When true, the linker skips creating a `node_modules/<name>` symlink in a
@@ -1945,8 +1743,6 @@ Fast-path check before running a full install.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_optimistic_repeat_install`, `NPM_CONFIG_OPTIMISTIC_REPEAT_INSTALL`
 
 When `true` (default), `aube run` / `aube exec` / `aube start` /
@@ -1964,8 +1760,6 @@ Scripts that must be present in every workspace project.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_required_scripts`, `NPM_CONFIG_REQUIRED_SCRIPTS`
 
 During install, aube verifies that the root package and every discovered
@@ -1977,8 +1771,6 @@ Run pre/post scripts automatically when a named script is invoked.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_enable_pre_post_scripts`, `NPM_CONFIG_ENABLE_PRE_POST_SCRIPTS`
 
 Controls whether `aube run build` also runs `prebuild` before `build`
@@ -1990,8 +1782,6 @@ Shell used to invoke package scripts.
 
 - Type: `path`
 - Default: `null (uses /bin/sh on Unix, cmd on Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_script_shell`, `NPM_CONFIG_SCRIPT_SHELL`
 
 Overrides the shell executable used for lifecycle and `aube run`
@@ -2003,8 +1793,6 @@ Use a JavaScript bash-like shell to run scripts cross-platform.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_shell_emulator`, `NPM_CONFIG_SHELL_EMULATOR`
 
 Accepted for pnpm config parity. aube does not embed pnpm's JavaScript
@@ -2017,8 +1805,6 @@ How catalog references in package.json are handled by `add`.
 
 - Type: `"manual" | "strict" | "prefer"`
 - Default: `"manual"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_catalog_mode`, `NPM_CONFIG_CATALOG_MODE`
 
 `manual` (the default) writes whatever range `aube add` resolved, even
@@ -2042,8 +1828,6 @@ Explicitly mark the environment as CI.
 
 - Type: `bool`
 - Default: `auto-detected`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `CI`, `npm_config_ci`, `NPM_CONFIG_CI`
 
 aube detects CI via `env::var("CI").is_ok()` in two places:
@@ -2060,8 +1844,6 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `npm_config_cleanup_unused_catalogs`, `NPM_CONFIG_CLEANUP_UNUSED_CATALOGS`
 
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
@@ -2080,8 +1862,6 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - Environment: `AUBE_LINK_CONCURRENCY`, `npm_config_link_concurrency`, `NPM_CONFIG_LINK_CONCURRENCY`
 
 Caps the dedicated linker worker pool used for filesystem-heavy
@@ -2104,8 +1884,6 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `AUBE_NO_LOCK`, `npm_config_aube_no_lock`, `NPM_CONFIG_AUBE_NO_LOCK`
 
 aube takes an advisory lock on `node_modules/` at the start of every
@@ -2136,8 +1914,6 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Environment: `AUBE_NO_AUTO_INSTALL`, `npm_config_aube_no_auto_install`, `NPM_CONFIG_AUBE_NO_AUTO_INSTALL`
 
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -16,122 +16,122 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-112 settings are listed here. 112 are currently implemented.
+112 settings are listed here.
 
-| Setting | Type | Status | Summary |
-| --- | --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
-| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | implemented | Specify architectures for optional dependency installation. |
-| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | implemented | Skip optional dependencies by name. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`registries`](#setting-registries) | `object` | implemented | Registry URLs, including scoped registry overrides. |
-| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
-| [`symlink`](#setting-symlink) | `bool` | implemented | Create symlinks in the virtual store directory. |
-| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | implemented | Write files to the modules directory. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
-| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | implemented | Max length for virtual store directory names. |
-| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | implemented | Populate the virtual store without creating top-level symlinks. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
-| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
-| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
-| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
-| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | implemented | Validate package names and versions in the store. |
-| [`httpsProxy`](#setting-httpsproxy) | `url` | implemented | Proxy URL for outgoing HTTPS requests. |
-| [`httpProxy`](#setting-httpproxy) | `url` | implemented | Proxy URL for outgoing HTTP requests. |
-| [`noProxy`](#setting-noproxy) | `string` | implemented | Comma-separated list of domains that bypass the proxy. |
-| [`localAddress`](#setting-localaddress) | `string` | implemented | Local interface IP address to bind registry connections to. |
-| [`maxsockets`](#setting-maxsockets) | `int` | implemented | Maximum concurrent connections per origin. |
-| [`strictSsl`](#setting-strictssl) | `bool` | implemented | Validate SSL certificates for HTTPS requests. |
-| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | implemented | Hosts for which aube performs shallow git clones. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
-| [`fetchRetries`](#setting-fetchretries) | `int` | implemented | Number of retry attempts for failed registry fetches. |
-| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | implemented | Exponential backoff factor for fetch retries. |
-| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | implemented | Minimum retry timeout in milliseconds. |
-| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | implemented | Maximum retry timeout in milliseconds. |
-| [`fetchTimeout`](#setting-fetchtimeout) | `int` | implemented | Max time (ms) to wait for an HTTP request. |
-| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | implemented | Warn if a metadata request exceeds this threshold (ms). |
-| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | implemented | Warn if download speed falls below this threshold (KiB/s). |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
-| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | implemented | Control color output in aube's CLI. |
-| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | implemented | Minimum log level to display. |
-| [`useBetaCli`](#setting-usebetacli) | `bool` | implemented | Opt into experimental CLI features. |
-| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | implemented | Install on all workspace packages by default. |
-| [`engineStrict`](#setting-enginestrict) | `bool` | implemented | Fail if a package is incompatible with the current Node version. |
-| [`npmPath`](#setting-npmpath) | `path` | implemented | Path to the npm binary aube should shell out to when needed. |
-| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | implemented | Enforce the `packageManager` field in package.json. |
-| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | implemented | Enforce the exact `packageManager` version from package.json. |
-| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | implemented | Auto-download the specified pnpm version when mismatched. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
-| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | implemented | Only read from the side-effects cache; don't write. |
-| [`unsafePerm`](#setting-unsafeperm) | `bool` | implemented | Drop to a non-root user when running scripts as root. |
-| [`nodeOptions`](#setting-nodeoptions) | `string` | implemented | Options passed to Node.js via NODE_OPTIONS. |
-| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | implemented | Check dependencies before running scripts. |
-| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | implemented | Exit with an error if dependencies have unreviewed build scripts. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
-| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | implemented | Allow all dependency build scripts automatically. |
-| [`nodeVersion`](#setting-nodeversion) | `string` | implemented | Node.js version aube reports when evaluating `engines` checks. |
-| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | implemented | Custom Node.js download mirror URLs. |
-| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | implemented | Version prefix used when installing a package. |
-| [`tag`](#setting-tag) | `string` | implemented | Default dist-tag used by `aube add` without a version. |
-| [`globalDir`](#setting-globaldir) | `path` | implemented | Directory where globally installed packages live. |
-| [`globalBinDir`](#setting-globalbindir) | `path` | implemented | Directory where global binaries are symlinked. |
-| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | implemented | Path to an additional .npmrc file consulted for registry authentication tokens. |
-| [`stateDir`](#setting-statedir) | `path` | implemented | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | implemented | Directory for package metadata and dlx cache. |
-| [`useStderr`](#setting-usestderr) | `bool` | implemented | Write all output to stderr instead of stdout. |
-| [`updateNotifier`](#setting-updatenotifier) | `bool` | implemented | Show an update notification when a newer aube is available. |
-| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | implemented | Create symlinks instead of shims for `.bin` entries. |
-| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | implemented | Disable pnpm's automatic dependency patching database. |
-| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | implemented | Dependency version resolution strategy. |
-| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | implemented | Whether the configured registry returns a `time` field in metadata. |
-| [`extendNodePath`](#setting-extendnodepath) | `bool` | implemented | Set NODE_PATH in command shims. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | implemented | Fast-path check before running a full install. |
-| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | implemented | Scripts that must be present in every workspace project. |
-| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | implemented | Run pre/post scripts automatically when a named script is invoked. |
-| [`scriptShell`](#setting-scriptshell) | `path` | implemented | Shell used to invoke package scripts. |
-| [`shellEmulator`](#setting-shellemulator) | `bool` | implemented | Use a JavaScript bash-like shell to run scripts cross-platform. |
-| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | implemented | How catalog references in package.json are handled by `add`. |
-| [`ci`](#setting-ci) | `bool` | implemented | Explicitly mark the environment as CI. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Summary |
+| --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
+| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
+| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
+| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
+| [`symlink`](#setting-symlink) | `bool` | Create symlinks in the virtual store directory. |
+| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | Write files to the modules directory. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
+| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | Max length for virtual store directory names. |
+| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | Populate the virtual store without creating top-level symlinks. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
+| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | Minutes before orphan packages are removed from the virtual store. |
+| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | Minutes before the dlx cache is considered stale. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
+| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
+| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | Only allow installs when the store server is running. |
+| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | Validate package names and versions in the store. |
+| [`httpsProxy`](#setting-httpsproxy) | `url` | Proxy URL for outgoing HTTPS requests. |
+| [`httpProxy`](#setting-httpproxy) | `url` | Proxy URL for outgoing HTTP requests. |
+| [`noProxy`](#setting-noproxy) | `string` | Comma-separated list of domains that bypass the proxy. |
+| [`localAddress`](#setting-localaddress) | `string` | Local interface IP address to bind registry connections to. |
+| [`maxsockets`](#setting-maxsockets) | `int` | Maximum concurrent connections per origin. |
+| [`strictSsl`](#setting-strictssl) | `bool` | Validate SSL certificates for HTTPS requests. |
+| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | Hosts for which aube performs shallow git clones. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
+| [`fetchRetries`](#setting-fetchretries) | `int` | Number of retry attempts for failed registry fetches. |
+| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | Exponential backoff factor for fetch retries. |
+| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | Minimum retry timeout in milliseconds. |
+| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | Maximum retry timeout in milliseconds. |
+| [`fetchTimeout`](#setting-fetchtimeout) | `int` | Max time (ms) to wait for an HTTP request. |
+| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | Warn if a metadata request exceeds this threshold (ms). |
+| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | Warn if download speed falls below this threshold (KiB/s). |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
+| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | Control color output in aube's CLI. |
+| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | Minimum log level to display. |
+| [`useBetaCli`](#setting-usebetacli) | `bool` | Opt into experimental CLI features. |
+| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | Install on all workspace packages by default. |
+| [`engineStrict`](#setting-enginestrict) | `bool` | Fail if a package is incompatible with the current Node version. |
+| [`npmPath`](#setting-npmpath) | `path` | Path to the npm binary aube should shell out to when needed. |
+| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | Enforce the `packageManager` field in package.json. |
+| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | Enforce the exact `packageManager` version from package.json. |
+| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | Auto-download the specified pnpm version when mismatched. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
+| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | Only read from the side-effects cache; don't write. |
+| [`unsafePerm`](#setting-unsafeperm) | `bool` | Drop to a non-root user when running scripts as root. |
+| [`nodeOptions`](#setting-nodeoptions) | `string` | Options passed to Node.js via NODE_OPTIONS. |
+| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | Check dependencies before running scripts. |
+| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | Exit with an error if dependencies have unreviewed build scripts. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
+| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | Allow all dependency build scripts automatically. |
+| [`nodeVersion`](#setting-nodeversion) | `string` | Node.js version aube reports when evaluating `engines` checks. |
+| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | Custom Node.js download mirror URLs. |
+| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | Version prefix used when installing a package. |
+| [`tag`](#setting-tag) | `string` | Default dist-tag used by `aube add` without a version. |
+| [`globalDir`](#setting-globaldir) | `path` | Directory where globally installed packages live. |
+| [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
+| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
+| [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
+| [`cacheDir`](#setting-cachedir) | `path` | Directory for package metadata and dlx cache. |
+| [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
+| [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
+| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | Create symlinks instead of shims for `.bin` entries. |
+| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | Disable pnpm's automatic dependency patching database. |
+| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | Dependency version resolution strategy. |
+| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | Whether the configured registry returns a `time` field in metadata. |
+| [`extendNodePath`](#setting-extendnodepath) | `bool` | Set NODE_PATH in command shims. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | Fast-path check before running a full install. |
+| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | Scripts that must be present in every workspace project. |
+| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | Run pre/post scripts automatically when a named script is invoked. |
+| [`scriptShell`](#setting-scriptshell) | `path` | Shell used to invoke package scripts. |
+| [`shellEmulator`](#setting-shellemulator) | `bool` | Use a JavaScript bash-like shell to run scripts cross-platform. |
+| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | How catalog references in package.json are handled by `add`. |
+| [`ci`](#setting-ci) | `bool` | Explicitly mark the environment as CI. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -141,9 +141,6 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_overrides`, `NPM_CONFIG_OVERRIDES`
 - .npmrc keys: `overrides`
 - Workspace YAML keys: `overrides`
@@ -159,9 +156,6 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_package_extensions`, `NPM_CONFIG_PACKAGE_EXTENSIONS`
 - .npmrc keys: `packageExtensions`
 - Workspace YAML keys: `packageExtensions`
@@ -176,9 +170,6 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_allowed_deprecated_versions`, `NPM_CONFIG_ALLOWED_DEPRECATED_VERSIONS`
 - .npmrc keys: `allowedDeprecatedVersions`
 - Workspace YAML keys: `allowedDeprecatedVersions`
@@ -193,9 +184,6 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_update_config_ignore_dependencies`, `NPM_CONFIG_UPDATE_CONFIG_IGNORE_DEPENDENCIES`
 - .npmrc keys: `updateConfig.ignoreDependencies`
 - Workspace YAML keys: `updateConfig.ignoreDependencies`
@@ -209,12 +197,8 @@ Specify architectures for optional dependency installation.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_supported_architectures`, `NPM_CONFIG_SUPPORTED_ARCHITECTURES`
 - .npmrc keys: `supportedArchitectures`
-- Workspace YAML keys: none
 
 Override the current platform/arch/libc triple used to filter optional
 dependencies. Useful when generating a lockfile for a target platform
@@ -226,12 +210,8 @@ Skip optional dependencies by name.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_ignored_optional_dependencies`, `NPM_CONFIG_IGNORED_OPTIONAL_DEPENDENCIES`
 - .npmrc keys: `ignoredOptionalDependencies`
-- Workspace YAML keys: none
 
 Named entries are skipped even if their platform/arch matches. Distinct
 from `--no-optional`, which drops *all* optional deps at install time.
@@ -242,9 +222,6 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_minimum_release_age`, `NPM_CONFIG_MINIMUM_RELEASE_AGE`
 - .npmrc keys: `minimumReleaseAge`
 - Workspace YAML keys: `minimumReleaseAge`
@@ -261,9 +238,6 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_minimum_release_age_exclude`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE`
 - .npmrc keys: `minimumReleaseAgeExclude`
 - Workspace YAML keys: `minimumReleaseAgeExclude`
@@ -278,9 +252,6 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_minimum_release_age_strict`, `NPM_CONFIG_MINIMUM_RELEASE_AGE_STRICT`
 - .npmrc keys: `minimumReleaseAgeStrict`
 - Workspace YAML keys: `minimumReleaseAgeStrict`
@@ -295,9 +266,6 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_trust_policy`, `NPM_CONFIG_TRUST_POLICY`
 - .npmrc keys: `trustPolicy`
 - Workspace YAML keys: `trustPolicy`
@@ -313,9 +281,6 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_trust_policy_exclude`, `NPM_CONFIG_TRUST_POLICY_EXCLUDE`
 - .npmrc keys: `trustPolicyExclude`
 - Workspace YAML keys: `trustPolicyExclude`
@@ -328,9 +293,6 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_trust_policy_ignore_after`, `NPM_CONFIG_TRUST_POLICY_IGNORE_AFTER`
 - .npmrc keys: `trustPolicyIgnoreAfter`
 - Workspace YAML keys: `trustPolicyIgnoreAfter`
@@ -343,9 +305,6 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_block_exotic_subdeps`, `NPM_CONFIG_BLOCK_EXOTIC_SUBDEPS`
 - .npmrc keys: `blockExoticSubdeps`
 - Workspace YAML keys: `blockExoticSubdeps`
@@ -360,12 +319,8 @@ Registry URLs, including scoped registry overrides.
 
 - Type: `object`
 - Default: `{ default = "https://registry.npmjs.org/" }`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_registries`, `NPM_CONFIG_REGISTRIES`
 - .npmrc keys: `registry`, `@scope:registry`, `//host/:_authToken`, `//host/:_auth`
-- Workspace YAML keys: none
 
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
 `.npmrc` via `aube_registry::config::NpmConfig` (see
@@ -385,9 +340,6 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_hoist`, `NPM_CONFIG_HOIST`
 - .npmrc keys: `hoist`
 - Workspace YAML keys: `hoist`
@@ -418,9 +370,6 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_hoist_workspace_packages`, `NPM_CONFIG_HOIST_WORKSPACE_PACKAGES`
 - .npmrc keys: `hoist-workspace-packages`, `hoistWorkspacePackages`
 - Workspace YAML keys: `hoistWorkspacePackages`
@@ -439,9 +388,6 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_hoist_pattern`, `NPM_CONFIG_HOIST_PATTERN`
 - .npmrc keys: `hoist-pattern`, `hoistPattern`
 - Workspace YAML keys: `hoistPattern`
@@ -465,8 +411,6 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - CLI flags: `public-hoist-pattern`
 - Environment: `npm_config_public_hoist_pattern`, `NPM_CONFIG_PUBLIC_HOIST_PATTERN`
 - .npmrc keys: `public-hoist-pattern`, `publicHoistPattern`
@@ -489,8 +433,6 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `shamefully-hoist`
 - Environment: `npm_config_shamefully_hoist`, `NPM_CONFIG_SHAMEFULLY_HOIST`
 - .npmrc keys: `shamefully-hoist`, `shamefullyHoist`
@@ -507,9 +449,6 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
-- Status: implemented
-- Added to registry: `2026-04-17`
-- CLI flags: none
 - Environment: `npm_config_modules_dir`, `NPM_CONFIG_MODULES_DIR`
 - .npmrc keys: `modulesDir`, `modules-dir`
 - Workspace YAML keys: `modulesDir`
@@ -536,8 +475,6 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `node-linker`
 - Environment: `npm_config_node_linker`, `NPM_CONFIG_NODE_LINKER`
 - .npmrc keys: `nodeLinker`
@@ -555,12 +492,8 @@ Create symlinks in the virtual store directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_symlink`, `NPM_CONFIG_SYMLINK`
 - .npmrc keys: `symlink`
-- Workspace YAML keys: none
 
 Accepted for pnpm parity. aube's isolated layout is structurally
 defined by the symlink graph under `node_modules/.aube/` — each
@@ -588,12 +521,8 @@ Write files to the modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_enable_modules_dir`, `NPM_CONFIG_ENABLE_MODULES_DIR`
 - .npmrc keys: `enableModulesDir`
-- Workspace YAML keys: none
 
 When `false`, aube resolves the dependency graph and writes
 `aube-lock.yaml` but skips every `node_modules/` side effect: no
@@ -608,9 +537,6 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_virtual_store_dir`, `NPM_CONFIG_VIRTUAL_STORE_DIR`
 - .npmrc keys: `virtualStoreDir`, `virtual-store-dir`
 - Workspace YAML keys: `virtualStoreDir`
@@ -641,12 +567,8 @@ Max length for virtual store directory names.
 
 - Type: `int`
 - Default: `120 (Linux/macOS), 60 (Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_virtual_store_dir_max_length`, `NPM_CONFIG_VIRTUAL_STORE_DIR_MAX_LENGTH`
 - .npmrc keys: `virtualStoreDirMaxLength`
-- Workspace YAML keys: none
 
 Caps the number of characters in a single `node_modules/.aube/<dep>`
 directory name. `dep_path_to_filename` already truncates-and-hashes
@@ -663,12 +585,8 @@ Populate the virtual store without creating top-level symlinks.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_virtual_store_only`, `NPM_CONFIG_VIRTUAL_STORE_ONLY`
 - .npmrc keys: `virtualStoreOnly`
-- Workspace YAML keys: none
 
 When `true`, aube still materializes every package into
 `node_modules/.aube/<dep>/node_modules/<name>` (and, in global-store
@@ -686,8 +604,6 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `package-import-method`
 - Environment: `npm_config_package_import_method`, `NPM_CONFIG_PACKAGE_IMPORT_METHOD`
 - .npmrc keys: `packageImportMethod`, `package-import-method`
@@ -710,12 +626,8 @@ Minutes before orphan packages are removed from the virtual store.
 
 - Type: `int`
 - Default: `10080`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_modules_cache_max_age`, `NPM_CONFIG_MODULES_CACHE_MAX_AGE`
 - .npmrc keys: `modulesCacheMaxAge`
-- Workspace YAML keys: none
 
 After each successful install, aube sweeps the per-project
 `node_modules/.aube/` virtual store and removes entries whose
@@ -734,12 +646,8 @@ Minutes before the dlx cache is considered stale.
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_dlx_cache_max_age`, `NPM_CONFIG_DLX_CACHE_MAX_AGE`
 - .npmrc keys: `dlx-cache-max-age`, `dlxCacheMaxAge`
-- Workspace YAML keys: none
 
 Accepted for pnpm parity. `aube dlx` currently installs into a fresh
 `tempfile::TempDir` per invocation and removes it on exit, so there is
@@ -754,9 +662,6 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `CI`, `npm_config_enable_global_virtual_store`, `NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
 - .npmrc keys: `enableGlobalVirtualStore`
 - Workspace YAML keys: `enableGlobalVirtualStore`
@@ -774,9 +679,6 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_store_dir`, `NPM_CONFIG_STORE_DIR`
 - .npmrc keys: `store-dir`, `storeDir`
 - Workspace YAML keys: `storeDir`
@@ -806,8 +708,6 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `verify-store-integrity`
 - Environment: `npm_config_verify_store_integrity`, `NPM_CONFIG_VERIFY_STORE_INTEGRITY`
 - .npmrc keys: `verify-store-integrity`, `verifyStoreIntegrity`
@@ -830,12 +730,8 @@ Only allow installs when the store server is running.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_use_running_store_server`, `NPM_CONFIG_USE_RUNNING_STORE_SERVER`
 - .npmrc keys: `use-running-store-server`, `useRunningStoreServer`
-- Workspace YAML keys: none
 
 Accepted for pnpm parity. aube has no long-running store-daemon
 component — every install talks directly to the on-disk CAS at
@@ -850,12 +746,8 @@ Validate package names and versions in the store.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_strict_store_pkg_content_check`, `NPM_CONFIG_STRICT_STORE_PKG_CONTENT_CHECK`
 - .npmrc keys: `strict-store-pkg-content-check`, `strictStorePkgContentCheck`
-- Workspace YAML keys: none
 
 After each registry tarball is imported, aube reads the freshly stored
 `package.json` and confirms its `name` and `version` match what the
@@ -881,12 +773,8 @@ Proxy URL for outgoing HTTPS requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `HTTPS_PROXY`, `https_proxy`, `npm_config_https_proxy`, `NPM_CONFIG_HTTPS_PROXY`
 - .npmrc keys: `https-proxy`, `httpsProxy`, `proxy`
-- Workspace YAML keys: none
 
 Forwards every HTTPS registry fetch through the given proxy URL.
 Honored by the `aube-registry` reqwest client. Resolution mirrors
@@ -899,12 +787,8 @@ Proxy URL for outgoing HTTP requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `HTTP_PROXY`, `http_proxy`, `PROXY`, `proxy`, `npm_config_http_proxy`, `NPM_CONFIG_HTTP_PROXY`
 - .npmrc keys: `http-proxy`, `httpProxy`
-- Workspace YAML keys: none
 
 HTTP counterpart to `httpsProxy`. Resolution mirrors pnpm:
 `.npmrc http-proxy` ?? resolved `httpsProxy` ?? `HTTP_PROXY` /
@@ -918,12 +802,8 @@ Comma-separated list of domains that bypass the proxy.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `NO_PROXY`, `no_proxy`, `npm_config_no_proxy`, `NPM_CONFIG_NO_PROXY`
 - .npmrc keys: `noproxy`, `noProxy`, `no-proxy`
-- Workspace YAML keys: none
 
 Passed through to `reqwest::NoProxy::from_string` verbatim, so
 wildcard and port-qualified hosts behave the same as curl / node.
@@ -936,12 +816,8 @@ Local interface IP address to bind registry connections to.
 
 - Type: `string`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_local_address`, `NPM_CONFIG_LOCAL_ADDRESS`
 - .npmrc keys: `local-address`, `localAddress`
-- Workspace YAML keys: none
 
 Used on multi-homed hosts where outbound traffic must leave a
 specific interface. Parsed as `IpAddr`; unparseable values are
@@ -953,12 +829,8 @@ Maximum concurrent connections per origin.
 
 - Type: `int`
 - Default: `networkConcurrency x 3`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_maxsockets`, `NPM_CONFIG_MAXSOCKETS`
 - .npmrc keys: `maxsockets`
-- Workspace YAML keys: none
 
 Plumbed into reqwest's `pool_max_idle_per_host`. This is the
 closest analogue to pnpm's per-origin socket cap — reqwest doesn't
@@ -971,12 +843,8 @@ Validate SSL certificates for HTTPS requests.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_strict_ssl`, `NPM_CONFIG_STRICT_SSL`
 - .npmrc keys: `strict-ssl`, `strictSsl`
-- Workspace YAML keys: none
 
 Defaults to `true`. Setting `strict-ssl=false` disables TLS
 certificate verification entirely via
@@ -992,9 +860,6 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_lockfile`, `NPM_CONFIG_LOCKFILE`
 - .npmrc keys: `lockfile`
 - Workspace YAML keys: `lockfile`
@@ -1021,8 +886,6 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `prefer-frozen-lockfile`
 - Environment: `npm_config_prefer_frozen_lockfile`, `NPM_CONFIG_PREFER_FROZEN_LOCKFILE`
 - .npmrc keys: `prefer-frozen-lockfile`
@@ -1042,9 +905,6 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_lockfile_include_tarball_url`, `NPM_CONFIG_LOCKFILE_INCLUDE_TARBALL_URL`
 - .npmrc keys: `lockfileIncludeTarballUrl`, `lockfile-include-tarball-url`
 - Workspace YAML keys: `lockfileIncludeTarballUrl`
@@ -1074,9 +934,6 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-13`
-- CLI flags: none
 - Environment: `npm_config_exclude_links_from_lockfile`, `NPM_CONFIG_EXCLUDE_LINKS_FROM_LOCKFILE`
 - .npmrc keys: `exclude-links-from-lockfile`, `excludeLinksFromLockfile`
 - Workspace YAML keys: `excludeLinksFromLockfile`
@@ -1099,9 +956,6 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_git_branch_lockfile`, `NPM_CONFIG_GIT_BRANCH_LOCKFILE`
 - .npmrc keys: `gitBranchLockfile`
 - Workspace YAML keys: `gitBranchLockfile`
@@ -1131,9 +985,6 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_merge_git_branch_lockfiles_branch_pattern`, `NPM_CONFIG_MERGE_GIT_BRANCH_LOCKFILES_BRANCH_PATTERN`
 - .npmrc keys: `mergeGitBranchLockfilesBranchPattern`
 - Workspace YAML keys: `mergeGitBranchLockfilesBranchPattern`
@@ -1166,9 +1017,6 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_peers_suffix_max_length`, `NPM_CONFIG_PEERS_SUFFIX_MAX_LENGTH`
 - .npmrc keys: `peersSuffixMaxLength`
 - Workspace YAML keys: `peersSuffixMaxLength`
@@ -1191,12 +1039,8 @@ Hosts for which aube performs shallow git clones.
 
 - Type: `list<string>`
 - Default: `["github.com", "gist.github.com", "gitlab.com", "bitbucket.com", "bitbucket.org"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_git_shallow_hosts`, `NPM_CONFIG_GIT_SHALLOW_HOSTS`
 - .npmrc keys: `git-shallow-hosts`, `gitShallowHosts`
-- Workspace YAML keys: none
 
 Consulted by `aube-store::git_shallow_clone` when cloning a git
 dependency. When the URL's hostname matches an entry in this list
@@ -1219,8 +1063,6 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `network-concurrency`
 - Environment: `npm_config_network_concurrency`, `NPM_CONFIG_NETWORK_CONCURRENCY`
 - .npmrc keys: `network-concurrency`, `networkConcurrency`
@@ -1245,12 +1087,8 @@ Number of retry attempts for failed registry fetches.
 
 - Type: `int`
 - Default: `2`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_retries`, `NPM_CONFIG_FETCH_RETRIES`
 - .npmrc keys: `fetch-retries`, `fetchRetries`
-- Workspace YAML keys: none
 
 Number of *additional* attempts the registry client makes after a
 transient failure (5xx / 429 / connection error). `2` means up to 3
@@ -1268,12 +1106,8 @@ Exponential backoff factor for fetch retries.
 
 - Type: `int`
 - Default: `10`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_retry_factor`, `NPM_CONFIG_FETCH_RETRY_FACTOR`
 - .npmrc keys: `fetch-retry-factor`, `fetchRetryFactor`
-- Workspace YAML keys: none
 
 Multiplier used between retry attempts. Attempt `n` waits
 `min(fetchRetryMintimeout * fetchRetryFactor ^ (n-1), fetchRetryMaxtimeout)`
@@ -1286,12 +1120,8 @@ Minimum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_retry_mintimeout`, `NPM_CONFIG_FETCH_RETRY_MINTIMEOUT`
 - .npmrc keys: `fetch-retry-mintimeout`, `fetchRetryMintimeout`
-- Workspace YAML keys: none
 
 Lower bound on the computed retry backoff. See `fetchRetryFactor`.
 
@@ -1301,12 +1131,8 @@ Maximum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_retry_maxtimeout`, `NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT`
 - .npmrc keys: `fetch-retry-maxtimeout`, `fetchRetryMaxtimeout`
-- Workspace YAML keys: none
 
 Upper bound on the computed retry backoff. See `fetchRetryFactor`.
 
@@ -1316,12 +1142,8 @@ Max time (ms) to wait for an HTTP request.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_timeout`, `NPM_CONFIG_FETCH_TIMEOUT`
 - .npmrc keys: `fetchTimeout`
-- Workspace YAML keys: none
 
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
 `.timeout()` so it covers headers + body together. A request that
@@ -1334,12 +1156,8 @@ Warn if a metadata request exceeds this threshold (ms).
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_warn_timeout_ms`, `NPM_CONFIG_FETCH_WARN_TIMEOUT_MS`
 - .npmrc keys: `fetchWarnTimeoutMs`
-- Workspace YAML keys: none
 
 Observability threshold for registry *metadata* requests (packument,
 dist-tags). When a successful response takes longer than
@@ -1358,12 +1176,8 @@ Warn if download speed falls below this threshold (KiB/s).
 
 - Type: `int`
 - Default: `50`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_fetch_min_speed_ki_bps`, `NPM_CONFIG_FETCH_MIN_SPEED_KI_BPS`
 - .npmrc keys: `fetchMinSpeedKiBps`
-- Workspace YAML keys: none
 
 Observability threshold for *tarball* downloads. When a tarball
 finishes with an end-to-end average throughput below this many KiB/s,
@@ -1384,8 +1198,6 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `auto-install-peers`
 - Environment: `npm_config_auto_install_peers`, `NPM_CONFIG_AUTO_INSTALL_PEERS`
 - .npmrc keys: `auto-install-peers`, `autoInstallPeers`
@@ -1402,9 +1214,6 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_dedupe_peer_dependents`, `NPM_CONFIG_DEDUPE_PEER_DEPENDENTS`
 - .npmrc keys: `dedupePeerDependents`
 - Workspace YAML keys: `dedupePeerDependents`
@@ -1423,9 +1232,6 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_dedupe_peers`, `NPM_CONFIG_DEDUPE_PEERS`
 - .npmrc keys: `dedupePeers`
 - Workspace YAML keys: `dedupePeers`
@@ -1442,9 +1248,6 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_strict_peer_dependencies`, `NPM_CONFIG_STRICT_PEER_DEPENDENCIES`
 - .npmrc keys: `strict-peer-dependencies`, `strictPeerDependencies`
 - Workspace YAML keys: `strictPeerDependencies`
@@ -1463,9 +1266,6 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_resolve_peers_from_workspace_root`, `NPM_CONFIG_RESOLVE_PEERS_FROM_WORKSPACE_ROOT`
 - .npmrc keys: `resolvePeersFromWorkspaceRoot`
 - Workspace YAML keys: `resolvePeersFromWorkspaceRoot`
@@ -1483,9 +1283,6 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_peer_dependency_rules_ignore_missing`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_IGNORE_MISSING`
 - .npmrc keys: `peerDependencyRules.ignoreMissing`
 - Workspace YAML keys: `peerDependencyRules.ignoreMissing`
@@ -1504,9 +1301,6 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_peer_dependency_rules_allowed_versions`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOWED_VERSIONS`
 - .npmrc keys: `peerDependencyRules.allowedVersions`
 - Workspace YAML keys: `peerDependencyRules.allowedVersions`
@@ -1526,9 +1320,6 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_peer_dependency_rules_allow_any`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_ALLOW_ANY`
 - .npmrc keys: `peerDependencyRules.allowAny`
 - Workspace YAML keys: `peerDependencyRules.allowAny`
@@ -1548,12 +1339,9 @@ Control color output in aube's CLI.
 
 - Type: `"auto" | "always" | "never"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `color`, `no-color`
 - Environment: `npm_config_color`, `NPM_CONFIG_COLOR`
 - .npmrc keys: `color`
-- Workspace YAML keys: none
 
 `--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree.
 
@@ -1563,12 +1351,9 @@ Minimum log level to display.
 
 - Type: `"debug" | "info" | "warn" | "error" | "silent"`
 - Default: `"warn"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `loglevel`, `verbose`, `v`, `silent`
 - Environment: `npm_config_loglevel`, `NPM_CONFIG_LOGLEVEL`
 - .npmrc keys: `loglevel`
-- Workspace YAML keys: none
 
 Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`.
 
@@ -1578,12 +1363,8 @@ Opt into experimental CLI features.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_use_beta_cli`, `NPM_CONFIG_USE_BETA_CLI`
 - .npmrc keys: `useBetaCli`
-- Workspace YAML keys: none
 
 Accepted from env and `.npmrc` for pnpm parity. aube currently has no beta-gated commands, so the setting is a no-op after validation.
 
@@ -1593,12 +1374,8 @@ Install on all workspace packages by default.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_recursive_install`, `NPM_CONFIG_RECURSIVE_INSTALL`
 - .npmrc keys: `recursiveInstall`
-- Workspace YAML keys: none
 
 When true, workspace installs resolve and link all importers by default. Set to false to opt out of implicit workspace-wide install behavior; explicit `--filter` / `--recursive` still wins.
 
@@ -1608,12 +1385,8 @@ Fail if a package is incompatible with the current Node version.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_engine_strict`, `NPM_CONFIG_ENGINE_STRICT`
 - .npmrc keys: `engine-strict`, `engineStrict`
-- Workspace YAML keys: none
 
 When on, an `engines.node` mismatch on the root project or any dependency fails the install. When off, mismatches are warnings only.
 
@@ -1623,12 +1396,8 @@ Path to the npm binary aube should shell out to when needed.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_npm_path`, `NPM_CONFIG_NPM_PATH`
 - .npmrc keys: `npmPath`
-- Workspace YAML keys: none
 
 Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`, `token`, `whoami`) when configured. Without it, aube keeps the explicit `use npm` error.
 
@@ -1638,12 +1407,8 @@ Enforce the `packageManager` field in package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_package_manager_strict`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT`
 - .npmrc keys: `packageManagerStrict`
-- Workspace YAML keys: none
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
 
@@ -1653,12 +1418,8 @@ Enforce the exact `packageManager` version from package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_package_manager_strict_version`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION`
 - .npmrc keys: `packageManagerStrictVersion`
-- Workspace YAML keys: none
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
 
@@ -1668,12 +1429,8 @@ Auto-download the specified pnpm version when mismatched.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_manage_package_manager_versions`, `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS`
 - .npmrc keys: `managePackageManagerVersions`
-- Workspace YAML keys: none
 
 Accepted for pnpm parity. aube does not download or re-exec other package-manager versions; when exact version enforcement is enabled, mismatches are reported instead.
 
@@ -1685,8 +1442,6 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `ignore-scripts`
 - Environment: `npm_config_ignore_scripts`, `NPM_CONFIG_IGNORE_SCRIPTS`
 - .npmrc keys: `ignore-scripts`, `ignoreScripts`
@@ -1708,9 +1463,6 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_child_concurrency`, `NPM_CONFIG_CHILD_CONCURRENCY`
 - .npmrc keys: `child-concurrency`, `childConcurrency`
 - Workspace YAML keys: `childConcurrency`
@@ -1732,8 +1484,6 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `side-effects-cache`
 - Environment: `npm_config_side_effects_cache`, `NPM_CONFIG_SIDE_EFFECTS_CACHE`
 - .npmrc keys: `side-effects-cache`, `sideEffectsCache`
@@ -1758,12 +1508,8 @@ Only read from the side-effects cache; don't write.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_side_effects_cache_readonly`, `NPM_CONFIG_SIDE_EFFECTS_CACHE_READONLY`
 - .npmrc keys: `sideEffectsCacheReadonly`
-- Workspace YAML keys: none
 
 When true, aube may restore allowlisted dependency build output from the
 side-effects cache but will not write new cache entries after scripts run.
@@ -1774,12 +1520,8 @@ Drop to a non-root user when running scripts as root.
 
 - Type: `bool`
 - Default: `false (as root), true (otherwise)`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_unsafe_perm`, `NPM_CONFIG_UNSAFE_PERM`
 - .npmrc keys: `unsafePerm`
-- Workspace YAML keys: none
 
 aube exports the resolved value to lifecycle and `run` scripts as
 `npm_config_unsafe_perm`, matching the environment surface npm-style
@@ -1791,12 +1533,8 @@ Options passed to Node.js via NODE_OPTIONS.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `NODE_OPTIONS`, `npm_config_node_options`, `NPM_CONFIG_NODE_OPTIONS`
 - .npmrc keys: `nodeOptions`
-- Workspace YAML keys: none
 
 When set in `.npmrc`, aube exports the value as `NODE_OPTIONS` for
 lifecycle scripts and `aube run` scripts. An existing `NODE_OPTIONS`
@@ -1808,12 +1546,8 @@ Check dependencies before running scripts.
 
 - Type: `"install" | "warn" | "error" | "prompt" | false`
 - Default: `"install"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_verify_deps_before_run`, `NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN`
 - .npmrc keys: `verifyDepsBeforeRun`
-- Workspace YAML keys: none
 
 Controls `run`, lifecycle shortcuts, `exec`, and implicit script commands.
 `install` preserves aube's auto-install behavior, `warn` reports stale
@@ -1826,12 +1560,8 @@ Exit with an error if dependencies have unreviewed build scripts.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_strict_dep_builds`, `NPM_CONFIG_STRICT_DEP_BUILDS`
 - .npmrc keys: `strictDepBuilds`
-- Workspace YAML keys: none
 
 aube never runs dependency lifecycle scripts unless the package is
 listed in `allowBuilds` or `--dangerously-allow-all-builds` is set.
@@ -1847,9 +1577,6 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_allow_builds`, `NPM_CONFIG_ALLOW_BUILDS`
 - .npmrc keys: `allowBuilds`
 - Workspace YAML keys: `allowBuilds`
@@ -1871,12 +1598,9 @@ Allow all dependency build scripts automatically.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `dangerously-allow-all-builds`
 - Environment: `npm_config_dangerously_allow_all_builds`, `NPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS`
 - .npmrc keys: `dangerouslyAllowAllBuilds`
-- Workspace YAML keys: none
 
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
 dependency's `preinstall` / `install` / `postinstall` / `prepare`
@@ -1896,12 +1620,8 @@ Node.js version aube reports when evaluating `engines` checks.
 
 - Type: `string`
 - Default: `` output of `node -v` with the leading `v` stripped ``
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_node_version`, `NPM_CONFIG_NODE_VERSION`
 - .npmrc keys: `node-version`, `nodeVersion`
-- Workspace YAML keys: none
 
 Paired with `engineStrict`. Set this in .npmrc to pin the Node version engines checks validate against, rather than probing `node --version` at install time.
 
@@ -1911,12 +1631,8 @@ Custom Node.js download mirror URLs.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_node_download_mirrors`, `NPM_CONFIG_NODE_DOWNLOAD_MIRRORS`
 - .npmrc keys: `nodeDownloadMirrors`
-- Workspace YAML keys: none
 
 Accepted for pnpm config parity. aube does not download Node.js itself,
 so the parsed mirror map is preserved for config introspection but has
@@ -1930,12 +1646,8 @@ Version prefix used when installing a package.
 
 - Type: `"^" | "~" | ""`
 - Default: `"^"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_save_prefix`, `NPM_CONFIG_SAVE_PREFIX`
 - .npmrc keys: `save-prefix`, `savePrefix`
-- Workspace YAML keys: none
 
 Resolved from `.npmrc`. `--save-exact` overrides to empty prefix.
 
@@ -1945,12 +1657,8 @@ Default dist-tag used by `aube add` without a version.
 
 - Type: `string`
 - Default: `"latest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_tag`, `NPM_CONFIG_TAG`
 - .npmrc keys: `tag`
-- Workspace YAML keys: none
 
 Resolved from `.npmrc`. Used by `aube add` when no version or dist-tag is specified.
 
@@ -1960,12 +1668,8 @@ Directory where globally installed packages live.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_global_dir`, `NPM_CONFIG_GLOBAL_DIR`
 - .npmrc keys: `globalDir`
-- Workspace YAML keys: none
 
 Overrides the directory where globally installed packages live. Falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
 
@@ -1975,12 +1679,8 @@ Directory where global binaries are symlinked.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_global_bin_dir`, `NPM_CONFIG_GLOBAL_BIN_DIR`
 - .npmrc keys: `globalBinDir`
-- Workspace YAML keys: none
 
 Overrides the directory where global binaries are symlinked. Independent of `globalDir`; falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
 
@@ -1990,12 +1690,8 @@ Path to an additional .npmrc file consulted for registry authentication tokens.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_npmrc_auth_file`, `NPM_CONFIG_NPMRC_AUTH_FILE`
 - .npmrc keys: `npmrc-auth-file`, `npmrcAuthFile`
-- Workspace YAML keys: none
 
 Points at an extra `.npmrc`-formatted file that aube reads *after*
 the user and project `.npmrc` files when resolving registry auth.
@@ -2022,12 +1718,8 @@ Directory for aube install-state files.
 
 - Type: `path`
 - Default: `.aube/.state`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_state_dir`, `NPM_CONFIG_STATE_DIR`
 - .npmrc keys: `stateDir`
-- Workspace YAML keys: none
 
 Overrides the directory for install state tracking. Defaults to `.aube/.state` relative to the project root.
 
@@ -2037,12 +1729,8 @@ Directory for package metadata and dlx cache.
 
 - Type: `path`
 - Default: `~/.cache/aube`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_cache_dir`, `NPM_CONFIG_CACHE_DIR`
 - .npmrc keys: `cache-dir`, `cacheDir`
-- Workspace YAML keys: none
 
 Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path.
 
@@ -2052,12 +1740,8 @@ Write all output to stderr instead of stdout.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_use_stderr`, `NPM_CONFIG_USE_STDERR`
 - .npmrc keys: `useStderr`
-- Workspace YAML keys: none
 
 Redirects stdout to stderr for the process lifetime. Resolved from `.npmrc` or the `--use-stderr` CLI flag.
 
@@ -2067,12 +1751,8 @@ Show an update notification when a newer aube is available.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_update_notifier`, `NPM_CONFIG_UPDATE_NOTIFIER`
 - .npmrc keys: `updateNotifier`
-- Workspace YAML keys: none
 
 After a successful `install`, `add`, or `update`, aube fetches
 `https://aube.en.dev/VERSION` and prints a one-line notice if the
@@ -2091,12 +1771,8 @@ Create symlinks instead of shims for `.bin` entries.
 
 - Type: `bool`
 - Default: `true (POSIX hoisted)`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_prefer_symlinked_executables`, `NPM_CONFIG_PREFER_SYMLINKED_EXECUTABLES`
 - .npmrc keys: `preferSymlinkedExecutables`
-- Workspace YAML keys: none
 
 POSIX only. Default (unset or `true`) creates a plain symlink from
 `node_modules/.bin/<name>` straight to the package's executable file —
@@ -2113,12 +1789,8 @@ Disable pnpm's automatic dependency patching database.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_ignore_compatibility_db`, `NPM_CONFIG_IGNORE_COMPATIBILITY_DB`
 - .npmrc keys: `ignoreCompatibilityDb`
-- Workspace YAML keys: none
 
 Accepted for pnpm config parity. pnpm ships a built-in compatibility
 database of auto-patches for known-broken packages; aube has no such
@@ -2131,12 +1803,9 @@ Dependency version resolution strategy.
 
 - Type: `"highest" | "time-based" | "lowest-direct"`
 - Default: `"highest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `resolution-mode`
 - Environment: `npm_config_resolution_mode`, `NPM_CONFIG_RESOLUTION_MODE`
 - .npmrc keys: `resolution-mode`, `resolutionMode`
-- Workspace YAML keys: none
 
 Controls how aube chooses versions during resolution. `highest` picks
 the newest satisfying version. `time-based` filters candidates through
@@ -2150,12 +1819,8 @@ Whether the configured registry returns a `time` field in metadata.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_registry_supports_time_field`, `NPM_CONFIG_REGISTRY_SUPPORTS_TIME_FIELD`
 - .npmrc keys: `registry-supports-time-field`, `registrySupportsTimeField`
-- Workspace YAML keys: none
 
 When `false` (the default, matching pnpm and npmjs.org's behavior),
 aube fetches the full (non-corgi) packument to read the `time:` map
@@ -2180,12 +1845,8 @@ Set NODE_PATH in command shims.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_extend_node_path`, `NPM_CONFIG_EXTEND_NODE_PATH`
 - .npmrc keys: `extendNodePath`
-- Workspace YAML keys: none
 
 When `true` (default), aube-generated `.bin` shims export
 `NODE_PATH="$basedir/.."` so the shimmed binary can resolve modules
@@ -2202,9 +1863,6 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_deploy_all_files`, `NPM_CONFIG_DEPLOY_ALL_FILES`
 - .npmrc keys: `deploy-all-files`, `deployAllFiles`
 - Workspace YAML keys: `deployAllFiles`
@@ -2225,9 +1883,6 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_dedupe_direct_deps`, `NPM_CONFIG_DEDUPE_DIRECT_DEPS`
 - .npmrc keys: `dedupe-direct-deps`, `dedupeDirectDeps`
 - Workspace YAML keys: `dedupeDirectDeps`
@@ -2248,12 +1903,8 @@ Fast-path check before running a full install.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_optimistic_repeat_install`, `NPM_CONFIG_OPTIMISTIC_REPEAT_INSTALL`
 - .npmrc keys: `optimisticRepeatInstall`
-- Workspace YAML keys: none
 
 When `true` (default), `aube run` / `aube exec` / `aube start` /
 `aube test` / `aube restart` consult `.aube/.state/install-state.json`
@@ -2270,12 +1921,8 @@ Scripts that must be present in every workspace project.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_required_scripts`, `NPM_CONFIG_REQUIRED_SCRIPTS`
 - .npmrc keys: `requiredScripts`
-- Workspace YAML keys: none
 
 During install, aube verifies that the root package and every discovered
 workspace package define each required script in `package.json`.
@@ -2286,12 +1933,8 @@ Run pre/post scripts automatically when a named script is invoked.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_enable_pre_post_scripts`, `NPM_CONFIG_ENABLE_PRE_POST_SCRIPTS`
 - .npmrc keys: `enablePrePostScripts`
-- Workspace YAML keys: none
 
 Controls whether `aube run build` also runs `prebuild` before `build`
 and `postbuild` after it when those scripts exist.
@@ -2302,12 +1945,8 @@ Shell used to invoke package scripts.
 
 - Type: `path`
 - Default: `null (uses /bin/sh on Unix, cmd on Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_script_shell`, `NPM_CONFIG_SCRIPT_SHELL`
 - .npmrc keys: `scriptShell`
-- Workspace YAML keys: none
 
 Overrides the shell executable used for lifecycle and `aube run`
 scripts. On Unix, aube invokes the configured shell with `-c`.
@@ -2318,12 +1957,8 @@ Use a JavaScript bash-like shell to run scripts cross-platform.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_shell_emulator`, `NPM_CONFIG_SHELL_EMULATOR`
 - .npmrc keys: `shellEmulator`
-- Workspace YAML keys: none
 
 Accepted for pnpm config parity. aube does not embed pnpm's JavaScript
 shell emulator, but it exports `npm_config_shell_emulator=true` for
@@ -2335,12 +1970,8 @@ How catalog references in package.json are handled by `add`.
 
 - Type: `"manual" | "strict" | "prefer"`
 - Default: `"manual"`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_catalog_mode`, `NPM_CONFIG_CATALOG_MODE`
 - .npmrc keys: `catalogMode`
-- Workspace YAML keys: none
 
 `manual` (the default) writes whatever range `aube add` resolved, even
 when the package is declared in the default catalog. `prefer` rewrites
@@ -2363,12 +1994,8 @@ Explicitly mark the environment as CI.
 
 - Type: `bool`
 - Default: `auto-detected`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `CI`, `npm_config_ci`, `NPM_CONFIG_CI`
 - .npmrc keys: `ci`
-- Workspace YAML keys: none
 
 aube detects CI via `env::var("CI").is_ok()` in two places:
 `aube-linker` (disables the global virtual store) and
@@ -2384,9 +2011,6 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `npm_config_cleanup_unused_catalogs`, `NPM_CONFIG_CLEANUP_UNUSED_CATALOGS`
 - .npmrc keys: `cleanupUnusedCatalogs`
 - Workspace YAML keys: `cleanupUnusedCatalogs`
@@ -2407,9 +2031,6 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-17`
-- CLI flags: none
 - Environment: `AUBE_LINK_CONCURRENCY`, `npm_config_link_concurrency`, `NPM_CONFIG_LINK_CONCURRENCY`
 - .npmrc keys: `link-concurrency`, `linkConcurrency`
 - Workspace YAML keys: `linkConcurrency`
@@ -2434,9 +2055,6 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
-- CLI flags: none
 - Environment: `AUBE_NO_LOCK`, `npm_config_aube_no_lock`, `NPM_CONFIG_AUBE_NO_LOCK`
 - .npmrc keys: `aubeNoLock`, `aube-no-lock`
 - Workspace YAML keys: `aubeNoLock`
@@ -2469,8 +2087,6 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - CLI flags: `no-install`
 - Environment: `AUBE_NO_AUTO_INSTALL`, `npm_config_aube_no_auto_install`, `NPM_CONFIG_AUBE_NO_AUTO_INSTALL`
 - .npmrc keys: `aubeNoAutoInstall`, `aube-no-auto-install`

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -16,122 +16,122 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-112 settings are listed here. 112 are currently implemented.
+112 settings are listed here.
 
-| Setting | Type | Status | Summary |
-| --- | --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
-| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | implemented | Specify architectures for optional dependency installation. |
-| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | implemented | Skip optional dependencies by name. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`registries`](#setting-registries) | `object` | implemented | Registry URLs, including scoped registry overrides. |
-| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
-| [`symlink`](#setting-symlink) | `bool` | implemented | Create symlinks in the virtual store directory. |
-| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | implemented | Write files to the modules directory. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
-| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | implemented | Max length for virtual store directory names. |
-| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | implemented | Populate the virtual store without creating top-level symlinks. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
-| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | implemented | Minutes before orphan packages are removed from the virtual store. |
-| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | implemented | Minutes before the dlx cache is considered stale. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
-| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | implemented | Only allow installs when the store server is running. |
-| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | implemented | Validate package names and versions in the store. |
-| [`httpsProxy`](#setting-httpsproxy) | `url` | implemented | Proxy URL for outgoing HTTPS requests. |
-| [`httpProxy`](#setting-httpproxy) | `url` | implemented | Proxy URL for outgoing HTTP requests. |
-| [`noProxy`](#setting-noproxy) | `string` | implemented | Comma-separated list of domains that bypass the proxy. |
-| [`localAddress`](#setting-localaddress) | `string` | implemented | Local interface IP address to bind registry connections to. |
-| [`maxsockets`](#setting-maxsockets) | `int` | implemented | Maximum concurrent connections per origin. |
-| [`strictSsl`](#setting-strictssl) | `bool` | implemented | Validate SSL certificates for HTTPS requests. |
-| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | implemented | Hosts for which aube performs shallow git clones. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
-| [`fetchRetries`](#setting-fetchretries) | `int` | implemented | Number of retry attempts for failed registry fetches. |
-| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | implemented | Exponential backoff factor for fetch retries. |
-| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | implemented | Minimum retry timeout in milliseconds. |
-| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | implemented | Maximum retry timeout in milliseconds. |
-| [`fetchTimeout`](#setting-fetchtimeout) | `int` | implemented | Max time (ms) to wait for an HTTP request. |
-| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | implemented | Warn if a metadata request exceeds this threshold (ms). |
-| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | implemented | Warn if download speed falls below this threshold (KiB/s). |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
-| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | implemented | Control color output in aube's CLI. |
-| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | implemented | Minimum log level to display. |
-| [`useBetaCli`](#setting-usebetacli) | `bool` | implemented | Opt into experimental CLI features. |
-| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | implemented | Install on all workspace packages by default. |
-| [`engineStrict`](#setting-enginestrict) | `bool` | implemented | Fail if a package is incompatible with the current Node version. |
-| [`npmPath`](#setting-npmpath) | `path` | implemented | Path to the npm binary aube should shell out to when needed. |
-| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | implemented | Enforce the `packageManager` field in package.json. |
-| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | implemented | Enforce the exact `packageManager` version from package.json. |
-| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | implemented | Auto-download the specified pnpm version when mismatched. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
-| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | implemented | Only read from the side-effects cache; don't write. |
-| [`unsafePerm`](#setting-unsafeperm) | `bool` | implemented | Drop to a non-root user when running scripts as root. |
-| [`nodeOptions`](#setting-nodeoptions) | `string` | implemented | Options passed to Node.js via NODE_OPTIONS. |
-| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | implemented | Check dependencies before running scripts. |
-| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | implemented | Exit with an error if dependencies have unreviewed build scripts. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
-| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | implemented | Allow all dependency build scripts automatically. |
-| [`nodeVersion`](#setting-nodeversion) | `string` | implemented | Node.js version aube reports when evaluating `engines` checks. |
-| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | implemented | Custom Node.js download mirror URLs. |
-| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | implemented | Version prefix used when installing a package. |
-| [`tag`](#setting-tag) | `string` | implemented | Default dist-tag used by `aube add` without a version. |
-| [`globalDir`](#setting-globaldir) | `path` | implemented | Directory where globally installed packages live. |
-| [`globalBinDir`](#setting-globalbindir) | `path` | implemented | Directory where global binaries are symlinked. |
-| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | implemented | Path to an additional .npmrc file consulted for registry authentication tokens. |
-| [`stateDir`](#setting-statedir) | `path` | implemented | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | implemented | Directory for package metadata and dlx cache. |
-| [`useStderr`](#setting-usestderr) | `bool` | implemented | Write all output to stderr instead of stdout. |
-| [`updateNotifier`](#setting-updatenotifier) | `bool` | implemented | Show an update notification when a newer aube is available. |
-| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | implemented | Create symlinks instead of shims for `.bin` entries. |
-| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | implemented | Disable pnpm's automatic dependency patching database. |
-| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | implemented | Dependency version resolution strategy. |
-| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | implemented | Whether the configured registry returns a `time` field in metadata. |
-| [`extendNodePath`](#setting-extendnodepath) | `bool` | implemented | Set NODE_PATH in command shims. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | implemented | Fast-path check before running a full install. |
-| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | implemented | Scripts that must be present in every workspace project. |
-| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | implemented | Run pre/post scripts automatically when a named script is invoked. |
-| [`scriptShell`](#setting-scriptshell) | `path` | implemented | Shell used to invoke package scripts. |
-| [`shellEmulator`](#setting-shellemulator) | `bool` | implemented | Use a JavaScript bash-like shell to run scripts cross-platform. |
-| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | implemented | How catalog references in package.json are handled by `add`. |
-| [`ci`](#setting-ci) | `bool` | implemented | Explicitly mark the environment as CI. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Summary |
+| --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
+| [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
+| [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
+| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
+| [`symlink`](#setting-symlink) | `bool` | Create symlinks in the virtual store directory. |
+| [`enableModulesDir`](#setting-enablemodulesdir) | `bool` | Write files to the modules directory. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
+| [`virtualStoreDirMaxLength`](#setting-virtualstoredirmaxlength) | `int` | Max length for virtual store directory names. |
+| [`virtualStoreOnly`](#setting-virtualstoreonly) | `bool` | Populate the virtual store without creating top-level symlinks. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
+| [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | Minutes before orphan packages are removed from the virtual store. |
+| [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | Minutes before the dlx cache is considered stale. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
+| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
+| [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | Only allow installs when the store server is running. |
+| [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | Validate package names and versions in the store. |
+| [`httpsProxy`](#setting-httpsproxy) | `url` | Proxy URL for outgoing HTTPS requests. |
+| [`httpProxy`](#setting-httpproxy) | `url` | Proxy URL for outgoing HTTP requests. |
+| [`noProxy`](#setting-noproxy) | `string` | Comma-separated list of domains that bypass the proxy. |
+| [`localAddress`](#setting-localaddress) | `string` | Local interface IP address to bind registry connections to. |
+| [`maxsockets`](#setting-maxsockets) | `int` | Maximum concurrent connections per origin. |
+| [`strictSsl`](#setting-strictssl) | `bool` | Validate SSL certificates for HTTPS requests. |
+| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`gitShallowHosts`](#setting-gitshallowhosts) | `list<string>` | Hosts for which aube performs shallow git clones. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
+| [`fetchRetries`](#setting-fetchretries) | `int` | Number of retry attempts for failed registry fetches. |
+| [`fetchRetryFactor`](#setting-fetchretryfactor) | `int` | Exponential backoff factor for fetch retries. |
+| [`fetchRetryMintimeout`](#setting-fetchretrymintimeout) | `int` | Minimum retry timeout in milliseconds. |
+| [`fetchRetryMaxtimeout`](#setting-fetchretrymaxtimeout) | `int` | Maximum retry timeout in milliseconds. |
+| [`fetchTimeout`](#setting-fetchtimeout) | `int` | Max time (ms) to wait for an HTTP request. |
+| [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | Warn if a metadata request exceeds this threshold (ms). |
+| [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | Warn if download speed falls below this threshold (KiB/s). |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
+| [`color`](#setting-color) | `"auto" \| "always" \| "never"` | Control color output in aube's CLI. |
+| [`loglevel`](#setting-loglevel) | `"debug" \| "info" \| "warn" \| "error" \| "silent"` | Minimum log level to display. |
+| [`useBetaCli`](#setting-usebetacli) | `bool` | Opt into experimental CLI features. |
+| [`recursiveInstall`](#setting-recursiveinstall) | `bool` | Install on all workspace packages by default. |
+| [`engineStrict`](#setting-enginestrict) | `bool` | Fail if a package is incompatible with the current Node version. |
+| [`npmPath`](#setting-npmpath) | `path` | Path to the npm binary aube should shell out to when needed. |
+| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | Enforce the `packageManager` field in package.json. |
+| [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | Enforce the exact `packageManager` version from package.json. |
+| [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | Auto-download the specified pnpm version when mismatched. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
+| [`sideEffectsCacheReadonly`](#setting-sideeffectscachereadonly) | `bool` | Only read from the side-effects cache; don't write. |
+| [`unsafePerm`](#setting-unsafeperm) | `bool` | Drop to a non-root user when running scripts as root. |
+| [`nodeOptions`](#setting-nodeoptions) | `string` | Options passed to Node.js via NODE_OPTIONS. |
+| [`verifyDepsBeforeRun`](#setting-verifydepsbeforerun) | `"install" \| "warn" \| "error" \| "prompt" \| false` | Check dependencies before running scripts. |
+| [`strictDepBuilds`](#setting-strictdepbuilds) | `bool` | Exit with an error if dependencies have unreviewed build scripts. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
+| [`dangerouslyAllowAllBuilds`](#setting-dangerouslyallowallbuilds) | `bool` | Allow all dependency build scripts automatically. |
+| [`nodeVersion`](#setting-nodeversion) | `string` | Node.js version aube reports when evaluating `engines` checks. |
+| [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | Custom Node.js download mirror URLs. |
+| [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | Version prefix used when installing a package. |
+| [`tag`](#setting-tag) | `string` | Default dist-tag used by `aube add` without a version. |
+| [`globalDir`](#setting-globaldir) | `path` | Directory where globally installed packages live. |
+| [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
+| [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
+| [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
+| [`cacheDir`](#setting-cachedir) | `path` | Directory for package metadata and dlx cache. |
+| [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
+| [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
+| [`preferSymlinkedExecutables`](#setting-prefersymlinkedexecutables) | `bool` | Create symlinks instead of shims for `.bin` entries. |
+| [`ignoreCompatibilityDb`](#setting-ignorecompatibilitydb) | `bool` | Disable pnpm's automatic dependency patching database. |
+| [`resolutionMode`](#setting-resolutionmode) | `"highest" \| "time-based" \| "lowest-direct"` | Dependency version resolution strategy. |
+| [`registrySupportsTimeField`](#setting-registrysupportstimefield) | `bool` | Whether the configured registry returns a `time` field in metadata. |
+| [`extendNodePath`](#setting-extendnodepath) | `bool` | Set NODE_PATH in command shims. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`optimisticRepeatInstall`](#setting-optimisticrepeatinstall) | `bool` | Fast-path check before running a full install. |
+| [`requiredScripts`](#setting-requiredscripts) | `list<string>` | Scripts that must be present in every workspace project. |
+| [`enablePrePostScripts`](#setting-enableprepostscripts) | `bool` | Run pre/post scripts automatically when a named script is invoked. |
+| [`scriptShell`](#setting-scriptshell) | `path` | Shell used to invoke package scripts. |
+| [`shellEmulator`](#setting-shellemulator) | `bool` | Use a JavaScript bash-like shell to run scripts cross-platform. |
+| [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | How catalog references in package.json are handled by `add`. |
+| [`ci`](#setting-ci) | `bool` | Explicitly mark the environment as CI. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -141,8 +141,6 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `overrides`
 
 A root-level map of package specs to the versions aube should force them
@@ -156,8 +154,6 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `packageExtensions`
 
 Patches a package's `dependencies`, `peerDependencies`, etc. at resolve
@@ -170,8 +166,6 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `allowedDeprecatedVersions`
 
 Maps a package name to a semver range for which the deprecation warning
@@ -184,8 +178,6 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `updateConfig.ignoreDependencies`
 
 Packages in this list are never bumped by `aube update`, even when a
@@ -197,8 +189,6 @@ Specify architectures for optional dependency installation.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `supportedArchitectures`
 
 Override the current platform/arch/libc triple used to filter optional
@@ -211,8 +201,6 @@ Skip optional dependencies by name.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `ignoredOptionalDependencies`
 
 Named entries are skipped even if their platform/arch matches. Distinct
@@ -224,8 +212,6 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `minimumReleaseAge`
 
 Supply-chain attack mitigation: packages published within the last N
@@ -240,8 +226,6 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `minimumReleaseAgeExclude`
 
 Use for trusted internal packages that need to be rolled out immediately
@@ -254,8 +238,6 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `minimumReleaseAgeStrict`
 
 By default the resolver falls back to the lowest satisfying version when
@@ -268,8 +250,6 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `trustPolicy`
 
 When set to `no-downgrade`, aube accepts and preserves the policy in the
@@ -283,8 +263,6 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `trustPolicyExclude`
 
 Whitelist for `trustPolicy`. Entries skip the downgrade check.
@@ -295,8 +273,6 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `trustPolicyIgnoreAfter`
 
 Useful for pinning very old versions that predate signing infrastructure.
@@ -307,8 +283,6 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `blockExoticSubdeps`
 
 When true, transitive deps referenced via `git+`, `file:`, or direct
@@ -321,8 +295,6 @@ Registry URLs, including scoped registry overrides.
 
 - Type: `object`
 - Default: `{ default = "https://registry.npmjs.org/" }`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `registry`, `@scope:registry`, `//host/:_authToken`, `//host/:_auth`
 
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
@@ -343,8 +315,6 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `hoist`
 
 Controls whether aube populates `node_modules/.aube/node_modules/` —
@@ -373,8 +343,6 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `hoist-workspace-packages`, `hoistWorkspacePackages`
 
 Controls whether workspace packages get their own symlinks in each
@@ -391,8 +359,6 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `hoist-pattern`, `hoistPattern`
 
 Glob list matched against package names. Any non-local package
@@ -414,8 +380,6 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - .npmrc keys: `public-hoist-pattern`, `publicHoistPattern`
 
 Glob list matched against package names. Any non-local package in the
@@ -435,8 +399,6 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `shamefully-hoist`, `shamefullyHoist`
 
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
@@ -450,8 +412,6 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - .npmrc keys: `modulesDir`, `modules-dir`
 
 The project-level directory that holds the top-level `<name>` entries
@@ -476,8 +436,6 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `nodeLinker`
 
 aube defaults to `isolated`, a strict symlink layout under
@@ -492,8 +450,6 @@ Create symlinks in the virtual store directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `symlink`
 
 Accepted for pnpm parity. aube's isolated layout is structurally
@@ -522,8 +478,6 @@ Write files to the modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `enableModulesDir`
 
 When `false`, aube resolves the dependency graph and writes
@@ -539,8 +493,6 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `virtualStoreDir`, `virtual-store-dir`
 
 Relocates the per-project `.aube/<dep>/node_modules/` tree that the
@@ -569,8 +521,6 @@ Max length for virtual store directory names.
 
 - Type: `int`
 - Default: `120 (Linux/macOS), 60 (Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `virtualStoreDirMaxLength`
 
 Caps the number of characters in a single `node_modules/.aube/<dep>`
@@ -588,8 +538,6 @@ Populate the virtual store without creating top-level symlinks.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `virtualStoreOnly`
 
 When `true`, aube still materializes every package into
@@ -608,8 +556,6 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `packageImportMethod`, `package-import-method`
 
 Controls how aube materializes files from the global content-addressable
@@ -629,8 +575,6 @@ Minutes before orphan packages are removed from the virtual store.
 
 - Type: `int`
 - Default: `10080`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `modulesCacheMaxAge`
 
 After each successful install, aube sweeps the per-project
@@ -650,8 +594,6 @@ Minutes before the dlx cache is considered stale.
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `dlx-cache-max-age`, `dlxCacheMaxAge`
 
 Accepted for pnpm parity. `aube dlx` currently installs into a fresh
@@ -667,8 +609,6 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `enableGlobalVirtualStore`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
@@ -684,8 +624,6 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `store-dir`, `storeDir`
 
 Defaults to aube's own store path (`~/.aube-store/v1/files/`). aube does not
@@ -713,8 +651,6 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `verify-store-integrity`, `verifyStoreIntegrity`
 
 aube verifies each package's `integrity` (SHA-512) against the tarball
@@ -734,8 +670,6 @@ Only allow installs when the store server is running.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `use-running-store-server`, `useRunningStoreServer`
 
 Accepted for pnpm parity. aube has no long-running store-daemon
@@ -751,8 +685,6 @@ Validate package names and versions in the store.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `strict-store-pkg-content-check`, `strictStorePkgContentCheck`
 
 After each registry tarball is imported, aube reads the freshly stored
@@ -779,8 +711,6 @@ Proxy URL for outgoing HTTPS requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `https-proxy`, `httpsProxy`, `proxy`
 
 Forwards every HTTPS registry fetch through the given proxy URL.
@@ -794,8 +724,6 @@ Proxy URL for outgoing HTTP requests.
 
 - Type: `url`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `http-proxy`, `httpProxy`
 
 HTTP counterpart to `httpsProxy`. Resolution mirrors pnpm:
@@ -810,8 +738,6 @@ Comma-separated list of domains that bypass the proxy.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `noproxy`, `noProxy`, `no-proxy`
 
 Passed through to `reqwest::NoProxy::from_string` verbatim, so
@@ -825,8 +751,6 @@ Local interface IP address to bind registry connections to.
 
 - Type: `string`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `local-address`, `localAddress`
 
 Used on multi-homed hosts where outbound traffic must leave a
@@ -839,8 +763,6 @@ Maximum concurrent connections per origin.
 
 - Type: `int`
 - Default: `networkConcurrency x 3`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `maxsockets`
 
 Plumbed into reqwest's `pool_max_idle_per_host`. This is the
@@ -854,8 +776,6 @@ Validate SSL certificates for HTTPS requests.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `strict-ssl`, `strictSsl`
 
 Defaults to `true`. Setting `strict-ssl=false` disables TLS
@@ -872,8 +792,6 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `lockfile`
 
 Controls whether aube reads and writes a lockfile during install. When
@@ -898,8 +816,6 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `prefer-frozen-lockfile`
 
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
@@ -916,8 +832,6 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `lockfileIncludeTarballUrl`, `lockfile-include-tarball-url`
 
 When true, aube's lockfile writer records the registry tarball URL in
@@ -945,8 +859,6 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - .npmrc keys: `exclude-links-from-lockfile`, `excludeLinksFromLockfile`
 
 When true, `link:` dependencies are omitted from the lockfile's
@@ -967,8 +879,6 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `gitBranchLockfile`
 
 When enabled, aube writes the lockfile to `aube-lock.<branch>.yaml`
@@ -996,8 +906,6 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `mergeGitBranchLockfilesBranchPattern`
 
 Complements `gitBranchLockfile`. Accepts a list of glob patterns. When
@@ -1028,8 +936,6 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `peersSuffixMaxLength`
 
 Caps the length of the peer-ID suffix appended to a `dep_path` in the
@@ -1050,8 +956,6 @@ Hosts for which aube performs shallow git clones.
 
 - Type: `list<string>`
 - Default: `["github.com", "gist.github.com", "gitlab.com", "bitbucket.com", "bitbucket.org"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `git-shallow-hosts`, `gitShallowHosts`
 
 Consulted by `aube-store::git_shallow_clone` when cloning a git
@@ -1075,8 +979,6 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `network-concurrency`, `networkConcurrency`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
@@ -1098,8 +1000,6 @@ Number of retry attempts for failed registry fetches.
 
 - Type: `int`
 - Default: `2`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retries`, `fetchRetries`
 
 Number of *additional* attempts the registry client makes after a
@@ -1118,8 +1018,6 @@ Exponential backoff factor for fetch retries.
 
 - Type: `int`
 - Default: `10`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retry-factor`, `fetchRetryFactor`
 
 Multiplier used between retry attempts. Attempt `n` waits
@@ -1133,8 +1031,6 @@ Minimum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retry-mintimeout`, `fetchRetryMintimeout`
 
 Lower bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1145,8 +1041,6 @@ Maximum retry timeout in milliseconds.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetch-retry-maxtimeout`, `fetchRetryMaxtimeout`
 
 Upper bound on the computed retry backoff. See `fetchRetryFactor`.
@@ -1157,8 +1051,6 @@ Max time (ms) to wait for an HTTP request.
 
 - Type: `int`
 - Default: `60000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetchTimeout`
 
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
@@ -1172,8 +1064,6 @@ Warn if a metadata request exceeds this threshold (ms).
 
 - Type: `int`
 - Default: `10000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetchWarnTimeoutMs`
 
 Observability threshold for registry *metadata* requests (packument,
@@ -1193,8 +1083,6 @@ Warn if download speed falls below this threshold (KiB/s).
 
 - Type: `int`
 - Default: `50`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `fetchMinSpeedKiBps`
 
 Observability threshold for *tarball* downloads. When a tarball
@@ -1216,8 +1104,6 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `auto-install-peers`, `autoInstallPeers`
 
 When true (the default), missing peer dependencies are auto-installed
@@ -1231,8 +1117,6 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `dedupePeerDependents`
 
 When true (the default), aube collapses packages that landed at
@@ -1249,8 +1133,6 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `dedupePeers`
 
 When true, lockfile peer suffixes emit `(18.2.0)` instead of the
@@ -1265,8 +1147,6 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `strict-peer-dependencies`, `strictPeerDependencies`
 
 When true, any unmet peer dependency (missing, or resolved to a version
@@ -1283,8 +1163,6 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `resolvePeersFromWorkspaceRoot`
 
 When true (the default), an unresolved peer falls back to the root
@@ -1300,8 +1178,6 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `peerDependencyRules.ignoreMissing`
 
 Glob list of peer dependency names whose "missing required peer" warning
@@ -1318,8 +1194,6 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `peerDependencyRules.allowedVersions`
 
 Map of peer selector to an additional semver range. Keys are either a
@@ -1337,8 +1211,6 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `peerDependencyRules.allowAny`
 
 Glob list of peer dependency names whose semver check should be
@@ -1356,8 +1228,6 @@ Control color output in aube's CLI.
 
 - Type: `"auto" | "always" | "never"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `color`
 
 `--color` / `--no-color`, `color=always|never|auto` in `.npmrc`, and `NPM_CONFIG_COLOR` all resolve before output initializes. The resolved choice is translated into `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR` so aube, diagnostics, progress rendering, and child processes agree.
@@ -1368,8 +1238,6 @@ Minimum log level to display.
 
 - Type: `"debug" | "info" | "warn" | "error" | "silent"`
 - Default: `"warn"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `loglevel`
 
 Controls aube's tracing filter. `-v` / `--verbose` is a shortcut for `debug`; `--silent`, `--reporter=silent`, and `loglevel=silent` suppress aube's own non-error stderr output. Also readable from `.npmrc` `loglevel`. CLI flags override `.npmrc`.
@@ -1380,8 +1248,6 @@ Opt into experimental CLI features.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `useBetaCli`
 
 Accepted from env and `.npmrc` for pnpm parity. aube currently has no beta-gated commands, so the setting is a no-op after validation.
@@ -1392,8 +1258,6 @@ Install on all workspace packages by default.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `recursiveInstall`
 
 When true, workspace installs resolve and link all importers by default. Set to false to opt out of implicit workspace-wide install behavior; explicit `--filter` / `--recursive` still wins.
@@ -1404,8 +1268,6 @@ Fail if a package is incompatible with the current Node version.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `engine-strict`, `engineStrict`
 
 When on, an `engines.node` mismatch on the root project or any dependency fails the install. When off, mismatches are warnings only.
@@ -1416,8 +1278,6 @@ Path to the npm binary aube should shell out to when needed.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `npmPath`
 
 Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`, `token`, `whoami`) when configured. Without it, aube keeps the explicit `use npm` error.
@@ -1428,8 +1288,6 @@ Enforce the `packageManager` field in package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `packageManagerStrict`
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
@@ -1440,8 +1298,6 @@ Enforce the exact `packageManager` version from package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `packageManagerStrictVersion`
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
@@ -1452,8 +1308,6 @@ Auto-download the specified pnpm version when mismatched.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `managePackageManagerVersions`
 
 Accepted for pnpm parity. aube does not download or re-exec other package-manager versions; when exact version enforcement is enabled, mismatches are reported instead.
@@ -1466,8 +1320,6 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `ignore-scripts`, `ignoreScripts`
 
 aube already skips dependency install scripts by default (security-first).
@@ -1486,8 +1338,6 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `child-concurrency`, `childConcurrency`
 
 Caps how many dependency lifecycle scripts run in parallel during the
@@ -1507,8 +1357,6 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `side-effects-cache`, `sideEffectsCache`
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
@@ -1530,8 +1378,6 @@ Only read from the side-effects cache; don't write.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `sideEffectsCacheReadonly`
 
 When true, aube may restore allowlisted dependency build output from the
@@ -1543,8 +1389,6 @@ Drop to a non-root user when running scripts as root.
 
 - Type: `bool`
 - Default: `false (as root), true (otherwise)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `unsafePerm`
 
 aube exports the resolved value to lifecycle and `run` scripts as
@@ -1557,8 +1401,6 @@ Options passed to Node.js via NODE_OPTIONS.
 
 - Type: `string`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `nodeOptions`
 
 When set in `.npmrc`, aube exports the value as `NODE_OPTIONS` for
@@ -1571,8 +1413,6 @@ Check dependencies before running scripts.
 
 - Type: `"install" | "warn" | "error" | "prompt" | false`
 - Default: `"install"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `verifyDepsBeforeRun`
 
 Controls `run`, lifecycle shortcuts, `exec`, and implicit script commands.
@@ -1586,8 +1426,6 @@ Exit with an error if dependencies have unreviewed build scripts.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `strictDepBuilds`
 
 aube never runs dependency lifecycle scripts unless the package is
@@ -1604,8 +1442,6 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `allowBuilds`
 
 Per-package allowlist for dependency lifecycle scripts. Read from
@@ -1625,8 +1461,6 @@ Allow all dependency build scripts automatically.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `dangerouslyAllowAllBuilds`
 
 Opt-out escape hatch for the `allowBuilds` allowlist: when set, every
@@ -1647,8 +1481,6 @@ Node.js version aube reports when evaluating `engines` checks.
 
 - Type: `string`
 - Default: `` output of `node -v` with the leading `v` stripped ``
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `node-version`, `nodeVersion`
 
 Paired with `engineStrict`. Set this in .npmrc to pin the Node version engines checks validate against, rather than probing `node --version` at install time.
@@ -1659,8 +1491,6 @@ Custom Node.js download mirror URLs.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `nodeDownloadMirrors`
 
 Accepted for pnpm config parity. aube does not download Node.js itself,
@@ -1675,8 +1505,6 @@ Version prefix used when installing a package.
 
 - Type: `"^" | "~" | ""`
 - Default: `"^"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `save-prefix`, `savePrefix`
 
 Resolved from `.npmrc`. `--save-exact` overrides to empty prefix.
@@ -1687,8 +1515,6 @@ Default dist-tag used by `aube add` without a version.
 
 - Type: `string`
 - Default: `"latest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `tag`
 
 Resolved from `.npmrc`. Used by `aube add` when no version or dist-tag is specified.
@@ -1699,8 +1525,6 @@ Directory where globally installed packages live.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `globalDir`
 
 Overrides the directory where globally installed packages live. Falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1711,8 +1535,6 @@ Directory where global binaries are symlinked.
 
 - Type: `path`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `globalBinDir`
 
 Overrides the directory where global binaries are symlinked. Independent of `globalDir`; falls back to `AUBE_HOME` / `PNPM_HOME` / platform default.
@@ -1723,8 +1545,6 @@ Path to an additional .npmrc file consulted for registry authentication tokens.
 
 - Type: `path`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `npmrc-auth-file`, `npmrcAuthFile`
 
 Points at an extra `.npmrc`-formatted file that aube reads *after*
@@ -1752,8 +1572,6 @@ Directory for aube install-state files.
 
 - Type: `path`
 - Default: `.aube/.state`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `stateDir`
 
 Overrides the directory for install state tracking. Defaults to `.aube/.state` relative to the project root.
@@ -1764,8 +1582,6 @@ Directory for package metadata and dlx cache.
 
 - Type: `path`
 - Default: `~/.cache/aube`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `cache-dir`, `cacheDir`
 
 Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path.
@@ -1776,8 +1592,6 @@ Write all output to stderr instead of stdout.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `useStderr`
 
 Redirects stdout to stderr for the process lifetime. Resolved from `.npmrc` or the `--use-stderr` CLI flag.
@@ -1788,8 +1602,6 @@ Show an update notification when a newer aube is available.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `updateNotifier`
 
 After a successful `install`, `add`, or `update`, aube fetches
@@ -1809,8 +1621,6 @@ Create symlinks instead of shims for `.bin` entries.
 
 - Type: `bool`
 - Default: `true (POSIX hoisted)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `preferSymlinkedExecutables`
 
 POSIX only. Default (unset or `true`) creates a plain symlink from
@@ -1828,8 +1638,6 @@ Disable pnpm's automatic dependency patching database.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `ignoreCompatibilityDb`
 
 Accepted for pnpm config parity. pnpm ships a built-in compatibility
@@ -1843,8 +1651,6 @@ Dependency version resolution strategy.
 
 - Type: `"highest" | "time-based" | "lowest-direct"`
 - Default: `"highest"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `resolution-mode`, `resolutionMode`
 
 Controls how aube chooses versions during resolution. `highest` picks
@@ -1859,8 +1665,6 @@ Whether the configured registry returns a `time` field in metadata.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `registry-supports-time-field`, `registrySupportsTimeField`
 
 When `false` (the default, matching pnpm and npmjs.org's behavior),
@@ -1886,8 +1690,6 @@ Set NODE_PATH in command shims.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `extendNodePath`
 
 When `true` (default), aube-generated `.bin` shims export
@@ -1905,8 +1707,6 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `deploy-all-files`, `deployAllFiles`
 
 When true, `aube deploy` copies every file in the source workspace
@@ -1925,8 +1725,6 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `dedupe-direct-deps`, `dedupeDirectDeps`
 
 When true, the linker skips creating a `node_modules/<name>` symlink in a
@@ -1945,8 +1743,6 @@ Fast-path check before running a full install.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `optimisticRepeatInstall`
 
 When `true` (default), `aube run` / `aube exec` / `aube start` /
@@ -1964,8 +1760,6 @@ Scripts that must be present in every workspace project.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `requiredScripts`
 
 During install, aube verifies that the root package and every discovered
@@ -1977,8 +1771,6 @@ Run pre/post scripts automatically when a named script is invoked.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `enablePrePostScripts`
 
 Controls whether `aube run build` also runs `prebuild` before `build`
@@ -1990,8 +1782,6 @@ Shell used to invoke package scripts.
 
 - Type: `path`
 - Default: `null (uses /bin/sh on Unix, cmd on Windows)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `scriptShell`
 
 Overrides the shell executable used for lifecycle and `aube run`
@@ -2003,8 +1793,6 @@ Use a JavaScript bash-like shell to run scripts cross-platform.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `shellEmulator`
 
 Accepted for pnpm config parity. aube does not embed pnpm's JavaScript
@@ -2017,8 +1805,6 @@ How catalog references in package.json are handled by `add`.
 
 - Type: `"manual" | "strict" | "prefer"`
 - Default: `"manual"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `catalogMode`
 
 `manual` (the default) writes whatever range `aube add` resolved, even
@@ -2042,8 +1828,6 @@ Explicitly mark the environment as CI.
 
 - Type: `bool`
 - Default: `auto-detected`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `ci`
 
 aube detects CI via `env::var("CI").is_ok()` in two places:
@@ -2060,8 +1844,6 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `cleanupUnusedCatalogs`
 
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
@@ -2080,8 +1862,6 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - .npmrc keys: `link-concurrency`, `linkConcurrency`
 
 Caps the dedicated linker worker pool used for filesystem-heavy
@@ -2104,8 +1884,6 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `aubeNoLock`, `aube-no-lock`
 
 aube takes an advisory lock on `node_modules/` at the start of every
@@ -2136,8 +1914,6 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - .npmrc keys: `aubeNoAutoInstall`, `aube-no-auto-install`
 
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs

--- a/docs/settings/workspace-yaml.md
+++ b/docs/settings/workspace-yaml.md
@@ -16,59 +16,59 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-49 settings are listed here. 49 are currently implemented.
+49 settings are listed here.
 
-| Setting | Type | Status | Summary |
-| --- | --- | --- | --- |
-| [`overrides`](#setting-overrides) | `object` | implemented | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
-| [`packageExtensions`](#setting-packageextensions) | `object` | implemented | Extend existing package definitions with additional information. |
-| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | implemented | Mute deprecation warnings for specific package versions. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | implemented | List of packages to ignore during update checks. |
-| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | implemented | Delay installation of newly published versions (minutes). |
-| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | implemented | Packages exempt from the minimumReleaseAge requirement. |
-| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | implemented | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | implemented | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | implemented | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | implemented | Ignore trust policy for packages older than this age (minutes). |
-| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | implemented | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
-| [`hoist`](#setting-hoist) | `bool` | implemented | Hoist all dependencies to the hidden modules directory. |
-| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | implemented | Symlink workspace packages into node_modules. |
-| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | implemented | Packages to hoist to the hidden modules directory. |
-| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | implemented | Packages to hoist directly to the root node_modules. |
-| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | implemented | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
-| [`modulesDir`](#setting-modulesdir) | `path` | implemented | Directory to install dependencies into. |
-| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | implemented | Strategy for linking Node packages into node_modules. |
-| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | implemented | Directory with links to the store. |
-| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | implemented | Method for importing packages from the store into node_modules. |
-| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | implemented | Use a per-user virtual store for all projects. |
-| [`storeDir`](#setting-storedir) | `path` | implemented | Location where packages are saved on disk (content-addressable store). |
-| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | implemented | Check store file integrity before linking. |
-| [`lockfile`](#setting-lockfile) | `bool` | implemented | Read and generate aube-lock.yaml. |
-| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | implemented | Perform a headless install if the lockfile already satisfies package.json. |
-| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | implemented | Add the full tarball URL to each lockfile entry. |
-| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | implemented | Skip local `link:` dependencies when writing the lockfile. |
-| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | implemented | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
-| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | implemented | Branch-name glob list for auto-merging branch lockfiles. |
-| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | implemented | Max length of the peer-ID suffix in lockfile dep_paths. |
-| [`networkConcurrency`](#setting-networkconcurrency) | `int` | implemented | Maximum concurrent HTTP(S) requests. |
-| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | implemented | Automatically install missing peer dependencies. |
-| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | implemented | Deduplicate packages that have peer dependencies. |
-| [`dedupePeers`](#setting-dedupepeers) | `bool` | implemented | Use version-only identifiers for peer suffixes in the lockfile. |
-| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | implemented | Fail if peer dependencies are missing or invalid. |
-| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | implemented | Use root workspace dependencies for peer resolution. |
-| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | implemented | Suppress warnings for specific missing peer dependencies. |
-| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | implemented | Override the accepted semver range for specific peer dependencies. |
-| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | implemented | Allow any peer version to resolve, bypassing semver checks. |
-| [`ignoreScripts`](#setting-ignorescripts) | `bool` | implemented | Skip all lifecycle scripts in package.json. |
-| [`childConcurrency`](#setting-childconcurrency) | `int` | implemented | Maximum number of concurrent script-executing child processes. |
-| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | implemented | Cache the results of install hooks. |
-| [`allowBuilds`](#setting-allowbuilds) | `object` | implemented | Explicitly allow or disallow script execution per package. |
-| [`deployAllFiles`](#setting-deployallfiles) | `bool` | implemented | Copy all files when deploying a workspace package. |
-| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | implemented | Skip symlinking workspace-root dependencies if identical across packages. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | implemented | Remove unused catalog entries during install. |
-| [`linkConcurrency`](#setting-linkconcurrency) | `int` | implemented | Maximum concurrent package materialization/linking tasks. |
-| [`aubeNoLock`](#setting-aubenolock) | `bool` | implemented | Disable aube's project-level advisory lock. |
-| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | implemented | Skip the auto-install staleness check in `aube run` / `aube exec`. |
+| Setting | Type | Summary |
+| --- | --- | --- |
+| [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |
+| [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
+| [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
+| [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
+| [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
+| [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
+| [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
+| [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
+| [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
+| [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
+| [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
+| [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
+| [`modulesDir`](#setting-modulesdir) | `path` | Directory to install dependencies into. |
+| [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
+| [`virtualStoreDir`](#setting-virtualstoredir) | `path` | Directory with links to the store. |
+| [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
+| [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
+| [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
+| [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
+| [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
+| [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
+| [`excludeLinksFromLockfile`](#setting-excludelinksfromlockfile) | `bool` | Skip local `link:` dependencies when writing the lockfile. |
+| [`gitBranchLockfile`](#setting-gitbranchlockfile) | `bool` | Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml). |
+| [`mergeGitBranchLockfilesBranchPattern`](#setting-mergegitbranchlockfilesbranchpattern) | `list<string>` | Branch-name glob list for auto-merging branch lockfiles. |
+| [`peersSuffixMaxLength`](#setting-peerssuffixmaxlength) | `int` | Max length of the peer-ID suffix in lockfile dep_paths. |
+| [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
+| [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
+| [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
+| [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
+| [`strictPeerDependencies`](#setting-strictpeerdependencies) | `bool` | Fail if peer dependencies are missing or invalid. |
+| [`resolvePeersFromWorkspaceRoot`](#setting-resolvepeersfromworkspaceroot) | `bool` | Use root workspace dependencies for peer resolution. |
+| [`peerDependencyRules.ignoreMissing`](#setting-peerdependencyrules-ignoremissing) | `list<string>` | Suppress warnings for specific missing peer dependencies. |
+| [`peerDependencyRules.allowedVersions`](#setting-peerdependencyrules-allowedversions) | `object` | Override the accepted semver range for specific peer dependencies. |
+| [`peerDependencyRules.allowAny`](#setting-peerdependencyrules-allowany) | `list<string>` | Allow any peer version to resolve, bypassing semver checks. |
+| [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
+| [`childConcurrency`](#setting-childconcurrency) | `int` | Maximum number of concurrent script-executing child processes. |
+| [`sideEffectsCache`](#setting-sideeffectscache) | `bool` | Cache the results of install hooks. |
+| [`allowBuilds`](#setting-allowbuilds) | `object` | Explicitly allow or disallow script execution per package. |
+| [`deployAllFiles`](#setting-deployallfiles) | `bool` | Copy all files when deploying a workspace package. |
+| [`dedupeDirectDeps`](#setting-dedupedirectdeps) | `bool` | Skip symlinking workspace-root dependencies if identical across packages. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
+| [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
+| [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
+| [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
 
 ## Dependency Resolution
 
@@ -78,8 +78,6 @@ Instruct aube to override any dependency in the dependency graph, including peer
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `overrides`
 
 A root-level map of package specs to the versions aube should force them
@@ -93,8 +91,6 @@ Extend existing package definitions with additional information.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `packageExtensions`
 
 Patches a package's `dependencies`, `peerDependencies`, etc. at resolve
@@ -107,8 +103,6 @@ Mute deprecation warnings for specific package versions.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `allowedDeprecatedVersions`
 
 Maps a package name to a semver range for which the deprecation warning
@@ -121,8 +115,6 @@ List of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `updateConfig.ignoreDependencies`
 
 Packages in this list are never bumped by `aube update`, even when a
@@ -134,8 +126,6 @@ Delay installation of newly published versions (minutes).
 
 - Type: `int`
 - Default: `1440`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `minimumReleaseAge`
 
 Supply-chain attack mitigation: packages published within the last N
@@ -150,8 +140,6 @@ Packages exempt from the minimumReleaseAge requirement.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `minimumReleaseAgeExclude`
 
 Use for trusted internal packages that need to be rolled out immediately
@@ -164,8 +152,6 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `minimumReleaseAgeStrict`
 
 By default the resolver falls back to the lowest satisfying version when
@@ -178,8 +164,6 @@ Behavior when a package's trust level decreases between installs.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `trustPolicy`
 
 When set to `no-downgrade`, aube accepts and preserves the policy in the
@@ -193,8 +177,6 @@ Packages exempt from trust policy checks.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `trustPolicyExclude`
 
 Whitelist for `trustPolicy`. Entries skip the downgrade check.
@@ -205,8 +187,6 @@ Ignore trust policy for packages older than this age (minutes).
 
 - Type: `int`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `trustPolicyIgnoreAfter`
 
 Useful for pinning very old versions that predate signing infrastructure.
@@ -217,8 +197,6 @@ Restrict transitive dependencies to trusted sources (registries, not git/tarball
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `blockExoticSubdeps`
 
 When true, transitive deps referenced via `git+`, `file:`, or direct
@@ -233,8 +211,6 @@ Hoist all dependencies to the hidden modules directory.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `hoist`
 
 Controls whether aube populates `node_modules/.aube/node_modules/` —
@@ -263,8 +239,6 @@ Symlink workspace packages into node_modules.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `hoistWorkspacePackages`
 
 Controls whether workspace packages get their own symlinks in each
@@ -281,8 +255,6 @@ Packages to hoist to the hidden modules directory.
 
 - Type: `list<string>`
 - Default: `["*"]`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `hoistPattern`
 
 Glob list matched against package names. Any non-local package
@@ -304,8 +276,6 @@ Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
 - Default: `[]`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - Workspace YAML keys: `publicHoistPattern`
 
 Glob list matched against package names. Any non-local package in the
@@ -325,8 +295,6 @@ Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `shamefullyHoist`
 
 Emulates npm's flat `node_modules` layout. Enables phantom dep bugs by
@@ -340,8 +308,6 @@ Directory to install dependencies into.
 
 - Type: `path`
 - Default: `"node_modules"`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - Workspace YAML keys: `modulesDir`
 
 The project-level directory that holds the top-level `<name>` entries
@@ -366,8 +332,6 @@ Strategy for linking Node packages into node_modules.
 
 - Type: `"isolated" | "hoisted" | "pnp"`
 - Default: `"isolated"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `nodeLinker`
 
 aube defaults to `isolated`, a strict symlink layout under
@@ -382,8 +346,6 @@ Directory with links to the store.
 
 - Type: `path`
 - Default: `"node_modules/.aube"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `virtualStoreDir`
 
 Relocates the per-project `.aube/<dep>/node_modules/` tree that the
@@ -412,8 +374,6 @@ Method for importing packages from the store into node_modules.
 
 - Type: `"auto" | "hardlink" | "copy" | "clone" | "clone-or-copy"`
 - Default: `"auto"`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `packageImportMethod`
 
 Controls how aube materializes files from the global content-addressable
@@ -433,8 +393,6 @@ Use a per-user virtual store for all projects.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `enableGlobalVirtualStore`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
@@ -450,8 +408,6 @@ Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
 - Default: `~/.aube-store/v1/files/`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `storeDir`
 
 Defaults to aube's own store path (`~/.aube-store/v1/files/`). aube does not
@@ -479,8 +435,6 @@ Check store file integrity before linking.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `verifyStoreIntegrity`
 
 aube verifies each package's `integrity` (SHA-512) against the tarball
@@ -502,8 +456,6 @@ Read and generate aube-lock.yaml.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `lockfile`
 
 Controls whether aube reads and writes a lockfile during install. When
@@ -528,8 +480,6 @@ Perform a headless install if the lockfile already satisfies package.json.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `preferFrozenLockfile`
 
 aube's default outside CI. Maps to `FrozenMode::Prefer` in
@@ -546,8 +496,6 @@ Add the full tarball URL to each lockfile entry.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `lockfileIncludeTarballUrl`
 
 When true, aube's lockfile writer records the registry tarball URL in
@@ -575,8 +523,6 @@ Skip local `link:` dependencies when writing the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-13`
 - Workspace YAML keys: `excludeLinksFromLockfile`
 
 When true, `link:` dependencies are omitted from the lockfile's
@@ -597,8 +543,6 @@ Generate branch-specific lockfile names (aube-lock.&lt;branch&gt;.yaml).
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `gitBranchLockfile`
 
 When enabled, aube writes the lockfile to `aube-lock.<branch>.yaml`
@@ -626,8 +570,6 @@ Branch-name glob list for auto-merging branch lockfiles.
 
 - Type: `list<string>`
 - Default: `null`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `mergeGitBranchLockfilesBranchPattern`
 
 Complements `gitBranchLockfile`. Accepts a list of glob patterns. When
@@ -658,8 +600,6 @@ Max length of the peer-ID suffix in lockfile dep_paths.
 
 - Type: `int`
 - Default: `1000`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peersSuffixMaxLength`
 
 Caps the length of the peer-ID suffix appended to a `dep_path` in the
@@ -680,8 +620,6 @@ Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
 - Default: `128 (tarballs), 64 (packuments)`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `networkConcurrency`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
@@ -705,8 +643,6 @@ Automatically install missing peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `autoInstallPeers`
 
 When true (the default), missing peer dependencies are auto-installed
@@ -720,8 +656,6 @@ Deduplicate packages that have peer dependencies.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `dedupePeerDependents`
 
 When true (the default), aube collapses packages that landed at
@@ -738,8 +672,6 @@ Use version-only identifiers for peer suffixes in the lockfile.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `dedupePeers`
 
 When true, lockfile peer suffixes emit `(18.2.0)` instead of the
@@ -754,8 +686,6 @@ Fail if peer dependencies are missing or invalid.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `strictPeerDependencies`
 
 When true, any unmet peer dependency (missing, or resolved to a version
@@ -772,8 +702,6 @@ Use root workspace dependencies for peer resolution.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `resolvePeersFromWorkspaceRoot`
 
 When true (the default), an unresolved peer falls back to the root
@@ -789,8 +717,6 @@ Suppress warnings for specific missing peer dependencies.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peerDependencyRules.ignoreMissing`
 
 Glob list of peer dependency names whose "missing required peer" warning
@@ -807,8 +733,6 @@ Override the accepted semver range for specific peer dependencies.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peerDependencyRules.allowedVersions`
 
 Map of peer selector to an additional semver range. Keys are either a
@@ -826,8 +750,6 @@ Allow any peer version to resolve, bypassing semver checks.
 
 - Type: `list<string>`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `peerDependencyRules.allowAny`
 
 Glob list of peer dependency names whose semver check should be
@@ -845,8 +767,6 @@ Skip all lifecycle scripts in package.json.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `ignoreScripts`
 
 aube already skips dependency install scripts by default (security-first).
@@ -865,8 +785,6 @@ Maximum number of concurrent script-executing child processes.
 
 - Type: `int`
 - Default: `5`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `childConcurrency`
 
 Caps how many dependency lifecycle scripts run in parallel during the
@@ -886,8 +804,6 @@ Cache the results of install hooks.
 
 - Type: `bool`
 - Default: `true`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `sideEffectsCache`
 
 When an allowlisted dependency runs lifecycle scripts, aube snapshots
@@ -909,8 +825,6 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `allowBuilds`
 
 Per-package allowlist for dependency lifecycle scripts. Read from
@@ -932,8 +846,6 @@ Copy all files when deploying a workspace package.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `deployAllFiles`
 
 When true, `aube deploy` copies every file in the source workspace
@@ -952,8 +864,6 @@ Skip symlinking workspace-root dependencies if identical across packages.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `dedupeDirectDeps`
 
 When true, the linker skips creating a `node_modules/<name>` symlink in a
@@ -972,8 +882,6 @@ Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `cleanupUnusedCatalogs`
 
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
@@ -992,8 +900,6 @@ Maximum concurrent package materialization/linking tasks.
 
 - Type: `int`
 - Default: `platform-specific`
-- Status: implemented
-- Added to registry: `2026-04-17`
 - Workspace YAML keys: `linkConcurrency`
 
 Caps the dedicated linker worker pool used for filesystem-heavy
@@ -1016,8 +922,6 @@ Disable aube's project-level advisory lock.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `aubeNoLock`
 
 aube takes an advisory lock on `node_modules/` at the start of every
@@ -1048,8 +952,6 @@ Skip the auto-install staleness check in `aube run` / `aube exec`.
 
 - Type: `bool`
 - Default: `false`
-- Status: implemented
-- Added to registry: `2026-04-12`
 - Workspace YAML keys: `aubeNoAutoInstall`
 
 `aube run <script>` normally checks `.aube/.state/install-state.json` and auto-installs


### PR DESCRIPTION
## Summary

- Every setting in `settings.toml` is now `implemented = true`, so the field is no-op ceremony. Strip it — along with the `since` date — from the registry, `SettingMeta`, `build.rs`, the docs generator, and the accessor audit, then regenerate `docs/settings/*.md`.
- Remove the `Pre-1.0: pnpm parity` section from `CLAUDE.md` — those rules were for the parity push, which is landing now.
- Skip empty source rows in generated settings pages so individual entries stop emitting `- CLI flags: none` / `- .npmrc keys: none` noise.

## Notes for reviewers

- No behavior change — `aube` does not read either of the removed fields at runtime. They were only consumed by the docs generator (Status column / "Added to registry" line) and the accessor audit's `implemented` filter.
- The accessor audit test was renamed to `every_setting_has_a_typed_accessor_caller` now that `implemented` no longer exists; the check itself is the same (filter out `typedAccessorUnused = true`, require a `resolved::<name>` caller).
- `docs/settings/*.md` regenerated via `cargo run -p aube-settings --bin generate-settings-docs`.

## Test plan

- [x] `cargo test -p aube-settings` (all 40 tests pass, including the accessor audit)
- [x] `cargo clippy --all-targets -- -D warnings` is clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to settings metadata/schema, docs generation output, and tests; no runtime settings behavior is altered.
> 
> **Overview**
> Drops the transitional `implemented` and `since` fields from `settings.toml` and the generated `SettingMeta`, simplifying the build-time metadata emission in `aube-settings`.
> 
> Updates the settings docs generator to remove the *status* column/lines and to omit empty source rows, and adjusts the accessor-audit test to apply to all settings (unless `typedAccessorUnused = true`).
> 
> Cleans up developer/docs text (`CLAUDE.md`, configuration docs) and regenerates `docs/settings/*` to match the new output format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d16fb4981d198bc38b3b9122a1ee7aa91f69ce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->