### PR TITLE
store: tolerate leading `v` in tarball package.json version

### DIFF
--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -706,7 +706,16 @@ pub fn validate_pkg_content(
         .map_err(|e| Error::Tar(format!("invalid package.json: {e}")))?;
     let actual_name = v.get("name").and_then(|n| n.as_str()).unwrap_or("");
     let actual_version = v.get("version").and_then(|v| v.as_str()).unwrap_or("");
-    if actual_name != expected_name || actual_version != expected_version {
+    // Tolerate a leading `v` on the tarball's version (e.g. "v2.0.8").
+    // Some publishers ship this shape; npm and bun normalize it on
+    // install, so aube does too rather than rejecting a package the
+    // other managers accept. The registry-side coordinate is the
+    // source of truth, so we only normalize the tarball side.
+    let actual_version_normalized = actual_version
+        .strip_prefix('v')
+        .filter(|rest| rest.starts_with(|c: char| c.is_ascii_digit()))
+        .unwrap_or(actual_version);
+    if actual_name != expected_name || actual_version_normalized != expected_version {
         // Only carry the *actual* coordinate the tarball declared.
         // Every caller wraps the error with the expected
         // `{name}@{version}: ` prefix (mirroring the Error::Integrity
@@ -1317,6 +1326,14 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("content mismatch"), "{msg}");
         assert!(msg.contains("declares lodash@9.9.9"), "{msg}");
+    }
+
+    #[test]
+    fn test_validate_pkg_content_tolerates_leading_v() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        let index = index_with_manifest(&store, "@upstash/ratelimit", "v2.0.8");
+        assert!(validate_pkg_content(&index, "@upstash/ratelimit", "2.0.8").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Some publishers ship a tarball whose `package.json` has `"version": "vX.Y.Z"` (leading `v`). `@upstash/ratelimit@2.0.8` is one concrete example.
- npm and bun normalize the `v` prefix on install. Aube's `validate_pkg_content` did a strict string compare, so it rejected those tarballs with `package.json content mismatch: tarball declares @upstash/ratelimit@v2.0.8` — even though the package is fine and installs everywhere else.
- Fix: in [crates/aube-store/src/lib.rs](crates/aube-store/src/lib.rs), strip a leading `v` (followed by a digit) from the tarball-declared version before comparing. The registry coordinate stays the source of truth; only the tarball side is normalized.

## Repro

```json
{ "name": "aube-repro", "version": "0.0.0", "private": true,
  "dependencies": { "@upstash/ratelimit": "2.0.8" } }
```

Before: `× @upstash/ratelimit@2.0.8: package.json content mismatch: tarball declares @upstash/ratelimit@v2.0.8`
After: install succeeds.

## Test plan

- [x] `cargo test -p aube-store validate_pkg_content` — added `test_validate_pkg_content_tolerates_leading_v`; all 6 tests pass
- [x] `cargo clippy -p aube-store --all-targets -- -D warnings` — clean
- [x] Existing mismatch tests still fail (name mismatch, true version mismatch) — the normalization is narrow (leading `v` + digit only) so genuine mismatches still error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `validate_pkg_content`, a security-relevant check used to detect tarball/registry coordinate mismatches; although the normalization is narrow, it slightly relaxes validation and could hide some publisher-side inconsistencies.
> 
> **Overview**
> `validate_pkg_content` now normalizes the tarball-declared `package.json` version by stripping a leading `v` *only when it’s followed by a digit* before comparing to the registry’s expected version, preventing false "content mismatch" failures for packages published as `vX.Y.Z`.
> 
> Adds a regression test (`test_validate_pkg_content_tolerates_leading_v`) to ensure `v2.0.8` is accepted when the expected version is `2.0.8`, while existing mismatch tests remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a0c14c90f0bfe1e97ebd37c252a4ba1b5fb17f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->