### PR TITLE
chore: release v1.0.0-beta.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "base64",
  "blake3",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -85,13 +85,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.6" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.6" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.6" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.6" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.6" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.6" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.6" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.6" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.6" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.6" }
+aube = { path = "crates/aube", version = "1.0.0-beta.7" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.7" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.7" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.7" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.7" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.7" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.7" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.7" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.7" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.7" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.6"
+version "1.0.0-beta.7"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.6...aube-linker-v1.0.0-beta.7) - 2026-04-19
+
+### Other
+
+- make workspace warm installs incremental ([#110](https://github.com/endevco/aube/pull/110))
+
 ## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.5...aube-linker-v1.0.0-beta.6) - 2026-04-19
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.6...aube-lockfile-v1.0.0-beta.7) - 2026-04-19
+
+### Other
+
+- pnpm compat: multi-document lockfile + override over npm-alias ([#116](https://github.com/endevco/aube/pull/116))
+- *(pnpm)* normalize empty-string root importer key ([#121](https://github.com/endevco/aube/pull/121))
+- byte-identical pnpm-lock.yaml / bun.lock on re-emit ([#107](https://github.com/endevco/aube/pull/107))
+- classify bare http(s) URLs as tarballs ([#114](https://github.com/endevco/aube/pull/114))
+- *(bun)* emit and parse non-root workspaces ([#104](https://github.com/endevco/aube/pull/104))
+
 ## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.5...aube-lockfile-v1.0.0-beta.6) - 2026-04-19
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.6...aube-manifest-v1.0.0-beta.7) - 2026-04-19
+
+### Other
+
+- tolerate legacy-array engines field ([#120](https://github.com/endevco/aube/pull/120))
+
 ## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.5...aube-manifest-v1.0.0-beta.6) - 2026-04-19
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.6...aube-registry-v1.0.0-beta.7) - 2026-04-19
+
+### Other
+
+- byte-identical pnpm-lock.yaml / bun.lock on re-emit ([#107](https://github.com/endevco/aube/pull/107))
+- registry + install: tolerate napi-rs packuments and warn on ignored builds ([#113](https://github.com/endevco/aube/pull/113))
+
 ## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.5...aube-registry-v1.0.0-beta.6) - 2026-04-19
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.6...aube-resolver-v1.0.0-beta.7) - 2026-04-19
+
+### Other
+
+- pnpm compat: multi-document lockfile + override over npm-alias ([#116](https://github.com/endevco/aube/pull/116))
+- link bare-semver deps to workspace packages (yarn/npm/bun style) ([#118](https://github.com/endevco/aube/pull/118))
+- byte-identical pnpm-lock.yaml / bun.lock on re-emit ([#107](https://github.com/endevco/aube/pull/107))
+- classify bare http(s) URLs as tarballs ([#114](https://github.com/endevco/aube/pull/114))
+
 ## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.5...aube-resolver-v1.0.0-beta.6) - 2026-04-19
 
 ### Other

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0-beta.6...aube-scripts-v1.0.0-beta.7) - 2026-04-19
+
+### Other
+
+- write per-dep .bin for transitive lifecycle-script bins ([#122](https://github.com/endevco/aube/pull/122))
+
 ## [1.0.0-beta.4](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0-beta.3...aube-scripts-v1.0.0-beta.4) - 2026-04-19
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.6...aube-settings-v1.0.0-beta.7) - 2026-04-19
+
+### Other
+
+- drop webpack and rollup from gvs auto-disable defaults ([#117](https://github.com/endevco/aube/pull/117))
+
 ## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.5...aube-settings-v1.0.0-beta.6) - 2026-04-19
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.6...aube-workspace-v1.0.0-beta.7) - 2026-04-19
+
+### Other
+
+- dedupe packages matched by overlapping patterns ([#119](https://github.com/endevco/aube/pull/119))
+
 ## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.5...aube-workspace-v1.0.0-beta.6) - 2026-04-19
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7](https://github.com/endevco/aube/compare/v1.0.0-beta.6...v1.0.0-beta.7) - 2026-04-19
+
+### Other
+
+- write per-dep .bin for transitive lifecycle-script bins ([#122](https://github.com/endevco/aube/pull/122))
+- make workspace warm installs incremental ([#110](https://github.com/endevco/aube/pull/110))
+- byte-identical pnpm-lock.yaml / bun.lock on re-emit ([#107](https://github.com/endevco/aube/pull/107))
+- drop webpack and rollup from gvs auto-disable defaults ([#117](https://github.com/endevco/aube/pull/117))
+- registry + install: tolerate napi-rs packuments and warn on ignored builds ([#113](https://github.com/endevco/aube/pull/113))
+- include bun.lock in --lockfile removal set ([#105](https://github.com/endevco/aube/pull/105))
+- fix --version / -V on aubr and aubx multicall shims ([#106](https://github.com/endevco/aube/pull/106))
+
 ## [1.0.0-beta.6](https://github.com/endevco/aube/compare/v1.0.0-beta.5...v1.0.0-beta.6) - 2026-04-19
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5546,7 +5546,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.6
+**Version**: 1.0.0-beta.7
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.6",
-  "releasedAt": "2026-04-19T19:00:45Z"
+  "version": "1.0.0-beta.7",
+  "releasedAt": "2026-04-19T22:39:20Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.7`

This PR bumps the workspace to `v1.0.0-beta.7` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a coordinated version bump and regenerated release metadata/docs; no functional code changes in this diff.
> 
> **Overview**
> **Release PR for `v1.0.0-beta.7`.** Updates `Cargo.toml`/`Cargo.lock` and internal crate dependency pins from `1.0.0-beta.6` to `1.0.0-beta.7`.
> 
> Regenerates release artifacts: per-crate `CHANGELOG.md` entries, CLI usage spec/docs (`aube.usage.kdl`, `docs/cli/*`), and `release.json` timestamps/version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 260cfcd87d7279ea9dfe090a39b9202ce62ed959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->