### PR TITLE
cli: AUBE_DEBUG/AUBE_LOG replace RUST_LOG for log control

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -38,7 +38,7 @@ flag --include-workspace-root help="Include the workspace root in recursive work
 }
 flag --loglevel help="Set the log level. Logs at or above this level are shown" global=#true {
     arg <LEVEL> {
-        choices debug info warn error silent
+        choices trace debug info warn error silent
     }
 }
 flag --no-color help="Disable colored output" global=#true {

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -973,12 +973,19 @@ fn resolve_loglevel(cli: &Cli, configured: Option<&str>) -> LogLevel {
     if let Some(level) = cli.loglevel {
         return level;
     }
-    if cli.verbose {
+    if cli.verbose || env_is_truthy("AUBE_DEBUG") || env_is_truthy("AUBE_TRACE") {
         return LogLevel::Debug;
     }
     configured
         .and_then(parse_loglevel)
         .unwrap_or(LogLevel::Warn)
+}
+
+fn env_is_truthy(name: &str) -> bool {
+    matches!(
+        std::env::var(name).as_deref().map(str::trim),
+        Ok("1" | "true" | "TRUE" | "yes" | "YES" | "y" | "Y")
+    )
 }
 
 fn parse_loglevel(raw: &str) -> Option<LogLevel> {
@@ -1003,13 +1010,14 @@ fn parse_color_mode(raw: &str) -> Option<ColorMode> {
 
 fn init_logging(cli: &Cli, effective_level: LogLevel) {
     let log_level = effective_level.filter();
-    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+    let env_filter = tracing_subscriber::EnvFilter::try_from_env("AUBE_LOG")
         .unwrap_or_else(|_| format!("aube={log_level},aube_cli={log_level}").into());
 
     // ndjson swaps the fmt layer for the JSON formatter so every tracing
     // event is serialized as a single line of JSON on stderr. The filter
     // itself is the same as every other mode — `--loglevel` / `--verbose`
-    // / `RUST_LOG` pick the verbosity, ndjson just changes the encoding.
+    // / `AUBE_DEBUG` / `AUBE_LOG` pick the verbosity, ndjson just changes
+    // the encoding.
     //
     // Every mode routes writes through `progress::PausingWriter`, which
     // pauses the clx progress display and holds the terminal lock across
@@ -1019,12 +1027,12 @@ fn init_logging(cli: &Cli, effective_level: LogLevel) {
     // degrades to a plain stderr flush.
     //
     // Timestamps are dropped unless the user asked for `debug` verbosity
-    // (via `-v` / `--loglevel=debug` / `RUST_LOG`). A default-verbosity
-    // install that emits deprecated-package warnings reads more like
-    // pnpm's `WARN: mathjax-full@3.2.2 is deprecated…` than a server
-    // log line; keeping the RFC3339 prefix just pushes the package
-    // name off the visible width for no gain. ndjson always keeps the
-    // timestamp — its whole point is machine-parseable records.
+    // (via `-v` / `--loglevel=debug` / `AUBE_DEBUG=1` / `AUBE_LOG`). A
+    // default-verbosity install that emits deprecated-package warnings
+    // reads more like pnpm's `WARN: mathjax-full@3.2.2 is deprecated…`
+    // than a server log line; keeping the RFC3339 prefix just pushes the
+    // package name off the visible width for no gain. ndjson always
+    // keeps the timestamp — its whole point is machine-parseable records.
     let drop_timestamp = !matches!(effective_level, LogLevel::Debug);
     let registry = tracing_subscriber::registry().with(env_filter);
     if matches!(cli.reporter, Some(ReporterType::Ndjson)) {

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -205,6 +205,7 @@ pub(crate) struct Cli {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[clap(rename_all = "lowercase")]
 pub(crate) enum LogLevel {
+    Trace,
     Debug,
     Info,
     Warn,
@@ -224,6 +225,7 @@ pub(crate) enum ReporterType {
 impl LogLevel {
     fn filter(self) -> &'static str {
         match self {
+            LogLevel::Trace => "trace",
             LogLevel::Debug => "debug",
             LogLevel::Info => "info",
             LogLevel::Warn => "warn",
@@ -973,7 +975,10 @@ fn resolve_loglevel(cli: &Cli, configured: Option<&str>) -> LogLevel {
     if let Some(level) = cli.loglevel {
         return level;
     }
-    if cli.verbose || env_is_truthy("AUBE_DEBUG") || env_is_truthy("AUBE_TRACE") {
+    if env_is_truthy("AUBE_TRACE") {
+        return LogLevel::Trace;
+    }
+    if cli.verbose || env_is_truthy("AUBE_DEBUG") {
         return LogLevel::Debug;
     }
     configured
@@ -990,6 +995,7 @@ fn env_is_truthy(name: &str) -> bool {
 
 fn parse_loglevel(raw: &str) -> Option<LogLevel> {
     match raw.trim().to_ascii_lowercase().as_str() {
+        "trace" => Some(LogLevel::Trace),
         "debug" => Some(LogLevel::Debug),
         "info" => Some(LogLevel::Info),
         "warn" | "warning" => Some(LogLevel::Warn),
@@ -1033,7 +1039,7 @@ fn init_logging(cli: &Cli, effective_level: LogLevel) {
     // than a server log line; keeping the RFC3339 prefix just pushes the
     // package name off the visible width for no gain. ndjson always
     // keeps the timestamp — its whole point is machine-parseable records.
-    let drop_timestamp = !matches!(effective_level, LogLevel::Debug);
+    let drop_timestamp = !matches!(effective_level, LogLevel::Debug | LogLevel::Trace);
     let registry = tracing_subscriber::registry().with(env_filter);
     if matches!(cli.reporter, Some(ReporterType::Ndjson)) {
         registry
@@ -1062,11 +1068,13 @@ fn init_logging(cli: &Cli, effective_level: LogLevel) {
     // with the reporter: `append-only` and `ndjson` both want line-at-a-time
     // output, and `debug`/`silent` already disabled the UI for their own
     // reasons.
-    let force_text = matches!(effective_level, LogLevel::Debug | LogLevel::Silent)
-        || matches!(
-            cli.reporter,
-            Some(ReporterType::AppendOnly) | Some(ReporterType::Ndjson)
-        );
+    let force_text = matches!(
+        effective_level,
+        LogLevel::Trace | LogLevel::Debug | LogLevel::Silent
+    ) || matches!(
+        cli.reporter,
+        Some(ReporterType::AppendOnly) | Some(ReporterType::Ndjson)
+    );
     if force_text {
         clx::progress::set_output(clx::progress::ProgressOutput::Text);
     }

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -987,9 +987,12 @@ fn resolve_loglevel(cli: &Cli, configured: Option<&str>) -> LogLevel {
 }
 
 fn env_is_truthy(name: &str) -> bool {
+    let Ok(raw) = std::env::var(name) else {
+        return false;
+    };
     matches!(
-        std::env::var(name).as_deref().map(str::trim),
-        Ok("1" | "true" | "TRUE" | "yes" | "YES" | "y" | "Y")
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "y"
     )
 }
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5471,6 +5471,7 @@
           "hide": false,
           "choices": {
             "choices": [
+              "trace",
               "debug",
               "info",
               "warn",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -79,6 +79,7 @@ Set the log level. Logs at or above this level are shown
 
 **Choices:**
 
+- `trace`
 - `debug`
 - `info`
 - `warn`

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -41,7 +41,9 @@ _common_setup() {
 
 	# Keep host shell logging preferences from overriding tests that assert
 	# aube's CLI/config loglevel behavior.
-	unset RUST_LOG
+	unset AUBE_LOG
+	unset AUBE_DEBUG
+	unset AUBE_TRACE
 
 	# Keep the update notifier (install.rs:… -> update_check.rs) from
 	# hitting aube.en.dev during BATS. Unsetting CI re-enables it by


### PR DESCRIPTION
## Summary

- Swap the logging env vars from `RUST_LOG` to an aube-prefixed trio, matching mise (`MISE_DEBUG`) and hk (`HK_LOG`):
  - `AUBE_DEBUG=1` / `AUBE_TRACE=1` — boolean shortcut, same effect as `--verbose` (sets the level to `debug`).
  - `AUBE_LOG` — full `tracing-subscriber` filter string (e.g. `aube=debug,aube_resolver=trace`), replacing the previous `RUST_LOG` hook.
- `init_logging` now reads `AUBE_LOG` via `EnvFilter::try_from_env` instead of `try_from_default_env`, so `RUST_LOG` no longer silently controls aube's output.
- BATS helper unsets `AUBE_LOG` / `AUBE_DEBUG` / `AUBE_TRACE` (replacing the old `unset RUST_LOG`), so a host-shell `AUBE_DEBUG=1` can't leak into the suite and flip tests that assert default-verbosity behavior.

## Why

Generic `RUST_*` env vars make it easy to accidentally crank up logging for *every* Rust binary in a shell session, and they don't signal that the var is aube-specific. The rest of the tool family (mise, hk) already uses a tool-prefixed convention, so aube should too.

## Test plan

- [x] `cargo build -p aube`
- [x] `cargo clippy -p aube --all-targets -- -D warnings`
- [x] `cargo test -p aube` (220 unit + 4 e2e, all pass)
- [x] Manual smoke: `AUBE_DEBUG=1 aube ...` bumps the effective loglevel to debug; plain `aube ...` still defaults to warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how runtime logging is configured: `RUST_LOG` no longer affects output and new env vars (`AUBE_LOG`/`AUBE_DEBUG`/`AUBE_TRACE`) can alter verbosity and progress UI behavior for existing scripts and users.
> 
> **Overview**
> **Switches CLI logging control from `RUST_LOG` to aube-prefixed env vars.** Logging now reads `AUBE_LOG` (full `tracing_subscriber` filter) and adds boolean shortcuts `AUBE_DEBUG` and `AUBE_TRACE` to raise verbosity, plus introduces a `trace` `--loglevel` option.
> 
> Updates logging initialization and related UX: `Trace` keeps timestamps and forces text/progress-safe output like debug, and the BATS test harness now unsets `AUBE_LOG`/`AUBE_DEBUG`/`AUBE_TRACE` to avoid host env leakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c7ac6f42a8373fa198afa6d0ef2b12e13cb398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->