### PR TITLE
catalog: discover root catalogs via package.json workspaces field

### DIFF
--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -605,6 +605,27 @@ fn merge_manifest_catalogs(out: &mut CatalogMap, manifest: &aube_manifest::Packa
     merge_catalog_source(out, &manifest.pnpm_catalog(), &manifest.pnpm_catalogs());
 }
 
+/// Walk upward from `start` looking for the nearest ancestor whose
+/// `package.json` declares a `workspaces` field. bun / npm / yarn mark
+/// the workspace root that way (no separate `pnpm-workspace.yaml`), so
+/// when `aube install` runs from a subpackage of one of those projects
+/// this is the only handle we have on the workspace root.
+///
+/// `start` itself is included in the walk; the closest ancestor wins
+/// (nested workspaces aren't a thing in any of pnpm / bun / npm /
+/// yarn).
+fn find_workspaces_field_root(start: &std::path::Path) -> Option<std::path::PathBuf> {
+    start.ancestors().find_map(|dir| {
+        let pkg = dir.join("package.json");
+        if !pkg.is_file() {
+            return None;
+        }
+        let manifest = aube_manifest::PackageJson::from_path(&pkg).ok()?;
+        manifest.workspaces.as_ref()?;
+        Some(dir.to_path_buf())
+    })
+}
+
 /// Discover catalog entries from every supported source and merge them
 /// into a single map for the resolver.
 ///
@@ -614,13 +635,16 @@ fn merge_manifest_catalogs(out: &mut CatalogMap, manifest: &aube_manifest::Packa
 ///    `package.json` (bun style).
 /// 2. `pnpm.catalog` / `pnpm.catalogs` in the project-root `package.json`.
 /// 3. Same two fields from the workspace-root `package.json` when it's
-///    a different file (monorepo subpackage installs).
+///    a different file (monorepo subpackage installs). The workspace
+///    root is the nearest ancestor with either a `pnpm-workspace.yaml` /
+///    `aube-workspace.yaml` or a `package.json` carrying a `workspaces`
+///    field — bun / npm / yarn projects use the latter and have no yaml.
 /// 4. `catalog:` / `catalogs:` in the nearest `pnpm-workspace.yaml` /
 ///    `aube-workspace.yaml` walking up from `project_root`.
 ///
-/// Walking up for the workspace yaml matters for monorepos where
-/// `aube install` runs from a subpackage — without this, the loader
-/// only looks in `project_root` and misses the root workspace file.
+/// Walking up matters for monorepos where `aube install` runs from a
+/// subpackage — without it, the loader only looks at `project_root`
+/// and misses the root workspace's catalogs entirely.
 ///
 /// Every command that builds a `Resolver` threads this map through
 /// `Resolver::with_catalogs`; otherwise the resolver hard-fails any
@@ -638,9 +662,15 @@ pub(crate) fn discover_catalogs(project_root: &std::path::Path) -> miette::Resul
     }
 
     // (3): workspace-root package.json catalogs, if the workspace root
-    // sits above the project root.
+    // sits above the project root. We resolve the workspace root from
+    // either marker — yaml first (pnpm convention), then `workspaces`
+    // field (bun / npm / yarn convention) — so a subpackage install in
+    // a non-pnpm monorepo still picks up the root catalog.
     let workspace_yaml_dir = crate::dirs::find_workspace_root(project_root);
-    if let Some(dir) = &workspace_yaml_dir
+    let workspace_root_dir = workspace_yaml_dir
+        .clone()
+        .or_else(|| find_workspaces_field_root(project_root));
+    if let Some(dir) = &workspace_root_dir
         && dir != project_root
         && let Ok(m) = aube_manifest::PackageJson::from_path(&dir.join("package.json"))
     {

--- a/test/catalogs.bats
+++ b/test/catalogs.bats
@@ -79,6 +79,66 @@ _setup_catalog_workspace() {
 	assert_dir_exists node_modules/is-odd
 }
 
+@test "aube install: bun-style root workspaces.catalog resolves from a subpackage" {
+	# Regression: bun / npm / yarn workspaces don't ship a
+	# `pnpm-workspace.yaml`; the workspace root is identified by a
+	# `workspaces` field in `package.json`. `aube install` from a
+	# subpackage used to miss that root entirely (catalog discovery only
+	# walked up looking for the yaml), so a `catalog:` ref defined in
+	# the root's `workspaces.catalog` failed with `UnknownCatalog`.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "root",
+		  "private": true,
+		  "workspaces": {
+		    "packages": ["packages/*"],
+		    "catalog": { "is-odd": "^3.0.1" }
+		  }
+		}
+	EOF
+	mkdir -p packages/lib
+	cat >packages/lib/package.json <<-'EOF'
+		{
+		  "name": "@test/lib",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "catalog:" }
+		}
+	EOF
+
+	cd packages/lib
+	run aube install
+	assert_success
+	assert_dir_exists node_modules/is-odd
+}
+
+@test "aube install: root pnpm.catalog (no yaml) resolves from a subpackage" {
+	# Same shape as the bun-style regression above, but the root carries
+	# a plain string-array `workspaces` field plus a `pnpm.catalog`
+	# block — common when migrating from npm / yarn to pnpm-style
+	# catalogs without adopting `pnpm-workspace.yaml`.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "root",
+		  "private": true,
+		  "workspaces": ["packages/*"],
+		  "pnpm": { "catalog": { "is-odd": "^3.0.1" } }
+		}
+	EOF
+	mkdir -p packages/lib
+	cat >packages/lib/package.json <<-'EOF'
+		{
+		  "name": "@test/lib",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "catalog:" }
+		}
+	EOF
+
+	cd packages/lib
+	run aube install
+	assert_success
+	assert_dir_exists node_modules/is-odd
+}
+
 @test "aube install: catalog: resolves from package.json workspaces.catalog" {
 	# Bun-style: catalogs live inline under `workspaces.catalog` in
 	# package.json. No pnpm-workspace.yaml needed.


### PR DESCRIPTION
## Summary

User reported `aube install` failing with a `catalog:` error on
`@opentelemetry/api` even though the workspace defined the package in a
catalog. Root cause: `discover_catalogs` only walked up looking for
`pnpm-workspace.yaml` / `aube-workspace.yaml`. bun / npm / yarn projects
mark the workspace root with a `workspaces` field in `package.json` and
ship no yaml, so installs run from a subpackage silently missed any
`workspaces.catalog` / `pnpm.catalog` defined at the root and the
resolver hard-failed every `catalog:` ref.

Fall back to walking up for the nearest ancestor `package.json` with a
`workspaces` field when no yaml is present, then merge that root's
catalogs through the existing precedence chain.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (full unit test suite — all green)
- [x] `mise run test:bats test/catalogs.bats` (22/22 including two new regression tests)
- [x] Manual repro: `aube install` from `packages/lib` with the catalog defined in the root `package.json` (both `workspaces.catalog` and `pnpm.catalog` shapes) — both succeed instead of failing with `UnknownCatalog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes catalog discovery/root resolution for monorepo subpackage installs and could alter which catalog source wins in edge cases; covered by new regression tests.
> 
> **Overview**
> Fixes `catalog:` resolution when running `aube install` from a monorepo subpackage in bun/npm/yarn-style workspaces that *don’t* have `pnpm-workspace.yaml`/`aube-workspace.yaml`.
> 
> `discover_catalogs` now falls back to walking up for the nearest ancestor `package.json` with a `workspaces` field to identify the workspace root, merges that root’s `workspaces.catalog`/`pnpm.catalog` into the existing precedence chain, and adds Bats tests covering both `workspaces.catalog` and `pnpm.catalog` root-only scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dff98319c60302c79d05bc72e98566b66881fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->