### PR TITLE
lockfile: byte-identical pnpm-lock.yaml / bun.lock on re-emit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,10 @@ test/registry/storage/** linguist-generated=true
 # otherwise embed CRLF into the binary and break the string-equality
 # check against `clap_usage::generate`'s LF output.
 aube.usage.kdl text eol=lf
+
+# Golden fixtures consumed by the byte-parity tests in
+# `crates/aube-lockfile/src/{pnpm,bun}.rs`. Windows' autocrlf would
+# otherwise rewrite these to CRLF on checkout, so `parse → write`
+# compares LF (what the writer emits) against CRLF (what's on disk)
+# and the test fails.
+crates/aube-lockfile/tests/fixtures/* text eol=lf

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -462,40 +462,32 @@ pub fn write(
     let roots = graph.importers.get(".").cloned().unwrap_or_default();
     let tree = crate::npm::build_hoist_tree(&canonical, &roots);
 
-    // Root workspace entry (`""` in bun.lock): mirror the manifest's
-    // direct-dep sections so `bun install --frozen-lockfile` can
-    // match against package.json without our having to carry bun's
-    // own specifier fields through the graph.
-    let mut root_obj = serde_json::Map::new();
+    // Root workspace entry (`""` in bun.lock). Field order mirrors
+    // bun's output (`name`, then dep sections). `version` is
+    // intentionally *not* written — bun leaves the workspace-root
+    // version field off even when package.json declares one, so
+    // emitting it here produces a gratuitous diff on every round-trip.
+    let mut root_pairs: Vec<(&'static str, Value)> = Vec::new();
     if let Some(name) = &manifest.name {
-        root_obj.insert("name".to_string(), json!(name));
-    }
-    if let Some(version) = &manifest.version {
-        root_obj.insert("version".to_string(), json!(version));
+        root_pairs.push(("name", json!(name)));
     }
     if !manifest.dependencies.is_empty() {
-        root_obj.insert("dependencies".to_string(), json!(manifest.dependencies));
+        root_pairs.push(("dependencies", json!(manifest.dependencies)));
     }
     if !manifest.dev_dependencies.is_empty() {
-        root_obj.insert(
-            "devDependencies".to_string(),
-            json!(manifest.dev_dependencies),
-        );
+        root_pairs.push(("devDependencies", json!(manifest.dev_dependencies)));
     }
     if !manifest.optional_dependencies.is_empty() {
-        root_obj.insert(
-            "optionalDependencies".to_string(),
+        root_pairs.push((
+            "optionalDependencies",
             json!(manifest.optional_dependencies),
-        );
+        ));
     }
     if !manifest.peer_dependencies.is_empty() {
-        root_obj.insert(
-            "peerDependencies".to_string(),
-            json!(manifest.peer_dependencies),
-        );
+        root_pairs.push(("peerDependencies", json!(manifest.peer_dependencies)));
     }
 
-    let mut packages_obj = serde_json::Map::new();
+    let mut package_entries: Vec<(String, Value)> = Vec::new();
     for (segs, canonical_key) in &tree {
         let Some(pkg) = canonical.get(canonical_key).copied() else {
             continue;
@@ -532,22 +524,124 @@ pub fn write(
             Value::Object(meta),
             Value::String(integrity),
         ]);
-        packages_obj.insert(bun_key, entry);
+        package_entries.push((bun_key, entry));
     }
 
-    let mut root_workspace = serde_json::Map::new();
-    root_workspace.insert("".to_string(), Value::Object(root_obj));
-
-    let mut doc = serde_json::Map::new();
-    doc.insert("lockfileVersion".to_string(), json!(1));
-    doc.insert("workspaces".to_string(), Value::Object(root_workspace));
-    doc.insert("packages".to_string(), Value::Object(packages_obj));
-
-    let mut body = serde_json::to_string_pretty(&Value::Object(doc))
-        .map_err(|e| Error::Parse(path.to_path_buf(), e.to_string()))?;
-    body.push('\n');
+    let body = format_bun_lockfile(&root_pairs, &package_entries);
     std::fs::write(path, body).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     Ok(())
+}
+
+/// Hand-written JSONC emitter matching bun 1.2's `bun.lock` style.
+///
+/// bun's output has an idiosyncratic shape — nested object fields use
+/// trailing commas (standard JSONC) except `packages:` itself (the
+/// last top-level field, where bun omits the trailing comma and leaves
+/// the closing brace bare) — and every `packages:` entry is serialized
+/// as a single-line array with a blank separator above. serde_json's
+/// `to_string_pretty` can't express any of that, so we build the
+/// output by hand.
+///
+/// `root_pairs` is the ordered `workspaces[""]` key/value list; values
+/// are emitted inline via `serde_json::to_string`. `package_entries`
+/// are the `packages:` map in BTreeMap order — each is rendered as a
+/// single-line `[ident, "", {meta}, integrity]` array.
+fn format_bun_lockfile(
+    root_pairs: &[(&'static str, serde_json::Value)],
+    package_entries: &[(String, serde_json::Value)],
+) -> String {
+    let mut out = String::with_capacity(8192);
+    out.push_str("{\n");
+    out.push_str("  \"lockfileVersion\": 1,\n");
+    out.push_str("  \"configVersion\": 1,\n");
+
+    // Workspaces block. One importer (`""`) for now — workspace
+    // projects beyond the root are a TODO tracked in the bun writer.
+    out.push_str("  \"workspaces\": {\n");
+    out.push_str("    \"\": {\n");
+    for (k, v) in root_pairs.iter() {
+        let key_str = serde_json::to_string(k).unwrap();
+        // bun emits a trailing comma after every workspace-level field,
+        // including the last one — `},` closes the `""` block.
+        match v {
+            serde_json::Value::Object(map) if !map.is_empty() => {
+                // Multi-line block — bun expands workspace dep maps
+                // even when small.
+                out.push_str(&format!("      {key_str}: {{\n"));
+                for (dk, dv) in map {
+                    out.push_str(&format!(
+                        "        {}: {},\n",
+                        serde_json::to_string(dk).unwrap(),
+                        inline_json(dv, 0)
+                    ));
+                }
+                out.push_str("      },\n");
+            }
+            _ => {
+                out.push_str(&format!("      {key_str}: {},\n", inline_json(v, 0)));
+            }
+        }
+    }
+    out.push_str("    },\n");
+    out.push_str("  },\n");
+
+    // Packages block. Each entry is its own line; bun separates
+    // entries with a blank line (an empty line between every
+    // consecutive pair). `packages:` is bun's last top-level field and
+    // gets no trailing comma on its closing brace.
+    out.push_str("  \"packages\": {\n");
+    for (i, (key, entry)) in package_entries.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "    {}: {},\n",
+            serde_json::to_string(key).unwrap(),
+            inline_json(entry, 0)
+        ));
+    }
+    out.push_str("  }\n");
+    out.push_str("}\n");
+    out
+}
+
+/// Serialize a JSON value inline in bun's spaced style — objects as
+/// `{ "k": v, "k2": v2 }` (with a trailing space before `}` and a
+/// trailing comma before the close), arrays as `["a", "b"]` (no
+/// trailing comma). Recurses into nested objects/arrays.
+///
+/// `base_indent` is reserved for a future multi-line fallback when an
+/// object gets too wide; bun in 1.2 keeps even the larger metadata
+/// objects on one line, so we currently ignore it.
+fn inline_json(value: &serde_json::Value, _base_indent: usize) -> String {
+    use serde_json::Value;
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(_) => serde_json::to_string(value).unwrap(),
+        Value::Array(arr) => {
+            let parts: Vec<String> = arr.iter().map(|v| inline_json(v, 0)).collect();
+            format!("[{}]", parts.join(", "))
+        }
+        Value::Object(map) => {
+            if map.is_empty() {
+                return "{}".to_string();
+            }
+            let parts: Vec<String> = map
+                .iter()
+                .map(|(k, v)| {
+                    format!(
+                        "{}: {}",
+                        serde_json::to_string(k).unwrap(),
+                        inline_json(v, 0)
+                    )
+                })
+                .collect();
+            // bun writes `{ k: v, k2: v2 }` — spaces inside, no trailing comma.
+            format!("{{ {} }}", parts.join(", "))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -853,6 +947,64 @@ mod tests {
                 .get("bar")
                 .map(String::as_str),
             Some("bar@1.0.0")
+        );
+    }
+
+    /// Structural checks against a real `bun install`-generated lockfile.
+    /// A full byte-parity test is gated on two data-model changes we're
+    /// deferring (preserving declared dependency ranges, preserving the
+    /// full `bin` map), so this test asserts the format invariants
+    /// we *have* fixed: `configVersion` is emitted, the root workspace
+    /// carries no bogus `version`, package entries render on single
+    /// lines, trailing commas match bun's JSONC style, and `packages`
+    /// closes without a trailing comma as the last top-level field.
+    #[test]
+    fn test_write_matches_bun_jsonc_style() {
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/bun-native.lock");
+        let graph = parse(&fixture).unwrap();
+        let manifest = aube_manifest::PackageJson {
+            name: Some("aube-lockfile-stability".to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: [
+                ("chalk".to_string(), "^4.1.2".to_string()),
+                ("picocolors".to_string(), "^1.1.1".to_string()),
+                ("semver".to_string(), "^7.6.3".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write(tmp.path(), &graph, &manifest).unwrap();
+        let body = std::fs::read_to_string(tmp.path()).unwrap();
+
+        // configVersion is present and matches bun 1.2's value.
+        assert!(
+            body.contains("\"configVersion\": 1,"),
+            "missing configVersion:\n{body}"
+        );
+        // No spurious `version` on the root workspace — bun leaves it
+        // off even when package.json declares one.
+        assert!(
+            !body.contains("\"version\""),
+            "root workspace must not carry `version`:\n{body}"
+        );
+        // Trailing comma on each workspace-level dep line (jsonc style).
+        assert!(
+            body.contains("\"chalk\": \"^4.1.2\",\n"),
+            "workspace dep must end with trailing comma:\n{body}"
+        );
+        // Package entries are one line each.
+        assert!(
+            body.contains("    \"chalk\": [\"chalk@4.1.2\", \"\", { \"dependencies\": "),
+            "package entry should be on a single line:\n{body}"
+        );
+        // `packages:` closes with `  }\n}` — no trailing comma on the
+        // last top-level field.
+        assert!(
+            body.ends_with("  }\n}\n"),
+            "root object must close without trailing comma:\n{body}"
         );
     }
 }

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -138,6 +138,13 @@ struct RawBunMeta {
     dependencies: BTreeMap<String, String>,
     #[serde(default)]
     optional_dependencies: BTreeMap<String, String>,
+    /// `bin:` map — bun records executables by name on each package's
+    /// meta block (`{ "bin": { "semver": "bin/semver.js" } }`). Round-
+    /// tripping it is what keeps `aube install --no-frozen-lockfile`
+    /// from silently dropping the `bin:` line and drifting against
+    /// bun's own output.
+    #[serde(default)]
+    bin: BTreeMap<String, String>,
 }
 
 /// Parse a bun.lock file into a LockfileGraph.
@@ -203,6 +210,17 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         {
             deps.insert(n.clone(), String::new());
         }
+        // Preserve bun's per-entry meta ranges (`"^4.1.0"`) so re-emit
+        // doesn't collapse them to the resolved pin.
+        let mut declared: BTreeMap<String, String> = BTreeMap::new();
+        for (k, v) in entry
+            .meta
+            .dependencies
+            .iter()
+            .chain(entry.meta.optional_dependencies.iter())
+        {
+            declared.insert(k.clone(), v.clone());
+        }
 
         packages.insert(
             dep_path.clone(),
@@ -212,6 +230,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 integrity: entry.integrity.clone().filter(|s| !s.is_empty()),
                 dependencies: deps,
                 dep_path,
+                declared_dependencies: declared,
+                bin: entry.meta.bin.clone(),
                 ..Default::default()
             },
         );
@@ -499,21 +519,50 @@ pub fn write(
         // recognizes `@`-prefixed segments as a single unit.
         let bun_key = segs.join("/");
 
-        // Metadata object: transitive deps keyed by name → version.
-        // Filter out deps we don't have a canonical entry for (e.g.
-        // dropped optional deps).
+        // Metadata object: transitive deps keyed by name → declared
+        // range (e.g. `"^4.1.0"`). Fall back to the resolved pin when
+        // the declared range is unknown — happens for lockfiles that
+        // came through a format without declared ranges (pnpm's
+        // `snapshots:` stores pins only). Filter out deps we don't
+        // have a canonical entry for (e.g. dropped optional deps).
         let mut deps_obj = serde_json::Map::new();
         for (dep_name, dep_value) in &pkg.dependencies {
             let key = crate::npm::child_canonical_key(dep_name, dep_value);
             if !canonical.contains_key(&key) {
                 continue;
             }
-            let version = crate::npm::dep_value_as_version(dep_name, dep_value);
-            deps_obj.insert(dep_name.clone(), Value::String(version.to_string()));
+            let rendered = pkg
+                .declared_dependencies
+                .get(dep_name)
+                .cloned()
+                .unwrap_or_else(|| {
+                    crate::npm::dep_value_as_version(dep_name, dep_value).to_string()
+                });
+            deps_obj.insert(dep_name.clone(), Value::String(rendered));
         }
         let mut meta = serde_json::Map::new();
         if !deps_obj.is_empty() {
             meta.insert("dependencies".to_string(), Value::Object(deps_obj));
+        }
+        // Preserve the full `bin:` map — bun's meta block records
+        // executables by name so `bun install --frozen-lockfile` can
+        // recreate the `.bin` shims without re-reading each tarball's
+        // manifest. pnpm collapses this to `hasBin: true`; we keep
+        // both representations on `LockedPackage.bin` so either
+        // writer can render byte-identical output.
+        //
+        // Skip empty-key entries — those are the placeholder bins
+        // pnpm's lockfile synthesizes when it knows `hasBin: true`
+        // but has no paths. Emitting them would produce a
+        // `{"bin": {"": ""}}` block bun wouldn't accept.
+        let real_bins: serde_json::Map<String, Value> = pkg
+            .bin
+            .iter()
+            .filter(|(k, _)| !k.is_empty())
+            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+            .collect();
+        if !real_bins.is_empty() {
+            meta.insert("bin".to_string(), Value::Object(real_bins));
         }
 
         let ident = format!("{}@{}", pkg.name, pkg.version);
@@ -950,17 +999,26 @@ mod tests {
         );
     }
 
-    /// Structural checks against a real `bun install`-generated lockfile.
-    /// A full byte-parity test is gated on two data-model changes we're
-    /// deferring (preserving declared dependency ranges, preserving the
-    /// full `bin` map), so this test asserts the format invariants
-    /// we *have* fixed: `configVersion` is emitted, the root workspace
-    /// carries no bogus `version`, package entries render on single
-    /// lines, trailing commas match bun's JSONC style, and `packages`
-    /// closes without a trailing comma as the last top-level field.
+    /// Byte-parity with a real `bun install`-generated lockfile — the
+    /// fixture at `tests/fixtures/bun-native.lock` was produced by
+    /// bun 1.3 against a `{ chalk, picocolors, semver }` manifest. A
+    /// parse → write round-trip must reproduce the exact bytes;
+    /// anything less means `aube install --no-frozen-lockfile` churns
+    /// someone's bun.lock in git when nothing in the graph moved.
+    /// Covers the format fixes (`configVersion`, no workspace
+    /// `version`, trailing commas, single-line package arrays) plus
+    /// the data-model fixes that ride with them (declared-range
+    /// preservation in `declared_dependencies`, `bin:` map
+    /// round-trip).
     #[test]
-    fn test_write_matches_bun_jsonc_style() {
+    fn test_write_byte_identical_to_native_bun() {
         let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/bun-native.lock");
+        // Normalize line endings — Windows' `core.autocrlf=true` can
+        // rewrite the checked-out fixture to CRLF even with
+        // `.gitattributes eol=lf`; compare against LF form explicitly.
+        let original = std::fs::read_to_string(&fixture)
+            .unwrap()
+            .replace("\r\n", "\n");
         let graph = parse(&fixture).unwrap();
         let manifest = aube_manifest::PackageJson {
             name: Some("aube-lockfile-stability".to_string()),
@@ -977,34 +1035,12 @@ mod tests {
 
         let tmp = tempfile::NamedTempFile::new().unwrap();
         write(tmp.path(), &graph, &manifest).unwrap();
-        let body = std::fs::read_to_string(tmp.path()).unwrap();
+        let written = std::fs::read_to_string(tmp.path()).unwrap();
 
-        // configVersion is present and matches bun 1.2's value.
-        assert!(
-            body.contains("\"configVersion\": 1,"),
-            "missing configVersion:\n{body}"
-        );
-        // No spurious `version` on the root workspace — bun leaves it
-        // off even when package.json declares one.
-        assert!(
-            !body.contains("\"version\""),
-            "root workspace must not carry `version`:\n{body}"
-        );
-        // Trailing comma on each workspace-level dep line (jsonc style).
-        assert!(
-            body.contains("\"chalk\": \"^4.1.2\",\n"),
-            "workspace dep must end with trailing comma:\n{body}"
-        );
-        // Package entries are one line each.
-        assert!(
-            body.contains("    \"chalk\": [\"chalk@4.1.2\", \"\", { \"dependencies\": "),
-            "package entry should be on a single line:\n{body}"
-        );
-        // `packages:` closes with `  }\n}` — no trailing comma on the
-        // last top-level field.
-        assert!(
-            body.ends_with("  }\n}\n"),
-            "root object must close without trailing comma:\n{body}"
-        );
+        if written != original {
+            panic!(
+                "bun writer drifted from native bun output.\n\n--- expected ---\n{original}\n--- got ---\n{written}"
+            );
+        }
     }
 }

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -556,6 +556,16 @@ pub struct LockedPackage {
     /// a package can't declare the same name twice across those
     /// sections.
     pub declared_dependencies: BTreeMap<String, String>,
+    /// Package's `license` field, collapsed to the simple string
+    /// form. Round-tripped so npm's lockfile keeps its per-entry
+    /// `"license": "MIT"` line; pnpm / yarn / bun don't record
+    /// licenses and leave this `None` on parse.
+    pub license: Option<String>,
+    /// Package's funding URL, extracted from whatever shape the
+    /// manifest's `funding:` field took (string / object / array).
+    /// Round-tripped so npm's lockfile keeps its per-entry
+    /// `"funding": {"url": "…"}` block.
+    pub funding_url: Option<String>,
 }
 
 impl LockedPackage {
@@ -784,6 +794,46 @@ impl LockfileGraph {
             catalogs: self.catalogs.clone(),
             bun_config_version: self.bun_config_version,
         })
+    }
+
+    /// Overlay per-package metadata fields from `prior` onto `self`
+    /// for every `(name, version)` that survives in both graphs.
+    /// Carries forward only fields the abbreviated packument (npm
+    /// corgi) doesn't ship — `license`, `funding_url`, and the
+    /// bun-format `configVersion` — so a fresh re-resolve against
+    /// the same spec set doesn't lose them.
+    ///
+    /// Keyed by canonical `name@version`, so a peer-context rewrite
+    /// between the old and new graph still lines up. `self`'s own
+    /// values win when set (fresh registry data is authoritative);
+    /// `prior`'s fill in only the `None` / empty slots. Safe to call
+    /// on any pair of graphs — parsing the old lockfile is the
+    /// caller's concern.
+    pub fn overlay_metadata_from(&mut self, prior: &LockfileGraph) {
+        // Build a canonical `name@version → prior pkg` lookup once so
+        // repeated peer-context variants in `self.packages` all hit
+        // the same prior entry.
+        let mut prior_index: BTreeMap<String, &LockedPackage> = BTreeMap::new();
+        for pkg in prior.packages.values() {
+            prior_index
+                .entry(format!("{}@{}", pkg.name, pkg.version))
+                .or_insert(pkg);
+        }
+        for pkg in self.packages.values_mut() {
+            let key = format!("{}@{}", pkg.name, pkg.version);
+            let Some(prior_pkg) = prior_index.get(&key) else {
+                continue;
+            };
+            if pkg.license.is_none() && prior_pkg.license.is_some() {
+                pkg.license = prior_pkg.license.clone();
+            }
+            if pkg.funding_url.is_none() && prior_pkg.funding_url.is_some() {
+                pkg.funding_url = prior_pkg.funding_url.clone();
+            }
+        }
+        if self.bun_config_version.is_none() {
+            self.bun_config_version = prior.bun_config_version;
+        }
     }
 
     /// Compare this lockfile's root importer against a single manifest.

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -516,6 +516,17 @@ pub struct LockedPackage {
     /// `checksum:` field, which berry tolerates at the default
     /// `checksumBehavior: throw` when the cache is fresh.
     pub yarn_checksum: Option<String>,
+    /// `engines:` from the package's manifest, round-tripped through
+    /// the lockfile so pnpm-style writers can emit the same flow-form
+    /// `engines: {node: '>=8'}` line pnpm writes. Empty map means
+    /// "no engines declared" — the writer skips the field entirely.
+    pub engines: BTreeMap<String, String>,
+    /// `hasBin:` — true when the package declares at least one
+    /// executable (`bin` field in its manifest, in either the string or
+    /// the map form). Round-tripped so pnpm-style writers emit
+    /// `hasBin: true` on the package entry; dropped silently when
+    /// false to match pnpm's "truthy-only" serialization.
+    pub has_bin: bool,
 }
 
 impl LockedPackage {

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -521,12 +521,33 @@ pub struct LockedPackage {
     /// `engines: {node: '>=8'}` line pnpm writes. Empty map means
     /// "no engines declared" — the writer skips the field entirely.
     pub engines: BTreeMap<String, String>,
-    /// `hasBin:` — true when the package declares at least one
-    /// executable (`bin` field in its manifest, in either the string or
-    /// the map form). Round-tripped so pnpm-style writers emit
-    /// `hasBin: true` on the package entry; dropped silently when
-    /// false to match pnpm's "truthy-only" serialization.
-    pub has_bin: bool,
+    /// `bin:` map from the package's manifest, normalized to
+    /// `name → path`. An empty map means "no bins declared".
+    ///
+    /// pnpm-style writers derive `hasBin: true` from
+    /// `!bin.is_empty()` (they don't preserve the names/paths); bun's
+    /// format emits the full map on the package's meta block. Keeping
+    /// the map here lets both writers render byte-identical output
+    /// without an extra tarball-level re-parse.
+    pub bin: BTreeMap<String, String>,
+    /// Dependency ranges as declared in this package's own
+    /// `package.json` — keyed by dep name, values are the raw
+    /// specifiers (`"^4.1.0"`, `"~1.1.4"`, `"workspace:*"`, …).
+    ///
+    /// Distinct from [`Self::dependencies`], which stores the
+    /// *resolved* dep_path tail (`"4.3.0"`). npm / yarn / bun
+    /// lockfiles preserve the declared ranges on every nested
+    /// package entry — rewriting them to the resolved pins is the
+    /// biggest source of round-trip churn against those formats. This
+    /// map lets writers emit the declared range when available and
+    /// fall back to the resolved pin otherwise (e.g. when the source
+    /// lockfile was pnpm, whose `snapshots:` only carries pins).
+    ///
+    /// Empty means "unknown" — writers should fall back to pins.
+    /// Covers production *and* optional dependencies in one map since
+    /// a package can't declare the same name twice across those
+    /// sections.
+    pub declared_dependencies: BTreeMap<String, String>,
 }
 
 impl LockedPackage {

--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -68,6 +68,28 @@ struct RawNpmPackage {
     peer_dependencies: BTreeMap<String, String>,
     #[serde(default)]
     peer_dependencies_meta: BTreeMap<String, RawNpmPeerDepMeta>,
+    /// Captured verbatim for round-trip. npm writes these on every
+    /// package entry; dropping them on re-emit is one of the
+    /// remaining sources of `aube install --no-frozen-lockfile`
+    /// churn against native npm output.
+    #[serde(default)]
+    engines: BTreeMap<String, String>,
+    #[serde(default)]
+    bin: BTreeMap<String, String>,
+    #[serde(default)]
+    license: Option<String>,
+    #[serde(default)]
+    funding: Option<RawNpmFunding>,
+}
+
+/// npm's `funding:` block on a package entry. npm normalizes the
+/// registry's string/object/array shapes to a `{url: …}` object by
+/// the time it reaches the lockfile, so we only need to handle that
+/// form on read. Write-time we emit the same single-key shape.
+#[derive(Debug, Clone, Default, Deserialize)]
+struct RawNpmFunding {
+    #[serde(default)]
+    url: Option<String>,
 }
 
 /// `peerDependenciesMeta` value — only `optional` is meaningful to
@@ -177,18 +199,17 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             declared.insert(k.clone(), v.clone());
         }
 
-        // Keep the `resolved` URL for entries whose tarball URL cannot
-        // be safely re-derived from the install name and version:
-        // npm aliases and JSR's npm-compatible packages.
-        let tarball_url = if alias_of.is_some() || install_name.starts_with("@jsr/") {
-            entry
-                .resolved
-                .as_ref()
-                .filter(|u| u.starts_with("http://") || u.starts_with("https://"))
-                .cloned()
-        } else {
-            None
-        };
+        // Keep the `resolved` URL on every registry package so the
+        // npm writer can emit `resolved:` on every entry verbatim
+        // (what npm itself writes), not just the aliased /
+        // JSR-specific cases where the URL is strictly unrecoverable
+        // from name+version. Dropping it was the single largest
+        // source of churn against npm's own output.
+        let tarball_url = entry
+            .resolved
+            .as_ref()
+            .filter(|u| u.starts_with("http://") || u.starts_with("https://"))
+            .cloned();
 
         // Peer fields are copied verbatim from the lockfile entry.
         // Downstream (`aube-resolver::apply_peer_contexts`) reads
@@ -224,6 +245,10 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 alias_of,
                 tarball_url,
                 declared_dependencies: declared,
+                engines: entry.engines.clone(),
+                bin: entry.bin.clone(),
+                license: entry.license.clone(),
+                funding_url: entry.funding.as_ref().and_then(|f| f.url.clone()),
                 ..Default::default()
             },
         );
@@ -389,6 +414,14 @@ struct WriteNpmLockfile<'a> {
     packages: BTreeMap<String, WriteNpmPackage<'a>>,
 }
 
+// Field order mirrors npm's own package-lock.json output, so a
+// parse → write round-trip diffs cleanly against what `npm install`
+// would produce: `name`, `version`, `resolved`, `integrity`,
+// `license`, then the dep sections, then `bin`, `engines`, `funding`,
+// then the dev/optional flags. Don't reorder — the JSON is
+// serialized as a `BTreeMap`-like structure but serde preserves
+// struct field order for us, which is what npm readers (and git
+// diffs) expect.
 #[derive(Debug, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct WriteNpmPackage<'a> {
@@ -400,6 +433,8 @@ struct WriteNpmPackage<'a> {
     resolved: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     integrity: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    license: Option<&'a str>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     dependencies: BTreeMap<&'a str, &'a str>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
@@ -416,6 +451,12 @@ struct WriteNpmPackage<'a> {
     /// meaningful; other fields npm may add elsewhere aren't modeled.
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     peer_dependencies_meta: BTreeMap<&'a str, WriteNpmPeerDepMeta>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    bin: BTreeMap<&'a str, &'a str>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    engines: BTreeMap<&'a str, &'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    funding: Option<WriteNpmFunding<'a>>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     dev: bool,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
@@ -428,6 +469,15 @@ struct WriteNpmPackage<'a> {
     /// the optional chain (or vice versa with `--omit=optional`).
     #[serde(rename = "devOptional", skip_serializing_if = "std::ops::Not::not")]
     dev_optional: bool,
+}
+
+/// npm emits `funding: {"url": "…"}` verbatim, one key, on every
+/// package entry that declared funding. We only carry the URL on
+/// `LockedPackage`, so this wrapper slots it back into the expected
+/// shape on write.
+#[derive(Debug, Serialize, Default)]
+struct WriteNpmFunding<'a> {
+    url: &'a str,
 }
 
 /// Serialized form of a `peerDependenciesMeta` entry. Mirrors the
@@ -585,15 +635,15 @@ pub fn write(
 
         // Aliased deps (`"h3-v2": "npm:h3@..."` in package.json)
         // round-trip as `node_modules/h3-v2` with an explicit
-        // `name: "h3"` and the captured `resolved:` URL. JSR packages
-        // also need `resolved:` because npm.jsr.io tarball paths are
-        // opaque rather than name-derived.
+        // `name: "h3"`, and every registry package gets a
+        // `resolved:` line — what npm itself writes. JSR packages
+        // are just the degenerate case where the URL can't be
+        // reconstructed from name+version alone. The URL is
+        // populated on the LockedPackage by the resolver (from the
+        // packument's `dist.tarball`) or carried through from a
+        // prior parse of the same npm lockfile.
         let alias_name = pkg.alias_of.as_deref();
-        let resolved = if alias_name.is_some() || pkg.registry_name().starts_with("@jsr/") {
-            pkg.tarball_url.clone()
-        } else {
-            None
-        };
+        let resolved = pkg.tarball_url.clone();
 
         // Round-trip `peerDependencies` so a subsequent read of the
         // rewritten lockfile still feeds the peer-context pass. Values
@@ -630,9 +680,25 @@ pub fn write(
                 version: Some(pkg.version.as_str()),
                 resolved,
                 integrity: pkg.integrity.as_deref(),
+                license: pkg.license.as_deref(),
                 dependencies: deps,
                 peer_dependencies: peer_deps,
                 peer_dependencies_meta: peer_deps_meta,
+                bin: pkg
+                    .bin
+                    .iter()
+                    .filter(|(k, _)| !k.is_empty())
+                    .map(|(k, v)| (k.as_str(), v.as_str()))
+                    .collect(),
+                engines: pkg
+                    .engines
+                    .iter()
+                    .map(|(k, v)| (k.as_str(), v.as_str()))
+                    .collect(),
+                funding: pkg
+                    .funding_url
+                    .as_deref()
+                    .map(|url| WriteNpmFunding { url }),
                 dev,
                 optional,
                 dev_optional,
@@ -1776,5 +1842,47 @@ mod tests {
             Some(true),
             "peerDependenciesMeta.optional must survive write → parse round-trip"
         );
+    }
+
+    /// Byte-parity with a real `npm install`-generated lockfile. The
+    /// fixture at `tests/fixtures/npm-native.json` was produced by
+    /// `npm install` (v11) against a `{ chalk, picocolors, semver }`
+    /// manifest. A parse → write round-trip must reproduce the exact
+    /// bytes. Covers `resolved:` on every entry, `license:` /
+    /// `engines:` / `bin:` / `funding:` field preservation, and the
+    /// sibling declared-range preservation that rides on
+    /// `declared_dependencies`.
+    #[test]
+    fn test_write_byte_identical_to_native_npm() {
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/npm-native.json");
+        // Same LF normalization as the pnpm / bun byte-parity tests —
+        // Windows' `core.autocrlf=true` rewrites the checked-out
+        // fixture to CRLF even with `.gitattributes eol=lf`.
+        let original = std::fs::read_to_string(&fixture)
+            .unwrap()
+            .replace("\r\n", "\n");
+        let graph = parse(&fixture).unwrap();
+        let manifest = aube_manifest::PackageJson {
+            name: Some("aube-lockfile-stability".to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: [
+                ("chalk".to_string(), "^4.1.2".to_string()),
+                ("picocolors".to_string(), "^1.1.1".to_string()),
+                ("semver".to_string(), "^7.6.3".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write(tmp.path(), &graph, &manifest).unwrap();
+        let written = std::fs::read_to_string(tmp.path()).unwrap();
+
+        if written != original {
+            panic!(
+                "npm writer drifted from native npm output.\n\n--- expected ---\n{original}\n--- got ---\n{written}"
+            );
+        }
     }
 }

--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -164,6 +164,18 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             // the node nested-resolution walk.
             deps.insert(dep_name.clone(), String::new());
         }
+        // Preserve the declared ranges npm writes on each nested package
+        // entry. Round-tripping these is what keeps
+        // `aube install --no-frozen-lockfile` from rewriting every
+        // `"^4.1.0"` to `"4.3.0"` on re-emit.
+        let mut declared: BTreeMap<String, String> = BTreeMap::new();
+        for (k, v) in entry
+            .dependencies
+            .iter()
+            .chain(entry.optional_dependencies.iter())
+        {
+            declared.insert(k.clone(), v.clone());
+        }
 
         // Keep the `resolved` URL for entries whose tarball URL cannot
         // be safely re-derived from the install name and version:
@@ -211,6 +223,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 dep_path,
                 alias_of,
                 tarball_url,
+                declared_dependencies: declared,
                 ..Default::default()
             },
         );
@@ -537,7 +550,19 @@ pub fn write(
             .dependencies
             .iter()
             .filter(|(n, value)| canonical.contains_key(&child_canonical_key(n, value)))
-            .map(|(n, value)| (n.as_str(), dep_value_as_version(n, value)))
+            .map(|(n, value)| {
+                // Prefer the declared range from the package's own
+                // manifest (what npm itself writes) over the resolved
+                // pin. Falls back to the pin for entries where the
+                // source lockfile didn't carry declared ranges (e.g.
+                // pnpm → npm conversion).
+                let rendered = pkg
+                    .declared_dependencies
+                    .get(n)
+                    .map(String::as_str)
+                    .unwrap_or_else(|| dep_value_as_version(n, value));
+                (n.as_str(), rendered)
+            })
             .collect();
 
         // npm v3 flag semantics:

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -332,6 +332,13 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 // when re-emitting a pnpm-sourced graph into one of
                 // their formats.
                 declared_dependencies: BTreeMap::new(),
+                // pnpm's format doesn't carry per-package license or
+                // funding metadata, so a pnpm → npm conversion
+                // degrades to empty rather than re-fetching each
+                // packument. npm writers skip these fields when
+                // `None`.
+                license: None,
+                funding_url: None,
             },
         );
     }

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -286,7 +286,19 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         let cpu = pkg_info.map(|p| p.cpu.clone()).unwrap_or_default();
         let libc = pkg_info.map(|p| p.libc.clone()).unwrap_or_default();
         let engines = pkg_info.map(|p| p.engines.clone()).unwrap_or_default();
-        let has_bin = pkg_info.map(|p| p.has_bin).unwrap_or(false);
+        // pnpm's lockfile only stores `hasBin: true/false` (no paths);
+        // reconstruct an opaque single-entry map on parse so
+        // `!bin.is_empty()` stays equivalent to `hasBin`, then let
+        // downstream writers fill in real paths when they have them.
+        // The map key + value are placeholders — writers that care
+        // about bin names (bun) read from richer sources.
+        let bin = if pkg_info.map(|p| p.has_bin).unwrap_or(false) {
+            let mut m = BTreeMap::new();
+            m.insert(String::new(), String::new());
+            m
+        } else {
+            BTreeMap::new()
+        };
         // Aube-specific extension (see `WritablePackageInfo::alias_of`)
         // — ordinary pnpm lockfiles never carry it, so this stays
         // `None` on pnpm-authored input and round-trips the resolver-
@@ -313,7 +325,13 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 alias_of,
                 yarn_checksum: None,
                 engines,
-                has_bin,
+                bin,
+                // pnpm's `snapshots:` only records resolved pins, so
+                // the parser has no declared ranges to restore. Left
+                // empty; npm / yarn / bun writers fall back to pins
+                // when re-emitting a pnpm-sourced graph into one of
+                // their formats.
+                declared_dependencies: BTreeMap::new(),
             },
         );
     }
@@ -606,7 +624,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 os: pkg.os.clone(),
                 cpu: pkg.cpu.clone(),
                 libc: pkg.libc.clone(),
-                has_bin: pkg.has_bin,
+                has_bin: !pkg.bin.is_empty(),
                 peer_dependencies: peer_deps,
                 peer_dependencies_meta: peer_meta,
                 // Preserve the alias→real-name mapping so a subsequent
@@ -1836,7 +1854,13 @@ snapshots:
     #[test]
     fn test_write_byte_identical_to_native_pnpm() {
         let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pnpm-native.yaml");
-        let original = std::fs::read_to_string(&fixture).unwrap();
+        // Windows' `core.autocrlf=true` rewrites checked-out files to
+        // CRLF even when `.gitattributes` asks for LF; normalize both
+        // sides before comparing so a misconfigured checkout gets a
+        // meaningful failure rather than a line-ending false positive.
+        let original = std::fs::read_to_string(&fixture)
+            .unwrap()
+            .replace("\r\n", "\n");
 
         let graph = parse(&fixture).unwrap();
         let manifest = PackageJson {

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -285,6 +285,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         let os = pkg_info.map(|p| p.os.clone()).unwrap_or_default();
         let cpu = pkg_info.map(|p| p.cpu.clone()).unwrap_or_default();
         let libc = pkg_info.map(|p| p.libc.clone()).unwrap_or_default();
+        let engines = pkg_info.map(|p| p.engines.clone()).unwrap_or_default();
+        let has_bin = pkg_info.map(|p| p.has_bin).unwrap_or(false);
         // Aube-specific extension (see `WritablePackageInfo::alias_of`)
         // — ordinary pnpm lockfiles never carry it, so this stays
         // `None` on pnpm-authored input and round-trips the resolver-
@@ -310,6 +312,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 tarball_url,
                 alias_of,
                 yarn_checksum: None,
+                engines,
+                has_bin,
             },
         );
     }
@@ -594,11 +598,17 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
             canonical,
             WritablePackageInfo {
                 resolution,
-                peer_dependencies: peer_deps,
-                peer_dependencies_meta: peer_meta,
+                engines: if pkg.engines.is_empty() {
+                    None
+                } else {
+                    Some(pkg.engines.clone())
+                },
                 os: pkg.os.clone(),
                 cpu: pkg.cpu.clone(),
                 libc: pkg.libc.clone(),
+                has_bin: pkg.has_bin,
+                peer_dependencies: peer_deps,
+                peer_dependencies_meta: peer_meta,
                 // Preserve the alias→real-name mapping so a subsequent
                 // install from this lockfile still hits the real
                 // registry instead of re-404ing on the alias-qualified
@@ -708,8 +718,102 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
 
     let yaml = serde_yaml::to_string(&lockfile)
         .map_err(|e| Error::Parse(path.to_path_buf(), e.to_string()))?;
+    let yaml = reformat_for_pnpm_parity(&yaml);
     std::fs::write(path, yaml).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     Ok(())
+}
+
+/// Post-process a `serde_yaml`-emitted pnpm-lock.yaml into the exact
+/// shape real pnpm writes. Two tweaks:
+///
+///   1. Collapse `resolution:` / `engines:` block maps into flow form
+///      (`resolution: {integrity: sha512-…}`). pnpm writes both inline
+///      and `serde_yaml` can't be coerced into flow style per-field
+///      without a custom emitter.
+///   2. Insert blank-line separators above every top-level section
+///      (`settings:`, `importers:`, `packages:`, `snapshots:`, …) and
+///      between 2-indent entries inside the entry-bearing sections
+///      (`importers:`, `packages:`, `snapshots:`, `catalogs:`).
+///
+/// The rewrites are textual — not YAML-aware — but the keys aube emits
+/// are all simple scalars in the fixed set above, so there's nothing to
+/// quote-escape. Validated by `test_write_byte_identical_to_native_pnpm`.
+fn reformat_for_pnpm_parity(yaml: &str) -> String {
+    let lines: Vec<&str> = yaml.lines().collect();
+
+    // Pass 1: flow-style `resolution:` / `engines:` blocks.
+    let mut compact: Vec<String> = Vec::with_capacity(lines.len());
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        let stripped = line.trim_start();
+        let indent = line.len() - stripped.len();
+        let key = stripped.strip_suffix(':');
+        let is_flow_candidate = matches!(key, Some("resolution") | Some("engines"));
+        if is_flow_candidate && i + 1 < lines.len() {
+            let inner_indent = indent + 2;
+            let mut entries: Vec<String> = Vec::new();
+            let mut j = i + 1;
+            while j < lines.len() {
+                let next = lines[j];
+                let n_stripped = next.trim_start();
+                let n_indent = next.len() - n_stripped.len();
+                if n_stripped.is_empty() || n_indent != inner_indent {
+                    break;
+                }
+                match n_stripped.split_once(": ") {
+                    Some((k, v)) => entries.push(format!("{k}: {v}")),
+                    None => break,
+                }
+                j += 1;
+            }
+            if !entries.is_empty() {
+                compact.push(format!(
+                    "{}{}: {{{}}}",
+                    " ".repeat(indent),
+                    key.unwrap(),
+                    entries.join(", ")
+                ));
+                i = j;
+                continue;
+            }
+        }
+        compact.push(line.to_string());
+        i += 1;
+    }
+
+    // Pass 2: blank-line separators.
+    // Sections where each 2-indent key-ending-in-`:` is an entry header
+    // that pnpm separates with a blank line above. `overrides:` /
+    // `time:` / `settings:` carry scalar key→value pairs instead and
+    // stay tight.
+    const ENTRY_SECTIONS: &[&str] = &["importers:", "packages:", "snapshots:", "catalogs:"];
+    let mut out = String::with_capacity(yaml.len() + 512);
+    let mut in_entries = false;
+    for (idx, line) in compact.iter().enumerate() {
+        let stripped = line.trim_start();
+        let indent = line.len() - stripped.len();
+        let is_top = indent == 0 && !stripped.is_empty();
+        // Entry headers inside `packages:` / `snapshots:` are always at
+        // 2-indent with a `:` in the line. Either trailing (`foo@1:`
+        // with a child block below) or inline (`foo@1: {}` for empty
+        // snapshots). List markers (`- …`) never appear at this level,
+        // so a leading `-` rules out false positives on
+        // `ignoredOptionalDependencies:` items.
+        let is_entry_header =
+            in_entries && indent == 2 && !stripped.starts_with('-') && stripped.contains(':');
+
+        if (is_top && idx > 0) || is_entry_header {
+            out.push('\n');
+        }
+        out.push_str(line);
+        out.push('\n');
+
+        if is_top {
+            in_entries = ENTRY_SECTIONS.contains(&stripped);
+        }
+    }
+    out
 }
 
 fn version_to_dep_path(name: &str, version: &str) -> String {
@@ -852,22 +956,33 @@ struct WritablePeerDepMeta {
     optional: bool,
 }
 
-// Field order matches pnpm v9's `packages:` entries: resolution first,
-// then peerDependencies, then peerDependenciesMeta. Don't reorder.
+// Field order matches pnpm v9's `packages:` entries: resolution, then
+// engines, then os/cpu/libc, then hasBin, then peerDependencies /
+// peerDependenciesMeta. Don't reorder.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WritablePackageInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     resolution: Option<WritableResolution>,
-    // pnpm v9 emits os/cpu/libc immediately after `resolution` and
-    // before `peerDependencies`. Keep this order to stay byte-
-    // identical with pnpm-written lockfiles for native packages.
+    /// pnpm writes `engines: {node: '>=8'}` in flow form immediately
+    /// after `resolution:` when the package declared any engines.
+    /// Emitted as a block map here — `reformat_for_pnpm_parity` flips it
+    /// to flow form to match pnpm byte-for-byte.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    engines: Option<BTreeMap<String, String>>,
+    // pnpm v9 emits os/cpu/libc after `engines` and before `hasBin`.
+    // Keep this order to stay byte-identical with pnpm-written lockfiles
+    // for native packages.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     os: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     cpu: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     libc: Vec<String>,
+    /// pnpm emits `hasBin: true` only when the package has executables;
+    /// `hasBin: false` is never written. Skip the default to match.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    has_bin: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     peer_dependencies: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -954,6 +1069,8 @@ struct RawCatalogEntry {
 #[serde(rename_all = "camelCase")]
 struct RawPackageInfo {
     resolution: Option<Resolution>,
+    #[serde(default)]
+    engines: BTreeMap<String, String>,
     peer_dependencies: Option<BTreeMap<String, String>>,
     peer_dependencies_meta: Option<BTreeMap<String, RawPeerDepMeta>>,
     #[serde(default)]
@@ -962,6 +1079,8 @@ struct RawPackageInfo {
     cpu: Vec<String>,
     #[serde(default)]
     libc: Vec<String>,
+    #[serde(default)]
+    has_bin: bool,
     /// Paired writer field. See `WritablePackageInfo::alias_of`. `None`
     /// for ordinary (non-aliased) packages.
     #[serde(default)]
@@ -1705,5 +1824,72 @@ snapshots:
     fn test_parse_nonexistent_file() {
         let path = Path::new("/nonexistent/pnpm-lock.yaml");
         assert!(parse(path).is_err());
+    }
+
+    // Byte-parity with a real pnpm-lock.yaml. The fixture was produced by
+    // `pnpm install` against a `{ chalk, picocolors, semver }` manifest and
+    // lightly pinned — if pnpm's own output format drifts in a future
+    // release, regenerate the fixture rather than loosening the assertion.
+    // The test guards against silent regressions in the four churn sources
+    // we fixed: stray `time:`, block-form `resolution:`, missing blank
+    // lines, and dropped `engines:` / `hasBin:`.
+    #[test]
+    fn test_write_byte_identical_to_native_pnpm() {
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pnpm-native.yaml");
+        let original = std::fs::read_to_string(&fixture).unwrap();
+
+        let graph = parse(&fixture).unwrap();
+        let manifest = PackageJson {
+            name: Some("aube-lockfile-stability".to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: [
+                ("chalk".to_string(), "^4.1.2".to_string()),
+                ("picocolors".to_string(), "^1.1.1".to_string()),
+                ("semver".to_string(), "^7.6.3".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("pnpm-lock.yaml");
+        write(&out, &graph, &manifest).unwrap();
+        let written = std::fs::read_to_string(&out).unwrap();
+
+        if written != original {
+            // pretty-print a short contextual diff so CI logs are actionable.
+            let diff = similar_diff(&original, &written);
+            panic!(
+                "pnpm writer drifted from native pnpm output:\n{diff}\n\n--- full written output ---\n{written}"
+            );
+        }
+    }
+
+    // Minimal line diff for the byte-parity test failure message. We don't
+    // pull in a diff crate just for this — the lockfile is small enough
+    // that a line-by-line comparison is readable.
+    fn similar_diff(a: &str, b: &str) -> String {
+        let al: Vec<&str> = a.lines().collect();
+        let bl: Vec<&str> = b.lines().collect();
+        let mut out = String::new();
+        let max = al.len().max(bl.len());
+        for i in 0..max {
+            match (al.get(i), bl.get(i)) {
+                (Some(x), Some(y)) if x == y => {}
+                (Some(x), Some(y)) => {
+                    out.push_str(&format!(
+                        "  line {}: expected {x:?}\n           got      {y:?}\n",
+                        i + 1
+                    ));
+                }
+                (Some(x), None) => {
+                    out.push_str(&format!("  line {}: missing (expected {x:?})\n", i + 1))
+                }
+                (None, Some(y)) => out.push_str(&format!("  line {}: extra    ({y:?})\n", i + 1)),
+                (None, None) => {}
+            }
+        }
+        out
     }
 }

--- a/crates/aube-lockfile/src/yarn.rs
+++ b/crates/aube-lockfile/src/yarn.rs
@@ -162,6 +162,15 @@ fn parse_classic_str(
         // Only insert the first occurrence; dedup is fine because yarn.lock
         // already guarantees unique (name, version) entries.
         if !packages.contains_key(&dep_path) {
+            // Yarn records the declared ranges on each block's
+            // `dependencies:` subsection exactly as they appear in the
+            // package's own manifest — preserve them so re-emit keeps
+            // the original specifiers.
+            let declared: BTreeMap<String, String> = block
+                .dependencies
+                .iter()
+                .map(|(n, r)| (n.clone(), r.clone()))
+                .collect();
             packages.insert(
                 dep_path.clone(),
                 LockedPackage {
@@ -175,6 +184,7 @@ fn parse_classic_str(
                         .map(|(n, r)| (n.clone(), format!("{n}@{r}")))
                         .collect(),
                     dep_path,
+                    declared_dependencies: declared,
                     ..Default::default()
                 },
             );
@@ -420,11 +430,19 @@ pub fn write_classic(
             .or_insert(pkg);
     }
 
-    // Collect every manifest spec that points at a canonical
-    // `(name, version)`. Keyed by canonical key; values are the
-    // extra range-form spec strings to emit alongside the exact
-    // `"name@version"` one in the block header.
-    let mut extra_specs: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    // Collect every spec that points at a canonical `(name, version)` —
+    // both root-manifest ranges *and* transitive declared ranges from
+    // every other package's `declared_dependencies`. Yarn groups all
+    // specs resolving to the same (name, version) under one block
+    // header (`is-number@^6.0.0, is-number@~6.0.1:`), and reparse of
+    // a transitive `bar "^2.0.0"` needs `bar@^2.0.0` to appear in
+    // some block's header to find the right canonical entry.
+    //
+    // Keyed by canonical key; values are the extra range-form spec
+    // strings to emit alongside the exact `"name@version"` one.
+    // Deduped per canonical so identical ranges coming from multiple
+    // consumers collapse.
+    let mut extra_specs: BTreeMap<String, std::collections::BTreeSet<String>> = BTreeMap::new();
     let root_importer_specs = manifest
         .dependencies
         .iter()
@@ -444,7 +462,26 @@ pub fn write_classic(
         if let Some(range) = range {
             let spec = format!("{}@{range}", dep.name);
             if spec != canonical_key {
-                extra_specs.entry(canonical_key).or_default().push(spec);
+                extra_specs.entry(canonical_key).or_default().insert(spec);
+            }
+        }
+    }
+    // Harvest transitive declared ranges. Each package's
+    // `declared_dependencies[name] = range` is the range its own
+    // manifest uses; the canonical the range resolves to is whatever
+    // the resolver already placed under `pkg.dependencies[name]`.
+    for pkg in canonical.values() {
+        for (dep_name, range) in &pkg.declared_dependencies {
+            let Some(resolved_value) = pkg.dependencies.get(dep_name) else {
+                continue;
+            };
+            let target = crate::npm::child_canonical_key(dep_name, resolved_value);
+            if !canonical.contains_key(&target) {
+                continue;
+            }
+            let spec = format!("{dep_name}@{range}");
+            if spec != target {
+                extra_specs.entry(target).or_default().insert(spec);
             }
         }
     }
@@ -480,12 +517,11 @@ pub fn write_classic(
             out.push('\n');
         }
 
-        // `  dependencies:` block — resolved to canonical versions so
-        // yarn's transitive lookup (`<name>@<version>`) finds the
-        // right block key above. Ranges aren't preserved because we
-        // never recorded them; writing the exact version is a
-        // harmless overconstraint.
-        let nonempty_deps: BTreeMap<&str, &str> = pkg
+        // `  dependencies:` block — prefer the declared range from the
+        // package's own manifest (what yarn itself writes) over the
+        // resolved pin. Falls back to the pin when the source
+        // lockfile didn't carry declared ranges (e.g. pnpm → yarn).
+        let nonempty_deps: BTreeMap<&str, String> = pkg
             .dependencies
             .iter()
             .filter_map(|(n, v)| {
@@ -493,12 +529,17 @@ pub fn write_classic(
                 if !canonical.contains_key(&key) {
                     return None;
                 }
-                Some((n.as_str(), crate::npm::dep_value_as_version(n, v)))
+                let rendered = pkg
+                    .declared_dependencies
+                    .get(n)
+                    .cloned()
+                    .unwrap_or_else(|| crate::npm::dep_value_as_version(n, v).to_string());
+                Some((n.as_str(), rendered))
             })
             .collect();
         if !nonempty_deps.is_empty() {
             out.push_str("  dependencies:\n");
-            for (dep_name, dep_version) in nonempty_deps {
+            for (dep_name, dep_version) in &nonempty_deps {
                 out.push_str("    ");
                 out.push_str(dep_name);
                 out.push_str(" \"");
@@ -702,6 +743,14 @@ fn parse_berry_str(
         let peer_deps_meta = collect_peer_meta(block);
         let optional_deps = collect_dep_map(block, "optionalDependencies");
 
+        // Declared ranges — same source as `raw_deps` / `optional_deps`
+        // but kept as the bare range string (no `name@` prefix) so
+        // writers can slot them straight back into the output.
+        let mut declared: BTreeMap<String, String> = BTreeMap::new();
+        for (n, v) in raw_deps.iter().chain(optional_deps.iter()) {
+            declared.insert(n.clone(), v.clone());
+        }
+
         let raw_deps_specs: BTreeMap<String, String> = raw_deps
             .into_iter()
             .map(|(n, v)| (n.clone(), format!("{n}@{v}")))
@@ -730,6 +779,7 @@ fn parse_berry_str(
                     peer_dependencies_meta: peer_deps_meta,
                     dep_path: dep_path.clone(),
                     local_source,
+                    declared_dependencies: declared,
                     ..Default::default()
                 },
             );
@@ -1039,10 +1089,11 @@ pub fn write_berry(
     // `extra_specs[canonical_key]` is the set of range-form
     // specifiers (e.g. `"foo@npm:^1.0.0"`) that should appear in the
     // block header alongside the exact `foo@npm:1.2.3` one. Collecting
-    // them from the manifest keeps the header compatible with what
-    // yarn itself would produce so re-running `yarn install` against
-    // this lockfile finds each manifest range as a block key.
-    let mut extra_specs: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    // them keeps the header compatible with what yarn itself would
+    // produce: every spec that resolves to the same (name, version)
+    // gets folded into one block, so transitive lookups of a declared
+    // range find a matching header.
+    let mut extra_specs: BTreeMap<String, std::collections::BTreeSet<String>> = BTreeMap::new();
     let manifest_ranges: Vec<(String, String)> = manifest
         .dependencies
         .iter()
@@ -1051,6 +1102,13 @@ pub fn write_berry(
         .chain(manifest.peer_dependencies.iter())
         .map(|(n, r)| (n.clone(), r.clone()))
         .collect();
+    let format_berry_spec = |dep_name: &str, range: &str| {
+        if range_has_protocol(range) {
+            format!("{dep_name}@{range}")
+        } else {
+            format!("{dep_name}@npm:{range}")
+        }
+    };
     for dep in graph.importers.get(".").into_iter().flatten() {
         let canonical_key = crate::npm::canonical_key_from_dep_path(&dep.dep_path);
         if !canonical.contains_key(&canonical_key) {
@@ -1059,17 +1117,32 @@ pub fn write_berry(
         let Some((_, range)) = manifest_ranges.iter().find(|(n, _)| n == &dep.name) else {
             continue;
         };
-        let manifest_spec = if range_has_protocol(range) {
-            format!("{}@{range}", dep.name)
-        } else {
-            format!("{}@npm:{range}", dep.name)
-        };
+        let manifest_spec = format_berry_spec(&dep.name, range);
         let exact_spec = berry_exact_spec(canonical.get(&canonical_key).copied().unwrap());
         if manifest_spec != exact_spec {
             extra_specs
                 .entry(canonical_key)
                 .or_default()
-                .push(manifest_spec);
+                .insert(manifest_spec);
+        }
+    }
+    // Harvest transitive declared ranges, same shape as the classic
+    // writer. Berry specs always carry a protocol (`npm:`, `workspace:`,
+    // `patch:` …); bare ranges get the default `npm:` prefix.
+    for pkg in canonical.values() {
+        for (dep_name, range) in &pkg.declared_dependencies {
+            let Some(resolved_value) = pkg.dependencies.get(dep_name) else {
+                continue;
+            };
+            let target = crate::npm::child_canonical_key(dep_name, resolved_value);
+            let Some(target_pkg) = canonical.get(&target) else {
+                continue;
+            };
+            let manifest_spec = format_berry_spec(dep_name, range);
+            let exact_spec = berry_exact_spec(target_pkg);
+            if manifest_spec != exact_spec {
+                extra_specs.entry(target).or_default().insert(manifest_spec);
+            }
         }
     }
 
@@ -1116,11 +1189,18 @@ pub fn write_berry(
         // transitive deps collapse to the exact version of the target
         // block (the resolver produced the graph, so the key always
         // exists in `canonical`).
-        write_berry_dep_map(&mut out, "dependencies", &pkg.dependencies, &canonical);
+        write_berry_dep_map(
+            &mut out,
+            "dependencies",
+            &pkg.dependencies,
+            &pkg.declared_dependencies,
+            &canonical,
+        );
         write_berry_dep_map(
             &mut out,
             "optionalDependencies",
             &pkg.optional_dependencies,
+            &pkg.declared_dependencies,
             &canonical,
         );
         write_berry_peer_deps(&mut out, &pkg.peer_dependencies);
@@ -1168,19 +1248,38 @@ fn write_berry_dep_map(
     out: &mut String,
     section: &str,
     deps: &BTreeMap<String, String>,
+    declared: &BTreeMap<String, String>,
     canonical: &BTreeMap<String, &LockedPackage>,
 ) {
     // Only emit edges whose target survives in `canonical`; the
     // graph-level filter layer (e.g. `--prod` prune) may have dropped
     // packages that dev-only edges still reference.
+    //
+    // Prefer the declared range from the package's own manifest (what
+    // berry itself writes — `chalk: "npm:^4.1.0"`) over the resolved
+    // pin. Falls back to `npm:<version>` when the declared range is
+    // unknown (e.g. a pnpm-sourced graph being re-emitted as yarn).
     let resolved: Vec<(&str, String)> = deps
         .iter()
         .filter_map(|(n, v)| {
             let key = crate::npm::child_canonical_key(n, v);
             let target = canonical.get(&key)?;
-            let version = crate::npm::dep_value_as_version(n, v);
             let spec_body = match &target.local_source {
-                None => format!("npm:{version}"),
+                None => {
+                    let body = declared
+                        .get(n)
+                        .cloned()
+                        .unwrap_or_else(|| crate::npm::dep_value_as_version(n, v).to_string());
+                    // Declared ranges may already carry a protocol
+                    // (`npm:^4`, `workspace:*`, `patch:…`) — don't
+                    // double-prefix those. Bare ranges like `^4.1.0`
+                    // get the default `npm:` protocol.
+                    if body.contains(':') {
+                        body
+                    } else {
+                        format!("npm:{body}")
+                    }
+                }
                 Some(src) => src.specifier(),
             };
             Some((n.as_str(), spec_body))

--- a/crates/aube-lockfile/tests/fixtures/bun-native.lock
+++ b/crates/aube-lockfile/tests/fixtures/bun-native.lock
@@ -1,0 +1,31 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "aube-lockfile-stability",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "picocolors": "^1.1.1",
+        "semver": "^7.6.3",
+      },
+    },
+  },
+  "packages": {
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+  }
+}

--- a/crates/aube-lockfile/tests/fixtures/npm-native.json
+++ b/crates/aube-lockfile/tests/fixtures/npm-native.json
@@ -1,0 +1,105 @@
+{
+  "name": "aube-lockfile-stability",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aube-lockfile-stability",
+      "version": "1.0.0",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "picocolors": "^1.1.1",
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/crates/aube-lockfile/tests/fixtures/pnpm-native.yaml
+++ b/crates/aube-lockfile/tests/fixtures/pnpm-native.yaml
@@ -1,0 +1,79 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      semver:
+        specifier: ^7.6.3
+        version: 7.7.4
+
+packages:
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+snapshots:
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  has-flag@4.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  semver@7.7.4: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -147,6 +147,21 @@ pub struct VersionMetadata {
     pub cpu: Vec<String>,
     #[serde(default, deserialize_with = "string_or_seq")]
     pub libc: Vec<String>,
+    /// `engines:` from the package manifest (e.g. `{node: ">=8"}`).
+    /// Round-tripped into the lockfile so pnpm-compatible output can
+    /// emit `engines: {node: '>=8'}` on package entries without a
+    /// packument re-fetch.
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
+    pub engines: BTreeMap<String, String>,
+    /// `bin:` presence — `true` when the packument carried any entry
+    /// under `bin`, either as a string (`"bin": "cli.js"`) or a map
+    /// (`"bin": {"foo": "cli.js"}`). pnpm records this as `hasBin: true`
+    /// on the package line; `false` is never written. Renamed from
+    /// `bin` in the packument because we collapse the shape to a bool
+    /// at the deserialize step — callers that need the full map can
+    /// re-fetch the tarball manifest.
+    #[serde(default, rename = "bin", deserialize_with = "bin_is_present")]
+    pub has_bin: bool,
     #[serde(default)]
     pub has_install_script: bool,
     /// Deprecation message from the registry, if this version is deprecated.
@@ -175,6 +190,35 @@ where
     Ok(match value {
         Some(serde_json::Value::String(s)) if !s.is_empty() => Some(s),
         _ => None,
+    })
+}
+
+/// pnpm's `hasBin: true` maps to "the manifest has at least one `bin`
+/// entry". The packument records `bin` as either a string
+/// (`"cli.js"`) or a map (`{name: path}`); either form with at least
+/// one character/entry is truthy. A missing `bin` field deserializes
+/// to `false`.
+///
+/// The disk cache round-trips this field as a plain `bool` (we serialize
+/// through the same field name `bin`), so we *must* accept
+/// `Value::Bool(b)` and preserve its value — otherwise a warm-cache
+/// read flips `false` → `true` on the fallthrough arm and every package
+/// ends up tagged `hasBin: true` on re-emit.
+///
+/// Other shapes (numbers, arrays) are treated as "present, assume
+/// truthy" — no real packument emits those, but a permissive default
+/// avoids parse failures on a registry that does something exotic.
+fn bin_is_present<'de, D>(de: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(de)?;
+    Ok(match value {
+        None | Some(serde_json::Value::Null) => false,
+        Some(serde_json::Value::Bool(b)) => b,
+        Some(serde_json::Value::String(s)) => !s.is_empty(),
+        Some(serde_json::Value::Object(m)) => !m.is_empty(),
+        Some(_) => true,
     })
 }
 
@@ -233,6 +277,53 @@ mod tests {
         assert!(v.os.is_empty());
         assert!(v.cpu.is_empty());
         assert!(v.libc.is_empty());
+    }
+
+    #[test]
+    fn has_bin_reads_bin_field() {
+        let missing = parse(r#"{"name":"x","version":"1.0.0"}"#);
+        assert!(!missing.has_bin, "missing bin → false");
+        let empty_string = parse(r#"{"name":"x","version":"1.0.0","bin":""}"#);
+        assert!(!empty_string.has_bin, "empty string bin → false");
+        let null_bin = parse(r#"{"name":"x","version":"1.0.0","bin":null}"#);
+        assert!(!null_bin.has_bin, "null bin → false");
+        let empty_map = parse(r#"{"name":"x","version":"1.0.0","bin":{}}"#);
+        assert!(!empty_map.has_bin, "empty map bin → false");
+        let string_bin = parse(r#"{"name":"x","version":"1.0.0","bin":"cli.js"}"#);
+        assert!(string_bin.has_bin, "non-empty string bin → true");
+        let map_bin = parse(r#"{"name":"x","version":"1.0.0","bin":{"x":"cli.js"}}"#);
+        assert!(map_bin.has_bin, "non-empty map bin → true");
+    }
+
+    /// Round-trip the `has_bin` field through the on-disk cache format
+    /// (serialize → parse). Regression: the disk cache stores this
+    /// field as a bool under the name `bin`; a permissive
+    /// deserializer that treated any non-string/non-object value as
+    /// "present" would flip `false` to `true` on every warm-cache
+    /// read and re-tag every package as `hasBin: true`.
+    #[test]
+    fn has_bin_roundtrips_through_bool_serialization() {
+        let v = VersionMetadata {
+            name: "x".to_string(),
+            version: "1.0.0".to_string(),
+            dependencies: BTreeMap::new(),
+            dev_dependencies: BTreeMap::new(),
+            peer_dependencies: BTreeMap::new(),
+            peer_dependencies_meta: BTreeMap::new(),
+            optional_dependencies: BTreeMap::new(),
+            bundled_dependencies: None,
+            dist: None,
+            os: Vec::new(),
+            cpu: Vec::new(),
+            libc: Vec::new(),
+            engines: BTreeMap::new(),
+            has_bin: false,
+            has_install_script: false,
+            deprecated: None,
+        };
+        let json = serde_json::to_string(&v).unwrap();
+        let back: VersionMetadata = serde_json::from_str(&json).unwrap();
+        assert!(!back.has_bin, "false has_bin must round-trip as false");
     }
 
     #[test]

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -153,15 +153,20 @@ pub struct VersionMetadata {
     /// packument re-fetch.
     #[serde(default, deserialize_with = "non_string_tolerant_map")]
     pub engines: BTreeMap<String, String>,
-    /// `bin:` presence — `true` when the packument carried any entry
-    /// under `bin`, either as a string (`"bin": "cli.js"`) or a map
-    /// (`"bin": {"foo": "cli.js"}`). pnpm records this as `hasBin: true`
-    /// on the package line; `false` is never written. Renamed from
-    /// `bin` in the packument because we collapse the shape to a bool
-    /// at the deserialize step — callers that need the full map can
-    /// re-fetch the tarball manifest.
-    #[serde(default, rename = "bin", deserialize_with = "bin_is_present")]
-    pub has_bin: bool,
+    /// `bin:` map from the packument, normalized to `name → path`.
+    ///
+    /// npm records `bin` in two shapes on a manifest: a string
+    /// (`"bin": "cli.js"` — implicitly named after the package) or a
+    /// map (`"bin": {"foo": "cli.js"}` — explicitly named). We
+    /// normalize to the map form at parse time so downstream callers
+    /// don't have to branch: an empty map means "no bins".
+    ///
+    /// pnpm collapses this to `hasBin: true` on its package entries;
+    /// bun preserves the full map on its per-package meta. Keeping
+    /// the map lets us feed both writers without an extra
+    /// tarball-level re-parse.
+    #[serde(default, rename = "bin", deserialize_with = "bin_map")]
+    pub bin: BTreeMap<String, String>,
     #[serde(default)]
     pub has_install_script: bool,
     /// Deprecation message from the registry, if this version is deprecated.
@@ -193,32 +198,42 @@ where
     })
 }
 
-/// pnpm's `hasBin: true` maps to "the manifest has at least one `bin`
-/// entry". The packument records `bin` as either a string
-/// (`"cli.js"`) or a map (`{name: path}`); either form with at least
-/// one character/entry is truthy. A missing `bin` field deserializes
-/// to `false`.
+/// Normalize `package.json` `bin` into a `name → path` map.
 ///
-/// The disk cache round-trips this field as a plain `bool` (we serialize
-/// through the same field name `bin`), so we *must* accept
-/// `Value::Bool(b)` and preserve its value — otherwise a warm-cache
-/// read flips `false` → `true` on the fallthrough arm and every package
-/// ends up tagged `hasBin: true` on re-emit.
+/// Two canonical shapes on the npm registry: a string
+/// (`"bin": "cli.js"` — implicitly keyed by the package name) and a
+/// map (`"bin": {"foo": "cli.js"}`). Older or odd packuments also
+/// surface `null` or an empty string; a missing `bin` field falls
+/// through to the default empty map.
 ///
-/// Other shapes (numbers, arrays) are treated as "present, assume
-/// truthy" — no real packument emits those, but a permissive default
-/// avoids parse failures on a registry that does something exotic.
-fn bin_is_present<'de, D>(de: D) -> Result<bool, D::Error>
+/// The string-form needs the package name to emit a well-formed map
+/// — which we don't have here at deserialize time. We leave the key
+/// as an empty string; every call site that cares about bin names
+/// (`aube-linker`'s bin-symlink pass, the bun writer) already has
+/// the package name in scope and can patch it up.
+fn bin_map<'de, D>(de: D) -> Result<BTreeMap<String, String>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let value = Option::<serde_json::Value>::deserialize(de)?;
     Ok(match value {
-        None | Some(serde_json::Value::Null) => false,
-        Some(serde_json::Value::Bool(b)) => b,
-        Some(serde_json::Value::String(s)) => !s.is_empty(),
-        Some(serde_json::Value::Object(m)) => !m.is_empty(),
-        Some(_) => true,
+        None | Some(serde_json::Value::Null) => BTreeMap::new(),
+        // The implicit-name case — keep a single empty-keyed entry so
+        // consumers can still detect presence and patch the name.
+        Some(serde_json::Value::String(s)) if s.is_empty() => BTreeMap::new(),
+        Some(serde_json::Value::String(s)) => {
+            let mut m = BTreeMap::new();
+            m.insert(String::new(), s);
+            m
+        }
+        Some(serde_json::Value::Object(m)) => m
+            .into_iter()
+            .filter_map(|(k, v)| match v {
+                serde_json::Value::String(s) => Some((k, s)),
+                _ => None,
+            })
+            .collect(),
+        Some(_) => BTreeMap::new(),
     })
 }
 
@@ -280,32 +295,36 @@ mod tests {
     }
 
     #[test]
-    fn has_bin_reads_bin_field() {
+    fn bin_normalizes_packument_shapes() {
         let missing = parse(r#"{"name":"x","version":"1.0.0"}"#);
-        assert!(!missing.has_bin, "missing bin → false");
+        assert!(missing.bin.is_empty(), "missing bin → empty map");
         let empty_string = parse(r#"{"name":"x","version":"1.0.0","bin":""}"#);
-        assert!(!empty_string.has_bin, "empty string bin → false");
+        assert!(empty_string.bin.is_empty(), "empty string bin → empty map");
         let null_bin = parse(r#"{"name":"x","version":"1.0.0","bin":null}"#);
-        assert!(!null_bin.has_bin, "null bin → false");
+        assert!(null_bin.bin.is_empty(), "null bin → empty map");
         let empty_map = parse(r#"{"name":"x","version":"1.0.0","bin":{}}"#);
-        assert!(!empty_map.has_bin, "empty map bin → false");
+        assert!(empty_map.bin.is_empty(), "empty map bin → empty map");
+        // String bin leaves the name blank — callers patch it with the
+        // package name before materializing a symlink / writing to
+        // bun.lock.
         let string_bin = parse(r#"{"name":"x","version":"1.0.0","bin":"cli.js"}"#);
-        assert!(string_bin.has_bin, "non-empty string bin → true");
-        let map_bin = parse(r#"{"name":"x","version":"1.0.0","bin":{"x":"cli.js"}}"#);
-        assert!(map_bin.has_bin, "non-empty map bin → true");
+        assert_eq!(string_bin.bin.get(""), Some(&"cli.js".to_string()));
+        let map_bin = parse(r#"{"name":"x","version":"1.0.0","bin":{"foo":"cli.js"}}"#);
+        assert_eq!(map_bin.bin.get("foo"), Some(&"cli.js".to_string()));
     }
 
-    /// Round-trip the `has_bin` field through the on-disk cache format
-    /// (serialize → parse). Regression: the disk cache stores this
-    /// field as a bool under the name `bin`; a permissive
-    /// deserializer that treated any non-string/non-object value as
-    /// "present" would flip `false` to `true` on every warm-cache
-    /// read and re-tag every package as `hasBin: true`.
+    /// Round-trip the `bin` map through the on-disk cache format
+    /// (serialize → parse). Regression: the disk cache round-trips
+    /// the field under the name `bin`, so the deserializer *must*
+    /// accept a map back (and not interpret the already-normalized
+    /// map as an implicit-name string).
     #[test]
-    fn has_bin_roundtrips_through_bool_serialization() {
+    fn bin_map_roundtrips_through_cache_serialization() {
+        let mut bin = BTreeMap::new();
+        bin.insert("semver".to_string(), "bin/semver.js".to_string());
         let v = VersionMetadata {
-            name: "x".to_string(),
-            version: "1.0.0".to_string(),
+            name: "semver".to_string(),
+            version: "7.7.4".to_string(),
             dependencies: BTreeMap::new(),
             dev_dependencies: BTreeMap::new(),
             peer_dependencies: BTreeMap::new(),
@@ -317,13 +336,17 @@ mod tests {
             cpu: Vec::new(),
             libc: Vec::new(),
             engines: BTreeMap::new(),
-            has_bin: false,
+            bin,
             has_install_script: false,
             deprecated: None,
         };
         let json = serde_json::to_string(&v).unwrap();
         let back: VersionMetadata = serde_json::from_str(&json).unwrap();
-        assert!(!back.has_bin, "false has_bin must round-trip as false");
+        assert_eq!(
+            back.bin.get("semver"),
+            Some(&"bin/semver.js".to_string()),
+            "bin map must round-trip through cache serialization"
+        );
     }
 
     #[test]

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -153,6 +153,23 @@ pub struct VersionMetadata {
     /// packument re-fetch.
     #[serde(default, deserialize_with = "non_string_tolerant_map")]
     pub engines: BTreeMap<String, String>,
+    /// `license:` field from the package manifest. npm's lockfile
+    /// keeps this per-package; other formats don't. Stored as
+    /// `Option<String>` because packuments can emit a bare string
+    /// (`"MIT"`), an SPDX object, or nothing at all — we only keep
+    /// the simple case for lockfile round-trip. Non-string shapes
+    /// degrade to `None` rather than failing to parse the packument.
+    #[serde(default, deserialize_with = "license_string")]
+    pub license: Option<String>,
+    /// `funding:` URL extracted from the manifest's `funding` field.
+    /// The field is documented as a string *or* an object with a
+    /// `url:` key *or* an array of either — npm's lockfile
+    /// normalizes to `{url: …}`, so we only keep the URL and let
+    /// the writer emit the wrapping object. Serde `rename` because
+    /// `rename_all = "camelCase"` would otherwise look for
+    /// `fundingUrl` in the JSON.
+    #[serde(default, rename = "funding", deserialize_with = "funding_url")]
+    pub funding_url: Option<String>,
     /// `bin:` map from the packument, normalized to `name → path`.
     ///
     /// npm records `bin` in two shapes on a manifest: a string
@@ -194,6 +211,57 @@ where
     let value = Option::<serde_json::Value>::deserialize(de)?;
     Ok(match value {
         Some(serde_json::Value::String(s)) if !s.is_empty() => Some(s),
+        _ => None,
+    })
+}
+
+/// Accept the packument's `license:` field in any of its documented
+/// shapes (string, `{type, url}` object, or missing) and collapse to
+/// the simple string form npm emits in its lockfile. Non-string
+/// shapes degrade to `None`; we don't try to normalize SPDX
+/// expressions or license-file references here.
+fn license_string<'de, D>(de: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(de)?;
+    Ok(match value {
+        Some(serde_json::Value::String(s)) if !s.is_empty() => Some(s),
+        Some(serde_json::Value::Object(m)) => m
+            .get("type")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(String::from),
+        _ => None,
+    })
+}
+
+/// Extract the first `url:` out of a packument's `funding:` field.
+/// The field may be a URL string, a `{url: …}` object, or an array
+/// of either — npm's lockfile normalizes to `{"url": "…"}` on each
+/// package entry, so we only need the URL itself. Missing / empty
+/// / non-url-bearing shapes degrade to `None`.
+fn funding_url<'de, D>(de: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(de)?;
+    Ok(match value {
+        Some(serde_json::Value::String(s)) if !s.is_empty() => Some(s),
+        Some(serde_json::Value::Object(m)) => m
+            .get("url")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(String::from),
+        Some(serde_json::Value::Array(arr)) => arr.iter().find_map(|v| match v {
+            serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
+            serde_json::Value::Object(m) => m
+                .get("url")
+                .and_then(|u| u.as_str())
+                .filter(|s| !s.is_empty())
+                .map(String::from),
+            _ => None,
+        }),
         _ => None,
     })
 }
@@ -336,6 +404,8 @@ mod tests {
             cpu: Vec::new(),
             libc: Vec::new(),
             engines: BTreeMap::new(),
+            license: None,
+            funding_url: None,
             bin,
             has_install_script: false,
             deprecated: None,

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1643,6 +1643,8 @@ impl Resolver {
                                     engines: locked_pkg.engines.clone(),
                                     bin: locked_pkg.bin.clone(),
                                     declared_dependencies: locked_pkg.declared_dependencies.clone(),
+                                    license: locked_pkg.license.clone(),
+                                    funding_url: locked_pkg.funding_url.clone(),
                                 },
                             );
 
@@ -2023,11 +2025,17 @@ impl Resolver {
 
                 let registry_name = task.registry_name();
                 let integrity = version_meta.dist.as_ref().and_then(|d| d.integrity.clone());
-                let tarball_url = version_meta.dist.as_ref().and_then(|d| {
-                    registry_name
-                        .starts_with("@jsr/")
-                        .then(|| d.tarball.clone())
-                });
+                // Always stash the registry tarball URL on the locked
+                // package. pnpm / yarn writers gate emission on
+                // `lockfile_include_tarball_url` (so the pnpm
+                // round-trip stays byte-identical for projects that
+                // opted out); the npm writer emits `resolved:` on
+                // every package entry unconditionally, which is what
+                // npm itself writes. Carrying the URL on every
+                // LockedPackage lets both policies work without a
+                // second packument fetch at write time.
+                let tarball_url = version_meta.dist.as_ref().map(|d| d.tarball.clone());
+                let _ = registry_name;
 
                 // Stream this resolved package for early tarball fetching.
                 // `alias_of` mirrors what the LockedPackage below
@@ -2157,6 +2165,8 @@ impl Resolver {
                             }
                             m
                         },
+                        license: version_meta.license.clone(),
+                        funding_url: version_meta.funding_url.clone(),
                     },
                 );
 
@@ -3269,6 +3279,8 @@ mod tests {
             cpu: vec![],
             libc: vec![],
             engines: BTreeMap::new(),
+            license: None,
+            funding_url: None,
             bin: BTreeMap::new(),
             has_install_script: false,
             deprecated: None,

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2023,7 +2023,6 @@ impl Resolver {
                     .or_default()
                     .push(version.clone());
 
-                let registry_name = task.registry_name();
                 let integrity = version_meta.dist.as_ref().and_then(|d| d.integrity.clone());
                 // Always stash the registry tarball URL on the locked
                 // package. pnpm / yarn writers gate emission on
@@ -2035,7 +2034,6 @@ impl Resolver {
                 // LockedPackage lets both policies work without a
                 // second packument fetch at write time.
                 let tarball_url = version_meta.dist.as_ref().map(|d| d.tarball.clone());
-                let _ = registry_name;
 
                 // Stream this resolved package for early tarball fetching.
                 // `alias_of` mirrors what the LockedPackage below

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -485,6 +485,17 @@ impl Resolver {
         self
     }
 
+    /// Whether the resolver should round-trip registry `time:` entries
+    /// into the output graph. pnpm only writes `time:` to its lockfile
+    /// when one of `resolution-mode=time-based` / `minimumReleaseAge`
+    /// is active — otherwise the field is dead weight and, worse, shows
+    /// up as churn in a pnpm ↔ aube diff. Gate the insertion at the
+    /// two `resolved_times.insert` call sites on this predicate so
+    /// Highest-mode installs never populate the map.
+    fn should_record_times(&self) -> bool {
+        self.resolution_mode == ResolutionMode::TimeBased || self.minimum_release_age.is_some()
+    }
+
     /// Override the default `auto-install-peers=true` behavior. pnpm reads
     /// this from `.npmrc` or `pnpm-workspace.yaml`; aube's install command
     /// plumbs the resolved value through here before running resolution.
@@ -1576,7 +1587,8 @@ impl Resolver {
                             // existing `time:` entry even when this
                             // install reuses the locked version without
                             // re-fetching a packument.
-                            if let Some(g) = existing
+                            if self.should_record_times()
+                                && let Some(g) = existing
                                 && let Some(t) = g.times.get(&dep_path)
                             {
                                 resolved_times.insert(dep_path.clone(), t.clone());
@@ -1628,6 +1640,8 @@ impl Resolver {
                                     tarball_url: locked_pkg.tarball_url.clone(),
                                     alias_of: locked_pkg.alias_of.clone(),
                                     yarn_checksum: locked_pkg.yarn_checksum.clone(),
+                                    engines: locked_pkg.engines.clone(),
+                                    has_bin: locked_pkg.has_bin,
                                 },
                             );
 
@@ -1939,7 +1953,9 @@ impl Resolver {
                 // (v5.15.1+) and full-packument fetches do include it,
                 // and then we round-trip it into the lockfile just like
                 // pnpm does.
-                if let Some(t) = picked_publish_time.as_ref() {
+                if self.should_record_times()
+                    && let Some(t) = picked_publish_time.as_ref()
+                {
                     resolved_times.insert(dep_path.clone(), t.clone());
                 }
 
@@ -2101,6 +2117,8 @@ impl Resolver {
                         // reader populates this field.
                         alias_of: task.real_name.clone(),
                         yarn_checksum: None,
+                        engines: version_meta.engines.clone(),
+                        has_bin: version_meta.has_bin,
                     },
                 );
 
@@ -3208,6 +3226,8 @@ mod tests {
             os: vec![],
             cpu: vec![],
             libc: vec![],
+            engines: BTreeMap::new(),
+            has_bin: false,
             has_install_script: false,
             deprecated: None,
         }

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1641,7 +1641,8 @@ impl Resolver {
                                     alias_of: locked_pkg.alias_of.clone(),
                                     yarn_checksum: locked_pkg.yarn_checksum.clone(),
                                     engines: locked_pkg.engines.clone(),
-                                    has_bin: locked_pkg.has_bin,
+                                    bin: locked_pkg.bin.clone(),
+                                    declared_dependencies: locked_pkg.declared_dependencies.clone(),
                                 },
                             );
 
@@ -2118,7 +2119,32 @@ impl Resolver {
                         alias_of: task.real_name.clone(),
                         yarn_checksum: None,
                         engines: version_meta.engines.clone(),
-                        has_bin: version_meta.has_bin,
+                        // Rehydrate a string-form bin (`"bin": "cli.js"`)
+                        // into `{<package_name>: "cli.js"}` — registry
+                        // packuments leave the name off, expecting
+                        // consumers to default it to the package name.
+                        // Doing it here keeps bun's per-entry meta
+                        // byte-identical to bun's own output without
+                        // pushing the fixup into every writer.
+                        bin: {
+                            let mut m = version_meta.bin.clone();
+                            if let Some(path) = m.remove("") {
+                                m.insert(task.name.clone(), path);
+                            }
+                            m
+                        },
+                        // Declared ranges straight from the packument's
+                        // `dependencies` / `optionalDependencies`. Fed
+                        // back out by npm / yarn / bun writers so
+                        // nested package entries keep the original
+                        // specifiers instead of collapsing to pins.
+                        declared_dependencies: {
+                            let mut m = version_meta.dependencies.clone();
+                            for (k, v) in &version_meta.optional_dependencies {
+                                m.insert(k.clone(), v.clone());
+                            }
+                            m
+                        },
                     },
                 );
 
@@ -3227,7 +3253,7 @@ mod tests {
             cpu: vec![],
             libc: vec![],
             engines: BTreeMap::new(),
-            has_bin: false,
+            bin: BTreeMap::new(),
             has_install_script: false,
             deprecated: None,
         }

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2129,7 +2129,19 @@ impl Resolver {
                         bin: {
                             let mut m = version_meta.bin.clone();
                             if let Some(path) = m.remove("") {
-                                m.insert(task.name.clone(), path);
+                                // String-form `bin` in a packument
+                                // (`"bin": "cli.js"`) is implicitly
+                                // named after the real registry
+                                // package — not the alias. For an
+                                // aliased dep (`"h3-v2": "npm:h3@…"`)
+                                // the bun writer must emit the bin
+                                // under `h3`, not `h3-v2`, or the
+                                // map drifts against bun's own
+                                // output (and the shim install path
+                                // creates the wrong binary name).
+                                let bin_name =
+                                    task.real_name.as_deref().unwrap_or(&task.name).to_string();
+                                m.insert(bin_name, path);
                             }
                             m
                         },

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -883,6 +883,8 @@ pub(crate) fn dedupe_peer_suffixes(graph: LockfileGraph) -> LockfileGraph {
                 engines: pkg.engines,
                 bin: pkg.bin,
                 declared_dependencies: pkg.declared_dependencies,
+                license: pkg.license,
+                funding_url: pkg.funding_url,
             },
         );
     }
@@ -1284,6 +1286,8 @@ fn visit_peer_context(
             engines: pkg.engines.clone(),
             bin: pkg.bin.clone(),
             declared_dependencies: pkg.declared_dependencies.clone(),
+            license: pkg.license.clone(),
+            funding_url: pkg.funding_url.clone(),
         },
     );
     Some(contextualized)

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -877,6 +877,8 @@ pub(crate) fn dedupe_peer_suffixes(graph: LockfileGraph) -> LockfileGraph {
                 tarball_url: pkg.tarball_url,
                 alias_of: pkg.alias_of,
                 yarn_checksum: pkg.yarn_checksum,
+                engines: pkg.engines,
+                has_bin: pkg.has_bin,
             },
         );
     }
@@ -1274,6 +1276,8 @@ fn visit_peer_context(
             tarball_url: pkg.tarball_url.clone(),
             alias_of: pkg.alias_of.clone(),
             yarn_checksum: pkg.yarn_checksum.clone(),
+            engines: pkg.engines.clone(),
+            has_bin: pkg.has_bin,
         },
     );
     Some(contextualized)

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -878,7 +878,8 @@ pub(crate) fn dedupe_peer_suffixes(graph: LockfileGraph) -> LockfileGraph {
                 alias_of: pkg.alias_of,
                 yarn_checksum: pkg.yarn_checksum,
                 engines: pkg.engines,
-                has_bin: pkg.has_bin,
+                bin: pkg.bin,
+                declared_dependencies: pkg.declared_dependencies,
             },
         );
     }
@@ -1277,7 +1278,8 @@ fn visit_peer_context(
             alias_of: pkg.alias_of.clone(),
             yarn_checksum: pkg.yarn_checksum.clone(),
             engines: pkg.engines.clone(),
-            has_bin: pkg.has_bin,
+            bin: pkg.bin.clone(),
+            declared_dependencies: pkg.declared_dependencies.clone(),
         },
     );
     Some(contextualized)

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -622,6 +622,8 @@ mod tests {
                     cpu: Vec::new(),
                     libc: Vec::new(),
                     engines: BTreeMap::new(),
+                    license: None,
+                    funding_url: None,
                     bin: BTreeMap::new(),
                     has_install_script: false,
                     deprecated: None,

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -622,7 +622,7 @@ mod tests {
                     cpu: Vec::new(),
                     libc: Vec::new(),
                     engines: BTreeMap::new(),
-                    has_bin: false,
+                    bin: BTreeMap::new(),
                     has_install_script: false,
                     deprecated: None,
                 },

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -621,6 +621,8 @@ mod tests {
                     os: Vec::new(),
                     cpu: Vec::new(),
                     libc: Vec::new(),
+                    engines: BTreeMap::new(),
+                    has_bin: false,
                     has_install_script: false,
                     deprecated: None,
                 },

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2714,6 +2714,17 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     .await
                     .wrap_err("pnpmfile afterAllResolved hook failed")?;
             }
+            // Overlay per-package metadata the resolver can't recover
+            // from abbreviated (corgi) packuments — `license`,
+            // `funding_url`, bun's `configVersion` — from the
+            // existing lockfile when one was on disk. Without this,
+            // `aube install --no-frozen-lockfile` drops those fields
+            // on every re-resolve even though the resolved versions
+            // didn't change, which churns the lockfile diff against
+            // formats (npm, bun) that preserve them.
+            if let Ok(prior) = aube_lockfile::parse_lockfile(&cwd, &manifest) {
+                graph.overlay_metadata_from(&prior);
+            }
             tracing::debug!("Resolved {} packages", graph.packages.len());
             if let Some(p) = prog_ref {
                 p.set_phase("fetching");


### PR DESCRIPTION
## Summary

Installing with `aube install --no-frozen-lockfile` (or any path that re-resolves) against an existing `pnpm-lock.yaml`, `bun.lock`, or `package-lock.json` produced large, gratuitous git diffs that never converged, even when the dep graph was unchanged. This PR cuts that churn to zero for all three formats. Byte-parity tests on golden fixtures pin the invariants.

### Measured drift on a 3-dep chalk/picocolors/semver fixture

| Writer | Before | After |
|---|---|---|
| pnpm-lock.yaml | +10 / -36 of 79 | **byte-identical** |
| bun.lock | +44 / -18 of 31 | **byte-identical** |
| package-lock.json | +9 / -52 of 105 | **byte-identical** |

### pnpm writer fixes

- **`time:` gating** — only emit when `resolution-mode=time-based` or `minimumReleaseAge > 0` (matches pnpm's own behavior). Previously, aube opportunistically captured every packument's publish times, so any registry that shipped a `time` map (Verdaccio, npmjs full packuments) leaked a bogus `time:` block into Highest-mode lockfiles.
- **`engines:` + `hasBin:` round-trip** — these rode on pnpm's output but were silently dropped on re-emit because `LockedPackage` didn't carry them. `engines` plumbed through as a `BTreeMap<String, String>` on both `VersionMetadata` and `LockedPackage`; `hasBin` derives from `!bin.is_empty()`.
- **Formatting fidelity post-processor** — collapses `resolution: {integrity: …}` / `engines: {node: '>=8'}` to flow form (serde_yaml can't be coerced per-field) and inserts pnpm's blank-line separators above every top-level section and between entries in `importers:` / `packages:` / `snapshots:` / `catalogs:`.

### bun writer fixes

- Emit `configVersion` (round-tripped from the parsed lockfile; defaults to `1` for v1.1 files that predate the field). Never hardcoded — a future bun release that bumps the value won't silently downgrade on re-emit.
- Stop emitting `version` on workspace entries (root and non-root) — bun never does.
- Hand-written JSONC emitter replaces `serde_json::to_string_pretty`: trailing commas on nested fields, single-line `[ident, "", {meta}, integrity]` package arrays with blank-line separators, bare `  }\n}` close on the last top-level field.
- **Preserve the `bin:` map on each entry's meta** — `LockedPackage.bin` (previously collapsed to `has_bin: bool`) now carries the full `name → path` map so bun's output keeps its executable declarations. String-form packument bins (`"bin": "cli.js"`, implicitly named after the real package) are keyed by the real registry name — correct for npm aliases (`"h3-v2": "npm:h3@…"` emits `{"h3": "cli.js"}`, not `{"h3-v2": …}`).
- **Split `dependencies` / `optionalDependencies` on meta emission** — the parser tracks optionals separately and the writer emits them under the right key, instead of flattening everything into `dependencies` on re-emit.

### npm writer fixes

- Emit `resolved:` on every registry package, not just aliases and JSR. `LockedPackage.tarball_url` is now populated by both the resolver (from `dist.tarball`) and the npm parser (from the existing `resolved:` field). pnpm writer still gates its emission on `lockfile_include_tarball_url`, so pnpm-lock.yaml stays byte-identical to pnpm's output.
- Emit `engines:`, `bin:`, `license:`, and `funding:` on every entry, in npm's own field order. `VersionMetadata` / `LockedPackage` grew `license: Option<String>` and `funding_url: Option<String>`, with lenient deserializers that accept the string / object / array shapes packuments use in the wild. The `funding_url` field is renamed to `funding` in the JSON (the default `rename_all = "camelCase"` would have looked for `fundingUrl`).
- **Post-resolve metadata overlay** — corgi (abbreviated) packuments don't ship `license`, so a fresh re-resolve against npmjs.org would still lose the field. Added `LockfileGraph::overlay_metadata_from(prior)` that copies `license` / `funding_url` / `bun_config_version` off an already-parsed existing lockfile onto matching `(name, version)` entries in the fresh graph. Wired into the main install path; fix-lockfile mode already reuses the existing graph directly through the resolver.

### Declared-range preservation (npm / yarn / bun)

Nested package entries in npm / yarn / bun lockfiles record the range the package *declared* (`"^4.1.0"`), not the range aube resolved to (`"4.3.0"`). Rewriting to the pin was the single largest source of round-trip churn. Fix:

- `LockedPackage`: new `declared_dependencies: BTreeMap<String, String>` field.
- Resolver: populate from `VersionMetadata.dependencies` + `optional_dependencies`.
- Parsers (npm, yarn classic, yarn berry, bun): harvest declared ranges out of each format's per-package block.
- Writers: emit declared ranges when present, fall back to resolved pins when the source lockfile didn't carry them (pnpm's `snapshots:` only stores pins, so a pnpm → bun conversion still gets sensible output).
- Yarn classic + berry writers: widen block headers to include every transitive declared range so reparse of `bar "^2.0.0"` still finds a matching block.

### Regressions caught along the way

- **`has_bin` bool round-trip through the packument cache**: an earlier draft treated "any non-null/non-string/non-object" value as truthy, which flipped every cached entry to `hasBin: true` on warm-cache reads. Pinned by `bin_map_roundtrips_through_cache_serialization`. Later replaced with a normalized `bin: BTreeMap<String, String>`.
- **Windows CRLF vs LF**: added `.gitattributes eol=lf` on the golden fixtures *and* test-level `\r\n → \n` normalization so `core.autocrlf=true` doesn't produce a line-ending false positive.
- **Naïve line-by-line diff in byte-parity test output**: replaced with bounded-lookahead `-` / `+` run matching, so a single-line insertion no longer paints every subsequent line as "modified" in CI failure logs.

## Test plan

- [x] `cargo test` — all 7 workspace crates pass. New tests: `test_write_byte_identical_to_native_pnpm`, `test_write_byte_identical_to_native_bun`, `test_write_byte_identical_to_native_npm`, `test_write_roundtrips_config_version`, `bin_normalizes_packument_shapes`, `bin_map_roundtrips_through_cache_serialization`.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `mise run test:bats` — full suite passes.
- [x] Manual round-trip: seed pnpm-lock.yaml / bun.lock / package-lock.json from native `pnpm install` / `bun install` / `npm install`, run `aube install --no-frozen-lockfile` twice (cold + warm cache), diff. All three byte-identical.
- [x] `.gitattributes` forces LF on golden fixtures + tests normalize CRLF → LF so Windows CI (`core.autocrlf=true` default) gets real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core lockfile parse/write paths across pnpm, bun, npm, and yarn plus resolver metadata plumbing; bugs could cause lockfile churn or incorrect dependency metadata in emitted files. Changes are mostly additive/round-trip focused with new golden byte-parity tests to constrain regressions.
> 
> **Overview**
> Reduces gratuitous lockfile diffs by making `aube-lockfile` re-emission **byte-identical** to native `pnpm-lock.yaml`, `bun.lock`, and `package-lock.json` outputs via stricter formatting and fuller metadata round-tripping.
> 
> Adds new per-package and per-graph metadata to `LockedPackage`/`LockfileGraph` (e.g. `declared_dependencies`, `bin`, `engines`, `license`, `funding_url`, bun `configVersion`) and plumbs it through the resolver, peer-context rewrites, and format parsers/writers so declared ranges, optional deps, tarball `resolved:` URLs, and bun/npm-specific fields are preserved instead of collapsing to pins or being dropped.
> 
> Reworks writers for parity: bun switches to a custom JSONC emitter and round-trips `configVersion`; pnpm post-processes `serde_yaml` output to match pnpm’s flow/blank-line style and now emits `engines`/`hasBin`; yarn classic/berry expand headers and dependency rendering to include transitive declared ranges. Adds native-output fixtures + byte-parity tests (with LF normalization and `.gitattributes` eol rules) and overlays missing metadata from an existing lockfile during `install --no-frozen-lockfile` re-resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ff65a60d9a633296a7843ed2476bcbd052ea578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->