### PR TITLE
install: drop webpack and rollup from gvs auto-disable defaults

### DIFF
--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -614,24 +614,33 @@ examples = [
 [disableGlobalVirtualStoreForPackages]
 description = "Package names whose presence in any importer forces per-project materialization."
 type = "list<string>"
-default = "[\"next\", \"nuxt\", \"vite\", \"vitepress\", \"rollup\", \"webpack\", \"parcel\"]"
+default = "[\"next\", \"nuxt\", \"vite\", \"vitepress\", \"parcel\"]"
 docs = """
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
 absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
 module resolvers follow symlinks to real paths and then walk up the
-directory tree — Rollup, Vite, Webpack, Parcel, Next.js's Turbopack —
-can't reach the project's `node_modules/` from inside the global
-store and produce errors like `Rollup failed to resolve import ...`
-or `Symlink ... is invalid, it points out of the filesystem root`.
+directory tree can't reach the project's `node_modules/` from inside
+the global store and produce errors like `Symlink ... is invalid, it
+points out of the filesystem root`.
 
 When `aube install` finds one of these names in any importer's
 `dependencies`, `devDependencies`, or `optionalDependencies`, it
 forces per-project materialization for that install and prints a
-one-line warning naming the trigger. The default list covers the
-bundlers most commonly declared as direct devDeps; add other
-packages here as you discover them (or set the list to `[]` to
-disable the heuristic entirely). `CI=1` already forces per-project
-mode, so the warning suppresses itself in that case.
+one-line warning naming the trigger.
+
+The default list — `next`, `nuxt`, `vite`, `vitepress`, `parcel` —
+covers the tools with concrete walk-up failures: Next.js's Turbopack
+canonicalizes through symlinks and walks up for app-router/monorepo
+detection, Vite/VitePress/Nuxt plugins walk up for config discovery
+(see [jdx/mise#9261](https://github.com/jdx/mise/pull/9261) for the
+VitePress case), and Parcel's resolver walks up for `.parcelrc`.
+Webpack and Rollup are *not* on the default list: plain Webpack
+resolves via the sibling symlinks aube already places inside
+`.aube/<pkg>/node_modules/`, and Rollup is rarely a direct dep (it's
+typically transitive of Vite). Add them back here if a specific
+plugin needs the fallback, or set the list to `[]` to disable the
+heuristic entirely. `CI=1` already forces per-project mode, so the
+warning suppresses itself in that case.
 """
 sources.cli = []
 sources.env = []

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1950,13 +1950,17 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
 
     // Auto-disable the global virtual store when any importer depends
     // on a package listed in `disableGlobalVirtualStoreForPackages`
-    // (default covers Next.js, Nuxt, Vite, VitePress, Rollup, Webpack,
-    // Parcel). Those resolvers follow `node_modules/<pkg>` symlinks to
-    // real paths and then walk up the directory tree; gvs makes
-    // `.aube/<pkg>` an absolute symlink into
-    // `~/.cache/aube/virtual-store/`, so the walk escapes the project
-    // and can't reach the top-level `node_modules/` where direct deps
-    // live. The list is the extension point — add other tools as they
+    // (default: Next.js, Nuxt, Vite, VitePress, Parcel). Those
+    // resolvers follow `node_modules/<pkg>` symlinks to real paths and
+    // then walk up the directory tree looking for configs, app-router
+    // roots, or hoisted deps; gvs makes `.aube/<pkg>` an absolute
+    // symlink into `~/.cache/aube/virtual-store/`, so the walk escapes
+    // the project and can't reach the top-level `node_modules/` where
+    // direct deps live. Plain Webpack and Rollup are deliberately
+    // *not* in the default list — Webpack resolves via the sibling
+    // symlinks aube places inside `.aube/<pkg>/node_modules/`, and
+    // Rollup is rarely a direct dep. The list is the extension
+    // point — add them back (or other tools) here as their failures
     // surface. `CI=1` already forces per-project mode in `Linker::new`,
     // so we don't warn in that case (behavior wouldn't change and the
     // message would just be noise). `virtualStoreOnly` installs skip

--- a/docs/settings/env.md
+++ b/docs/settings/env.md
@@ -639,25 +639,34 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next", "nuxt", "vite", "vitepress", "rollup", "webpack", "parcel"]`
+- Default: `["next", "nuxt", "vite", "vitepress", "parcel"]`
 - Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
 
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
 absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
 module resolvers follow symlinks to real paths and then walk up the
-directory tree — Rollup, Vite, Webpack, Parcel, Next.js's Turbopack —
-can't reach the project's `node_modules/` from inside the global
-store and produce errors like `Rollup failed to resolve import ...`
-or `Symlink ... is invalid, it points out of the filesystem root`.
+directory tree can't reach the project's `node_modules/` from inside
+the global store and produce errors like `Symlink ... is invalid, it
+points out of the filesystem root`.
 
 When `aube install` finds one of these names in any importer's
 `dependencies`, `devDependencies`, or `optionalDependencies`, it
 forces per-project materialization for that install and prints a
-one-line warning naming the trigger. The default list covers the
-bundlers most commonly declared as direct devDeps; add other
-packages here as you discover them (or set the list to `[]` to
-disable the heuristic entirely). `CI=1` already forces per-project
-mode, so the warning suppresses itself in that case.
+one-line warning naming the trigger.
+
+The default list — `next`, `nuxt`, `vite`, `vitepress`, `parcel` —
+covers the tools with concrete walk-up failures: Next.js's Turbopack
+canonicalizes through symlinks and walks up for app-router/monorepo
+detection, Vite/VitePress/Nuxt plugins walk up for config discovery
+(see [jdx/mise#9261](https://github.com/jdx/mise/pull/9261) for the
+VitePress case), and Parcel's resolver walks up for `.parcelrc`.
+Webpack and Rollup are *not* on the default list: plain Webpack
+resolves via the sibling symlinks aube already places inside
+`.aube/<pkg>/node_modules/`, and Rollup is rarely a direct dep (it's
+typically transitive of Vite). Add them back here if a specific
+plugin needs the fallback, or set the list to `[]` to disable the
+heuristic entirely. `CI=1` already forces per-project mode, so the
+warning suppresses itself in that case.
 
 ## Store
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -695,7 +695,7 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next", "nuxt", "vite", "vitepress", "rollup", "webpack", "parcel"]`
+- Default: `["next", "nuxt", "vite", "vitepress", "parcel"]`
 - Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
 - .npmrc keys: `disableGlobalVirtualStoreForPackages`, `disable-global-virtual-store-for-packages`
 - Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
@@ -703,19 +703,28 @@ Package names whose presence in any importer forces per-project materialization.
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
 absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
 module resolvers follow symlinks to real paths and then walk up the
-directory tree — Rollup, Vite, Webpack, Parcel, Next.js's Turbopack —
-can't reach the project's `node_modules/` from inside the global
-store and produce errors like `Rollup failed to resolve import ...`
-or `Symlink ... is invalid, it points out of the filesystem root`.
+directory tree can't reach the project's `node_modules/` from inside
+the global store and produce errors like `Symlink ... is invalid, it
+points out of the filesystem root`.
 
 When `aube install` finds one of these names in any importer's
 `dependencies`, `devDependencies`, or `optionalDependencies`, it
 forces per-project materialization for that install and prints a
-one-line warning naming the trigger. The default list covers the
-bundlers most commonly declared as direct devDeps; add other
-packages here as you discover them (or set the list to `[]` to
-disable the heuristic entirely). `CI=1` already forces per-project
-mode, so the warning suppresses itself in that case.
+one-line warning naming the trigger.
+
+The default list — `next`, `nuxt`, `vite`, `vitepress`, `parcel` —
+covers the tools with concrete walk-up failures: Next.js's Turbopack
+canonicalizes through symlinks and walks up for app-router/monorepo
+detection, Vite/VitePress/Nuxt plugins walk up for config discovery
+(see [jdx/mise#9261](https://github.com/jdx/mise/pull/9261) for the
+VitePress case), and Parcel's resolver walks up for `.parcelrc`.
+Webpack and Rollup are *not* on the default list: plain Webpack
+resolves via the sibling symlinks aube already places inside
+`.aube/<pkg>/node_modules/`, and Rollup is rarely a direct dep (it's
+typically transitive of Vite). Add them back here if a specific
+plugin needs the fallback, or set the list to `[]` to disable the
+heuristic entirely. `CI=1` already forces per-project mode, so the
+warning suppresses itself in that case.
 
 ## Store
 

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -639,25 +639,34 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next", "nuxt", "vite", "vitepress", "rollup", "webpack", "parcel"]`
+- Default: `["next", "nuxt", "vite", "vitepress", "parcel"]`
 - .npmrc keys: `disableGlobalVirtualStoreForPackages`, `disable-global-virtual-store-for-packages`
 
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
 absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
 module resolvers follow symlinks to real paths and then walk up the
-directory tree — Rollup, Vite, Webpack, Parcel, Next.js's Turbopack —
-can't reach the project's `node_modules/` from inside the global
-store and produce errors like `Rollup failed to resolve import ...`
-or `Symlink ... is invalid, it points out of the filesystem root`.
+directory tree can't reach the project's `node_modules/` from inside
+the global store and produce errors like `Symlink ... is invalid, it
+points out of the filesystem root`.
 
 When `aube install` finds one of these names in any importer's
 `dependencies`, `devDependencies`, or `optionalDependencies`, it
 forces per-project materialization for that install and prints a
-one-line warning naming the trigger. The default list covers the
-bundlers most commonly declared as direct devDeps; add other
-packages here as you discover them (or set the list to `[]` to
-disable the heuristic entirely). `CI=1` already forces per-project
-mode, so the warning suppresses itself in that case.
+one-line warning naming the trigger.
+
+The default list — `next`, `nuxt`, `vite`, `vitepress`, `parcel` —
+covers the tools with concrete walk-up failures: Next.js's Turbopack
+canonicalizes through symlinks and walks up for app-router/monorepo
+detection, Vite/VitePress/Nuxt plugins walk up for config discovery
+(see [jdx/mise#9261](https://github.com/jdx/mise/pull/9261) for the
+VitePress case), and Parcel's resolver walks up for `.parcelrc`.
+Webpack and Rollup are *not* on the default list: plain Webpack
+resolves via the sibling symlinks aube already places inside
+`.aube/<pkg>/node_modules/`, and Rollup is rarely a direct dep (it's
+typically transitive of Vite). Add them back here if a specific
+plugin needs the fallback, or set the list to `[]` to disable the
+heuristic entirely. `CI=1` already forces per-project mode, so the
+warning suppresses itself in that case.
 
 ## Store
 

--- a/docs/settings/workspace-yaml.md
+++ b/docs/settings/workspace-yaml.md
@@ -423,25 +423,34 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next", "nuxt", "vite", "vitepress", "rollup", "webpack", "parcel"]`
+- Default: `["next", "nuxt", "vite", "vitepress", "parcel"]`
 - Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
 
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
 absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
 module resolvers follow symlinks to real paths and then walk up the
-directory tree — Rollup, Vite, Webpack, Parcel, Next.js's Turbopack —
-can't reach the project's `node_modules/` from inside the global
-store and produce errors like `Rollup failed to resolve import ...`
-or `Symlink ... is invalid, it points out of the filesystem root`.
+directory tree can't reach the project's `node_modules/` from inside
+the global store and produce errors like `Symlink ... is invalid, it
+points out of the filesystem root`.
 
 When `aube install` finds one of these names in any importer's
 `dependencies`, `devDependencies`, or `optionalDependencies`, it
 forces per-project materialization for that install and prints a
-one-line warning naming the trigger. The default list covers the
-bundlers most commonly declared as direct devDeps; add other
-packages here as you discover them (or set the list to `[]` to
-disable the heuristic entirely). `CI=1` already forces per-project
-mode, so the warning suppresses itself in that case.
+one-line warning naming the trigger.
+
+The default list — `next`, `nuxt`, `vite`, `vitepress`, `parcel` —
+covers the tools with concrete walk-up failures: Next.js's Turbopack
+canonicalizes through symlinks and walks up for app-router/monorepo
+detection, Vite/VitePress/Nuxt plugins walk up for config discovery
+(see [jdx/mise#9261](https://github.com/jdx/mise/pull/9261) for the
+VitePress case), and Parcel's resolver walks up for `.parcelrc`.
+Webpack and Rollup are *not* on the default list: plain Webpack
+resolves via the sibling symlinks aube already places inside
+`.aube/<pkg>/node_modules/`, and Rollup is rarely a direct dep (it's
+typically transitive of Vite). Add them back here if a specific
+plugin needs the fallback, or set the list to `[]` to disable the
+heuristic entirely. `CI=1` already forces per-project mode, so the
+warning suppresses itself in that case.
 
 ## Store
 


### PR DESCRIPTION
## Summary
Trim the default `disableGlobalVirtualStoreForPackages` list from 7 entries to 5 by removing `webpack` and `rollup`. Both were added defensively in #101 without a concrete reproduction of the walk-up failure they were meant to mitigate.

## Rationale
- **Webpack** — plain webpack resolves via the sibling symlinks aube already places inside `.aube/<pkg>/node_modules/`, so the "resolver walks up past the project root" failure mode doesn't fire for vanilla webpack apps. Plugin-specific walk-ups (e.g. `tsconfig-paths-webpack-plugin`) do exist but are narrow enough to belong on an opt-in basis, not the default.
- **Rollup** — rarely declared as a direct dep; it's almost always transitive of Vite (which stays in the list). Direct-dep Rollup users are library authors with small dep graphs where the walk-up rarely bites.

Every remaining entry has a documented walk-up failure: Next.js's Turbopack canonicalizes through symlinks and walks up for app-router/monorepo detection; Vite/VitePress/Nuxt plugins walk up for config discovery ([jdx/mise#9261](https://github.com/jdx/mise/pull/9261) was the concrete VitePress reproduction that motivated #101); Parcel's resolver walks up for `.parcelrc`.

Users can still add Webpack or Rollup back via `.npmrc` if a specific plugin needs the fallback.

## Changes
- `crates/aube-settings/settings.toml` — default list + explanatory docs.
- `crates/aube/src/commands/install/mod.rs` — inline comment on the heuristic updated to match.
- `docs/settings/*.md` — regenerated from the settings source.

## Test plan
- [x] `cargo clippy -p aube --all-targets -- -D warnings` clean.
- [x] Manual: fixture declaring `webpack` + `rollup` no longer triggers the "disabling global virtual store" warning; adding `next` still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the default heuristic list for auto-disabling the global virtual store and updates accompanying documentation/comments; no core install/linking logic is altered.
> 
> **Overview**
> Narrows the default `disableGlobalVirtualStoreForPackages` triggers used to auto-disable the global virtual store during `aube install`, removing `webpack` and `rollup` so they no longer force per-project materialization by default.
> 
> Updates the setting registry and regenerated docs to explain the rationale (keep concrete walk-up-failure tools like Next/Vite/Parcel, and treat Webpack/Rollup as opt-in overrides) and aligns the inline installer comment with the new default behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c76de229fd1af0705ea125a883d7ec36463ce0bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->