### PR TITLE
resolver: honor pnpm overrides "-" removal marker

### DIFF
--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1090,6 +1090,21 @@ impl Resolver {
                         &task.range,
                         &task.ancestors,
                     ) {
+                        // pnpm's removal marker: an override value of
+                        // `"-"` drops the dep edge entirely. Skip before
+                        // catalog/alias rewrites so `-` never reaches
+                        // the registry resolver. The dropped edge never
+                        // gets written to the parent's `.dependencies`
+                        // map (that write happens downstream) and, for
+                        // direct deps, never gets pushed into the
+                        // importer's direct-dep list.
+                        if override_spec == "-" {
+                            tracing::trace!("override: {}@{} -> dropped", task.name, task.range,);
+                            if task.is_root {
+                                note_root_done!();
+                            }
+                            continue 'outer;
+                        }
                         // An override may itself point at a catalog
                         // entry (e.g. `"overrides": {"foo": "catalog:"}`).
                         // The catalog pre-pass above already ran against

--- a/test/overrides.bats
+++ b/test/overrides.bats
@@ -297,6 +297,65 @@ teardown() {
 	assert_dir_exists node_modules/.aube/is-number@6.0.0
 }
 
+@test "override value \"-\" removes a transitive dep entirely" {
+	# pnpm's removal marker: `"-"` drops the dep edge from the graph.
+	# is-odd@3.0.1 normally pulls is-number@^6.0.0 — removing it means
+	# no version of is-number should land in the virtual store.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-overrides",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "3.0.1" },
+		  "pnpm": { "overrides": { "is-number": "-" } }
+		}
+	EOF
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_dir_exists node_modules/.aube/is-odd@3.0.1
+	run test -d node_modules/.aube/is-number@6.0.0
+	assert_failure
+	# No is-number snapshot should land in the lockfile packages block.
+	run grep -E "^ +/is-number@" aube-lock.yaml
+	assert_failure
+}
+
+@test "parent>child \"-\" selector removes only the matching edge" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-overrides",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "3.0.1" },
+		  "overrides": { "is-odd>is-number": "-" }
+		}
+	EOF
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_dir_exists node_modules/.aube/is-odd@3.0.1
+	run test -d node_modules/.aube/is-number@6.0.0
+	assert_failure
+}
+
+@test "override value \"-\" removes a direct dep" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-overrides",
+		  "version": "1.0.0",
+		  "dependencies": {
+		    "is-odd": "3.0.1",
+		    "is-number": "6.0.0"
+		  },
+		  "overrides": { "is-number": "-" }
+		}
+	EOF
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_dir_exists node_modules/.aube/is-odd@3.0.1
+	run test -d node_modules/.aube/is-number@6.0.0
+	assert_failure
+	run test -L node_modules/is-number
+	assert_failure
+}
+
 @test "changing overrides re-resolves the lockfile on next install" {
 	# First install with no override.
 	cat >package.json <<-'EOF'

--- a/test/overrides.bats
+++ b/test/overrides.bats
@@ -314,8 +314,10 @@ teardown() {
 	assert_dir_exists node_modules/.aube/is-odd@3.0.1
 	run test -d node_modules/.aube/is-number@6.0.0
 	assert_failure
-	# No is-number snapshot should land in the lockfile packages block.
-	run grep -E "^ +/is-number@" aube-lock.yaml
+	# No is-number snapshot should land in the lockfile. The override
+	# value here is `-`, so the `overrides:` block won't carry an
+	# `is-number@` substring either.
+	run grep 'is-number@' aube-lock.yaml
 	assert_failure
 }
 


### PR DESCRIPTION
## Summary
- Skip the resolve task when an override matches and the replacement value is `"-"`, pnpm's removal marker (docs: [pnpm overrides](https://pnpm.io/11.x/settings#overrides)). Previously the `-` string leaked through the override pipeline and was passed to `version_satisfies`, which couldn't match anything — so the user saw the override silently fail.
- The skip runs before the catalog/alias rewrites so `-` never reaches the registry resolver or catalog indirection.
- Works for direct deps, transitive deps, and all selector shapes (bare name, `parent>child`, yarn `**/foo`, yarn `parent/child`, version-qualified).

## Test plan
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `mise run test:bats test/overrides.bats` — all 21 pass, including the three new removal cases:
  - `"-"` removes a transitive dep entirely
  - `parent>child` `"-"` selector removes only the matching edge
  - `"-"` removes a direct dep (no top-level symlink, no virtual-store entry)

Fixes https://github.com/endevco/aube/discussions/96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency resolution to drop edges when an override resolves to `"-"`, which can remove direct or transitive packages from the graph and lockfile. Risk is moderate because it alters core resolution behavior but is narrowly scoped and covered by new integration tests.
> 
> **Overview**
> Implements pnpm-compatible override deletion: when `pick_override_spec` returns `"-"`, the resolver now skips the resolve task entirely so the dependency edge is removed rather than attempting to resolve an invalid range.
> 
> Adds BATS coverage ensuring `"-"` overrides remove (1) a transitive dep, (2) a specific `parent>child` edge, and (3) a direct dep (including no `node_modules` symlink and no lockfile snapshot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e4f758a2761e016770fe901a70da7403900fbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->