### PR TITLE
registry + install: tolerate napi-rs packuments and warn on ignored builds

### DIFF
--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -5,8 +5,12 @@ use std::collections::BTreeMap;
 /// to be either a single string (e.g. `"libc": "glibc"`) or an array
 /// of strings (e.g. `"libc": ["glibc"]`). An explicit `null` is also
 /// treated as "no constraint", same as the field being absent — some
-/// packuments emit it. Normalize all three shapes to a `Vec<String>`
-/// so the platform filter doesn't have to care.
+/// packuments emit it. Napi-rs additionally publishes `"libc": [null]`
+/// on its Windows/macOS native-binding packages (e.g.
+/// `@oxc-parser/binding-win32-x64-msvc`), meaning "no libc constraint";
+/// drop null array entries so that shape round-trips to an empty vec
+/// instead of failing the whole packument parse. Normalize all shapes
+/// to a `Vec<String>` so the platform filter doesn't have to care.
 fn string_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
 where
     D: Deserializer<'de>,
@@ -15,12 +19,18 @@ where
     #[serde(untagged)]
     enum StringOrSeq {
         String(String),
-        Seq(Vec<String>),
+        Seq(Vec<serde_json::Value>),
     }
     Ok(match Option::<StringOrSeq>::deserialize(deserializer)? {
         None => Vec::new(),
         Some(StringOrSeq::String(s)) => vec![s],
-        Some(StringOrSeq::Seq(v)) => v,
+        Some(StringOrSeq::Seq(v)) => v
+            .into_iter()
+            .filter_map(|e| match e {
+                serde_json::Value::String(s) => Some(s),
+                _ => None,
+            })
+            .collect(),
     })
 }
 
@@ -233,6 +243,31 @@ mod tests {
         assert!(v.os.is_empty());
         assert!(v.cpu.is_empty());
         assert!(v.libc.is_empty());
+    }
+
+    /// Napi-rs emits `"libc": [null]` on Windows/macOS native-binding
+    /// publishes (e.g. `@oxc-parser/binding-win32-x64-msvc`), meaning
+    /// "no libc constraint". Drop the null entry so the packument
+    /// parses — otherwise every version with that shape blocks resolve.
+    #[test]
+    fn libc_array_containing_null_drops_null() {
+        let v = parse(r#"{"name":"x","version":"1.0.0","libc":[null]}"#);
+        assert!(v.libc.is_empty());
+    }
+
+    #[test]
+    fn os_cpu_libc_arrays_drop_non_string_entries() {
+        let v = parse(
+            r#"{
+                "name":"x","version":"1.0.0",
+                "os":["linux",null,42],
+                "cpu":["x64",null],
+                "libc":["glibc",{"x":1}]
+            }"#,
+        );
+        assert_eq!(v.os, vec!["linux"]);
+        assert_eq!(v.cpu, vec!["x64"]);
+        assert_eq!(v.libc, vec!["glibc"]);
     }
 
     #[test]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3605,6 +3605,31 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         );
     }
 
+    // Surface packages whose build scripts were skipped because they're
+    // not on the `allowBuilds` / `onlyBuiltDependencies` allowlist. Without
+    // this, a fresh install of a project that depends on native bindings
+    // (`better-sqlite3`, `esbuild`, napi-rs packages, etc.) looks like it
+    // succeeded but leaves those packages unbuilt — the failure only
+    // surfaces later when something tries to `require` the binding.
+    // Skipped under `--ignore-scripts`, `virtualStoreOnly`, and
+    // `strictDepBuilds=true` (the strict path already errored above).
+    if !opts.ignore_scripts && !strict_dep_builds_setting && !virtual_store_only {
+        let unreviewed = unreviewed_dep_builds(
+            &aube_dir,
+            &graph_for_link,
+            &build_policy,
+            virtual_store_dir_max_length,
+            placements_ref,
+        )?;
+        if !unreviewed.is_empty() {
+            tracing::warn!(
+                "ignored build scripts for {} package(s): {}. Run `aube approve-builds` to review and enable them, or set `strictDepBuilds=true` to fail installs that have unreviewed builds.",
+                unreviewed.len(),
+                unreviewed.join(", ")
+            );
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3622,10 +3622,24 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             placements_ref,
         )?;
         if !unreviewed.is_empty() {
+            // Cap the inline list so a napi-rs / prebuilt-variants tree
+            // (tens of per-platform binding packages) doesn't splat into
+            // one hard-to-scan line. Users who want the full list run
+            // `aube ignored-builds`.
+            const MAX_INLINE: usize = 5;
+            let list = if unreviewed.len() <= MAX_INLINE {
+                unreviewed.join(", ")
+            } else {
+                format!(
+                    "{}, and {} more",
+                    unreviewed[..MAX_INLINE].join(", "),
+                    unreviewed.len() - MAX_INLINE
+                )
+            };
             tracing::warn!(
                 "ignored build scripts for {} package(s): {}. Run `aube approve-builds` to review and enable them, or set `strictDepBuilds=true` to fail installs that have unreviewed builds.",
                 unreviewed.len(),
-                unreviewed.join(", ")
+                list
             );
         }
     }

--- a/test/approve_builds.bats
+++ b/test/approve_builds.bats
@@ -15,6 +15,58 @@ teardown() {
 	_common_teardown
 }
 
+@test "install warns about ignored build scripts" {
+	cat >package.json <<'JSON'
+{
+  "name": "install-ignored-warn-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "aube-test-builds-marker": "^1.0.0"
+  }
+}
+JSON
+	run aube install
+	assert_success
+	assert_output --partial "ignored build scripts"
+	assert_output --partial "aube-test-builds-marker"
+	assert_output --partial "aube approve-builds"
+}
+
+@test "install does not warn when build is allowed" {
+	cat >package.json <<'JSON'
+{
+  "name": "install-no-warn-allowed-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "aube-test-builds-marker": "^1.0.0"
+  },
+  "pnpm": {
+    "allowBuilds": {
+      "aube-test-builds-marker": true
+    }
+  }
+}
+JSON
+	run aube install
+	assert_success
+	refute_output --partial "ignored build scripts"
+}
+
+@test "install does not warn when --ignore-scripts is set" {
+	cat >package.json <<'JSON'
+{
+  "name": "install-no-warn-ignore-scripts-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "aube-test-builds-marker": "^1.0.0"
+  }
+}
+JSON
+	run aube install --ignore-scripts
+	assert_success
+	refute_output --partial "ignored build scripts"
+}
+
 @test "ignored-builds lists deps whose scripts were skipped" {
 	cat >package.json <<'JSON'
 {


### PR DESCRIPTION
## Summary

- **registry**: tolerate `"libc": [null]` in packument `os` / `cpu` / `libc` arrays. Napi-rs publishes this shape on its Windows/macOS native-binding packages (33 versions of `@oxc-parser/binding-win32-x64-msvc` alone), meaning "no libc constraint". The strict `Vec<String>` deserializer rejected it, which killed the whole packument and blocked resolve for any tree that merely listed the package — even when the running platform wouldn't select the Windows binary. Switch the inner shape to `Vec<serde_json::Value>` and drop non-string entries, mirroring the tolerance already in `non_string_tolerant_map`.
- **install**: after a successful install, warn when dependencies had build scripts that were skipped because they're not on the `allowBuilds` / `onlyBuiltDependencies` allowlist. Without this, a fresh install of a project that depends on native bindings (`better-sqlite3`, napi-rs packages, etc.) looks like it succeeded but leaves those packages unbuilt — the failure only surfaces later at runtime ("Could not locate the bindings file"), with no breadcrumb back to aube's build-approval gate. The warning points at `aube approve-builds` so users have a direct path to review and enable them (or opt into `strictDepBuilds=true` for a hard fail). Suppressed under `--ignore-scripts`, `virtualStoreOnly`, and `strictDepBuilds=true` (the strict path already errors earlier).

Both surfaced while trying `aube i` on [lavilleavelo/cyclopolis](https://github.com/lavilleavelo/cyclopolis) — a Nuxt project with native deps.

## Test plan

- [x] `cargo test -p aube-registry --lib` — new cases cover `libc: [null]` and mixed `os`/`cpu`/`libc` arrays containing non-strings
- [x] `mise run test:bats test/approve_builds.bats` — new cases cover the install-time warn, the no-warn-when-allowed path, and the no-warn-under-`--ignore-scripts` path
- [x] `mise run test:bats test/lifecycle_scripts.bats` — existing strictDepBuilds tests still pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to more-tolerant registry metadata deserialization and an additional post-install warning, without altering install/link behavior or security-critical flows.
> 
> **Overview**
> Improves packument parsing for `os`/`cpu`/`libc` by accepting arrays containing `null` or other non-strings (notably napi-rs’ `"libc": [null]`) and filtering them out instead of failing deserialization, with added unit tests.
> 
> After a successful install, emits a warning when dependency build scripts were skipped due to missing `allowBuilds`/`onlyBuiltDependencies` approval (suppressed under `--ignore-scripts`, `virtualStoreOnly`, and `strictDepBuilds=true`), and adds Bats tests covering the warn/no-warn cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11e3324bd591e09194a2ba0bef5b09a2dd05b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->