### PR TITLE
workspace: dedupe packages matched by overlapping patterns

### DIFF
--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -36,12 +36,22 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
         return Ok(vec![]);
     }
 
+    // Overlapping patterns are valid and common — a project may list
+    // both `packages/*` and a specific `packages/slack` entry, or mix
+    // a glob with an explicit nested path (`packages/sdk/js`). Dedupe
+    // so downstream consumers (linker importer iteration, bin wiring,
+    // filter matching) see each workspace package exactly once;
+    // otherwise `link_workspace` tries to symlink the same top-level
+    // dep twice and blows up with EEXIST.
+    let mut seen = std::collections::HashSet::new();
     let mut packages = Vec::new();
     for pattern in &patterns {
         let full_pattern = project_dir.join(pattern).join("package.json");
         if let Ok(entries) = glob::glob(full_pattern.to_str().unwrap_or_default()) {
             for entry in entries.flatten() {
-                if let Some(parent) = entry.parent() {
+                if let Some(parent) = entry.parent()
+                    && seen.insert(parent.to_path_buf())
+                {
                     packages.push(parent.to_path_buf());
                 }
             }
@@ -184,5 +194,41 @@ mod tests {
         write(&dir.path().join("package.json"), r#"{"name":"solo"}"#);
         let found = find_workspace_packages(dir.path()).unwrap();
         assert!(found.is_empty());
+    }
+
+    /// Real projects (opencode, for one) list both a glob and an
+    /// explicit nested path that the glob already matches. Without
+    /// dedup, `link_workspace` later symlinks the same workspace dep
+    /// twice into a downstream importer's `node_modules` and fails
+    /// with EEXIST on the second write.
+    #[test]
+    fn overlapping_patterns_dedupe_matched_packages() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("package.json"),
+            r#"{"name":"root","workspaces":["packages/*","packages/slack","packages/sdk/js"]}"#,
+        );
+        write(&dir.path().join("packages/slack/package.json"), "{}");
+        write(&dir.path().join("packages/sdk/js/package.json"), "{}");
+        write(&dir.path().join("packages/other/package.json"), "{}");
+
+        let found = find_workspace_packages(dir.path()).unwrap();
+        // slack is matched by both `packages/*` and the explicit
+        // `packages/slack`; must appear exactly once.
+        let slack_count = found
+            .iter()
+            .filter(|p| p.ends_with("packages/slack"))
+            .count();
+        assert_eq!(slack_count, 1, "slack appeared {slack_count} times");
+        // Nested-path entries (`packages/sdk/js`) that a simple
+        // `packages/*` glob would NOT match still show up via the
+        // explicit pattern.
+        assert_eq!(
+            names(found),
+            ["js", "other", "slack"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        );
     }
 }


### PR DESCRIPTION
## Summary

Real projects list both a glob and an explicit nested path that the glob already matches. Example from [`sst/opencode`](https://github.com/sst/opencode/blob/dev/package.json):

```json
"workspaces": {
  "packages": ["packages/*", "packages/console/*", "packages/sdk/js", "packages/slack"]
}
```

`packages/slack` is matched by **both** `packages/*` and the explicit `packages/slack` entry. `find_workspace_packages` was pushing each glob match onto a `Vec<PathBuf>` with no dedup, so downstream consumers saw the same workspace directory twice. In particular, `link_workspace`'s importer loop cleaned and repopulated `packages/slack/node_modules/` twice, which on the second pass tried to recreate the `@opencode-ai/sdk` workspace symlink that the first pass had just written — blowing up on `std::os::unix::fs::symlink` with `EEXIST`:

```
Error:   × failed to link workspace node_modules
  ╰─▶ I/O error at /.../packages/slack/node_modules/@opencode-ai/sdk:
      File exists (os error 17)
```

Dedupe matched package directories across patterns while preserving first-match order. Nothing upstream of this fix was relying on the duplicate.

### Minimal repro (before this change)

```json
{ "private": true,
  "workspaces": { "packages": ["packages/*", "packages/slack"] } }
```
…with `packages/slack/package.json` declaring a `workspace:*` dep on another workspace package reproduces the same EEXIST.

Surfaced while testing aube against [`sst/opencode`](https://github.com/sst/opencode). After this change, opencode's 2,374-package workspace resolves and links cleanly (follow-up failures are in an unrelated lifecycle-script code path).

## Test plan

- [x] `cargo test -p aube-workspace` — 15 passed (includes new `overlapping_patterns_dedupe_matched_packages`)
- [x] `cargo clippy -p aube-workspace --all-targets -- -D warnings` — clean
- [x] Manual end-to-end: minimal repro with the overlapping-glob shape now installs; `sst/opencode` clears the linker phase (2,381 symlinks, 31s warm-cache)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to workspace package discovery that only removes duplicate paths; main risk is unintended ordering/uniqueness assumptions in downstream consumers.
> 
> **Overview**
> **Prevents duplicate workspace directories when `workspaces` patterns overlap.** `find_workspace_packages` now dedupes matched package paths across multiple glob/explicit patterns (while preserving first-seen order) to avoid downstream `link_workspace` attempting to link/symlink the same workspace twice.
> 
> Adds a regression test covering overlapping glob + explicit nested-path patterns to ensure duplicates are eliminated and explicitly-specified deep paths are still included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8e645139d3672822cb5e5382ae759e3a61d8dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->