### PR TITLE
lockfile: normalize git selector fragments

### DIFF
--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -354,7 +354,7 @@ impl LocalSource {
 /// so the caller can fall through to other protocol parsers.
 pub fn parse_git_spec(spec: &str) -> Option<(String, Option<String>)> {
     let (body, committish) = match spec.find('#') {
-        Some(idx) => (&spec[..idx], Some(spec[idx + 1..].to_string())),
+        Some(idx) => (&spec[..idx], normalize_git_fragment(&spec[idx + 1..])),
         None => (spec, None),
     };
     let is_bare_transport = body.starts_with("https://")
@@ -389,6 +389,43 @@ pub fn parse_git_spec(spec: &str) -> Option<(String, Option<String>)> {
         return None;
     };
     Some((url, committish))
+}
+
+/// Normalize git URL fragments used by npm-compatible lockfiles.
+///
+/// Plain git accepts `#<ref>`, while npm and Yarn Berry also write
+/// key/value fragments such as `#commit=<sha>` for pinned git deps.
+/// Downstream code passes this value directly to `git ls-remote` and
+/// `git checkout`, so strip the selector key here and keep only the
+/// actual ref name or SHA.
+pub(crate) fn normalize_git_fragment(fragment: &str) -> Option<String> {
+    if fragment.is_empty() {
+        return None;
+    }
+
+    let mut fallback: Option<&str> = None;
+    let mut preferred: Option<&str> = None;
+    for part in fragment.split('&') {
+        if part.is_empty() {
+            continue;
+        }
+        let (key, value) = part.split_once('=').unwrap_or(("", part));
+        if value.is_empty() {
+            continue;
+        }
+        match key {
+            "commit" => {
+                preferred = Some(value);
+                break;
+            }
+            "tag" | "head" | "branch" | "" => {
+                fallback.get_or_insert(value);
+            }
+            _ => {}
+        }
+    }
+
+    preferred.or(fallback).map(ToString::to_string)
 }
 
 /// A single resolved package in the lockfile.
@@ -1505,6 +1542,22 @@ mod git_spec_tests {
     fn github_shorthand_expands_and_roundtrips() {
         let (url, _) = parse_git_spec("github:user/repo").unwrap();
         assert_eq!(url, "https://github.com/user/repo.git");
+    }
+
+    #[test]
+    fn commit_selector_fragment_normalizes_to_sha() {
+        let sha = "abcdef0123456789abcdef0123456789abcdef01";
+        let (url, committish) =
+            parse_git_spec(&format!("https://host/user/repo.git#commit={sha}")).unwrap();
+        assert_eq!(url, "https://host/user/repo.git");
+        assert_eq!(committish.as_deref(), Some(sha));
+    }
+
+    #[test]
+    fn named_selector_fragment_normalizes_to_ref() {
+        let (url, committish) = parse_git_spec("git+https://host/user/repo#tag=v1.2.3").unwrap();
+        assert_eq!(url, "https://host/user/repo");
+        assert_eq!(committish.as_deref(), Some("v1.2.3"));
     }
 }
 

--- a/crates/aube-lockfile/src/yarn.rs
+++ b/crates/aube-lockfile/src/yarn.rs
@@ -962,7 +962,8 @@ fn strip_hash_fragment(s: &str) -> &str {
 /// If the URL has a `#<commit>` suffix, return `<commit>`. Used for
 /// git-over-http berry specs that pin the resolved commit after `#`.
 fn extract_commit_hash(url: &str) -> Option<String> {
-    url.split_once('#').map(|(_, b)| b.to_string())
+    url.split_once('#')
+        .and_then(|(_, b)| crate::normalize_git_fragment(b))
 }
 
 fn strip_commit_hash(url: &str) -> String {
@@ -1674,9 +1675,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-pkg@https://github.com/user/repo.git#commit=abc123":
+"git-pkg@https://github.com/user/repo.git#commit=abcdef0123456789abcdef0123456789abcdef01":
   version: 2.0.0
-  resolution: "git-pkg@https://github.com/user/repo.git#commit=abc123"
+  resolution: "git-pkg@https://github.com/user/repo.git#commit=abcdef0123456789abcdef0123456789abcdef01"
   languageName: node
   linkType: hard
 
@@ -1709,7 +1710,11 @@ __metadata:
 
         // `.git` on https → git source, not tarball.
         let git = by_name["git-pkg"];
-        assert!(matches!(&git.local_source, Some(LocalSource::Git(_))));
+        let Some(LocalSource::Git(git)) = &git.local_source else {
+            panic!("expected git LocalSource");
+        };
+        assert_eq!(git.url, "https://github.com/user/repo.git");
+        assert_eq!(git.resolved, "abcdef0123456789abcdef0123456789abcdef01");
 
         // `git+ssh:` prefix → git source.
         let ssh = by_name["ssh-git-pkg"];


### PR DESCRIPTION
## What changed

- Normalize npm/Yarn-style git URL fragments such as `#commit=<sha>` to the actual checkout ref during git spec parsing.
- Reuse the same normalization for Yarn Berry git lockfile entries so `resolved` stores the SHA instead of `commit=<sha>`.
- Add regression coverage for the exact `#commit=<sha>` shape that previously reached `git checkout` literally.

## Why

Yarn Berry can record pinned git dependencies as `https://repo.git#commit=<sha>`. Aube preserved `commit=<sha>` as the ref, which made the store try `git checkout commit=<sha>` and fail with a pathspec error.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-lockfile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git URL parsing and Yarn Berry lockfile interpretation for git dependencies, which can alter how refs/SHAs are resolved and checked out during installs. Scope is limited to lockfile parsing with added tests, but impacts dependency fetching behavior.
> 
> **Overview**
> **Git dependency parsing now normalizes selector-style URL fragments** so inputs like `#commit=<sha>` or `#tag=<ref>` are reduced to the actual SHA/ref before being passed downstream.
> 
> This behavior is reused in the Yarn Berry parser so git `resolution` URLs store the correct `resolved` SHA (not the `commit=<sha>` string), with targeted unit tests added/updated to cover the new fragment handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e44032ce1b95bf5818a2d4d1f16328a5f056e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->