### PR TITLE
pnpm compat: multi-document lockfile + override over npm-alias

### DIFF
--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -1049,8 +1049,8 @@ struct WritableSnapshot {
 /// previous single-document parse.
 fn parse_raw_lockfile(content: &str) -> Result<RawPnpmLockfile, serde_yaml::Error> {
     let mut best: Option<(u64, RawPnpmLockfile)> = None;
-    let mut last_err: Option<serde_yaml::Error> = None;
-    for doc in serde_yaml::Deserializer::from_str(content) {
+    let mut first_err: Option<serde_yaml::Error> = None;
+    for (idx, doc) in serde_yaml::Deserializer::from_str(content).enumerate() {
         match RawPnpmLockfile::deserialize(doc) {
             Ok(raw) => {
                 let score = project_lockfile_score(&raw);
@@ -1059,10 +1059,22 @@ fn parse_raw_lockfile(content: &str) -> Result<RawPnpmLockfile, serde_yaml::Erro
                     _ => Some((score, raw)),
                 };
             }
-            Err(e) => last_err = Some(e),
+            Err(e) => {
+                // Log every per-document failure so a multi-doc lockfile
+                // where every document fails surfaces all the diagnostic
+                // signal at `RUST_LOG=aube_lockfile=debug`. The returned
+                // error is the *first* failure, which tends to be the
+                // most explanatory — later docs often fail with cascading
+                // schema mismatches once the first doc has set
+                // expectations off-kilter.
+                tracing::debug!("pnpm-lock.yaml document {idx} failed to parse: {e}");
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
+            }
         }
     }
-    match (best, last_err) {
+    match (best, first_err) {
         (Some((_, raw)), _) => Ok(raw),
         (None, Some(e)) => Err(e),
         // No documents at all — defer to the single-doc parser so the

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 /// Parse a pnpm-lock.yaml file into a LockfileGraph.
 pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     let content = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
-    let raw: RawPnpmLockfile = serde_yaml::from_str(&content)
+    let raw = parse_raw_lockfile(&content)
         .map_err(|e| Error::Parse(path.to_path_buf(), e.to_string()))?;
 
     // Parse importers (direct deps of each workspace package).
@@ -1034,6 +1034,75 @@ struct WritableSnapshot {
     bundled_dependencies: Option<Vec<String>>,
 }
 
+/// Parse `pnpm-lock.yaml` content, tolerating pnpm v11's multi-document
+/// layout.
+///
+/// pnpm v11 splits the lockfile into two YAML documents: a bootstrap
+/// document that tracks pnpm's own `packageManagerDependencies` /
+/// `configDependencies`, and the "real" project lockfile (with the
+/// workspace's `dependencies` / `devDependencies`, `settings`,
+/// `catalogs`, `overrides`, `patchedDependencies`, etc.). We want the
+/// second one. Heuristic: score every parseable document by
+/// project-lockfile signal (real importer deps + settings/catalogs/
+/// overrides + packages/snapshots count) and take the highest. If only
+/// one document is present (pnpm v9/v10 and older) this reduces to the
+/// previous single-document parse.
+fn parse_raw_lockfile(content: &str) -> Result<RawPnpmLockfile, serde_yaml::Error> {
+    let mut best: Option<(u64, RawPnpmLockfile)> = None;
+    let mut last_err: Option<serde_yaml::Error> = None;
+    for doc in serde_yaml::Deserializer::from_str(content) {
+        match RawPnpmLockfile::deserialize(doc) {
+            Ok(raw) => {
+                let score = project_lockfile_score(&raw);
+                best = match best {
+                    Some((prev, _)) if prev >= score => best,
+                    _ => Some((score, raw)),
+                };
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    match (best, last_err) {
+        (Some((_, raw)), _) => Ok(raw),
+        (None, Some(e)) => Err(e),
+        // No documents at all — defer to the single-doc parser so the
+        // error surface matches what callers saw before.
+        (None, None) => serde_yaml::from_str(content),
+    }
+}
+
+/// Score for picking the "main" document out of a multi-document
+/// `pnpm-lock.yaml`. Weighted so a document with real importer
+/// dependencies beats one with only `packageManagerDependencies`
+/// (pnpm v11's bootstrap doc has the latter but no regular deps).
+fn project_lockfile_score(raw: &RawPnpmLockfile) -> u64 {
+    let importer_dep_count: usize = raw
+        .importers
+        .values()
+        .map(|i| {
+            i.dependencies.as_ref().map(|m| m.len()).unwrap_or(0)
+                + i.dev_dependencies.as_ref().map(|m| m.len()).unwrap_or(0)
+                + i.optional_dependencies
+                    .as_ref()
+                    .map(|m| m.len())
+                    .unwrap_or(0)
+        })
+        .sum();
+    let mut score = importer_dep_count as u64 * 1000;
+    if raw.settings.is_some() {
+        score += 100;
+    }
+    if raw.catalogs.as_ref().is_some_and(|c| !c.is_empty()) {
+        score += 100;
+    }
+    if raw.overrides.as_ref().is_some_and(|o| !o.is_empty()) {
+        score += 100;
+    }
+    score += raw.packages.len() as u64;
+    score += raw.snapshots.len() as u64;
+    score
+}
+
 // -- Raw serde types for pnpm-lock.yaml v9 (deserialization) --
 
 #[derive(Debug, Deserialize)]
@@ -1960,5 +2029,69 @@ snapshots:
             }
         }
         out
+    }
+
+    #[test]
+    fn parse_multi_document_lockfile_picks_project_doc() {
+        // pnpm v11 emits two YAML documents in one file: a bootstrap
+        // doc for `packageManagerDependencies` and the real project
+        // lockfile. We want the latter.
+        let yaml = r#"---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    packageManagerDependencies:
+      pnpm:
+        specifier: 11.0.0-rc.1
+        version: 11.0.0-rc.1
+
+packages:
+
+  'pnpm@11.0.0-rc.1':
+    resolution: {integrity: sha512-aaa}
+
+snapshots:
+
+  'pnpm@11.0.0-rc.1': {}
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+
+importers:
+
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.0
+        version: 4.17.21
+
+packages:
+
+  'lodash@4.17.21':
+    resolution: {integrity: sha512-bbb}
+
+snapshots:
+
+  'lodash@4.17.21': {}
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(&path, yaml).unwrap();
+        let graph = parse(&path).expect("multi-doc lockfile should parse");
+        let root = graph.importers.get(".").expect("root importer");
+        let names: Vec<_> = root.iter().map(|d| d.name.as_str()).collect();
+        assert!(
+            names.contains(&"lodash"),
+            "expected lodash from project doc, got {names:?}"
+        );
+        assert!(
+            !names.contains(&"pnpm"),
+            "bootstrap doc's packageManagerDependencies should not leak in, got {names:?}"
+        );
     }
 }

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -1048,9 +1048,20 @@ struct WritableSnapshot {
 /// one document is present (pnpm v9/v10 and older) this reduces to the
 /// previous single-document parse.
 fn parse_raw_lockfile(content: &str) -> Result<RawPnpmLockfile, serde_yaml::Error> {
+    // Hard cap on documents inspected. pnpm v11 emits exactly two;
+    // anything beyond a handful is pathological. This also guards
+    // against malformed YAML that puts
+    // `serde_yaml::Deserializer::from_str`'s iterator into an
+    // infinite-yield state — `test_parse_invalid_yaml` tripped that
+    // mode on Windows CI with an unbounded loop.
+    const MAX_DOCUMENTS: usize = 16;
+
     let mut best: Option<(u64, RawPnpmLockfile)> = None;
     let mut first_err: Option<serde_yaml::Error> = None;
-    for (idx, doc) in serde_yaml::Deserializer::from_str(content).enumerate() {
+    for (idx, doc) in serde_yaml::Deserializer::from_str(content)
+        .enumerate()
+        .take(MAX_DOCUMENTS)
+    {
         match RawPnpmLockfile::deserialize(doc) {
             Ok(raw) => {
                 let score = project_lockfile_score(&raw);
@@ -1060,17 +1071,19 @@ fn parse_raw_lockfile(content: &str) -> Result<RawPnpmLockfile, serde_yaml::Erro
                 };
             }
             Err(e) => {
-                // Log every per-document failure so a multi-doc lockfile
-                // where every document fails surfaces all the diagnostic
-                // signal at `RUST_LOG=aube_lockfile=debug`. The returned
-                // error is the *first* failure, which tends to be the
-                // most explanatory — later docs often fail with cascading
-                // schema mismatches once the first doc has set
-                // expectations off-kilter.
+                // Log every per-document failure so a multi-doc
+                // lockfile where every document fails surfaces all the
+                // diagnostic signal at `RUST_LOG=aube_lockfile=debug`.
+                // Break on the first failure: a malformed document
+                // typically puts serde_yaml's iterator into a state
+                // where further iteration is either more garbage or an
+                // infinite loop (see `test_parse_invalid_yaml`). The
+                // returned error is the first failure, which is both
+                // most explanatory and the only one we actually
+                // observed.
                 tracing::debug!("pnpm-lock.yaml document {idx} failed to parse: {e}");
-                if first_err.is_none() {
-                    first_err = Some(e);
-                }
+                first_err = Some(e);
+                break;
             }
         }
     }

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1174,6 +1174,27 @@ impl Resolver {
                                 effective_spec
                             );
                             task.range = effective_spec;
+                            // If the override replaced the spec with a
+                            // bare range (not itself an `npm:` / `jsr:`
+                            // alias), it's targeting `task.name` —
+                            // implicitly undoing any prior alias
+                            // rewrite. Without this, an override that
+                            // fires after a catalog-aliased entry
+                            // (e.g. catalog `js-yaml:
+                            // npm:@zkochan/js-yaml@0.0.11`, override
+                            // `js-yaml@<3.14.2: ^3.14.2`) would keep
+                            // `task.real_name = @zkochan/js-yaml` and
+                            // try to fetch `^3.14.2` from a packument
+                            // that only carries `0.0.x`. If the
+                            // override's value is itself an alias, the
+                            // alias pass below picks up the new target
+                            // on the next loop iteration.
+                            if task.real_name.is_some()
+                                && !task.range.starts_with("npm:")
+                                && !task.range.starts_with("jsr:")
+                            {
+                                task.real_name = None;
+                            }
                             changed = true;
                         }
                     }
@@ -5229,6 +5250,64 @@ mod tests {
         assert_eq!(root.len(), 1);
         assert_eq!(root[0].name, "odd-alias");
         assert_eq!(root[0].dep_path, "odd-alias@3.0.1");
+    }
+
+    // Catalog-aliased dep + selector override targeting the original
+    // (alias) name with a bare-range replacement. Reproduces the
+    // pnpm/pnpm `js-yaml: npm:@zkochan/js-yaml@0.0.11` + `js-yaml@<3.14.2:
+    // ^3.14.2` shape: the catalog rewrites js-yaml to the @zkochan
+    // package, then the override fires by user-facing name and
+    // replaces the range with `^3.14.2`. Without clearing
+    // `task.real_name` in the override path, the resolver kept fetching
+    // `@zkochan/js-yaml`'s packument and bailed with "no version of
+    // js-yaml matches range ^3.14.2".
+    #[tokio::test]
+    async fn override_with_bare_range_undoes_prior_catalog_alias() {
+        let real_js_yaml = make_packument("js-yaml", &["3.14.2"], "3.14.2");
+        let aliased = make_packument("@zkochan/js-yaml", &["0.0.11"], "0.0.11");
+
+        let client = Arc::new(aube_registry::client::RegistryClient::new(
+            "http://127.0.0.1:0",
+        ));
+        let mut catalogs: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+        catalogs.entry("default".to_string()).or_default().insert(
+            "js-yaml".to_string(),
+            "npm:@zkochan/js-yaml@0.0.11".to_string(),
+        );
+        let mut overrides: BTreeMap<String, String> = BTreeMap::new();
+        overrides.insert("js-yaml@<3.14.2".to_string(), "^3.14.2".to_string());
+
+        let mut resolver = Resolver::new(client)
+            .with_catalogs(catalogs)
+            .with_overrides(overrides);
+        resolver.cache.insert("js-yaml".to_string(), real_js_yaml);
+        resolver
+            .cache
+            .insert("@zkochan/js-yaml".to_string(), aliased);
+
+        let mut manifest = PackageJson::default();
+        manifest
+            .dependencies
+            .insert("js-yaml".to_string(), "catalog:".to_string());
+
+        let graph = resolver
+            .resolve(&manifest, None)
+            .await
+            .expect("override should redirect back to real js-yaml");
+
+        let pkg = graph
+            .packages
+            .get("js-yaml@3.14.2")
+            .expect("override target must resolve to real js-yaml@3.14.2");
+        assert_eq!(pkg.name, "js-yaml");
+        assert_eq!(pkg.version, "3.14.2");
+        assert!(
+            pkg.alias_of.is_none(),
+            "bare-range override must clear the prior npm: alias, got alias_of={:?}",
+            pkg.alias_of,
+        );
+        assert!(!graph.packages.contains_key("js-yaml@0.0.11"));
+        assert!(!graph.packages.contains_key("@zkochan/js-yaml@0.0.11"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Two compat fixes that together let `aube install` get past the lockfile-parse / early-resolve stages on pnpm/pnpm itself (which uses pnpm v11). Previously aube failed at the very first step.

### 1. `lockfile(pnpm)`: multi-document lockfiles

pnpm v11 emits two YAML documents in `pnpm-lock.yaml`: a bootstrap doc tracking the package manager itself (`packageManagerDependencies` / `configDependencies`) and the real project lockfile (importer deps, `settings`, `catalogs`, `overrides`, `patchedDependencies`, etc.). `serde_yaml::from_str` rejects multi-document input, so `aube install` against a v11 lockfile bailed with:

```
× failed to parse lockfile
╰▶ deserializing from YAML containing more than one document is not supported
```

Fix: parse every document with `serde_yaml::Deserializer::from_str`, score each by project-lockfile signal (real importer deps + `settings`/`catalogs`/`overrides` + packages/snapshots count), and pick the highest. Single-document v9/v10 lockfiles still work — only one document, so it wins by default.

### 2. `resolver`: bare-range override over npm-alias

When a `catalog:` entry resolves to an `npm:` alias and a selector override matches the user-facing name, the override loop overwrote `task.range` but left `task.real_name` pointing at the aliased target. The registry fetch then asked for the override's range against the *aliased* package's packument and failed.

Reproduces from pnpm/pnpm's workspace config:

```yaml
catalog:
  js-yaml: npm:@zkochan/js-yaml@0.0.11
overrides:
  js-yaml@<3.14.2: '^3.14.2'
```

The override targets the user-facing `js-yaml` and replaces the spec with a bare `^3.14.2` — pnpm's semantic is "undo the alias and fetch real `js-yaml@^3.14.2`." Aube was sending `^3.14.2` against the `@zkochan/js-yaml` packument, which only publishes `0.0.x`, and bailing with `no version of js-yaml matches range ^3.14.2`.

Fix: when an override's effective spec is a bare range (not itself an `npm:` / `jsr:` alias that the next loop iteration would rewrite), clear `task.real_name`. The override is targeting `task.name` and implicitly replaces the entire spec.

## End-to-end verification

`aube install` against a fresh clone of pnpm/pnpm:

| | Before | After |
|---|---|---|
| Lockfile parse | fails at line 181 (multi-doc YAML) | parses the project doc |
| Resolve (lockfile-less, fresh) | fails at 21 / 21 packages (override+alias) | 214+ packages resolved |

Resolution still hits a separate downstream bug after 214 packages (`registry error for : I/O error: missing field 'name'`) — that's an unrelated parse issue with one of the packuments, out of scope for this PR.

## Test plan

- [x] New unit test `parse_multi_document_lockfile_picks_project_doc` in [crates/aube-lockfile/src/pnpm.rs](crates/aube-lockfile/src/pnpm.rs) — multi-doc lockfile, asserts project doc's deps win, bootstrap doc's `packageManagerDependencies` don't leak in
- [x] New unit test `override_with_bare_range_undoes_prior_catalog_alias` in [crates/aube-resolver/src/lib.rs](crates/aube-resolver/src/lib.rs) — pnpm/pnpm's exact catalog+override shape, asserts the resolved package is real `js-yaml@3.14.2` with no `alias_of`
- [x] `cargo test -p aube-resolver --lib` — 98 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean (pre-commit hook)
- [x] `cargo fmt --check` clean (pre-commit hook)
- [x] Manual: `aube install` against pnpm/pnpm gets past both failure points

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pnpm lockfile parsing and resolver override/alias handling, which can affect dependency graph construction for pnpm projects. Risk is mitigated by added targeted regression tests, but mis-selection of YAML documents or alias clearing could change resolution outcomes.
> 
> **Overview**
> Improves pnpm v11 compatibility by updating the pnpm lockfile parser to handle multi-document `pnpm-lock.yaml` files, selecting the most likely project lockfile document via a scoring heuristic and adding safeguards against pathological YAML iteration.
> 
> Fixes resolver behavior where a selector override that replaces an `npm:`/`jsr:`-aliased spec with a bare range now clears `real_name` so resolution targets the original package again (with a regression test covering the catalog-alias + override case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14cf976c554223c6c700b6a2ab919aa94969d7d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->