### PR TITLE
docs(bench): bump default link rate to 500mbit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,10 +88,10 @@ machines and over time:
 
 ```bash
 flock /tmp/aube-bench.lock \
-  env BENCH_HERMETIC=1 BENCH_BANDWIDTH=100mbit mise run bench
+  env BENCH_HERMETIC=1 BENCH_BANDWIDTH=500mbit mise run bench
 ```
 
-`BENCH_HERMETIC=1` removes npmjs CDN variance; `BENCH_BANDWIDTH=100mbit`
+`BENCH_HERMETIC=1` removes npmjs CDN variance; `BENCH_BANDWIDTH=500mbit`
 pins the simulated link at a "fast home broadband" baseline so two
 runs on different ISPs / CI runners produce comparable numbers. Drop
 the bandwidth cap (or raise it) for loopback-speed measurements; lower


### PR DESCRIPTION
## Summary
- Update the hermetic benchmark guidance in CLAUDE.md to use `BENCH_BANDWIDTH=500mbit` as the default fast-broadband baseline (was `100mbit`).
- Verified via `flock /tmp/aube-bench.lock env BENCH_HERMETIC=1 BENCH_BANDWIDTH=500mbit mise run bench`.

## Benchmark results (500mbit hermetic)

| # | Scenario | aube | bun | pnpm | npm | yarn | vs pnpm | vs bun |
|---|---|---|---|---|---|---|---|---|
| 1 | CI install (warm cache) | 0.148s ± 0.019s | 0.419s ± 0.013s | 1.024s ± 0.022s | 2.806s ± 0.040s | 2.451s ± 0.062s | 6.9x faster | 2.8x faster |
| 2 | CI install (cold cache) | 1.106s ± 0.035s | 0.937s ± 0.017s | 1.582s ± 0.020s | 4.179s ± 0.058s | 6.590s ± 0.064s | 1.4x faster | 1.2x slower |
| 3 | Install + run test | 0.021s ± 0.001s | 0.040s ± 0.002s | 0.453s ± 0.021s | 0.610s ± 0.008s | 0.348s ± 0.007s | 21.6x faster | 1.9x faster |
| 4 | Add dependency | 0.208s ± 0.009s | 0.419s ± 0.016s | 1.333s ± 0.021s | 2.911s ± 0.031s | 2.536s ± 0.064s | 6.4x faster | 2.0x faster |

Note: `benchmarks/results.json` is unchanged — that's the published "real internet" baseline and must only be refreshed via `mise run bench:bump` (no hermetic/bandwidth env).

## Test plan
- [ ] Confirm the new default is what we want long-term (cold-cache changes shape vs 100mbit since aube's download phase is less bottlenecked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adjusts recommended benchmark parameters without affecting runtime code or published benchmark artifacts.
> 
> **Overview**
> Updates `CLAUDE.md` benchmark guidance to default hermetic runs to `BENCH_BANDWIDTH=500mbit` (from `100mbit`) to better represent a fast-broadband baseline when running `mise run bench` under `flock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 924786b23f1222f802bbb4e9ef4e07e62ed59bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->