### PR TITLE
resolver: preserve npm-alias as folder name on fresh resolve

### DIFF
--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -285,6 +285,11 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         let os = pkg_info.map(|p| p.os.clone()).unwrap_or_default();
         let cpu = pkg_info.map(|p| p.cpu.clone()).unwrap_or_default();
         let libc = pkg_info.map(|p| p.libc.clone()).unwrap_or_default();
+        // Aube-specific extension (see `WritablePackageInfo::alias_of`)
+        // — ordinary pnpm lockfiles never carry it, so this stays
+        // `None` on pnpm-authored input and round-trips the resolver-
+        // emitted value for aliased packages.
+        let alias_of = pkg_info.and_then(|p| p.alias_of.clone());
 
         packages.insert(
             dep_path.clone(),
@@ -303,7 +308,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 libc,
                 bundled_dependencies,
                 tarball_url,
-                alias_of: None,
+                alias_of,
             },
         );
     }
@@ -588,6 +593,11 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 os: pkg.os.clone(),
                 cpu: pkg.cpu.clone(),
                 libc: pkg.libc.clone(),
+                // Preserve the alias→real-name mapping so a subsequent
+                // install from this lockfile still hits the real
+                // registry instead of re-404ing on the alias-qualified
+                // tarball URL.
+                alias_of: pkg.alias_of.clone(),
             },
         );
     }
@@ -856,6 +866,14 @@ struct WritablePackageInfo {
     peer_dependencies: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     peer_dependencies_meta: Option<BTreeMap<String, WritablePeerDepMeta>>,
+    /// Real registry name for npm-alias deps. Aube-specific extension
+    /// (pnpm encodes aliases in the snapshot key itself — e.g.
+    /// `odd-alias@npm:is-odd@3.0.1` — but aube keys by `alias@version`
+    /// for linker simplicity, so the real name has to round-trip
+    /// out-of-band via this field). Omitted for non-aliased packages
+    /// so non-alias lockfiles stay byte-identical to pnpm's output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alias_of: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -938,6 +956,10 @@ struct RawPackageInfo {
     cpu: Vec<String>,
     #[serde(default)]
     libc: Vec<String>,
+    /// Paired writer field. See `WritablePackageInfo::alias_of`. `None`
+    /// for ordinary (non-aliased) packages.
+    #[serde(default)]
+    alias_of: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -152,10 +152,28 @@ pub struct ResolvedPackage {
     pub name: String,
     pub version: String,
     pub integrity: Option<String>,
+    /// Real registry name when this package is an npm-alias
+    /// (`"h3-v2": "npm:h3@..."`). `name` is the alias (`h3-v2` — the
+    /// folder in `node_modules/`), `alias_of` is what the streaming
+    /// fetch client uses to derive the tarball URL and store-index
+    /// key. `None` for non-aliased packages, in which case `name`
+    /// already matches the registry.
+    pub alias_of: Option<String>,
     /// Set for non-registry packages (`file:` / `link:`). Downstream
     /// fetchers short-circuit the tarball path and materialize from
     /// disk instead.
     pub local_source: Option<LocalSource>,
+}
+
+impl ResolvedPackage {
+    /// Registry lookup name — `alias_of` when set, otherwise `name`.
+    /// Every tarball URL + store index site routes through this
+    /// accessor so aliased packages resolve to the real registry
+    /// entry without leaking the alias-qualified name into network
+    /// requests (where it would 404).
+    pub fn registry_name(&self) -> &str {
+        self.alias_of.as_deref().unwrap_or(&self.name)
+    }
 }
 
 /// Which version-picking strategy the resolver uses for a workspace.
@@ -311,12 +329,39 @@ struct ResolveTask {
     /// (e.g. `"npm:real-pkg@^2.0.0"` for an alias, or `"^4.17.0"` for a normal range).
     /// Only set for root deps; recorded into the lockfile for drift detection.
     original_specifier: Option<String>,
+    /// Real registry package name for npm-alias tasks.
+    ///
+    /// When a task arrives with `range` like `"npm:h3@2.0.1-rc.20"`,
+    /// the preprocessing loop strips the prefix and sets this field to
+    /// the real package name (`"h3"`) while *keeping* `name` as the
+    /// user-facing alias (`"h3-v2"`, the key the package.json used).
+    /// Every identity-facing site — dep_path formation, direct-dep
+    /// records, parent `dependencies` wiring, the resolved-versions
+    /// dedupe map — uses `name`, so the alias survives all the way
+    /// to the linker and ends up as `node_modules/<alias>/` with
+    /// `LockedPackage.alias_of = Some(real_name)`. Only registry
+    /// I/O (packument fetch, tarball URL derivation) consults this
+    /// field.
+    ///
+    /// `None` for ordinary (non-aliased) tasks — `name` is already
+    /// the registry name and nothing downstream needs to distinguish.
+    real_name: Option<String>,
     /// Outermost-first chain of `(name, version)` ancestors above this
     /// task in the dependency graph, used by `parent>child` override
     /// selectors. Empty for root/importer deps. Each child-enqueue
     /// site is responsible for extending its parent's chain with the
     /// parent's own `(name, version)` frame.
     ancestors: Vec<(String, String)>,
+}
+
+impl ResolveTask {
+    /// Name to use for registry operations (packument fetch, tarball
+    /// URL). Returns `real_name` for aliased tasks and `name`
+    /// otherwise. Every call site that talks to the registry goes
+    /// through this accessor so alias handling stays localized.
+    fn registry_name(&self) -> &str {
+        self.real_name.as_deref().unwrap_or(&self.name)
+    }
 }
 
 impl Resolver {
@@ -664,6 +709,7 @@ impl Resolver {
                     parent: None,
                     importer: importer_path.clone(),
                     original_specifier: Some(range.clone()),
+                    real_name: None,
                     ancestors: Vec::new(),
                 });
             }
@@ -676,6 +722,7 @@ impl Resolver {
                     parent: None,
                     importer: importer_path.clone(),
                     original_specifier: Some(range.clone()),
+                    real_name: None,
                     ancestors: Vec::new(),
                 });
             }
@@ -694,6 +741,7 @@ impl Resolver {
                     parent: None,
                     importer: importer_path.clone(),
                     original_specifier: Some(range.clone()),
+                    real_name: None,
                     ancestors: Vec::new(),
                 });
             }
@@ -1024,14 +1072,27 @@ impl Resolver {
                     {
                         let real_name = rest[..at_idx].to_string();
                         let real_range = rest[at_idx + 1..].to_string();
-                        if real_name != task.name || real_range != task.range {
+                        // Keep `task.name` as the user-facing alias
+                        // (the key the package.json used) and stash
+                        // the registry name on `real_name` so every
+                        // identity-facing site — dep_path formation,
+                        // direct-dep records, parent wiring — sees
+                        // the alias, while only packument/tarball
+                        // fetch sites (via `task.registry_name()`)
+                        // hit the real package. Overwriting
+                        // `task.name` here would collapse
+                        // `node_modules/h3-v2/` to `node_modules/h3/`
+                        // and any `require("h3-v2")` would break.
+                        if task.real_name.as_deref() != Some(real_name.as_str())
+                            || real_range != task.range
+                        {
                             tracing::trace!(
                                 "npm alias: {} -> {}@{}",
                                 task.name,
                                 real_name,
                                 real_range
                             );
-                            task.name = real_name;
+                            task.real_name = Some(real_name);
                             task.range = real_range;
                             changed = true;
                         }
@@ -1211,6 +1272,11 @@ impl Resolver {
                                 name: linked_name.clone(),
                                 version: real_version.clone(),
                                 integrity: None,
+                                // local_source deps aren't aliased —
+                                // `file:`/`link:` specifiers go
+                                // through the local-source branch,
+                                // not the `npm:` rewrite.
+                                alias_of: None,
                                 local_source: Some(local.clone()),
                             });
                         }
@@ -1229,6 +1295,7 @@ impl Resolver {
                                     parent: Some(dep_path.clone()),
                                     importer: task.importer.clone(),
                                     original_specifier: None,
+                                    real_name: None,
                                     ancestors: child_ancestors.clone(),
                                 });
                             }
@@ -1410,6 +1477,14 @@ impl Resolver {
                                     name: task.name.clone(),
                                     version: version.clone(),
                                     integrity: locked_pkg.integrity.clone(),
+                                    // Carry the alias identity
+                                    // through the reuse path — the
+                                    // existing `locked_pkg` already
+                                    // records it if the lockfile held
+                                    // an aliased entry, so the
+                                    // streaming fetch still hits the
+                                    // real registry name.
+                                    alias_of: locked_pkg.alias_of.clone(),
                                     local_source: locked_pkg.local_source.clone(),
                                 });
                             }
@@ -1470,6 +1545,7 @@ impl Resolver {
                                     parent: Some(dep_path.clone()),
                                     importer: task.importer.clone(),
                                     original_specifier: None,
+                                    real_name: None,
                                     ancestors: child_ancestors.clone(),
                                 });
                             }
@@ -1493,8 +1569,14 @@ impl Resolver {
                 // in the cache because it landed while an earlier
                 // task was being waited on.
                 let wait_start = std::time::Instant::now();
-                while !self.cache.contains_key(&task.name) {
-                    ensure_fetch!(&task.name);
+                // Cache is keyed by the *registry* name — for aliased
+                // tasks `task.name` is the user-facing alias (e.g.
+                // `h3-v2`), which would never hit. `registry_name()`
+                // returns the alias-resolved target (`h3`) on
+                // aliased tasks and `task.name` otherwise.
+                let fetch_name = task.registry_name().to_string();
+                while !self.cache.contains_key(&fetch_name) {
+                    ensure_fetch!(&fetch_name);
                     match in_flight.join_next().await {
                         Some(Ok(Ok((name, packument)))) => {
                             in_flight_names.remove(&name);
@@ -1514,7 +1596,7 @@ impl Resolver {
                             // hold this name, so a None here means
                             // the spawn failed silently. Surface it.
                             return Err(Error::Registry(
-                                task.name.clone(),
+                                fetch_name.clone(),
                                 "packument fetch disappeared before completing".to_string(),
                             ));
                         }
@@ -1539,9 +1621,14 @@ impl Resolver {
                 // sub-loop over `processed_batch` in the old wave
                 // code; here it's inline as the tail of the per-task
                 // pipeline now that we know the packument is in
-                // cache.
-                let packument = self.cache.get(&task.name).ok_or_else(|| {
-                    Error::Registry(task.name.clone(), "packument not in cache".to_string())
+                // cache. `registry_name()` is the cache key for
+                // aliased tasks (cache is populated under the real
+                // registry name), so use the same accessor here.
+                let packument = self.cache.get(task.registry_name()).ok_or_else(|| {
+                    Error::Registry(
+                        task.registry_name().to_string(),
+                        "packument not in cache".to_string(),
+                    )
                 })?;
 
                 // Find locked version
@@ -1803,13 +1890,19 @@ impl Resolver {
 
                 let integrity = version_meta.dist.as_ref().and_then(|d| d.integrity.clone());
 
-                // Stream this resolved package for early tarball fetching
+                // Stream this resolved package for early tarball fetching.
+                // `alias_of` mirrors what the LockedPackage below
+                // will carry — the streaming fetch consumer in
+                // install.rs uses it to derive the real tarball URL
+                // for aliased packages where `name` alone (`h3-v2`)
+                // would 404.
                 if let Some(ref tx) = self.resolved_tx {
                     let _ = tx.send(ResolvedPackage {
                         dep_path: dep_path.clone(),
                         name: task.name.clone(),
                         version: version.clone(),
                         integrity: integrity.clone(),
+                        alias_of: task.real_name.clone(),
                         local_source: None,
                     });
                 }
@@ -1873,7 +1966,14 @@ impl Resolver {
                             v
                         },
                         tarball_url: None,
-                        alias_of: None,
+                        // `name` is the alias for npm-aliased tasks
+                        // (`"h3-v2": "npm:h3@..."` → name = "h3-v2"),
+                        // so stash the real registry name here. The
+                        // lockfile writer + installer consult
+                        // `alias_of` whenever they need to hit the
+                        // registry, matching how the npm-lockfile
+                        // reader populates this field.
+                        alias_of: task.real_name.clone(),
                     },
                 );
 
@@ -1921,6 +2021,7 @@ impl Resolver {
                         parent: Some(dep_path.clone()),
                         importer: task.importer.clone(),
                         original_specifier: None,
+                        real_name: None,
                         ancestors: child_ancestors.clone(),
                     });
                 }
@@ -1955,6 +2056,7 @@ impl Resolver {
                         parent: Some(dep_path.clone()),
                         importer: task.importer.clone(),
                         original_specifier: None,
+                        real_name: None,
                         ancestors: child_ancestors.clone(),
                     });
                 }
@@ -2042,6 +2144,7 @@ impl Resolver {
                             parent: Some(dep_path.clone()),
                             importer: task.importer.clone(),
                             original_specifier: None,
+                            real_name: None,
                             ancestors: child_ancestors.clone(),
                         });
                     }
@@ -6090,5 +6193,58 @@ mod tests {
             "default cap corrupted output: {:?}",
             out.packages.keys().collect::<Vec<_>>()
         );
+    }
+
+    // Fresh resolve: when the root manifest carries
+    // `"odd-alias": "npm:is-odd@3.0.1"`, the resolver must emit the
+    // graph keyed by the *alias* and stash the real registry name in
+    // `alias_of`. Before this fix, `task.name` was clobbered to
+    // `is-odd` at the `npm:` rewrite site, which collapsed
+    // `node_modules/odd-alias/` to `node_modules/is-odd/` and broke
+    // `require("odd-alias")` at runtime.
+    #[tokio::test]
+    async fn fresh_resolve_preserves_npm_alias_as_folder_name() {
+        let is_odd = make_packument("is-odd", &["3.0.1"], "3.0.1");
+
+        // Pre-seed the cache under the *real* package name — the
+        // whole point of the fix is that the registry fetch keys by
+        // the real name (`is-odd`), not the alias-qualified
+        // `odd-alias` that would 404 the registry.
+        let client = Arc::new(aube_registry::client::RegistryClient::new(
+            "http://127.0.0.1:0",
+        ));
+        let mut resolver = Resolver::new(client);
+        resolver.cache.insert("is-odd".to_string(), is_odd);
+
+        let mut manifest = PackageJson::default();
+        manifest
+            .dependencies
+            .insert("odd-alias".to_string(), "npm:is-odd@3.0.1".to_string());
+
+        let graph = resolver
+            .resolve(&manifest, None)
+            .await
+            .expect("alias resolve failed");
+
+        // Graph key and `LockedPackage.name` both carry the alias —
+        // that's what the linker drops into `node_modules/` and what
+        // any `require("odd-alias")` walks to.
+        let pkg = graph
+            .packages
+            .get("odd-alias@3.0.1")
+            .expect("aliased package must be keyed by the alias dep_path");
+        assert_eq!(pkg.name, "odd-alias");
+        assert_eq!(pkg.version, "3.0.1");
+        assert_eq!(pkg.alias_of.as_deref(), Some("is-odd"));
+        assert_eq!(pkg.registry_name(), "is-odd");
+
+        // No stray `is-odd@3.0.1` entry from the rewrite leaking the
+        // real name past the alias boundary.
+        assert!(!graph.packages.contains_key("is-odd@3.0.1"));
+
+        let root = graph.importers.get(".").unwrap();
+        assert_eq!(root.len(), 1);
+        assert_eq!(root[0].name, "odd-alias");
+        assert_eq!(root[0].dep_path, "odd-alias@3.0.1");
     }
 }

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -3570,15 +3570,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         continue;
                     }
 
-                    // Check index cache first. This path consumes
-                    // `ResolvedPackage` values streaming from the
-                    // resolver, which already rewrites `npm:` aliases
-                    // into the real package name before emission — so
-                    // `pkg.name` is always the registry name here.
-                    // (Aliased entries round-tripping *from* the
-                    // lockfile go through `fetch_packages`, which
-                    // handles aliases via `LockedPackage::alias_of`.)
-                    if let Some(index) = fetch_store.load_index(&pkg.name, &pkg.version) {
+                    // Check index cache first. `registry_name()` is
+                    // the real package name on the registry — equal
+                    // to `name` for the common case, and the alias's
+                    // real target for npm-alias entries (where the
+                    // alias-qualified name would miss the cache and
+                    // later 404 the tarball fetch).
+                    let pkg_registry_name = pkg.registry_name().to_string();
+                    if let Some(index) = fetch_store.load_index(&pkg_registry_name, &pkg.version) {
                         let _ = materialize_tx.send((pkg.dep_path.clone(), index.clone()));
                         indices.insert(pkg.dep_path, index);
                         cached_count += 1;
@@ -3599,7 +3598,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     handles.push(tokio::spawn(async move {
                         let _row = row;
                         let permit = sem.acquire().await.unwrap();
-                        let url = client.tarball_url(&pkg.name, &pkg.version);
+                        let url = client.tarball_url(&pkg_registry_name, &pkg.version);
                         tracing::trace!("Fetching {}@{}", pkg.name, pkg.version);
 
                         let bytes = client.fetch_tarball_bytes(&url).await.map_err(|e| {
@@ -3618,18 +3617,25 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         // even though the network itself is idle during extract.
                         drop(permit);
 
-                        // Move CPU/blocking work onto the blocking thread pool
-                        let pkg_name = pkg.name.clone();
+                        // Move CPU/blocking work onto the blocking thread pool.
+                        // `pkg_display_name` is the alias when aliased
+                        // (what the user wrote in package.json) —
+                        // nicer in progress/error output than the
+                        // real registry name. Validation and cache
+                        // key use `pkg_registry_name` to match the
+                        // tarball's actual identity.
+                        let pkg_display_name = pkg.name.clone();
                         let pkg_version = pkg.version.clone();
                         let dep_path = pkg.dep_path.clone();
                         let integrity = pkg.integrity.clone();
                         let index = tokio::task::spawn_blocking(move || -> miette::Result<_> {
                             if fetch_verify_integrity && let Some(ref expected) = integrity {
-                                aube_store::verify_integrity(&bytes, expected)
-                                    .map_err(|e| miette!("{pkg_name}@{pkg_version}: {e}"))?;
+                                aube_store::verify_integrity(&bytes, expected).map_err(|e| {
+                                    miette!("{pkg_display_name}@{pkg_version}: {e}")
+                                })?;
                             }
                             let index = store.import_tarball(&bytes).map_err(|e| {
-                                miette!("failed to import {pkg_name}@{pkg_version}: {e}")
+                                miette!("failed to import {pkg_display_name}@{pkg_version}: {e}")
                             })?;
                             // strictStorePkgContentCheck: see the
                             // matching block in `fetch_packages_with_root`
@@ -3637,13 +3643,24 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             // honor the same setting or the no-lockfile
                             // path would silently let through manifest
                             // mismatches that the lockfile path catches.
+                            // Validates against the *registry* name —
+                            // the tarball's package.json records the
+                            // real name, not the alias, so comparing
+                            // against `pkg_display_name` would fail
+                            // every aliased install.
                             if fetch_strict_pkg_content_check {
-                                aube_store::validate_pkg_content(&index, &pkg_name, &pkg_version)
-                                    .map_err(|e| miette!("{pkg_name}@{pkg_version}: {e}"))?;
+                                aube_store::validate_pkg_content(
+                                    &index,
+                                    &pkg_registry_name,
+                                    &pkg_version,
+                                )
+                                .map_err(|e| miette!("{pkg_display_name}@{pkg_version}: {e}"))?;
                             }
-                            if let Err(e) = store.save_index(&pkg_name, &pkg_version, &index) {
+                            if let Err(e) =
+                                store.save_index(&pkg_registry_name, &pkg_version, &index)
+                            {
                                 tracing::warn!(
-                                    "Failed to cache index for {pkg_name}@{pkg_version}: {e}"
+                                    "Failed to cache index for {pkg_display_name}@{pkg_version}: {e}"
                                 );
                             }
                             Ok(index)

--- a/test/install.bats
+++ b/test/install.bats
@@ -763,3 +763,56 @@ JSON
 	assert_output --partial "ignoring network-concurrency=0"
 	assert_dir_exists node_modules
 }
+
+# Fresh resolve: `"<alias>": "npm:<real>@<ver>"` must land as
+# `node_modules/<alias>/`, not `node_modules/<real>/`. The resolver
+# used to clobber `task.name` to the real name at the `npm:` rewrite
+# site, collapsing the alias and breaking `require("<alias>")` at
+# runtime. The lockfile round-trip (via `LockedPackage.alias_of`) was
+# already correct; this test guards the resolver path.
+@test "aube install preserves npm-alias as folder on fresh resolve" {
+	cat >package.json <<'JSON'
+{
+  "name": "alias-fresh",
+  "version": "1.0.0",
+  "dependencies": {
+    "odd-alias": "npm:is-odd@3.0.1"
+  }
+}
+JSON
+
+	run aube install
+	assert_success
+
+	# Alias survives as the top-level folder name.
+	assert_link_exists node_modules/odd-alias
+	assert_not_exists node_modules/is-odd
+
+	# Virtual store entry is keyed by the alias too — a transitive
+	# consumer declaring `odd-alias` walks the .aube tree by that
+	# exact string, so the folder has to match.
+	alias_dir="$(find -L node_modules/.aube -maxdepth 1 -type d -name 'odd-alias@3.0.1*' 2>/dev/null | head -1)"
+	assert [ -n "$alias_dir" ]
+	assert_not_exists node_modules/.aube/is-odd@3.0.1
+
+	# The emitted lockfile records the real name via `aliasOf:` so a
+	# subsequent install hits the real registry entry instead of
+	# re-404ing on the alias-qualified tarball URL. Also check the
+	# importer still encodes the original `npm:` specifier — without
+	# it, drift detection would see `odd-alias: 3.0.1` and re-resolve
+	# every install.
+	run grep -F "aliasOf: is-odd" aube-lock.yaml
+	assert_success
+	run grep -F "specifier: npm:is-odd@3.0.1" aube-lock.yaml
+	assert_success
+
+	# Round-trip: a second install from the emitted lockfile must
+	# re-use the alias identity — otherwise the writer lost the
+	# `aliasOf:` data and the reader would try to fetch `odd-alias`
+	# from the registry (404).
+	rm -rf node_modules
+	run aube install --frozen-lockfile
+	assert_success
+	assert_link_exists node_modules/odd-alias
+	assert_not_exists node_modules/is-odd
+}


### PR DESCRIPTION
## Summary

Fixes the fresh-resolve path (no lockfile) for projects declaring npm aliases in `package.json`. Given `"h3-v2": "npm:h3@2.0.1-rc.20"`, `aube install` was producing `node_modules/h3/` instead of `node_modules/h3-v2/` — anything that `require("h3-v2")` broke at runtime. The lockfile-driven path was already correct (earlier alias PR); this closes the fresh-resolve gap.

## Why

The `npm:` rewrite at the top of the task loop overwrote `task.name` from `h3-v2` (the package.json key) to `h3` (the real registry name). Every downstream identity site — dep_path formation, `DirectDep.name`, `LockedPackage.name`, parent `dependencies` wiring, the `visited` / `resolved_versions` dedupe maps — then saw the real name and lost the alias.

## What changed

- `ResolveTask.real_name: Option<String>` + a `task.registry_name()` accessor. The rewrite now sets `real_name = Some("h3")` while leaving `task.name = "h3-v2"` alone, so identity sites see the alias and only packument cache + tarball URL derivation consult the real name.
- `ResolvedPackage.alias_of` + `registry_name()`, mirrored from the `LockedPackage` shape. The streaming fetch consumer in `install.rs` now derives tarball URLs from the real name so aliased packages don't 404.
- Lockfile round-trip: aube/pnpm writer (and reader) emit/consume an `aliasOf:` field on aliased snapshots. Without it, a second install would read back `LockedPackage { name: "h3-v2", alias_of: None }` and re-404 on fetch. `skip_serializing_if = Option::is_none` keeps non-alias lockfiles byte-identical to pnpm's output.
- The LockedPackage emitted at task completion now carries `alias_of = task.real_name.clone()` — matching exactly how the npm-lockfile reader already populates it, so linker/writer/store paths stay symmetric across the two entry paths.

## Notes for the reviewer

- Aube-specific `aliasOf:` field. pnpm itself encodes aliases in the snapshot key as `alias@npm:real@ver`, but aube keys by `alias@version` for linker simplicity (the `aube-dir-entry-name` filename derivation and sibling-symlink walker both expect the simpler key shape). An out-of-band `aliasOf:` field is the minimum round-trip fix; porting to pnpm's in-key encoding is bigger surgery and not strictly needed.
- `hoist_auto_installed_peers` and `apply_peer_contexts` already walk via `DirectDep.name` and `LockedPackage.dependencies` — both carry the alias after this change — so peer resolution continues to Do The Right Thing.
- Pre-existing BATS flake under parallelism (`list.bats` / `--parseable emits tab-separated lines`) hit once during the suite run but passes in isolation and doesn't touch any code in this PR.

## Test plan

- [x] `cargo test -p aube-resolver --lib fresh_resolve_preserves_npm_alias_as_folder_name` — new resolver unit test: pre-seeds the cache under the real name (`is-odd`), resolves a manifest declaring `"odd-alias": "npm:is-odd@3.0.1"`, asserts the graph is keyed by the alias with `alias_of = Some("is-odd")` and no stray real-name entry
- [x] `cargo test --workspace --exclude aube-registry` — all pass (aube-registry has a pre-existing `~/.npmrc` auth-token-leak flake, unrelated)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Full BATS suite via `mise run test:bats` — only the pre-existing parallelism flake mentioned above; all new/related tests green
- [x] New BATS regression: fresh `aube install` lands `node_modules/odd-alias/`, emits `aliasOf: is-odd` in the lockfile, `--frozen-lockfile` round-trip re-uses the alias
- [x] End-to-end: TanStack Start React starter, fresh resolve — `aube i && aube dev` → `VITE v8.0.8 ready in 821 ms` on `:3000`. Before: `Cannot find package 'h3-v2'` from `@tanstack/start-server-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dependency resolution, lockfile serialization, and tarball fetching paths to support npm aliases; mistakes could lead to incorrect `node_modules` layout or registry fetch/cache misses.
> 
> **Overview**
> Fixes *fresh installs (no existing lockfile)* for npm alias deps so the alias remains the `node_modules/<alias>/` folder name while registry/network I/O uses the real package name.
> 
> The resolver now tracks alias targets separately (`ResolveTask.real_name`, `ResolvedPackage.alias_of`) and routes packument/tarball lookups through `registry_name()` without overwriting the alias identity used for dep paths and graph wiring.
> 
> The pnpm lockfile reader/writer round-trips an Aube-specific `aliasOf` field on package entries, and `install.rs` uses `ResolvedPackage.registry_name()` for store index/tarball URL/strict content checks while keeping user-facing output keyed by the alias. Adds unit + BATS regression tests covering alias folder layout and lockfile round-trip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit affe18b0976b20e75c2a29e82686813366b0ba14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->