### PR TITLE
store: skip PAX global/extension tar headers

### DIFF
--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -374,7 +374,11 @@ impl Store {
 
             let mut entry = entry.map_err(|e| Error::Tar(e.to_string()))?;
 
-            // Directories don't carry content, skip them. Every other
+            // Directories don't carry content, skip them. PAX global
+            // and extension headers (type `g` / `x`) carry metadata
+            // only — GitHub-generated tarballs (e.g. `imap@0.8.19`)
+            // start with one that embeds the source git blob SHA.
+            // npm/pnpm/bun tolerate these; we do too. Every other
             // non-regular entry type (symlink, hardlink, character
             // device, block device, fifo) is rejected. Real npm
             // packages ship files and directories only. Symlink and
@@ -382,7 +386,12 @@ impl Store {
             // node-tar CVE-2021-37701 class and have no legitimate
             // use here.
             let entry_type = entry.header().entry_type();
-            if entry_type.is_dir() {
+            if entry_type.is_dir()
+                || matches!(
+                    entry_type,
+                    tar::EntryType::XGlobalHeader | tar::EntryType::XHeader
+                )
+            {
                 continue;
             }
             if !matches!(
@@ -1846,6 +1855,43 @@ mod tests {
         store.ensure_shards_exist().unwrap();
         let err = store.import_tarball(&tarball).unwrap_err();
         assert!(matches!(err, Error::Tar(_)));
+    }
+
+    #[test]
+    fn test_import_tarball_skips_pax_global_header() {
+        // GitHub-generated tarballs (e.g. `imap@0.8.19`) start with a
+        // PAX global header carrying the source git blob SHA in a
+        // `comment=...` record. The entry is metadata-only and has no
+        // file content; npm/pnpm/bun skip it silently. The extractor
+        // must not reject the tarball on sight.
+        let gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut ar = tar::Builder::new(gz);
+
+        let pax_body = b"52 comment=867aa88a335a266b904e0b5d1a3b0b5d1a3b0b5d1\n";
+        let mut gh = tar::Header::new_ustar();
+        gh.set_path("pax_global_header").unwrap();
+        gh.set_size(pax_body.len() as u64);
+        gh.set_mode(0o644);
+        gh.set_entry_type(tar::EntryType::XGlobalHeader);
+        gh.set_cksum();
+        ar.append(&gh, &pax_body[..]).unwrap();
+
+        let body = b"// ok";
+        let mut fh = tar::Header::new_gnu();
+        fh.set_path("package/index.js").unwrap();
+        fh.set_size(body.len() as u64);
+        fh.set_mode(0o644);
+        fh.set_cksum();
+        ar.append(&fh, &body[..]).unwrap();
+
+        let tarball = ar.into_inner().unwrap().finish().unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+        let index = store.import_tarball(&tarball).unwrap();
+        assert!(index.contains_key("index.js"));
+        assert!(!index.contains_key("pax_global_header"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `aube install imap@0.8.19` (and any other GitHub-generated tarball) was failing with `tarball entry type XGlobalHeader is not allowed`. The `imap` tarball starts with a PAX global header (tar type `g`, `pax_global_header`) whose body is `comment=867aa88a335a266b904e0…` — the source git blob SHA that GitHub stamps into every tarball it produces.
- npm/pnpm/bun tolerate these metadata-only entries. Skip `XGlobalHeader` and `XHeader` in `Store::import_tarball` alongside directories. The rest of the allowlist (reject symlinks/hardlinks/device nodes — the CVE-2021-37701 class) is unchanged.

## Repro

```
package.json: { "dependencies": { "imap": "0.8.19" } }
.npmrc:       package-manager-strict=false
```

Before: `aube install` errors on tarball extraction.
After: installs cleanly; the PAX header is dropped from the package index.

## Test plan

- [x] `cargo test -p aube-store --lib` — 56 passed, including the new `test_import_tarball_skips_pax_global_header` regression (PAX global header followed by a regular file: file imports, header is not indexed)
- [x] `cargo clippy -p aube-store --all-targets -- -D warnings` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tarball extraction validation (a security-sensitive area) by expanding the set of non-file entries that are silently skipped, so mistakes could weaken archive hardening despite keeping symlink/hardlink/device rejection intact.
> 
> **Overview**
> `Store::import_tarball` now **skips PAX metadata entries** (`tar::EntryType::XGlobalHeader` and `XHeader`) in addition to directories, instead of rejecting the whole tarball when these headers appear (notably in GitHub-generated archives).
> 
> Adds a regression test (`test_import_tarball_skips_pax_global_header`) that builds a tarball containing a PAX global header plus a normal file and asserts the file imports while the header is not indexed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200ce01e131fd40ba23abf3b11ee6e3acbbead8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->