### PR TITLE
registry: tolerate null elements inside os/cpu/libc arrays

### DIFF
--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -7,6 +7,16 @@ use std::collections::BTreeMap;
 /// treated as "no constraint", same as the field being absent — some
 /// packuments emit it. Normalize all three shapes to a `Vec<String>`
 /// so the platform filter doesn't have to care.
+///
+/// Also tolerant of non-string elements *inside* an array: some
+/// packages (e.g. `@oxc-transform/binding-win32-x64-msvc` pre-0.17)
+/// publish `"libc": [null]` to mean "no libc constraint" on a native
+/// Windows binary. A strict `Vec<String>` would blow up the whole
+/// packument with `data did not match any variant of untagged enum
+/// StringOrSeq`, blocking resolution of any range that selects one of
+/// those versions. Drop non-string entries silently — same shape
+/// tolerance `non_string_tolerant_map` applies at the map level, and
+/// the same thing npm / pnpm / bun do in practice.
 fn string_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
 where
     D: Deserializer<'de>,
@@ -15,12 +25,18 @@ where
     #[serde(untagged)]
     enum StringOrSeq {
         String(String),
-        Seq(Vec<String>),
+        Seq(Vec<serde_json::Value>),
     }
     Ok(match Option::<StringOrSeq>::deserialize(deserializer)? {
         None => Vec::new(),
         Some(StringOrSeq::String(s)) => vec![s],
-        Some(StringOrSeq::Seq(v)) => v,
+        Some(StringOrSeq::Seq(v)) => v
+            .into_iter()
+            .filter_map(|item| match item {
+                serde_json::Value::String(s) => Some(s),
+                _ => None,
+            })
+            .collect(),
     })
 }
 
@@ -233,6 +249,27 @@ mod tests {
         assert!(v.os.is_empty());
         assert!(v.cpu.is_empty());
         assert!(v.libc.is_empty());
+    }
+
+    /// `@oxc-transform/binding-win32-x64-msvc` and similar native
+    /// Windows binaries publish `"libc": [null]` on some versions to
+    /// mean "no libc constraint". The array-of-null shape would blow
+    /// up a strict `Vec<String>` and take down every packument that
+    /// merely *lists* an affected version; tolerate it by dropping
+    /// non-string elements, same as `null` at the top level.
+    #[test]
+    fn array_with_null_element_is_filtered() {
+        let v =
+            parse(r#"{"name":"x","version":"1.0.0","os":["win32"],"cpu":["x64"],"libc":[null]}"#);
+        assert_eq!(v.os, vec!["win32"]);
+        assert_eq!(v.cpu, vec!["x64"]);
+        assert!(v.libc.is_empty());
+    }
+
+    #[test]
+    fn array_with_mixed_null_and_string_keeps_strings() {
+        let v = parse(r#"{"name":"x","version":"1.0.0","libc":[null,"glibc",null,"musl"]}"#);
+        assert_eq!(v.libc, vec!["glibc", "musl"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Some packages (e.g. [`@oxc-transform/binding-win32-x64-msvc`](https://www.npmjs.com/package/@oxc-transform/binding-win32-x64-msvc) pre-0.17) publish `"libc": [null]` on native Windows binaries to signal "no libc constraint". A strict `Vec<String>` inside our `StringOrSeq` deserializer failed the whole packument with `data did not match any variant of untagged enum StringOrSeq`, blocking any install whose resolver touched one of those versions — even when the user's range didn't actually select them.

Match the tolerance `non_string_tolerant_map` already applies at the map level: drop non-string elements silently, same as an explicit top-level `null`. npm / pnpm / bun all behave this way in practice.

### Repro (before this change)

```
$ cat package.json
{ "name": "r", "version": "0.0.0", "private": true,
  "dependencies": { "@oxc-transform/binding-win32-x64-msvc": "*" } }

$ aube install
Error:   × failed to resolve dependencies
  ╰─▶ registry error for @oxc-transform/binding-win32-x64-msvc: I/O error:
      data did not match any variant of untagged enum StringOrSeq
```

Inspecting the packument: 20 of the 150 published versions carry `"libc": [null]`. After this change, those elements are filtered out and the packument parses.

Surfaced while testing aube against [`sst/opencode`](https://github.com/sst/opencode) — `@oxc-transform/binding-win32-x64-msvc` shows up transitively via `@typescript/native-preview` and blocked resolution of the whole tree.

## Test plan

- [x] `cargo test -p aube-registry --lib` — 86 passed
- [x] `cargo test --lib` — 549 passed (full workspace)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] New unit tests: `[null]` array is filtered to empty; mixed `[null, "glibc", null, "musl"]` keeps the strings; existing `null`/string/array/missing-field paths still pass (regression guard).
- [x] Manual end-to-end: minimal repro project with just `@oxc-transform/binding-win32-x64-msvc: "*"` now resolves and lockfiles at `0.126.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only relaxes JSON deserialization for `os`/`cpu`/`libc` fields and adds unit tests, reducing resolver failures on malformed registry metadata.
> 
> **Overview**
> Improves packument parsing tolerance for version metadata `os`/`cpu`/`libc` constraints by accepting arrays with non-string elements (e.g. `[null]`) and silently filtering those entries instead of failing deserialization.
> 
> Adds regression tests covering `[null]` and mixed `[null, "glibc", ...]` array shapes while preserving existing behavior for string, array, `null`, and missing-field cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e7304964f344f52efae811e010dd0ec52e54dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->