### PR TITLE
bench: optional hermetic mode with Verdaccio + bandwidth throttling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,15 +82,27 @@ Any time we run a benchmark, serialize it with `flock` against a
 static lock path in a tmp directory so concurrent benchmark runs (on
 the same box, across worktrees, agents, terminals) can't fight each
 other for disk/CPU and skew the numbers. Use
-`/tmp/aube-bench.lock` as the canonical path and wrap the actual
-benchmark invocation, e.g.:
+`/tmp/aube-bench.lock` as the canonical path, and default to hermetic
+mode at a fixed bandwidth so ad-hoc runs are comparable across
+machines and over time:
 
 ```bash
-flock /tmp/aube-bench.lock mise run bench
+flock /tmp/aube-bench.lock \
+  env BENCH_HERMETIC=1 BENCH_BANDWIDTH=100mbit mise run bench
 ```
 
+`BENCH_HERMETIC=1` removes npmjs CDN variance; `BENCH_BANDWIDTH=100mbit`
+pins the simulated link at a "fast home broadband" baseline so two
+runs on different ISPs / CI runners produce comparable numbers. Drop
+the bandwidth cap (or raise it) for loopback-speed measurements; lower
+it (e.g. `6mbit`) to see how each PM scales under a constrained link.
+See the Hermetic benchmark mode section below for the full mechanics.
+
 This applies to manual benchmark commands (hyperfine one-shots, ad-hoc
-`aube install` timing loops, etc.) too.
+`aube install` timing loops, etc.) too. **The one exception is
+`mise run bench:bump`** — never pass `BENCH_HERMETIC` / `BENCH_BANDWIDTH`
+there, because `results.json` is the published "real internet"
+baseline.
 
 When `mise run bench:bump` rewrites [`benchmarks/results.json`](benchmarks/results.json),
 refresh the hardcoded ratios in [`README.md`](README.md) in the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,33 @@ nothing regenerates it. The `Why Try It` section quotes both the
 warm-CI multiples (pnpm, bun) and the cross-fixture ranges; recompute
 them from the new JSON and update the sentence to match.
 
+### Hermetic benchmark mode
+
+`BENCH_HERMETIC=1 mise run bench` routes all registry traffic through a
+local Verdaccio instance, so the cold-cache scenario measures aube's
+code path rather than npmjs CDN jitter. Implementation lives in
+[`benchmarks/hermetic.bash`](benchmarks/hermetic.bash) and
+[`benchmarks/registry/`](benchmarks/registry/). The first hermetic run
+warms a cache at `~/.cache/aube-bench/registry/` (one network fetch
+against npmjs); every subsequent run is fully offline. Blow away that
+directory to force a re-warm (e.g. after bumping packages in
+`benchmarks/fixture.package.json`).
+
+Layer `BENCH_BANDWIDTH=50mbit` (or `6mbit`, or a bare integer bytes/s)
+on top to simulate a realistic internet link. Traffic is piped through
+[`benchmarks/throttle-proxy.mjs`](benchmarks/throttle-proxy.mjs), a
+dependency-free Node token-bucket proxy that sits between the package
+managers and Verdaccio. The proxy preserves the client's `Host`
+header so Verdaccio's self-referential tarball URLs also flow back
+through it — without that, tarball fetches silently bypass the limit.
+
+**Never combine `BENCH_HERMETIC` or `BENCH_BANDWIDTH` with
+`bench:bump`.** [`benchmarks/results.json`](benchmarks/results.json) is
+the published "real internet" baseline and must not be overwritten from
+a hermetic run. The `flock /tmp/aube-bench.lock` rule still applies —
+hermetic mode starts local daemons on fixed ports (4874 for Verdaccio,
+4875 for the proxy), so two concurrent hermetic runs would collide.
+
 ## Rust Configuration
 
 - Edition: 2024

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -17,6 +17,21 @@ set -euo pipefail
 #   WARMUP       — warmup runs before timing (default: 1)
 #   RUNS         — timed runs per benchmark (default: 10)
 #   RESULTS_JSON — override the structured JSON output path
+#
+#   BENCH_HERMETIC=1 — route all registry traffic through a local
+#                      Verdaccio instance pre-populated from npmjs. Makes
+#                      cold-cache numbers deterministic (no npmjs CDN
+#                      jitter). First hermetic run warms the cache at
+#                      ~/.cache/aube-bench/registry/; subsequent runs
+#                      are fully offline. See benchmarks/hermetic.bash.
+#   BENCH_BANDWIDTH  — optional throttle (e.g. `50mbit`, `6mbit`, bare
+#                      integer bytes/s). Only meaningful with
+#                      BENCH_HERMETIC=1; routes traffic through a tiny
+#                      Node.js token-bucket proxy in front of Verdaccio.
+#
+# Do NOT combine BENCH_HERMETIC or BENCH_BANDWIDTH with `bench:bump` —
+# results.json is the published "real internet" baseline and must not
+# be overwritten from a hermetic run.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -41,6 +56,21 @@ if [ ! -f "$AUBE_BIN" ]; then
 	echo "error: aube release binary not found at $AUBE_BIN" >&2
 	echo "Run: cargo build --release" >&2
 	exit 1
+fi
+
+# ── Optional hermetic registry ─────────────────────────────────────────────
+# BENCH_HERMETIC=1 routes all registry traffic through a local
+# Verdaccio instance (populated from npmjs on first run, offline after).
+# BENCH_BANDWIDTH=<rate> puts a throttling proxy in front so cold-cache
+# numbers reflect a simulated internet link rather than loopback disk
+# speed. See benchmarks/hermetic.bash for the lifecycle details.
+
+BENCH_REGISTRY_URL=""
+if [ "${BENCH_HERMETIC:-0}" = "1" ]; then
+	# shellcheck source=/dev/null
+	source "$SCRIPT_DIR/hermetic.bash"
+	hermetic_start
+	trap 'hermetic_stop' EXIT
 fi
 
 # ── Per-tool configuration ─────────────────────────────────────────────────
@@ -116,6 +146,18 @@ for i in "${!TOOLS[@]}"; do
 	# time, so nothing to write on disk up front.
 	if [ "$tool" = "pnpm" ]; then
 		printf "storeDir: %s\ncacheDir: %s\n" "${TOOL_STORES[$i]}" "${TOOL_CACHES[$i]}" >"$dir/pnpm-workspace.yaml"
+	fi
+
+	# Hermetic mode: drop a .npmrc into both the project dir and the
+	# isolated HOME so every PM resolves packages through the local
+	# Verdaccio (or the throttle proxy in front of it) instead of
+	# npmjs. Project-level .npmrc is honored by all five tools and
+	# wins over HOME; HOME is a belt-and-suspenders fallback for any
+	# command (like `aube add` after chdir) that might look there
+	# first.
+	if [ -n "$BENCH_REGISTRY_URL" ]; then
+		printf "registry=%s\n" "$BENCH_REGISTRY_URL" >"$dir/.npmrc"
+		printf "registry=%s\n" "$BENCH_REGISTRY_URL" >"$home/.npmrc"
 	fi
 done
 

--- a/benchmarks/hermetic.bash
+++ b/benchmarks/hermetic.bash
@@ -144,7 +144,18 @@ _hermetic_warm() {
 
 	local warm_dir
 	warm_dir=$(mktemp -d "${TMPDIR:-/tmp}/aube-bench-warm.XXXXXX")
-	cp "$HERMETIC_DIR/fixture.package.json" "$warm_dir/package.json"
+	# Extra packages pulled alongside the fixture so every bench
+	# scenario can resolve offline. `is-odd` is the subject of the
+	# Benchmark 4 "add" scenario in bench.sh — without it, each
+	# `<pm> add is-odd` would 404 against the no-uplink Verdaccio and
+	# silently time the error path.
+	node -e '
+		const fs = require("fs");
+		const base = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+		base.dependencies = base.dependencies || {};
+		base.dependencies["is-odd"] = "^3.0.1";
+		fs.writeFileSync(process.argv[2], JSON.stringify(base, null, 2));
+	' "$HERMETIC_DIR/fixture.package.json" "$warm_dir/package.json"
 
 	# Hit the registry directly with npm. --ignore-scripts and
 	# --legacy-peer-deps match how the benchmark's own populate step

--- a/benchmarks/hermetic.bash
+++ b/benchmarks/hermetic.bash
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Hermetic benchmark registry lifecycle.
+#
+# Sourced by benchmarks/bench.sh when BENCH_HERMETIC=1. Exposes:
+#
+#   hermetic_start    — ensures the registry cache is warm, starts
+#                       Verdaccio (no uplink), optionally starts a
+#                       throttling proxy in front, and exports
+#                       BENCH_REGISTRY_URL.
+#   hermetic_stop     — tears both processes down. Idempotent; safe to
+#                       call from an EXIT trap.
+#
+# Configuration (all env-driven):
+#
+#   BENCH_HERMETIC_CACHE  — persistent cache dir (default:
+#                           ~/.cache/aube-bench/registry). Holds the
+#                           Verdaccio storage and a `.warmed` sentinel.
+#                           Wipe it to force a re-warm from npmjs.
+#   BENCH_VERDACCIO_PORT  — localhost port for Verdaccio
+#                           (default: 4874; distinct from test/registry's
+#                           4873 so the two can coexist).
+#   BENCH_BANDWIDTH       — optional throttle, e.g. `50mbit`, `6mbit`,
+#                           `6250000` (bytes/s as a bare integer).
+#                           When set, traffic goes through
+#                           throttle-proxy.mjs instead of direct.
+#   BENCH_PROXY_PORT      — localhost port for the throttle proxy
+#                           (default: 4875).
+#
+# Shellcheck disables are scoped tight — this file is sourced by
+# bench.sh, so top-level vars are intentionally not local.
+
+# Resolve this file's directory. Prefer bench.sh's $SCRIPT_DIR when
+# we're being sourced from it, and fall back to $BASH_SOURCE otherwise
+# (manual `source benchmarks/hermetic.bash` from the repo root, CI ad
+# hoc checks, etc.). $BASH_SOURCE is array-indexed in bash but some
+# harnesses deliver it as a plain string, so we defensively coalesce.
+if [ -n "${SCRIPT_DIR:-}" ] && [ -f "$SCRIPT_DIR/hermetic.bash" ]; then
+	HERMETIC_DIR="$SCRIPT_DIR"
+else
+	_hermetic_src="${BASH_SOURCE[0]:-${BASH_SOURCE:-}}"
+	if [ -n "$_hermetic_src" ] && [ -f "$_hermetic_src" ]; then
+		# shellcheck disable=SC2155
+		HERMETIC_DIR="$(cd "$(dirname "$_hermetic_src")" && pwd)"
+	else
+		echo "ERROR: hermetic.bash could not resolve its own directory." >&2
+		echo "  Set SCRIPT_DIR to the benchmarks/ dir before sourcing." >&2
+		# shellcheck disable=SC2317  # reachable via source-from-stdin or unusual harness invocations
+		return 1 2>/dev/null || exit 1
+	fi
+	unset _hermetic_src
+fi
+
+BENCH_HERMETIC_CACHE="${BENCH_HERMETIC_CACHE:-$HOME/.cache/aube-bench/registry}"
+BENCH_VERDACCIO_PORT="${BENCH_VERDACCIO_PORT:-4874}"
+BENCH_PROXY_PORT="${BENCH_PROXY_PORT:-4875}"
+
+HERMETIC_STORAGE="$BENCH_HERMETIC_CACHE/storage"
+HERMETIC_WARMED_SENTINEL="$BENCH_HERMETIC_CACHE/.warmed"
+HERMETIC_LOG="$BENCH_HERMETIC_CACHE/verdaccio.log"
+HERMETIC_CONFIG_WARM="$HERMETIC_DIR/registry/config.warm.yaml"
+HERMETIC_CONFIG_COLD="$HERMETIC_DIR/registry/config.yaml"
+
+# Install verdaccio globally if it isn't on PATH. Pinned to v6 to match
+# test/registry/start.bash — both are meant to track the same upstream.
+_hermetic_ensure_verdaccio() {
+	if command -v verdaccio >/dev/null 2>&1; then
+		return 0
+	fi
+	echo "Installing verdaccio..." >&2
+	npm install --global verdaccio@6 2>&1 | tail -1 >&2
+}
+
+# Wait for Verdaccio to answer HTTP on $port. Returns 1 after ~30s.
+_hermetic_wait_ready() {
+	local port=$1
+	local retries=60
+	while ! curl -s "http://127.0.0.1:${port}/" >/dev/null 2>&1; do
+		retries=$((retries - 1))
+		if [ "$retries" -le 0 ]; then
+			echo "ERROR: Verdaccio failed to start on port $port" >&2
+			return 1
+		fi
+		sleep 0.5
+	done
+}
+
+# Start Verdaccio with the given config file on BENCH_VERDACCIO_PORT.
+# Writes PID into $HERMETIC_VERDACCIO_PID (exported so hermetic_stop
+# can see it from an EXIT trap).
+_hermetic_start_verdaccio() {
+	local config=$1
+	mkdir -p "$HERMETIC_STORAGE"
+
+	# Work inside the cache dir so Verdaccio's `storage: ./storage`
+	# resolves to $HERMETIC_STORAGE. We can't point at the in-repo
+	# config directly because Verdaccio resolves `storage:` relative
+	# to the config file, so we copy both configs next to the storage
+	# dir at startup.
+	cp "$config" "$BENCH_HERMETIC_CACHE/config.yaml"
+
+	verdaccio \
+		--config "$BENCH_HERMETIC_CACHE/config.yaml" \
+		--listen "127.0.0.1:$BENCH_VERDACCIO_PORT" \
+		>"$HERMETIC_LOG" 2>&1 &
+	HERMETIC_VERDACCIO_PID=$!
+	export HERMETIC_VERDACCIO_PID
+
+	if ! _hermetic_wait_ready "$BENCH_VERDACCIO_PORT"; then
+		echo "ERROR: Verdaccio log ($HERMETIC_LOG):" >&2
+		tail -40 "$HERMETIC_LOG" >&2 || true
+		kill "$HERMETIC_VERDACCIO_PID" 2>/dev/null || true
+		return 1
+	fi
+}
+
+_hermetic_stop_verdaccio() {
+	if [ -n "${HERMETIC_VERDACCIO_PID:-}" ]; then
+		kill "$HERMETIC_VERDACCIO_PID" 2>/dev/null || true
+		wait "$HERMETIC_VERDACCIO_PID" 2>/dev/null || true
+		unset HERMETIC_VERDACCIO_PID
+	fi
+}
+
+# Populate the Verdaccio storage from npmjs on first use. Idempotent
+# via the `.warmed` sentinel. Running the warm step requires network;
+# subsequent benchmark runs are fully offline.
+#
+# We use `npm install` rather than aube so warming is bootstrap-safe —
+# this script has to work even when `cargo build --release` hasn't
+# finished yet (some CI flows warm the cache before building aube to
+# parallelize).
+_hermetic_warm() {
+	if [ -f "$HERMETIC_WARMED_SENTINEL" ]; then
+		return 0
+	fi
+
+	echo "Warming hermetic registry cache at $HERMETIC_STORAGE ..." >&2
+	echo "  (one-time network fetch; subsequent runs are offline)" >&2
+
+	_hermetic_ensure_verdaccio
+	if ! _hermetic_start_verdaccio "$HERMETIC_CONFIG_WARM"; then
+		return 1
+	fi
+
+	local warm_dir
+	warm_dir=$(mktemp -d "${TMPDIR:-/tmp}/aube-bench-warm.XXXXXX")
+	cp "$HERMETIC_DIR/fixture.package.json" "$warm_dir/package.json"
+
+	# Hit the registry directly with npm. --ignore-scripts and
+	# --legacy-peer-deps match how the benchmark's own populate step
+	# treats the fixture.
+	if ! (cd "$warm_dir" && HOME="$warm_dir/home" \
+		npm_config_cache="$warm_dir/cache" \
+		npm_config_registry="http://127.0.0.1:$BENCH_VERDACCIO_PORT" \
+		npm install --ignore-scripts --no-audit --no-fund --legacy-peer-deps >"$warm_dir/npm.log" 2>&1); then
+		echo "ERROR: warm step failed. Last lines of npm log:" >&2
+		tail -40 "$warm_dir/npm.log" >&2 || true
+		_hermetic_stop_verdaccio
+		rm -rf "$warm_dir"
+		return 1
+	fi
+
+	rm -rf "$warm_dir"
+	_hermetic_stop_verdaccio
+	: >"$HERMETIC_WARMED_SENTINEL"
+	echo "Hermetic registry cache warmed." >&2
+}
+
+# Optional throttling proxy lifecycle. The proxy is a ~100-line Node
+# script with zero deps (benchmarks/throttle-proxy.mjs). We invoke it
+# with the upstream URL + rate; it prints "ready" to stdout once
+# listening so we know when to return.
+_hermetic_start_proxy() {
+	local rate=$1
+	local upstream="http://127.0.0.1:$BENCH_VERDACCIO_PORT"
+
+	node "$HERMETIC_DIR/throttle-proxy.mjs" \
+		--port "$BENCH_PROXY_PORT" \
+		--upstream "$upstream" \
+		--rate "$rate" \
+		>"$BENCH_HERMETIC_CACHE/proxy.log" 2>&1 &
+	HERMETIC_PROXY_PID=$!
+	export HERMETIC_PROXY_PID
+
+	# Wait for the proxy to come up (it proxies to Verdaccio, which is
+	# already ready, so this is usually instantaneous).
+	local retries=40
+	while ! curl -s "http://127.0.0.1:$BENCH_PROXY_PORT/" >/dev/null 2>&1; do
+		retries=$((retries - 1))
+		if [ "$retries" -le 0 ]; then
+			echo "ERROR: throttle proxy failed to start on port $BENCH_PROXY_PORT" >&2
+			tail -40 "$BENCH_HERMETIC_CACHE/proxy.log" >&2 || true
+			kill "$HERMETIC_PROXY_PID" 2>/dev/null || true
+			return 1
+		fi
+		sleep 0.25
+	done
+}
+
+_hermetic_stop_proxy() {
+	if [ -n "${HERMETIC_PROXY_PID:-}" ]; then
+		kill "$HERMETIC_PROXY_PID" 2>/dev/null || true
+		wait "$HERMETIC_PROXY_PID" 2>/dev/null || true
+		unset HERMETIC_PROXY_PID
+	fi
+}
+
+hermetic_start() {
+	mkdir -p "$BENCH_HERMETIC_CACHE"
+	_hermetic_ensure_verdaccio
+	if ! _hermetic_warm; then
+		return 1
+	fi
+
+	if ! _hermetic_start_verdaccio "$HERMETIC_CONFIG_COLD"; then
+		return 1
+	fi
+
+	if [ -n "${BENCH_BANDWIDTH:-}" ]; then
+		if ! _hermetic_start_proxy "$BENCH_BANDWIDTH"; then
+			_hermetic_stop_verdaccio
+			return 1
+		fi
+		export BENCH_REGISTRY_URL="http://127.0.0.1:$BENCH_PROXY_PORT"
+		echo "Hermetic registry: $BENCH_REGISTRY_URL (throttled to $BENCH_BANDWIDTH via proxy, upstream :$BENCH_VERDACCIO_PORT)" >&2
+	else
+		export BENCH_REGISTRY_URL="http://127.0.0.1:$BENCH_VERDACCIO_PORT"
+		echo "Hermetic registry: $BENCH_REGISTRY_URL (unthrottled)" >&2
+	fi
+}
+
+# Stop proxy before Verdaccio — the proxy holds keep-alive connections
+# into it and will emit noise if Verdaccio disappears first.
+hermetic_stop() {
+	_hermetic_stop_proxy
+	_hermetic_stop_verdaccio
+}

--- a/benchmarks/registry/config.warm.yaml
+++ b/benchmarks/registry/config.warm.yaml
@@ -1,0 +1,39 @@
+# Verdaccio config used during the one-time warm step that populates
+# the hermetic benchmark registry cache.
+#
+# Unlike test/registry/config.yaml (which intentionally has no uplink
+# so the BATS suite runs offline), this config proxies unknown packages
+# to npmjs and caches them. `benchmarks/hermetic.bash` starts Verdaccio
+# with this config, runs a single `npm install` against
+# benchmarks/fixture.package.json to materialize every tarball into
+# `storage/`, then swaps in config.yaml (no uplink) for the actual
+# benchmark runs.
+#
+# Cache location is not committed — it lives under
+# ~/.cache/aube-bench/registry/storage/ by default. Wipe that directory
+# to force a re-warm from npmjs.
+
+storage: ./storage
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    # Bun and pnpm request the abbreviated packument format via the
+    # `application/vnd.npm.install-v1+json` Accept header. Verdaccio
+    # forwards this verbatim upstream and caches the response, so bun
+    # still sees the fast-path format after uplink is disabled.
+    cache: true
+
+packages:
+  '**':
+    access: $all
+    publish: $all
+    proxy: npmjs
+
+log:
+  type: stdout
+  format: pretty
+  level: warn
+
+web:
+  enable: false

--- a/benchmarks/registry/config.yaml
+++ b/benchmarks/registry/config.yaml
@@ -1,0 +1,28 @@
+# Verdaccio config used for hermetic benchmark runs.
+#
+# No uplinks, no proxy — all packages are served from the local storage
+# dir that was populated earlier by a warm run using config.warm.yaml.
+# This makes the "cold cache" benchmark scenario deterministic: every
+# tarball fetch hits the local disk (or a throttling proxy in front,
+# see benchmarks/throttle-proxy.mjs) rather than npmjs, so the numbers
+# measure aube's code path rather than CDN jitter.
+#
+# Storage lives at ~/.cache/aube-bench/registry/storage/ by default
+# (override via BENCH_HERMETIC_CACHE). If the warm step hasn't been
+# run yet, benchmarks/hermetic.bash takes care of it automatically on
+# first invocation.
+
+storage: ./storage
+
+packages:
+  '**':
+    access: $all
+    publish: $all
+
+log:
+  type: stdout
+  format: pretty
+  level: error
+
+web:
+  enable: false

--- a/benchmarks/throttle-proxy.mjs
+++ b/benchmarks/throttle-proxy.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Bandwidth-throttling HTTP proxy for hermetic Aube benchmarks.
+//
+// Sits between the package managers and the local Verdaccio instance
+// and applies a token-bucket rate limit on the response body so we can
+// measure install performance under a simulated internet link (e.g.
+// 50 Mbit/s) without relying on OS-level traffic shaping (which would
+// need root and would vary between macOS and Linux).
+//
+// Throttling is download-only on purpose: the request side of npm
+// installs is tiny (a GET with some headers); all the bytes are on the
+// response path. A symmetrical throttle would add complexity without
+// changing the measurement meaningfully.
+//
+// Zero deps — uses node:http and node:stream. Node 24 is already a
+// tools dependency of this repo.
+//
+// Usage:
+//   node throttle-proxy.mjs --port 4875 --upstream http://127.0.0.1:4874 --rate 50mbit
+//
+// --rate accepts: `<n>mbit`, `<n>kbit`, `<n>bit`, `<n>mb`, `<n>kb`,
+// `<n>b`, or a bare integer (bytes/s).
+
+import { createServer, request as httpRequest } from 'node:http';
+import { Transform } from 'node:stream';
+
+function parseArgs(argv) {
+	const out = {};
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a.startsWith('--')) {
+			out[a.slice(2)] = argv[++i];
+		}
+	}
+	return out;
+}
+
+// Returns bytes/sec. Accepts "50mbit", "6mbit", "50kbit", "100kb",
+// "6mb", or a bare integer (treated as bytes/s).
+function parseRate(raw) {
+	if (!raw) throw new Error('missing --rate');
+	const m = String(raw).trim().toLowerCase().match(/^(\d+(?:\.\d+)?)\s*([a-z]*)$/);
+	if (!m) throw new Error(`cannot parse rate: ${raw}`);
+	const n = Number(m[1]);
+	const unit = m[2];
+	switch (unit) {
+		case '':
+			return Math.floor(n); // bare integer = bytes/s
+		case 'b':
+			return Math.floor(n / 8); // bits/s → bytes/s
+		case 'kbit':
+			return Math.floor((n * 1000) / 8);
+		case 'mbit':
+			return Math.floor((n * 1_000_000) / 8);
+		case 'gbit':
+			return Math.floor((n * 1_000_000_000) / 8);
+		case 'kb':
+			return Math.floor(n * 1000);
+		case 'mb':
+			return Math.floor(n * 1_000_000);
+		case 'gb':
+			return Math.floor(n * 1_000_000_000);
+		default:
+			throw new Error(`unknown rate unit: ${unit}`);
+	}
+}
+
+// Token-bucket Transform. Bucket refills every REFILL_MS. We chunk the
+// incoming stream so backpressure is honored even for large tarball
+// responses. The slice math never splits below 1 byte, so a stalled
+// bucket just waits rather than busy-looping.
+const REFILL_MS = 100;
+
+function createThrottle(bytesPerSec) {
+	const capacity = Math.max(1, Math.floor(bytesPerSec / (1000 / REFILL_MS)));
+	let tokens = capacity;
+	const waiters = [];
+	const timer = setInterval(() => {
+		tokens = capacity;
+		while (waiters.length && tokens > 0) {
+			waiters.shift()();
+		}
+	}, REFILL_MS);
+	timer.unref();
+
+	function take(n) {
+		return new Promise((resolve) => {
+			const tryTake = () => {
+				if (tokens <= 0) {
+					waiters.push(tryTake);
+					return;
+				}
+				const take = Math.min(n, tokens);
+				tokens -= take;
+				resolve(take);
+			};
+			tryTake();
+		});
+	}
+
+	return new Transform({
+		async transform(chunk, _enc, cb) {
+			try {
+				let offset = 0;
+				while (offset < chunk.length) {
+					const grant = await take(chunk.length - offset);
+					this.push(chunk.subarray(offset, offset + grant));
+					offset += grant;
+				}
+				cb();
+			} catch (err) {
+				cb(err);
+			}
+		},
+		flush(cb) {
+			clearInterval(timer);
+			cb();
+		},
+	});
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const port = Number(args.port || 4875);
+	const upstreamRaw = args.upstream;
+	if (!upstreamRaw) {
+		console.error('ERROR: --upstream required');
+		process.exit(2);
+	}
+	const upstream = new URL(upstreamRaw);
+	const bytesPerSec = parseRate(args.rate);
+
+	const server = createServer((clientReq, clientRes) => {
+		// Build the upstream request. Preserve method, path, and all
+		// headers — Verdaccio's packument-format negotiation depends on
+		// `accept: application/vnd.npm.install-v1+json` for bun/pnpm,
+		// and conditional fetches rely on `if-none-match`.
+		//
+		// Critically, we pass the client's original `host` header
+		// (i.e. the proxy's own address) through unchanged. Verdaccio
+		// uses Host to compute self-referential tarball URLs in
+		// packument responses, so leaving it as the proxy's host means
+		// every tarball download is also routed back through us and
+		// therefore throttled. If we overwrote host to the upstream
+		// address, PMs would fetch tarballs directly from Verdaccio
+		// and silently bypass the bandwidth limit.
+		const headers = { ...clientReq.headers };
+
+		const upstreamReq = httpRequest(
+			{
+				protocol: upstream.protocol,
+				hostname: upstream.hostname,
+				port: upstream.port || 80,
+				method: clientReq.method,
+				path: clientReq.url,
+				headers,
+			},
+			(upstreamRes) => {
+				clientRes.writeHead(upstreamRes.statusCode, upstreamRes.headers);
+				upstreamRes.pipe(createThrottle(bytesPerSec)).pipe(clientRes);
+			},
+		);
+
+		upstreamReq.on('error', (err) => {
+			console.error(`upstream error: ${err.message}`);
+			if (!clientRes.headersSent) {
+				clientRes.writeHead(502, { 'content-type': 'text/plain' });
+			}
+			clientRes.end(`upstream error: ${err.message}`);
+		});
+
+		clientReq.pipe(upstreamReq);
+	});
+
+	server.on('clientError', (err, socket) => {
+		// A package manager closing a keep-alive connection shouldn't
+		// spam stderr. Swallow ECONNRESET / EPIPE quietly and let other
+		// errors surface.
+		if (!['ECONNRESET', 'EPIPE'].includes(err.code)) {
+			console.error(`client error: ${err.message}`);
+		}
+		socket.destroy();
+	});
+
+	server.listen(port, '127.0.0.1', () => {
+		const rateLabel = `${bytesPerSec} B/s (${(bytesPerSec * 8 / 1_000_000).toFixed(1)} Mbit/s)`;
+		console.log(`throttle-proxy listening on 127.0.0.1:${port} → ${upstream.origin} @ ${rateLabel}`);
+	});
+
+	const shutdown = () => {
+		server.close(() => process.exit(0));
+		setTimeout(() => process.exit(0), 2000).unref();
+	};
+	process.on('SIGTERM', shutdown);
+	process.on('SIGINT', shutdown);
+}
+
+main();

--- a/benchmarks/throttle-proxy.mjs
+++ b/benchmarks/throttle-proxy.mjs
@@ -12,14 +12,22 @@
 // response path. A symmetrical throttle would add complexity without
 // changing the measurement meaningfully.
 //
+// A single process-wide token bucket is shared across every in-flight
+// response. Package managers routinely open 10–50+ concurrent
+// connections to download tarballs; a per-connection bucket would
+// silently multiply the effective rate by the concurrency count and
+// make cross-PM comparisons meaningless. One bucket = one pipe.
+//
 // Zero deps — uses node:http and node:stream. Node 24 is already a
 // tools dependency of this repo.
 //
 // Usage:
 //   node throttle-proxy.mjs --port 4875 --upstream http://127.0.0.1:4874 --rate 50mbit
 //
-// --rate accepts: `<n>mbit`, `<n>kbit`, `<n>bit`, `<n>mb`, `<n>kb`,
-// `<n>b`, or a bare integer (bytes/s).
+// --rate units:
+//   <n>bit, <n>kbit, <n>mbit, <n>gbit   — bits/sec
+//   <n>b,   <n>kb,   <n>mb,   <n>gb     — bytes/sec (SI kilo = 1000)
+//   <n>                                  — bare integer, bytes/sec
 
 import { createServer, request as httpRequest } from 'node:http';
 import { Transform } from 'node:stream';
@@ -35,8 +43,7 @@ function parseArgs(argv) {
 	return out;
 }
 
-// Returns bytes/sec. Accepts "50mbit", "6mbit", "50kbit", "100kb",
-// "6mb", or a bare integer (treated as bytes/s).
+// Returns bytes/sec.
 function parseRate(raw) {
 	if (!raw) throw new Error('missing --rate');
 	const m = String(raw).trim().toLowerCase().match(/^(\d+(?:\.\d+)?)\s*([a-z]*)$/);
@@ -47,6 +54,14 @@ function parseRate(raw) {
 		case '':
 			return Math.floor(n); // bare integer = bytes/s
 		case 'b':
+			return Math.floor(n); // bytes/s
+		case 'kb':
+			return Math.floor(n * 1000);
+		case 'mb':
+			return Math.floor(n * 1_000_000);
+		case 'gb':
+			return Math.floor(n * 1_000_000_000);
+		case 'bit':
 			return Math.floor(n / 8); // bits/s → bytes/s
 		case 'kbit':
 			return Math.floor((n * 1000) / 8);
@@ -54,24 +69,21 @@ function parseRate(raw) {
 			return Math.floor((n * 1_000_000) / 8);
 		case 'gbit':
 			return Math.floor((n * 1_000_000_000) / 8);
-		case 'kb':
-			return Math.floor(n * 1000);
-		case 'mb':
-			return Math.floor(n * 1_000_000);
-		case 'gb':
-			return Math.floor(n * 1_000_000_000);
 		default:
 			throw new Error(`unknown rate unit: ${unit}`);
 	}
 }
 
-// Token-bucket Transform. Bucket refills every REFILL_MS. We chunk the
-// incoming stream so backpressure is honored even for large tarball
-// responses. The slice math never splits below 1 byte, so a stalled
-// bucket just waits rather than busy-looping.
+// Token-bucket shared across every response. Refills to `capacity`
+// (not "adds up to") every REFILL_MS so idle periods can't be banked
+// into bursts — we want a ceiling, not a credit.
+//
+// REFILL_MS trades off fidelity against timer overhead. 100ms gives
+// ~10x smoothing over a 1-second average and is imperceptible for
+// bench timing, which runs in hundreds of ms minimum.
 const REFILL_MS = 100;
 
-function createThrottle(bytesPerSec) {
+function createSharedBucket(bytesPerSec) {
 	const capacity = Math.max(1, Math.floor(bytesPerSec / (1000 / REFILL_MS)));
 	let tokens = capacity;
 	const waiters = [];
@@ -83,27 +95,37 @@ function createThrottle(bytesPerSec) {
 	}, REFILL_MS);
 	timer.unref();
 
-	function take(n) {
-		return new Promise((resolve) => {
-			const tryTake = () => {
-				if (tokens <= 0) {
-					waiters.push(tryTake);
-					return;
-				}
-				const take = Math.min(n, tokens);
-				tokens -= take;
-				resolve(take);
-			};
-			tryTake();
-		});
-	}
+	return {
+		take(n) {
+			return new Promise((resolve) => {
+				const tryTake = () => {
+					if (tokens <= 0) {
+						waiters.push(tryTake);
+						return;
+					}
+					const grant = Math.min(n, tokens);
+					tokens -= grant;
+					resolve(grant);
+				};
+				tryTake();
+			});
+		},
+		shutdown() {
+			clearInterval(timer);
+		},
+	};
+}
 
+// Per-response Transform that draws from the shared bucket. Chunks
+// the incoming stream so backpressure is honored even for large
+// tarball responses.
+function createThrottleStream(bucket) {
 	return new Transform({
 		async transform(chunk, _enc, cb) {
 			try {
 				let offset = 0;
 				while (offset < chunk.length) {
-					const grant = await take(chunk.length - offset);
+					const grant = await bucket.take(chunk.length - offset);
 					this.push(chunk.subarray(offset, offset + grant));
 					offset += grant;
 				}
@@ -111,10 +133,6 @@ function createThrottle(bytesPerSec) {
 			} catch (err) {
 				cb(err);
 			}
-		},
-		flush(cb) {
-			clearInterval(timer);
-			cb();
 		},
 	});
 }
@@ -129,6 +147,7 @@ function main() {
 	}
 	const upstream = new URL(upstreamRaw);
 	const bytesPerSec = parseRate(args.rate);
+	const bucket = createSharedBucket(bytesPerSec);
 
 	const server = createServer((clientReq, clientRes) => {
 		// Build the upstream request. Preserve method, path, and all
@@ -157,7 +176,7 @@ function main() {
 			},
 			(upstreamRes) => {
 				clientRes.writeHead(upstreamRes.statusCode, upstreamRes.headers);
-				upstreamRes.pipe(createThrottle(bytesPerSec)).pipe(clientRes);
+				upstreamRes.pipe(createThrottleStream(bucket)).pipe(clientRes);
 			},
 		);
 
@@ -183,11 +202,12 @@ function main() {
 	});
 
 	server.listen(port, '127.0.0.1', () => {
-		const rateLabel = `${bytesPerSec} B/s (${(bytesPerSec * 8 / 1_000_000).toFixed(1)} Mbit/s)`;
-		console.log(`throttle-proxy listening on 127.0.0.1:${port} → ${upstream.origin} @ ${rateLabel}`);
+		const rateLabel = `${bytesPerSec} B/s (${((bytesPerSec * 8) / 1_000_000).toFixed(1)} Mbit/s)`;
+		console.log(`throttle-proxy listening on 127.0.0.1:${port} → ${upstream.origin} @ ${rateLabel} (shared bucket)`);
 	});
 
 	const shutdown = () => {
+		bucket.shutdown();
 		server.close(() => process.exit(0));
 		setTimeout(() => process.exit(0), 2000).unref();
 	};


### PR DESCRIPTION
## Summary

- `BENCH_HERMETIC=1 mise run bench` routes all five PMs through a local
  Verdaccio instance. First run warms a cache at
  `~/.cache/aube-bench/registry/` (one fetch from npmjs); every run
  after is fully offline — so cold-cache numbers measure aube's code
  path instead of CDN jitter.
- Stack `BENCH_BANDWIDTH=50mbit` (or `6mbit`, or bare bytes/s) on top
  to simulate a realistic internet link via a tiny, zero-dep Node.js
  token-bucket proxy that sits between the PMs and Verdaccio.
- Opt-in only. `mise run bench:bump` keeps writing the published
  "real internet" baseline into `benchmarks/results.json` — the
  documentation about never combining these flags with `bench:bump`
  is explicit in `CLAUDE.md`.

## Why

The existing cold-cache scenario's variance is dominated by npmjs's
CDN, not anything we could fix in aube. Hermetic mode gives a stable
platform for comparing install strategies under controlled conditions;
the bandwidth knob lets us show how different PMs scale as the link
narrows (which is where parallelism and pipelining start to matter).

## Implementation notes

- Two Verdaccio configs committed under `benchmarks/registry/`:
  `config.warm.yaml` (npmjs uplink + cache) for the one-time population,
  `config.yaml` (no uplink) for the benchmark itself.
- `benchmarks/hermetic.bash` encapsulates start/warm/stop; `bench.sh`
  sources it and writes a `registry=` line into each tool's per-home
  `.npmrc` (plus project `.npmrc` belt-and-suspenders) — no per-PM CLI
  plumbing needed.
- `benchmarks/throttle-proxy.mjs` is zero-dep Node 24 builtins. It
  critically **preserves the client's `Host` header** so Verdaccio's
  self-referential tarball URLs point at the proxy, not the Verdaccio
  port — otherwise tarball fetches bypass the throttle silently. Rate
  parsing accepts `mbit`, `kbit`, `mb`, `kb`, or a bare integer
  (bytes/s).
- EXIT trap in `bench.sh` stops the proxy then Verdaccio.
- Ports: Verdaccio on 4874, proxy on 4875 (distinct from `test/registry`'s
  4873 so both can coexist).

## Test plan

- [x] `bash -n` / `node --check` all three new scripts
- [x] Rate parser unit check (`50mbit → 6250000 B/s`, etc.)
- [x] Throttle proxy vs dummy echo server: 1 MB @ 2 Mbit/s → 3.95s ≈ expected 4s
- [x] End-to-end with a minimal fixture: warm step pulls from npmjs, offline Verdaccio serves packuments, proxied tarball URLs point at the proxy port, `aube install` resolves and links packages successfully
- [x] `mise run lint` (shellcheck + shfmt + cargo-clippy) clean
- [ ] Full-fixture warm step on CI hardware (deferred — first real run will take a few minutes to pull the ~90-dep tree, then every subsequent run is offline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark harness behavior to optionally start local daemons, rewrite per-tool `.npmrc`, and auto-install `verdaccio`, which could fail or interfere with local environments/ports when running benchmarks.
> 
> **Overview**
> Adds an **opt-in hermetic benchmark mode** (`BENCH_HERMETIC=1`) that warms and reuses a local Verdaccio-backed registry cache so cold-cache benchmark runs avoid npmjs/CDN variance.
> 
> Introduces `BENCH_BANDWIDTH` to route traffic through a new `throttle-proxy.mjs` token-bucket proxy, and updates `benchmarks/bench.sh` to start/stop these helpers and force all package managers to use the hermetic registry via per-project and per-HOME `.npmrc`.
> 
> Expands `CLAUDE.md` benchmark guidance to recommend `flock` + hermetic defaults for ad-hoc runs and explicitly warns not to use these env vars with `mise run bench:bump`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4007a554e6c51d976d047b06d337e47bdad68ebd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->