### PR TITLE
lockfile: match pnpm ignored optionals order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
 /.cache
 /docs/.aube/
-/docs/aube-lock.yaml
 /docs/node_modules/

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -756,16 +756,9 @@ struct WritablePnpmLockfile {
     // for the no-overrides case (the field is skipped when empty).
     #[serde(skip_serializing_if = "Option::is_none")]
     overrides: Option<BTreeMap<String, String>>,
-    /// pnpm v9 emits a top-level `ignoredOptionalDependencies:` array
-    /// when the root manifest's `pnpm.ignoredOptionalDependencies` is
-    /// non-empty. Placed between `overrides:` and `time:` to match
-    /// pnpm's field order; skipped when empty so a no-ignored install
-    /// stays byte-for-byte identical to pnpm's output.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    ignored_optional_dependencies: Option<Vec<String>>,
     /// pnpm v9 emits a top-level `catalogs:` map after
-    /// `ignoredOptionalDependencies:` and before `importers:` when
-    /// `pnpm-workspace.yaml` declares any referenced catalog entries.
+    /// `overrides:` and before `importers:` when `pnpm-workspace.yaml`
+    /// declares any referenced catalog entries.
     /// Skipped when empty so a no-catalogs install stays byte-identical
     /// to pnpm output.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -779,6 +772,13 @@ struct WritablePnpmLockfile {
     time: Option<BTreeMap<String, String>>,
     importers: BTreeMap<String, WritableImporter>,
     packages: BTreeMap<String, WritablePackageInfo>,
+    /// pnpm v9 emits a top-level `ignoredOptionalDependencies:` array
+    /// after `packages:` and before `snapshots:` when the root
+    /// manifest's `pnpm.ignoredOptionalDependencies` is non-empty.
+    /// Skipped when empty so a no-ignored install stays byte-for-byte
+    /// identical to pnpm's output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ignored_optional_dependencies: Option<Vec<String>>,
     snapshots: BTreeMap<String, WritableSnapshot>,
 }
 
@@ -1531,6 +1531,55 @@ snapshots:
             .expect("react catalog entry");
         assert_eq!(entry.specifier, "^18.0.0");
         assert_eq!(entry.version, "18.2.0");
+    }
+
+    #[test]
+    fn ignored_optional_dependencies_section_matches_pnpm_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let lockfile_path = dir.path().join("pnpm-lock.yaml");
+
+        let mut ignored_optional_dependencies = std::collections::BTreeSet::new();
+        ignored_optional_dependencies.insert("fsevents".to_string());
+
+        let mut default_cat = BTreeMap::new();
+        default_cat.insert(
+            "react".to_string(),
+            CatalogEntry {
+                specifier: "^18.0.0".to_string(),
+                version: "18.2.0".to_string(),
+            },
+        );
+        let mut catalogs = BTreeMap::new();
+        catalogs.insert("default".to_string(), default_cat);
+
+        let graph = LockfileGraph {
+            ignored_optional_dependencies,
+            catalogs,
+            ..Default::default()
+        };
+        let manifest = PackageJson {
+            name: Some("test".to_string()),
+            version: Some("0.0.0".to_string()),
+            ..Default::default()
+        };
+        write(&lockfile_path, &graph, &manifest).unwrap();
+
+        let yaml = std::fs::read_to_string(&lockfile_path).unwrap();
+        let catalogs = yaml.find("\ncatalogs:").expect("missing catalogs");
+        let importers = yaml.find("\nimporters:").expect("missing importers");
+        let packages = yaml.find("\npackages:").expect("missing packages");
+        let ignored = yaml
+            .find("\nignoredOptionalDependencies:")
+            .expect("missing ignoredOptionalDependencies");
+        let snapshots = yaml.find("\nsnapshots:").expect("missing snapshots");
+
+        assert!(
+            catalogs < importers
+                && importers < packages
+                && packages < ignored
+                && ignored < snapshots,
+            "unexpected pnpm section order:\n{yaml}"
+        );
     }
 
     // Build a graph with one `link:` dep and one registry dep, write it

--- a/docs/aube-lock.yaml
+++ b/docs/aube-lock.yaml
@@ -29,10 +29,18 @@ time:
   '@docsearch/js@3.8.2': 2024-12-17T15:34:38.867Z
   '@docsearch/react@3.8.2': 2024-12-17T15:34:36.229Z
   '@esbuild/darwin-arm64@0.21.5': 2024-06-09T21:17:13.758Z
+  '@esbuild/darwin-x64@0.21.5': 2024-06-09T21:17:00.976Z
+  '@esbuild/linux-arm64@0.21.5': 2024-06-09T21:17:23.384Z
+  '@esbuild/linux-x64@0.21.5': 2024-06-09T21:17:15.111Z
   '@iconify-json/simple-icons@1.2.78': 2026-04-13T04:57:35.352Z
   '@iconify/types@2.0.0': 2022-09-08T06:23:03.369Z
   '@jridgewell/sourcemap-codec@1.5.5': 2025-08-12T06:43:59.139Z
   '@rollup/rollup-darwin-arm64@4.60.2': 2026-04-18T13:58:27.555Z
+  '@rollup/rollup-darwin-x64@4.60.2': 2026-04-18T13:59:28.701Z
+  '@rollup/rollup-linux-arm64-gnu@4.60.2': 2026-04-18T13:58:41.555Z
+  '@rollup/rollup-linux-arm64-musl@4.60.2': 2026-04-18T13:58:45.162Z
+  '@rollup/rollup-linux-x64-gnu@4.60.2': 2026-04-18T13:59:43.183Z
+  '@rollup/rollup-linux-x64-musl@4.60.2': 2026-04-18T13:59:46.857Z
   '@shikijs/core@2.5.0': 2025-02-18T09:10:12.142Z
   '@shikijs/engine-javascript@2.5.0': 2025-02-18T09:09:26.369Z
   '@shikijs/engine-oniguruma@2.5.0': 2025-02-18T09:09:33.593Z
@@ -263,6 +271,27 @@ packages:
     - darwin
     cpu:
     - arm64
+  '@esbuild/darwin-x64@0.21.5':
+    resolution:
+      integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
+    os:
+    - darwin
+    cpu:
+    - x64
+  '@esbuild/linux-arm64@0.21.5':
+    resolution:
+      integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
+    os:
+    - linux
+    cpu:
+    - arm64
+  '@esbuild/linux-x64@0.21.5':
+    resolution:
+      integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
+    os:
+    - linux
+    cpu:
+    - x64
   '@iconify-json/simple-icons@1.2.78':
     resolution:
       integrity: sha512-I3lkNp0Qu7q2iZWkdcf/I2hqGhzK6qxdILh9T7XqowQrnpmG/BayDsiCf6PktDoWlW0U971xA5g+panm+NFrfQ==
@@ -279,6 +308,49 @@ packages:
     - darwin
     cpu:
     - arm64
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution:
+      integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==
+    os:
+    - darwin
+    cpu:
+    - x64
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution:
+      integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution:
+      integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution:
+      integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution:
+      integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
   '@shikijs/core@2.5.0':
     resolution:
       integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==
@@ -764,12 +836,20 @@ snapshots:
       algoliasearch: 5.50.2
       search-insights: 2.17.3
   '@esbuild/darwin-arm64@0.21.5': {}
+  '@esbuild/darwin-x64@0.21.5': {}
+  '@esbuild/linux-arm64@0.21.5': {}
+  '@esbuild/linux-x64@0.21.5': {}
   '@iconify-json/simple-icons@1.2.78':
     dependencies:
       '@iconify/types': 2.0.0
   '@iconify/types@2.0.0': {}
   '@jridgewell/sourcemap-codec@1.5.5': {}
   '@rollup/rollup-darwin-arm64@4.60.2': {}
+  '@rollup/rollup-darwin-x64@4.60.2': {}
+  '@rollup/rollup-linux-arm64-gnu@4.60.2': {}
+  '@rollup/rollup-linux-arm64-musl@4.60.2': {}
+  '@rollup/rollup-linux-x64-gnu@4.60.2': {}
+  '@rollup/rollup-linux-x64-musl@4.60.2': {}
   '@shikijs/core@2.5.0':
     dependencies:
       '@shikijs/engine-javascript': 2.5.0
@@ -932,6 +1012,9 @@ snapshots:
   esbuild@0.21.5:
     optionalDependencies:
       '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
   estree-walker@2.0.2: {}
   focus-trap@7.8.0:
     dependencies:
@@ -1013,6 +1096,11 @@ snapshots:
       '@types/estree': 1.0.8
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
       fsevents: 2.3.3
   search-insights@2.17.3: {}
   shiki@2.5.0:

--- a/docs/aube-lock.yaml
+++ b/docs/aube-lock.yaml
@@ -1,0 +1,1101 @@
+lockfileVersion: '9.0'
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+time:
+  '@algolia/abtesting@1.16.2': 2026-04-14T16:35:13.229Z
+  '@algolia/autocomplete-core@1.17.7': 2024-11-05T15:07:05.611Z
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7': 2024-11-05T15:07:23.472Z
+  '@algolia/autocomplete-preset-algolia@1.17.7': 2024-11-05T15:08:03.592Z
+  '@algolia/autocomplete-shared@1.17.7': 2024-11-05T15:08:10.663Z
+  '@algolia/client-abtesting@5.50.2': 2026-04-14T16:35:13.673Z
+  '@algolia/client-analytics@5.50.2': 2026-04-14T16:35:13.103Z
+  '@algolia/client-common@5.50.2': 2026-04-14T16:35:05.733Z
+  '@algolia/client-insights@5.50.2': 2026-04-14T16:35:16.104Z
+  '@algolia/client-personalization@5.50.2': 2026-04-14T16:35:17.331Z
+  '@algolia/client-query-suggestions@5.50.2': 2026-04-14T16:35:17.616Z
+  '@algolia/client-search@5.50.2': 2026-04-14T16:35:18.082Z
+  '@algolia/ingestion@1.50.2': 2026-04-14T16:35:21.912Z
+  '@algolia/monitoring@1.50.2': 2026-04-14T16:35:22.250Z
+  '@algolia/recommend@5.50.2': 2026-04-14T16:35:22.424Z
+  '@algolia/requester-browser-xhr@5.50.2': 2026-04-14T16:35:08.842Z
+  '@algolia/requester-fetch@5.50.2': 2026-04-14T16:35:09.130Z
+  '@algolia/requester-node-http@5.50.2': 2026-04-14T16:35:09.050Z
+  '@babel/helper-string-parser@7.27.1': 2025-04-30T15:08:26.501Z
+  '@babel/helper-validator-identifier@7.28.5': 2025-10-23T15:17:38.203Z
+  '@babel/parser@7.29.2': 2026-03-16T22:33:19.657Z
+  '@babel/types@7.29.0': 2026-01-31T17:39:13.578Z
+  '@docsearch/css@3.8.2': 2024-12-17T15:34:33.806Z
+  '@docsearch/js@3.8.2': 2024-12-17T15:34:38.867Z
+  '@docsearch/react@3.8.2': 2024-12-17T15:34:36.229Z
+  '@esbuild/darwin-arm64@0.21.5': 2024-06-09T21:17:13.758Z
+  '@iconify-json/simple-icons@1.2.78': 2026-04-13T04:57:35.352Z
+  '@iconify/types@2.0.0': 2022-09-08T06:23:03.369Z
+  '@jridgewell/sourcemap-codec@1.5.5': 2025-08-12T06:43:59.139Z
+  '@rollup/rollup-darwin-arm64@4.60.2': 2026-04-18T13:58:27.555Z
+  '@shikijs/core@2.5.0': 2025-02-18T09:10:12.142Z
+  '@shikijs/engine-javascript@2.5.0': 2025-02-18T09:09:26.369Z
+  '@shikijs/engine-oniguruma@2.5.0': 2025-02-18T09:09:33.593Z
+  '@shikijs/langs@2.5.0': 2025-02-18T09:09:39.465Z
+  '@shikijs/themes@2.5.0': 2025-02-18T09:10:04.997Z
+  '@shikijs/transformers@2.5.0': 2025-02-18T09:10:36.901Z
+  '@shikijs/types@2.5.0': 2025-02-18T09:09:20.251Z
+  '@shikijs/vscode-textmate@10.0.2': 2025-02-15T16:46:32.096Z
+  '@types/estree@1.0.8': 2025-06-06T00:04:34.692Z
+  '@types/hast@3.0.4': 2024-01-30T22:06:19.288Z
+  '@types/linkify-it@5.0.0': 2024-05-01T18:07:46.092Z
+  '@types/markdown-it@14.1.2': 2024-07-25T05:07:30.523Z
+  '@types/mdast@4.0.4': 2024-05-14T07:35:37.616Z
+  '@types/mdurl@2.0.0': 2024-05-01T18:08:10.612Z
+  '@types/unist@3.0.3': 2024-08-15T02:19:16.553Z
+  '@types/web-bluetooth@0.0.21': 2025-02-28T23:32:05.029Z
+  '@ungap/structured-clone@1.3.0': 2025-01-23T14:13:01.275Z
+  '@vitejs/plugin-vue@5.2.4': 2025-05-09T09:47:50.969Z
+  '@vue/compiler-core@3.5.32': 2026-04-03T05:41:04.047Z
+  '@vue/compiler-dom@3.5.32': 2026-04-03T05:41:07.863Z
+  '@vue/compiler-sfc@3.5.32': 2026-04-03T05:41:12.043Z
+  '@vue/compiler-ssr@3.5.32': 2026-04-03T05:41:16.007Z
+  '@vue/devtools-api@7.7.9': 2025-11-17T14:28:13.410Z
+  '@vue/devtools-kit@7.7.9': 2025-11-17T14:28:05.469Z
+  '@vue/devtools-shared@7.7.9': 2025-11-17T14:28:02.466Z
+  '@vue/reactivity@3.5.32': 2026-04-03T05:41:19.887Z
+  '@vue/runtime-core@3.5.32': 2026-04-03T05:41:24.116Z
+  '@vue/runtime-dom@3.5.32': 2026-04-03T05:41:27.865Z
+  '@vue/server-renderer@3.5.32': 2026-04-03T05:41:31.772Z
+  '@vue/shared@3.5.32': 2026-04-03T05:41:35.866Z
+  '@vueuse/core@12.8.2': 2025-03-05T11:39:34.178Z
+  '@vueuse/integrations@12.8.2': 2025-03-05T11:41:34.399Z
+  '@vueuse/metadata@12.8.2': 2025-03-05T11:39:15.362Z
+  '@vueuse/shared@12.8.2': 2025-03-05T11:39:22.947Z
+  algoliasearch@5.50.2: 2026-04-14T16:35:28.490Z
+  birpc@2.9.0: 2025-12-03T06:40:16.657Z
+  ccount@2.0.1: 2021-10-28T09:38:13.774Z
+  character-entities-html4@2.1.0: 2021-10-29T14:28:35.375Z
+  character-entities-legacy@3.0.0: 2021-10-29T12:50:20.435Z
+  comma-separated-tokens@2.0.3: 2022-11-14T09:09:04.761Z
+  copy-anything@4.0.5: 2025-03-24T18:18:23.270Z
+  csstype@3.2.3: 2025-11-17T11:42:27.045Z
+  dequal@2.0.3: 2022-07-11T23:29:04.965Z
+  devlop@1.1.0: 2023-06-29T15:17:11.346Z
+  emoji-regex-xs@1.0.0: 2024-06-28T16:22:28.678Z
+  entities@7.0.1: 2026-01-21T13:46:30.165Z
+  esbuild@0.21.5: 2024-06-09T21:17:41.628Z
+  estree-walker@2.0.2: 2020-12-08T17:07:42.670Z
+  focus-trap@7.8.0: 2026-01-10T22:24:14.284Z
+  fsevents@2.3.3: 2023-08-21T16:24:22.854Z
+  hast-util-to-html@9.0.5: 2025-02-19T13:34:47.133Z
+  hast-util-whitespace@3.0.0: 2023-07-31T15:52:12.042Z
+  hookable@5.5.3: 2023-03-30T13:33:47.930Z
+  html-void-elements@3.0.0: 2023-05-19T10:17:19.335Z
+  is-what@5.5.0: 2025-09-22T17:10:23.658Z
+  magic-string@0.30.21: 2025-10-24T00:59:47.122Z
+  mark.js@8.11.1: 2018-01-11T22:55:52.210Z
+  mdast-util-to-hast@13.2.1: 2025-11-23T21:08:34.155Z
+  micromark-util-character@2.1.1: 2024-11-12T11:17:13.750Z
+  micromark-util-encode@2.0.1: 2024-11-12T11:17:34.206Z
+  micromark-util-sanitize-uri@2.0.1: 2024-11-12T11:17:48.745Z
+  micromark-util-symbol@2.0.1: 2024-11-12T11:17:55.709Z
+  micromark-util-types@2.0.2: 2025-02-27T13:55:27.982Z
+  minisearch@7.2.0: 2025-09-16T12:42:12.453Z
+  mitt@3.0.1: 2023-07-04T17:31:47.638Z
+  nanoid@3.3.11: 2025-03-18T23:06:32.923Z
+  oniguruma-to-es@3.1.1: 2025-02-20T16:19:37.749Z
+  perfect-debounce@1.0.0: 2023-05-03T23:17:12.783Z
+  picocolors@1.1.1: 2024-10-16T18:20:03.921Z
+  postcss@8.5.10: 2026-04-15T14:42:53.378Z
+  preact@10.29.1: 2026-04-03T10:43:57.080Z
+  property-information@7.1.0: 2025-05-08T07:00:48.463Z
+  regex-recursion@6.0.2: 2025-02-01T00:57:00.191Z
+  regex-utilities@2.3.0: 2024-08-31T18:40:34.903Z
+  regex@6.1.0: 2025-12-09T01:33:47.153Z
+  rfdc@1.4.1: 2024-06-12T10:18:29.594Z
+  rollup@4.60.2: 2026-04-18T13:59:58.613Z
+  search-insights@2.17.3: 2024-11-18T02:06:21.689Z
+  shiki@2.5.0: 2025-02-18T09:10:30.900Z
+  source-map-js@1.2.1: 2024-09-08T16:22:55.645Z
+  space-separated-tokens@2.0.2: 2022-11-14T08:54:14.011Z
+  speakingurl@14.0.1: 2017-08-23T06:43:02.759Z
+  stringify-entities@4.0.4: 2024-04-03T13:04:46.263Z
+  superjson@2.2.6: 2025-11-27T13:27:45.738Z
+  tabbable@6.4.0: 2025-12-31T17:29:46.264Z
+  trim-lines@3.0.1: 2022-07-03T12:54:20.493Z
+  unist-util-is@6.0.1: 2025-10-16T18:01:47.398Z
+  unist-util-position@5.0.0: 2023-07-07T09:59:34.316Z
+  unist-util-stringify-position@4.0.0: 2023-07-07T10:09:26.763Z
+  unist-util-visit-parents@6.0.2: 2025-10-16T18:20:45.045Z
+  unist-util-visit@5.1.0: 2026-01-22T19:02:58.977Z
+  vfile-message@4.0.3: 2025-07-26T15:08:12.656Z
+  vfile@6.0.3: 2024-08-27T09:12:42.377Z
+  vite@5.4.21: 2025-10-20T05:32:04.015Z
+  vitepress@1.6.4: 2025-08-05T13:40:31.197Z
+  vue@3.5.32: 2026-04-03T05:41:39.680Z
+  zwitch@2.0.4: 2022-11-16T09:09:14.038Z
+importers:
+  .:
+    dependencies:
+      '@algolia/client-search':
+        specifier: '>= 4.9.1 < 6'
+        version: 5.50.2
+      algoliasearch:
+        specifier: '>= 4.9.1 < 6'
+        version: 5.50.2
+      focus-trap:
+        specifier: ^7
+        version: 7.8.0
+      postcss:
+        specifier: ^8
+        version: 8.5.10
+      search-insights:
+        specifier: '>= 1 < 3'
+        version: 2.17.3
+      vite:
+        specifier: ^5.0.0 || ^6.0.0
+        version: 5.4.21
+      vue:
+        specifier: ^3.2.25
+        version: 3.5.32
+    devDependencies:
+      vitepress:
+        specifier: ^1.5.0
+        version: 1.6.4(postcss@8.5.10)
+packages:
+  '@algolia/abtesting@1.16.2':
+    resolution:
+      integrity: sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==
+  '@algolia/autocomplete-core@1.17.7':
+    resolution:
+      integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7':
+    resolution:
+      integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==
+    peerDependencies:
+      search-insights: '>= 1 < 3'
+  '@algolia/autocomplete-preset-algolia@1.17.7':
+    resolution:
+      integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+  '@algolia/autocomplete-shared@1.17.7':
+    resolution:
+      integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+  '@algolia/client-abtesting@5.50.2':
+    resolution:
+      integrity: sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==
+  '@algolia/client-analytics@5.50.2':
+    resolution:
+      integrity: sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==
+  '@algolia/client-common@5.50.2':
+    resolution:
+      integrity: sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==
+  '@algolia/client-insights@5.50.2':
+    resolution:
+      integrity: sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==
+  '@algolia/client-personalization@5.50.2':
+    resolution:
+      integrity: sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==
+  '@algolia/client-query-suggestions@5.50.2':
+    resolution:
+      integrity: sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==
+  '@algolia/client-search@5.50.2':
+    resolution:
+      integrity: sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==
+  '@algolia/ingestion@1.50.2':
+    resolution:
+      integrity: sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==
+  '@algolia/monitoring@1.50.2':
+    resolution:
+      integrity: sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==
+  '@algolia/recommend@5.50.2':
+    resolution:
+      integrity: sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==
+  '@algolia/requester-browser-xhr@5.50.2':
+    resolution:
+      integrity: sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==
+  '@algolia/requester-fetch@5.50.2':
+    resolution:
+      integrity: sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==
+  '@algolia/requester-node-http@5.50.2':
+    resolution:
+      integrity: sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==
+  '@babel/helper-string-parser@7.27.1':
+    resolution:
+      integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution:
+      integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+  '@babel/parser@7.29.2':
+    resolution:
+      integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
+  '@babel/types@7.29.0':
+    resolution:
+      integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
+  '@docsearch/css@3.8.2':
+    resolution:
+      integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==
+  '@docsearch/js@3.8.2':
+    resolution:
+      integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==
+  '@docsearch/react@3.8.2':
+    resolution:
+      integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==
+    peerDependencies:
+      '@types/react': '>= 16.8.0 < 19.0.0'
+      react: '>= 16.8.0 < 19.0.0'
+      react-dom: '>= 16.8.0 < 19.0.0'
+      search-insights: '>= 1 < 3'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      search-insights:
+        optional: true
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution:
+      integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+    os:
+    - darwin
+    cpu:
+    - arm64
+  '@iconify-json/simple-icons@1.2.78':
+    resolution:
+      integrity: sha512-I3lkNp0Qu7q2iZWkdcf/I2hqGhzK6qxdILh9T7XqowQrnpmG/BayDsiCf6PktDoWlW0U971xA5g+panm+NFrfQ==
+  '@iconify/types@2.0.0':
+    resolution:
+      integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution:
+      integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution:
+      integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==
+    os:
+    - darwin
+    cpu:
+    - arm64
+  '@shikijs/core@2.5.0':
+    resolution:
+      integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==
+  '@shikijs/engine-javascript@2.5.0':
+    resolution:
+      integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==
+  '@shikijs/engine-oniguruma@2.5.0':
+    resolution:
+      integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==
+  '@shikijs/langs@2.5.0':
+    resolution:
+      integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==
+  '@shikijs/themes@2.5.0':
+    resolution:
+      integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==
+  '@shikijs/transformers@2.5.0':
+    resolution:
+      integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==
+  '@shikijs/types@2.5.0':
+    resolution:
+      integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution:
+      integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==
+  '@types/estree@1.0.8':
+    resolution:
+      integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+  '@types/hast@3.0.4':
+    resolution:
+      integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
+  '@types/linkify-it@5.0.0':
+    resolution:
+      integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==
+  '@types/markdown-it@14.1.2':
+    resolution:
+      integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==
+  '@types/mdast@4.0.4':
+    resolution:
+      integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
+  '@types/mdurl@2.0.0':
+    resolution:
+      integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
+  '@types/unist@3.0.3':
+    resolution:
+      integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
+  '@types/web-bluetooth@0.0.21':
+    resolution:
+      integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==
+  '@ungap/structured-clone@1.3.0':
+    resolution:
+      integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+  '@vitejs/plugin-vue@5.2.4':
+    resolution:
+      integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+  '@vue/compiler-core@3.5.32':
+    resolution:
+      integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==
+  '@vue/compiler-dom@3.5.32':
+    resolution:
+      integrity: sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==
+  '@vue/compiler-sfc@3.5.32':
+    resolution:
+      integrity: sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==
+  '@vue/compiler-ssr@3.5.32':
+    resolution:
+      integrity: sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==
+  '@vue/devtools-api@7.7.9':
+    resolution:
+      integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==
+  '@vue/devtools-kit@7.7.9':
+    resolution:
+      integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==
+  '@vue/devtools-shared@7.7.9':
+    resolution:
+      integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==
+  '@vue/reactivity@3.5.32':
+    resolution:
+      integrity: sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==
+  '@vue/runtime-core@3.5.32':
+    resolution:
+      integrity: sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==
+  '@vue/runtime-dom@3.5.32':
+    resolution:
+      integrity: sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==
+  '@vue/server-renderer@3.5.32':
+    resolution:
+      integrity: sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==
+    peerDependencies:
+      vue: 3.5.32
+  '@vue/shared@3.5.32':
+    resolution:
+      integrity: sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==
+  '@vueuse/core@12.8.2':
+    resolution:
+      integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==
+  '@vueuse/integrations@12.8.2':
+    resolution:
+      integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==
+    peerDependencies:
+      async-validator: ^4
+      axios: ^1
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
+  '@vueuse/metadata@12.8.2':
+    resolution:
+      integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==
+  '@vueuse/shared@12.8.2':
+    resolution:
+      integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==
+  algoliasearch@5.50.2:
+    resolution:
+      integrity: sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==
+  birpc@2.9.0:
+    resolution:
+      integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==
+  ccount@2.0.1:
+    resolution:
+      integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+  character-entities-html4@2.1.0:
+    resolution:
+      integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
+  character-entities-legacy@3.0.0:
+    resolution:
+      integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
+  comma-separated-tokens@2.0.3:
+    resolution:
+      integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
+  copy-anything@4.0.5:
+    resolution:
+      integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==
+  csstype@3.2.3:
+    resolution:
+      integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
+  dequal@2.0.3:
+    resolution:
+      integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+  devlop@1.1.0:
+    resolution:
+      integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+  emoji-regex-xs@1.0.0:
+    resolution:
+      integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==
+  entities@7.0.1:
+    resolution:
+      integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
+  esbuild@0.21.5:
+    resolution:
+      integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+  estree-walker@2.0.2:
+    resolution:
+      integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+  focus-trap@7.8.0:
+    resolution:
+      integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==
+  fsevents@2.3.3:
+    resolution:
+      integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+    os:
+    - darwin
+  hast-util-to-html@9.0.5:
+    resolution:
+      integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
+  hast-util-whitespace@3.0.0:
+    resolution:
+      integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
+  hookable@5.5.3:
+    resolution:
+      integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==
+  html-void-elements@3.0.0:
+    resolution:
+      integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
+  is-what@5.5.0:
+    resolution:
+      integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==
+  magic-string@0.30.21:
+    resolution:
+      integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  mark.js@8.11.1:
+    resolution:
+      integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==
+  mdast-util-to-hast@13.2.1:
+    resolution:
+      integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==
+  micromark-util-character@2.1.1:
+    resolution:
+      integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
+  micromark-util-encode@2.0.1:
+    resolution:
+      integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
+  micromark-util-sanitize-uri@2.0.1:
+    resolution:
+      integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
+  micromark-util-symbol@2.0.1:
+    resolution:
+      integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
+  micromark-util-types@2.0.2:
+    resolution:
+      integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==
+  minisearch@7.2.0:
+    resolution:
+      integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==
+  mitt@3.0.1:
+    resolution:
+      integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+  nanoid@3.3.11:
+    resolution:
+      integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+  oniguruma-to-es@3.1.1:
+    resolution:
+      integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==
+  perfect-debounce@1.0.0:
+    resolution:
+      integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==
+  picocolors@1.1.1:
+    resolution:
+      integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+  postcss@8.5.10:
+    resolution:
+      integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
+  preact@10.29.1:
+    resolution:
+      integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==
+  property-information@7.1.0:
+    resolution:
+      integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
+  regex-recursion@6.0.2:
+    resolution:
+      integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==
+  regex-utilities@2.3.0:
+    resolution:
+      integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==
+  regex@6.1.0:
+    resolution:
+      integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==
+  rfdc@1.4.1:
+    resolution:
+      integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
+  rollup@4.60.2:
+    resolution:
+      integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==
+  search-insights@2.17.3:
+    resolution:
+      integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==
+  shiki@2.5.0:
+    resolution:
+      integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==
+  source-map-js@1.2.1:
+    resolution:
+      integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+  space-separated-tokens@2.0.2:
+    resolution:
+      integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
+  speakingurl@14.0.1:
+    resolution:
+      integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==
+  stringify-entities@4.0.4:
+    resolution:
+      integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==
+  superjson@2.2.6:
+    resolution:
+      integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==
+  tabbable@6.4.0:
+    resolution:
+      integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==
+  trim-lines@3.0.1:
+    resolution:
+      integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
+  unist-util-is@6.0.1:
+    resolution:
+      integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==
+  unist-util-position@5.0.0:
+    resolution:
+      integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==
+  unist-util-stringify-position@4.0.0:
+    resolution:
+      integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+  unist-util-visit-parents@6.0.2:
+    resolution:
+      integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==
+  unist-util-visit@5.1.0:
+    resolution:
+      integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
+  vfile-message@4.0.3:
+    resolution:
+      integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==
+  vfile@6.0.3:
+    resolution:
+      integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
+  vite@5.4.21:
+    resolution:
+      integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+  vitepress@1.6.4:
+    resolution:
+      integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==
+    peerDependencies:
+      markdown-it-mathjax3: ^4
+      postcss: ^8
+    peerDependenciesMeta:
+      markdown-it-mathjax3:
+        optional: true
+      postcss:
+        optional: true
+  vue@3.5.32:
+    resolution:
+      integrity: sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+  zwitch@2.0.4:
+    resolution:
+      integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==
+snapshots:
+  '@algolia/abtesting@1.16.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  '@algolia/autocomplete-core@1.17.7':
+    dependencies:
+      '@algolia/autocomplete-plugin-algolia-insights': 1.17.7(search-insights@2.17.3)
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
+      search-insights: 2.17.3
+  '@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
+      '@algolia/client-search': 5.50.2
+      algoliasearch: 5.50.2
+  '@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)':
+    dependencies:
+      '@algolia/client-search': 5.50.2
+      algoliasearch: 5.50.2
+  '@algolia/client-abtesting@5.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  '@algolia/client-analytics@5.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  '@algolia/client-common@5.50.2': {}
+  '@algolia/client-insights@5.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  '@algolia/client-personalization@5.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  '@algolia/client-query-suggestions@5.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  '@algolia/client-search@5.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  '@algolia/ingestion@1.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  '@algolia/monitoring@1.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  '@algolia/recommend@5.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  '@algolia/requester-browser-xhr@5.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+  '@algolia/requester-fetch@5.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+  '@algolia/requester-node-http@5.50.2':
+    dependencies:
+      '@algolia/client-common': 5.50.2
+  '@babel/helper-string-parser@7.27.1': {}
+  '@babel/helper-validator-identifier@7.28.5': {}
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+  '@docsearch/css@3.8.2': {}
+  '@docsearch/js@3.8.2':
+    dependencies:
+      '@docsearch/react': 3.8.2(search-insights@2.17.3)
+      preact: 10.29.1
+  '@docsearch/react@3.8.2(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-core': 1.17.7
+      '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
+      '@docsearch/css': 3.8.2
+      algoliasearch: 5.50.2
+      search-insights: 2.17.3
+  '@esbuild/darwin-arm64@0.21.5': {}
+  '@iconify-json/simple-icons@1.2.78':
+    dependencies:
+      '@iconify/types': 2.0.0
+  '@iconify/types@2.0.0': {}
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+  '@rollup/rollup-darwin-arm64@4.60.2': {}
+  '@shikijs/core@2.5.0':
+    dependencies:
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+  '@shikijs/engine-javascript@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 3.1.1
+  '@shikijs/engine-oniguruma@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+  '@shikijs/langs@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+  '@shikijs/themes@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+  '@shikijs/transformers@2.5.0':
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/types': 2.5.0
+  '@shikijs/types@2.5.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+  '@shikijs/vscode-textmate@10.0.2': {}
+  '@types/estree@1.0.8': {}
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+  '@types/linkify-it@5.0.0': {}
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+  '@types/mdurl@2.0.0': {}
+  '@types/unist@3.0.3': {}
+  '@types/web-bluetooth@0.0.21': {}
+  '@ungap/structured-clone@1.3.0': {}
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.32)':
+    dependencies:
+      vite: 5.4.21
+      vue: 3.5.32
+  '@vue/compiler-core@3.5.32':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/shared': 3.5.32
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+  '@vue/compiler-dom@3.5.32':
+    dependencies:
+      '@vue/compiler-core': 3.5.32
+      '@vue/shared': 3.5.32
+  '@vue/compiler-sfc@3.5.32':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/compiler-core': 3.5.32
+      '@vue/compiler-dom': 3.5.32
+      '@vue/compiler-ssr': 3.5.32
+      '@vue/shared': 3.5.32
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.10
+      source-map-js: 1.2.1
+  '@vue/compiler-ssr@3.5.32':
+    dependencies:
+      '@vue/compiler-dom': 3.5.32
+      '@vue/shared': 3.5.32
+  '@vue/devtools-api@7.7.9':
+    dependencies:
+      '@vue/devtools-kit': 7.7.9
+  '@vue/devtools-kit@7.7.9':
+    dependencies:
+      '@vue/devtools-shared': 7.7.9
+      birpc: 2.9.0
+      hookable: 5.5.3
+      mitt: 3.0.1
+      perfect-debounce: 1.0.0
+      speakingurl: 14.0.1
+      superjson: 2.2.6
+  '@vue/devtools-shared@7.7.9':
+    dependencies:
+      rfdc: 1.4.1
+  '@vue/reactivity@3.5.32':
+    dependencies:
+      '@vue/shared': 3.5.32
+  '@vue/runtime-core@3.5.32':
+    dependencies:
+      '@vue/reactivity': 3.5.32
+      '@vue/shared': 3.5.32
+  '@vue/runtime-dom@3.5.32':
+    dependencies:
+      '@vue/reactivity': 3.5.32
+      '@vue/runtime-core': 3.5.32
+      '@vue/shared': 3.5.32
+      csstype: 3.2.3
+  '@vue/server-renderer@3.5.32(vue@3.5.32)':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.32
+      '@vue/shared': 3.5.32
+      vue: 3.5.32
+  '@vue/shared@3.5.32': {}
+  '@vueuse/core@12.8.2':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 12.8.2
+      '@vueuse/shared': 12.8.2
+      vue: 3.5.32
+  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)':
+    dependencies:
+      '@vueuse/core': 12.8.2
+      '@vueuse/shared': 12.8.2
+      focus-trap: 7.8.0
+      vue: 3.5.32
+  '@vueuse/metadata@12.8.2': {}
+  '@vueuse/shared@12.8.2':
+    dependencies:
+      vue: 3.5.32
+  algoliasearch@5.50.2:
+    dependencies:
+      '@algolia/abtesting': 1.16.2
+      '@algolia/client-abtesting': 5.50.2
+      '@algolia/client-analytics': 5.50.2
+      '@algolia/client-common': 5.50.2
+      '@algolia/client-insights': 5.50.2
+      '@algolia/client-personalization': 5.50.2
+      '@algolia/client-query-suggestions': 5.50.2
+      '@algolia/client-search': 5.50.2
+      '@algolia/ingestion': 1.50.2
+      '@algolia/monitoring': 1.50.2
+      '@algolia/recommend': 5.50.2
+      '@algolia/requester-browser-xhr': 5.50.2
+      '@algolia/requester-fetch': 5.50.2
+      '@algolia/requester-node-http': 5.50.2
+  birpc@2.9.0: {}
+  ccount@2.0.1: {}
+  character-entities-html4@2.1.0: {}
+  character-entities-legacy@3.0.0: {}
+  comma-separated-tokens@2.0.3: {}
+  copy-anything@4.0.5:
+    dependencies:
+      is-what: 5.5.0
+  csstype@3.2.3: {}
+  dequal@2.0.3: {}
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+  emoji-regex-xs@1.0.0: {}
+  entities@7.0.1: {}
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/darwin-arm64': 0.21.5
+  estree-walker@2.0.2: {}
+  focus-trap@7.8.0:
+    dependencies:
+      tabbable: 6.4.0
+  fsevents@2.3.3: {}
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+  hookable@5.5.3: {}
+  html-void-elements@3.0.0: {}
+  is-what@5.5.0: {}
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+  mark.js@8.11.1: {}
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+  micromark-util-encode@2.0.1: {}
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+  micromark-util-symbol@2.0.1: {}
+  micromark-util-types@2.0.2: {}
+  minisearch@7.2.0: {}
+  mitt@3.0.1: {}
+  nanoid@3.3.11: {}
+  oniguruma-to-es@3.1.1:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+  perfect-debounce@1.0.0: {}
+  picocolors@1.1.1: {}
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+  preact@10.29.1: {}
+  property-information@7.1.0: {}
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+  regex-utilities@2.3.0: {}
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+  rfdc@1.4.1: {}
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      fsevents: 2.3.3
+  search-insights@2.17.3: {}
+  shiki@2.5.0:
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/langs': 2.5.0
+      '@shikijs/themes': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+  source-map-js@1.2.1: {}
+  space-separated-tokens@2.0.2: {}
+  speakingurl@14.0.1: {}
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.0.5
+  tabbable@6.4.0: {}
+  trim-lines@3.0.1: {}
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+  vite@5.4.21:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      fsevents: 2.3.3
+  vitepress@1.6.4(postcss@8.5.10):
+    dependencies:
+      '@docsearch/css': 3.8.2
+      '@docsearch/js': 3.8.2
+      '@iconify-json/simple-icons': 1.2.78
+      '@shikijs/core': 2.5.0
+      '@shikijs/transformers': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@types/markdown-it': 14.1.2
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21)(vue@3.5.32)
+      '@vue/devtools-api': 7.7.9
+      '@vue/shared': 3.5.32
+      '@vueuse/core': 12.8.2
+      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)
+      focus-trap: 7.8.0
+      mark.js: 8.11.1
+      minisearch: 7.2.0
+      postcss: 8.5.10
+      shiki: 2.5.0
+      vite: 5.4.21
+      vue: 3.5.32
+  vue@3.5.32:
+    dependencies:
+      '@vue/compiler-dom': 3.5.32
+      '@vue/compiler-sfc': 3.5.32
+      '@vue/runtime-dom': 3.5.32
+      '@vue/server-renderer': 3.5.32(vue@3.5.32)
+      '@vue/shared': 3.5.32
+  zwitch@2.0.4: {}

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,6 +5,13 @@
     "docs:build": "npm run settings:gen && vitepress build",
     "docs:preview": "vitepress preview"
   },
+  "pnpm": {
+    "supportedArchitectures": {
+      "os": ["current", "linux"],
+      "cpu": ["current", "x64"],
+      "libc": ["current", "glibc"]
+    }
+  },
   "devDependencies": {
     "vitepress": "^1.5.0"
   }

--- a/mise.lock
+++ b/mise.lock
@@ -39,6 +39,38 @@ checksum = "sha256:6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_windows_amd64.zip"
 provenance = "github-attestations"
 
+[[tools.cargo-binstall]]
+version = "1.18.1"
+backend = "aqua:cargo-bins/cargo-binstall"
+
+[tools.cargo-binstall."platforms.linux-arm64"]
+checksum = "sha256:c55962a0115f9716b709216de7f8bdd59d6ba8738779e60b051b4593f677717a"
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-unknown-linux-musl.tgz"
+
+[tools.cargo-binstall."platforms.linux-arm64-musl"]
+checksum = "sha256:c55962a0115f9716b709216de7f8bdd59d6ba8738779e60b051b4593f677717a"
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-unknown-linux-musl.tgz"
+
+[tools.cargo-binstall."platforms.linux-x64"]
+checksum = "sha256:cf2a4b54494ea8555d6349685e9a301efc1051d9fba6308c76914b2486f8700f"
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-unknown-linux-musl.tgz"
+
+[tools.cargo-binstall."platforms.linux-x64-musl"]
+checksum = "sha256:cf2a4b54494ea8555d6349685e9a301efc1051d9fba6308c76914b2486f8700f"
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-unknown-linux-musl.tgz"
+
+[tools.cargo-binstall."platforms.macos-arm64"]
+checksum = "sha256:955abf167994c90f3547e233edace4c0f794465dd4aa408249b38999aa5ca3cf"
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-apple-darwin.zip"
+
+[tools.cargo-binstall."platforms.macos-x64"]
+checksum = "sha256:e06370bec7143668653bb7c09d0b8b689fc703dd4fa58ec5847c4b571d8a490d"
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-apple-darwin.zip"
+
+[tools.cargo-binstall."platforms.windows-x64"]
+checksum = "sha256:89706aa5215c164d8d091597a470fee72308ac87e8553af395ea77db844a888c"
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-pc-windows-msvc.zip"
+
 [[tools."github:bnjbvr/cargo-machete"]]
 version = "0.9.2"
 backend = "github:bnjbvr/cargo-machete"

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ _.path = ["./bin"]
 
 [tools]
 actionlint = "latest"
+cargo-binstall = "latest"
 "github:bnjbvr/cargo-machete" = "latest"
 "github:foresterre/cargo-msrv" = "latest"
 hk = "latest"


### PR DESCRIPTION
## Summary

- move `ignoredOptionalDependencies` serialization after `packages` so pnpm-lock.yaml section order matches pnpm output
- add a regression test that checks the relative pnpm section order
- add and track the docs `aube-lock.yaml` so CI/docs installs use the committed dependency graph
- declare docs `pnpm.supportedArchitectures` for current local installs plus Linux x64/glibc CI, so Rollup and esbuild native optional packages are present in the lockfile
- add `cargo-binstall` to the mise toolchain so lint tools can install reliably in CI

## Validation

- `cargo fmt --check`
- `cargo test -p aube-lockfile`
- `mise run lint`
- `cargo build`
- `cd docs && ../target/debug/aube install --lockfile-only --force`
- `cd docs && ../target/debug/aube install --frozen-lockfile && ../target/debug/aube run docs:build`

## Notes

I checked the lockfile section order against locally generated `pnpm 10.33.0` lockfiles; pnpm emits `ignoredOptionalDependencies` between `packages` and `snapshots`.

The docs lockfile is now intentionally tracked. The Linux docs build needs the Rollup native package `@rollup/rollup-linux-x64-gnu`, so `docs/package.json` widens `pnpm.supportedArchitectures` before regenerating the lockfile.