### PR TITLE
cli: clarify packageManagerStrict rejection message

### DIFF
--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -1113,7 +1113,8 @@ fn enforce_package_manager_guardrails(settings: &StartupSettings) -> miette::Res
             Ok(())
         }
         other => Err(miette!(
-            "packageManager uses unsupported package manager `{other}`. aube only accepts `aube` and `pnpm` when packageManagerStrict=true."
+            "packageManager in {} uses unsupported package manager `{other}`. aube's packageManagerStrict guard is on by default and only accepts `aube` and `pnpm`; remove or change the `packageManager` field, or set `packageManagerStrict=false` in .npmrc to skip this guard.",
+            path.display()
         )),
     }
 }


### PR DESCRIPTION
## Summary

- The guardrail error fired as soon as a `package.json` had e.g. `packageManager: "bun@..."`, because `packageManagerStrict` defaults to `true`. The old wording — `aube only accepts aube and pnpm when packageManagerStrict=true` — read like the user had opted in, and offered no path forward.
- Rewrite the message to state the default explicitly and name the two escape hatches (change/remove the `packageManager` field, or set `packageManagerStrict=false` in `.npmrc`). Include the `package.json` path so workspace users can find the right file.

## Test plan

- [x] `cargo build -p aube`
- [ ] `cargo clippy --all-targets -- -D warnings` (covered by pre-commit hook at commit time)
- [ ] Existing `test/guardrails.bats` still asserts the `"unsupported package manager"` substring, which the new message preserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes CLI error text for unsupported `packageManager` values, with no behavior or data-flow changes.
> 
> **Overview**
> Clarifies the `packageManagerStrict` guardrail rejection when `package.json` specifies an unsupported `packageManager`.
> 
> The error now includes the specific `package.json` path and explicitly states the guard is *enabled by default*, with actionable next steps (remove/change `packageManager`, or set `packageManagerStrict=false` in `.npmrc`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68805fae09fe7589805942eefe0418a616d4b0a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->