### PR TITLE
cli: add global gvs override

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -20,6 +20,12 @@ flag --aggregate-output help="Group workspace command output after each package 
 flag --color help="Force colored output even when stderr is not a TTY" global=#true {
     long_help "Force colored output even when stderr is not a TTY.\n\nOverrides `NO_COLOR` / `CLICOLOR=0`. Mutually exclusive with `--no-color`."
 }
+flag "--disable-global-virtual-store --disable-gvs" help="Force the shared global virtual store off for this invocation" global=#true {
+    long_help "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`."
+}
+flag "--enable-global-virtual-store --enable-gvs" help="Force the shared global virtual store on for this invocation" global=#true {
+    long_help "Force the shared global virtual store on for this invocation.\n\nOverrides CI's default per-project materialization and the `disableGlobalVirtualStoreForPackages` auto-disable heuristic."
+}
 flag --fail-if-no-match help="Error when a workspace selector matches no packages" global=#true {
     long_help "Error when a workspace selector matches no packages.\n\nAccepted globally; selected commands already fail on empty matches."
 }

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -581,22 +581,35 @@ examples = []
 [enableGlobalVirtualStore]
 description = "Use a per-user virtual store for all projects."
 type = "bool"
-default = "false"
+default = "undefined"
 docs = """
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
-It's enabled by default and disabled under CI (see `aube-linker`, which
-checks the `CI` env var). pnpm gained the same feature later; we expose
-it through `CI=1` rather than a dedicated config knob.
+It's enabled by default outside CI and disabled under CI (see
+`aube-linker`, which checks the `CI` env var). Set
+`enableGlobalVirtualStore=false` in `.npmrc` or `pnpm-workspace.yaml`
+to force per-project materialization for a project.
+
+`aube dlx` defaults this setting to `false` for its scratch installs so
+CLIs with undeclared runtime imports can still use the hidden-hoist
+fallback inside the temporary project. Pass
+`aube dlx --enable-gvs <pkg>` when you want to force the shared virtual
+store on for a dlx invocation.
+
+The global flags are one-shot CLI sources for the same setting:
+`--disable-global-virtual-store` resolves this setting to `false`, and
+`--enable-global-virtual-store` resolves it to `true`. The enable flag
+can force the shared virtual store on even in CI or when package
+compatibility heuristics would normally disable it.
 """
-sources.cli = []
-sources.env = ["CI"]
+sources.cli = ["enable-global-virtual-store", "disable-global-virtual-store"]
+sources.env = []
 sources.npmrc = ["enableGlobalVirtualStore"]
 sources.workspaceYaml = ["enableGlobalVirtualStore"]
-examples = []
-# Read as `WorkspaceConfig.enable_global_virtual_store` via serde
-# deserialization in `aube-manifest`, then routed through
-# `aube-linker`. The typed accessor would double up on that path.
-typedAccessorUnused = true
+examples = [
+  "echo 'enableGlobalVirtualStore=false' >> .npmrc",
+  "aube --disable-global-virtual-store install",
+  "aube dlx --enable-gvs create-vite",
+]
 
 [disableGlobalVirtualStoreForPackages]
 description = "Package names whose presence in any importer forces per-project materialization."

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -152,7 +152,7 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
     // observe the user's real cwd instead of a dir that's about to vanish.
     let prev_cwd = {
         let _cwd_guard = CwdGuard::switch_to(&project_dir)?;
-        let install_result = super::install::run(InstallOptions::with_mode(FrozenMode::No)).await;
+        let install_result = super::install::run(dlx_install_options()).await;
         let prev = _cwd_guard.original.clone();
         install_result.wrap_err("dlx install failed")?;
         prev
@@ -223,6 +223,24 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
         std::process::exit(status.code().unwrap_or(1));
     }
     Ok(())
+}
+
+fn dlx_install_options() -> InstallOptions {
+    let mut opts = InstallOptions::with_mode(FrozenMode::No);
+    // `dlx` executes bins from a throwaway project and deletes that project
+    // immediately. Keeping package materialization inside the scratch tree is
+    // what lets Node walk through `node_modules/.aube/node_modules`, the
+    // hidden hoist fallback used by CLIs with undeclared runtime imports.
+    let gvs = super::global_virtual_store_flags();
+    if gvs.is_set() {
+        opts.cli_flags.extend(gvs.to_cli_flag_bag());
+    } else {
+        opts.cli_flags.push((
+            "disable-global-virtual-store".to_string(),
+            "false".to_string(),
+        ));
+    }
+    opts
 }
 
 /// RAII guard that swaps the process cwd on construction and restores it
@@ -333,6 +351,24 @@ mod tests {
         assert_eq!(bin_name_for("cowsay@1.5.0"), "cowsay");
         assert_eq!(bin_name_for("@scope/foo@2"), "foo");
         assert_eq!(bin_name_for("@scope/foo"), "foo");
+    }
+
+    #[test]
+    fn dlx_install_disables_global_virtual_store() {
+        let opts = dlx_install_options();
+        let empty_npmrc = Vec::new();
+        let empty_workspace = std::collections::BTreeMap::new();
+        let empty_env = Vec::new();
+        let ctx = aube_settings::ResolveCtx {
+            npmrc: &empty_npmrc,
+            workspace_yaml: &empty_workspace,
+            env: &empty_env,
+            cli: &opts.cli_flags,
+        };
+        assert_eq!(
+            aube_settings::resolved::enable_global_virtual_store(&ctx),
+            Some(false)
+        );
     }
 
     fn write_pkg_json(modules_dir: &std::path::Path, pkg_name: &str, pkg_json: serde_json::Value) {

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -33,6 +33,35 @@ pub struct GlobalFrozenFlags {
     pub prefer_frozen: bool,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GlobalVirtualStoreFlags {
+    pub enable: bool,
+    pub disable: bool,
+}
+
+impl GlobalVirtualStoreFlags {
+    pub fn to_cli_flag_bag(self) -> Vec<(String, String)> {
+        let mut out = Vec::new();
+        if self.enable {
+            out.push((
+                "enable-global-virtual-store".to_string(),
+                "true".to_string(),
+            ));
+        }
+        if self.disable {
+            out.push((
+                "disable-global-virtual-store".to_string(),
+                "false".to_string(),
+            ));
+        }
+        out
+    }
+
+    pub fn is_set(self) -> bool {
+        self.enable || self.disable
+    }
+}
+
 impl FrozenMode {
     /// Resolve the user's flag combination to a single mode.
     /// `--frozen-lockfile` and `--no-frozen-lockfile` and `--prefer-frozen-lockfile`
@@ -219,7 +248,11 @@ impl InstallArgs {
     /// flags explicitly present on the command line are emitted —
     /// unset flags stay out of the bag so they don't override
     /// lower-precedence sources with their clap-derived default.
-    pub fn to_cli_flag_bag(&self, global: GlobalFrozenFlags) -> Vec<(String, String)> {
+    pub fn to_cli_flag_bag(
+        &self,
+        global: GlobalFrozenFlags,
+        global_gvs: GlobalVirtualStoreFlags,
+    ) -> Vec<(String, String)> {
         let mut out: Vec<(String, String)> = Vec::new();
         if let Some(mode) = self.resolution_mode.as_deref() {
             out.push(("resolution-mode".to_string(), mode.to_string()));
@@ -236,6 +269,7 @@ impl InstallArgs {
         if self.shamefully_hoist {
             out.push(("shamefully-hoist".to_string(), "true".to_string()));
         }
+        out.extend(global_gvs.to_cli_flag_bag());
         if global.frozen {
             out.push(("frozen-lockfile".to_string(), "true".to_string()));
         }
@@ -3137,7 +3171,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // gvs path — suppress the warning there too.
     let gvs_triggers =
         aube_settings::resolved::disable_global_virtual_store_for_packages(&settings_ctx);
-    let use_global_virtual_store_override = {
+    let explicit_global_virtual_store =
+        aube_settings::resolved::enable_global_virtual_store(&settings_ctx);
+    let use_global_virtual_store_override = explicit_global_virtual_store.or_else(|| {
         let triggered_by = find_gvs_incompatible_trigger(&manifests, &gvs_triggers);
         // Match `Linker::new`'s exact gvs check — it keys off the `CI`
         // env var alone, not `npm_config_ci` / `NPM_CONFIG_CI`. Using a
@@ -3159,7 +3195,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         } else {
             None
         }
-    };
+    });
 
     // Remember which lockfile format the project currently uses so
     // every downstream write site (the `--lockfile-only` short-circuit

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -73,6 +73,7 @@ use std::sync::{OnceLock, RwLock};
 /// `add`/`remove`/`update`/…) can pick them up without plumbing a
 /// context struct through every command signature.
 static GLOBAL_FROZEN: OnceLock<install::GlobalFrozenFlags> = OnceLock::new();
+static GLOBAL_VIRTUAL_STORE: OnceLock<install::GlobalVirtualStoreFlags> = OnceLock::new();
 
 /// Process-wide registry override from the top-level `--registry=<url>`
 /// flag. Applied in `make_client` (and any direct `NpmConfig::load`
@@ -139,6 +140,10 @@ pub(crate) fn set_global_frozen_flags(flags: install::GlobalFrozenFlags) {
     let _ = GLOBAL_FROZEN.set(flags);
 }
 
+pub(crate) fn set_global_virtual_store_flags(flags: install::GlobalVirtualStoreFlags) {
+    let _ = GLOBAL_VIRTUAL_STORE.set(flags);
+}
+
 pub(crate) fn set_global_output_flags(flags: GlobalOutputFlags) {
     let _ = GLOBAL_OUTPUT.set(flags);
 }
@@ -148,6 +153,10 @@ pub(crate) fn set_global_output_flags(flags: GlobalOutputFlags) {
 /// bypass `async_main`.
 pub(crate) fn global_frozen_flags() -> install::GlobalFrozenFlags {
     GLOBAL_FROZEN.get().copied().unwrap_or_default()
+}
+
+pub(crate) fn global_virtual_store_flags() -> install::GlobalVirtualStoreFlags {
+    GLOBAL_VIRTUAL_STORE.get().copied().unwrap_or_default()
 }
 
 pub(crate) fn global_output_flags() -> GlobalOutputFlags {

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -82,6 +82,30 @@ pub(crate) struct Cli {
     #[arg(long, global = true, conflicts_with = "no_color")]
     color: bool,
 
+    /// Force the shared global virtual store off for this invocation.
+    ///
+    /// Packages are materialized inside the project's virtual store
+    /// instead of symlinked from `~/.cache/aube/virtual-store/`.
+    #[arg(
+        long,
+        visible_alias = "disable-gvs",
+        global = true,
+        conflicts_with = "enable_global_virtual_store"
+    )]
+    disable_global_virtual_store: bool,
+
+    /// Force the shared global virtual store on for this invocation.
+    ///
+    /// Overrides CI's default per-project materialization and the
+    /// `disableGlobalVirtualStoreForPackages` auto-disable heuristic.
+    #[arg(
+        long,
+        visible_alias = "enable-gvs",
+        global = true,
+        conflicts_with = "disable_global_virtual_store"
+    )]
+    enable_global_virtual_store: bool,
+
     /// Error when a workspace selector matches no packages.
     ///
     /// Accepted globally; selected commands already fail on empty matches.
@@ -606,7 +630,9 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
     // point (direct `install`, chained `add`/`remove`/`update`, bare
     // `aube`, auto-install via `ensure_installed`) honors them.
     let global_frozen = frozen_flags_from_cli(&cli);
+    let global_gvs = global_virtual_store_flags_from_cli(&cli);
     commands::set_global_frozen_flags(global_frozen);
+    commands::set_global_virtual_store_flags(global_gvs);
     commands::set_registry_override(cli.registry.clone());
     commands::set_global_output_flags(commands::GlobalOutputFlags {
         silent: matches!(effective_level, LogLevel::Silent),
@@ -646,6 +672,7 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
             run_install_command(
                 args,
                 global_frozen,
+                global_gvs,
                 effective_filter.clone(),
                 cli.workspace_root,
             )
@@ -698,6 +725,7 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
             let nested = Cli::try_parse_from(argv).into_diagnostic()?;
             let nested_filter = compute_effective_filter(&nested);
             let nested_frozen = merge_nested_frozen_flags(global_frozen, &nested);
+            let nested_gvs = merge_nested_global_virtual_store_flags(global_gvs, &nested);
             let _registry_guard = commands::scoped_registry_override(nested.registry.clone());
             match nested.command {
                 Some(Commands::Add(args)) => {
@@ -707,8 +735,14 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
                 Some(Commands::Deploy(args)) => commands::deploy::run(args, nested_filter).await?,
                 Some(Commands::Exec(args)) => commands::exec::run(args, nested_filter).await?,
                 Some(Commands::Install(args)) => {
-                    run_install_command(args, nested_frozen, nested_filter, nested.workspace_root)
-                        .await?;
+                    run_install_command(
+                        args,
+                        nested_frozen,
+                        nested_gvs,
+                        nested_filter,
+                        nested.workspace_root,
+                    )
+                    .await?;
                 }
                 Some(Commands::List(args)) => commands::list::run(args, nested_filter).await?,
                 Some(Commands::La(mut args)) | Some(Commands::Ll(mut args)) => {
@@ -1183,6 +1217,13 @@ fn frozen_flags_from_cli(cli: &Cli) -> commands::install::GlobalFrozenFlags {
     }
 }
 
+fn global_virtual_store_flags_from_cli(cli: &Cli) -> commands::install::GlobalVirtualStoreFlags {
+    commands::install::GlobalVirtualStoreFlags {
+        enable: cli.enable_global_virtual_store,
+        disable: cli.disable_global_virtual_store,
+    }
+}
+
 fn merge_nested_frozen_flags(
     outer: commands::install::GlobalFrozenFlags,
     nested: &Cli,
@@ -1194,9 +1235,21 @@ fn merge_nested_frozen_flags(
     }
 }
 
+fn merge_nested_global_virtual_store_flags(
+    outer: commands::install::GlobalVirtualStoreFlags,
+    nested: &Cli,
+) -> commands::install::GlobalVirtualStoreFlags {
+    if outer.is_set() {
+        outer
+    } else {
+        global_virtual_store_flags_from_cli(nested)
+    }
+}
+
 async fn run_install_command(
     args: commands::install::InstallArgs,
     global_frozen: commands::install::GlobalFrozenFlags,
+    global_gvs: commands::install::GlobalVirtualStoreFlags,
     filter: aube_workspace::selector::EffectiveFilter,
     workspace_root_already: bool,
 ) -> miette::Result<()> {
@@ -1221,7 +1274,7 @@ async fn run_install_command(
         .into_diagnostic()
         .wrap_err("failed to load workspace config")?;
     let env = aube_settings::values::capture_env();
-    let cli_flags = args.to_cli_flag_bag(global_frozen);
+    let cli_flags = args.to_cli_flag_bag(global_frozen, global_gvs);
     let ctx = aube_settings::ResolveCtx {
         npmrc: &npmrc,
         workspace_yaml: &raw_ws,

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5380,6 +5380,34 @@
         "global": true
       },
       {
+        "name": "disable-global-virtual-store",
+        "usage": "--disable-global-virtual-store",
+        "help": "Force the shared global virtual store off for this invocation",
+        "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+        "help_first_line": "Force the shared global virtual store off for this invocation",
+        "short": [],
+        "long": [
+          "disable-global-virtual-store",
+          "disable-gvs"
+        ],
+        "hide": false,
+        "global": true
+      },
+      {
+        "name": "enable-global-virtual-store",
+        "usage": "--enable-global-virtual-store",
+        "help": "Force the shared global virtual store on for this invocation",
+        "help_long": "Force the shared global virtual store on for this invocation.\n\nOverrides CI's default per-project materialization and the `disableGlobalVirtualStoreForPackages` auto-disable heuristic.",
+        "help_first_line": "Force the shared global virtual store on for this invocation",
+        "short": [],
+        "long": [
+          "enable-global-virtual-store",
+          "enable-gvs"
+        ],
+        "hide": false,
+        "global": true
+      },
+      {
         "name": "fail-if-no-match",
         "usage": "--fail-if-no-match",
         "help": "Error when a workspace selector matches no packages",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -43,6 +43,18 @@ Force colored output even when stderr is not a TTY.
 
 Overrides `NO_COLOR` / `CLICOLOR=0`. Mutually exclusive with `--no-color`.
 
+### `--disable-global-virtual-store`
+
+Force the shared global virtual store off for this invocation.
+
+Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+
+### `--enable-global-virtual-store`
+
+Force the shared global virtual store on for this invocation.
+
+Overrides CI's default per-project materialization and the `disableGlobalVirtualStoreForPackages` auto-disable heuristic.
+
 ### `--fail-if-no-match`
 
 Error when a workspace selector matches no packages.

--- a/docs/settings/cli.md
+++ b/docs/settings/cli.md
@@ -16,7 +16,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-15 settings are listed here.
+16 settings are listed here.
 
 | Setting | Type | Summary |
 | --- | --- | --- |
@@ -24,6 +24,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
 | [`nodeLinker`](#setting-nodelinker) | `"isolated" \| "hoisted" \| "pnp"` | Strategy for linking Node packages into node_modules. |
 | [`packageImportMethod`](#setting-packageimportmethod) | `"auto" \| "hardlink" \| "copy" \| "clone" \| "clone-or-copy"` | Method for importing packages from the store into node_modules. |
+| [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
 | [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
 | [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
 | [`networkConcurrency`](#setting-networkconcurrency) | `int` | Maximum concurrent HTTP(S) requests. |
@@ -102,6 +103,38 @@ currently falls back to copy when reflink is unsupported — strict
 enforcement is planned for a future release), and `clone-or-copy`
 tries reflink first and falls back to a plain copy instead of
 hardlinking. Overridable per-invocation with `--package-import-method`.
+
+### `enableGlobalVirtualStore` {#setting-enableglobalvirtualstore}
+
+Use a per-user virtual store for all projects.
+
+- Type: `bool`
+- Default: `undefined`
+- CLI flags: `enable-global-virtual-store`, `disable-global-virtual-store`
+
+aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
+It's enabled by default outside CI and disabled under CI (see
+`aube-linker`, which checks the `CI` env var). Set
+`enableGlobalVirtualStore=false` in `.npmrc` or `pnpm-workspace.yaml`
+to force per-project materialization for a project.
+
+`aube dlx` defaults this setting to `false` for its scratch installs so
+CLIs with undeclared runtime imports can still use the hidden-hoist
+fallback inside the temporary project. Pass
+`aube dlx --enable-gvs <pkg>` when you want to force the shared virtual
+store on for a dlx invocation.
+
+The global flags are one-shot CLI sources for the same setting:
+`--disable-global-virtual-store` resolves this setting to `false`, and
+`--enable-global-virtual-store` resolves it to `true`. The enable flag
+can force the shared virtual store on even in CI or when package
+compatibility heuristics would normally disable it.
+
+Examples:
+
+- `echo 'enableGlobalVirtualStore=false' >> .npmrc`
+- `aube --disable-global-virtual-store install`
+- `aube dlx --enable-gvs create-vite`
 
 ## Store
 

--- a/docs/settings/env.md
+++ b/docs/settings/env.md
@@ -609,13 +609,32 @@ config-surface change.
 Use a per-user virtual store for all projects.
 
 - Type: `bool`
-- Default: `false`
-- Environment: `CI`, `npm_config_enable_global_virtual_store`, `NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
+- Default: `undefined`
+- Environment: `npm_config_enable_global_virtual_store`, `NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
-It's enabled by default and disabled under CI (see `aube-linker`, which
-checks the `CI` env var). pnpm gained the same feature later; we expose
-it through `CI=1` rather than a dedicated config knob.
+It's enabled by default outside CI and disabled under CI (see
+`aube-linker`, which checks the `CI` env var). Set
+`enableGlobalVirtualStore=false` in `.npmrc` or `pnpm-workspace.yaml`
+to force per-project materialization for a project.
+
+`aube dlx` defaults this setting to `false` for its scratch installs so
+CLIs with undeclared runtime imports can still use the hidden-hoist
+fallback inside the temporary project. Pass
+`aube dlx --enable-gvs <pkg>` when you want to force the shared virtual
+store on for a dlx invocation.
+
+The global flags are one-shot CLI sources for the same setting:
+`--disable-global-virtual-store` resolves this setting to `false`, and
+`--enable-global-virtual-store` resolves it to `true`. The enable flag
+can force the shared virtual store on even in CI or when package
+compatibility heuristics would normally disable it.
+
+Examples:
+
+- `echo 'enableGlobalVirtualStore=false' >> .npmrc`
+- `aube --disable-global-virtual-store install`
+- `aube dlx --enable-gvs create-vite`
 
 ### `disableGlobalVirtualStoreForPackages` {#setting-disableglobalvirtualstoreforpackages}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -662,15 +662,35 @@ config-surface change.
 Use a per-user virtual store for all projects.
 
 - Type: `bool`
-- Default: `false`
-- Environment: `CI`, `npm_config_enable_global_virtual_store`, `NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
+- Default: `undefined`
+- CLI flags: `enable-global-virtual-store`, `disable-global-virtual-store`
+- Environment: `npm_config_enable_global_virtual_store`, `NPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
 - .npmrc keys: `enableGlobalVirtualStore`
 - Workspace YAML keys: `enableGlobalVirtualStore`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
-It's enabled by default and disabled under CI (see `aube-linker`, which
-checks the `CI` env var). pnpm gained the same feature later; we expose
-it through `CI=1` rather than a dedicated config knob.
+It's enabled by default outside CI and disabled under CI (see
+`aube-linker`, which checks the `CI` env var). Set
+`enableGlobalVirtualStore=false` in `.npmrc` or `pnpm-workspace.yaml`
+to force per-project materialization for a project.
+
+`aube dlx` defaults this setting to `false` for its scratch installs so
+CLIs with undeclared runtime imports can still use the hidden-hoist
+fallback inside the temporary project. Pass
+`aube dlx --enable-gvs <pkg>` when you want to force the shared virtual
+store on for a dlx invocation.
+
+The global flags are one-shot CLI sources for the same setting:
+`--disable-global-virtual-store` resolves this setting to `false`, and
+`--enable-global-virtual-store` resolves it to `true`. The enable flag
+can force the shared virtual store on even in CI or when package
+compatibility heuristics would normally disable it.
+
+Examples:
+
+- `echo 'enableGlobalVirtualStore=false' >> .npmrc`
+- `aube --disable-global-virtual-store install`
+- `aube dlx --enable-gvs create-vite`
 
 ### `disableGlobalVirtualStoreForPackages` {#setting-disableglobalvirtualstoreforpackages}
 

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -609,13 +609,32 @@ config-surface change.
 Use a per-user virtual store for all projects.
 
 - Type: `bool`
-- Default: `false`
+- Default: `undefined`
 - .npmrc keys: `enableGlobalVirtualStore`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
-It's enabled by default and disabled under CI (see `aube-linker`, which
-checks the `CI` env var). pnpm gained the same feature later; we expose
-it through `CI=1` rather than a dedicated config knob.
+It's enabled by default outside CI and disabled under CI (see
+`aube-linker`, which checks the `CI` env var). Set
+`enableGlobalVirtualStore=false` in `.npmrc` or `pnpm-workspace.yaml`
+to force per-project materialization for a project.
+
+`aube dlx` defaults this setting to `false` for its scratch installs so
+CLIs with undeclared runtime imports can still use the hidden-hoist
+fallback inside the temporary project. Pass
+`aube dlx --enable-gvs <pkg>` when you want to force the shared virtual
+store on for a dlx invocation.
+
+The global flags are one-shot CLI sources for the same setting:
+`--disable-global-virtual-store` resolves this setting to `false`, and
+`--enable-global-virtual-store` resolves it to `true`. The enable flag
+can force the shared virtual store on even in CI or when package
+compatibility heuristics would normally disable it.
+
+Examples:
+
+- `echo 'enableGlobalVirtualStore=false' >> .npmrc`
+- `aube --disable-global-virtual-store install`
+- `aube dlx --enable-gvs create-vite`
 
 ### `disableGlobalVirtualStoreForPackages` {#setting-disableglobalvirtualstoreforpackages}
 

--- a/docs/settings/workspace-yaml.md
+++ b/docs/settings/workspace-yaml.md
@@ -393,13 +393,32 @@ hardlinking. Overridable per-invocation with `--package-import-method`.
 Use a per-user virtual store for all projects.
 
 - Type: `bool`
-- Default: `false`
+- Default: `undefined`
 - Workspace YAML keys: `enableGlobalVirtualStore`
 
 aube ships its own global virtual store under `~/.cache/aube/virtual-store/`.
-It's enabled by default and disabled under CI (see `aube-linker`, which
-checks the `CI` env var). pnpm gained the same feature later; we expose
-it through `CI=1` rather than a dedicated config knob.
+It's enabled by default outside CI and disabled under CI (see
+`aube-linker`, which checks the `CI` env var). Set
+`enableGlobalVirtualStore=false` in `.npmrc` or `pnpm-workspace.yaml`
+to force per-project materialization for a project.
+
+`aube dlx` defaults this setting to `false` for its scratch installs so
+CLIs with undeclared runtime imports can still use the hidden-hoist
+fallback inside the temporary project. Pass
+`aube dlx --enable-gvs <pkg>` when you want to force the shared virtual
+store on for a dlx invocation.
+
+The global flags are one-shot CLI sources for the same setting:
+`--disable-global-virtual-store` resolves this setting to `false`, and
+`--enable-global-virtual-store` resolves it to `true`. The enable flag
+can force the shared virtual store on even in CI or when package
+compatibility heuristics would normally disable it.
+
+Examples:
+
+- `echo 'enableGlobalVirtualStore=false' >> .npmrc`
+- `aube --disable-global-virtual-store install`
+- `aube dlx --enable-gvs create-vite`
 
 ### `disableGlobalVirtualStoreForPackages` {#setting-disableglobalvirtualstoreforpackages}
 

--- a/test/dlx.bats
+++ b/test/dlx.bats
@@ -75,3 +75,9 @@ teardown() {
 	assert_success
 	assert_line "7.0.0"
 }
+
+@test "aube dlx accepts the global gvs override after the subcommand" {
+	run aube dlx --enable-gvs semver 1.2.3
+	assert_success
+	assert_line "1.2.3"
+}

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -116,6 +116,29 @@ JSON
 	[ -L node_modules/.aube/is-odd@3.0.1 ]
 }
 
+@test "--disable-global-virtual-store forces per-project materialization" {
+	_setup_basic_fixture
+
+	run aube install --disable-global-virtual-store
+	assert_success
+	[ -d node_modules/.aube/is-odd@3.0.1 ]
+	[ ! -L node_modules/.aube/is-odd@3.0.1 ]
+}
+
+@test "--enable-global-virtual-store overrides package auto-disable" {
+	_make_fake_dep next
+	mkdir -p app
+	cd app
+	cat >package.json <<'JSON'
+{"name":"app","version":"0.0.0","dependencies":{"next":"link:../fake-next","is-odd":"3.0.1"}}
+JSON
+
+	run aube install --enable-global-virtual-store
+	assert_success
+	refute_output --partial "disableGlobalVirtualStoreForPackages"
+	[ -L node_modules/.aube/is-odd@3.0.1 ]
+}
+
 @test "CI=1 suppresses the gvs-disable warning because gvs is already off" {
 	# Under CI, Linker::new already picks per-project materialization,
 	# so the warning would be noise. Detection is still correct —


### PR DESCRIPTION
## Summary
- add global `--enable-gvs` / `--disable-gvs` aliases for the full `--enable-global-virtual-store` / `--disable-global-virtual-store` flags
- keep this as a CLI-only override for the existing GVS behavior; this PR does not add a second persistent setting
- make `dlx` default to per-project materialization so scratch installs can use the hidden-hoist fallback for CLIs with undeclared runtime imports
- document that `enableGlobalVirtualStore` has this `dlx` default-off behavior and can still be forced on with `aube dlx --enable-gvs <pkg>`
- update usage metadata and BATS coverage for `aube dlx --enable-gvs ...`

## Why
`neonctl@latest` imports `cliui` at runtime without declaring it directly. When `dlx` used the shared global virtual store, the scratch project could not reach the hidden-hoist fallback path and Node failed with `ERR_MODULE_NOT_FOUND`.

Defaulting `dlx` to per-project materialization fixes that class of CLI, while the global flag gives users an explicit one-shot escape hatch without adding another config field.

## Validation
- `cargo fmt --check`
- `cargo test -p aube-settings`
- `cargo test -p aube`
- `mise run test:bats test/nextjs_gvs_autodisable.bats test/dlx.bats`
- `target/debug/aubx neonctl@latest init --help`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install/linking configuration resolution and changes `dlx` install behavior, which can affect how dependencies are materialized across projects and CI. While scoped to flags and defaults, it impacts a core path (`install`/`dlx`) so regressions would surface broadly.
> 
> **Overview**
> Adds global CLI overrides `--enable-global-virtual-store`/`--disable-global-virtual-store` (plus `--enable-gvs`/`--disable-gvs` aliases) and wires them through settings resolution so they can *force* GVS on/off for a single invocation.
> 
> Changes `aube dlx` to default to **per-project materialization** by injecting a one-shot disable flag into its internal install options, while still honoring an explicit global enable/disable override when provided. Updates the GVS auto-disable heuristic to respect an explicit `enableGlobalVirtualStore` value, and expands BATS/unit coverage for the new flags and `dlx` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7fbef12e733f23dca4b2ad5e24d62ab541a4f07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->