### PR TITLE
docs: add releases link to docs nav

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -97,6 +97,7 @@ gtag('config', 'G-WD1RRC0F8C');`,
       { text: "Benchmarks", link: "/benchmarks" },
       { text: "CLI Reference", link: "/cli/" },
       { text: "Settings", link: "/settings/" },
+      { text: "Releases", link: "https://github.com/endevco/aube/releases" },
     ],
 
     sidebar: [


### PR DESCRIPTION
## Summary

- add a top-level docs nav item for GitHub releases

## Validation

- `npm run docs:build`

Note: VitePress emitted the existing chunk-size warning during the build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adds a new external navigation link; no runtime or business logic is modified.
> 
> **Overview**
> Adds a **Releases** item to the VitePress top navigation, linking users directly to the project’s GitHub releases page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be038a1c521a3f942d8d8064c0a8f3c68776acb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->