### PR TITLE
lockfile(npm): resolve peer deps when installing from package-lock.json

### DIFF
--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -55,6 +55,29 @@ struct RawNpmPackage {
     dev_dependencies: BTreeMap<String, String>,
     #[serde(default)]
     optional_dependencies: BTreeMap<String, String>,
+    /// npm v7+ records `peerDependencies` verbatim on each package
+    /// entry (pulled straight from the package's own `package.json`
+    /// at lockfile-write time). The flat npm layout relies on peers
+    /// being auto-installed into *some* ancestor `node_modules/` so
+    /// Node's upward walk finds them, but aube's isolated layout
+    /// wants them as explicit siblings — without this field, the
+    /// resolver's peer-context pass has nothing to work with on the
+    /// lockfile-driven install path and peers silently go missing
+    /// from `.aube/<dep_path>/node_modules/`.
+    #[serde(default)]
+    peer_dependencies: BTreeMap<String, String>,
+    #[serde(default)]
+    peer_dependencies_meta: BTreeMap<String, RawNpmPeerDepMeta>,
+}
+
+/// `peerDependenciesMeta` value — only `optional` is meaningful to
+/// us today (matches pnpm's model). Other fields that might appear
+/// (`description`, etc.) are preserved only as far as serde's
+/// `deny_unknown_fields` stays off.
+#[derive(Debug, Clone, Default, Deserialize)]
+struct RawNpmPeerDepMeta {
+    #[serde(default)]
+    optional: bool,
 }
 
 /// Parse a package-lock.json or npm-shrinkwrap.json file into a LockfileGraph.
@@ -157,6 +180,27 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             None
         };
 
+        // Peer fields are copied verbatim from the lockfile entry.
+        // Downstream (`aube-resolver::apply_peer_contexts`) reads
+        // these two maps to decide which packages need a peer-context
+        // suffix and which sibling symlinks to create in the isolated
+        // virtual store. An npm lockfile without these fields
+        // populated here would silently produce a tree where
+        // peer-dependent packages can't find their peers at runtime.
+        let peer_dependencies = entry.peer_dependencies.clone();
+        let peer_dependencies_meta: BTreeMap<String, crate::PeerDepMeta> = entry
+            .peer_dependencies_meta
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    crate::PeerDepMeta {
+                        optional: v.optional,
+                    },
+                )
+            })
+            .collect();
+
         graph.packages.insert(
             dep_path.clone(),
             LockedPackage {
@@ -164,6 +208,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 version,
                 integrity: entry.integrity.clone(),
                 dependencies: deps,
+                peer_dependencies,
+                peer_dependencies_meta,
                 dep_path,
                 alias_of,
                 tarball_url,
@@ -510,6 +556,16 @@ pub fn write(
             None
         };
 
+        // Round-trip `peerDependencies` so a subsequent read of the
+        // rewritten lockfile still feeds the peer-context pass. Values
+        // are the declared peer ranges; they never carry the peer
+        // suffix the snapshot side uses, so no re-encoding is needed.
+        let peer_deps: BTreeMap<&str, &str> = pkg
+            .peer_dependencies
+            .iter()
+            .map(|(n, v)| (n.as_str(), v.as_str()))
+            .collect();
+
         packages.insert(
             install_path.clone(),
             WriteNpmPackage {
@@ -518,6 +574,7 @@ pub fn write(
                 resolved,
                 integrity: pkg.integrity.as_deref(),
                 dependencies: deps,
+                peer_dependencies: peer_deps,
                 dev,
                 optional,
                 dev_optional,
@@ -1496,5 +1553,149 @@ mod tests {
         let pkg = &reparsed.packages["h3-v2@2.0.1-rc.20"];
         assert_eq!(pkg.alias_of.as_deref(), Some("h3"));
         assert_eq!(pkg.registry_name(), "h3");
+    }
+
+    /// npm v7+ writes `peerDependencies` / `peerDependenciesMeta` onto
+    /// every package entry. The parser must populate the matching
+    /// `LockedPackage` fields so the resolver's `apply_peer_contexts`
+    /// pass (run on npm-lockfile installs to wire peer siblings in the
+    /// isolated virtual store) actually has peer info to work with.
+    /// Before this parser change, peer-dependent packages like
+    /// `@tanstack/devtools-vite` would install without a sibling
+    /// `vite` link and die at runtime.
+    #[test]
+    fn test_parse_peer_dependencies() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+            "name": "peer-test",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "peer-test",
+                    "version": "1.0.0",
+                    "dependencies": { "devtools-vite": "0.6.0", "vite": "8.0.0" }
+                },
+                "node_modules/devtools-vite": {
+                    "version": "0.6.0",
+                    "integrity": "sha512-a",
+                    "peerDependencies": {
+                        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                    },
+                    "peerDependenciesMeta": {
+                        "vite": { "optional": false }
+                    }
+                },
+                "node_modules/vite": {
+                    "version": "8.0.0",
+                    "integrity": "sha512-b"
+                }
+            }
+        }"#;
+        std::fs::write(tmp.path(), content).unwrap();
+
+        let graph = parse(tmp.path()).unwrap();
+        let devtools = &graph.packages["devtools-vite@0.6.0"];
+        assert_eq!(
+            devtools.peer_dependencies.get("vite").map(String::as_str),
+            Some("^6.0.0 || ^7.0.0 || ^8.0.0")
+        );
+        assert_eq!(
+            devtools
+                .peer_dependencies_meta
+                .get("vite")
+                .map(|m| m.optional),
+            Some(false)
+        );
+    }
+
+    /// Packages without peer fields keep both maps empty — guard
+    /// against accidental defaulting to `optional: true` or spurious
+    /// keys showing up in the LockedPackage from serde leak paths.
+    #[test]
+    fn test_parse_no_peer_fields_stays_empty() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+            "name": "no-peers",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": { "name": "no-peers", "version": "1.0.0", "dependencies": { "foo": "1.0.0" } },
+                "node_modules/foo": { "version": "1.0.0", "integrity": "sha512-x" }
+            }
+        }"#;
+        std::fs::write(tmp.path(), content).unwrap();
+
+        let graph = parse(tmp.path()).unwrap();
+        let foo = &graph.packages["foo@1.0.0"];
+        assert!(foo.peer_dependencies.is_empty());
+        assert!(foo.peer_dependencies_meta.is_empty());
+    }
+
+    /// Writer round-trips `peerDependencies` so a second `parse()` on
+    /// the rewritten lockfile still feeds the peer-context pass. The
+    /// install path writes out the lockfile after every install; if
+    /// peers vanished on the first write-back, the *next* install
+    /// would ship without peer siblings again.
+    #[test]
+    fn test_write_roundtrip_peer_dependencies() {
+        let mut graph = LockfileGraph::default();
+        let mut peer_deps = BTreeMap::new();
+        peer_deps.insert("vite".to_string(), "^6.0.0 || ^7.0.0 || ^8.0.0".to_string());
+        graph.packages.insert(
+            "devtools-vite@0.6.0".to_string(),
+            LockedPackage {
+                name: "devtools-vite".to_string(),
+                version: "0.6.0".to_string(),
+                integrity: Some("sha512-a".to_string()),
+                dep_path: "devtools-vite@0.6.0".to_string(),
+                peer_dependencies: peer_deps,
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "vite@8.0.0".to_string(),
+            LockedPackage {
+                name: "vite".to_string(),
+                version: "8.0.0".to_string(),
+                integrity: Some("sha512-b".to_string()),
+                dep_path: "vite@8.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+        graph.importers.insert(
+            ".".to_string(),
+            vec![
+                DirectDep {
+                    name: "devtools-vite".to_string(),
+                    dep_path: "devtools-vite@0.6.0".to_string(),
+                    dep_type: DepType::Production,
+                    specifier: None,
+                },
+                DirectDep {
+                    name: "vite".to_string(),
+                    dep_path: "vite@8.0.0".to_string(),
+                    dep_type: DepType::Production,
+                    specifier: None,
+                },
+            ],
+        );
+
+        let manifest = test_manifest();
+        let out = tempfile::NamedTempFile::new().unwrap();
+        write(out.path(), &graph, &manifest).unwrap();
+
+        let body = std::fs::read_to_string(out.path()).unwrap();
+        assert!(
+            body.contains("\"peerDependencies\""),
+            "expected peerDependencies block to round-trip; got:\n{body}"
+        );
+
+        let reparsed = parse(out.path()).unwrap();
+        let devtools = &reparsed.packages["devtools-vite@0.6.0"];
+        assert_eq!(
+            devtools.peer_dependencies.get("vite").map(String::as_str),
+            Some("^6.0.0 || ^7.0.0 || ^8.0.0")
+        );
     }
 }

--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -397,6 +397,14 @@ struct WriteNpmPackage<'a> {
     optional_dependencies: BTreeMap<&'a str, &'a str>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     peer_dependencies: BTreeMap<&'a str, &'a str>,
+    /// Paired with `peer_dependencies` above. Required for round-trip
+    /// parity: the `optional: true` bit gates
+    /// `hoist_auto_installed_peers` and `detect_unmet_peers` — dropping
+    /// it on write-back would silently re-flag every optional peer as
+    /// required on the next install. Only the `optional` key is
+    /// meaningful; other fields npm may add elsewhere aren't modeled.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    peer_dependencies_meta: BTreeMap<&'a str, WriteNpmPeerDepMeta>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     dev: bool,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
@@ -409,6 +417,15 @@ struct WriteNpmPackage<'a> {
     /// the optional chain (or vice versa with `--omit=optional`).
     #[serde(rename = "devOptional", skip_serializing_if = "std::ops::Not::not")]
     dev_optional: bool,
+}
+
+/// Serialized form of a `peerDependenciesMeta` entry. Mirrors the
+/// reader's `RawNpmPeerDepMeta` so writer → reader → writer round
+/// trips byte-identically for every meta variant we model today.
+#[derive(Debug, Serialize, Default)]
+struct WriteNpmPeerDepMeta {
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    optional: bool,
 }
 
 /// Serialize a [`LockfileGraph`] as a `package-lock.json` v3 file.
@@ -565,6 +582,24 @@ pub fn write(
             .iter()
             .map(|(n, v)| (n.as_str(), v.as_str()))
             .collect();
+        // Paired `peerDependenciesMeta` round-trip. The `optional: true`
+        // bit is what `hoist_auto_installed_peers` and
+        // `detect_unmet_peers` key off to distinguish "user opted
+        // out" from "peer missing and required" — dropping this
+        // on write-back silently re-flags every optional peer as
+        // required on the next install.
+        let peer_deps_meta: BTreeMap<&str, WriteNpmPeerDepMeta> = pkg
+            .peer_dependencies_meta
+            .iter()
+            .map(|(n, m)| {
+                (
+                    n.as_str(),
+                    WriteNpmPeerDepMeta {
+                        optional: m.optional,
+                    },
+                )
+            })
+            .collect();
 
         packages.insert(
             install_path.clone(),
@@ -575,6 +610,7 @@ pub fn write(
                 integrity: pkg.integrity.as_deref(),
                 dependencies: deps,
                 peer_dependencies: peer_deps,
+                peer_dependencies_meta: peer_deps_meta,
                 dev,
                 optional,
                 dev_optional,
@@ -1642,6 +1678,14 @@ mod tests {
         let mut graph = LockfileGraph::default();
         let mut peer_deps = BTreeMap::new();
         peer_deps.insert("vite".to_string(), "^6.0.0 || ^7.0.0 || ^8.0.0".to_string());
+        // Include an `optional: true` entry so the round-trip covers
+        // `peerDependenciesMeta` — without it, the writer's meta
+        // block isn't exercised and the round-trip would silently
+        // re-flag the peer as required on every subsequent install
+        // (see `hoist_auto_installed_peers` + `detect_unmet_peers`,
+        // which key off `optional`).
+        let mut peer_deps_meta = BTreeMap::new();
+        peer_deps_meta.insert("vite".to_string(), crate::PeerDepMeta { optional: true });
         graph.packages.insert(
             "devtools-vite@0.6.0".to_string(),
             LockedPackage {
@@ -1650,6 +1694,7 @@ mod tests {
                 integrity: Some("sha512-a".to_string()),
                 dep_path: "devtools-vite@0.6.0".to_string(),
                 peer_dependencies: peer_deps,
+                peer_dependencies_meta: peer_deps_meta,
                 ..Default::default()
             },
         );
@@ -1690,12 +1735,24 @@ mod tests {
             body.contains("\"peerDependencies\""),
             "expected peerDependencies block to round-trip; got:\n{body}"
         );
+        assert!(
+            body.contains("\"peerDependenciesMeta\""),
+            "expected peerDependenciesMeta block to round-trip; got:\n{body}"
+        );
 
         let reparsed = parse(out.path()).unwrap();
         let devtools = &reparsed.packages["devtools-vite@0.6.0"];
         assert_eq!(
             devtools.peer_dependencies.get("vite").map(String::as_str),
             Some("^6.0.0 || ^7.0.0 || ^8.0.0")
+        );
+        assert_eq!(
+            devtools
+                .peer_dependencies_meta
+                .get("vite")
+                .map(|m| m.optional),
+            Some(true),
+            "peerDependenciesMeta.optional must survive write → parse round-trip"
         );
     }
 }

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2231,15 +2231,24 @@ pub fn detect_unmet_peers(graph: &LockfileGraph) -> Vec<UnmetPeer> {
     unmet
 }
 
-/// Walk every resolved package's declared peer deps and hoist any peer
-/// that isn't already a direct dep of the importer up to the importer's
-/// `dependencies` list. This is what pnpm's `auto-install-peers=true`
-/// produces in its v9 lockfile: if you depend on a package whose
-/// `peerDependencies` declares `react`, and you don't list `react` in
-/// your own `package.json`, pnpm adds it to your importer's dependencies
-/// with the declared peer range as the specifier, and the linker creates
-/// a top-level `node_modules/react` symlink you can import from your own
-/// code.
+/// Promote unmet peers to importer direct deps.
+///
+/// Walks every resolved package's declared peer deps and hoists any
+/// peer that isn't already a direct dep of the importer up to the
+/// importer's `dependencies` list — what pnpm's
+/// `auto-install-peers=true` produces in its v9 lockfile. If you
+/// depend on a package whose `peerDependencies` declares `react` and
+/// you don't list `react` yourself, pnpm (and now aube) adds it to
+/// your importer's dependencies with the declared peer range as the
+/// specifier, and the linker creates a top-level
+/// `node_modules/react` symlink you can import from your own code.
+///
+/// Public so lockfile-driven installs that need to re-derive peer
+/// wiring (npm/yarn/bun formats, which don't record peer contexts)
+/// can run this before [`apply_peer_contexts`] to match fresh-resolve
+/// behavior. Idempotent in the npm case: npm v7+ already hoists
+/// auto-installed peers into root's `dependencies`, so they arrive
+/// pre-`satisfied` and no additions are emitted.
 ///
 /// Algorithm:
 ///   1. For each importer, collect the set of names already in its
@@ -2257,22 +2266,6 @@ pub fn detect_unmet_peers(graph: &LockfileGraph) -> Vec<UnmetPeer> {
 ///
 /// Leaves everything else about the graph untouched — no packages are
 /// added or removed, only importer entries grow.
-/// Promote unmet peers to importer direct deps.
-///
-/// For each importer, walks the resolved dep closure and lifts every
-/// peer declaration that isn't already satisfied (by another direct
-/// dep or by some other resolved version in the graph) into the
-/// importer's direct-dep list, so pnpm-style top-level
-/// `node_modules/<peer>` symlinks get created and the lockfile's
-/// `importers.` section lists the peer the way pnpm's
-/// `auto-install-peers=true` mode does.
-///
-/// Public so lockfile-driven installs that need to re-derive peer
-/// wiring (npm/yarn/bun formats, which don't record peer contexts)
-/// can run this before [`apply_peer_contexts`] to match fresh-resolve
-/// behavior. Idempotent in the npm case: npm v7+ already hoists
-/// auto-installed peers into root's `dependencies`, so they arrive
-/// pre-`satisfied` and no additions are emitted.
 pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
     let importer_paths: Vec<String> = graph.importers.keys().cloned().collect();
     for importer_path in importer_paths {
@@ -2456,8 +2449,10 @@ pub struct PeerContextOptions {
     pub dedupe_peers: bool,
     /// When true, unresolved peers can be satisfied by a dep declared
     /// at the root importer (`"."`) even if no ancestor scope carries
-    /// the peer. Runs between own-deps and graph-wide scan in
-    /// [`visit_peer_context`].
+    /// the peer. Runs between own-deps and graph-wide scan in the
+    /// peer-context visitor — see `visit_peer_context` in this
+    /// module for the owning implementation (intentionally crate-
+    /// private; the public API here is the option flag itself).
     pub resolve_from_workspace_root: bool,
     /// Byte cap on the peer-ID suffix after which the entire suffix
     /// is hashed to `_<10-char-sha256-hex>`. pnpm's default is 1000.

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2257,7 +2257,23 @@ pub fn detect_unmet_peers(graph: &LockfileGraph) -> Vec<UnmetPeer> {
 ///
 /// Leaves everything else about the graph untouched — no packages are
 /// added or removed, only importer entries grow.
-fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
+/// Promote unmet peers to importer direct deps.
+///
+/// For each importer, walks the resolved dep closure and lifts every
+/// peer declaration that isn't already satisfied (by another direct
+/// dep or by some other resolved version in the graph) into the
+/// importer's direct-dep list, so pnpm-style top-level
+/// `node_modules/<peer>` symlinks get created and the lockfile's
+/// `importers.` section lists the peer the way pnpm's
+/// `auto-install-peers=true` mode does.
+///
+/// Public so lockfile-driven installs that need to re-derive peer
+/// wiring (npm/yarn/bun formats, which don't record peer contexts)
+/// can run this before [`apply_peer_contexts`] to match fresh-resolve
+/// behavior. Idempotent in the npm case: npm v7+ already hoists
+/// auto-installed peers into root's `dependencies`, so they arrive
+/// pre-`satisfied` and no additions are emitted.
+pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
     let importer_paths: Vec<String> = graph.importers.keys().cloned().collect();
     for importer_path in importer_paths {
         let Some(direct_deps) = graph.importers.get(&importer_path) else {
@@ -2428,24 +2444,24 @@ fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
 /// `resolve-peers-from-workspace-root`, `peers-suffix-max-length`)
 /// through the `Resolver`'s `with_*` setters.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct PeerContextOptions {
+pub struct PeerContextOptions {
     /// When true, run the cross-subtree peer-variant collapse pass
     /// after every iteration of the fixed-point loop. Matches pnpm's
     /// default.
-    pub(crate) dedupe_peer_dependents: bool,
+    pub dedupe_peer_dependents: bool,
     /// When true, emit suffixes as `(version)` instead of
     /// `(name@version)`. Affects both the package key, the reference
     /// tails stored in `dependencies`, and the cycle-break form of
     /// `contains_canonical_back_ref`.
-    pub(crate) dedupe_peers: bool,
+    pub dedupe_peers: bool,
     /// When true, unresolved peers can be satisfied by a dep declared
     /// at the root importer (`"."`) even if no ancestor scope carries
     /// the peer. Runs between own-deps and graph-wide scan in
     /// [`visit_peer_context`].
-    pub(crate) resolve_from_workspace_root: bool,
+    pub resolve_from_workspace_root: bool,
     /// Byte cap on the peer-ID suffix after which the entire suffix
     /// is hashed to `_<10-char-sha256-hex>`. pnpm's default is 1000.
-    pub(crate) peers_suffix_max_length: usize,
+    pub peers_suffix_max_length: usize,
 }
 
 impl Default for PeerContextOptions {
@@ -2459,7 +2475,26 @@ impl Default for PeerContextOptions {
     }
 }
 
-fn apply_peer_contexts(canonical: LockfileGraph, options: &PeerContextOptions) -> LockfileGraph {
+/// Compute peer-context suffixes over an already-resolved graph.
+///
+/// Takes a *canonical* graph — one `LockedPackage` per `(name,
+/// version)` with `peer_dependencies` populated — and produces a
+/// *contextualized* graph whose keys and transitive references carry
+/// `(peer@ver)` suffixes when packages resolve peers differently in
+/// different subtrees. Drives the sibling-symlink wiring in
+/// `aube-linker` for peers, so every fetch/materialize site sees a
+/// per-context identity for any package whose peers disambiguate.
+///
+/// Public so lockfile-driven installs can run the pass over graphs
+/// parsed from npm/yarn/bun lockfiles (which emit canonical form —
+/// no peer suffixes — and would otherwise leave peer-dependent
+/// packages without their peers as `.aube/<pkg>/node_modules/<peer>`
+/// siblings). Fresh resolves call it internally from
+/// `Resolver::resolve`.
+pub fn apply_peer_contexts(
+    canonical: LockfileGraph,
+    options: &PeerContextOptions,
+) -> LockfileGraph {
     const MAX_ITERATIONS: usize = 16;
     let mut current = canonical;
     let mut previous_keys: Option<std::collections::BTreeSet<String>> = None;

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -3378,6 +3378,44 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 &supported_architectures,
                 &ignored_optional_deps,
             );
+            // npm/yarn(v1)/bun lockfiles serialize a flat, pre-hoisted
+            // tree with no peer context — they rely on Node's upward
+            // `node_modules/` walk to find peer deps, which the
+            // isolated virtual store breaks. Fresh resolves flow
+            // through `Resolver::resolve_workspace`, which runs
+            // `hoist_auto_installed_peers` + `apply_peer_contexts` on
+            // its way out; the lockfile path has to replicate those
+            // two steps explicitly or peer-dependent packages
+            // (e.g. `@tanstack/devtools-vite` peering on `vite`)
+            // install with no sibling peer link and die at runtime
+            // with `Cannot find package`.
+            //
+            // `aube-lock.yaml` / `pnpm-lock.yaml` already carry
+            // peer-context suffixes and peer edges merged into
+            // `dependencies`, so we skip them — re-running the pass
+            // would double-suffix every key.
+            if matches!(
+                kind,
+                aube_lockfile::LockfileKind::Npm | aube_lockfile::LockfileKind::NpmShrinkwrap
+            ) {
+                let peer_pass_start = std::time::Instant::now();
+                let pkgs_before = graph.packages.len();
+                graph = aube_resolver::hoist_auto_installed_peers(graph);
+                let peer_options = aube_resolver::PeerContextOptions {
+                    dedupe_peer_dependents: resolve_dedupe_peer_dependents(&settings_ctx),
+                    dedupe_peers: resolve_dedupe_peers(&settings_ctx),
+                    resolve_from_workspace_root: resolve_peers_from_workspace_root(&settings_ctx),
+                    peers_suffix_max_length: resolve_peers_suffix_max_length(&settings_ctx),
+                };
+                graph = aube_resolver::apply_peer_contexts(graph, &peer_options);
+                tracing::debug!(
+                    "peer-context pass (lockfile={:?}) {} → {} packages in {:.1?}",
+                    kind,
+                    pkgs_before,
+                    graph.packages.len(),
+                    peer_pass_start.elapsed()
+                );
+            }
             let source_label = match kind {
                 aube_lockfile::LockfileKind::Aube => "Lockfile",
                 aube_lockfile::LockfileKind::Pnpm => "pnpm-lock.yaml",

--- a/test/package_lock_write.bats
+++ b/test/package_lock_write.bats
@@ -346,3 +346,75 @@ JSON
 	assert_success
 	assert [ ! -f aube-lock.yaml ]
 }
+
+# npm lockfiles record peer deps on each package entry but emit a flat,
+# pre-hoisted tree — Node's upward `node_modules/` walk finds peers at
+# runtime. aube's isolated virtual store layout can't walk upward like
+# that; it needs peer deps wired as explicit siblings in the peering
+# package's `.aube/<dep_path>/node_modules/`. Without running the
+# resolver's `apply_peer_contexts` pass over the parsed npm graph,
+# every peer-dependent package (e.g. `@tanstack/devtools-vite` peering
+# on `vite`) installs without its peer sibling and dies at runtime
+# with `Cannot find package 'vite'`.
+@test "aube install wires peer dep siblings from package-lock.json" {
+	# Synthetic setup: declare a peer in the lockfile (using existing
+	# offline fixtures is-odd + is-number — is-odd doesn't actually
+	# peer on is-number, but the install path doesn't care; what we
+	# care about is that the peer pass sees the declaration and
+	# produces a contextualized sibling symlink).
+	cat >package.json <<'JSON'
+{
+  "name": "peer-sibling-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-odd": "3.0.1",
+    "is-number": "6.0.0"
+  }
+}
+JSON
+
+	cat >package-lock.json <<'JSON'
+{
+  "name": "peer-sibling-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "peer-sibling-test",
+      "version": "1.0.0",
+      "dependencies": { "is-odd": "3.0.1", "is-number": "6.0.0" }
+    },
+    "node_modules/is-odd": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz",
+      "integrity": "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==",
+      "peerDependencies": { "is-number": "^6.0.0" }
+    },
+    "node_modules/is-number": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-6.0.0.tgz",
+      "integrity": "sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg=="
+    }
+  }
+}
+JSON
+
+	run aube install
+	assert_success
+
+	# is-odd should now live at a peer-contextualized `.aube/` path.
+	# Use a glob because the context suffix gets hashed into the
+	# directory name and we don't want to hardcode the exact hash.
+	# `.aube/<entry>` is a symlink into the global virtual store, so
+	# `find` needs `-L` to follow it (`-type d` alone wouldn't match).
+	is_odd_dir="$(find -L node_modules/.aube -maxdepth 1 -type d -name 'is-odd@3.0.1*' 2>/dev/null | head -1)"
+	assert [ -n "$is_odd_dir" ]
+
+	# The peer must be wired as a sibling inside is-odd's
+	# `node_modules/`. Without the peer pass the directory only
+	# contains `is-odd/` and Node's require("is-number") from is-odd
+	# fails under the isolated layout.
+	assert [ -e "$is_odd_dir/node_modules/is-number" ]
+	assert [ -e "$is_odd_dir/node_modules/is-odd" ]
+}


### PR DESCRIPTION
## Summary

- Makes `aube dev` work on projects installed from a `package-lock.json` that has peer deps — unblocks the TanStack Start starter's `aube i && aube dev` flow. Before this, peer-dependent packages (e.g. `@tanstack/devtools-vite` peering on `vite`) installed without a sibling peer link under `.aube/<dep_path>/node_modules/` and died at runtime with `Cannot find package 'vite'`.
- The root cause: npm lockfiles serialize a flat, pre-hoisted tree with no peer-context suffixes and rely on Node's upward `node_modules/` walk. aube's isolated layout can't walk upward — it needs peers as explicit siblings. Fresh resolves already run `hoist_auto_installed_peers` + `apply_peer_contexts`; the lockfile-driven install path skipped the resolver entirely.
- Two hooks:
  - npm parser now captures `peerDependencies` + `peerDependenciesMeta` (npm v7+ writes them on every package entry). Writer round-trips them.
  - After `platform::filter_graph` on the npm/shrinkwrap branch, run `hoist_auto_installed_peers` + `apply_peer_contexts` with the same settings the fresh-resolve path uses. `aube-lock.yaml`/`pnpm-lock.yaml` already carry peer context — explicitly skipped so we don't double-suffix keys.
- Exposes `apply_peer_contexts`, `hoist_auto_installed_peers`, and `PeerContextOptions` (fields included) as `pub` in `aube-resolver` so the install crate can drive the pass standalone.

## Notes for the reviewer

- `hoist_auto_installed_peers` is idempotent on npm input: npm v7+ already lifts auto-installed peers into root's `dependencies` before writing the lockfile, so they arrive pre-`satisfied` in the hoist pass and no additions are emitted. Running both passes on npm graphs is cheap (~milliseconds on the TanStack starter — 380 packages).
- Yarn v1 and bun lockfiles aren't wired into the peer-pass branch in this PR. They'd follow the same pattern but need their own parsers to capture `peerDependencies` first.
- Pre-existing BATS flake under parallelism (`cat.bats` / `find-hash --json exits non-zero`) hit once during the suite run but passes in isolation and doesn't touch any code in this PR.

## Test plan

- [x] `cargo test -p aube-lockfile --lib` — 124 pass (3 new: peer parse, empty-default guard, write round-trip)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Full workspace `cargo test` (excluding the pre-existing `aube-registry` auth-token-leak flake) — all pass
- [x] Full BATS suite via `mise run test:bats` — only the pre-existing parallelism flake mentioned above, all new/related tests green
- [x] End-to-end on TanStack Start React starter: `npm install` + `aube i` + `aube dev` → `VITE v8.0.8 ready in 1301 ms` on `:3000`
- [x] New BATS regression: synthetic `package-lock.json` declares `is-number` as a peer of `is-odd` — after `aube install`, `.aube/is-odd@3.0.1_is-number@6.0.0/node_modules/is-number` exists as a sibling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lockfile parsing/writing and the lockfile-driven install path to run peer-resolution passes; mistakes could alter dependency graphs or produce incorrect `node_modules` layouts for npm lockfile installs.
> 
> **Overview**
> Enables correct peer-dependency wiring when installing from npm `package-lock.json`/`npm-shrinkwrap.json` by **parsing and round-tripping** `peerDependencies` plus `peerDependenciesMeta.optional` in the npm lockfile reader/writer.
> 
> On the lockfile-driven install path, npm/shrinkwrap graphs now explicitly run `hoist_auto_installed_peers` and the public `apply_peer_contexts` pass (with settings-derived `PeerContextOptions`) so peer-dependent packages get sibling peer links under the isolated virtual store.
> 
> Exports `hoist_auto_installed_peers`, `apply_peer_contexts`, and `PeerContextOptions` from `aube-resolver`, and adds unit + BATS regressions to ensure peer data survives write/parse and peer siblings are created for npm installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93baad9f2562c784d0c50834129670b5995c9657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->