### PR TITLE
Fix two aube install issues on real RN monorepos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ version = "1.0.0-beta.5"
 dependencies = [
  "aube-manifest",
  "glob",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1408,7 +1408,7 @@ default = "true"
 docs = "When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard."
 sources.cli = []
 sources.env = []
-sources.npmrc = ["packageManagerStrict"]
+sources.npmrc = ["package-manager-strict", "packageManagerStrict"]
 examples = []
 
 [packageManagerStrictVersion]
@@ -1418,7 +1418,7 @@ default = "false"
 docs = "When enabled, `packageManager: \"aube@<version>\"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic."
 sources.cli = []
 sources.env = []
-sources.npmrc = ["packageManagerStrictVersion"]
+sources.npmrc = ["package-manager-strict-version", "packageManagerStrictVersion"]
 examples = []
 
 [managePackageManagerVersions]

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -520,6 +520,30 @@ mod tests {
     }
 
     #[test]
+    fn resolves_package_manager_strict_kebab_case() {
+        // pnpm's `.npmrc` convention is kebab-case. Real-world yarn/npm
+        // projects that want to bypass the guardrail need the kebab
+        // spelling to work.
+        let e = entries(&[("package-manager-strict", "false")]);
+        assert_eq!(bool_from_npmrc("packageManagerStrict", &e), Some(false));
+    }
+
+    #[test]
+    fn resolves_package_manager_strict_camel_case() {
+        let e = entries(&[("packageManagerStrict", "false")]);
+        assert_eq!(bool_from_npmrc("packageManagerStrict", &e), Some(false));
+    }
+
+    #[test]
+    fn resolves_package_manager_strict_version_kebab_case() {
+        let e = entries(&[("package-manager-strict-version", "true")]);
+        assert_eq!(
+            bool_from_npmrc("packageManagerStrictVersion", &e),
+            Some(true)
+        );
+    }
+
+    #[test]
     fn resolves_git_shallow_hosts_kebab_case() {
         // pnpm's `.npmrc` convention is kebab-case; settings.toml
         // must list both spellings so projects copied from a pnpm

--- a/crates/aube-workspace/Cargo.toml
+++ b/crates/aube-workspace/Cargo.toml
@@ -13,3 +13,6 @@ include = ["src/**/*.rs"]
 aube-manifest = { workspace = true }
 glob = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -1,7 +1,9 @@
 //! Workspace support for aube.
 //!
-//! Reads pnpm-workspace.yaml to discover workspace packages.
-//! Supports the `workspace:` protocol for inter-package dependencies.
+//! Reads pnpm-workspace.yaml to discover workspace packages, falling back
+//! to `package.json`'s `workspaces` field (yarn/npm/bun shape) when no
+//! yaml is present. Supports the `workspace:` protocol for inter-package
+//! dependencies.
 
 pub mod selector;
 
@@ -10,7 +12,13 @@ use std::path::{Path, PathBuf};
 pub use aube_manifest::workspace::WorkspaceConfig;
 pub use selector::{Selector, WorkspacePkg};
 
-/// Discover workspace packages from pnpm-workspace.yaml.
+/// Discover workspace package directories.
+///
+/// Precedence:
+/// 1. `aube-workspace.yaml` / `pnpm-workspace.yaml` `packages:` (authoritative
+///    when present — pnpm/aube projects keep yaml as source of truth).
+/// 2. `package.json#workspaces` (yarn/npm/bun shape — array form or the
+///    `{ packages: [...] }` object form).
 pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error> {
     let config = WorkspaceConfig::load(project_dir).map_err(|e| match e {
         aube_manifest::Error::Io(p, e) => Error::Io(p, e),
@@ -18,12 +26,18 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
         _ => Error::Parse(project_dir.to_path_buf(), e.to_string()),
     })?;
 
-    if config.packages.is_empty() {
+    let patterns: Vec<String> = if !config.packages.is_empty() {
+        config.packages.clone()
+    } else {
+        package_json_workspace_patterns(project_dir)?
+    };
+
+    if patterns.is_empty() {
         return Ok(vec![]);
     }
 
     let mut packages = Vec::new();
-    for pattern in &config.packages {
+    for pattern in &patterns {
         let full_pattern = project_dir.join(pattern).join("package.json");
         if let Ok(entries) = glob::glob(full_pattern.to_str().unwrap_or_default()) {
             for entry in entries.flatten() {
@@ -37,10 +51,138 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
     Ok(packages)
 }
 
+/// Read the `workspaces` field from `<project_dir>/package.json`. Returns
+/// an empty vec if the file is missing or the field is absent — a bare
+/// package.json without `workspaces` is a single-package project, not an
+/// error. Parse errors propagate so typos surface instead of silently
+/// yielding an empty workspace.
+fn package_json_workspace_patterns(project_dir: &Path) -> Result<Vec<String>, Error> {
+    let path = project_dir.join("package.json");
+    if !path.is_file() {
+        return Ok(vec![]);
+    }
+    let pkg = aube_manifest::PackageJson::from_path(&path).map_err(|e| match e {
+        aube_manifest::Error::Io(p, e) => Error::Io(p, e),
+        aube_manifest::Error::Parse(p, e) => Error::Parse(p, e.to_string()),
+        other => Error::Parse(path.clone(), other.to_string()),
+    })?;
+    Ok(pkg
+        .workspaces
+        .as_ref()
+        .map(|w| w.patterns().to_vec())
+        .unwrap_or_default())
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("I/O error at {0}: {1}")]
     Io(PathBuf, std::io::Error),
     #[error("failed to parse {0}: {1}")]
     Parse(PathBuf, String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn names(packages: Vec<PathBuf>) -> BTreeSet<String> {
+        packages
+            .into_iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn finds_packages_from_pnpm_workspace_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'\n",
+        );
+        write(&dir.path().join("packages/a/package.json"), "{}");
+        write(&dir.path().join("packages/b/package.json"), "{}");
+
+        let found = find_workspace_packages(dir.path()).unwrap();
+        assert_eq!(
+            names(found),
+            ["a", "b"].iter().map(|s| s.to_string()).collect()
+        );
+    }
+
+    #[test]
+    fn falls_back_to_package_json_workspaces_array() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("package.json"),
+            r#"{"name":"root","workspaces":["apps/*","packages/*"]}"#,
+        );
+        write(&dir.path().join("apps/example/package.json"), "{}");
+        write(&dir.path().join("packages/ui/package.json"), "{}");
+
+        let found = find_workspace_packages(dir.path()).unwrap();
+        assert_eq!(
+            names(found),
+            ["example", "ui"].iter().map(|s| s.to_string()).collect()
+        );
+    }
+
+    #[test]
+    fn falls_back_to_package_json_workspaces_object() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("package.json"),
+            r#"{"name":"root","workspaces":{"packages":["apps/*"]}}"#,
+        );
+        write(&dir.path().join("apps/example/package.json"), "{}");
+
+        let found = find_workspace_packages(dir.path()).unwrap();
+        assert_eq!(
+            names(found),
+            ["example"].iter().map(|s| s.to_string()).collect()
+        );
+    }
+
+    #[test]
+    fn yaml_wins_when_both_present() {
+        // If pnpm-workspace.yaml defines packages, the fallback to
+        // package.json#workspaces is not consulted — pnpm-style
+        // projects treat yaml as source of truth.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'from-yaml/*'\n",
+        );
+        write(
+            &dir.path().join("package.json"),
+            r#"{"name":"root","workspaces":["from-json/*"]}"#,
+        );
+        write(&dir.path().join("from-yaml/y/package.json"), "{}");
+        write(&dir.path().join("from-json/j/package.json"), "{}");
+
+        let found = find_workspace_packages(dir.path()).unwrap();
+        assert_eq!(names(found), ["y"].iter().map(|s| s.to_string()).collect());
+    }
+
+    #[test]
+    fn missing_package_json_without_yaml_is_empty_not_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let found = find_workspace_packages(dir.path()).unwrap();
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn package_json_without_workspaces_field_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join("package.json"), r#"{"name":"solo"}"#);
+        let found = find_workspace_packages(dir.path()).unwrap();
+        assert!(found.is_empty());
+    }
 }

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -1196,7 +1196,7 @@ fn enforce_package_manager_guardrails(settings: &StartupSettings) -> miette::Res
             Ok(())
         }
         other => Err(miette!(
-            "packageManager in {} uses unsupported package manager `{other}`. aube's packageManagerStrict guard is on by default and only accepts `aube` and `pnpm`; remove or change the `packageManager` field, or set `packageManagerStrict=false` in .npmrc to skip this guard.",
+            "packageManager in {} uses unsupported package manager `{other}`. aube's packageManagerStrict guard is on by default and only accepts `aube` and `pnpm`; remove or change the `packageManager` field, or set `package-manager-strict=false` (or `packageManagerStrict=false`) in .npmrc to skip this guard.",
             path.display()
         )),
     }

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1452,7 +1452,7 @@ Enforce the `packageManager` field in package.json.
 - Type: `bool`
 - Default: `true`
 - Environment: `npm_config_package_manager_strict`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT`
-- .npmrc keys: `packageManagerStrict`
+- .npmrc keys: `package-manager-strict`, `packageManagerStrict`
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
 
@@ -1463,7 +1463,7 @@ Enforce the exact `packageManager` version from package.json.
 - Type: `bool`
 - Default: `false`
 - Environment: `npm_config_package_manager_strict_version`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION`
-- .npmrc keys: `packageManagerStrictVersion`
+- .npmrc keys: `package-manager-strict-version`, `packageManagerStrictVersion`
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
 

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -1329,7 +1329,7 @@ Enforce the `packageManager` field in package.json.
 
 - Type: `bool`
 - Default: `true`
-- .npmrc keys: `packageManagerStrict`
+- .npmrc keys: `package-manager-strict`, `packageManagerStrict`
 
 When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
 
@@ -1339,7 +1339,7 @@ Enforce the exact `packageManager` version from package.json.
 
 - Type: `bool`
 - Default: `false`
-- .npmrc keys: `packageManagerStrictVersion`
+- .npmrc keys: `package-manager-strict-version`, `packageManagerStrictVersion`
 
 When enabled, `packageManager: "aube@<version>"` must match the running aube version exactly. `pnpm@...` cannot be exact-version satisfied by aube and fails with a clear diagnostic.
 


### PR DESCRIPTION
## Summary

Fixes two real-world friction points surfaced while testing `aube install` against popular React Native monorepos ([callstack/react-native-paper](https://github.com/callstack/react-native-paper), [byCedric/expo-monorepo-example](https://github.com/byCedric/expo-monorepo-example)):

- **`workspace: discover packages from package.json#workspaces fallback`** — `find_workspace_packages` now reads `package.json`'s `workspaces` field (yarn/npm/bun shape, array or `{ packages: [...] }`) when no `aube-workspace.yaml` / `pnpm-workspace.yaml` defines packages. Yaml remains authoritative when both are present, so pnpm/aube projects keep their source of truth.
- **`settings: accept kebab-case .npmrc keys for packageManagerStrict`** — adds `package-manager-strict` and `package-manager-strict-version` to the `sources.npmrc` alias lists. pnpm's `.npmrc` convention is kebab-case, and projects copied from a pnpm setup were failing silently on the camelCase-only form. Error message updated to show both spellings.

Before these, the Expo-style pnpm monorepo installed cleanly, but yarn-workspace monorepos (paper, reanimated, ignite, etc.) needed two manual workarounds — a hand-authored `pnpm-workspace.yaml` *and* camelCase `packageManagerStrict=false` in `.npmrc` — to even begin an install.

## Test plan

- [x] `cargo test --workspace` — all tests pass; 6 new tests added (4 in `aube-workspace`, 2 in `aube-settings`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] End-to-end: synthetic yarn-style monorepo (`workspaces: ["apps/*", "packages/*"]`) now installs with correct workspace symlinks, `workspace:*` deps resolve, and transitive registry deps are reachable
- [x] End-to-end: existing pnpm monorepo ([byCedric/expo-monorepo-example](https://github.com/byCedric/expo-monorepo-example)) still installs identically (1087 pkgs, workspace linkage unchanged)
- [x] End-to-end: `package-manager-strict=false` in `.npmrc` now bypasses the packageManager guardrail
- [x] `docs/settings/{index,npmrc}.md` regenerated via `cargo run -p aube-settings --bin generate-settings-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace package discovery and package-manager guardrail configuration parsing, which can alter which packages are treated as part of a monorepo and whether installs are blocked or allowed based on `.npmrc` settings.
> 
> **Overview**
> **Fixes two install-time compatibility gaps for real-world monorepos.** Workspace discovery now falls back to `package.json#workspaces` (array or `{ packages: [...] }`) when no `aube-workspace.yaml`/`pnpm-workspace.yaml` `packages` are defined, while keeping YAML authoritative when present.
> 
> Settings resolution/docs now accept pnpm-style kebab-case `.npmrc` keys for `packageManagerStrict` and `packageManagerStrictVersion` (and updates the guardrail error message accordingly), with added tests and a `tempfile` dev-dependency to validate the new workspace discovery behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c646b05d20bfa88d280a01ed3906bf7638c3d661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->