### PR TITLE
registry: tolerate object-valued dep-map entries in packuments

### DIFF
--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -48,7 +48,7 @@ where
 /// when the user's range doesn't select it. Drop the unparseable
 /// entries so the resolver sees the same shape npmjs would have served
 /// for a modern publish. pnpm and bun behave the same way.
-fn null_tolerant_string_map<'de, D>(de: D) -> Result<BTreeMap<String, String>, D::Error>
+fn non_string_tolerant_map<'de, D>(de: D) -> Result<BTreeMap<String, String>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -101,7 +101,7 @@ pub struct Packument {
     #[serde(
         rename = "dist-tags",
         default,
-        deserialize_with = "null_tolerant_string_map"
+        deserialize_with = "non_string_tolerant_map"
     )]
     pub dist_tags: BTreeMap<String, String>,
     /// Per-version publish timestamps (ISO-8601). Populated
@@ -112,7 +112,7 @@ pub struct Packument {
     /// resolver round-trips it into the lockfile's top-level `time:`
     /// block — matching pnpm's `publishedAt` wiring — and, in
     /// time-based mode, uses it to derive the publish-date cutoff.
-    #[serde(default, deserialize_with = "null_tolerant_string_map")]
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
     pub time: BTreeMap<String, String>,
 }
 
@@ -122,15 +122,15 @@ pub struct Packument {
 pub struct VersionMetadata {
     pub name: String,
     pub version: String,
-    #[serde(default, deserialize_with = "null_tolerant_string_map")]
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
     pub dependencies: BTreeMap<String, String>,
-    #[serde(default, deserialize_with = "null_tolerant_string_map")]
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
     pub dev_dependencies: BTreeMap<String, String>,
-    #[serde(default, deserialize_with = "null_tolerant_string_map")]
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
     pub peer_dependencies: BTreeMap<String, String>,
     #[serde(default)]
     pub peer_dependencies_meta: BTreeMap<String, PeerDepMeta>,
-    #[serde(default, deserialize_with = "null_tolerant_string_map")]
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
     pub optional_dependencies: BTreeMap<String, String>,
     /// `bundledDependencies` from the packument. Either a list of dep
     /// names or `true` (meaning "bundle every `dependencies` entry").

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -24,28 +24,42 @@ where
     })
 }
 
-/// Deserialize a `BTreeMap<String, String>` tolerant to `null` — both at
-/// the whole-map level (`"dist-tags": null` → empty map) and at the
-/// value level (`{"latest": null}` → entry dropped).
+/// Deserialize a `BTreeMap<String, String>` tolerant to any non-string
+/// value — both at the whole-map level (`"dist-tags": null` → empty
+/// map) and at the value level (`{"latest": null}` or
+/// `{"vows": {"version": "0.6.4", ...}}` → entry dropped).
 ///
-/// Some registry proxies (notably JFrog Artifactory's npm remote) emit
-/// `null` in places where npmjs.org always emits a string: stripped /
-/// tombstoned `dist-tags` values, per-version `time` entries for
-/// deleted versions, or dep-map entries that were redacted by a
-/// mirroring filter. The strict `BTreeMap<String, String>` shape would
-/// fail these with `invalid type: null, expected a string`, blocking
-/// the whole install even though the null is semantically "not
-/// present." Drop those entries so the resolver sees the same shape it
-/// would have seen from npmjs.
+/// Two real-world sources of non-string values:
+///
+/// 1. Registry proxies (notably JFrog Artifactory's npm remote) emit
+///    `null` in places where npmjs.org always emits a string: stripped
+///    / tombstoned `dist-tags` values, per-version `time` entries for
+///    deleted versions, or dep-map entries that were redacted by a
+///    mirroring filter.
+/// 2. Ancient publishes — some packages from the 2012–2013 era
+///    (`deep-diff@0.1.0`, for example) have `devDependencies` entries
+///    shaped like `{"version": "0.6.4", "dependencies": {...}}`
+///    instead of a plain version string, because an old npm client
+///    serialized a resolved tree into the manifest.
+///
+/// A strict `BTreeMap<String, String>` shape would fail these with
+/// `invalid type: ..., expected a string`, blocking an install of any
+/// package whose packument merely *lists* an affected version — even
+/// when the user's range doesn't select it. Drop the unparseable
+/// entries so the resolver sees the same shape npmjs would have served
+/// for a modern publish. pnpm and bun behave the same way.
 fn null_tolerant_string_map<'de, D>(de: D) -> Result<BTreeMap<String, String>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let maybe: Option<BTreeMap<String, Option<String>>> = Option::deserialize(de)?;
+    let maybe: Option<BTreeMap<String, serde_json::Value>> = Option::deserialize(de)?;
     Ok(maybe
         .unwrap_or_default()
         .into_iter()
-        .filter_map(|(k, v)| v.map(|s| (k, s)))
+        .filter_map(|(k, v)| match v {
+            serde_json::Value::String(s) => Some((k, s)),
+            _ => None,
+        })
         .collect())
 }
 
@@ -259,6 +273,29 @@ mod tests {
         assert_eq!(v.dev_dependencies.len(), 1);
         assert_eq!(v.peer_dependencies.len(), 1);
         assert_eq!(v.optional_dependencies.len(), 1);
+    }
+
+    /// Ancient publishes (e.g. `deep-diff@0.1.0`, published 2013) have
+    /// dep-map entries where the value is an object
+    /// (`{"version": "0.6.4", "dependencies": {...}}`) rather than a
+    /// version string. That shape would fail a strict string-valued
+    /// map — drop those entries, same as null ones, so the packument
+    /// still parses and unaffected versions stay resolvable.
+    #[test]
+    fn dependency_maps_drop_object_valued_entries() {
+        let v = parse(
+            r#"{
+                "name": "deep-diff",
+                "version": "0.1.0",
+                "devDependencies": {
+                    "vows": {"version": "0.6.4", "dependencies": {"diff": {"version": "1.0.4"}}},
+                    "extend": {"version": "1.1.1"},
+                    "lodash": "0.9.2"
+                }
+            }"#,
+        );
+        assert_eq!(v.dev_dependencies.len(), 1);
+        assert_eq!(v.dev_dependencies["lodash"], "0.9.2");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix `aube install deep-diff@^0.3.5` (and any range that merely *lists* an affected ancient version) crashing with a packument parse error.

## Root cause

`deep-diff@0.1.0` (published 2013) has `devDependencies.vows` shaped like `{"version": "0.6.4", "dependencies": {...}}` — an old npm client serialized a resolved tree into the manifest instead of writing a plain version string. Our registry parser had `dev_dependencies: BTreeMap<String, String>` and bailed on the whole packument with `invalid type: map, expected a string`, so we couldn't resolve *any* version of `deep-diff`, even though the range the user asked for doesn't include `0.1.0`.

## Fix

Extend `null_tolerant_string_map` to drop **any** non-string value (not just `null`), and rebrand it from "null-tolerant" to "tolerates non-string entries" in the doc comment. pnpm and bun handle this the same way. Added a regression test covering the deep-diff shape (`{version, dependencies}`) alongside the existing null-entry test.

## Test plan

- [x] `cargo test -p aube-registry` — new `dependency_maps_drop_object_valued_entries` test passes, existing tests unchanged
- [x] `cargo clippy -p aube-registry --all-targets -- -D warnings` — clean
- [ ] Reviewer: sanity-check that the other `null_tolerant_string_map` call sites (`dist-tags`, `time`) still behave correctly — in practice both are always string-valued in real packuments, so widening from `Option<String>` to `Value` is a superset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: parsing is widened to ignore malformed/non-string map values, which may silently drop unexpected entries but only affects metadata deserialization (no auth/data writes).
> 
> **Overview**
> Improves packument parsing robustness by changing the string map deserializer to **drop any non-string values** (not just `null`) across `dist-tags`, `time`, and all dependency maps.
> 
> Adds a regression test covering ancient npm publishes where dependency entries are objects (e.g. `deep-diff@0.1.0`), ensuring installs don’t fail due to unparseable entries in unused versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0eb778d39527c84f4fc6cc4d88ca30bf5bebf90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->