### PR TITLE
chore: release v1.0.0-beta.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "base64",
  "blake3",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -3152,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1c326f5796df635de915cc1b2d29485423df10a4997be6103091772f503451"
+checksum = "15ee875bc02244694d5b380ba437349d269cf168bbd84e896437c579317ac6e4"
 dependencies = [
  "base64",
  "hex",
@@ -3170,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6271208173601a0f058f5fb5354561905a7ead9b4185d85a6c2ed97fbdd31338"
+checksum = "c38e3886caf4e1a5a20806c0dc0f5acf33a0bd9c720415ece9e44ddc7a7bf1c1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -3192,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042ca72ca33e7981b84565137ed8beee52fd907914e86691feda4fd837b5a022"
+checksum = "399c813a3bb8997ebd2ed01564bf23318960dc1ca88104c72bd5719c629522c5"
 dependencies = [
  "base64",
  "reqwest 0.13.2",
@@ -3209,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692e1c1037124c0305e6e342c6a5fa180a31d6ce0eafc0e6c8f001d200083f8d"
+checksum = "eaa2a84ceb4b2a7bd42cff428555b7ac8897ce22b8c74a56558b53ac6ff10af9"
 dependencies = [
  "base64",
  "hex",
@@ -3222,9 +3222,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5890d2f982b19694ecf0c95ffb222aa167ff65e2ccb1f81e312c0d6f0c3d9ce5"
+checksum = "4fd4ae883c74bfb7c7d85d5a21bd054c9589d4109a28ab6db55e43ab94f417b7"
 dependencies = [
  "ambient-id",
  "base64",
@@ -3242,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21abbf2ab10930dd2eb77cbc4c24b1efa6da89f6f0dce9b28b7c1362e7b80da8"
+checksum = "c012c1a119e2533d236d5d4244fec16e3be1243ce3fa0e0e9130cb6fc5f830c9"
 dependencies = [
  "base64",
  "hex",
@@ -3260,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4cb10b998aefc5fbe0248a3353e0175e4f44a92437ecca2aa39d05f36427"
+checksum = "5ecc951910318de1475041aa6a749f0a0671cfc82c14ae458df25cf93944cacf"
 dependencies = [
  "base64",
  "serde_json",
@@ -3280,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f9d2f2dc33e04c80cfd5f11c93b64f0a2555b1d7f92b5aa16307266f05ad8c"
+checksum = "6fa1be3a70fdefac1156561f70b44263601dce6ca8ce7022c0c51b142ec0138f"
 dependencies = [
  "base64",
  "chrono",
@@ -3298,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43c677d430038c216b4f6368efc8cea42f35eca4d20fe5fcf51133d71b3b51b"
+checksum = "2d48313c1591c98f6233882786809069ff8f047271d3ffac48fb34966f61ba4e"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -3324,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa6bca8f329e06c7ccb5b9f9be82b165b2be063396be0ee57b13402b994744"
+checksum = "7cb6793ac7a0960807ed731055763f0cdf3ae356c5eccfdb21a44b9671e96d6c"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -85,13 +85,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.5" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.5" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.5" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.5" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.5" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.5" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.5" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.5" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.5" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.5" }
+aube = { path = "crates/aube", version = "1.0.0-beta.6" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.6" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.6" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.6" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.6" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.6" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.6" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.6" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.6" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.6" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.5"
+version "1.0.0-beta.6"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.5...aube-linker-v1.0.0-beta.6) - 2026-04-19
+
+### Other
+
+- reject traversing and non-regular tar entries on import ([#85](https://github.com/endevco/aube/pull/85))
+- sanitize shebang interpreter before shim interpolation ([#84](https://github.com/endevco/aube/pull/84))
+
 ## [1.0.0-beta.5](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.4...aube-linker-v1.0.0-beta.5) - 2026-04-19
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.5...aube-lockfile-v1.0.0-beta.6) - 2026-04-19
+
+### Other
+
+- match pnpm ignored optionals order ([#90](https://github.com/endevco/aube/pull/90))
+
 ## [1.0.0-beta.5](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.4...aube-lockfile-v1.0.0-beta.5) - 2026-04-19
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.5...aube-manifest-v1.0.0-beta.6) - 2026-04-19
+
+### Other
+
+- widen disableGlobalVirtualStoreForPackages default list ([#101](https://github.com/endevco/aube/pull/101))
+- accept aube.* as alias for pnpm.* config keys ([#97](https://github.com/endevco/aube/pull/97))
+
 ## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.2...aube-manifest-v1.0.0-beta.3) - 2026-04-19
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.5...aube-registry-v1.0.0-beta.6) - 2026-04-19
+
+### Other
+
+- gate slow-tarball warning on elapsed > 1s to match pnpm ([#93](https://github.com/endevco/aube/pull/93))
+- gate tokenHelper to user scope and sanitize the value ([#89](https://github.com/endevco/aube/pull/89))
+- tolerate object-valued dep-map entries in packuments ([#92](https://github.com/endevco/aube/pull/92))
+- url-encode scoped names and expand packument accept header ([#83](https://github.com/endevco/aube/pull/83))
+- tolerate null values in packument string maps ([#76](https://github.com/endevco/aube/pull/76))
+
 ## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.2...aube-registry-v1.0.0-beta.3) - 2026-04-19
 
 ### Added

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.5...aube-resolver-v1.0.0-beta.6) - 2026-04-19
+
+### Other
+
+- dedupe root deps declared in multiple sections ([#102](https://github.com/endevco/aube/pull/102))
+- widen aube-lock.yaml to every common platform ([#94](https://github.com/endevco/aube/pull/94))
+- honor pnpm overrides "-" removal marker ([#98](https://github.com/endevco/aube/pull/98))
+- extract peer-context pass into its own module ([#91](https://github.com/endevco/aube/pull/91))
+- resolve catalog: indirection on override targets ([#78](https://github.com/endevco/aube/pull/78))
+
 ## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.2...aube-resolver-v1.0.0-beta.3) - 2026-04-19
 
 ### Added

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.5...aube-settings-v1.0.0-beta.6) - 2026-04-19
+
+### Other
+
+- widen disableGlobalVirtualStoreForPackages default list ([#101](https://github.com/endevco/aube/pull/101))
+- auto-synthesize kebab/camel npmrc key aliases ([#99](https://github.com/endevco/aube/pull/99))
+- gate slow-tarball warning on elapsed > 1s to match pnpm ([#93](https://github.com/endevco/aube/pull/93))
+- split into frozen/settings/side_effects_cache submodules ([#88](https://github.com/endevco/aube/pull/88))
+- move install state to node_modules/.aube-state ([#80](https://github.com/endevco/aube/pull/80))
+- Fix two aube install issues on real RN monorepos ([#82](https://github.com/endevco/aube/pull/82))
+
 ## [1.0.0-beta.5](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.4...aube-settings-v1.0.0-beta.5) - 2026-04-19
 
 ### Other

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.5...aube-store-v1.0.0-beta.6) - 2026-04-19
+
+### Other
+
+- skip PAX global/extension tar headers ([#100](https://github.com/endevco/aube/pull/100))
+- tolerate leading `v` in tarball package.json version ([#95](https://github.com/endevco/aube/pull/95))
+- reject traversing and non-regular tar entries on import ([#85](https://github.com/endevco/aube/pull/85))
+- cap tarball decompression to prevent gzip-bomb dos ([#79](https://github.com/endevco/aube/pull/79))
+- reject dash-prefixed urls and commits passed to git ([#75](https://github.com/endevco/aube/pull/75))
+
 ## [1.0.0-beta.3](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.2...aube-store-v1.0.0-beta.3) - 2026-04-19
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.5...aube-workspace-v1.0.0-beta.6) - 2026-04-19
+
+### Other
+
+- Fix two aube install issues on real RN monorepos ([#82](https://github.com/endevco/aube/pull/82))
+- reject dash-prefixed urls and commits passed to git ([#75](https://github.com/endevco/aube/pull/75))
+
 ## [1.0.0-beta.2](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.1...aube-workspace-v1.0.0-beta.2) - 2026-04-18
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6](https://github.com/endevco/aube/compare/v1.0.0-beta.5...v1.0.0-beta.6) - 2026-04-19
+
+### Other
+
+- widen disableGlobalVirtualStoreForPackages default list ([#101](https://github.com/endevco/aube/pull/101))
+- widen aube-lock.yaml to every common platform ([#94](https://github.com/endevco/aube/pull/94))
+- split into frozen/settings/side_effects_cache submodules ([#88](https://github.com/endevco/aube/pull/88))
+- *(progress)* split ci-mode state into own module ([#87](https://github.com/endevco/aube/pull/87))
+- move install state to node_modules/.aube-state ([#80](https://github.com/endevco/aube/pull/80))
+- Fix two aube install issues on real RN monorepos ([#82](https://github.com/endevco/aube/pull/82))
+- exit silently on ctrl-c at script picker ([#81](https://github.com/endevco/aube/pull/81))
+
 ## [1.0.0-beta.5](https://github.com/endevco/aube/compare/v1.0.0-beta.4...v1.0.0-beta.5) - 2026-04-19
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5546,7 +5546,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.5
+**Version**: 1.0.0-beta.6
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.5",
-  "releasedAt": "2026-04-19T14:11:39Z"
+  "version": "1.0.0-beta.6",
+  "releasedAt": "2026-04-19T19:00:45Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.6`

This PR bumps the workspace to `v1.0.0-beta.6` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a version/changelog/docs release bump with dependency lockfile updates; runtime behavior only changes insofar as the new crate and `sigstore-*` versions are picked up.
> 
> **Overview**
> Updates the workspace and all internal `aube-*` crates from `1.0.0-beta.5` to `1.0.0-beta.6`, refreshing `Cargo.lock` (including `sigstore-*` patch bumps) and release metadata.
> 
> Regenerates release artifacts to match the new version, including per-crate `CHANGELOG.md` entries, `aube.usage.kdl`, and the generated CLI docs (`docs/cli/*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d1745d0a3ed8525448221bcdd1bfb6d95103ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->