### PR TITLE
cli: pluralize counted nouns in CLI output

### DIFF
--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -1106,9 +1106,8 @@ async fn run_global_inner(
 
     if !linked.is_empty() {
         eprintln!(
-            "Linked {} bin{} into {}",
-            linked.len(),
-            if linked.len() == 1 { "" } else { "s" },
+            "Linked {} into {}",
+            pluralizer::pluralize("bin", linked.len() as isize, true),
             layout.bin_dir.display()
         );
     }

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -601,9 +601,8 @@ fn render_table(rows: &[Row]) {
     }
     println!();
     println!(
-        "{} vulnerabilit{} found",
-        rows.len(),
-        if rows.len() == 1 { "y" } else { "ies" }
+        "{} found",
+        pluralizer::pluralize("vulnerability", rows.len() as isize, true)
     );
 }
 

--- a/crates/aube/src/commands/clean.rs
+++ b/crates/aube/src/commands/clean.rs
@@ -134,22 +134,16 @@ async fn run_as(invoked_as: &str, args: CleanArgs) -> miette::Result<()> {
     if removed_nm == 0 && removed_locks == 0 {
         eprintln!("Nothing to clean");
     } else {
-        let nm_word = if removed_nm == 1 {
-            "directory"
-        } else {
-            "directories"
-        };
+        let nm_word = pluralizer::pluralize("directory", removed_nm as isize, false);
         // Only mention lockfiles when we actually removed at least one
         // — "Removed 1 node_modules directory, 0 lockfiles" was just
         // noise when `--lockfile` was passed against a tree that had
         // no lockfile to begin with.
         if removed_locks > 0 {
-            let lock_word = if removed_locks == 1 {
-                "lockfile"
-            } else {
-                "lockfiles"
-            };
-            eprintln!("Removed {removed_nm} node_modules {nm_word}, {removed_locks} {lock_word}");
+            eprintln!(
+                "Removed {removed_nm} node_modules {nm_word}, {}",
+                pluralizer::pluralize("lockfile", removed_locks as isize, true)
+            );
         } else {
             eprintln!("Removed {removed_nm} node_modules {nm_word}");
         }

--- a/crates/aube/src/commands/deprecate.rs
+++ b/crates/aube/src/commands/deprecate.rs
@@ -131,7 +131,10 @@ pub async fn apply(
         } else {
             "deprecate"
         };
-        eprintln!("Would {verb} {} version(s) of {name}:", matched.len());
+        eprintln!(
+            "Would {verb} {} of {name}:",
+            pluralizer::pluralize("version", matched.len() as isize, true)
+        );
         for v in &matched {
             eprintln!("  {v}");
         }

--- a/crates/aube/src/commands/deprecate.rs
+++ b/crates/aube/src/commands/deprecate.rs
@@ -152,7 +152,10 @@ pub async fn apply(
     } else {
         "Deprecated"
     };
-    eprintln!("{verb} {} version(s) of {name}:", matched.len());
+    eprintln!(
+        "{verb} {} of {name}:",
+        pluralizer::pluralize("version", matched.len() as isize, true)
+    );
     for v in &matched {
         eprintln!("  {v}");
     }

--- a/crates/aube/src/commands/fetch.rs
+++ b/crates/aube/src/commands/fetch.rs
@@ -101,10 +101,9 @@ pub async fn run(args: FetchArgs) -> miette::Result<()> {
     };
 
     eprintln!(
-        "Fetching {} of {} package{} from {}",
+        "Fetching {} of {} from {}",
         filtered.len(),
-        total_packages,
-        if total_packages == 1 { "" } else { "s" },
+        pluralizer::pluralize("package", total_packages as isize, true),
         kind.filename()
     );
 

--- a/crates/aube/src/commands/install.rs
+++ b/crates/aube/src/commands/install.rs
@@ -2224,9 +2224,8 @@ fn maybe_cleanup_unused_catalogs(
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_else(|| ws_path.display().to_string());
         tracing::info!(
-            "cleanupUnusedCatalogs: pruned {} entr{} from {filename}",
-            dropped.len(),
-            if dropped.len() == 1 { "y" } else { "ies" }
+            "cleanupUnusedCatalogs: pruned {} from {filename}",
+            pluralizer::pluralize("entry", dropped.len() as isize, true)
         );
     }
     Ok(())

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -288,8 +288,8 @@ async fn run_recursive(
             .collect::<Vec<_>>()
             .join("\n");
         return Err(miette!(
-            "aube publish: {} package(s) failed:\n{joined}",
-            failures.len()
+            "aube publish: {} failed:\n{joined}",
+            pluralizer::pluralize("package", failures.len() as isize, true)
         ));
     }
     Ok(())

--- a/crates/aube/src/commands/store.rs
+++ b/crates/aube/src/commands/store.rs
@@ -137,8 +137,8 @@ async fn add(specs: Vec<String>) -> miette::Result<()> {
     }
 
     eprintln!(
-        "Added {added} package{} to the store",
-        if added == 1 { "" } else { "s" }
+        "Added {} to the store",
+        pluralizer::pluralize("package", added as isize, true)
     );
     Ok(())
 }
@@ -244,8 +244,8 @@ fn prune() -> miette::Result<()> {
     }
 
     eprintln!(
-        "Pruned {removed_files} file{} ({:.1} MB) from the store",
-        if removed_files == 1 { "" } else { "s" },
+        "Pruned {} ({:.1} MB) from the store",
+        pluralizer::pluralize("file", removed_files as isize, true),
         removed_bytes as f64 / 1_048_576.0
     );
     Ok(())
@@ -295,8 +295,8 @@ fn status() -> miette::Result<()> {
 
     if broken.is_empty() {
         eprintln!(
-            "Store is consistent: {checked} package{} verified",
-            if checked == 1 { "" } else { "s" }
+            "Store is consistent: {} verified",
+            pluralizer::pluralize("package", checked as isize, true)
         );
         Ok(())
     } else {
@@ -307,9 +307,9 @@ fn status() -> miette::Result<()> {
             println!("corrupt: {line}");
         }
         Err(miette!(
-            "store contains {} corrupted file{}",
+            "store contains {} corrupted {}",
             broken.len(),
-            if broken.len() == 1 { "" } else { "s" }
+            pluralizer::pluralize("file", broken.len() as isize, false)
         ))
     }
 }

--- a/crates/aube/src/progress.rs
+++ b/crates/aube/src/progress.rs
@@ -47,7 +47,7 @@ const CI_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 const TTY_MAX_VISIBLE_FETCH_ROWS: usize = 5;
 
 fn overflow_fetch_label(count: usize) -> String {
-    let word = if count == 1 { "package" } else { "packages" };
+    let word = pluralizer::pluralize("package", count as isize, false);
     format!("{count} more {word}…")
 }
 
@@ -349,15 +349,13 @@ impl InstallProgress {
         elapsed: Duration,
     ) {
         if linked == 0 && top_level_linked == 0 {
-            let word = if total_packages == 1 {
-                "package"
-            } else {
-                "packages"
-            };
             let msg = if total_packages == 0 {
                 "Already up to date".to_string()
             } else {
-                format!("Already up to date ({total_packages} {word})")
+                format!(
+                    "Already up to date ({})",
+                    pluralizer::pluralize("package", total_packages as isize, true)
+                )
             };
             // Same `aube VERSION by en.dev · …` shape in both TTY and
             // CI modes so the no-op line reads as part of the install
@@ -380,14 +378,14 @@ impl InstallProgress {
         if !matches!(self.mode, Mode::Tty { .. }) {
             return;
         }
-        let word = if linked == 1 { "package" } else { "packages" };
         // Single line: `aube VERSION by en.dev · ✓ installed N packages in Xs`.
         // Same `aube VERSION by en.dev` shape the progress bar drew
         // while the install was running, joined to the green
         // success line by a middle dot so the whole thing reads as
         // one continuous status.
         let msg = format!(
-            "✓ installed {linked} {word} in {}",
+            "✓ installed {} in {}",
+            pluralizer::pluralize("package", linked as isize, true),
             format_duration(elapsed)
         );
         let line = format!(

--- a/test/deprecate.bats
+++ b/test/deprecate.bats
@@ -58,7 +58,7 @@ _deprecated_field() {
 	_require_registry
 	run aube deprecate 'is-odd@3.0.1' 'please use is-even'
 	assert_success
-	assert_output --partial 'Deprecated 1 version(s) of is-odd'
+	assert_output --partial 'Deprecated 1 version of is-odd'
 	assert_output --partial '3.0.1'
 
 	run _deprecated_field is-odd 3.0.1
@@ -72,7 +72,7 @@ _deprecated_field() {
 
 	run aube undeprecate 'is-odd@0.1.2'
 	assert_success
-	assert_output --partial 'Undeprecated 1 version(s) of is-odd'
+	assert_output --partial 'Undeprecated 1 version of is-odd'
 
 	# After undeprecate the field is either absent or the empty string,
 	# depending on what the registry does with `deprecated: ""`. Both
@@ -89,7 +89,7 @@ _deprecated_field() {
 	_require_registry
 	run aube deprecate --dry-run 'is-number@3.0.0' 'noop'
 	assert_success
-	assert_output --partial 'Would deprecate 1 version(s) of is-number'
+	assert_output --partial 'Would deprecate 1 version of is-number'
 
 	run _deprecated_field is-number 3.0.0
 	assert_output 'null'


### PR DESCRIPTION
## Summary

- Adds the [`pluralizer`](https://crates.io/crates/pluralizer) crate to the `aube` binary and routes 12 hand-rolled pluralization ternaries through it across the install progress UI (`progress.rs`) and the `store`, `fetch`, `add`, `audit`, `deprecate`, `publish`, `install`, and `clean` commands.
- Fixes the `N version(s)` / `N package(s)` awkwardness by producing real singular/plural forms (e.g. `1 version`, `3 versions`).
- Drops bespoke `if n == 1 { "y" } else { "ies" }` and `"" / "s"` logic — `vulnerability → vulnerabilities`, `entry → entries`, `directory → directories` all come out correct without per-site handling.

## Why

Scanning for pluralization opportunities turned up ~9 user-facing sites where we hand-rolled this per message. Consolidating on one crate removes the inconsistency (some sites used `if n == 1 { "" } else { "s" }`, others used `"(s)"`), keeps new call sites honest, and gets the y/ies rules right for free.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p aube` (226 passing)
- [x] Verified pluralizer output for each word used (package/file/bin/vulnerability/version/entry/directory/lockfile) at counts 0/1/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI/logging strings (plus adding the small `pluralizer` dependency), with no behavioral impact on install/audit/publish flows beyond message text.
> 
> **Overview**
> Standardizes counted-noun phrasing across the CLI by routing previously hand-rolled pluralization logic (e.g., `"package(s)"`, `y/ies`, `""/"s"`) through `pluralizer::pluralize` in commands like `add`, `audit`, `clean`, `fetch`, `install`, `publish`, `store`, and the install progress UI.
> 
> Adds the `pluralizer` crate to `aube` and updates E2E expectations for `deprecate`/`undeprecate` to match the new output (e.g., `1 version` instead of `1 version(s)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f62f41b77dafec4356d27b7f2c273812a7290353. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->