### PR TITLE
docs(home): link & float release pill to top-right

### DIFF
--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -93,6 +93,7 @@ const spinner = computed(() => spinners[spinnerIndex.value]);
 const aubeVersion = __AUBE_VERSION__;
 const releasedAt = __AUBE_RELEASED_AT__;
 const terminalVersion = aubeVersion.split("-")[0] || aubeVersion;
+const releaseNotesUrl = `https://github.com/endevco/aube/releases/tag/v${aubeVersion}`;
 function formatReleasePhrase() {
   if (!releasedAt) {
     releasePhrase.value = "release date pending";
@@ -206,7 +207,15 @@ watch(progressBarEl, (el, previousEl) => {
       <div class="aube-hero-copy">
         <div class="aube-release">
           <span></span>
-          <span>v{{ aubeVersion }} · {{ releasePhrase }}</span>
+          <span>
+            <a
+              class="aube-release-version"
+              :href="releaseNotesUrl"
+              target="_blank"
+              rel="noreferrer"
+            >v{{ aubeVersion }}</a>
+            · {{ releasePhrase }}
+          </span>
         </div>
         <p class="aube-pronunciation">aube /ob/ - pronounced "ohb"</p>
         <h1 id="aube-hero-title">A new dawn <em>for node installs.</em></h1>

--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -203,20 +203,20 @@ watch(progressBarEl, (el, previousEl) => {
 <template>
   <main class="aube-home">
     <div class="aube-hero-glow" aria-hidden="true"></div>
+    <div class="aube-release">
+      <span></span>
+      <span>
+        <a
+          class="aube-release-version"
+          :href="releaseNotesUrl"
+          target="_blank"
+          rel="noreferrer"
+        >v{{ aubeVersion }}</a>
+        · {{ releasePhrase }}
+      </span>
+    </div>
     <section class="aube-hero" aria-labelledby="aube-hero-title">
       <div class="aube-hero-copy">
-        <div class="aube-release">
-          <span></span>
-          <span>
-            <a
-              class="aube-release-version"
-              :href="releaseNotesUrl"
-              target="_blank"
-              rel="noreferrer"
-            >v{{ aubeVersion }}</a>
-            · {{ releasePhrase }}
-          </span>
-        </div>
         <p class="aube-pronunciation">aube /ob/ - pronounced "ohb"</p>
         <h1 id="aube-hero-title">A new dawn <em>for node installs.</em></h1>
         <p class="aube-lede">

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -217,6 +217,19 @@ body {
   width: 6px;
 }
 
+.aube-release-version {
+  color: inherit;
+  text-decoration: none;
+  transition: color 120ms ease;
+}
+
+.aube-release-version:hover,
+.aube-release-version:focus-visible {
+  color: var(--aube-accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .aube-pronunciation {
   color: var(--aube-faint);
   font-family: var(--aube-mono);

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -205,8 +205,11 @@ body {
   font-size: 12px;
   gap: 10px;
   letter-spacing: 0;
-  margin-bottom: 28px;
   padding: 7px 12px;
+  position: absolute;
+  right: 32px;
+  top: 32px;
+  z-index: 1;
 }
 
 .aube-release span:first-child {
@@ -217,14 +220,15 @@ body {
   width: 6px;
 }
 
-.aube-release-version {
+.aube-release .aube-release-version {
   color: inherit;
+  font-weight: inherit;
   text-decoration: none;
   transition: color 120ms ease;
 }
 
-.aube-release-version:hover,
-.aube-release-version:focus-visible {
+.aube-release .aube-release-version:hover,
+.aube-release .aube-release-version:focus-visible {
   color: var(--aube-accent);
   text-decoration: underline;
   text-underline-offset: 3px;
@@ -1186,6 +1190,11 @@ body {
 @media (max-width: 960px) {
   .aube-home {
     padding: 54px 20px 80px;
+  }
+
+  .aube-release {
+    margin-bottom: 28px;
+    position: static;
   }
 
   .aube-hero {


### PR DESCRIPTION
## Summary
- Wrap the `v<version>` text in the hero release pill with an anchor to `https://github.com/endevco/aube/releases/tag/v<version>`, so readers on the landing page can click through to the release notes for the version the docs were built with.
- Float the pill out of `.aube-hero-copy` and absolutely position it at the top-right of `.aube-home`, freeing vertical space in the hero column. Below 960px the pill falls back to static flow above the hero copy so it doesn't crowd narrow viewports or collide with the navbar.
- Keep the pill visually unchanged at rest: `.aube-release .aube-release-version` inherits color and drops the underline. The selector is scoped through `.aube-release` to outweigh VitePress's `.vp-doc a` rule (0,1,1), which was forcing the version into accent color + underline at rest. Hover/focus picks up the accent color and an offset underline.

## Test plan
- [x] Verified in Playwright at 1280×900: pill sits at top-right (~108px from top, ~32px from right), hero copy reflows up to the pronunciation line, version link is muted at rest, coral + underlined on hover/focus, and clicks open `releases/tag/v1.0.0-beta.3` in a new tab.
- [x] Verified at 600×900: pill drops to static flow above the hero copy with the original 28px bottom margin restored.
- [ ] Sanity-check on a real preview deploy once Cloudflare Pages picks up the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation landing-page UI tweaks only (adds an external link and minor responsive styling), with no impact on core app logic or data handling.
> 
> **Overview**
> Adds a clickable version badge on the docs landing page that links the displayed `v<version>` to the matching GitHub release notes in a new tab.
> 
> Updates `.aube-release` styling to position the pill in the top-right on desktop, adds `.aube-release-version` link styles to keep the pill’s muted appearance until hover/focus, and restores the prior flow layout on small screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 700edafae2816addda0a233befc4ca577e2ee8a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->