### PR TITLE
docs: remove settings count sentence

### DIFF
--- a/crates/aube-settings/src/bin/generate_settings_docs.rs
+++ b/crates/aube-settings/src/bin/generate_settings_docs.rs
@@ -230,8 +230,6 @@ fn same_filter(a: SourceFilter, b: SourceFilter) -> bool {
 fn render_summary(out: &mut String, settings: &[&SettingRef<'_>]) {
     writeln!(out, "## Summary").unwrap();
     writeln!(out).unwrap();
-    writeln!(out, "{} settings are listed here.", settings.len()).unwrap();
-    writeln!(out).unwrap();
     writeln!(out, "| Setting | Type | Summary |").unwrap();
     writeln!(out, "| --- | --- | --- |").unwrap();
     for setting in settings {

--- a/docs/settings/cli.md
+++ b/docs/settings/cli.md
@@ -16,8 +16,6 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-16 settings are listed here.
-
 | Setting | Type | Summary |
 | --- | --- | --- |
 | [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |

--- a/docs/settings/env.md
+++ b/docs/settings/env.md
@@ -16,8 +16,6 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-113 settings are listed here.
-
 | Setting | Type | Summary |
 | --- | --- | --- |
 | [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -16,8 +16,6 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-113 settings are listed here.
-
 | Setting | Type | Summary |
 | --- | --- | --- |
 | [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -16,8 +16,6 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-113 settings are listed here.
-
 | Setting | Type | Summary |
 | --- | --- | --- |
 | [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |

--- a/docs/settings/workspace-yaml.md
+++ b/docs/settings/workspace-yaml.md
@@ -16,8 +16,6 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 
 ## Summary
 
-50 settings are listed here.
-
 | Setting | Type | Summary |
 | --- | --- | --- |
 | [`overrides`](#setting-overrides) | `object` | Instruct aube to override any dependency in the dependency graph, including peer dependencies. |


### PR DESCRIPTION
## Summary
- stop generating the `N settings are listed here.` sentence in settings docs summaries
- regenerate all settings docs views so the count line is removed consistently

## Validation
- `cargo fmt --check`
- `cargo test -p aube-settings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only affects generated markdown output by removing a redundant “N settings are listed here.” sentence, with no runtime or settings behavior changes.
> 
> **Overview**
> Removes the auto-generated “`N` settings are listed here.” line from the settings docs summary table output.
> 
> Regenerates all settings docs views (`index`, `.npmrc`, `workspace-yaml`, `env`, `cli`) so the Summary section consistently starts directly with the table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac047f1f8a70fc703e7af3271f29d8be72800fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->