### PR TITLE
docs: emit VERSION file from site build

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vitepress";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -181,5 +181,13 @@ gtag('config', 'G-WD1RRC0F8C');`,
       __AUBE_VERSION__: JSON.stringify(aubeVersion),
       __AUBE_RELEASED_AT__: JSON.stringify(aubeReleasedAt),
     },
+    plugins: [
+      {
+        name: "aube-version-file",
+        closeBundle() {
+          writeFileSync(resolve(configDir, "dist/VERSION"), `${aubeVersion}\n`);
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- writes a root `VERSION` file during the VitePress docs build
- uses the existing workspace-derived Aube version, so GitHub Pages can serve `https://aube.en.dev/VERSION`
- avoids a separate release/R2 publishing workflow

## Validation

- `cargo build`
- `cd docs && ../target/debug/aube install && ../target/debug/aube run docs:build`
- verified `docs/.vitepress/dist/VERSION` contained `1.0.0-beta.4`
- `actionlint .github/workflows/docs.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation build-only change that writes an extra artifact during bundling, with minimal chance of affecting runtime behavior outside the generated `dist/` output.
> 
> **Overview**
> **Docs builds now emit a version marker file.** The VitePress config adds a small Vite plugin (`aube-version-file`) that, on `closeBundle`, writes `dist/VERSION` containing the workspace-derived `aubeVersion`.
> 
> This exposes the built docs site version as a static asset (e.g., for GitHub Pages) without changing site content or app/runtime logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a00bc6df67aabbe1b7955386b8826a3576734a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->