### PR TITLE
ci(copr-publish): add fedora-44 chroots, drop epel-9

### DIFF
--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -12,7 +12,7 @@ on:
       chroots:
         description: "COPR chroots to target (space-separated)"
         required: false
-        default: "fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 epel-9-aarch64 epel-9-x86_64"
+        default: "fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64"
         type: string
 
 env:
@@ -46,7 +46,7 @@ jobs:
           VERSION="${TAG#v}"
 
           if [ "${{ github.event_name }}" = "release" ]; then
-            CHROOTS="fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64 epel-9-aarch64 epel-9-x86_64"
+            CHROOTS="fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64"
           else
             CHROOTS="${{ inputs.chroots }}"
           fi

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 PACKAGE_NAME="${PACKAGE_NAME:-aube}"
-CHROOTS="${CHROOTS:-fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64}"
+CHROOTS="${CHROOTS:-fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64}"
 BUILD_PROFILE="${BUILD_PROFILE:-release}"
 MAINTAINER_NAME="${MAINTAINER_NAME:-aube Release Bot}"
 MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-noreply@aube.en.dev}"
@@ -19,7 +19,7 @@ usage() {
 	echo "Options:"
 	echo "  -v, --version VERSION        Package version (required)"
 	echo "  -p, --profile PROFILE        Build profile (default: release)"
-	echo "  -c, --chroots CHROOTS        COPR chroots (default: fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64)"
+	echo "  -c, --chroots CHROOTS        COPR chroots (default: fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64)"
 	echo "  -o, --owner OWNER            COPR owner (default: jdxcode)"
 	echo "  -j, --project PROJECT        COPR project (default: aube)"
 	echo "  -n, --name NAME              Package name (default: aube)"


### PR DESCRIPTION
## Summary

- Add `fedora-44-aarch64` / `fedora-44-x86_64` to the COPR chroot list. Fedora 44 chroots are live on copr.fedorainfracloud.org and ship rust 1.94.1, well above our MSRV 1.93.
- Drop `epel-9-*`. RHEL 9.7 ships rust-toolset 1.88, too old for edition 2024 / MSRV 1.93 — those builds would always fail. EPEL 10 stays (CentOS Stream 10 has rust 1.94.1).
- Align `packaging/copr/build-copr.sh`'s default chroot list with the workflow default so manual invocations target the same set.

Motivated by the failed [v1.0.0-beta.5 copr-publish run](https://github.com/endevco/aube/actions/runs/24631399812) — the project didn't exist yet and I'm creating it now. When enabling chroots on the COPR project, tick exactly this set and skip EPEL 9.

## Test plan

- [ ] `workflow_dispatch` a copr-publish run against a recent tag once the `jdxcode/aube` COPR project exists, confirm all 10 chroots build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes CI/build configuration for which COPR chroots are targeted, with no production code or packaging logic changes.
> 
> **Overview**
> Updates the COPR publishing workflow and `packaging/copr/build-copr.sh` defaults to target Fedora 44 (and Rawhide) chroots and to stop building for EPEL 9.
> 
> Also aligns the workflow’s `workflow_dispatch` default `chroots` input and the release-triggered `CHROOTS` list with the script’s default so manual and CI invocations build the same set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06b43fb7fe03e4f1c45a76cdc20184ed044dedc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->