### PR TITLE
registry: tolerate null values in packument string maps

### DIFF
--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -840,7 +840,20 @@ mod tests {
         )
         .unwrap();
 
-        let config = NpmConfig::load(dir.path());
+        // HOME + env isolation: `NpmConfig::load` would layer the
+        // developer's real `~/.npmrc` and `NPM_CONFIG_REGISTRY` env
+        // var on top of the project file, either of which can shadow
+        // the `registry=` we're asserting on.
+        let home = tempfile::tempdir().unwrap();
+        let mut config = NpmConfig {
+            registry: "https://registry.npmjs.org/".to_string(),
+            ..Default::default()
+        };
+        config.apply(load_npmrc_entries_with_home(
+            Some(home.path()),
+            None,
+            dir.path(),
+        ));
 
         assert_eq!(config.registry, "https://custom.registry.com/");
         assert_eq!(
@@ -874,7 +887,13 @@ mod tests {
         )
         .unwrap();
 
-        let config = NpmConfig::load(dir.path());
+        let home = tempfile::tempdir().unwrap();
+        let mut config = NpmConfig::default();
+        config.apply(load_npmrc_entries_with_home(
+            Some(home.path()),
+            None,
+            dir.path(),
+        ));
         let expected = base64::engine::general_purpose::STANDARD.encode("alice:s3cr3t");
         assert_eq!(
             config.basic_auth_for("https://registry.example.com/"),
@@ -924,7 +943,13 @@ mod tests {
         )
         .unwrap();
 
-        let config = NpmConfig::load(dir.path());
+        let home = tempfile::tempdir().unwrap();
+        let mut config = NpmConfig::default();
+        config.apply(load_npmrc_entries_with_home(
+            Some(home.path()),
+            None,
+            dir.path(),
+        ));
         let tls = &config
             .registry_config_for("https://registry.example.com/")
             .expect("registry config")
@@ -942,7 +967,25 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join(".npmrc"), "_authToken=global-token\n").unwrap();
 
-        let config = NpmConfig::load(dir.path());
+        // Isolate from the host's real `~/.npmrc`: a developer or CI
+        // runner with `//registry.npmjs.org/:_authToken=...` already
+        // logged in would have that URI-specific token beat our
+        // project-level `_authToken` fallback, since `auth_token_for`
+        // checks per-URI auth before dropping to `global_auth_token`.
+        // `NpmConfig::load` is the host-reading entry point we
+        // deliberately avoid here; `load_npmrc_entries_with_home` lets
+        // us pin the user home to a tempdir without mutating
+        // process-wide env vars.
+        let home = tempfile::tempdir().unwrap();
+        let mut config = NpmConfig {
+            registry: "https://registry.npmjs.org/".to_string(),
+            ..Default::default()
+        };
+        config.apply(load_npmrc_entries_with_home(
+            Some(home.path()),
+            None,
+            dir.path(),
+        ));
         // Global token used as fallback
         assert_eq!(
             config.auth_token_for("https://registry.npmjs.org/"),
@@ -953,8 +996,20 @@ mod tests {
     #[test]
     fn test_config_defaults() {
         let dir = tempfile::tempdir().unwrap();
-        // No .npmrc at all
-        let config = NpmConfig::load(dir.path());
+        // No .npmrc at all. Same HOME isolation rationale as
+        // `test_config_global_auth_token` — without it this assertion
+        // flakes on any developer box whose `~/.npmrc` has ever been
+        // touched by `npm login`.
+        let home = tempfile::tempdir().unwrap();
+        let mut config = NpmConfig {
+            registry: "https://registry.npmjs.org/".to_string(),
+            ..Default::default()
+        };
+        config.apply(load_npmrc_entries_with_home(
+            Some(home.path()),
+            None,
+            dir.path(),
+        ));
         assert_eq!(config.registry, "https://registry.npmjs.org/");
         assert!(
             config
@@ -972,7 +1027,13 @@ mod tests {
         )
         .unwrap();
 
-        let config = NpmConfig::load(dir.path());
+        let home = tempfile::tempdir().unwrap();
+        let mut config = NpmConfig::default();
+        config.apply(load_npmrc_entries_with_home(
+            Some(home.path()),
+            None,
+            dir.path(),
+        ));
         assert_eq!(
             config.registry_for("@private/my-lib"),
             "https://private.registry.com/"

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -108,6 +108,34 @@ impl NpmConfig {
         Self::load_with_env(project_dir, &env)
     }
 
+    /// Test-only loader that reads `project_dir/.npmrc` with a
+    /// tempdir pinned as the user's `$HOME` and no env-var merge, so
+    /// the developer's real `~/.npmrc` and `NPM_CONFIG_*` vars can't
+    /// bleed into assertions. Returns a config seeded the same way
+    /// [`NpmConfig::load`] does (npmjs default registry, builtin `@jsr`
+    /// scope), so assertions that pin `.registry` or scoped lookups
+    /// behave the same as they would on a fresh user machine.
+    ///
+    /// Keep the `TempDir` binding alive inside the function scope:
+    /// `load_npmrc_entries_with_home` reads the files synchronously
+    /// and returns before the tempdir drops, so callers don't need to
+    /// juggle the handle themselves.
+    #[cfg(test)]
+    pub(crate) fn load_isolated(project_dir: &Path) -> Self {
+        let home = tempfile::tempdir().expect("tempdir for isolated config load");
+        let mut config = Self {
+            registry: "https://registry.npmjs.org/".to_string(),
+            ..Default::default()
+        };
+        config.apply(load_npmrc_entries_with_home(
+            Some(home.path()),
+            None,
+            project_dir,
+        ));
+        config.apply_builtin_scoped_defaults();
+        config
+    }
+
     /// Same as [`NpmConfig::load`] but takes a captured env snapshot
     /// instead of reading `std::env` directly. Tests that assert on
     /// file-only behavior pass an empty slice so `npm_config_*` vars
@@ -840,20 +868,11 @@ mod tests {
         )
         .unwrap();
 
-        // HOME + env isolation: `NpmConfig::load` would layer the
-        // developer's real `~/.npmrc` and `NPM_CONFIG_REGISTRY` env
-        // var on top of the project file, either of which can shadow
-        // the `registry=` we're asserting on.
-        let home = tempfile::tempdir().unwrap();
-        let mut config = NpmConfig {
-            registry: "https://registry.npmjs.org/".to_string(),
-            ..Default::default()
-        };
-        config.apply(load_npmrc_entries_with_home(
-            Some(home.path()),
-            None,
-            dir.path(),
-        ));
+        // HOME + env isolation via `load_isolated`: `NpmConfig::load`
+        // would layer the developer's real `~/.npmrc` and
+        // `NPM_CONFIG_REGISTRY` env var on top of the project file,
+        // either of which can shadow the `registry=` we're asserting on.
+        let config = NpmConfig::load_isolated(dir.path());
 
         assert_eq!(config.registry, "https://custom.registry.com/");
         assert_eq!(
@@ -887,13 +906,7 @@ mod tests {
         )
         .unwrap();
 
-        let home = tempfile::tempdir().unwrap();
-        let mut config = NpmConfig::default();
-        config.apply(load_npmrc_entries_with_home(
-            Some(home.path()),
-            None,
-            dir.path(),
-        ));
+        let config = NpmConfig::load_isolated(dir.path());
         let expected = base64::engine::general_purpose::STANDARD.encode("alice:s3cr3t");
         assert_eq!(
             config.basic_auth_for("https://registry.example.com/"),
@@ -943,13 +956,7 @@ mod tests {
         )
         .unwrap();
 
-        let home = tempfile::tempdir().unwrap();
-        let mut config = NpmConfig::default();
-        config.apply(load_npmrc_entries_with_home(
-            Some(home.path()),
-            None,
-            dir.path(),
-        ));
+        let config = NpmConfig::load_isolated(dir.path());
         let tls = &config
             .registry_config_for("https://registry.example.com/")
             .expect("registry config")
@@ -967,25 +974,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join(".npmrc"), "_authToken=global-token\n").unwrap();
 
-        // Isolate from the host's real `~/.npmrc`: a developer or CI
-        // runner with `//registry.npmjs.org/:_authToken=...` already
-        // logged in would have that URI-specific token beat our
-        // project-level `_authToken` fallback, since `auth_token_for`
-        // checks per-URI auth before dropping to `global_auth_token`.
-        // `NpmConfig::load` is the host-reading entry point we
-        // deliberately avoid here; `load_npmrc_entries_with_home` lets
-        // us pin the user home to a tempdir without mutating
-        // process-wide env vars.
-        let home = tempfile::tempdir().unwrap();
-        let mut config = NpmConfig {
-            registry: "https://registry.npmjs.org/".to_string(),
-            ..Default::default()
-        };
-        config.apply(load_npmrc_entries_with_home(
-            Some(home.path()),
-            None,
-            dir.path(),
-        ));
+        // Isolate from the host's real `~/.npmrc` via `load_isolated`:
+        // a developer or CI runner with
+        // `//registry.npmjs.org/:_authToken=...` already logged in
+        // would have that URI-specific token beat our project-level
+        // `_authToken` fallback, since `auth_token_for` checks
+        // per-URI auth before dropping to `global_auth_token`.
+        let config = NpmConfig::load_isolated(dir.path());
         // Global token used as fallback
         assert_eq!(
             config.auth_token_for("https://registry.npmjs.org/"),
@@ -1000,16 +995,7 @@ mod tests {
         // `test_config_global_auth_token` — without it this assertion
         // flakes on any developer box whose `~/.npmrc` has ever been
         // touched by `npm login`.
-        let home = tempfile::tempdir().unwrap();
-        let mut config = NpmConfig {
-            registry: "https://registry.npmjs.org/".to_string(),
-            ..Default::default()
-        };
-        config.apply(load_npmrc_entries_with_home(
-            Some(home.path()),
-            None,
-            dir.path(),
-        ));
+        let config = NpmConfig::load_isolated(dir.path());
         assert_eq!(config.registry, "https://registry.npmjs.org/");
         assert!(
             config
@@ -1027,13 +1013,7 @@ mod tests {
         )
         .unwrap();
 
-        let home = tempfile::tempdir().unwrap();
-        let mut config = NpmConfig::default();
-        config.apply(load_npmrc_entries_with_home(
-            Some(home.path()),
-            None,
-            dir.path(),
-        ));
+        let config = NpmConfig::load_isolated(dir.path());
         assert_eq!(
             config.registry_for("@private/my-lib"),
             "https://private.registry.com/"

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -24,6 +24,31 @@ where
     })
 }
 
+/// Deserialize a `BTreeMap<String, String>` tolerant to `null` — both at
+/// the whole-map level (`"dist-tags": null` → empty map) and at the
+/// value level (`{"latest": null}` → entry dropped).
+///
+/// Some registry proxies (notably JFrog Artifactory's npm remote) emit
+/// `null` in places where npmjs.org always emits a string: stripped /
+/// tombstoned `dist-tags` values, per-version `time` entries for
+/// deleted versions, or dep-map entries that were redacted by a
+/// mirroring filter. The strict `BTreeMap<String, String>` shape would
+/// fail these with `invalid type: null, expected a string`, blocking
+/// the whole install even though the null is semantically "not
+/// present." Drop those entries so the resolver sees the same shape it
+/// would have seen from npmjs.
+fn null_tolerant_string_map<'de, D>(de: D) -> Result<BTreeMap<String, String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let maybe: Option<BTreeMap<String, Option<String>>> = Option::deserialize(de)?;
+    Ok(maybe
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(k, v)| v.map(|s| (k, s)))
+        .collect())
+}
+
 pub mod client;
 pub mod config;
 pub mod jsr;
@@ -59,7 +84,11 @@ pub struct Packument {
     pub name: String,
     #[serde(default)]
     pub versions: BTreeMap<String, VersionMetadata>,
-    #[serde(rename = "dist-tags", default)]
+    #[serde(
+        rename = "dist-tags",
+        default,
+        deserialize_with = "null_tolerant_string_map"
+    )]
     pub dist_tags: BTreeMap<String, String>,
     /// Per-version publish timestamps (ISO-8601). Populated
     /// opportunistically: npmjs.org's corgi (abbreviated) packument
@@ -69,7 +98,7 @@ pub struct Packument {
     /// resolver round-trips it into the lockfile's top-level `time:`
     /// block — matching pnpm's `publishedAt` wiring — and, in
     /// time-based mode, uses it to derive the publish-date cutoff.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_tolerant_string_map")]
     pub time: BTreeMap<String, String>,
 }
 
@@ -79,15 +108,15 @@ pub struct Packument {
 pub struct VersionMetadata {
     pub name: String,
     pub version: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_tolerant_string_map")]
     pub dependencies: BTreeMap<String, String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_tolerant_string_map")]
     pub dev_dependencies: BTreeMap<String, String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_tolerant_string_map")]
     pub peer_dependencies: BTreeMap<String, String>,
     #[serde(default)]
     pub peer_dependencies_meta: BTreeMap<String, PeerDepMeta>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_tolerant_string_map")]
     pub optional_dependencies: BTreeMap<String, String>,
     /// `bundledDependencies` from the packument. Either a list of dep
     /// names or `true` (meaning "bundle every `dependencies` entry").
@@ -207,5 +236,86 @@ mod tests {
 
         let v = parse(r#"{"name":"x","version":"1.0.1","deprecated":false}"#);
         assert!(v.deprecated.is_none());
+    }
+
+    /// Artifactory's npm remote proxies sometimes emit `null` entries
+    /// in dep maps where stripped/redacted deps used to be. The
+    /// resolver must not bail on that — the null dep is semantically
+    /// "not present", same shape npmjs would have served.
+    #[test]
+    fn dependency_maps_drop_null_entries() {
+        let v = parse(
+            r#"{
+                "name": "x",
+                "version": "1.0.0",
+                "dependencies": {"kept": "^1", "stripped": null},
+                "devDependencies": {"dkept": "^2", "dstripped": null},
+                "peerDependencies": {"pkept": "^3", "pstripped": null},
+                "optionalDependencies": {"okept": "^4", "ostripped": null}
+            }"#,
+        );
+        assert_eq!(v.dependencies.len(), 1);
+        assert_eq!(v.dependencies["kept"], "^1");
+        assert_eq!(v.dev_dependencies.len(), 1);
+        assert_eq!(v.peer_dependencies.len(), 1);
+        assert_eq!(v.optional_dependencies.len(), 1);
+    }
+
+    #[test]
+    fn dependency_maps_null_whole_field_is_empty() {
+        let v = parse(
+            r#"{
+                "name": "x",
+                "version": "1.0.0",
+                "dependencies": null,
+                "devDependencies": null,
+                "peerDependencies": null,
+                "optionalDependencies": null
+            }"#,
+        );
+        assert!(v.dependencies.is_empty());
+        assert!(v.dev_dependencies.is_empty());
+        assert!(v.peer_dependencies.is_empty());
+        assert!(v.optional_dependencies.is_empty());
+    }
+
+    fn parse_packument(json: &str) -> Packument {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn packument_dist_tags_drops_null_tag() {
+        let p = parse_packument(
+            r#"{
+                "name": "pkg",
+                "dist-tags": {"latest": "1.2.3", "beta": null}
+            }"#,
+        );
+        assert_eq!(p.dist_tags.len(), 1);
+        assert_eq!(p.dist_tags["latest"], "1.2.3");
+    }
+
+    #[test]
+    fn packument_dist_tags_null_whole_field_is_empty() {
+        let p = parse_packument(r#"{"name":"pkg","dist-tags":null}"#);
+        assert!(p.dist_tags.is_empty());
+    }
+
+    #[test]
+    fn packument_time_drops_null_entries() {
+        let p = parse_packument(
+            r#"{
+                "name": "pkg",
+                "time": {"1.0.0": "2024-01-01T00:00:00.000Z", "0.9.0": null}
+            }"#,
+        );
+        assert_eq!(p.time.len(), 1);
+        assert!(p.time.contains_key("1.0.0"));
+    }
+
+    #[test]
+    fn packument_time_null_whole_field_is_empty() {
+        let p = parse_packument(r#"{"name":"pkg","time":null}"#);
+        assert!(p.time.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Artifactory's npm remote proxy sometimes emits `null` where npmjs.org emits a string — a stripped `dist-tags` entry, a tombstoned per-version `time` entry, or a redacted dep-map entry. The strict `BTreeMap<String, String>` shape on [`Packument`](crates/aube-registry/src/lib.rs) and `VersionMetadata` failed those packuments with `invalid type: null, expected a string`, blocking installs against internal Artifactory registries that users are otherwise happy with (same registry works with npm and pnpm 10).

The failure surfaces through `fetch_packument_with_time_cached` (the `needs_time` path fired by `resolution-mode=time-based` or `minimumReleaseAge`), which re-parses a full packument `Value` into `Packument` and wraps the serde error as `Error::Io`. User-visible shape was:

```
registry error for <internal package>: I/O error: invalid type: null, expected a string
```

## What changed

- Added `null_tolerant_string_map`: treats `"field": null` as an empty map and drops `{"key": null}` entries, matching what pnpm/npm effectively get from plain `JSON.parse` + object walks.
- Applied it to the six string-valued map fields where Artifactory-proxied packuments are known to emit nulls:
  - `Packument.dist_tags`
  - `Packument.time`
  - `VersionMetadata.dependencies`
  - `VersionMetadata.dev_dependencies`
  - `VersionMetadata.peer_dependencies`
  - `VersionMetadata.optional_dependencies`
- Added six unit tests covering both "whole field is null" and "entry value is null" for each flavor.

`peer_dependencies_meta` is unchanged — its value is a struct, not a string, and we have no report of nulls there.

## Not in scope

The user also reported a burst of `retrying HTTP request after transport error ... backoff_ms=10000` warnings. Those are the pnpm-compatible retry defaults (`fetch-retries=2`, `fetch-retry-mintimeout=10000`) working as designed against a flaky upstream — unrelated to the parse bug.

## Test plan

- [x] `cargo test -p aube-registry --lib tests::` — all new tests green
- [x] `cargo clippy -p aube-registry --all-targets -- -D warnings`
- [ ] Reporter retests `aube install` against their Artifactory-backed repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches packument/metadata deserialization used on every registry fetch; while the change is small and well-tested, it can subtly alter how malformed registry responses are interpreted (dropping null entries instead of erroring).
> 
> **Overview**
> **Improves compatibility with registry proxies (e.g., Artifactory) that emit `null` values** by making string-valued maps in `Packument`/`VersionMetadata` deserialize `null` as *absent* (whole field `null` → empty map; per-key `null` → entry dropped) instead of failing the entire packument parse.
> 
> **Stabilizes registry config unit tests** by adding a test-only `NpmConfig::load_isolated` loader that prevents the developer/CI machine’s `~/.npmrc` and `NPM_CONFIG_*` env from influencing assertions, and updates affected tests to use it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b55b7a72aec088895e18903887dd7d43ac88ddab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->