### PR TITLE
chore: release v1.0.0-beta.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "base64",
  "blake3",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -2156,9 +2156,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
 dependencies = [
  "is-wsl",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -85,13 +85,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.4" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.4" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.4" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.4" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.4" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.4" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.4" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.4" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.4" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.4" }
+aube = { path = "crates/aube", version = "1.0.0-beta.5" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.5" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.5" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.5" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.5" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.5" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.5" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.5" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.5" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.5" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.4"
+version "1.0.0-beta.5"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.5](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.4...aube-linker-v1.0.0-beta.5) - 2026-04-19
+
+### Other
+
+- use strum derives for Severity and NodeLinker ([#69](https://github.com/endevco/aube/pull/69))
+
 ## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.2...aube-linker-v1.0.0-beta.3) - 2026-04-19
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.5](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.4...aube-lockfile-v1.0.0-beta.5) - 2026-04-19
+
+### Other
+
+- normalize git selector fragments ([#62](https://github.com/endevco/aube/pull/62))
+
 ## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.2...aube-lockfile-v1.0.0-beta.3) - 2026-04-19
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.5](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.4...aube-settings-v1.0.0-beta.5) - 2026-04-19
+
+### Other
+
+- remove settings count sentence ([#64](https://github.com/endevco/aube/pull/64))
+- add global gvs override ([#61](https://github.com/endevco/aube/pull/61))
+
 ## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.2...aube-settings-v1.0.0-beta.3) - 2026-04-19
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.5](https://github.com/endevco/aube/compare/v1.0.0-beta.4...v1.0.0-beta.5) - 2026-04-19
+
+### Other
+
+- pluralize counted nouns in CLI output ([#70](https://github.com/endevco/aube/pull/70))
+- use strum derives for Severity and NodeLinker ([#69](https://github.com/endevco/aube/pull/69))
+- keep filtered workspace installs rooted ([#67](https://github.com/endevco/aube/pull/67))
+- accept registry flag on install ([#63](https://github.com/endevco/aube/pull/63))
+- add global gvs override ([#61](https://github.com/endevco/aube/pull/61))
+
 ## [1.0.0-beta.4](https://github.com/endevco/aube/compare/v1.0.0-beta.3...v1.0.0-beta.4) - 2026-04-19
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5546,7 +5546,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.4
+**Version**: 1.0.0-beta.5
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.4",
-  "releasedAt": "2026-04-19T04:22:52Z"
+  "version": "1.0.0-beta.5",
+  "releasedAt": "2026-04-19T14:11:39Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.5`

This PR bumps the workspace to `v1.0.0-beta.5` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is primarily a version/metadata release bump with regenerated changelogs/docs and a `Cargo.lock` refresh (including `open` 5.3.4).
> 
> **Overview**
> Updates the workspace/package versions from `1.0.0-beta.4` to `1.0.0-beta.5` across `Cargo.toml`, `Cargo.lock`, and the internal crate dependency pins.
> 
> Regenerates release artifacts for the new version: per-crate `CHANGELOG.md` entries, `aube.usage.kdl`, generated CLI docs (`docs/cli/*`), and `release.json` timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c2aaf39028eb7c6f3f8569db54ef25fd852d68e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->