### PR TITLE
docs: add homebrew tap install

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,0 +1,88 @@
+name: publish-homebrew
+
+# Homebrew/core does not accept beta releases, so releases are published
+# to the Endev tap until aube is stable enough for the main formula index.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish to Homebrew (e.g. v1.0.0-beta.4)"
+        required: true
+        type: string
+
+concurrency:
+  group: publish-homebrew
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish Homebrew formula
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      TAP_REPO: endevco/homebrew-tap
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            echo "::error::no tag from release event or workflow_dispatch input"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ steps.tag.outputs.tag }}
+
+      - name: Compute source archive checksum
+        id: source
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          curl -fsSL "https://github.com/endevco/aube/archive/refs/tags/${TAG}.tar.gz" -o source.tar.gz
+          echo "sha256=$(sha256sum source.tar.gz | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Render formula
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          SOURCE_SHA256: ${{ steps.source.outputs.sha256 }}
+        run: |
+          mkdir -p dist
+          ./packaging/homebrew/render-formula.sh > dist/aube.rb
+
+      - name: Publish to tap
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "::error::AUBE_GH_TOKEN is required to push ${TAP_REPO}"
+            exit 1
+          fi
+
+          git clone --depth 1 "https://x-access-token:${GITHUB_TOKEN}@github.com/${TAP_REPO}.git" tap
+          mkdir -p tap/Formula
+          cp dist/aube.rb tap/Formula/aube.rb
+
+          cd tap
+          if [ -z "$(git status --porcelain -- Formula/aube.rb)" ]; then
+            echo "Formula/aube.rb already matches aube ${VERSION}"
+            exit 0
+          fi
+
+          git config user.name "aube Release Bot"
+          git config user.email "noreply@aube.en.dev"
+          git add Formula/aube.rb
+          git commit -m "aube: update to ${VERSION}"
+          git push

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ aube is also published on npm:
 npm install -g @endevco/aube
 ```
 
+While aube is beta, Homebrew installs come from the Endev tap:
+
+```sh
+brew install endevco/tap/aube
+```
+
 See [other install methods](https://aube.en.dev/installation).
 
 ## First Install

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,6 +23,17 @@ cargo install aube --locked
 same dependency versions CI built against. The compiled binary lands in
 `~/.cargo/bin/aube`.
 
+## From Homebrew
+
+Homebrew/core does not accept beta releases, so aube is published from
+the Endev tap for now:
+
+```sh
+brew install endevco/tap/aube
+```
+
+The tap formula builds from source and installs shell completions.
+
 ## From npm
 
 aube is also published on npm as `@endevco/aube`:

--- a/packaging/homebrew/render-formula.sh
+++ b/packaging/homebrew/render-formula.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TAG="${TAG:?TAG is required, e.g. v1.0.0-beta.4}"
+SOURCE_SHA256="${SOURCE_SHA256:?SOURCE_SHA256 is required}"
+
+SOURCE_URL="https://github.com/endevco/aube/archive/refs/tags/${TAG}.tar.gz"
+
+cat <<FORMULA
+class Aube < Formula
+  desc "Fast Node.js package manager that drops into existing projects"
+  homepage "https://aube.en.dev"
+  url "${SOURCE_URL}"
+  sha256 "${SOURCE_SHA256}"
+  license "MIT"
+
+  depends_on "rust" => :build
+  depends_on "usage" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/aube")
+    generate_completions_from_executable(bin/"aube", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/aube --version")
+    assert_match "Usage:", shell_output("#{bin}/aube --help")
+  end
+end
+FORMULA


### PR DESCRIPTION
## Summary

- document `brew install endevco/tap/aube` in the README and installation guide while aube is still beta
- add a Homebrew formula renderer for the Endev tap
- add a post-release `publish-homebrew` workflow that computes the source archive checksum and pushes `Formula/aube.rb` to `endevco/homebrew-tap` with the existing `AUBE_GH_TOKEN` PAT

## Context

Homebrew/core will not accept aube while it is in beta, so the Endev tap is the supported Homebrew install path for now. The tap has already been bootstrapped and updated to `v1.0.0-beta.4`; this PR makes the docs and future release automation match that distribution path.

## Validation

- `actionlint .github/workflows/publish-homebrew.yml`
- `bash -n packaging/homebrew/render-formula.sh`
- rendered formula `ruby -c`
- `git diff --check`
- `brew audit --formula --strict endevco/tap/aube`
- `brew fetch --build-from-source endevco/tap/aube`
- commit hooks: `actionlint`, `shellcheck`, `shfmt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a release-triggered GitHub Action that renders and pushes a Homebrew formula to an external tap using a PAT, which affects release automation and credentialed Git operations. Failures or misconfigurations could publish incorrect formula metadata/checksums.
> 
> **Overview**
> **Homebrew tap support is added for beta releases.** Docs now advertise installing via `brew install endevco/tap/aube` in `README.md` and `docs/installation.md`.
> 
> A new `publish-homebrew` GitHub Actions workflow runs on release (or manually with a tag), computes the release source tarball SHA256, renders a Homebrew formula via `packaging/homebrew/render-formula.sh`, and pushes `Formula/aube.rb` updates to `endevco/homebrew-tap` using `secrets.AUBE_GH_TOKEN`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46777f6140172df693c2cfcaafd324615f903c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->