### PR TITLE
resolver: dedupe root deps declared in multiple sections

### DIFF
--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -5200,4 +5200,74 @@ mod tests {
         assert_eq!(root[0].name, "p-map");
         assert_eq!(root[0].dep_type, DepType::Production);
     }
+
+    // `dependencies` also wins over `optionalDependencies` when the
+    // same name appears in both — same race hazard, same fix.
+    #[tokio::test]
+    async fn same_dep_in_dependencies_and_optional_dependencies_dedupes() {
+        let pmap = make_packument("p-map", &["7.0.4"], "7.0.4");
+
+        let client = Arc::new(aube_registry::client::RegistryClient::new(
+            "http://127.0.0.1:0",
+        ));
+        let mut resolver = Resolver::new(client);
+        resolver.cache.insert("p-map".to_string(), pmap);
+
+        let mut manifest = PackageJson::default();
+        manifest
+            .dependencies
+            .insert("p-map".to_string(), "7.0.4".to_string());
+        manifest
+            .optional_dependencies
+            .insert("p-map".to_string(), "7.0.4".to_string());
+
+        let graph = resolver
+            .resolve(&manifest, None)
+            .await
+            .expect("resolve failed");
+
+        let root = graph.importers.get(".").unwrap();
+        assert_eq!(
+            root.len(),
+            1,
+            "p-map must appear once in root deps, got {root:?}"
+        );
+        assert_eq!(root[0].name, "p-map");
+        assert_eq!(root[0].dep_type, DepType::Production);
+    }
+
+    // With no `dependencies` entry, `devDependencies` wins over
+    // `optionalDependencies`. Covers the remaining overlap branch.
+    #[tokio::test]
+    async fn same_dep_in_dev_and_optional_dependencies_dedupes() {
+        let pmap = make_packument("p-map", &["7.0.4"], "7.0.4");
+
+        let client = Arc::new(aube_registry::client::RegistryClient::new(
+            "http://127.0.0.1:0",
+        ));
+        let mut resolver = Resolver::new(client);
+        resolver.cache.insert("p-map".to_string(), pmap);
+
+        let mut manifest = PackageJson::default();
+        manifest
+            .dev_dependencies
+            .insert("p-map".to_string(), "7.0.4".to_string());
+        manifest
+            .optional_dependencies
+            .insert("p-map".to_string(), "7.0.4".to_string());
+
+        let graph = resolver
+            .resolve(&manifest, None)
+            .await
+            .expect("resolve failed");
+
+        let root = graph.importers.get(".").unwrap();
+        assert_eq!(
+            root.len(),
+            1,
+            "p-map must appear once in root deps, got {root:?}"
+        );
+        assert_eq!(root[0].name, "p-map");
+        assert_eq!(root[0].dep_type, DepType::Dev);
+    }
 }

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -753,7 +753,17 @@ impl Resolver {
             tracing::debug!("minimumReleaseAge cutoff: {}", c);
         }
 
-        // Seed queue with direct deps from all importers
+        // Seed queue with direct deps from all importers.
+        //
+        // When a package is declared in more than one section
+        // (`dependencies` + `devDependencies`, etc.) we keep only the
+        // highest-priority entry — `dependencies` > `devDependencies` >
+        // `optionalDependencies` — matching pnpm, which silently drops
+        // the lower-priority duplicates on resolve. Without this the
+        // same name gets pushed into the importer's `DirectDep` list
+        // twice (once per section), and the linker's parallel step 2
+        // races to create the same `node_modules/<name>` symlink from
+        // two tasks, producing an `EEXIST` on the loser.
         for (importer_path, manifest) in manifests {
             importers.insert(importer_path.clone(), Vec::new());
 
@@ -771,6 +781,9 @@ impl Resolver {
                 });
             }
             for (name, range) in &manifest.dev_dependencies {
+                if manifest.dependencies.contains_key(name) {
+                    continue;
+                }
                 queue.push_back(ResolveTask {
                     name: name.clone(),
                     range: range.clone(),
@@ -788,6 +801,11 @@ impl Resolver {
                     tracing::debug!(
                         "ignoring optional dependency {name} (pnpm.ignoredOptionalDependencies)"
                     );
+                    continue;
+                }
+                if manifest.dependencies.contains_key(name)
+                    || manifest.dev_dependencies.contains_key(name)
+                {
                     continue;
                 }
                 queue.push_back(ResolveTask {
@@ -5142,5 +5160,44 @@ mod tests {
         assert_eq!(root.len(), 1);
         assert_eq!(root[0].name, "@std/collections");
         assert_eq!(root[0].dep_path, "@std/collections@1.1.6");
+    }
+
+    // A package listed in both `dependencies` and `devDependencies`
+    // must appear in the resolved importer's direct-dep list exactly
+    // once, with `dep_type = Production` (matches pnpm: production
+    // wins, dev entry is silently dropped). Without dedupe the linker
+    // sees the same name twice and parallel step 2 races to create
+    // the shared `node_modules/<name>` symlink, producing EEXIST.
+    #[tokio::test]
+    async fn same_dep_in_dependencies_and_dev_dependencies_dedupes() {
+        let pmap = make_packument("p-map", &["7.0.4"], "7.0.4");
+
+        let client = Arc::new(aube_registry::client::RegistryClient::new(
+            "http://127.0.0.1:0",
+        ));
+        let mut resolver = Resolver::new(client);
+        resolver.cache.insert("p-map".to_string(), pmap);
+
+        let mut manifest = PackageJson::default();
+        manifest
+            .dependencies
+            .insert("p-map".to_string(), "7.0.4".to_string());
+        manifest
+            .dev_dependencies
+            .insert("p-map".to_string(), "7.0.4".to_string());
+
+        let graph = resolver
+            .resolve(&manifest, None)
+            .await
+            .expect("resolve failed");
+
+        let root = graph.importers.get(".").unwrap();
+        assert_eq!(
+            root.len(),
+            1,
+            "p-map must appear once in root deps, got {root:?}"
+        );
+        assert_eq!(root[0].name, "p-map");
+        assert_eq!(root[0].dep_type, DepType::Production);
     }
 }


### PR DESCRIPTION
## Summary

Two related bugs, one root cause: a package listed in both
`dependencies` and `devDependencies` of the same `package.json` made
`aube install` fail with an `EEXIST` symlink error, and then on the
next run report `Already up to date (1 package)` even though the first
install had failed.

Repro:

```json
{
  "dependencies":    { "p-map": "7.0.4" },
  "devDependencies": { "p-map": "7.0.4" }
}
```

```
$ aube install
Error:   × failed to link node_modules
  ╰─▶ I/O error at .../node_modules/p-map: File exists (os error 17)

$ aube install
aube 1.0.0-beta.5 by en.dev · Already up to date (1 package)
```

## Root cause

The resolver seeded a `ResolveTask` for every section, so the same
name landed in the importer's `DirectDep` list twice (once from
dependencies, once from devDependencies — both flowed through the
sibling-dedupe branch and each pushed their own entry). The linker's
parallel step 2 then had two rayon tasks racing to create the same
`node_modules/<name>` symlink — one won, the other got `EEXIST`.

After the partial failure, `node_modules/<name>` existed. On the
next install, both duplicate root-dep entries hit the "already
placed" short-circuit, `top_level_linked` stayed at 0, and the
summary line wrongly read `Already up to date`.

## Fix

Dedupe at the resolver seed: if a name is already covered by a
higher-priority section, skip seeding it from the lower one.
Priority is `dependencies` > `devDependencies` > `optionalDependencies`,
matching what pnpm writes in the resolved lockfile (dev/optional
duplicates are silently dropped).

With the fix both reproductions behave correctly: the first install
succeeds and reports `✓ installed 1 package`, the second correctly
reports `Already up to date (1 package)`.

## Test plan

- [x] New unit test `same_dep_in_dependencies_and_dev_dependencies_dedupes` asserts one-entry root deps with `DepType::Production`
- [x] `cargo test -p aube-resolver -p aube-linker` (92 + linker tests passing)
- [x] `cargo clippy -p aube-resolver --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] End-to-end: rebuilt `aube`, ran against the reproducer — first install succeeds, second reports "Already up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes root dependency seeding logic in the resolver, which can affect which direct deps are resolved/linked for a project (especially when the same package is declared in multiple sections). Scope is small and covered by new unit tests, but impacts install correctness.
> 
> **Overview**
> Prevents duplicate root `ResolveTask`s when the same package name appears in multiple manifest sections by skipping lower-priority entries (`dependencies` > `devDependencies` > `optionalDependencies`), aligning behavior with pnpm and avoiding linker `EEXIST` symlink races.
> 
> Adds unit tests asserting that overlapping declarations are resolved exactly once and that the surviving direct dep has the expected `DepType` (production beats dev/optional; dev beats optional).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c8bfde0d1727f9ff90ccff222006c4408f9396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->