### PR TITLE
resolver: link bare-semver deps to workspace packages (yarn/npm/bun style)

### DIFF
--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -691,7 +691,11 @@ impl Resolver {
     /// Resolve all dependencies for a workspace (multiple importers).
     ///
     /// `manifests` is a list of (importer_path, PackageJson) — e.g. (".", root), ("packages/app", app).
-    /// `workspace_packages` maps package name → version for workspace: protocol resolution.
+    /// `workspace_packages` maps package name → version. Used both for
+    /// explicit `workspace:` protocol resolution and for yarn/npm/bun
+    /// style linkage where a bare semver range on a workspace-package
+    /// name resolves to the local copy when its version satisfies the
+    /// range.
     pub async fn resolve_workspace(
         &mut self,
         manifests: &[(String, PackageJson)],
@@ -975,12 +979,21 @@ impl Resolver {
             ($name:expr, $range:expr) => {{
                 let r: &str = $range;
                 let n: &str = $name;
+                // A bare semver range that matches a workspace package
+                // will resolve to the workspace without ever reading
+                // the packument, so prefetching would just be a
+                // speculative 404 on e.g. an unpublished monorepo
+                // package.
+                let workspace_hit = workspace_packages
+                    .get(n)
+                    .is_some_and(|ws_v| version_satisfies(ws_v, r));
                 !r.starts_with("workspace:")
                     && !r.starts_with("catalog:")
                     && !r.starts_with("npm:")
                     && !r.starts_with("jsr:")
                     && !is_non_registry_specifier(r)
                     && !self.overrides.contains_key(n)
+                    && !workspace_hit
             }};
         }
 
@@ -1418,9 +1431,24 @@ impl Resolver {
                     continue;
                 }
 
-                // Handle workspace: protocol — resolve to workspace package version
-                if task.range.starts_with("workspace:")
-                    && let Some(ws_version) = workspace_packages.get(&task.name)
+                // Handle workspace linkage. Two cases resolve to the
+                // workspace package rather than the registry:
+                //   1. Explicit `workspace:` protocol (pnpm/yarn-berry
+                //      style). The range after the prefix is accepted
+                //      unconditionally — the user asserted this should
+                //      link.
+                //   2. Bare semver range whose name matches a workspace
+                //      package whose version satisfies the range. This
+                //      is the yarn-v1 / npm / bun default: siblings pin
+                //      each other with normal version strings and
+                //      expect the workspace to win over the registry.
+                //      A workspace is typically either unpublished or
+                //      is itself the source of truth for its name, so
+                //      preferring the local copy matches every other
+                //      mainstream pm.
+                if let Some(ws_version) = workspace_packages.get(&task.name)
+                    && (task.range.starts_with("workspace:")
+                        || version_satisfies(ws_version, &task.range))
                 {
                     let dep_path = dep_path_for(&task.name, ws_version);
                     if task.is_root

--- a/test/workspace.bats
+++ b/test/workspace.bats
@@ -388,6 +388,77 @@ _setup_shared_direct_dep_workspace() {
 	assert_output "from-workspace"
 }
 
+@test "aube install: caret range on workspace-package name links to local copy" {
+	# Range form (not exact pin): workspace at 1.2.3 satisfies `^1.0.0`
+	# in the consumer, so the short-circuit must still fire. Exercises
+	# the non-trivial `version_satisfies` path — an exact-match test
+	# alone wouldn't catch a regression in range parsing.
+	mkdir -p packages/app packages/lib
+	cat >package.json <<-'EOF'
+		{
+		  "name": "root",
+		  "version": "0.0.0",
+		  "private": true,
+		  "workspaces": ["packages/*"]
+		}
+	EOF
+	cat >packages/lib/package.json <<-'EOF'
+		{ "name": "@test/lib", "version": "1.2.3" }
+	EOF
+	cat >packages/app/package.json <<-'EOF'
+		{
+		  "name": "@test/app",
+		  "version": "1.0.0",
+		  "dependencies": { "@test/lib": "^1.0.0" }
+		}
+	EOF
+
+	run aube install
+	assert_success
+
+	assert_link_exists packages/app/node_modules/@test/lib
+	resolved="$(readlink -f packages/app/node_modules/@test/lib)"
+	[[ "$resolved" == *"/packages/lib" ]]
+}
+
+@test "aube install: workspace-name miss falls through to registry, not stolen" {
+	# Workspace has @test/lib@1.0.0 but the consumer pins `^2.0.0`.
+	# The short-circuit must NOT hijack the name just because it
+	# matches a workspace package — version has to satisfy too.
+	# Expected behavior: resolver falls through to the registry and
+	# surfaces a registry-shaped error (the fixture registry does not
+	# serve @test/lib). Guards against a regression where a workspace
+	# miss silently links the wrong version.
+	mkdir -p packages/app packages/lib
+	cat >package.json <<-'EOF'
+		{
+		  "name": "root",
+		  "version": "0.0.0",
+		  "private": true,
+		  "workspaces": ["packages/*"]
+		}
+	EOF
+	cat >packages/lib/package.json <<-'EOF'
+		{ "name": "@test/lib", "version": "1.0.0" }
+	EOF
+	cat >packages/app/package.json <<-'EOF'
+		{
+		  "name": "@test/app",
+		  "version": "1.0.0",
+		  "dependencies": { "@test/lib": "^2.0.0" }
+		}
+	EOF
+
+	run aube install
+	assert_failure
+	# The error must be a registry error (we went past the workspace
+	# branch), not a silent success that linked the wrong version.
+	assert_output --partial "registry error for @test/lib"
+	# And no symlink was created.
+	run test -e packages/app/node_modules/@test/lib
+	assert_failure
+}
+
 @test "aube install: dedupeDirectDeps=true keeps child symlink when versions differ" {
 	mkdir -p packages/app
 	# Root pins is-number@3.0.0, child pins is-number@6.0.0 — both are

--- a/test/workspace.bats
+++ b/test/workspace.bats
@@ -336,6 +336,58 @@ _setup_shared_direct_dep_workspace() {
 	assert_output "function"
 }
 
+@test "aube install: bare-semver range links to workspace package (yarn/npm/bun style)" {
+	# yarn v1, npm, and bun workspaces let siblings pin each other with
+	# a plain semver range — `"@test/lib": "1.0.0"` rather than
+	# `"workspace:*"` — and link to the local workspace copy when name
+	# + version match. Repro of excalidraw's monorepo, where inner
+	# packages pin `@excalidraw/common: 0.18.0` and expect it to
+	# resolve from the workspace rather than the registry (where it
+	# does not exist).
+	mkdir -p packages/app packages/lib
+	cat >package.json <<-'EOF'
+		{
+		  "name": "root",
+		  "version": "0.0.0",
+		  "private": true,
+		  "workspaces": ["packages/*"]
+		}
+	EOF
+	cat >packages/lib/package.json <<-'EOF'
+		{
+		  "name": "@test/lib",
+		  "version": "1.0.0"
+		}
+	EOF
+	cat >packages/lib/index.js <<-'EOF'
+		module.exports = "from-workspace";
+	EOF
+	# No `workspace:` protocol — bare semver, matches lib's version.
+	cat >packages/app/package.json <<-'EOF'
+		{
+		  "name": "@test/app",
+		  "version": "1.0.0",
+		  "dependencies": { "@test/lib": "1.0.0" }
+		}
+	EOF
+
+	run aube install
+	assert_success
+
+	# The app's @test/lib entry links to the workspace copy, proving
+	# the resolver preferred the local package over a registry lookup
+	# (which would have failed since @test/lib has never been
+	# published).
+	assert_link_exists packages/app/node_modules/@test/lib
+	resolved="$(readlink -f packages/app/node_modules/@test/lib)"
+	[[ "$resolved" == *"/packages/lib" ]]
+
+	cd packages/app
+	run node -e "console.log(require('@test/lib'))"
+	assert_success
+	assert_output "from-workspace"
+}
+
 @test "aube install: dedupeDirectDeps=true keeps child symlink when versions differ" {
 	mkdir -p packages/app
 	# Root pins is-number@3.0.0, child pins is-number@6.0.0 — both are


### PR DESCRIPTION
## Summary

- yarn v1, npm, and bun workspaces let siblings pin each other with a plain semver range (`"@scope/lib": "1.0.0"`) and expect the local workspace copy to win over the registry when the name and version match. aube discovered the workspace importers but the resolver only consulted `workspace_packages` when the range started with `workspace:`, so bare-semver refs fell through to the registry and failed with `no version of <name> matches range <x>` — reproducible on the [excalidraw](https://github.com/excalidraw/excalidraw) monorepo, which pins `@excalidraw/common: 0.18.0` across `packages/math`, `packages/element`, and `packages/excalidraw`.
- Extend the workspace short-circuit to also fire when the range does not use the protocol but the workspace package's version satisfies the range. The `workspace:` branch keeps its existing unconditional behavior.
- Skip the speculative registry prefetch for workspace-satisfied names so we don't waste a 404 round-trip on an unpublished local package.
- Adds a BATS regression covering the yarn-style shape: a root `package.json#workspaces` with an importer pinning a sibling by bare semver, asserting the top-level `node_modules/@scope/lib` link points at the workspace copy and the package is `require()`-able from the consumer.

## Test plan

- [x] `cargo test --workspace` (0 failures)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `mise run test:bats test/workspace.bats` (all 14 tests pass, including the new one)
- [x] Manual repro on excalidraw: before → `no version of @excalidraw/common matches range 0.18.0`; after → install succeeds and `packages/math/node_modules/@excalidraw/common` links to `packages/common`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace dependency resolution semantics to prefer local workspace packages for matching bare semver ranges, which can affect install outcomes across monorepos. Risk is mitigated by added regression tests but touches core resolution/prefetch logic.
> 
> **Overview**
> **Workspace installs now prefer local packages for yarn/npm/bun-style bare semver deps.** The resolver’s workspace short-circuit is expanded to link a workspace package not only for explicit `workspace:` specs, but also when a dependency name matches a workspace package and its version satisfies the requested semver range.
> 
> To reduce wasted network work, speculative registry packument prefetching is skipped for deps that will resolve via this workspace-satisfied path. Adds BATS coverage for exact and caret-range workspace linking and for the version-mismatch case falling through to a registry error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090d88da095ff1b04fba038e4c0415e0a2bd689d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->