### PR TITLE
resolver(alias): preserve alias folder name through fresh resolve

### DIFF
--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -286,6 +286,16 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         let cpu = pkg_info.map(|p| p.cpu.clone()).unwrap_or_default();
         let libc = pkg_info.map(|p| p.libc.clone()).unwrap_or_default();
 
+        // An explicit `name:` in the `packages:` entry that differs
+        // from the snapshot-key-derived name means the entry was
+        // written as an npm-alias (see `WritablePackageInfo::name`).
+        // Promote that real name to `alias_of` so `registry_name()`
+        // can route fetches/store keys through the real package
+        // instead of the alias-qualified snapshot key.
+        let alias_of = pkg_info
+            .and_then(|p| p.name.clone())
+            .filter(|real| real != &name);
+
         packages.insert(
             dep_path.clone(),
             LockedPackage {
@@ -303,7 +313,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 libc,
                 bundled_dependencies,
                 tarball_url,
-                alias_of: None,
+                alias_of,
             },
         );
     }
@@ -582,6 +592,12 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         packages.insert(
             canonical,
             WritablePackageInfo {
+                // `name: <real>` is emitted only for aliased packages
+                // so the next parse can tell an alias-keyed snapshot
+                // from a genuine package that happens to be named
+                // `odd-alias`. Non-aliased entries skip the field —
+                // round-trip stays byte-identical to pnpm's output.
+                name: pkg.alias_of.clone(),
                 resolution,
                 peer_dependencies: peer_deps,
                 peer_dependencies_meta: peer_meta,
@@ -841,6 +857,20 @@ struct WritablePeerDepMeta {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WritablePackageInfo {
+    /// Populated for npm-alias entries (`"odd-alias": "npm:is-odd@..."`)
+    /// so the reader can recover the real registry name on a
+    /// subsequent parse — without it the alias-keyed snapshot looks
+    /// like a regular dep called `odd-alias`, fetches 404 against
+    /// `registry.npmjs.org/odd-alias/...`, and the round-trip breaks.
+    /// Skipped for non-aliased entries so the common case stays
+    /// byte-identical to pnpm's output.
+    ///
+    /// `name:` at this position matches pnpm's own legacy convention
+    /// for disambiguating installs whose dep_path can't uniquely
+    /// identify the package (their reader tolerates the field on
+    /// registry packages too — unknown `name:` is a no-op for them).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     resolution: Option<WritableResolution>,
     // pnpm v9 emits os/cpu/libc immediately after `resolution` and
@@ -929,6 +959,13 @@ struct RawCatalogEntry {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RawPackageInfo {
+    /// Present when the previous writer marked this entry as an
+    /// npm-alias (see [`WritablePackageInfo::name`]). On read, a
+    /// `name:` value that doesn't match the snapshot key's name
+    /// portion means the entry is aliased and the registered real
+    /// package identity lives here.
+    #[serde(default)]
+    name: Option<String>,
     resolution: Option<Resolution>,
     peer_dependencies: Option<BTreeMap<String, String>>,
     peer_dependencies_meta: Option<BTreeMap<String, RawPeerDepMeta>>,
@@ -1628,5 +1665,142 @@ snapshots:
     fn test_parse_nonexistent_file() {
         let path = Path::new("/nonexistent/pnpm-lock.yaml");
         assert!(parse(path).is_err());
+    }
+
+    /// Regression: a [`LockedPackage`] with `alias_of = Some(real)`
+    /// must round-trip a `name: <real>` marker in the `packages:`
+    /// entry so the reader can recover the real registry identity
+    /// on a subsequent parse. Without the marker the alias-keyed
+    /// snapshot (`odd-alias@3.0.1`) parses back as a plain package
+    /// called `odd-alias`, the next install hits
+    /// `registry.npmjs.org/odd-alias/...`, and the round-trip breaks.
+    #[test]
+    fn test_npm_alias_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let lockfile_path = dir.path().join("aube-lock.yaml");
+
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "odd-alias@3.0.1".to_string(),
+            LockedPackage {
+                name: "odd-alias".to_string(),
+                version: "3.0.1".to_string(),
+                integrity: Some("sha512-alias".to_string()),
+                dep_path: "odd-alias@3.0.1".to_string(),
+                alias_of: Some("is-odd".to_string()),
+                ..Default::default()
+            },
+        );
+        // Non-aliased sibling — its `packages:` entry must stay free
+        // of a `name:` field or we'd emit noise for every regular dep.
+        packages.insert(
+            "is-number@6.0.0".to_string(),
+            LockedPackage {
+                name: "is-number".to_string(),
+                version: "6.0.0".to_string(),
+                integrity: Some("sha512-num".to_string()),
+                dep_path: "is-number@6.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+        let mut importers = BTreeMap::new();
+        importers.insert(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "odd-alias".to_string(),
+                dep_path: "odd-alias@3.0.1".to_string(),
+                dep_type: DepType::Production,
+                specifier: Some("npm:is-odd@3.0.1".to_string()),
+            }],
+        );
+        let graph = LockfileGraph {
+            importers,
+            packages,
+            ..Default::default()
+        };
+        let mut deps = BTreeMap::new();
+        deps.insert("odd-alias".to_string(), "npm:is-odd@3.0.1".to_string());
+        let manifest = PackageJson {
+            name: Some("aliased-project".to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: deps,
+            dev_dependencies: BTreeMap::new(),
+            peer_dependencies: BTreeMap::new(),
+            optional_dependencies: BTreeMap::new(),
+            update_config: None,
+            scripts: BTreeMap::new(),
+            engines: BTreeMap::new(),
+            workspaces: None,
+            bundled_dependencies: None,
+            extra: BTreeMap::new(),
+        };
+
+        write(&lockfile_path, &graph, &manifest).unwrap();
+        let body = std::fs::read_to_string(&lockfile_path).unwrap();
+
+        // `name: is-odd` must appear under the alias snapshot, and
+        // must NOT be emitted for the non-aliased sibling — matching
+        // pnpm's convention of keeping `packages:` entries free of
+        // redundant `name:` fields.
+        assert!(
+            body.contains("odd-alias@3.0.1:\n    name: is-odd"),
+            "alias marker missing; got:\n{body}"
+        );
+        assert!(
+            !body.contains("is-number@6.0.0:\n    name:"),
+            "non-aliased package should skip the `name:` field; got:\n{body}"
+        );
+
+        let reparsed = parse(&lockfile_path).unwrap();
+        let pkg = reparsed
+            .packages
+            .get("odd-alias@3.0.1")
+            .expect("aliased entry must round-trip under the alias-keyed dep_path");
+        assert_eq!(pkg.name, "odd-alias");
+        assert_eq!(pkg.alias_of.as_deref(), Some("is-odd"));
+        assert_eq!(pkg.registry_name(), "is-odd");
+
+        let plain = &reparsed.packages["is-number@6.0.0"];
+        assert!(plain.alias_of.is_none());
+        assert_eq!(plain.registry_name(), "is-number");
+    }
+
+    /// Guards against a regression where the reader conflates the
+    /// snapshot key's name with a present `name:` field when both
+    /// match. That's a non-alias entry (some writer — or a
+    /// hand-edit — chose to be explicit about the name) and must
+    /// leave `alias_of` empty.
+    #[test]
+    fn test_redundant_name_field_not_treated_as_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let lockfile_path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &lockfile_path,
+            r#"lockfileVersion: '9.0'
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.0
+packages:
+  foo@1.0.0:
+    name: foo
+    resolution:
+      integrity: sha512-abc
+snapshots:
+  foo@1.0.0: {}
+"#,
+        )
+        .unwrap();
+        let graph = parse(&lockfile_path).unwrap();
+        let pkg = &graph.packages["foo@1.0.0"];
+        assert!(
+            pkg.alias_of.is_none(),
+            "a `name:` field that matches the snapshot name is not an alias marker"
+        );
     }
 }

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -317,6 +317,40 @@ struct ResolveTask {
     /// site is responsible for extending its parent's chain with the
     /// parent's own `(name, version)` frame.
     ancestors: Vec<(String, String)>,
+    /// For npm-alias tasks (`"odd-alias": "npm:is-odd@..."`): the
+    /// original alias key from the consumer's `package.json`. `None`
+    /// for non-aliased tasks.
+    ///
+    /// The `npm:` rewrite further down flips `task.name` to the real
+    /// registry name so packument/tarball fetches hit the right URL,
+    /// but the *linker* still needs to place the dep under the alias
+    /// (consumers `require("odd-alias")` by the key they wrote, not
+    /// by the underlying package name). Preserving the alias here is
+    /// what lets downstream `LockedPackage` and `DirectDep`
+    /// construction sites use `folder_name()` / `registry_name()` to
+    /// pick the right name for each job.
+    alias: Option<String>,
+}
+
+impl ResolveTask {
+    /// The name that belongs on `LockedPackage` / `DirectDep` — the
+    /// *consumer-facing* key. For aliased tasks (`task.alias =
+    /// Some("odd-alias")`) that's the alias; for plain tasks it's
+    /// just `task.name`, which already was the key the consumer used.
+    /// Registry IO (packument + tarball fetch, CAS index key) takes
+    /// `task.name` directly and leaves this helper alone — those
+    /// always want the real name, whether aliased or not.
+    fn folder_name(&self) -> &str {
+        self.alias.as_deref().unwrap_or(&self.name)
+    }
+
+    /// `LockedPackage.alias_of` value for this task: `Some(real)`
+    /// when aliased so `LockedPackage::registry_name()` downstream
+    /// can route fetches/store lookups through the real name,
+    /// `None` otherwise.
+    fn alias_of(&self) -> Option<String> {
+        self.alias.as_ref().map(|_| self.name.clone())
+    }
 }
 
 impl Resolver {
@@ -665,6 +699,7 @@ impl Resolver {
                     importer: importer_path.clone(),
                     original_specifier: Some(range.clone()),
                     ancestors: Vec::new(),
+                    alias: None,
                 });
             }
             for (name, range) in &manifest.dev_dependencies {
@@ -677,6 +712,7 @@ impl Resolver {
                     importer: importer_path.clone(),
                     original_specifier: Some(range.clone()),
                     ancestors: Vec::new(),
+                    alias: None,
                 });
             }
             for (name, range) in &manifest.optional_dependencies {
@@ -695,6 +731,7 @@ impl Resolver {
                     importer: importer_path.clone(),
                     original_specifier: Some(range.clone()),
                     ancestors: Vec::new(),
+                    alias: None,
                 });
             }
         }
@@ -1031,6 +1068,23 @@ impl Resolver {
                                 real_name,
                                 real_range
                             );
+                            // Stash the original key *before* rewriting —
+                            // every downstream site (LockedPackage.name,
+                            // DirectDep.name, dep_path) needs to refer to
+                            // the alias, not the real registry name, or
+                            // consumers `require("<alias>")` from
+                            // anywhere in the tree will miss. The rewrite
+                            // itself is still needed so packument and
+                            // tarball fetches hit the real URL.
+                            //
+                            // A second pass through this loop (after an
+                            // override or catalog rewrite that re-introduces
+                            // an `npm:` spec) must not overwrite the alias
+                            // with the intermediate real name — preserve
+                            // the outermost alias only.
+                            if task.alias.is_none() {
+                                task.alias = Some(task.name.clone());
+                            }
                             task.name = real_name;
                             task.range = real_range;
                             changed = true;
@@ -1230,6 +1284,7 @@ impl Resolver {
                                     importer: task.importer.clone(),
                                     original_specifier: None,
                                     ancestors: child_ancestors.clone(),
+                                    alias: None,
                                 });
                             }
                         }
@@ -1281,12 +1336,27 @@ impl Resolver {
                 // in the pipelined loop we run it up front so
                 // dedupable tasks never block on a fetch or a
                 // lockfile scan.
-                if let Some(matched_ver) = resolved_versions.get(&task.name).and_then(|versions| {
-                    versions
-                        .iter()
-                        .find(|v| version_satisfies(v, &task.range))
-                        .cloned()
-                }) {
+                //
+                // Aliased tasks bypass sibling dedupe entirely —
+                // their graph entry lives under the alias-keyed
+                // dep_path (`alias-num@7.0.0`), not the real-name
+                // one (`is-number@7.0.0`), so snapping a transitive
+                // `is-number` reference at the aliased version
+                // would produce a dangling `is-number@7.0.0` edge
+                // with no matching `LockedPackage`. The alias
+                // snapshot and its non-aliased sibling are
+                // distinct entries; let the aliased task fall
+                // through to lockfile-reuse or fresh fetch under
+                // its own alias-keyed dep_path.
+                if task.alias.is_none()
+                    && let Some(matched_ver) =
+                        resolved_versions.get(&task.name).and_then(|versions| {
+                            versions
+                                .iter()
+                                .find(|v| version_satisfies(v, &task.range))
+                                .cloned()
+                        })
+                {
                     let dep_path = dep_path_for(&task.name, &matched_ver);
                     if task.is_root
                         && let Some(deps) = importers.get_mut(&task.importer)
@@ -1322,9 +1392,19 @@ impl Resolver {
                 // loop the cache is populated incrementally and the
                 // gate was a false optimization.
                 {
+                    // Match on `folder_name` — that's what
+                    // `LockedPackage.name` holds in the alias-keyed
+                    // graph this resolver produces, so the lookup
+                    // finds the alias entry the previous install
+                    // wrote. A plain `p.name == task.name` compare
+                    // would miss every aliased lockfile entry and
+                    // fall through to a redundant fresh fetch (which
+                    // also 404s under the alias-qualified registry
+                    // URL), losing the alias round-trip entirely.
                     if let Some(locked_pkg) = existing.and_then(|g| {
                         g.packages.values().find(|p| {
-                            p.name == task.name && version_satisfies(&p.version, &task.range)
+                            p.name == task.folder_name()
+                                && version_satisfies(&p.version, &task.range)
                         })
                     }) {
                         // Drop optional deps whose platform constraints
@@ -1359,13 +1439,18 @@ impl Resolver {
                             continue;
                         }
                         let version = locked_pkg.version.clone();
-                        let dep_path = dep_path_for(&task.name, &version);
+                        // Same folder_name/alias reasoning as the
+                        // registry path below — when the existing
+                        // lockfile already captured an `npm:` alias
+                        // the task carries it, and both the graph key
+                        // and every referencing dep map need to match.
+                        let dep_path = dep_path_for(task.folder_name(), &version);
 
                         if task.is_root
                             && let Some(deps) = importers.get_mut(&task.importer)
                         {
                             deps.push(DirectDep {
-                                name: task.name.clone(),
+                                name: task.folder_name().to_string(),
                                 dep_path: dep_path.clone(),
                                 dep_type: task.dep_type,
                                 specifier: task.original_specifier.clone(),
@@ -1374,13 +1459,14 @@ impl Resolver {
                         if let Some(ref parent_dp) = task.parent
                             && let Some(parent_pkg) = resolved.get_mut(parent_dp)
                         {
+                            let folder_key = task.folder_name().to_string();
                             parent_pkg
                                 .dependencies
-                                .insert(task.name.clone(), version.clone());
+                                .insert(folder_key.clone(), version.clone());
                             if task.dep_type == DepType::Optional {
                                 parent_pkg
                                     .optional_dependencies
-                                    .insert(task.name.clone(), version.clone());
+                                    .insert(folder_key, version.clone());
                             }
                         }
                         if !visited.contains(&dep_path) {
@@ -1420,7 +1506,7 @@ impl Resolver {
                             resolved.insert(
                                 dep_path.clone(),
                                 LockedPackage {
-                                    name: task.name.clone(),
+                                    name: task.folder_name().to_string(),
                                     version: version.clone(),
                                     integrity: locked_pkg.integrity.clone(),
                                     dependencies: BTreeMap::new(),
@@ -1436,7 +1522,21 @@ impl Resolver {
                                     libc: locked_pkg.libc.clone(),
                                     bundled_dependencies: locked_pkg.bundled_dependencies.clone(),
                                     tarball_url: locked_pkg.tarball_url.clone(),
-                                    alias_of: locked_pkg.alias_of.clone(),
+                                    // Prefer the task's alias (the
+                                    // fresh view from the consumer
+                                    // re-entering the resolver) over
+                                    // whatever the lockfile recorded;
+                                    // fall back to the lockfile entry
+                                    // when the consumer didn't supply
+                                    // one (e.g., resolving the same
+                                    // package during a different run
+                                    // where this call site had nothing
+                                    // to do with an alias). Matching
+                                    // npm's alias detection, `None`
+                                    // is the non-aliased default.
+                                    alias_of: task
+                                        .alias_of()
+                                        .or_else(|| locked_pkg.alias_of.clone()),
                                 },
                             );
 
@@ -1471,6 +1571,7 @@ impl Resolver {
                                     importer: task.importer.clone(),
                                     original_specifier: None,
                                     ancestors: child_ancestors.clone(),
+                                    alias: None,
                                 });
                             }
                         }
@@ -1725,7 +1826,15 @@ impl Resolver {
                 }
 
                 let version = version_meta.version.clone();
-                let dep_path = dep_path_for(&task.name, &version);
+                // Key the graph entry by `folder_name` — the alias for
+                // aliased tasks, the real name otherwise. Consumers of
+                // `"odd-alias": "npm:is-odd@..."` refer to this dep as
+                // `odd-alias` everywhere in their tree; the linker
+                // creates `node_modules/odd-alias/` from this name,
+                // and transitive symlinks are rebuilt by concatenating
+                // `{folder_name}@{tail}`. Registry IO still uses
+                // `task.registry_name()` via `LockedPackage::registry_name()`.
+                let dep_path = dep_path_for(task.folder_name(), &version);
 
                 // Record publish time for the cutoff / `time:` block
                 // whenever the packument carries one — matches pnpm,
@@ -1740,29 +1849,38 @@ impl Resolver {
                     resolved_times.insert(dep_path.clone(), t.clone());
                 }
 
-                // Record root dep
+                // Record root dep. `DirectDep.name` is the alias the
+                // importer's `package.json` keyed this dep by
+                // (`folder_name()`), not the registry name — that's
+                // what the linker places under `node_modules/<name>/`
+                // and what any `require(...)` in user code uses.
                 if task.is_root
                     && let Some(deps) = importers.get_mut(&task.importer)
                 {
                     deps.push(DirectDep {
-                        name: task.name.clone(),
+                        name: task.folder_name().to_string(),
                         dep_path: dep_path.clone(),
                         dep_type: task.dep_type,
                         specifier: task.original_specifier.clone(),
                     });
                 }
 
-                // Wire parent
+                // Wire parent. Use the alias here for the same reason
+                // as above — the parent's `package.json` referenced
+                // this dep by its alias, so that's the key the linker
+                // uses when walking `parent.dependencies` to plant
+                // sibling symlinks.
                 if let Some(ref parent_dp) = task.parent
                     && let Some(parent_pkg) = resolved.get_mut(parent_dp)
                 {
+                    let folder_key = task.folder_name().to_string();
                     parent_pkg
                         .dependencies
-                        .insert(task.name.clone(), version.clone());
+                        .insert(folder_key.clone(), version.clone());
                     if task.dep_type == DepType::Optional {
                         parent_pkg
                             .optional_dependencies
-                            .insert(task.name.clone(), version.clone());
+                            .insert(folder_key, version.clone());
                     }
                 }
 
@@ -1795,11 +1913,19 @@ impl Resolver {
                     }
                 }
 
-                // Track this version
-                resolved_versions
-                    .entry(task.name.clone())
-                    .or_default()
-                    .push(version.clone());
+                // Track this version for sibling dedupe — but only
+                // for non-aliased tasks. An aliased task's graph
+                // entry lives at the alias-keyed dep_path, so if a
+                // later non-aliased consumer deduped against it,
+                // it'd pick up `<real>@<ver>` as a reference to a
+                // snapshot that doesn't exist (see the paired
+                // sibling-dedupe guard above).
+                if task.alias.is_none() {
+                    resolved_versions
+                        .entry(task.name.clone())
+                        .or_default()
+                        .push(version.clone());
+                }
 
                 let integrity = version_meta.dist.as_ref().and_then(|d| d.integrity.clone());
 
@@ -1855,7 +1981,10 @@ impl Resolver {
                 resolved.insert(
                     dep_path.clone(),
                     LockedPackage {
-                        name: task.name.clone(),
+                        // Alias for aliased tasks, real name otherwise.
+                        // The linker's `.aube/<dep_path>/node_modules/<name>/`
+                        // layout uses this field as the folder name.
+                        name: task.folder_name().to_string(),
                         version: version.clone(),
                         integrity,
                         dependencies: BTreeMap::new(),
@@ -1873,7 +2002,11 @@ impl Resolver {
                             v
                         },
                         tarball_url: None,
-                        alias_of: None,
+                        // `Some(real)` for aliased tasks routes
+                        // `registry_name()` / fetch URL / store
+                        // index through the registry name; `None`
+                        // means `name` is already the registry name.
+                        alias_of: task.alias_of(),
                     },
                 );
 
@@ -1922,6 +2055,7 @@ impl Resolver {
                         importer: task.importer.clone(),
                         original_specifier: None,
                         ancestors: child_ancestors.clone(),
+                        alias: None,
                     });
                 }
 
@@ -1956,6 +2090,7 @@ impl Resolver {
                         importer: task.importer.clone(),
                         original_specifier: None,
                         ancestors: child_ancestors.clone(),
+                        alias: None,
                     });
                 }
 
@@ -2043,6 +2178,7 @@ impl Resolver {
                             importer: task.importer.clone(),
                             original_specifier: None,
                             ancestors: child_ancestors.clone(),
+                            alias: None,
                         });
                     }
                 }

--- a/test/package_lock_write.bats
+++ b/test/package_lock_write.bats
@@ -280,9 +280,8 @@ EOF
 # lands as a distinct top-level folder, not as the real package name.
 #
 # Covers the lockfile-driven path (default / `--frozen-lockfile`).
-# A separate fresh-resolve path through the resolver does not yet
-# preserve the alias-as-folder-name — see the TODO in
-# `aube-resolver::task.name` rewriting for `npm:` specifiers.
+# The sibling test below covers the fresh-resolve path through the
+# resolver (no lockfile).
 @test "aube install handles npm-alias in package-lock.json" {
 	cat >package.json <<'JSON'
 {
@@ -345,4 +344,59 @@ JSON
 	run grep -F 'https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz' package-lock.json
 	assert_success
 	assert [ ! -f aube-lock.yaml ]
+}
+
+# Fresh-resolve complement to the test above: no lockfile on disk,
+# only a `"<alias>": "npm:<real>@..."` in `package.json`. The
+# resolver used to rewrite `task.name` from alias to real and forget
+# the alias, so `node_modules/odd-alias/` came out as
+# `node_modules/is-odd/` and `require("odd-alias")` from user code
+# broke. Verify both the top-level layout and the generated
+# `aube-lock.yaml` preserve the alias so the second (frozen) install
+# reuses the locked entry instead of re-fetching under the alias
+# name and 404-ing.
+@test "aube install handles npm-alias on fresh resolve (no lockfile)" {
+	cat >package.json <<'JSON'
+{
+  "name": "alias-fresh-resolve",
+  "version": "1.0.0",
+  "dependencies": {
+    "odd-alias": "npm:is-odd@3.0.1"
+  }
+}
+JSON
+
+	run aube install
+	assert_success
+
+	# Alias landed as its own top-level folder, not as the real name.
+	assert_link_exists node_modules/odd-alias
+	assert_not_exists node_modules/is-odd
+
+	# The virtual store entry is keyed by alias (consistent with the
+	# npm-lockfile path). Without this, a later install reading back
+	# the lockfile has no way to rebuild the `node_modules/odd-alias`
+	# symlink.
+	assert_dir_exists node_modules/.aube/odd-alias@3.0.1
+
+	# The generated `aube-lock.yaml` must carry `name: is-odd` under
+	# the aliased snapshot. Without it, the reader can't distinguish
+	# an alias from a genuine package called `odd-alias`, and the
+	# next frozen install would hit the registry for `odd-alias` and
+	# 404.
+	assert_file_exists aube-lock.yaml
+	run grep -F "name: is-odd" aube-lock.yaml
+	assert_success
+	run grep -E "specifier: npm:is-odd@3.0.1" aube-lock.yaml
+	assert_success
+
+	# Second (frozen) install from the same lockfile must still end
+	# up with the alias folder — guards against regressing the
+	# lockfile-reuse lookup that used to search `p.name == task.name`
+	# (the real name, which never matches the alias-keyed entry).
+	rm -rf node_modules
+	run aube install
+	assert_success
+	assert_link_exists node_modules/odd-alias
+	assert_not_exists node_modules/is-odd
 }


### PR DESCRIPTION
## Summary

- Fixes fresh-resolve alias handling: `"odd-alias": "npm:is-odd@..."` now lands at `node_modules/odd-alias/`, not `node_modules/is-odd/`. PR #30 fixed this for the npm-lockfile path; this completes the story for fresh resolves (no lockfile) and re-resolves.
- Concrete user-visible win: **`aube i && aube dev` on the TanStack Start starter works end-to-end now**. The starter's `@tanstack/start-server-core` has a nested `"h3-v2": "npm:h3@..."`; fresh-resolve was creating `node_modules/h3/` instead of `node_modules/h3-v2/`, and `require("h3-v2")` from start-server-core failed at runtime.

## What changed

- Add `ResolveTask.alias: Option<String>`; stash the original key before the `npm:` rewrite flips `task.name` to the real registry name.
- Route `LockedPackage.name`, `DirectDep.name`, `dep_path`, and parent-wire-up through `task.folder_name()` (alias when aliased, real name otherwise). Registry IO still uses `task.name` via `LockedPackage::registry_name()` (from PR #30).
- Skip sibling-dedupe + `resolved_versions` for aliased tasks — the alias-keyed graph entry can't be the dedup target for a non-aliased consumer without minting a dangling `<real>@<ver>` edge. Fresh-resolve of the override-alias test fixture proves the case.
- Lockfile-reuse lookup matches on `p.name == task.folder_name()` so a previously-written aube-lock.yaml gets found by its alias on the next install.
- aube-lock.yaml round-trip: writer emits `packages.<dep>.name: <real>` (pnpm's own convention for disambiguating installs) only for aliased entries; reader promotes that to `alias_of` when it differs from the dep_path name. Non-aliased entries stay byte-identical to pnpm's output.

## Test plan

- [x] New pnpm unit tests: alias round-trip + a guard that a redundant `name:` matching the snapshot key is not treated as an alias.
- [x] New BATS test: fresh-resolve of `"odd-alias": "npm:is-odd@3.0.1"` produces `node_modules/odd-alias/`, writes `name: is-odd` into aube-lock.yaml, and a second frozen install reuses the locked entry without re-fetching.
- [x] Existing `override applies to the real package behind an npm: alias direct dep` test still passes (it required the sibling-dedupe skip to avoid a dangling edge).
- [x] `cargo test --workspace --exclude aube-registry` — 582/582 pass. (aube-registry failures are pre-existing env leaks from `~/.npmrc`.)
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] Full BATS suite — no regressions (one Verdaccio connectivity flake retried clean).
- [x] End-to-end: `aube i && aube dev` on the TanStack Start starter starts Vite on `http://localhost:3000/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how npm `npm:` alias dependencies are keyed and reused across resolve, lockfile write/read, and install; mistakes could break module layout (`node_modules/<alias>`) or cause incorrect registry fetches/404s. Scope is contained to alias handling paths but touches core resolver and lockfile serialization logic.
> 
> **Overview**
> Ensures npm-style alias deps (`"odd-alias": "npm:is-odd@..."`) keep the *alias* as the consumer-facing name and `dep_path` (so installs create `node_modules/odd-alias/`) while still routing registry fetches through the real package name.
> 
> Updates the resolver to track an explicit alias on tasks, bypass alias-unsafe sibling dedupe, and make lockfile reuse and graph wiring use `folder_name()` for keys while recording `LockedPackage.alias_of` for registry identity. Updates pnpm lockfile read/write to round-trip an alias marker via `packages.<key>.name: <real>` only for aliased entries, with new unit tests and BATS coverage for fresh-resolve and frozen reinstall behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f1ab00e1abff53b44e9570e9c48510fb8904f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->