### PR TITLE
clean: include bun.lock in --lockfile removal set

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -167,7 +167,7 @@ cmd ci help="Clean install: delete node_modules, then install with frozen lockfi
 }
 cmd clean help="Remove `node_modules` across every workspace project" {
     long_help "Remove `node_modules` across every workspace project.\n\n`--lockfile` / `-l` also deletes lockfiles. A `clean` script in the root `package.json` overrides the built-in."
-    flag "-l --lockfile" help="Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`)"
+    flag "-l --lockfile" help="Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)"
 }
 cmd completion help="Generate shell completions (bash, zsh, fish)" {
     arg <SHELL> help="The shell to generate completions for (bash, zsh, fish)"
@@ -601,7 +601,7 @@ cmd publish help="Publish the current package to the registry" {
 }
 cmd purge help="Alias for `clean` — remove `node_modules` across every workspace project" {
     long_help "Alias for `clean` — remove `node_modules` across every workspace project.\n\nA `purge` script in the root `package.json` overrides the built-in."
-    flag "-l --lockfile" help="Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`)"
+    flag "-l --lockfile" help="Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)"
 }
 cmd rebuild help="Re-run root lifecycle scripts and allowlisted dependency builds" {
     alias rb

--- a/crates/aube/src/commands/clean.rs
+++ b/crates/aube/src/commands/clean.rs
@@ -9,8 +9,9 @@
 //!   `pnpm-workspace.yaml`) and delete each project's `node_modules/`.
 //! - With `--lockfile` / `-l`, also remove the root lockfiles:
 //!   `aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`,
-//!   `npm-shrinkwrap.json`, and `yarn.lock`. Workspace children don't
-//!   carry their own lockfile so the flag only touches the root.
+//!   `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock`. Workspace
+//!   children don't carry their own lockfile so the flag only touches
+//!   the root.
 //!
 //! Unlike `aube ci`, `clean` never reinstalls — it's a pure "wipe the
 //! tree" command.
@@ -22,7 +23,7 @@ use miette::{Context, IntoDiagnostic};
 pub struct CleanArgs {
     /// Also remove lockfiles at the workspace root
     /// (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`,
-    /// `npm-shrinkwrap.json`, `yarn.lock`).
+    /// `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`).
     #[arg(short = 'l', long)]
     pub lockfile: bool,
 }
@@ -35,6 +36,7 @@ const LOCKFILE_NAMES: &[&str] = &[
     "package-lock.json",
     "npm-shrinkwrap.json",
     "yarn.lock",
+    "bun.lock",
 ];
 
 pub async fn run(args: CleanArgs) -> miette::Result<()> {

--- a/docs/cli/clean.md
+++ b/docs/cli/clean.md
@@ -11,4 +11,4 @@ Remove `node_modules` across every workspace project.
 
 ### `-l --lockfile`
 
-Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`)
+Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -643,8 +643,8 @@
           {
             "name": "lockfile",
             "usage": "-l --lockfile",
-            "help": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`)",
-            "help_first_line": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`)",
+            "help": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)",
+            "help_first_line": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)",
             "short": [
               "l"
             ],
@@ -3581,8 +3581,8 @@
           {
             "name": "lockfile",
             "usage": "-l --lockfile",
-            "help": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`)",
-            "help_first_line": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`)",
+            "help": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)",
+            "help_first_line": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)",
             "short": [
               "l"
             ],

--- a/docs/cli/purge.md
+++ b/docs/cli/purge.md
@@ -11,4 +11,4 @@ A `purge` script in the root `package.json` overrides the built-in.
 
 ### `-l --lockfile`
 
-Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`)
+Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)

--- a/test/clean.bats
+++ b/test/clean.bats
@@ -48,13 +48,15 @@ EOF
 	: >aube-lock.yaml
 	: >pnpm-lock.yaml
 	: >package-lock.json
+	: >bun.lock
 
 	run aube clean --lockfile
 	assert_success
-	assert_output --partial "3 lockfiles"
+	assert_output --partial "4 lockfiles"
 	assert [ ! -e aube-lock.yaml ]
 	assert [ ! -e pnpm-lock.yaml ]
 	assert [ ! -e package-lock.json ]
+	assert [ ! -e bun.lock ]
 }
 
 @test "aube clean walks workspace packages" {


### PR DESCRIPTION
## Summary
- `aube clean --lockfile` was supposed to wipe every root lockfile aube understands, but `LOCKFILE_NAMES` in [clean.rs](crates/aube/src/commands/clean.rs) was missing `bun.lock` — so bun-lockfile projects ran `clean --lockfile`, saw it "succeed," and were left with `bun.lock` still on disk.
- Added `bun.lock` to the constant and updated the module docstring and `--lockfile` help text so they match the actual behavior and the lockfile set documented in `CLAUDE.md` / `detect_existing_lockfile_kind`.
- Extended the existing `aube clean --lockfile also removes the root lockfile(s)` bats case to cover `bun.lock` so this can't regress silently.

## Test plan
- [x] `cargo build`
- [x] `mise run test:bats test/clean.bats` — all 10 cases pass, including the expanded `--lockfile` case now asserting "4 lockfiles" and `[ ! -e bun.lock ]`.

## Notes for reviewer
- Scope is intentionally narrow to the reported bug. Not touched: branch-specific lockfiles (`aube-lock.<branch>.yaml` / `pnpm-lock.<branch>.yaml` written when `git-branch-lockfile` is enabled) are also not picked up by this constant — happy to do that in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, additive change to the `clean`/`purge` lockfile deletion list plus help-text and a regression test; it only affects runs where `--lockfile` is passed.
> 
> **Overview**
> `aube clean --lockfile` (and `aube purge --lockfile`) now also removes the root `bun.lock` file, aligning behavior with the documented lockfile set.
> 
> CLI help text/usage docs were updated accordingly, and the existing bats test was extended to assert `bun.lock` is removed and the summary count increments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e9dca6b68e30241e4597d8691f4c243f3b9853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->