### PR TITLE
catalog: discover from workspace root + package.json sources

### DIFF
--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -84,7 +84,11 @@ impl BundledDependencies {
 pub enum Workspaces {
     Array(Vec<String>),
     Object {
-        #[serde(default)]
+        // `packages` stays required (no `#[serde(default)]`) so that a
+        // typo like `"pacakges"` fails deserialization instead of
+        // silently producing an empty vec. Bun's object form always
+        // includes `packages`, so this doesn't lock out the catalog use
+        // case.
         packages: Vec<String>,
         #[serde(default)]
         nohoist: Vec<String>,

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -84,9 +84,19 @@ impl BundledDependencies {
 pub enum Workspaces {
     Array(Vec<String>),
     Object {
+        #[serde(default)]
         packages: Vec<String>,
         #[serde(default)]
         nohoist: Vec<String>,
+        /// Bun-style default catalog nested under `workspaces.catalog`.
+        /// Aube reads it in addition to `pnpm-workspace.yaml`'s `catalog:`
+        /// so bun projects that migrated config into package.json keep
+        /// working.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        catalog: BTreeMap<String, String>,
+        /// Bun-style named catalogs nested under `workspaces.catalogs`.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        catalogs: BTreeMap<String, BTreeMap<String, String>>,
     },
 }
 
@@ -95,6 +105,26 @@ impl Workspaces {
         match self {
             Workspaces::Array(v) => v,
             Workspaces::Object { packages, .. } => packages,
+        }
+    }
+
+    /// Bun-style default catalog (`workspaces.catalog`). Empty when the
+    /// `workspaces` field is an array or the object form has no catalog.
+    pub fn catalog(&self) -> &BTreeMap<String, String> {
+        static EMPTY: std::sync::OnceLock<BTreeMap<String, String>> = std::sync::OnceLock::new();
+        match self {
+            Workspaces::Array(_) => EMPTY.get_or_init(BTreeMap::new),
+            Workspaces::Object { catalog, .. } => catalog,
+        }
+    }
+
+    /// Bun-style named catalogs (`workspaces.catalogs`).
+    pub fn catalogs(&self) -> &BTreeMap<String, BTreeMap<String, String>> {
+        static EMPTY: std::sync::OnceLock<BTreeMap<String, BTreeMap<String, String>>> =
+            std::sync::OnceLock::new();
+        match self {
+            Workspaces::Array(_) => EMPTY.get_or_init(BTreeMap::new),
+            Workspaces::Object { catalogs, .. } => catalogs,
         }
     }
 }
@@ -160,6 +190,46 @@ impl PackageJson {
         };
         arr.iter()
             .filter_map(|v| v.as_str().map(String::from))
+            .collect()
+    }
+
+    /// Extract `pnpm.catalog` — a default catalog defined inline in
+    /// package.json under the `pnpm` object. pnpm itself reads catalogs
+    /// only from `pnpm-workspace.yaml`, but aube also honors this
+    /// location so single-package projects can declare catalogs without
+    /// maintaining a separate workspace file.
+    pub fn pnpm_catalog(&self) -> BTreeMap<String, String> {
+        let Some(pnpm) = self.extra.get("pnpm").and_then(|v| v.as_object()) else {
+            return BTreeMap::new();
+        };
+        let Some(map) = pnpm.get("catalog").and_then(|v| v.as_object()) else {
+            return BTreeMap::new();
+        };
+        map.iter()
+            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+            .collect()
+    }
+
+    /// Extract `pnpm.catalogs` — named catalogs nested under the `pnpm`
+    /// object. Pairs with [`pnpm_catalog`] for a fully-package.json-local
+    /// catalog declaration.
+    pub fn pnpm_catalogs(&self) -> BTreeMap<String, BTreeMap<String, String>> {
+        let Some(pnpm) = self.extra.get("pnpm").and_then(|v| v.as_object()) else {
+            return BTreeMap::new();
+        };
+        let Some(outer) = pnpm.get("catalogs").and_then(|v| v.as_object()) else {
+            return BTreeMap::new();
+        };
+        outer
+            .iter()
+            .filter_map(|(name, inner)| {
+                let inner = inner.as_object()?;
+                let entries: BTreeMap<String, String> = inner
+                    .iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect();
+                Some((name.clone(), entries))
+            })
             .collect()
     }
 

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1021,26 +1021,31 @@ impl Resolver {
                         n.to_string()
                     }
                 }) {
-                    match self
-                        .catalogs
-                        .get(&catalog_name)
-                        .and_then(|c| c.get(&task.name))
-                    {
-                        Some(real_range) => {
-                            tracing::trace!(
-                                "catalog: {} {} -> {}",
-                                task.name,
-                                task.range,
-                                real_range
-                            );
-                            catalog_picks
-                                .entry(catalog_name.clone())
-                                .or_default()
-                                .insert(task.name.clone(), real_range.clone());
-                            task.range = real_range.clone();
-                        }
+                    match self.catalogs.get(&catalog_name) {
+                        Some(catalog) => match catalog.get(&task.name) {
+                            Some(real_range) => {
+                                tracing::trace!(
+                                    "catalog: {} {} -> {}",
+                                    task.name,
+                                    task.range,
+                                    real_range
+                                );
+                                catalog_picks
+                                    .entry(catalog_name.clone())
+                                    .or_default()
+                                    .insert(task.name.clone(), real_range.clone());
+                                task.range = real_range.clone();
+                            }
+                            None => {
+                                return Err(Error::UnknownCatalogEntry {
+                                    name: task.name.clone(),
+                                    spec: task.range.clone(),
+                                    catalog: catalog_name,
+                                });
+                            }
+                        },
                         None => {
-                            return Err(Error::UnknownCatalogRef {
+                            return Err(Error::UnknownCatalog {
                                 name: task.name.clone(),
                                 spec: task.range.clone(),
                                 catalog: catalog_name,
@@ -4123,9 +4128,17 @@ pub enum Error {
     #[error("registry error for {0}: {1}")]
     Registry(String, String),
     #[error(
+        "{name}: catalog reference `{spec}` does not resolve — catalog `{catalog}` is not defined (add it to `catalog:` / `catalogs.{catalog}:` in pnpm-workspace.yaml, or under `workspaces.catalog` / `pnpm.catalog` in package.json)"
+    )]
+    UnknownCatalog {
+        name: String,
+        spec: String,
+        catalog: String,
+    },
+    #[error(
         "{name}: catalog reference `{spec}` does not resolve — catalog `{catalog}` has no entry for `{name}`"
     )]
-    UnknownCatalogRef {
+    UnknownCatalogEntry {
         name: String,
         spec: String,
         catalog: String,

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -2841,7 +2841,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     let (ws_config_shared, raw_workspace) = aube_manifest::workspace::load_both(&cwd)
         .into_diagnostic()
         .wrap_err("failed to load workspace config")?;
-    let workspace_catalogs = super::workspace_catalog_map(&ws_config_shared);
+    // Catalog discovery walks up for the workspace yaml and also pulls
+    // from package.json's `workspaces.catalog` / `pnpm.catalog`, so
+    // `aube install` run from a monorepo subpackage still sees the root
+    // workspace's catalog. See `discover_catalogs` for the precedence
+    // order.
+    let workspace_catalogs = super::discover_catalogs(&cwd)?;
     let settings_ctx = aube_settings::ResolveCtx {
         npmrc: &npmrc_entries,
         workspace_yaml: &raw_workspace,

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -566,42 +566,103 @@ pub(crate) fn packument_full_cache_dir() -> std::path::PathBuf {
     resolved_cache_dir(&cwd).join("packuments-full-v1")
 }
 
-/// Reshape an already-loaded `WorkspaceConfig` into the catalog map the
-/// resolver consumes — outer key is the catalog name, with the unnamed
-/// `catalog:` field landing under `default`. Empty when the workspace
-/// declares neither.
-///
-/// Every command that builds a `Resolver` needs to thread this map
-/// through `Resolver::with_catalogs`, otherwise the resolver hard-fails
-/// on any existing `catalog:` dep with `UnknownCatalogRef`.
-pub(crate) fn workspace_catalog_map(
-    ws_config: &aube_manifest::WorkspaceConfig,
-) -> std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>> {
-    let mut out: std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>> =
-        std::collections::BTreeMap::new();
-    if !ws_config.catalog.is_empty() {
-        out.insert("default".to_string(), ws_config.catalog.clone());
+/// Type alias for the catalog map the resolver consumes — outer key is
+/// the catalog name (`default` for the unnamed catalog), inner map goes
+/// from package name to version range.
+pub(crate) type CatalogMap =
+    std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>;
+
+/// Merge `default_cat` / `named_cats` into `out`. Later calls overwrite
+/// earlier entries — callers invoke this in ascending precedence order
+/// so the highest-priority source lands last.
+fn merge_catalog_source(
+    out: &mut CatalogMap,
+    default_cat: &std::collections::BTreeMap<String, String>,
+    named_cats: &CatalogMap,
+) {
+    if !default_cat.is_empty() {
+        let entry = out.entry("default".to_string()).or_default();
+        for (k, v) in default_cat {
+            entry.insert(k.clone(), v.clone());
+        }
     }
-    for (name, entries) in &ws_config.catalogs {
-        out.insert(name.clone(), entries.clone());
+    for (name, entries) in named_cats {
+        let bucket = out.entry(name.clone()).or_default();
+        for (k, v) in entries {
+            bucket.insert(k.clone(), v.clone());
+        }
     }
-    out
 }
 
-/// Load `pnpm-workspace.yaml` (or `aube-workspace.yaml`) and extract its
-/// catalog map. Convenience wrapper for commands that don't already have
-/// a parsed `WorkspaceConfig` on hand. Commands that *do* (e.g.
-/// `install`) should call [`workspace_catalog_map`] directly to avoid
-/// re-reading the file.
-pub(crate) fn load_workspace_catalogs(
-    cwd: &std::path::Path,
-) -> miette::Result<std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>>
-{
+/// Pull the bun-style `workspaces.catalog` / `workspaces.catalogs` and
+/// pnpm-style `pnpm.catalog` / `pnpm.catalogs` out of a single
+/// package.json and merge them into `out`. Precedence within one
+/// manifest: `pnpm.*` wins over `workspaces.*`.
+fn merge_manifest_catalogs(out: &mut CatalogMap, manifest: &aube_manifest::PackageJson) {
+    if let Some(ws) = &manifest.workspaces {
+        merge_catalog_source(out, ws.catalog(), ws.catalogs());
+    }
+    merge_catalog_source(out, &manifest.pnpm_catalog(), &manifest.pnpm_catalogs());
+}
+
+/// Discover catalog entries from every supported source and merge them
+/// into a single map for the resolver.
+///
+/// Sources, in ascending precedence (later overrides earlier on a per-
+/// entry basis):
+/// 1. `workspaces.catalog` / `workspaces.catalogs` in the project-root
+///    `package.json` (bun style).
+/// 2. `pnpm.catalog` / `pnpm.catalogs` in the project-root `package.json`.
+/// 3. Same two fields from the workspace-root `package.json` when it's
+///    a different file (monorepo subpackage installs).
+/// 4. `catalog:` / `catalogs:` in the nearest `pnpm-workspace.yaml` /
+///    `aube-workspace.yaml` walking up from `project_root`.
+///
+/// Walking up for the workspace yaml matters for monorepos where
+/// `aube install` runs from a subpackage — without this, the loader
+/// only looks in `project_root` and misses the root workspace file.
+///
+/// Every command that builds a `Resolver` threads this map through
+/// `Resolver::with_catalogs`; otherwise the resolver hard-fails any
+/// `catalog:` dep with `UnknownCatalog(Entry)`.
+pub(crate) fn discover_catalogs(project_root: &std::path::Path) -> miette::Result<CatalogMap> {
     use miette::{Context, IntoDiagnostic};
-    let (ws_config, _raw) = aube_manifest::workspace::load_both(cwd)
+
+    let mut out = CatalogMap::new();
+
+    // (1)+(2): project-root package.json catalogs.
+    let project_manifest_path = project_root.join("package.json");
+    let project_manifest = aube_manifest::PackageJson::from_path(&project_manifest_path).ok();
+    if let Some(m) = &project_manifest {
+        merge_manifest_catalogs(&mut out, m);
+    }
+
+    // (3): workspace-root package.json catalogs, if the workspace root
+    // sits above the project root.
+    let workspace_yaml_dir = crate::dirs::find_workspace_root(project_root);
+    if let Some(dir) = &workspace_yaml_dir
+        && dir != project_root
+        && let Ok(m) = aube_manifest::PackageJson::from_path(&dir.join("package.json"))
+    {
+        merge_manifest_catalogs(&mut out, &m);
+    }
+
+    // (4): workspace yaml catalogs, highest precedence. Loaded from the
+    // walk-up directory when present, else from `project_root`.
+    let yaml_dir = workspace_yaml_dir.as_deref().unwrap_or(project_root);
+    let (ws_config, _raw) = aube_manifest::workspace::load_both(yaml_dir)
         .into_diagnostic()
         .wrap_err("failed to load workspace config")?;
-    Ok(workspace_catalog_map(&ws_config))
+    merge_catalog_source(&mut out, &ws_config.catalog, &ws_config.catalogs);
+
+    out.retain(|_, v| !v.is_empty());
+    Ok(out)
+}
+
+/// Convenience alias preserved for existing call sites; forwards to
+/// [`discover_catalogs`] so every command sees the same merged view.
+pub(crate) fn load_workspace_catalogs(cwd: &std::path::Path) -> miette::Result<CatalogMap> {
+    discover_catalogs(cwd)
 }
 
 /// Walk up from `start` looking for a directory that contains an

--- a/test/catalogs.bats
+++ b/test/catalogs.bats
@@ -90,6 +90,7 @@ _setup_catalog_workspace() {
 		    "is-odd": "catalog:"
 		  },
 		  "workspaces": {
+		    "packages": [],
 		    "catalog": {
 		      "is-odd": "^3.0.1"
 		    }

--- a/test/catalogs.bats
+++ b/test/catalogs.bats
@@ -63,6 +63,120 @@ _setup_catalog_workspace() {
 	assert_dir_exists packages/app/node_modules/is-even
 }
 
+@test "aube install: catalog resolves when run from a subpackage" {
+	# Regression: `aube install` run from inside a monorepo subpackage
+	# used to miss the root `pnpm-workspace.yaml` entirely because the
+	# loader only peeked at the project root (the nearest package.json).
+	# Now it walks up for the workspace yaml.
+	_setup_catalog_workspace
+
+	cd packages/lib
+	run aube install
+	assert_success
+
+	# Linked inside the subpackage even though the catalog lives up
+	# one directory in `pnpm-workspace.yaml`.
+	assert_dir_exists node_modules/is-odd
+}
+
+@test "aube install: catalog: resolves from package.json workspaces.catalog" {
+	# Bun-style: catalogs live inline under `workspaces.catalog` in
+	# package.json. No pnpm-workspace.yaml needed.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "aube-test-workspaces-catalog",
+		  "version": "0.0.0",
+		  "dependencies": {
+		    "is-odd": "catalog:"
+		  },
+		  "workspaces": {
+		    "catalog": {
+		      "is-odd": "^3.0.1"
+		    }
+		  }
+		}
+	EOF
+
+	run aube install
+	assert_success
+	assert_dir_exists node_modules/is-odd
+}
+
+@test "aube install: catalog: resolves from package.json pnpm.catalog" {
+	# pnpm-style catalogs declared inline in package.json under `pnpm`.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "aube-test-pnpm-catalog",
+		  "version": "0.0.0",
+		  "dependencies": {
+		    "is-odd": "catalog:"
+		  },
+		  "pnpm": {
+		    "catalog": {
+		      "is-odd": "^3.0.1"
+		    }
+		  }
+		}
+	EOF
+
+	run aube install
+	assert_success
+	assert_dir_exists node_modules/is-odd
+}
+
+@test "aube install: named catalog from pnpm.catalogs" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "aube-test-pnpm-catalogs",
+		  "version": "0.0.0",
+		  "dependencies": {
+		    "is-even": "catalog:evens"
+		  },
+		  "pnpm": {
+		    "catalogs": {
+		      "evens": {
+		        "is-even": "^1.0.0"
+		      }
+		    }
+		  }
+		}
+	EOF
+
+	run aube install
+	assert_success
+	assert_dir_exists node_modules/is-even
+}
+
+@test "aube install: workspace yaml wins over package.json catalog" {
+	# When both sources define the same entry, the workspace yaml wins
+	# (see `discover_catalogs` precedence in crates/aube/src/commands/mod.rs).
+	cat >pnpm-workspace.yaml <<-'EOF'
+		catalog:
+		  is-odd: ^3.0.1
+	EOF
+	cat >package.json <<-'EOF'
+		{
+		  "name": "aube-test-catalog-precedence",
+		  "version": "0.0.0",
+		  "dependencies": {
+		    "is-odd": "catalog:"
+		  },
+		  "pnpm": {
+		    "catalog": {
+		      "is-odd": "^0.1.0"
+		    }
+		  }
+		}
+	EOF
+
+	run aube install
+	assert_success
+	# Workspace yaml's ^3.0.1 wins, so the resolved range is 3.x.
+	run node -e 'console.log(require("is-odd/package.json").version)'
+	assert_success
+	[[ "$output" =~ ^3\. ]]
+}
+
 @test "aube install: lockfile records catalogs section" {
 	_setup_catalog_workspace
 	aube install


### PR DESCRIPTION
## Summary

Reported: `aube install` inside a monorepo subpackage fails with

```
@types/node: catalog reference `catalog:` does not resolve — catalog `default` has no entry for `@types/node`
```

even when `@types/node` is clearly in the user's catalog.

**Root cause:** catalog loading only peeked at the *exact* directory where `find_project_root` landed (the nearest ancestor with `package.json`). In a monorepo, that's the subpackage — it never walked up to find the root `pnpm-workspace.yaml`. And aube had no support for catalogs declared inside `package.json` (bun-style `workspaces.catalog` or pnpm-style `pnpm.catalog`).

## What changed

- New `discover_catalogs(project_root)` helper in `crates/aube/src/commands/mod.rs` walks up for the workspace yaml and merges four sources in ascending precedence:
  1. project-root `package.json` → `workspaces.catalog` / `workspaces.catalogs`
  2. project-root `package.json` → `pnpm.catalog` / `pnpm.catalogs`
  3. workspace-root `package.json` (same two, when different from the project root)
  4. `catalog:` / `catalogs:` in the nearest `pnpm-workspace.yaml` / `aube-workspace.yaml` found by walking up
- `crates/aube-manifest` extensions:
  - `Workspaces::Object` now carries optional `catalog` / `catalogs` (bun format).
  - `PackageJson::pnpm_catalog()` / `pnpm_catalogs()` for pnpm-in-package.json.
- `install.rs` switched from `workspace_catalog_map(&ws_config_shared)` (which only saw the subpackage-local yaml) to `discover_catalogs(&cwd)`.
- Resolver error split: `UnknownCatalogRef` → `UnknownCatalog` (catalog not defined anywhere) + `UnknownCatalogEntry` (catalog exists but missing this package). The new message also points users at all four supported declaration sites.

## Notes for reviewers

- `ws_config_shared` in `install.rs` is still loaded only from the project-root `cwd`, which means non-catalog workspace-yaml settings (e.g. `allowBuilds`) still don't inherit from a higher workspace root when running from a subpackage. That's a larger, orthogonal fix — intentionally out of scope here.
- Precedence within a single `package.json`: `pnpm.*` wins over `workspaces.*`. Across files, the workspace yaml wins, which is why the "workspace yaml wins over package.json catalog" test asserts the 3.x range beats the 0.1.x range.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `mise run test:bats test/catalogs.bats` — all 20 pass, including 5 new tests: subpackage install, `workspaces.catalog`, `pnpm.catalog`, `pnpm.catalogs`, precedence
- [ ] Reporter confirms their monorepo install now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency catalog discovery and resolution error handling during installs, which can affect how versions are selected in monorepos and single-package projects. Risk is moderated by clear precedence rules and expanded integration tests covering the new sources and regression case.
> 
> **Overview**
> Fixes `catalog:` dependency resolution when running `aube install` from a monorepo subpackage by **walking up to the workspace root** and merging catalogs from multiple locations.
> 
> Adds support for catalogs declared inline in `package.json` (bun-style `workspaces.catalog`/`workspaces.catalogs` and pnpm-style `pnpm.catalog`/`pnpm.catalogs`) with a defined precedence order, and updates install to use the new `discover_catalogs` path.
> 
> Improves resolver failures by splitting “unknown catalog” vs “missing catalog entry” errors with a more actionable message, and extends `test/catalogs.bats` to cover subpackage installs, package.json catalog sources, and precedence behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 960b5ef0463bfb8cd6d7a751c2566fa895b42512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->