### PR TITLE
cli: fix --version / -V on aubr and aubx multicall shims

### DIFF
--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -32,6 +32,16 @@ fn rewrite_multicall_argv(mut args: Vec<OsString>) -> Vec<OsString> {
         _ => return args,
     };
     args[0] = OsString::from("aube");
+    // `--version` / `-V` belong to the top-level `aube` command; `run` and
+    // `dlx` don't accept them, and for `dlx` the bare word would be parsed
+    // as a package name and trigger a registry lookup. Short-circuit to
+    // `aube --version` so the shims report the binary's version.
+    if matches!(
+        args.get(1).and_then(|s| s.to_str()),
+        Some("--version") | Some("-V")
+    ) {
+        return args;
+    }
     args.insert(1, OsString::from(subcommand));
     args
 }
@@ -1457,6 +1467,28 @@ mod multicall_tests {
         // parses as the `run` subcommand with no positional — same as
         // the user typing `aube run` directly.
         assert_eq!(rewrite_multicall_argv(os(&["aubr"])), os(&["aube", "run"]));
+    }
+
+    #[test]
+    fn version_flag_short_circuits_to_top_level() {
+        // `aubr --version` / `aubx --version` should print the aube
+        // version, not trip the `run` / `dlx` parsers.
+        assert_eq!(
+            rewrite_multicall_argv(os(&["aubr", "--version"])),
+            os(&["aube", "--version"])
+        );
+        assert_eq!(
+            rewrite_multicall_argv(os(&["aubx", "--version"])),
+            os(&["aube", "--version"])
+        );
+        assert_eq!(
+            rewrite_multicall_argv(os(&["aubr", "-V"])),
+            os(&["aube", "-V"])
+        );
+        assert_eq!(
+            rewrite_multicall_argv(os(&["aubx.exe", "-V"])),
+            os(&["aube", "-V"])
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- `aubr --version` / `aubr -V` and `aubx --version` / `aubx -V` didn't print the aube version as expected. The multicall rewrite in [main.rs](crates/aube/src/main.rs) injected the subcommand first, so clap parsed the argv as `aube run --version` (unknown flag → exit 2) or `aube dlx --version` (treated `--version` as a package name → registry lookup error).
- Short-circuit `rewrite_multicall_argv` when argv[1] is `--version` or `-V`, so the shims fall through to the top-level `aube --version` handler.

## Test plan

- [x] `cargo test -p aube --bin aube multicall` — all 6 multicall tests pass, including the new `version_flag_short_circuits_to_top_level` case
- [x] Manual: `aubr --version`, `aubr -V`, `aubx --version`, `aubx -V` all print `aube 1.0.0-beta.6` and exit 0
- [x] Manual: `aube --version` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated CLI argv rewrite change with added unit coverage; main impact is how `--version`/`-V` are handled for multicall shims.
> 
> **Overview**
> Fixes multicall shim invocations (`aubr`, `aubx`) so `--version`/`-V` are handled by the top-level `aube` command instead of being rewritten into `run`/`dlx` (which previously caused parse errors or unintended registry lookups).
> 
> Adds a focused `multicall` unit test to assert the new short-circuit behavior across both flags and Windows `.exe` shim names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93c9ef1f06594ca29cc9b6df01da2e259ae0ae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->