### PR TITLE
run: exit silently on ctrl-c at script picker

### DIFF
--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -166,10 +166,16 @@ fn prompt_for_script() -> miette::Result<String> {
         let label = format!("{name}: {cmd}");
         picker = picker.option(demand::DemandOption::new(name.clone()).label(&label));
     }
-    picker
-        .run()
-        .into_diagnostic()
-        .wrap_err("failed to read script selection")
+    match picker.run() {
+        Ok(name) => Ok(name),
+        // Ctrl-C / Esc cancels the prompt — exit silently with the
+        // conventional SIGINT code rather than printing a miette error
+        // for what was a deliberate user action.
+        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => std::process::exit(130),
+        Err(e) => Err(e)
+            .into_diagnostic()
+            .wrap_err("failed to read script selection"),
+    }
 }
 
 /// Read `package.json` and return its `scripts` entries in the order


### PR DESCRIPTION
## Summary

- Pressing Ctrl-C (or Esc) at the `aube run` interactive script picker was bubbling up `demand`'s `io::ErrorKind::Interrupted` as a miette diagnostic ("failed to read script selection: read interrupted"). That's noise — the user deliberately cancelled.
- Match the interrupt explicitly in `prompt_for_script` and `std::process::exit(130)` (the conventional SIGINT exit code) instead.

## Test plan

- [ ] `aube run` in a project with scripts, then press Ctrl-C at the picker — no error output, exit code 130.
- [ ] `aube run` and pick a script normally — still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts interactive prompt error handling to treat user interrupts as a clean cancellation, without changing script execution logic.
> 
> **Overview**
> Improves `aube run`’s interactive script picker to treat Ctrl-C/Esc as a deliberate cancel: it now exits silently with code `130` instead of surfacing an `Interrupted` I/O error as a miette diagnostic.
> 
> All other picker errors still propagate as `failed to read script selection` diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e0fc1d8fd85612ccb099dc04f511ea34fd06982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->