### PR TITLE
chore: release v1.0.0-beta.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "base64",
  "blake3",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -3930,9 +3930,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -82,13 +82,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.3" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.3" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.3" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.3" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.3" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.3" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.3" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.3" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.3" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.3" }
+aube = { path = "crates/aube", version = "1.0.0-beta.4" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.4" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.4" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.4" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.4" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.4" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.4" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.4" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.4" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.4" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.3"
+version "1.0.0-beta.4"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.4](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0-beta.3...aube-scripts-v1.0.0-beta.4) - 2026-04-19
+
+### Other
+
+- support name wildcards in the build allowlist ([#49](https://github.com/endevco/aube/pull/49))
+
 ## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0-beta.1...aube-scripts-v1.0.0-beta.2) - 2026-04-18
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.4](https://github.com/endevco/aube/compare/v1.0.0-beta.3...v1.0.0-beta.4) - 2026-04-19
+
+### Other
+
+- discover root catalogs via package.json workspaces field ([#56](https://github.com/endevco/aube/pull/56))
+
 ## [1.0.0-beta.3](https://github.com/endevco/aube/compare/v1.0.0-beta.2...v1.0.0-beta.3) - 2026-04-19
 
 ### Added

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5657,7 +5657,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.3
+**Version**: 1.0.0-beta.4
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.3",
-  "releasedAt": "2026-04-19T01:58:05Z"
+  "version": "1.0.0-beta.4",
+  "releasedAt": "2026-04-19T04:22:52Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.4`

This PR bumps the workspace to `v1.0.0-beta.4` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is primarily a version/docs/changelog refresh with a minor `Cargo.lock` dependency update, and no functional code changes in the diff.
> 
> **Overview**
> Updates the workspace and all internal crates to `1.0.0-beta.4`, including `Cargo.toml` dependency version pins and the generated usage/CLI docs (`aube.usage.kdl`, `docs/cli/*`).
> 
> Regenerates release metadata and changelogs (`release.json`, per-crate `CHANGELOG.md`) and refreshes `Cargo.lock` (including bumping `typenum` to `1.20.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd635269aa271ad63036b4bcde168b1fe0eacf9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->