### PR TITLE
store: reject traversing and non-regular tar entries on import

### DIFF
--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -412,6 +412,7 @@ pub(crate) fn link_hoisted_importer(
         let mut parents: BTreeSet<PathBuf> = BTreeSet::new();
         parents.insert(pkg_dir.clone());
         for rel_path in index.keys() {
+            crate::validate_index_key(rel_path)?;
             let target = pkg_dir.join(rel_path);
             if let Some(parent) = target.parent() {
                 parents.insert(parent.to_path_buf());
@@ -422,6 +423,7 @@ pub(crate) fn link_hoisted_importer(
         }
 
         for (rel_path, stored) in index {
+            crate::validate_index_key(rel_path)?;
             let target = pkg_dir.join(rel_path);
             linker.link_file_fresh(&stored.store_path, &target)?;
             stats.files_linked += 1;

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -411,6 +411,9 @@ pub(crate) fn link_hoisted_importer(
         let _ = std::fs::remove_file(&pkg_dir);
         let mut parents: BTreeSet<PathBuf> = BTreeSet::new();
         parents.insert(pkg_dir.clone());
+        // Validate every key once here. The file-linking loop below
+        // walks the same immutable index, so skipping the check
+        // there is safe.
         for rel_path in index.keys() {
             crate::validate_index_key(rel_path)?;
             let target = pkg_dir.join(rel_path);
@@ -423,7 +426,8 @@ pub(crate) fn link_hoisted_importer(
         }
 
         for (rel_path, stored) in index {
-            crate::validate_index_key(rel_path)?;
+            // Key already validated in the parent-collection loop
+            // above. The index is immutable between the two loops.
             let target = pkg_dir.join(rel_path);
             linker.link_file_fresh(&stored.store_path, &target)?;
             stats.files_linked += 1;

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -1699,6 +1699,9 @@ impl Linker {
         let pkg_nm_parent = base_dir.join(&subdir).join("node_modules");
         let mut parents: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
         parents.insert(pkg_nm_dir.clone());
+        // Validate every key once here. The file-linking loop below
+        // walks the same immutable index, so skipping the check
+        // there is safe.
         for rel_path in index.keys() {
             validate_index_key(rel_path)?;
             let target = pkg_nm_dir.join(rel_path);
@@ -1727,7 +1730,8 @@ impl Linker {
         // the unlink syscall on every file. For a 1.4k-package install
         // that's ~45k wasted `unlink` calls on the hot path.
         for (rel_path, stored) in index {
-            validate_index_key(rel_path)?;
+            // Key already validated in the parent-collection loop
+            // above. The index is immutable between the two loops.
             let target = pkg_nm_dir.join(rel_path);
 
             self.link_file_fresh(&stored.store_path, &target)?;

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -1700,6 +1700,7 @@ impl Linker {
         let mut parents: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
         parents.insert(pkg_nm_dir.clone());
         for rel_path in index.keys() {
+            validate_index_key(rel_path)?;
             let target = pkg_nm_dir.join(rel_path);
             if let Some(parent) = target.parent() {
                 parents.insert(parent.to_path_buf());
@@ -1726,6 +1727,7 @@ impl Linker {
         // the unlink syscall on every file. For a 1.4k-package install
         // that's ~45k wasted `unlink` calls on the hot path.
         for (rel_path, stored) in index {
+            validate_index_key(rel_path)?;
             let target = pkg_nm_dir.join(rel_path);
 
             self.link_file_fresh(&stored.store_path, &target)?;
@@ -1868,6 +1870,47 @@ pub enum Error {
         "internal: missing package index for {0} — caller skipped `load_index` but the package wasn't already materialized"
     )]
     MissingPackageIndex(String),
+    #[error("refusing to materialize unsafe index key: {0:?}")]
+    UnsafeIndexKey(String),
+}
+
+/// Defence in depth for the tarball path-traversal class. The
+/// primary guard lives in `aube_store::import_tarball`, which
+/// refuses malformed entries before they enter the `PackageIndex`.
+/// This helper is the last check before `base.join(key)` is
+/// written through the linker, so an index loaded from a cache
+/// file that predates the store-side validation (or a bug that
+/// lets a traversing key slip past it) still cannot produce a
+/// file outside the package root.
+fn validate_index_key(key: &str) -> Result<(), Error> {
+    if key.is_empty()
+        || key.starts_with('/')
+        || key.starts_with('\\')
+        || key.contains('\0')
+        || key.contains('\\')
+    {
+        return Err(Error::UnsafeIndexKey(key.to_string()));
+    }
+    // Reject any `..` component or Windows drive prefix like `C:`
+    // that would make `Path::join` escape the base.
+    for component in std::path::Path::new(key).components() {
+        match component {
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => {
+                return Err(Error::UnsafeIndexKey(key.to_string()));
+            }
+            std::path::Component::Normal(os) => {
+                if let Some(s) = os.to_str()
+                    && s.contains(':')
+                {
+                    return Err(Error::UnsafeIndexKey(key.to_string()));
+                }
+            }
+            std::path::Component::CurDir => {}
+        }
+    }
+    Ok(())
 }
 
 /// Decide whether an existing `node_modules/<name>` entry can be left
@@ -2509,5 +2552,72 @@ mod tests {
             std::fs::read_to_string(&foo1).unwrap(),
             std::fs::read_to_string(&foo2).unwrap()
         );
+    }
+
+    // ---------------------------------------------------------------
+    // `validate_index_key` rejects every shape of index key that
+    // would make `base.join(key)` escape `base`. Primary defence is
+    // in `aube-store::import_tarball`; this is the last-chance guard
+    // before the linker actually writes to disk.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn validate_index_key_accepts_normal_keys() {
+        validate_index_key("index.js").unwrap();
+        validate_index_key("lib/sub/a.js").unwrap();
+        validate_index_key("package.json").unwrap();
+        validate_index_key("a/b/c/d/e/f.js").unwrap();
+    }
+
+    #[test]
+    fn validate_index_key_rejects_empty() {
+        assert!(matches!(
+            validate_index_key(""),
+            Err(Error::UnsafeIndexKey(_))
+        ));
+    }
+
+    #[test]
+    fn validate_index_key_rejects_leading_slash() {
+        assert!(matches!(
+            validate_index_key("/etc/passwd"),
+            Err(Error::UnsafeIndexKey(_))
+        ));
+        assert!(matches!(
+            validate_index_key("\\evil"),
+            Err(Error::UnsafeIndexKey(_))
+        ));
+    }
+
+    #[test]
+    fn validate_index_key_rejects_parent_dir() {
+        assert!(matches!(
+            validate_index_key("../../etc/passwd"),
+            Err(Error::UnsafeIndexKey(_))
+        ));
+        assert!(matches!(
+            validate_index_key("lib/../../../etc"),
+            Err(Error::UnsafeIndexKey(_))
+        ));
+    }
+
+    #[test]
+    fn validate_index_key_rejects_nul_and_backslash() {
+        assert!(matches!(
+            validate_index_key("lib\0evil"),
+            Err(Error::UnsafeIndexKey(_))
+        ));
+        assert!(matches!(
+            validate_index_key("lib\\..\\etc"),
+            Err(Error::UnsafeIndexKey(_))
+        ));
+    }
+
+    #[test]
+    fn validate_index_key_rejects_windows_drive() {
+        assert!(matches!(
+            validate_index_key("C:Windows"),
+            Err(Error::UnsafeIndexKey(_))
+        ));
     }
 }

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -460,11 +460,22 @@ impl Store {
 fn normalize_tar_entry_path(raw: &Path) -> Result<Option<String>, Error> {
     use std::path::Component;
 
+    // Peek past any leading `.` segments (`./package/foo.js` appears
+    // in some tar implementations' wrapper representations) so the
+    // first-component reject and the wrapper-strip both work off the
+    // same "first real" position. Running the reject before the
+    // stripping loop would otherwise let `./../file` silently
+    // consume the `..` as the wrapper.
+    let mut components = raw.components().peekable();
+    while matches!(components.peek(), Some(Component::CurDir)) {
+        components.next();
+    }
+
     // Reject absolute, drive-prefixed, or `..`-rooted paths before
-    // any wrapper-strip runs. A naive "skip the first component"
-    // would otherwise strip the `RootDir` marker and accept `/etc`
-    // as `etc`.
-    match raw.components().next() {
+    // wrapper-strip runs. A naive "skip the first component" would
+    // otherwise strip the `RootDir` marker and accept `/etc` as
+    // `etc`, or consume a leading `..` as the wrapper.
+    match components.peek() {
         Some(Component::RootDir) => {
             return Err(Error::Tar(format!(
                 "tarball entry path is absolute: {raw:?}"
@@ -483,14 +494,9 @@ fn normalize_tar_entry_path(raw: &Path) -> Result<Option<String>, Error> {
         _ => {}
     }
 
-    // Skip leading `.` components, then drop the first real
-    // component as the wrapper directory. npm convention is
-    // `package/`, but some packages ship the package name or
-    // another identifier. Whatever it is, drop it.
-    let mut components = raw.components().peekable();
-    while matches!(components.peek(), Some(Component::CurDir)) {
-        components.next();
-    }
+    // Drop the first real component as the wrapper directory. npm
+    // convention is `package/`, but some packages ship the package
+    // name or another identifier. Whatever it is, drop it.
     components.next();
 
     let mut out = String::new();
@@ -1707,6 +1713,18 @@ mod tests {
     #[test]
     fn normalize_tar_entry_path_rejects_parent_dir() {
         let err = normalize_tar_entry_path(Path::new("package/../etc/passwd")).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn normalize_tar_entry_path_rejects_parent_dir_after_leading_cur_dir() {
+        // `./../file` must be rejected. An earlier version of the
+        // validator ran the ParentDir check against the raw first
+        // component, so the `.` passed it and the `..` was then
+        // silently consumed as the wrapper directory.
+        let err = normalize_tar_entry_path(Path::new("./../file")).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+        let err = normalize_tar_entry_path(Path::new("././../etc/passwd")).unwrap_err();
         assert!(matches!(err, Error::Tar(_)));
     }
 

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -374,8 +374,24 @@ impl Store {
 
             let mut entry = entry.map_err(|e| Error::Tar(e.to_string()))?;
 
-            if entry.header().entry_type().is_dir() {
+            // Directories don't carry content, skip them. Every other
+            // non-regular entry type (symlink, hardlink, character
+            // device, block device, fifo) is rejected. Real npm
+            // packages ship files and directories only. Symlink and
+            // hardlink entries are the load-bearing primitive of the
+            // node-tar CVE-2021-37701 class and have no legitimate
+            // use here.
+            let entry_type = entry.header().entry_type();
+            if entry_type.is_dir() {
                 continue;
+            }
+            if !matches!(
+                entry_type,
+                tar::EntryType::Regular | tar::EntryType::Continuous
+            ) {
+                return Err(Error::Tar(format!(
+                    "tarball entry type {entry_type:?} is not allowed"
+                )));
             }
 
             // Reject oversized entries up front on the declared size
@@ -396,23 +412,10 @@ impl Store {
                 .path()
                 .map_err(|e| Error::Tar(e.to_string()))?
                 .to_path_buf();
-            // Strip the first path component. npm convention is `package/`, but
-            // some packages publish tarballs with the package name (or other names)
-            // as the top-level directory. The first component is always the
-            // wrapper and should be stripped regardless of its name.
-            let rel_path = {
-                let mut components = raw_path.components();
-                components.next(); // skip the wrapper directory
-                let stripped: PathBuf = components.collect();
-                let s = if stripped.as_os_str().is_empty() {
-                    raw_path.to_string_lossy().to_string()
-                } else {
-                    stripped.to_string_lossy().to_string()
-                };
-                // Package indices are keyed with `/` separators on every
-                // platform so the lockfile and linker see identical keys
-                // regardless of where the tarball was extracted.
-                s.replace('\\', "/")
+            let Some(rel_path) = normalize_tar_entry_path(&raw_path)? else {
+                // Entry was the wrapper directory itself with no
+                // interior path after stripping. Nothing to store.
+                continue;
             };
 
             // Clamp the upfront allocation to a sane ceiling so a
@@ -434,6 +437,111 @@ impl Store {
         }
 
         Ok(index)
+    }
+}
+
+/// Strip the wrapper directory from `raw` and return a safe POSIX-style
+/// index key, or refuse the entry outright.
+///
+/// Rejects every shape that would let a crafted tarball place the
+/// eventual `pkg_dir.join(key)` file outside the package root:
+/// `..` anywhere in the remaining path, absolute paths, Windows
+/// drive prefixes, backslash separators smuggled inside a single
+/// component, NUL bytes, and `:` (which `Path::components` surfaces
+/// as `Normal("C:evil")` on unix where it wouldn't parse as a
+/// drive prefix). Non-UTF-8 paths are also rejected because the
+/// stored index is a JSON map keyed by string.
+///
+/// `Ok(None)` means the entry stripped down to the wrapper itself
+/// and should be skipped by the caller.
+///
+/// Matches the class of defences node-tar added for CVE-2021-32804,
+/// CVE-2021-37713, and what pnpm added for CVE-2024-27298.
+fn normalize_tar_entry_path(raw: &Path) -> Result<Option<String>, Error> {
+    use std::path::Component;
+
+    // Reject absolute, drive-prefixed, or `..`-rooted paths before
+    // any wrapper-strip runs. A naive "skip the first component"
+    // would otherwise strip the `RootDir` marker and accept `/etc`
+    // as `etc`.
+    match raw.components().next() {
+        Some(Component::RootDir) => {
+            return Err(Error::Tar(format!(
+                "tarball entry path is absolute: {raw:?}"
+            )));
+        }
+        Some(Component::Prefix(_)) => {
+            return Err(Error::Tar(format!(
+                "tarball entry path has a Windows drive prefix: {raw:?}"
+            )));
+        }
+        Some(Component::ParentDir) => {
+            return Err(Error::Tar(format!(
+                "tarball entry path escapes package root via `..`: {raw:?}"
+            )));
+        }
+        _ => {}
+    }
+
+    // Skip leading `.` components, then drop the first real
+    // component as the wrapper directory. npm convention is
+    // `package/`, but some packages ship the package name or
+    // another identifier. Whatever it is, drop it.
+    let mut components = raw.components().peekable();
+    while matches!(components.peek(), Some(Component::CurDir)) {
+        components.next();
+    }
+    components.next();
+
+    let mut out = String::new();
+    for comp in components {
+        match comp {
+            Component::Normal(os) => {
+                let s = os.to_str().ok_or_else(|| {
+                    Error::Tar(format!(
+                        "tarball entry path contains non-UTF-8 bytes: {raw:?}"
+                    ))
+                })?;
+                if s.is_empty()
+                    || s.contains('\0')
+                    || s.contains('\\')
+                    || s.contains('/')
+                    || s.contains(':')
+                {
+                    return Err(Error::Tar(format!(
+                        "tarball entry path contains a malformed component: {raw:?}"
+                    )));
+                }
+                if !out.is_empty() {
+                    out.push('/');
+                }
+                out.push_str(s);
+            }
+            Component::ParentDir => {
+                return Err(Error::Tar(format!(
+                    "tarball entry path escapes package root via `..`: {raw:?}"
+                )));
+            }
+            Component::RootDir => {
+                return Err(Error::Tar(format!(
+                    "tarball entry path is absolute: {raw:?}"
+                )));
+            }
+            Component::Prefix(_) => {
+                return Err(Error::Tar(format!(
+                    "tarball entry path has a Windows drive prefix: {raw:?}"
+                )));
+            }
+            // `.` components are harmless and appear in some tar
+            // implementations' wrapper representations.
+            Component::CurDir => {}
+        }
+    }
+
+    if out.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(out))
     }
 }
 
@@ -1525,6 +1633,196 @@ mod tests {
             other => panic!("expected Error::Tar, got {other:?}"),
         };
         assert!(msg.contains("entry cap"), "unexpected error: {msg}");
+    }
+
+    // ---------------------------------------------------------------
+    // Path traversal / zip-slip defences.
+    //
+    // A malicious tarball can try to write files outside the package
+    // directory at install time by crafting entry paths with `..`,
+    // absolute roots, Windows drive prefixes, or smuggled separators
+    // inside a single component. `normalize_tar_entry_path` must
+    // refuse every such shape before the key enters the
+    // `PackageIndex`, and `import_tarball` must refuse symlink /
+    // hardlink / device / fifo entries regardless of their path.
+    // ---------------------------------------------------------------
+
+    fn build_raw_named_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        // The `tar` crate's `Builder::append` refuses to write `..`
+        // paths and other malformed shapes, which is precisely what
+        // this test suite needs to construct. Write the header
+        // `name` field raw to bypass the safety check — a real
+        // attacker uploading a `.tgz` to a registry has no such
+        // guard.
+        let gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut ar = tar::Builder::new(gz);
+        for (path, data) in entries {
+            let mut h = tar::Header::new_gnu();
+            h.set_path("placeholder").unwrap();
+            let name = &mut h.as_old_mut().name;
+            name.fill(0);
+            let bytes = path.as_bytes();
+            assert!(bytes.len() < 100, "path too long for ustar name field");
+            name[..bytes.len()].copy_from_slice(bytes);
+            h.set_size(data.len() as u64);
+            h.set_mode(0o644);
+            h.set_cksum();
+            ar.append(&h, *data).unwrap();
+        }
+        ar.into_inner().unwrap().finish().unwrap()
+    }
+
+    #[test]
+    fn normalize_tar_entry_path_accepts_plain_keys() {
+        assert_eq!(
+            normalize_tar_entry_path(Path::new("package/index.js")).unwrap(),
+            Some("index.js".to_string())
+        );
+        assert_eq!(
+            normalize_tar_entry_path(Path::new("package/lib/util/a.js")).unwrap(),
+            Some("lib/util/a.js".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_tar_entry_path_skips_wrapper_only_entry() {
+        assert_eq!(
+            normalize_tar_entry_path(Path::new("package")).unwrap(),
+            None
+        );
+        assert_eq!(
+            normalize_tar_entry_path(Path::new("package/")).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn normalize_tar_entry_path_collapses_cur_dir() {
+        assert_eq!(
+            normalize_tar_entry_path(Path::new("package/./foo.js")).unwrap(),
+            Some("foo.js".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_tar_entry_path_rejects_parent_dir() {
+        let err = normalize_tar_entry_path(Path::new("package/../etc/passwd")).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn normalize_tar_entry_path_rejects_absolute_path() {
+        let err = normalize_tar_entry_path(Path::new("/etc/passwd")).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn normalize_tar_entry_path_rejects_smuggled_backslash() {
+        // On unix `Path::components` leaves `a\b` as one Normal
+        // component with a literal backslash inside. Reject.
+        let err = normalize_tar_entry_path(Path::new("package/a\\..\\etc")).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn normalize_tar_entry_path_rejects_colon_smuggle() {
+        // On unix `C:evil` parses as `Normal("C:evil")`, not a
+        // Prefix. Reject defensively.
+        let err = normalize_tar_entry_path(Path::new("package/C:evil")).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn normalize_tar_entry_path_rejects_nul() {
+        let err = normalize_tar_entry_path(Path::new("package/a\0b")).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn test_import_tarball_rejects_parent_dir_escape() {
+        // End-to-end: the crafted tarball that the prior zip-slip
+        // reproducer used. `import_tarball` must refuse it and
+        // produce no `PackageIndex` entries.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+        let tarball = build_raw_named_tarball(&[
+            ("package/package.json", b"{}"),
+            ("package/../../../etc/cron.d/evil", b"* * * * * root id\n"),
+        ]);
+        let err = store.import_tarball(&tarball).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn test_import_tarball_rejects_absolute_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+        let tarball = build_raw_named_tarball(&[
+            ("package/package.json", b"{}"),
+            ("/etc/passwd", b"root:x:0:0\n"),
+        ]);
+        let err = store.import_tarball(&tarball).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn test_import_tarball_rejects_symlink_entry() {
+        // Symlink entries let a malicious package place the eventual
+        // `pkg_dir.join(key)` file through a symlink that points
+        // outside the package root. Refuse the entire class.
+        let gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut ar = tar::Builder::new(gz);
+        let mut h = tar::Header::new_gnu();
+        h.set_path("package/sneaky").unwrap();
+        h.set_size(0);
+        h.set_mode(0o644);
+        h.set_entry_type(tar::EntryType::Symlink);
+        h.set_link_name("/etc/passwd").unwrap();
+        h.set_cksum();
+        ar.append(&h, &[][..]).unwrap();
+        let tarball = ar.into_inner().unwrap().finish().unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+        let err = store.import_tarball(&tarball).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn test_import_tarball_rejects_hardlink_entry() {
+        let gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut ar = tar::Builder::new(gz);
+        let mut h = tar::Header::new_gnu();
+        h.set_path("package/clobber").unwrap();
+        h.set_size(0);
+        h.set_mode(0o644);
+        h.set_entry_type(tar::EntryType::Link);
+        h.set_link_name("../../../../home/victim/.ssh/authorized_keys")
+            .unwrap();
+        h.set_cksum();
+        ar.append(&h, &[][..]).unwrap();
+        let tarball = ar.into_inner().unwrap().finish().unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+        let err = store.import_tarball(&tarball).unwrap_err();
+        assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn test_import_tarball_still_accepts_normal_nested_paths() {
+        // Regression guard: the validator must not refuse legitimate
+        // deep paths that top-1000 packages actually ship.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+        let tarball = build_tarball("package/lib/sub/a.js", b"// hi");
+        let index = store.import_tarball(&tarball).unwrap();
+        assert!(index.contains_key("lib/sub/a.js"));
     }
 
     #[test]


### PR DESCRIPTION
`import_tarball` stripped only the first path component from each tar entry and fed the remainder verbatim into the `PackageIndex`. Every shape of malformed path was accepted: `..` anywhere after the wrapper, absolute roots (`/etc/passwd`), Windows drive prefixes, backslash-smuggled separators inside a single component (`package/a\..\etc` on unix where `Path::components` does not split on backslash), NUL bytes, non-UTF-8 bytes.

The linker then wrote each entry at `pkg_dir.join(key)`. Because `Path::join` on an absolute operand discards the base and `..` walks upward, a malicious published package could write any file on disk at install time with no lifecycle script involvement. The `allowBuilds` deny default does not cover this step.

Same class as fixes node-tar shipped for CVE-2021-32804 and CVE-2021-37713, and what pnpm shipped for CVE-2024-27298.

## Changes

1. `aube_store::normalize_tar_entry_path` rejects every malformed path shape before the key enters the `PackageIndex`. Absolute, drive-prefixed, and `..`-rooted paths are refused before wrapper stripping. Interior `\`, `:`, NUL, and non-UTF-8 components are refused.

2. `aube_store::import_tarball` now refuses every non-regular tar entry type. Only `Regular` and `Continuous` entries are extracted; symlink, hardlink, device, and fifo entries are rejected. Real npm packages never ship anything else, and symlink / hardlink entries are the load-bearing primitive of the node-tar hardlink traversal family.

3. `aube_linker::validate_index_key` adds a second validation pass before `pkg_dir.join(key)` in both the isolated and hoisted materializers. Defence in depth in case a `PackageIndex` serialized by an older aube build is loaded from cache, or any bug lets a traversing key slip past the store-side check.

## Tests

19 new tests covering the accept path (plain keys, deep nested, leading `.`), the reject matrix (parent dir, root, drive prefix, backslash smuggle, colon smuggle, NUL, non-UTF-8), the symlink / hardlink entry types, and the linker-side key validation. Full workspace is 513 / 513 in both debug and release.

## Cross-platform

No new `#[cfg]` gates. `Path::components` handles Windows / unix separator differences natively, and the interior `\` / `:` checks close the remaining gap where unix would leave a Windows-style smuggle as a single `Normal` component.