### PR TITLE
ci(ppa-publish): escape tilde in DEB_VERSION replacement

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -59,7 +59,9 @@ jobs:
           # Deb version: SemVer `-` prerelease separators collate as
           # newer than release in dpkg; `~` collates as older, which is
           # what we want. `1.0.0-beta.1` -> `1.0.0~beta.1`.
-          DEB_VERSION="${VERSION//-/~}${VERSION_SUFFIX}"
+          # Backslash-escape the tilde: bash performs tilde expansion on
+          # the replacement string in ${var//pat/rep}, even inside "...".
+          DEB_VERSION="${VERSION//-/\~}${VERSION_SUFFIX}"
 
           {
             echo "VERSION=${VERSION}"


### PR DESCRIPTION
## Summary
- `DEB_VERSION="${VERSION//-/~}${VERSION_SUFFIX}"` looked correct, but bash performs **tilde expansion on the replacement string** in `${var//pat/rep}` — even inside `"..."`. On the runner, `~` expanded to `$HOME` (`/home/runner`), so for `VERSION=1.0.0-beta.3` we got `DEB_VERSION=1.0.0/home/runnerbeta.3`, and `debuild` bailed with `version number contains illegal character '/'`.
- Fix: backslash-escape the tilde (`\~`) to suppress tilde expansion. One-char change plus a comment explaining the gotcha.

## Observed failure
[v1.0.0-beta.3 ppa-publish run](https://github.com/endevco/aube/actions/runs/24619298456/job/71986903032):
```
debuild: warning: debian/changelog(l1): version '1.0.0/home/runnerbeta.3~resolute1' is invalid: version number contains illegal character '/'
dpkg-buildpackage: error: version number does not start with digit
```

## Note on v1.0.0-beta.3
The PPA step for `v1.0.0-beta.3` won't retroactively succeed from this fix alone — the workflow checks out from the tag ref, and the tag still points at the broken code. Separate decision needed: move the tag, cut `v1.0.0-beta.4`, or skip PPA for beta.3.

## Test plan
- [ ] Merge, then re-tag or cut a new release and confirm the `Create source package for each distribution` step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that fixes Debian version string generation to avoid bash tilde expansion breaking builds; impact is limited to PPA publishing.
> 
> **Overview**
> Fixes the `ppa-publish` GitHub Actions workflow’s Debian version computation by escaping `~` in the `${VERSION//-/...}` replacement, preventing bash tilde expansion (e.g., `~` -> `$HOME`) from producing invalid `DEB_VERSION` values.
> 
> Adds an inline comment documenting the bash gotcha for future maintenance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46fabc5a6f6ffcee65e0d58bba7bb6e1b0b4ec7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->