### PR TITLE
resolver: widen aube-lock.yaml to every common platform

### DIFF
--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -180,6 +180,14 @@ pub struct ResolvedPackage {
     /// fetchers short-circuit the tarball path and materialize from
     /// disk instead.
     pub local_source: Option<LocalSource>,
+    /// npm `os`/`cpu`/`libc` arrays straight from the packument (or
+    /// lockfile) — carried so the streaming fetch coordinator can skip
+    /// tarball downloads for optional natives that won't install on the
+    /// host, even when the resolver's graph filter was widened to keep
+    /// those entries in the lockfile for other platforms.
+    pub os: Vec<String>,
+    pub cpu: Vec<String>,
+    pub libc: Vec<String>,
 }
 
 impl ResolvedPackage {
@@ -1338,6 +1346,12 @@ impl Resolver {
                                 // not the `npm:` rewrite.
                                 alias_of: None,
                                 local_source: Some(local.clone()),
+                                // Local `file:`/`link:` packages never
+                                // carry npm-style platform constraints —
+                                // they're whatever the user points at.
+                                os: Vec::new(),
+                                cpu: Vec::new(),
+                                libc: Vec::new(),
                             });
                         }
                         // Enqueue transitive deps of the local package
@@ -1547,6 +1561,9 @@ impl Resolver {
                                     // real registry name.
                                     alias_of: locked_pkg.alias_of.clone(),
                                     local_source: locked_pkg.local_source.clone(),
+                                    os: locked_pkg.os.clone(),
+                                    cpu: locked_pkg.cpu.clone(),
+                                    libc: locked_pkg.libc.clone(),
                                 });
                             }
 
@@ -1973,6 +1990,9 @@ impl Resolver {
                         tarball_url: tarball_url.clone(),
                         alias_of: task.real_name.clone(),
                         local_source: None,
+                        os: version_meta.os.clone(),
+                        cpu: version_meta.cpu.clone(),
+                        libc: version_meta.libc.clone(),
                     });
                 }
 

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -180,6 +180,16 @@ pub struct ResolvedPackage {
     /// fetchers short-circuit the tarball path and materialize from
     /// disk instead.
     pub local_source: Option<LocalSource>,
+    /// npm `os`/`cpu`/`libc` arrays straight from the packument (or
+    /// lockfile). The streaming fetch coordinator uses them to defer
+    /// tarball downloads for optional natives that won't install on
+    /// the host — a post-resolve catch-up pass after `filter_graph`
+    /// fetches anything that survived the graph trim but got deferred,
+    /// so required-platform-mismatched packages (which `filter_graph`
+    /// doesn't drop) still get their tarball before link.
+    pub os: Vec<String>,
+    pub cpu: Vec<String>,
+    pub libc: Vec<String>,
 }
 
 impl ResolvedPackage {
@@ -1338,6 +1348,14 @@ impl Resolver {
                                 // not the `npm:` rewrite.
                                 alias_of: None,
                                 local_source: Some(local.clone()),
+                                // Local `file:`/`link:` packages never
+                                // carry npm-style platform constraints
+                                // — they're whatever the user points
+                                // at, so the fetch coordinator treats
+                                // them as unconstrained (always fetch).
+                                os: Vec::new(),
+                                cpu: Vec::new(),
+                                libc: Vec::new(),
                             });
                         }
                         // Enqueue transitive deps of the local package
@@ -1547,6 +1565,9 @@ impl Resolver {
                                     // real registry name.
                                     alias_of: locked_pkg.alias_of.clone(),
                                     local_source: locked_pkg.local_source.clone(),
+                                    os: locked_pkg.os.clone(),
+                                    cpu: locked_pkg.cpu.clone(),
+                                    libc: locked_pkg.libc.clone(),
                                 });
                             }
 
@@ -1973,6 +1994,9 @@ impl Resolver {
                         tarball_url: tarball_url.clone(),
                         alias_of: task.real_name.clone(),
                         local_source: None,
+                        os: version_meta.os.clone(),
+                        cpu: version_meta.cpu.clone(),
+                        libc: version_meta.libc.clone(),
                     });
                 }
 

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -180,14 +180,6 @@ pub struct ResolvedPackage {
     /// fetchers short-circuit the tarball path and materialize from
     /// disk instead.
     pub local_source: Option<LocalSource>,
-    /// npm `os`/`cpu`/`libc` arrays straight from the packument (or
-    /// lockfile) — carried so the streaming fetch coordinator can skip
-    /// tarball downloads for optional natives that won't install on the
-    /// host, even when the resolver's graph filter was widened to keep
-    /// those entries in the lockfile for other platforms.
-    pub os: Vec<String>,
-    pub cpu: Vec<String>,
-    pub libc: Vec<String>,
 }
 
 impl ResolvedPackage {
@@ -1346,12 +1338,6 @@ impl Resolver {
                                 // not the `npm:` rewrite.
                                 alias_of: None,
                                 local_source: Some(local.clone()),
-                                // Local `file:`/`link:` packages never
-                                // carry npm-style platform constraints —
-                                // they're whatever the user points at.
-                                os: Vec::new(),
-                                cpu: Vec::new(),
-                                libc: Vec::new(),
                             });
                         }
                         // Enqueue transitive deps of the local package
@@ -1561,9 +1547,6 @@ impl Resolver {
                                     // real registry name.
                                     alias_of: locked_pkg.alias_of.clone(),
                                     local_source: locked_pkg.local_source.clone(),
-                                    os: locked_pkg.os.clone(),
-                                    cpu: locked_pkg.cpu.clone(),
-                                    libc: locked_pkg.libc.clone(),
                                 });
                             }
 
@@ -1990,9 +1973,6 @@ impl Resolver {
                         tarball_url: tarball_url.clone(),
                         alias_of: task.real_name.clone(),
                         local_source: None,
-                        os: version_meta.os.clone(),
-                        cpu: version_meta.cpu.clone(),
-                        libc: version_meta.libc.clone(),
                     });
                 }
 

--- a/crates/aube-resolver/src/platform.rs
+++ b/crates/aube-resolver/src/platform.rs
@@ -52,13 +52,18 @@ impl SupportedArchitectures {
     /// / yarn / npm outputs stay host-only (pnpm parity) so we don't
     /// silently change the shape of a non-native lockfile.
     ///
-    /// darwin-x64 is intentionally omitted: Apple Silicon is the
+    /// darwin-x64 is not in the baseline matrix: Apple Silicon is the
     /// shipping Mac platform, and several major native package
-    /// ecosystems (sharp, swc) have already dropped Intel Mac binaries.
-    /// A user still on an Intel Mac can add `"x64"` back via
-    /// `pnpm.supportedArchitectures.cpu`.
+    /// ecosystems (sharp, swc) have already dropped Intel Mac binaries,
+    /// so an Apple Silicon developer's lockfile doesn't need to bake in
+    /// Intel Mac natives for other contributors. The host's own triple
+    /// is always added to the set, though — an Intel Mac user installing
+    /// on that same machine gets darwin-x64 natives because the host
+    /// triple joins the matrix here. Exotic hosts (freebsd, ppc64, …)
+    /// get the same treatment: their native deps still install for the
+    /// user, and the wide matrix covers everyone else.
     pub fn aube_lock_default() -> Self {
-        let combos = vec![
+        let mut combos = vec![
             ("darwin".to_string(), "arm64".to_string(), String::new()),
             ("linux".to_string(), "x64".to_string(), "glibc".to_string()),
             ("linux".to_string(), "x64".to_string(), "musl".to_string()),
@@ -71,6 +76,17 @@ impl SupportedArchitectures {
             ("win32".to_string(), "x64".to_string(), String::new()),
             ("win32".to_string(), "arm64".to_string(), String::new()),
         ];
+        // Ensure the host's own triple is always included. Without this
+        // step an Intel Mac user (darwin-x64) would silently lose their
+        // own native optional deps — the cross-platform widening dropped
+        // them from the matrix, and the post-resolve `filter_graph` can't
+        // bring back packages that never entered the graph in the first
+        // place.
+        let host = host_triple();
+        let host_triple_owned = (host.0.to_string(), host.1.to_string(), host.2.to_string());
+        if !combos.contains(&host_triple_owned) {
+            combos.push(host_triple_owned);
+        }
         Self {
             os: Vec::new(),
             cpu: Vec::new(),
@@ -361,17 +377,32 @@ mod tests {
     }
 
     #[test]
-    fn aube_lock_default_excludes_darwin_x64_and_exotic_triples() {
-        // Intel Mac binaries are intentionally out of the default
-        // matrix: Apple Silicon is the shipping Mac platform, and
-        // several major native ecosystems (sharp, swc) have dropped
-        // darwin-x64 outright. Users still on Intel Macs can widen with
-        // `pnpm.supportedArchitectures.cpu: ["current", "x64"]`.
+    fn aube_lock_default_always_accepts_host_triple() {
+        // The wide matrix excludes darwin-x64 by design (see
+        // `aube_lock_default`'s doc), but the host's own triple is
+        // unconditionally added to the set. An Intel Mac or a freebsd
+        // box that runs `aube install` must still get its own native
+        // optional deps, regardless of which combinations the baseline
+        // matrix covers.
         let sup = SupportedArchitectures::aube_lock_default();
-        assert!(!is_supported(&s(&["darwin"]), &s(&["x64"]), &[], &sup));
-        // Exotic triples (freebsd, ppc64, …) aren't in the default set
-        // either — users with those targets still need to opt in.
-        assert!(!is_supported(&s(&["freebsd"]), &s(&["x64"]), &[], &sup));
+        let (os, cpu, libc) = host_triple();
+        let pkg_libc = if libc.is_empty() { vec![] } else { s(&[libc]) };
+        assert!(is_supported(&s(&[os]), &s(&[cpu]), &pkg_libc, &sup));
+    }
+
+    #[test]
+    fn aube_lock_default_rejects_exotic_non_host_triples() {
+        // Exotic triples the host isn't running as (openbsd, ppc64, …)
+        // stay out of the default set — users targeting them still need
+        // to opt in via `pnpm.supportedArchitectures`.
+        let sup = SupportedArchitectures::aube_lock_default();
+        let (os, _, _) = host_triple();
+        if os != "openbsd" {
+            assert!(!is_supported(&s(&["openbsd"]), &s(&["x64"]), &[], &sup));
+        }
+        if os != "aix" {
+            assert!(!is_supported(&s(&["aix"]), &s(&["ppc64"]), &[], &sup));
+        }
     }
 
     #[test]

--- a/crates/aube-resolver/src/platform.rs
+++ b/crates/aube-resolver/src/platform.rs
@@ -25,18 +25,67 @@
 /// literal `"current"` inside any array expands to the same host value
 /// so users can write `["current", "linux"]` to keep their native
 /// platform *and* also resolve optionals for Linux.
+///
+/// `explicit_combinations` sidesteps the cartesian expansion entirely —
+/// [`aube_lock_default`] uses it to emit a hand-picked matrix that
+/// drops rare combinations (darwin-x64) without shrinking the OS / CPU
+/// lists a user might inspect.
 #[derive(Debug, Clone, Default)]
 pub struct SupportedArchitectures {
     pub os: Vec<String>,
     pub cpu: Vec<String>,
     pub libc: Vec<String>,
+    /// When `Some`, `combinations()` returns these triples verbatim
+    /// instead of computing `os` × `cpu` × `libc`. Lets a preset prune
+    /// individual (os, cpu, libc) combinations the cartesian product
+    /// would otherwise include.
+    pub explicit_combinations: Option<Vec<(String, String, String)>>,
 }
 
 impl SupportedArchitectures {
+    /// Wide default used when resolving into `aube-lock.yaml` with no
+    /// user-declared `pnpm.supportedArchitectures`. Covers the common
+    /// npm OS / CPU / libc combinations so optional native deps for
+    /// every major platform land in the lockfile on a first resolve —
+    /// a project resolved on macOS installs correctly on Linux CI
+    /// without the user having to hand-edit their manifest. pnpm-lock
+    /// / yarn / npm outputs stay host-only (pnpm parity) so we don't
+    /// silently change the shape of a non-native lockfile.
+    ///
+    /// darwin-x64 is intentionally omitted: Apple Silicon is the
+    /// shipping Mac platform, and several major native package
+    /// ecosystems (sharp, swc) have already dropped Intel Mac binaries.
+    /// A user still on an Intel Mac can add `"x64"` back via
+    /// `pnpm.supportedArchitectures.cpu`.
+    pub fn aube_lock_default() -> Self {
+        let combos = vec![
+            ("darwin".to_string(), "arm64".to_string(), String::new()),
+            ("linux".to_string(), "x64".to_string(), "glibc".to_string()),
+            ("linux".to_string(), "x64".to_string(), "musl".to_string()),
+            (
+                "linux".to_string(),
+                "arm64".to_string(),
+                "glibc".to_string(),
+            ),
+            ("linux".to_string(), "arm64".to_string(), "musl".to_string()),
+            ("win32".to_string(), "x64".to_string(), String::new()),
+            ("win32".to_string(), "arm64".to_string(), String::new()),
+        ];
+        Self {
+            os: Vec::new(),
+            cpu: Vec::new(),
+            libc: Vec::new(),
+            explicit_combinations: Some(combos),
+        }
+    }
+
     /// Expand any `"current"` entries to the host triple and default
     /// empty arrays to `[host]`. The result is a non-empty list of
     /// (os, cpu, libc) combinations the caller can test against.
     fn combinations(&self) -> Vec<(String, String, String)> {
+        if let Some(ref explicit) = self.explicit_combinations {
+            return explicit.clone();
+        }
         let host = host_triple();
         let expand = |field: &[String], host_val: &str| -> Vec<String> {
             if field.is_empty() {
@@ -288,11 +337,49 @@ mod tests {
     }
 
     #[test]
+    fn aube_lock_default_accepts_every_common_native() {
+        // A first-time `aube install` run on macOS must still pull the
+        // Linux / Windows native variants into `aube-lock.yaml` so the
+        // committed lockfile installs cleanly on CI — that's the whole
+        // point of the wide default.
+        let sup = SupportedArchitectures::aube_lock_default();
+        assert!(is_supported(&s(&["darwin"]), &s(&["arm64"]), &[], &sup));
+        assert!(is_supported(
+            &s(&["linux"]),
+            &s(&["x64"]),
+            &s(&["glibc"]),
+            &sup
+        ));
+        assert!(is_supported(
+            &s(&["linux"]),
+            &s(&["arm64"]),
+            &s(&["musl"]),
+            &sup
+        ));
+        assert!(is_supported(&s(&["win32"]), &s(&["x64"]), &[], &sup));
+        assert!(is_supported(&s(&["win32"]), &s(&["arm64"]), &[], &sup));
+    }
+
+    #[test]
+    fn aube_lock_default_excludes_darwin_x64_and_exotic_triples() {
+        // Intel Mac binaries are intentionally out of the default
+        // matrix: Apple Silicon is the shipping Mac platform, and
+        // several major native ecosystems (sharp, swc) have dropped
+        // darwin-x64 outright. Users still on Intel Macs can widen with
+        // `pnpm.supportedArchitectures.cpu: ["current", "x64"]`.
+        let sup = SupportedArchitectures::aube_lock_default();
+        assert!(!is_supported(&s(&["darwin"]), &s(&["x64"]), &[], &sup));
+        // Exotic triples (freebsd, ppc64, …) aren't in the default set
+        // either — users with those targets still need to opt in.
+        assert!(!is_supported(&s(&["freebsd"]), &s(&["x64"]), &[], &sup));
+    }
+
+    #[test]
     fn filter_graph_prunes_transitive_optional_platform_mismatches() {
         let supported = SupportedArchitectures {
             os: s(&["darwin"]),
             cpu: s(&["arm64"]),
-            libc: vec![],
+            ..Default::default()
         };
         let mut graph = aube_lockfile::LockfileGraph::default();
         graph.importers.insert(

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2469,28 +2469,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let fetch_verify_integrity = verify_store_integrity_setting;
             let fetch_strict_pkg_content_check = strict_store_pkg_content_check_setting;
             let fetch_git_shallow_hosts = resolve_git_shallow_hosts(&settings_ctx);
-            // Host-side platform filter for the streaming fetch. The
-            // resolver widens its graph filter for aube-lock.yaml so the
-            // committed lockfile carries native optionals for every
-            // common platform, but that widening must NOT make us
-            // download foreign-platform tarballs — after resolve the
-            // `filter_graph` pass trims the graph back to the host and
-            // the linker never looks at those packages. Matches the
-            // same narrow set the post-resolve `filter_graph` call
-            // below runs against, so a package we skip here is exactly
-            // a package the linker would have dropped anyway.
-            let (fetch_sup_os, fetch_sup_cpu, fetch_sup_libc) =
-                manifest.pnpm_supported_architectures();
-            let fetch_supported_arch = aube_resolver::SupportedArchitectures {
-                os: fetch_sup_os,
-                cpu: fetch_sup_cpu,
-                libc: fetch_sup_libc,
-                ..Default::default()
-            };
-            let fetch_ignored_optional: std::collections::BTreeSet<String> = manifest
-                .pnpm_ignored_optional_dependencies()
-                .into_iter()
-                .collect();
             // Channel for pipelining GVS population into the fetch
             // stream: each imported (dep_path, index) is forwarded to a
             // materializer task that runs concurrently with the rest of
@@ -2506,34 +2484,18 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 let mut cached_count = 0usize;
 
                 while let Some(pkg) = resolved_rx.recv().await {
-                    // Skip tarball downloads for packages the linker
-                    // will throw away at filter_graph time. Registry
-                    // packages carrying platform constraints that don't
-                    // match the host fall into this bucket whenever the
-                    // resolver was widened for aube-lock.yaml; local
-                    // `file:`/`link:` deps carry empty os/cpu/libc so
-                    // they always pass. A name in `ignoredOptionalDependencies`
-                    // is likewise never linked. Skipping here keeps the
-                    // progress totals honest (no `inc_total` bump) and
-                    // avoids materializing tarballs the linker will
-                    // never look at.
-                    if pkg.local_source.is_none()
-                        && (fetch_ignored_optional.contains(&pkg.name)
-                            || !aube_resolver::is_supported(
-                                &pkg.os,
-                                &pkg.cpu,
-                                &pkg.libc,
-                                &fetch_supported_arch,
-                            ))
-                    {
-                        tracing::debug!(
-                            "skipping tarball fetch for {}@{}: platform/ignored — filter_graph will drop it before link",
-                            pkg.name,
-                            pkg.version
-                        );
-                        continue;
-                    }
-
+                    // The fetch coordinator deliberately does NOT skip
+                    // platform-mismatched packages: `filter_graph` below
+                    // only prunes optional edges, so a required dep
+                    // with platform constraints (rare, e.g. a broken
+                    // package missing an optional-marker) stays in the
+                    // graph and still needs a store index. A fetch-time
+                    // filter would cost nothing for optionals (win) but
+                    // silently break the required case (link-time
+                    // "missing index" error). When aube-lock widening
+                    // pulls in foreign-platform natives, those tarballs
+                    // land in the CAS but never make it into
+                    // `node_modules` — over-fetch, not over-link.
                     // Each resolved package bumps the overall denominator by
                     // one. Cached packages are immediately credited against
                     // the numerator; missing ones get a transient child row.

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2097,7 +2097,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 settings_ctx: &settings_ctx,
                 workspace_catalogs: &workspace_catalogs,
                 opts: &opts,
-                target_lockfile_kind: source_kind_before,
+                // `lockfile=false` collapses to `None` so the resolver
+                // doesn't waste a fetch widening a lockfile that will
+                // never be written. With lockfiles enabled, a missing
+                // `source_kind_before` means "we'll create the default
+                // aube-lock.yaml", so the aube-native wide default
+                // applies.
+                target_lockfile_kind: lockfile_enabled
+                    .then(|| source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube)),
             },
             read_package_hook,
         );
@@ -2433,7 +2440,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     settings_ctx: &settings_ctx,
                     workspace_catalogs: &workspace_catalogs,
                     opts: &opts,
-                    target_lockfile_kind: source_kind_before,
+                    // Same disambiguation as the `--lockfile-only` path:
+                    // `None` only when no lockfile will be written, so
+                    // widening to every common platform doesn't happen
+                    // just to be discarded.
+                    target_lockfile_kind: lockfile_enabled
+                        .then(|| source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube)),
                 },
                 read_package_hook,
             );

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2469,6 +2469,27 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let fetch_verify_integrity = verify_store_integrity_setting;
             let fetch_strict_pkg_content_check = strict_store_pkg_content_check_setting;
             let fetch_git_shallow_hosts = resolve_git_shallow_hosts(&settings_ctx);
+            // Host-side platform filter for the streaming fetch. The
+            // resolver widens its graph filter for aube-lock.yaml so
+            // the committed lockfile carries native optionals for every
+            // common platform, but that widening mustn't make us
+            // download every foreign-platform tarball up front — most
+            // of them will disappear when `filter_graph` trims optional
+            // edges below, and only a vanishingly rare broken-package
+            // shape (required dep with platform constraints) actually
+            // needs the fetch. A post-resolve catch-up pass picks up
+            // those stragglers from the finalized graph; here we just
+            // defer. `filter_graph` keys off the same narrow manifest
+            // set, so a deferred package that survives the trim is
+            // exactly one the catch-up must fetch.
+            let (fetch_sup_os, fetch_sup_cpu, fetch_sup_libc) =
+                manifest.pnpm_supported_architectures();
+            let fetch_supported_arch = aube_resolver::SupportedArchitectures {
+                os: fetch_sup_os,
+                cpu: fetch_sup_cpu,
+                libc: fetch_sup_libc,
+                ..Default::default()
+            };
             // Channel for pipelining GVS population into the fetch
             // stream: each imported (dep_path, index) is forwarded to a
             // materializer task that runs concurrently with the rest of
@@ -2484,18 +2505,30 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 let mut cached_count = 0usize;
 
                 while let Some(pkg) = resolved_rx.recv().await {
-                    // The fetch coordinator deliberately does NOT skip
-                    // platform-mismatched packages: `filter_graph` below
-                    // only prunes optional edges, so a required dep
-                    // with platform constraints (rare, e.g. a broken
-                    // package missing an optional-marker) stays in the
-                    // graph and still needs a store index. A fetch-time
-                    // filter would cost nothing for optionals (win) but
-                    // silently break the required case (link-time
-                    // "missing index" error). When aube-lock widening
-                    // pulls in foreign-platform natives, those tarballs
-                    // land in the CAS but never make it into
-                    // `node_modules` — over-fetch, not over-link.
+                    // Defer platform-mismatched registry packages to
+                    // the post-filter_graph catch-up pass: almost all
+                    // of them are optional natives that `filter_graph`
+                    // is about to drop, so fetching up front would just
+                    // waste bandwidth. Local `file:`/`link:` deps
+                    // always fetch here — they carry empty platform
+                    // arrays and `is_supported` treats them as
+                    // unconstrained.
+                    if pkg.local_source.is_none()
+                        && !aube_resolver::is_supported(
+                            &pkg.os,
+                            &pkg.cpu,
+                            &pkg.libc,
+                            &fetch_supported_arch,
+                        )
+                    {
+                        tracing::debug!(
+                            "deferring tarball fetch for {}@{}: platform mismatch (catch-up will cover survivors)",
+                            pkg.name,
+                            pkg.version
+                        );
+                        continue;
+                    }
+
                     // Each resolved package bumps the overall denominator by
                     // one. Cached packages are immediately credited against
                     // the numerator; missing ones get a transient child row.
@@ -2889,7 +2922,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     return Err(e);
                 }
             };
-            let (canonical_indices, cached, fetched) = fetch_result;
+            let (canonical_indices, mut cached, mut fetched) = fetch_result;
             tracing::debug!(
                 "phase:fetch {:.1?} ({fetched} packages, {cached} cached)",
                 fetch_phase_start.elapsed()
@@ -2914,7 +2947,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // `LockedPackage`. Multiple contextualized variants of the
             // same canonical package share a single set of files, so
             // cloning the PackageIndex is cheap relative to re-extraction.
-            let indices = remap_indices_to_contextualized(&canonical_indices, &graph);
+            let mut indices = remap_indices_to_contextualized(&canonical_indices, &graph);
 
             // Write the lockfile in whatever format the project was
             // already using. If no lockfile existed, create aube's
@@ -2990,6 +3023,58 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 &install_supported_architectures,
                 &install_ignored_optional,
             );
+
+            // Catch-up fetch: the streaming coordinator deferred
+            // platform-mismatched registry tarballs on the assumption
+            // `filter_graph` would drop them. Anything still in
+            // `graph.packages` without a store index is a survivor
+            // (i.e. reached via a non-optional edge) and needs its
+            // tarball before the linker runs. In practice this set is
+            // usually empty: platform-constrained packages are almost
+            // always `optionalDependencies`, and `filter_graph` culls
+            // those. The rare non-empty case is a broken package that
+            // declares `os`/`cpu` without marking itself optional — we
+            // still install it with a warning, matching pnpm's
+            // `packageIsInstallable` behavior.
+            let missing_packages: BTreeMap<String, aube_lockfile::LockedPackage> = graph
+                .packages
+                .iter()
+                .filter(|(dep_path, _)| !indices.contains_key(*dep_path))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            if !missing_packages.is_empty() {
+                tracing::debug!(
+                    "catch-up fetch for {} package(s) deferred by the streaming filter but kept by filter_graph",
+                    missing_packages.len()
+                );
+                let cwd_for_catchup_client = cwd.clone();
+                let catchup_network_mode = opts.network_mode;
+                let (catchup_indices, catchup_cached, catchup_fetched) = fetch_packages_with_root(
+                    &missing_packages,
+                    &store,
+                    || {
+                        std::sync::Arc::new(
+                            make_client(&cwd_for_catchup_client)
+                                .with_network_mode(catchup_network_mode),
+                        )
+                    },
+                    prog_ref,
+                    &cwd,
+                    &aube_dir,
+                    /*skip_already_linked_shortcut=*/ has_workspace,
+                    virtual_store_dir_max_length,
+                    opts.ignore_scripts,
+                    network_concurrency_setting,
+                    verify_store_integrity_setting,
+                    strict_store_pkg_content_check_setting,
+                    opts.git_prepare_depth,
+                    resolve_git_shallow_hosts(&settings_ctx),
+                )
+                .await?;
+                indices.extend(catchup_indices);
+                cached += catchup_cached;
+                fetched += catchup_fetched;
+            }
 
             (graph, indices, cached, fetched)
         }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2097,6 +2097,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 settings_ctx: &settings_ctx,
                 workspace_catalogs: &workspace_catalogs,
                 opts: &opts,
+                target_lockfile_kind: source_kind_before,
             },
             read_package_hook,
         );
@@ -2267,6 +2268,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 os: sup_os,
                 cpu: sup_cpu,
                 libc: sup_libc,
+                ..Default::default()
             };
             let ignored_optional_deps: std::collections::BTreeSet<String> = manifest
                 .pnpm_ignored_optional_dependencies()
@@ -2431,6 +2433,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     settings_ctx: &settings_ctx,
                     workspace_catalogs: &workspace_catalogs,
                     opts: &opts,
+                    target_lockfile_kind: source_kind_before,
                 },
                 read_package_hook,
             );
@@ -2938,6 +2941,31 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             } else {
                 tracing::debug!("lockfile=false: skipping lockfile write");
             }
+
+            // Trim the in-memory graph down to host-installable optionals
+            // before it reaches the linker. When the resolver widened its
+            // platform filter for aube-lock.yaml, the graph (and now the
+            // lockfile) carries native packages for every major platform;
+            // `node_modules` must still only get the host's. Mirrors the
+            // filter pass the lockfile-happy branch above runs against a
+            // parsed lockfile. A no-op when the manifest didn't trigger
+            // widening (graph was already host-only).
+            let (sup_os, sup_cpu, sup_libc) = manifest.pnpm_supported_architectures();
+            let install_supported_architectures = aube_resolver::SupportedArchitectures {
+                os: sup_os,
+                cpu: sup_cpu,
+                libc: sup_libc,
+                ..Default::default()
+            };
+            let install_ignored_optional: std::collections::BTreeSet<String> = manifest
+                .pnpm_ignored_optional_dependencies()
+                .into_iter()
+                .collect();
+            aube_resolver::platform::filter_graph(
+                &mut graph,
+                &install_supported_architectures,
+                &install_ignored_optional,
+            );
 
             (graph, indices, cached, fetched)
         }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2469,6 +2469,28 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let fetch_verify_integrity = verify_store_integrity_setting;
             let fetch_strict_pkg_content_check = strict_store_pkg_content_check_setting;
             let fetch_git_shallow_hosts = resolve_git_shallow_hosts(&settings_ctx);
+            // Host-side platform filter for the streaming fetch. The
+            // resolver widens its graph filter for aube-lock.yaml so the
+            // committed lockfile carries native optionals for every
+            // common platform, but that widening must NOT make us
+            // download foreign-platform tarballs — after resolve the
+            // `filter_graph` pass trims the graph back to the host and
+            // the linker never looks at those packages. Matches the
+            // same narrow set the post-resolve `filter_graph` call
+            // below runs against, so a package we skip here is exactly
+            // a package the linker would have dropped anyway.
+            let (fetch_sup_os, fetch_sup_cpu, fetch_sup_libc) =
+                manifest.pnpm_supported_architectures();
+            let fetch_supported_arch = aube_resolver::SupportedArchitectures {
+                os: fetch_sup_os,
+                cpu: fetch_sup_cpu,
+                libc: fetch_sup_libc,
+                ..Default::default()
+            };
+            let fetch_ignored_optional: std::collections::BTreeSet<String> = manifest
+                .pnpm_ignored_optional_dependencies()
+                .into_iter()
+                .collect();
             // Channel for pipelining GVS population into the fetch
             // stream: each imported (dep_path, index) is forwarded to a
             // materializer task that runs concurrently with the rest of
@@ -2484,6 +2506,34 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 let mut cached_count = 0usize;
 
                 while let Some(pkg) = resolved_rx.recv().await {
+                    // Skip tarball downloads for packages the linker
+                    // will throw away at filter_graph time. Registry
+                    // packages carrying platform constraints that don't
+                    // match the host fall into this bucket whenever the
+                    // resolver was widened for aube-lock.yaml; local
+                    // `file:`/`link:` deps carry empty os/cpu/libc so
+                    // they always pass. A name in `ignoredOptionalDependencies`
+                    // is likewise never linked. Skipping here keeps the
+                    // progress totals honest (no `inc_total` bump) and
+                    // avoids materializing tarballs the linker will
+                    // never look at.
+                    if pkg.local_source.is_none()
+                        && (fetch_ignored_optional.contains(&pkg.name)
+                            || !aube_resolver::is_supported(
+                                &pkg.os,
+                                &pkg.cpu,
+                                &pkg.libc,
+                                &fetch_supported_arch,
+                            ))
+                    {
+                        tracing::debug!(
+                            "skipping tarball fetch for {}@{}: platform/ignored — filter_graph will drop it before link",
+                            pkg.name,
+                            pkg.version
+                        );
+                        continue;
+                    }
+
                     // Each resolved package bumps the overall denominator by
                     // one. Cached packages are immediately credited against
                     // the numerator; missing ones get a transient child row.

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -484,14 +484,17 @@ pub(super) struct ResolverConfigInputs<'a> {
     pub(super) workspace_catalogs:
         &'a std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
     pub(super) opts: &'a InstallOptions,
-    /// Lockfile format aube will write on the way out — `None` means no
-    /// lockfile exists yet and we'll default to `aube-lock.yaml`. Drives
+    /// Lockfile format aube will write on the way out, or `None` when
+    /// `lockfile=false` and no lockfile will be written at all. Drives
     /// whether the resolver widens its platform filter to cover every
-    /// common OS/CPU/libc combination (aube-lock.yaml is meant to be a
-    /// cross-platform, committed artifact) or keeps the pnpm-style
-    /// host-only default for foreign formats (pnpm-lock.yaml, yarn.lock,
-    /// package-lock.json, bun.lock) so aube doesn't quietly diverge from
-    /// what the other PM would have written.
+    /// common OS/CPU/libc combination: aube-lock.yaml is meant to be a
+    /// cross-platform committed artifact, so `Some(Aube)` opts in to
+    /// the wide default. Foreign formats (`Some(Pnpm | Npm | …)`) keep
+    /// pnpm's host-only default so aube doesn't silently bake more
+    /// packages into them than the native tool would have written, and
+    /// `None` skips widening entirely — nothing consumes the extra
+    /// resolutions. Callers compute this as
+    /// `lockfile_enabled.then(|| source_kind_before.unwrap_or(Aube))`.
     pub(super) target_lockfile_kind: Option<aube_lockfile::LockfileKind>,
 }
 
@@ -529,10 +532,7 @@ pub(super) fn configure_resolver(
     // packages than the native tool would have produced.
     let manifest_set_supported_arch =
         !(sup_os.is_empty() && sup_cpu.is_empty() && sup_libc.is_empty());
-    let writes_aube_lock = matches!(
-        target_lockfile_kind,
-        None | Some(aube_lockfile::LockfileKind::Aube)
-    );
+    let writes_aube_lock = target_lockfile_kind == Some(aube_lockfile::LockfileKind::Aube);
     let supported_architectures = if !manifest_set_supported_arch && writes_aube_lock {
         aube_resolver::SupportedArchitectures::aube_lock_default()
     } else {

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -484,6 +484,15 @@ pub(super) struct ResolverConfigInputs<'a> {
     pub(super) workspace_catalogs:
         &'a std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
     pub(super) opts: &'a InstallOptions,
+    /// Lockfile format aube will write on the way out — `None` means no
+    /// lockfile exists yet and we'll default to `aube-lock.yaml`. Drives
+    /// whether the resolver widens its platform filter to cover every
+    /// common OS/CPU/libc combination (aube-lock.yaml is meant to be a
+    /// cross-platform, committed artifact) or keeps the pnpm-style
+    /// host-only default for foreign formats (pnpm-lock.yaml, yarn.lock,
+    /// package-lock.json, bun.lock) so aube doesn't quietly diverge from
+    /// what the other PM would have written.
+    pub(super) target_lockfile_kind: Option<aube_lockfile::LockfileKind>,
 }
 
 pub(super) fn configure_resolver(
@@ -497,6 +506,7 @@ pub(super) fn configure_resolver(
         settings_ctx,
         workspace_catalogs,
         opts,
+        target_lockfile_kind,
     } = inputs;
     let auto_install_peers = resolve_auto_install_peers(settings_ctx);
     let exclude_links_from_lockfile = resolve_exclude_links_from_lockfile(settings_ctx);
@@ -506,10 +516,32 @@ pub(super) fn configure_resolver(
     let resolve_peers_from_workspace_root_opt = resolve_peers_from_workspace_root(settings_ctx);
     let registry_supports_time_field = resolve_registry_supports_time_field(settings_ctx);
     let (sup_os, sup_cpu, sup_libc) = manifest.pnpm_supported_architectures();
-    let supported_architectures = aube_resolver::SupportedArchitectures {
-        os: sup_os,
-        cpu: sup_cpu,
-        libc: sup_libc,
+    // aube-lock.yaml is a committed, cross-platform artifact: if the
+    // user hasn't declared `pnpm.supportedArchitectures` we widen the
+    // resolver's platform filter to cover every common OS/CPU/libc so
+    // Linux-native optionals (e.g. `@rollup/rollup-linux-x64-gnu`)
+    // land in the lockfile even when `aube install` is run on macOS.
+    // Install-time filtering (see `filter_graph` call on the lockfile
+    // branch) still runs against the unmodified manifest setting, so
+    // `node_modules` stays trimmed to the host. For foreign lockfiles
+    // (pnpm-lock.yaml, yarn.lock, package-lock.json, bun.lock) we keep
+    // pnpm's host-only default — aube shouldn't silently bake in more
+    // packages than the native tool would have produced.
+    let manifest_set_supported_arch =
+        !(sup_os.is_empty() && sup_cpu.is_empty() && sup_libc.is_empty());
+    let writes_aube_lock = matches!(
+        target_lockfile_kind,
+        None | Some(aube_lockfile::LockfileKind::Aube)
+    );
+    let supported_architectures = if !manifest_set_supported_arch && writes_aube_lock {
+        aube_resolver::SupportedArchitectures::aube_lock_default()
+    } else {
+        aube_resolver::SupportedArchitectures {
+            os: sup_os,
+            cpu: sup_cpu,
+            libc: sup_libc,
+            ..Default::default()
+        }
     };
     let effective_overrides = manifest.overrides_map();
     let mut effective_overrides = effective_overrides;

--- a/test/optional_platform.bats
+++ b/test/optional_platform.bats
@@ -30,6 +30,62 @@ teardown() {
 	assert_not_exists node_modules/aube-test-optional-win32
 }
 
+@test "aube-lock.yaml captures cross-platform optional natives by default" {
+	# When aube writes its native lockfile format it widens the resolver's
+	# platform filter so Linux / Windows / arm64 optional natives are
+	# recorded alongside the host's — a lockfile resolved on one platform
+	# must install cleanly on every other platform without the user
+	# hand-rolling `pnpm.supportedArchitectures`.
+	cat >package.json <<-'JSON'
+		{
+		  "name": "cross-platform-lockfile-test",
+		  "version": "0.0.0",
+		  "optionalDependencies": {
+		    "aube-test-optional-win32": "1.0.0"
+		  }
+		}
+	JSON
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_exists aube-lock.yaml
+	# win32-only optional must still not be linked on non-win32 hosts…
+	assert_not_exists node_modules/aube-test-optional-win32
+	# …but it MUST land in the committed lockfile so a Windows CI run
+	# resolving from this file picks it up.
+	run grep -F 'aube-test-optional-win32@1.0.0' aube-lock.yaml
+	assert_success
+}
+
+@test "pnpm-lock.yaml keeps pnpm's host-only default" {
+	# Aube preserves whatever lockfile format was already on disk. For
+	# pnpm-lock.yaml that means matching pnpm's default: optionals for
+	# other platforms are NOT baked in unless the user opts in with
+	# `pnpm.supportedArchitectures`. Otherwise aube would silently
+	# diverge from what `pnpm install` would have produced in the same
+	# repo.
+	: >pnpm-lock.yaml
+	cat >package.json <<-'JSON'
+		{
+		  "name": "pnpm-lock-host-only",
+		  "version": "0.0.0",
+		  "optionalDependencies": {
+		    "aube-test-optional-win32": "1.0.0"
+		  }
+		}
+	JSON
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_exists pnpm-lock.yaml
+	assert_not_exists aube-lock.yaml
+	# The manifest's `optionalDependencies:` block round-trips into the
+	# importer record regardless of platform (pnpm does the same), so
+	# don't grep for the bare name. What we actually care about is the
+	# resolved `packages:` entry — that's what a subsequent install on a
+	# matching platform would use, and what we want aube to have skipped.
+	run grep -F 'aube-test-optional-win32@1.0.0:' pnpm-lock.yaml
+	assert_failure
+}
+
 @test "pnpm.supportedArchitectures widens the match set" {
 	cat >package.json <<-'JSON'
 		{

--- a/test/optional_platform.bats
+++ b/test/optional_platform.bats
@@ -56,6 +56,34 @@ teardown() {
 	assert_success
 }
 
+@test "required platform-mismatched dep still gets fetched and linked" {
+	# Regression guard for the catch-up fetch pass. Streaming fetch
+	# defers platform-mismatched tarballs because filter_graph usually
+	# drops them — but filter_graph only prunes *optional* edges. A
+	# required dep that declares `os: ["win32"]` on a non-Windows host
+	# survives the graph trim, so its tarball must be fetched after the
+	# stream closes or the linker errors out with a missing store index.
+	# This fixture is declared in `dependencies` (NOT optional) so we
+	# exercise the exact code path cursor[bot] flagged. pnpm installs
+	# the same package the same way (with a warning); aube matches.
+	cat >package.json <<-'JSON'
+		{
+		  "name": "required-platform-mismatch-test",
+		  "version": "0.0.0",
+		  "dependencies": {
+		    "aube-test-optional-win32": "1.0.0"
+		  }
+		}
+	JSON
+	run aube install --no-frozen-lockfile
+	assert_success
+	# The required-platform-mismatched dep must still land in
+	# node_modules: aube honors pnpm's `packageIsInstallable` semantics
+	# for required deps, and the catch-up fetch guarantees the store
+	# index is present when the linker runs.
+	assert_exists node_modules/aube-test-optional-win32/package.json
+}
+
 @test "pnpm-lock.yaml keeps pnpm's host-only default" {
 	# Aube preserves whatever lockfile format was already on disk. For
 	# pnpm-lock.yaml that means matching pnpm's default: optionals for


### PR DESCRIPTION
## Summary
Fixes the cross-platform lockfile footgun reported in [jdx/usage#594](https://github.com/jdx/usage/pull/594): an `aube install` on macOS used to produce an `aube-lock.yaml` missing `@rollup/rollup-linux-*`, `@esbuild/linux-*`, etc., and Linux CI would fail at module-resolve time. The user's workaround was hand-writing a `pnpm.supportedArchitectures` stanza into `package.json`.

## What changes
- **Wide default for `aube-lock.yaml`.** When the resolver is about to write `aube-lock.yaml` and the manifest has no explicit `pnpm.supportedArchitectures`, widen the platform filter to an explicit matrix: darwin-arm64, linux × {x64, arm64} × {glibc, musl}, win32 × {x64, arm64}. darwin-x64 is out of the baseline (Intel Macs are end-of-life, and sharp / swc have dropped those binaries) but the host's own triple is always appended, so an Intel Mac (or a freebsd / ppc64 box) still installs its own natives.
- **Foreign lockfiles stay host-only.** `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, and `bun.lock` keep pnpm's host-only default — aube shouldn't silently bake more packages into them than the native tool would have written.
- **Lockfile disabled ≠ "write aube-lock.yaml".** The widening only fires when aube is actually going to write `aube-lock.yaml`. `lockfile=false` skips widening entirely — no wasted resolution for a lockfile that will never exist.
- **`node_modules` stays host-only.** An in-memory `filter_graph` pass after the lockfile write trims the wide graph down to host-installable optionals, mirroring the pass that already runs on the lockfile-happy install branch.
- **Streaming fetch defers foreign-platform tarballs and catches up after `filter_graph`.** The widened graph would otherwise pull every platform's native tarball into `~/.aube-store/` on a fresh resolve. The streaming coordinator now skips platform-mismatched registry tarballs up front; after `filter_graph` trims optional mismatches, a catch-up pass fetches any survivor whose store index is still missing — which handles the rare required-platform-mismatched case (broken packages that declare `os`/`cpu` without the optional marker) that `filter_graph` doesn't touch. Common-case fresh installs end up fetching only what the host actually links. Local `file:`/`link:` deps carry no platform constraints and always fetch inline.

## Commits
1. `resolver: widen aube-lock.yaml to every common platform` — wide default + post-write filter_graph on the fresh-resolve path.
2. `install: disambiguate target_lockfile_kind when lockfile disabled` — fixes an overloaded `None` so `lockfile=false` doesn't needlessly widen.
3. `install: add host to wide matrix, skip mismatched tarball fetches` — always include the host triple in the default matrix; first attempt at fetch-time skipping.
4. `install: revert fetch-time platform filter — filter_graph only prunes optionals` — withdraws the naive fetch-time filter after Cursor Bugbot flagged that required-platform-mismatched deps would silently break.
5. `install: defer platform-mismatched fetches, catch up after filter_graph` — correct two-phase design: defer in streaming, catch up for survivors.

## Test plan
- [x] `cargo test` — all workspace crates (`aube-resolver` gains 2 new tests pinning the matrix shape and the always-include-host guarantee).
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`.
- [x] `mise run test:bats test/optional_platform.bats` — three new integration tests:
  - `aube-lock.yaml captures cross-platform optional natives by default`
  - `pnpm-lock.yaml keeps pnpm's host-only default`
  - `required platform-mismatched dep still gets fetched and linked` (regression guard for the catch-up pass)
- [x] `mise run test:bats` across `install.bats`, `add.bats`, `ignored_optional_dependencies.bats`, `lockfile_settings.bats`, `resolve.bats`, `dedupe.bats` — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)