### PR TITLE
resolver: resolve catalog: indirection on override targets

### DIFF
--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1067,16 +1067,59 @@ impl Resolver {
                         &task.name,
                         &task.range,
                         &task.ancestors,
-                    ) && task.range != override_spec
-                    {
-                        tracing::trace!(
-                            "override: {}@{} -> {}",
-                            task.name,
-                            task.range,
+                    ) {
+                        // An override may itself point at a catalog
+                        // entry (e.g. `"overrides": {"foo": "catalog:"}`).
+                        // The catalog pre-pass above already ran against
+                        // the original range, so resolve the indirection
+                        // here before assigning — otherwise `catalog:`
+                        // leaks through to the registry resolver.
+                        let effective_spec = if let Some(catalog_name) =
+                            override_spec.strip_prefix("catalog:").map(|n| {
+                                if n.is_empty() {
+                                    "default".to_string()
+                                } else {
+                                    n.to_string()
+                                }
+                            }) {
+                            match self.catalogs.get(&catalog_name) {
+                                Some(catalog) => match catalog.get(&task.name) {
+                                    Some(real_range) => {
+                                        catalog_picks
+                                            .entry(catalog_name.clone())
+                                            .or_default()
+                                            .insert(task.name.clone(), real_range.clone());
+                                        real_range.clone()
+                                    }
+                                    None => {
+                                        return Err(Error::UnknownCatalogEntry {
+                                            name: task.name.clone(),
+                                            spec: override_spec.clone(),
+                                            catalog: catalog_name,
+                                        });
+                                    }
+                                },
+                                None => {
+                                    return Err(Error::UnknownCatalog {
+                                        name: task.name.clone(),
+                                        spec: override_spec.clone(),
+                                        catalog: catalog_name,
+                                    });
+                                }
+                            }
+                        } else {
                             override_spec
-                        );
-                        task.range = override_spec;
-                        changed = true;
+                        };
+                        if task.range != effective_spec {
+                            tracing::trace!(
+                                "override: {}@{} -> {}",
+                                task.name,
+                                task.range,
+                                effective_spec
+                            );
+                            task.range = effective_spec;
+                            changed = true;
+                        }
                     }
                     if let Some(rest) = task.range.strip_prefix("npm:")
                         && let Some(at_idx) = rest.rfind('@')

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1074,7 +1074,10 @@ impl Resolver {
                         // the original range, so resolve the indirection
                         // here before assigning — otherwise `catalog:`
                         // leaks through to the registry resolver.
-                        let effective_spec = if let Some(catalog_name) =
+                        // Compute the resolved spec first; stash the
+                        // catalog pick in a local so we only record it
+                        // if the override actually moves `task.range`.
+                        let (effective_spec, pending_pick) = if let Some(catalog_name) =
                             override_spec.strip_prefix("catalog:").map(|n| {
                                 if n.is_empty() {
                                     "default".to_string()
@@ -1084,13 +1087,10 @@ impl Resolver {
                             }) {
                             match self.catalogs.get(&catalog_name) {
                                 Some(catalog) => match catalog.get(&task.name) {
-                                    Some(real_range) => {
-                                        catalog_picks
-                                            .entry(catalog_name.clone())
-                                            .or_default()
-                                            .insert(task.name.clone(), real_range.clone());
-                                        real_range.clone()
-                                    }
+                                    Some(real_range) => (
+                                        real_range.clone(),
+                                        Some((catalog_name, real_range.clone())),
+                                    ),
                                     None => {
                                         return Err(Error::UnknownCatalogEntry {
                                             name: task.name.clone(),
@@ -1108,9 +1108,15 @@ impl Resolver {
                                 }
                             }
                         } else {
-                            override_spec
+                            (override_spec, None)
                         };
                         if task.range != effective_spec {
+                            if let Some((catalog_name, real_range)) = pending_pick {
+                                catalog_picks
+                                    .entry(catalog_name)
+                                    .or_default()
+                                    .insert(task.name.clone(), real_range);
+                            }
                             tracing::trace!(
                                 "override: {}@{} -> {}",
                                 task.name,

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -609,6 +609,46 @@ impl Resolver {
         self
     }
 
+    /// Resolve a `catalog:[<name>]` specifier to its pinned range. Returns
+    /// `None` when `spec` isn't a catalog reference, or
+    /// `Some((catalog_name, real_range))` when it is. The catalog name is
+    /// normalized — the bare `catalog:` form maps to the `default` catalog.
+    /// Errors on an unknown catalog or missing entry.
+    ///
+    /// Shared between the pre-override catalog rewrite (directly-declared
+    /// `catalog:` deps) and the override handler (`"overrides":
+    /// {"pkg": "catalog:"}`), so both paths stay in lockstep.
+    fn resolve_catalog_spec(
+        &self,
+        task_name: &str,
+        spec: &str,
+    ) -> Result<Option<(String, String)>, Error> {
+        let Some(catalog_name) = spec.strip_prefix("catalog:").map(|n| {
+            if n.is_empty() {
+                "default".to_string()
+            } else {
+                n.to_string()
+            }
+        }) else {
+            return Ok(None);
+        };
+        match self.catalogs.get(&catalog_name) {
+            Some(catalog) => match catalog.get(task_name) {
+                Some(real_range) => Ok(Some((catalog_name, real_range.clone()))),
+                None => Err(Error::UnknownCatalogEntry {
+                    name: task_name.to_string(),
+                    spec: spec.to_string(),
+                    catalog: catalog_name,
+                }),
+            },
+            None => Err(Error::UnknownCatalog {
+                name: task_name.to_string(),
+                spec: spec.to_string(),
+                catalog: catalog_name,
+            }),
+        }
+    }
+
     /// Resolve all dependencies from a package.json.
     ///
     /// Uses batch-parallel BFS: each "wave" drains the queue, identifies
@@ -1020,44 +1060,15 @@ impl Resolver {
                 // `catalog:...` text stays in `original_specifier` so
                 // the lockfile importer keeps the catalog reference and
                 // drift detection works.
-                if let Some(catalog_name) = task.range.strip_prefix("catalog:").map(|n| {
-                    if n.is_empty() {
-                        "default".to_string()
-                    } else {
-                        n.to_string()
-                    }
-                }) {
-                    match self.catalogs.get(&catalog_name) {
-                        Some(catalog) => match catalog.get(&task.name) {
-                            Some(real_range) => {
-                                tracing::trace!(
-                                    "catalog: {} {} -> {}",
-                                    task.name,
-                                    task.range,
-                                    real_range
-                                );
-                                catalog_picks
-                                    .entry(catalog_name.clone())
-                                    .or_default()
-                                    .insert(task.name.clone(), real_range.clone());
-                                task.range = real_range.clone();
-                            }
-                            None => {
-                                return Err(Error::UnknownCatalogEntry {
-                                    name: task.name.clone(),
-                                    spec: task.range.clone(),
-                                    catalog: catalog_name,
-                                });
-                            }
-                        },
-                        None => {
-                            return Err(Error::UnknownCatalog {
-                                name: task.name.clone(),
-                                spec: task.range.clone(),
-                                catalog: catalog_name,
-                            });
-                        }
-                    }
+                if let Some((catalog_name, real_range)) =
+                    self.resolve_catalog_spec(&task.name, &task.range)?
+                {
+                    tracing::trace!("catalog: {} {} -> {}", task.name, task.range, real_range);
+                    catalog_picks
+                        .entry(catalog_name)
+                        .or_default()
+                        .insert(task.name.clone(), real_range.clone());
+                    task.range = real_range;
                 }
 
                 for _ in 0..2 {
@@ -1074,42 +1085,16 @@ impl Resolver {
                         // the original range, so resolve the indirection
                         // here before assigning — otherwise `catalog:`
                         // leaks through to the registry resolver.
-                        // Compute the resolved spec first; stash the
-                        // catalog pick in a local so we only record it
-                        // if the override actually moves `task.range`.
-                        let (effective_spec, pending_pick) = if let Some(catalog_name) =
-                            override_spec.strip_prefix("catalog:").map(|n| {
-                                if n.is_empty() {
-                                    "default".to_string()
-                                } else {
-                                    n.to_string()
+                        // Stash the catalog pick in a local so we only
+                        // record it if the override actually moves
+                        // `task.range`.
+                        let (effective_spec, pending_pick) =
+                            match self.resolve_catalog_spec(&task.name, &override_spec)? {
+                                Some((catalog_name, real_range)) => {
+                                    (real_range.clone(), Some((catalog_name, real_range)))
                                 }
-                            }) {
-                            match self.catalogs.get(&catalog_name) {
-                                Some(catalog) => match catalog.get(&task.name) {
-                                    Some(real_range) => (
-                                        real_range.clone(),
-                                        Some((catalog_name, real_range.clone())),
-                                    ),
-                                    None => {
-                                        return Err(Error::UnknownCatalogEntry {
-                                            name: task.name.clone(),
-                                            spec: override_spec.clone(),
-                                            catalog: catalog_name,
-                                        });
-                                    }
-                                },
-                                None => {
-                                    return Err(Error::UnknownCatalog {
-                                        name: task.name.clone(),
-                                        spec: override_spec.clone(),
-                                        catalog: catalog_name,
-                                    });
-                                }
-                            }
-                        } else {
-                            (override_spec, None)
-                        };
+                                None => (override_spec, None),
+                            };
                         if task.range != effective_spec {
                             if let Some((catalog_name, real_range)) = pending_pick {
                                 catalog_picks

--- a/test/catalogs.bats
+++ b/test/catalogs.bats
@@ -541,3 +541,36 @@ _setup_catalog_workspace() {
 	after="$(cat pnpm-workspace.yaml)"
 	[ "$before" = "$after" ]
 }
+
+@test "aube install: overrides value of catalog: resolves through catalog" {
+	# Regression: `"overrides": {"pkg": "catalog:"}` used to leak the
+	# raw `catalog:` string through to the registry resolver because
+	# the catalog rewrite only ran against the user's declared range,
+	# not the override target. The override must resolve the catalog
+	# indirection too.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "aube-test-override-catalog",
+		  "private": true,
+		  "dependencies": {
+		    "is-odd": "^0.1.0"
+		  },
+		  "overrides": {
+		    "is-odd": "catalog:"
+		  },
+		  "pnpm": {
+		    "catalog": {
+		      "is-odd": "3.0.1"
+		    }
+		  }
+		}
+	EOF
+
+	run aube install
+	assert_success
+	assert_dir_exists node_modules/is-odd
+	# The declared range `^0.1.0` would pick 0.1.2; the override
+	# through the catalog must promote to 3.0.1.
+	run cat node_modules/is-odd/package.json
+	assert_output --partial '"version": "3.0.1"'
+}

--- a/test/catalogs.bats
+++ b/test/catalogs.bats
@@ -574,3 +574,34 @@ _setup_catalog_workspace() {
 	run cat node_modules/is-odd/package.json
 	assert_output --partial '"version": "3.0.1"'
 }
+
+@test "aube install: overrides value of catalog:<name> resolves through named catalog" {
+	# Same shape as the default-catalog case above, but the override
+	# targets a named catalog (`catalog:pinned`) — the resolver must
+	# look up the `pinned` catalog, not `default`.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "aube-test-override-named-catalog",
+		  "private": true,
+		  "dependencies": {
+		    "is-odd": "^0.1.0"
+		  },
+		  "overrides": {
+		    "is-odd": "catalog:pinned"
+		  },
+		  "pnpm": {
+		    "catalogs": {
+		      "pinned": {
+		        "is-odd": "3.0.1"
+		      }
+		    }
+		  }
+		}
+	EOF
+
+	run aube install
+	assert_success
+	assert_dir_exists node_modules/is-odd
+	run cat node_modules/is-odd/package.json
+	assert_output --partial '"version": "3.0.1"'
+}


### PR DESCRIPTION
## Summary

`"overrides": {"pkg": "catalog:"}` used to leak the literal string `catalog:` through to the registry resolver, failing with an unhelpful "invalid version" error. The catalog rewrite ran once as a pre-pass against the user's declared range only — when the override pass later replaced `task.range` with `"catalog:"`, nothing re-resolved it.

The fix handles the indirection inside the override loop: when the picked override spec starts with `catalog:`, resolve it through `self.catalogs` (recording the pick) before assigning to `task.range`. Idempotent across loop iterations because the resolved range equals `task.range` on the second pass.

## Repro

```json
{
  "dependencies": { "is-odd": "^0.1.0" },
  "overrides":    { "is-odd": "catalog:" },
  "pnpm": { "catalog": { "is-odd": "3.0.1" } }
}
```

Before: `aube install` fails with `catalog reference 'catalog:' does not resolve`.
After: installs `is-odd@3.0.1` (the override promotes the declared `^0.1.0` through the catalog to the pinned version).

## Test plan

- [x] Added regression test in [test/catalogs.bats](test/catalogs.bats): `overrides value of catalog: resolves through catalog`
- [x] `mise run test:bats test/catalogs.bats` — all 23 tests pass
- [x] `cargo test -p aube-resolver` — 91 tests pass
- [x] `cargo clippy -p aube-resolver --all-targets -- -D warnings` clean

## Note for reviewer

The original bug report (#opentelemetry/api repro) uses a top-level `"catalog": {}` field in `package.json`, which aube doesn't recognize — only `pnpm-workspace.yaml`, `workspaces.catalog`, and `pnpm.catalog` are read. The fix here is for the `override -> catalog:` indirection regardless of which catalog source is configured; whether to also accept top-level `catalog` is a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency resolution behavior by resolving `catalog:`/`catalog:<name>` indirection inside the overrides loop, which can affect the final versions selected for overridden packages. Risk is moderate because it touches core resolution logic but is narrowly scoped and covered by new regression tests.
> 
> **Overview**
> Fixes a resolver bug where override rules like `"overrides": {"pkg": "catalog:"}` could leave the literal `catalog:` string in `task.range`, causing registry resolution failures.
> 
> Introduces a shared `resolve_catalog_spec` helper and applies it both in the initial catalog rewrite pass and when applying overrides, ensuring override targets that reference catalogs are resolved to real version ranges and recorded in `catalog_picks`. Adds Bats regression tests for default and named catalogs to verify the override-through-catalog behavior installs the pinned version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e246a61c605a3ff93d22fa4e34e9195519623256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->