### PR TITLE
install: widen disableGlobalVirtualStoreForPackages default list

### DIFF
--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -30,13 +30,16 @@ pub struct WorkspaceConfig {
 
     /// Package names whose presence in any importer forces
     /// per-project materialization (disabling the global virtual
-    /// store for that install). Defaults to `["next"]` — Turbopack
-    /// rejects `node_modules/<pkg>` symlinks that canonicalize
-    /// outside the project's filesystem root. Add more names as
-    /// you discover tools with the same restriction; set to `[]` to
-    /// disable the heuristic. Declared here so `settings.toml`'s
-    /// workspaceYaml source stays in sync with the actual
-    /// deserialize surface.
+    /// store for that install). Defaults to the common bundler /
+    /// framework direct-devDeps whose module resolvers follow
+    /// symlinks then walk up (Next.js's Turbopack, Vite, Rollup,
+    /// Webpack, Parcel, Nuxt, VitePress) — the global virtual store
+    /// makes `.aube/<pkg>` an absolute symlink that escapes the
+    /// project's filesystem root, which those resolvers can't walk
+    /// back from. Add more names as you discover tools with the same
+    /// restriction; set to `[]` to disable the heuristic. Declared
+    /// here so `settings.toml`'s workspaceYaml source stays in sync
+    /// with the actual deserialize surface.
     #[serde(default)]
     pub disable_global_virtual_store_for_packages: Option<Vec<String>>,
 

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -614,22 +614,24 @@ examples = [
 [disableGlobalVirtualStoreForPackages]
 description = "Package names whose presence in any importer forces per-project materialization."
 type = "list<string>"
-default = "[\"next\"]"
+default = "[\"next\", \"nuxt\", \"vite\", \"vitepress\", \"rollup\", \"webpack\", \"parcel\"]"
 docs = """
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
-absolute symlink into `~/.cache/aube/virtual-store/`. Some tools —
-most notably Next.js's Turbopack — canonicalize every symlink under
-`node_modules/` and reject any target that resolves outside the
-project's "filesystem root", producing errors like `Symlink ... is
-invalid, it points out of the filesystem root`.
+absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
+module resolvers follow symlinks to real paths and then walk up the
+directory tree — Rollup, Vite, Webpack, Parcel, Next.js's Turbopack —
+can't reach the project's `node_modules/` from inside the global
+store and produce errors like `Rollup failed to resolve import ...`
+or `Symlink ... is invalid, it points out of the filesystem root`.
 
 When `aube install` finds one of these names in any importer's
 `dependencies`, `devDependencies`, or `optionalDependencies`, it
 forces per-project materialization for that install and prints a
-one-line warning naming the trigger. Defaults to `["next"]`; add
-other packages here as you discover them, or set the list to `[]` to
-disable the heuristic. `CI=1` already forces per-project mode, so the
-warning suppresses itself in that case.
+one-line warning naming the trigger. The default list covers the
+bundlers most commonly declared as direct devDeps; add other
+packages here as you discover them (or set the list to `[]` to
+disable the heuristic entirely). `CI=1` already forces per-project
+mode, so the warning suppresses itself in that case.
 """
 sources.cli = []
 sources.env = []

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1950,16 +1950,18 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
 
     // Auto-disable the global virtual store when any importer depends
     // on a package listed in `disableGlobalVirtualStoreForPackages`
-    // (default `["next"]`). Turbopack canonicalizes every
-    // `node_modules/<pkg>` symlink and rejects targets outside the
-    // project dir; gvs makes `.aube/<pkg>` an absolute symlink into
-    // `~/.cache/aube/virtual-store/`, which trips that check. The
-    // list is the extension point — add other tools as they surface.
-    // `CI=1` already forces per-project mode in `Linker::new`, so we
-    // don't warn in that case (behavior wouldn't change and the
+    // (default covers Next.js, Nuxt, Vite, VitePress, Rollup, Webpack,
+    // Parcel). Those resolvers follow `node_modules/<pkg>` symlinks to
+    // real paths and then walk up the directory tree; gvs makes
+    // `.aube/<pkg>` an absolute symlink into
+    // `~/.cache/aube/virtual-store/`, so the walk escapes the project
+    // and can't reach the top-level `node_modules/` where direct deps
+    // live. The list is the extension point — add other tools as they
+    // surface. `CI=1` already forces per-project mode in `Linker::new`,
+    // so we don't warn in that case (behavior wouldn't change and the
     // message would just be noise). `virtualStoreOnly` installs skip
-    // the final top-level symlink pass, so Turbopack never sees the
-    // gvs path — suppress the warning there too.
+    // the final top-level symlink pass, so the incompatible resolver
+    // never sees the gvs path — suppress the warning there too.
     let gvs_triggers =
         aube_settings::resolved::disable_global_virtual_store_for_packages(&settings_ctx);
     let explicit_global_virtual_store =
@@ -1980,7 +1982,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             && !virtual_store_only_setting
         {
             tracing::warn!(
-                "disabling global virtual store: `{name}` is in disableGlobalVirtualStoreForPackages (packages in that list are known to be incompatible with gvs-linked node_modules, e.g. Next.js's Turbopack rejects symlinks that escape the project root). Set the list to `[]` in .npmrc to opt out."
+                "disabling global virtual store: `{name}` is in disableGlobalVirtualStoreForPackages (packages in that list have bundler-style module resolvers that follow symlinks and walk up, which can't reach the project root when `.aube/<pkg>` symlinks into the global store). Set the list to `[]` in .npmrc to opt out."
             );
             Some(false)
         } else {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1982,7 +1982,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             && !virtual_store_only_setting
         {
             tracing::warn!(
-                "disabling global virtual store: `{name}` is in disableGlobalVirtualStoreForPackages (packages in that list have bundler-style module resolvers that follow symlinks and walk up, which can't reach the project root when `.aube/<pkg>` symlinks into the global store). Set the list to `[]` in .npmrc to opt out."
+                "disabling global virtual store: `{name}` is in disableGlobalVirtualStoreForPackages (packages in that list have bundler-style module resolvers that follow symlinks and walk up, which can't reach the project root when `.aube/<pkg>` symlinks into the global store). To silence this warning while keeping the fallback, add `enableGlobalVirtualStore=false` to .npmrc; to opt out of the heuristic entirely, set `disableGlobalVirtualStoreForPackages=[]`."
             );
             Some(false)
         } else {

--- a/docs/settings/env.md
+++ b/docs/settings/env.md
@@ -639,23 +639,25 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next"]`
+- Default: `["next", "nuxt", "vite", "vitepress", "rollup", "webpack", "parcel"]`
 - Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
 
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
-absolute symlink into `~/.cache/aube/virtual-store/`. Some tools —
-most notably Next.js's Turbopack — canonicalize every symlink under
-`node_modules/` and reject any target that resolves outside the
-project's "filesystem root", producing errors like `Symlink ... is
-invalid, it points out of the filesystem root`.
+absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
+module resolvers follow symlinks to real paths and then walk up the
+directory tree — Rollup, Vite, Webpack, Parcel, Next.js's Turbopack —
+can't reach the project's `node_modules/` from inside the global
+store and produce errors like `Rollup failed to resolve import ...`
+or `Symlink ... is invalid, it points out of the filesystem root`.
 
 When `aube install` finds one of these names in any importer's
 `dependencies`, `devDependencies`, or `optionalDependencies`, it
 forces per-project materialization for that install and prints a
-one-line warning naming the trigger. Defaults to `["next"]`; add
-other packages here as you discover them, or set the list to `[]` to
-disable the heuristic. `CI=1` already forces per-project mode, so the
-warning suppresses itself in that case.
+one-line warning naming the trigger. The default list covers the
+bundlers most commonly declared as direct devDeps; add other
+packages here as you discover them (or set the list to `[]` to
+disable the heuristic entirely). `CI=1` already forces per-project
+mode, so the warning suppresses itself in that case.
 
 ## Store
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -695,25 +695,27 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next"]`
+- Default: `["next", "nuxt", "vite", "vitepress", "rollup", "webpack", "parcel"]`
 - Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
 - .npmrc keys: `disableGlobalVirtualStoreForPackages`, `disable-global-virtual-store-for-packages`
 - Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
 
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
-absolute symlink into `~/.cache/aube/virtual-store/`. Some tools —
-most notably Next.js's Turbopack — canonicalize every symlink under
-`node_modules/` and reject any target that resolves outside the
-project's "filesystem root", producing errors like `Symlink ... is
-invalid, it points out of the filesystem root`.
+absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
+module resolvers follow symlinks to real paths and then walk up the
+directory tree — Rollup, Vite, Webpack, Parcel, Next.js's Turbopack —
+can't reach the project's `node_modules/` from inside the global
+store and produce errors like `Rollup failed to resolve import ...`
+or `Symlink ... is invalid, it points out of the filesystem root`.
 
 When `aube install` finds one of these names in any importer's
 `dependencies`, `devDependencies`, or `optionalDependencies`, it
 forces per-project materialization for that install and prints a
-one-line warning naming the trigger. Defaults to `["next"]`; add
-other packages here as you discover them, or set the list to `[]` to
-disable the heuristic. `CI=1` already forces per-project mode, so the
-warning suppresses itself in that case.
+one-line warning naming the trigger. The default list covers the
+bundlers most commonly declared as direct devDeps; add other
+packages here as you discover them (or set the list to `[]` to
+disable the heuristic entirely). `CI=1` already forces per-project
+mode, so the warning suppresses itself in that case.
 
 ## Store
 

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -639,23 +639,25 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next"]`
+- Default: `["next", "nuxt", "vite", "vitepress", "rollup", "webpack", "parcel"]`
 - .npmrc keys: `disableGlobalVirtualStoreForPackages`, `disable-global-virtual-store-for-packages`
 
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
-absolute symlink into `~/.cache/aube/virtual-store/`. Some tools —
-most notably Next.js's Turbopack — canonicalize every symlink under
-`node_modules/` and reject any target that resolves outside the
-project's "filesystem root", producing errors like `Symlink ... is
-invalid, it points out of the filesystem root`.
+absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
+module resolvers follow symlinks to real paths and then walk up the
+directory tree — Rollup, Vite, Webpack, Parcel, Next.js's Turbopack —
+can't reach the project's `node_modules/` from inside the global
+store and produce errors like `Rollup failed to resolve import ...`
+or `Symlink ... is invalid, it points out of the filesystem root`.
 
 When `aube install` finds one of these names in any importer's
 `dependencies`, `devDependencies`, or `optionalDependencies`, it
 forces per-project materialization for that install and prints a
-one-line warning naming the trigger. Defaults to `["next"]`; add
-other packages here as you discover them, or set the list to `[]` to
-disable the heuristic. `CI=1` already forces per-project mode, so the
-warning suppresses itself in that case.
+one-line warning naming the trigger. The default list covers the
+bundlers most commonly declared as direct devDeps; add other
+packages here as you discover them (or set the list to `[]` to
+disable the heuristic entirely). `CI=1` already forces per-project
+mode, so the warning suppresses itself in that case.
 
 ## Store
 

--- a/docs/settings/workspace-yaml.md
+++ b/docs/settings/workspace-yaml.md
@@ -423,23 +423,25 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next"]`
+- Default: `["next", "nuxt", "vite", "vitepress", "rollup", "webpack", "parcel"]`
 - Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
 
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
-absolute symlink into `~/.cache/aube/virtual-store/`. Some tools —
-most notably Next.js's Turbopack — canonicalize every symlink under
-`node_modules/` and reject any target that resolves outside the
-project's "filesystem root", producing errors like `Symlink ... is
-invalid, it points out of the filesystem root`.
+absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
+module resolvers follow symlinks to real paths and then walk up the
+directory tree — Rollup, Vite, Webpack, Parcel, Next.js's Turbopack —
+can't reach the project's `node_modules/` from inside the global
+store and produce errors like `Rollup failed to resolve import ...`
+or `Symlink ... is invalid, it points out of the filesystem root`.
 
 When `aube install` finds one of these names in any importer's
 `dependencies`, `devDependencies`, or `optionalDependencies`, it
 forces per-project materialization for that install and prints a
-one-line warning naming the trigger. Defaults to `["next"]`; add
-other packages here as you discover them, or set the list to `[]` to
-disable the heuristic. `CI=1` already forces per-project mode, so the
-warning suppresses itself in that case.
+one-line warning naming the trigger. The default list covers the
+bundlers most commonly declared as direct devDeps; add other
+packages here as you discover them (or set the list to `[]` to
+disable the heuristic entirely). `CI=1` already forces per-project
+mode, so the warning suppresses itself in that case.
 
 ## Store
 


### PR DESCRIPTION
## Summary

The `disableGlobalVirtualStoreForPackages` heuristic auto-falls back to per-project materialization when an importer declares a package whose resolver can't handle gvs's symlink-to-global-store layout. Previous default `["next"]` only caught Next.js/Turbopack, but the same walk-up-after-symlink-follow pattern is standard across Rollup- and Webpack-family resolvers — so any project that declares `vite`, `vitepress`, `rollup`, `webpack`, `parcel`, or `nuxt` directly was silently broken on local installs and had to reach for workarounds.

Canonical example: [jdx/mise#9261](https://github.com/jdx/mise/pull/9261) had to add `.npmrc node-linker=hoisted` + manual Vite `resolve.alias` entries + three `vscode-*` direct-dep additions to get `vitepress build` working under aube. All of that becomes unnecessary once `vitepress` is in the default list.

New default: `["next", "nuxt", "vite", "vitepress", "rollup", "webpack", "parcel"]`. Gvs stays on by default for every other project — the selling point is intact.

## Details

- Matcher is exact-string against direct `dependencies` / `devDependencies` / `optionalDependencies`; peer-only declarations intentionally don't trigger (a lib that declares `vite` as a peer isn't itself a Vite app).
- Users can opt out by setting the list to `[]` in `.npmrc` or `pnpm-workspace.yaml`.
- Users can force gvs back on with `aube install --enable-gvs` even when the heuristic fires.
- Warning message is updated to stop singling out Next.js/Turbopack; the inline comment and manifest-side docstring follow.

## Verification

Reproduced with the mise docs fixture (bare `package.json` with `vitepress`, `vitepress-plugin-*`):

```
$ aube install
WARN  disabling global virtual store: `vitepress` is in disableGlobalVirtualStoreForPackages ...
  ✓ 2.3s · resolved 262 · reused 262

$ realpath node_modules/vitepress
/private/tmp/aube-repro/mise-docs/node_modules/.aube/.../node_modules/vitepress   # inside project

$ npx vitepress build docs
✓ building client + server bundles...
✓ rendering pages...
build complete in 4.13s.
```

## Test plan

- [x] `cargo test -p aube-settings -p aube-manifest` (76 tests pass).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] End-to-end: fresh install of the mise VitePress fixture triggers the heuristic on `vitepress`, install succeeds, `vitepress build` succeeds with no user config.

## Future work

- Glob support (`@vitejs/*`) so apps that declare `@vitejs/plugin-vue` but not `vite` directly also trigger. Out of scope here.
- Benchmark a structural alternative (keep gvs on, switch materialization to project-local real dirs with CAS-hardlinked files) that would fix all such cases without a known-bad list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default install behavior by disabling the global virtual store for more projects (those depending on common bundlers/frameworks), which may impact performance/disk usage and could surprise users relying on gvs.
> 
> **Overview**
> Expands the `disableGlobalVirtualStoreForPackages` heuristic’s default trigger list from just `next` to include common bundlers/frameworks (`nuxt`, `vite`, `vitepress`, `rollup`, `webpack`, `parcel`), causing `aube install` to automatically fall back to per-project materialization when these are direct deps.
> 
> Updates the associated docs/comments and refines the install-time warning text to describe the broader “follow symlinks then walk up” resolver incompatibility and to clarify opt-out/override knobs (`enableGlobalVirtualStore=false` vs `disableGlobalVirtualStoreForPackages=[]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96c8c65e08b171ac1d3f119a218d9500c6f91d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->