### PR TITLE
bench: use no-op test script in fixture

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -317,9 +317,8 @@ CMDS["ci-cold:yarn"]="cd {project} && HOME={home} YARN_CACHE_FOLDER={cache} {bin
 # Each tool does "install then run the `test` script" via its own idiomatic
 # command. aube has no install-test alias because `aube test` auto-installs
 # before running the script; pnpm and npm ship `install-test`; bun and yarn
-# need an explicit chain. The fixture's `test` script is a trivial
-# `node -e "console.log('ok')"` so this measures install + script dispatch,
-# not test-runtime work.
+# need an explicit chain. The fixture's `test` script is the POSIX shell
+# no-op `:`, so this measures install + script dispatch, not test-runtime work.
 CMDS["install-test:aube"]="cd {project} && HOME={home} XDG_CACHE_HOME={cache} {bin} test >/dev/null 2>&1"
 CMDS["install-test:bun"]="cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1 && HOME={home} BUN_INSTALL={home}/.bun {bin} run test >/dev/null 2>&1"
 # `npm install-test` (the `install` variant, not `ci`) is the right

--- a/benchmarks/fixture.package.json
+++ b/benchmarks/fixture.package.json
@@ -94,6 +94,6 @@
     "jest-environment-jsdom": "^29.7.0"
   },
   "scripts": {
-    "test": "node -e \"console.log('ok')\""
+    "test": ":"
   }
 }


### PR DESCRIPTION
## Summary
- replace the benchmark fixture `test` script with the POSIX shell no-op `:`
- update the install-test benchmark comment to describe the cheaper script

## Why
The install-test benchmark is meant to measure install/state validation plus script dispatch, not Node startup or test-runtime work. Using `:` keeps the script path present while making the script itself as cheap as possible.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('benchmarks/fixture.package.json','utf8')); console.log('json ok')"`
- commit hooks: `shfmt` and `shellcheck` on `benchmarks/bench.sh`
- smoke-checked `:` through `aubr test`, `bun run test`, and `pnpm test` on minimal temp packages before committing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: benchmark-only change that swaps the fixture `test` script to a no-op; it doesn’t affect production code paths but will change benchmark timing baselines.
> 
> **Overview**
> Updates the benchmark fixture’s `test` script from a Node one-liner to the POSIX no-op `:` to reduce non-install overhead in the install+test scenario.
> 
> Adjusts the `bench.sh` comment for the `install-test` benchmark to reflect that it now measures install/state validation plus script dispatch rather than Node startup/runtime work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 846ba443881c3fe4528794358932c45b53f5af0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->