### PR TITLE
store: reject dash-prefixed urls and commits passed to git

### DIFF
--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -509,6 +509,35 @@ pub enum Error {
     Git(String),
 }
 
+/// Reject values that would be interpreted by git as an option when
+/// handed to a subcommand as a positional argument. Defense against
+/// the CVE-2017-1000117 class of argv injection.
+///
+/// Modern git releases refuse dash-prefixed URLs at the CLI layer,
+/// but this check still matters:
+///
+/// - self-hosted runners still ship older git binaries,
+/// - the same helper is reused for committish values fed to
+///   `git checkout`, where a `--` terminator can't be used because it
+///   would turn the committish into a pathspec.
+///
+/// A NUL byte is also rejected. It never appears in a legitimate url,
+/// ref, or commit, and is a recurring split point for tool pipelines
+/// downstream.
+fn validate_git_positional(value: &str, kind: &str) -> Result<(), Error> {
+    if value.starts_with('-') {
+        return Err(Error::Git(format!(
+            "refusing to pass {kind} starting with `-` to git: {value:?}"
+        )));
+    }
+    if value.contains('\0') {
+        return Err(Error::Git(format!(
+            "refusing to pass {kind} containing NUL byte to git"
+        )));
+    }
+    Ok(())
+}
+
 /// Resolve a git ref (branch name, tag, or partial commit) to a full
 /// 40-char commit SHA by shelling out to `git ls-remote`. `committish`
 /// of `None` means resolve `HEAD`. An input that already looks like a
@@ -518,6 +547,7 @@ pub enum Error {
 /// `refs/heads/<ref>`, falling back to the HEAD of the repo when the
 /// caller passes `None`.
 pub fn git_resolve_ref(url: &str, committish: Option<&str>) -> Result<String, Error> {
+    validate_git_positional(url, "git url")?;
     // Already a full commit SHA? No network round-trip needed.
     if let Some(c) = committish
         && c.len() == 40
@@ -530,9 +560,12 @@ pub fn git_resolve_ref(url: &str, committish: Option<&str>) -> Result<String, Er
     // symbolic ref resolves, and some hosts (and our bare-repo test
     // fixtures) leave HEAD dangling. Listing everything also lets us
     // fall back to `main` / `master` without a second network call.
+    //
+    // `--` terminates git's own option parsing so an attacker-supplied
+    // url that slips a leading `-` past `validate_git_positional` (we
+    // don't expect this, but defense in depth) can't land as an option.
     let out = std::process::Command::new("git")
-        .arg("ls-remote")
-        .arg(url)
+        .args(["ls-remote", "--", url])
         .output()
         .map_err(|e| Error::Git(format!("spawn git ls-remote {url}: {e}")))?;
     if !out.status.success() {
@@ -686,6 +719,8 @@ pub fn git_url_host(url: &str) -> Option<&str> {
 /// [`git_host_in_list`].
 pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathBuf, Error> {
     use std::process::Command;
+    validate_git_positional(url, "git url")?;
+    validate_git_positional(commit, "git commit")?;
     // Deterministic path keyed by url+commit so two callers in the
     // same process (resolver → installer) reuse the same checkout
     // instead of re-cloning. Two different repos that happen to
@@ -768,18 +803,25 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
 
     let do_clone = || -> Result<(), Error> {
         run_in(&scratch, &["init", "-q"])?;
-        run_in(&scratch, &["remote", "add", "origin", url])?;
+        run_in(&scratch, &["remote", "add", "--", "origin", url])?;
         // Shallow fetch by raw SHA only works when the remote allows
         // uploads of any reachable object (GitHub/GitLab/Bitbucket
         // do; many self-hosted servers don't). Fall back to a full
         // fetch on any failure. When `shallow` is false — caller
         // said the host isn't on the shallow list — skip the depth=1
         // attempt entirely to avoid a guaranteed-wasted round trip.
-        let shallow_ok =
-            shallow && run_in(&scratch, &["fetch", "--depth", "1", "-q", "origin", commit]).is_ok();
+        let shallow_ok = shallow
+            && run_in(
+                &scratch,
+                &["fetch", "--depth", "1", "-q", "--", "origin", commit],
+            )
+            .is_ok();
         if !shallow_ok {
-            run_in(&scratch, &["fetch", "-q", "origin"])?;
+            run_in(&scratch, &["fetch", "-q", "--", "origin"])?;
         }
+        // `git checkout -- <commit>` treats <commit> as a pathspec, so
+        // we cannot use the argv separator here. `validate_git_positional`
+        // at function entry already rejected a leading `-` on `commit`.
         run_in(&scratch, &["checkout", "-q", commit])?;
         Ok(())
     };
@@ -1192,5 +1234,52 @@ mod tests {
             "https://github.com/user/repo.git",
             &hosts
         ));
+    }
+
+    #[test]
+    fn test_validate_git_positional_accepts_normal_values() {
+        validate_git_positional("https://github.com/u/r.git", "git url").unwrap();
+        validate_git_positional("git@github.com:u/r.git", "git url").unwrap();
+        validate_git_positional("main", "git commit").unwrap();
+        validate_git_positional("0123456789abcdef0123456789abcdef01234567", "git commit").unwrap();
+    }
+
+    #[test]
+    fn test_validate_git_positional_rejects_dash_prefix() {
+        // CVE-2017-1000117 class: git treats a leading `-` as an
+        // option. `--upload-pack=...` is the classic payload.
+        let err = validate_git_positional("--upload-pack=/tmp/evil", "git url").unwrap_err();
+        assert!(matches!(err, Error::Git(_)));
+        let err = validate_git_positional("-oX", "git commit").unwrap_err();
+        assert!(matches!(err, Error::Git(_)));
+    }
+
+    #[test]
+    fn test_validate_git_positional_rejects_nul() {
+        let err = validate_git_positional("normal\0tail", "git url").unwrap_err();
+        assert!(matches!(err, Error::Git(_)));
+    }
+
+    #[test]
+    fn test_git_resolve_ref_rejects_dash_prefixed_url() {
+        // Must refuse before ever spawning `git ls-remote`. Confirms
+        // the validation runs at the public entry point.
+        let err = git_resolve_ref("--upload-pack=/tmp/evil", None).unwrap_err();
+        assert!(matches!(err, Error::Git(_)));
+    }
+
+    #[test]
+    fn test_git_shallow_clone_rejects_dash_prefixed_url() {
+        let err = git_shallow_clone("--upload-pack=/tmp/evil", "main", false).unwrap_err();
+        assert!(matches!(err, Error::Git(_)));
+    }
+
+    #[test]
+    fn test_git_shallow_clone_rejects_dash_prefixed_commit() {
+        // `git checkout -- <commit>` treats <commit> as a pathspec,
+        // so the `--` separator is unavailable at that call site.
+        // The entry-point check is the only defense.
+        let err = git_shallow_clone("https://github.com/u/r.git", "-X-evil", false).unwrap_err();
+        assert!(matches!(err, Error::Git(_)));
     }
 }

--- a/crates/aube-workspace/src/selector.rs
+++ b/crates/aube-workspace/src/selector.rs
@@ -418,6 +418,21 @@ fn changed_since(
     packages: &[IndexedPackage],
     rev: &str,
 ) -> Result<BTreeSet<usize>, SelectError> {
+    // `git diff <revspec> -- <paths>` can't accept a `--` terminator
+    // before the revspec, so a rev that begins with `-` would land as
+    // an option. Reject at the boundary as defense against the
+    // CVE-2017-1000117 class of argv injection. NUL is rejected too
+    // because it never appears in a legitimate ref.
+    if rev.starts_with('-') {
+        return Err(SelectError::GitFailed(format!(
+            "refusing to pass revspec starting with `-` to git: {rev:?}"
+        )));
+    }
+    if rev.contains('\0') {
+        return Err(SelectError::GitFailed(
+            "refusing to pass revspec containing NUL byte to git".to_string(),
+        ));
+    }
     let revspec = format!("{rev}...HEAD");
     let git_root = git_root(workspace_root)?;
     let output = Command::new("git")
@@ -663,5 +678,32 @@ mod tests {
             dir: &dir,
             workspace_root: root,
         }));
+    }
+
+    #[test]
+    fn changed_since_rejects_dash_prefixed_rev() {
+        // CVE-2017-1000117 class: a rev beginning with `-` would be
+        // interpreted by `git diff` as an option because the
+        // subcommand does not accept a `--` terminator before the
+        // revspec. Reject at the boundary before the format! call.
+        // The validation runs before `git_root`, so `workspace_root`
+        // does not need to exist for this test.
+        let err =
+            changed_since(Path::new("/nonexistent"), &[], "--upload-pack=/tmp/evil").unwrap_err();
+        let msg = match err {
+            SelectError::GitFailed(m) => m,
+            other => panic!("expected GitFailed, got {other:?}"),
+        };
+        assert!(msg.contains("refusing"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn changed_since_rejects_nul_in_rev() {
+        let err = changed_since(Path::new("/nonexistent"), &[], "main\0evil").unwrap_err();
+        let msg = match err {
+            SelectError::GitFailed(m) => m,
+            other => panic!("expected GitFailed, got {other:?}"),
+        };
+        assert!(msg.contains("refusing"), "unexpected error: {msg}");
     }
 }


### PR DESCRIPTION
Defends against the CVE-2017-1000117 class of git argv injection. Adds `validate_git_positional` to refuse any user-influenced url, committish, or revspec that begins with `-` (git would parse it as an option) or contains a NUL byte, and wires the check into the public entry points in `aube-store` and `aube-workspace`.

Where the subcommand accepts one, the `--` argv terminator is also inserted so a dash-prefixed value that slips past the validation cannot land as an option. `git checkout <commit>` and `git diff <revspec>` cannot use `--` at that position (it would turn the following argument into a pathspec), so those sites rely on the entry-point validation alone.

Eight regression tests cover the accept/reject paths and confirm the check fires before any `git` subprocess is spawned.