### PR TITLE
ci(release): drop swatinem cache from upload-assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,6 @@ jobs:
         with:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: rust-${{ matrix.target }}
       # taiki-e/upload-rust-binary-action builds via cargo/cross, packages
       # the named bins into a single `<archive>.{tar.gz,zip}`, and uploads
       # it onto the existing release for `tag`. Multi-bin mode requires an


### PR DESCRIPTION
## Summary
- Remove the `Swatinem/rust-cache@v2` step from the `upload-assets` job in `.github/workflows/release.yml`.

## Test plan
- [ ] Next release run builds upload-assets targets without the cache step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that removes a build cache step; main impact is potentially slower or less reliable release builds if compilation now hits network or rebuilds more often.
> 
> **Overview**
> Removes the `Swatinem/rust-cache@v2` caching step from the `upload-assets` job in `.github/workflows/release.yml`, so release binaries are built and uploaded without the Rust dependency cache layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d11dce0008a1c24ec8ecda15f321b1d927aca4cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->