### PR TITLE
copr: escape tilde in RPM_VERSION + document PPA/COPR installs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,6 +39,8 @@ Because the install happens via `preinstall`, this does not work with
 
 ## Ubuntu (PPA)
 
+**Supported:** Ubuntu 26.04 (resolute).
+
 Aube publishes signed `.deb` packages to the Launchpad PPA
 [`ppa:jdxcode/aube`](https://launchpad.net/~jdxcode/+archive/ubuntu/aube):
 
@@ -48,18 +50,32 @@ sudo apt update
 sudo apt install aube
 ```
 
-This installs `aube`, plus `aubr` and `aubx` symlinks (the multicall
-shims for `aube run` and `aube dlx`) into `/usr/bin`. Future upgrades
-go through `apt`:
+Future upgrades go through `apt`:
 
 ```sh
 sudo apt update && sudo apt install --only-upgrade aube
 ```
 
-Currently the PPA only builds for **Ubuntu 26.04 (resolute)**. On
-older releases, `add-apt-repository` will succeed but `apt update`
-returns a 404 because no `Release` file is published for that series —
-use mise, `cargo install`, or the npm package instead.
+## Fedora / RHEL (COPR)
+
+**Supported:** Fedora 42, Fedora 43, Fedora Rawhide, EPEL 9, EPEL 10
+(RHEL / Rocky / Alma 9 and 10), both `x86_64` and `aarch64`.
+
+Aube publishes RPMs to the COPR project
+[`jdxcode/aube`](https://copr.fedorainfracloud.org/coprs/jdxcode/aube/):
+
+```sh
+sudo dnf copr enable jdxcode/aube
+sudo dnf install aube
+```
+
+The `dnf copr` subcommand ships with `dnf-plugins-core` — install that
+first on EPEL and anywhere else the plugin isn't already pulled in.
+Future upgrades go through the package manager:
+
+```sh
+sudo dnf upgrade aube
+```
 
 ## From source
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,6 +37,30 @@ Because the install happens via `preinstall`, this does not work with
 `--ignore-scripts` or in offline/air-gapped caches. Prefer mise or
 `cargo install` for those environments.
 
+## Ubuntu (PPA)
+
+Aube publishes signed `.deb` packages to the Launchpad PPA
+[`ppa:jdxcode/aube`](https://launchpad.net/~jdxcode/+archive/ubuntu/aube):
+
+```sh
+sudo add-apt-repository -y ppa:jdxcode/aube
+sudo apt update
+sudo apt install aube
+```
+
+This installs `aube`, plus `aubr` and `aubx` symlinks (the multicall
+shims for `aube run` and `aube dlx`) into `/usr/bin`. Future upgrades
+go through `apt`:
+
+```sh
+sudo apt update && sudo apt install --only-upgrade aube
+```
+
+Currently the PPA only builds for **Ubuntu 26.04 (resolute)**. On
+older releases, `add-apt-repository` will succeed but `apt update`
+returns a 404 because no `Release` file is published for that series —
+use mise, `cargo install`, or the npm package instead.
+
 ## From source
 
 If you want to build the current checkout yourself, use the standard source

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,8 +33,11 @@ npm install -g @endevco/aube
 npx @endevco/aube --version
 ```
 
-Because the install happens via `preinstall`, this does not work with
-`--ignore-scripts` or in offline/air-gapped caches. Prefer mise or
+The `preinstall` script drops the platform-appropriate native binary
+into place. If you install with `--ignore-scripts`, that step is
+skipped and every `aube` invocation goes through a node shim instead
+— which defeats the whole point of having a fast, native CLI. It also
+won't work in offline/air-gapped caches. Prefer mise or
 `cargo install` for those environments.
 
 ## Ubuntu (PPA)
@@ -45,8 +48,8 @@ Aube publishes signed `.deb` packages to the Launchpad PPA
 [`ppa:jdxcode/aube`](https://launchpad.net/~jdxcode/+archive/ubuntu/aube):
 
 ```sh
+sudo apt install -y software-properties-common   # if add-apt-repository isn't already available
 sudo add-apt-repository -y ppa:jdxcode/aube
-sudo apt update
 sudo apt install aube
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,9 +19,11 @@ latest released `aube` from crates.io:
 cargo install aube --locked
 ```
 
+::: info
 `--locked` makes cargo honor the committed `Cargo.lock` so you get the
 same dependency versions CI built against. The compiled binary lands in
 `~/.cargo/bin/aube`.
+:::
 
 ## From npm
 
@@ -33,12 +35,14 @@ npm install -g @endevco/aube
 npx @endevco/aube --version
 ```
 
+::: warning
 The `preinstall` script drops the platform-appropriate native binary
 into place. If you install with `--ignore-scripts`, that step is
 skipped and every `aube` invocation goes through a node shim instead
 — which defeats the whole point of having a fast, native CLI. It also
 won't work in offline/air-gapped caches. Prefer mise or
 `cargo install` for those environments.
+:::
 
 ## Ubuntu (PPA)
 

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -94,7 +94,11 @@ fi
 # RPM Version field disallows `-`. Convert SemVer prerelease separators
 # to `~` so `1.0.0-beta.1` becomes `1.0.0~beta.1`, which rpm collates
 # as older than `1.0.0` (correct pre-release ordering).
-RPM_VERSION="${VERSION//-/~}"
+# Backslash-escape the tilde: bash performs tilde expansion on the
+# replacement string in ${var//pat/rep}, even inside "...", so an
+# unescaped `~` turns into $HOME and corrupts the Version field (e.g.
+# `1.0.0-beta.4` -> `1.0.0/github/homebeta.4` on GitHub Actions).
+RPM_VERSION="${VERSION//-/\~}"
 # Tarball name keeps the original SemVer string so GitHub's /archive URL
 # matches Source0 exactly.
 TARBALL_VERSION="${VERSION}"


### PR DESCRIPTION
## Summary
- Document the `ppa:jdxcode/aube` install path in [docs/installation.md](docs/installation.md).
- Covers `add-apt-repository` + `apt install aube`, the `apt --only-upgrade` refresh, and the resolute-only caveat.

## Why
Verified end-to-end install against the v1.0.0-beta.4 PPA publish in an `ubuntu:devel` (resolute, 26.04) container — `aube 1.0.0-beta.4` plus the `aubr`/`aubx` multicall symlinks land in `/usr/bin`. No docs entry pointed users there. Older Ubuntu releases currently 404 on `apt update` since the workflow only builds `resolute`, so the section flags that and points to mise / cargo / npm as the fallback.

## Test plan
- [x] `apt install aube` inside `ubuntu:devel` resolves `1.0.0~beta.4~resolute1` and installs cleanly.
- [x] `aube --version` reports `1.0.0-beta.4`, `aubr --help` / `aubx --help` dispatch to `run` / `dlx`.
- [ ] Docs site builds (VitePress) — not re-checked, only a new `##` section added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release packaging and documentation: the `RPM_VERSION` substitution used for COPR builds changes behavior and could affect produced RPM metadata/version ordering if wrong. Otherwise changes are small and isolated to install docs and a single build script line.
> 
> **Overview**
> Adds Linux distro install documentation to `docs/installation.md`, including supported Ubuntu PPA (`ppa:jdxcode/aube`) and Fedora/RHEL COPR (`jdxcode/aube`) instructions, and clarifies npm install caveats via admonitions.
> 
> Fixes COPR packaging version generation in `packaging/copr/build-copr.sh` by escaping `~` in the `${VERSION//-/...}` replacement to prevent bash tilde expansion from corrupting prerelease RPM `Version` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e777012caf2956e116eba3263a694cb02593957a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->