### PR TITLE
registry(auth): longest-prefix .npmrc lookup with default-port stripping

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -200,23 +200,28 @@ impl RegistryClient {
                 return Some(token.to_string());
             }
             if let Some(helper) = auth.token_helper.as_deref() {
-                return self.cached_token_helper_result(registry_url, helper);
+                return self.cached_token_helper_result(helper);
             }
         }
         None
     }
 
-    fn cached_token_helper_result(&self, registry_url: &str, helper: &str) -> Option<String> {
-        let cache_key = crate::config::registry_uri_key_pub(registry_url);
+    /// Cache key is the helper command itself, not the registry URL:
+    /// `run_token_helper` spawns the helper as a subprocess that returns
+    /// a token determined entirely by the command, with no URL input.
+    /// Keying by URL would defeat the cache for tarball fetches (each
+    /// tarball has a unique path) and re-spawn the helper hundreds of
+    /// times during a large install.
+    fn cached_token_helper_result(&self, helper: &str) -> Option<String> {
         {
             let cache = self.token_helper_cache.lock().ok()?;
-            if let Some(token) = cache.get(&cache_key) {
+            if let Some(token) = cache.get(helper) {
                 return token.clone();
             }
         }
         let token = crate::config::run_token_helper(helper);
         if let Ok(mut cache) = self.token_helper_cache.lock() {
-            cache.insert(cache_key, token.clone());
+            cache.insert(helper.to_string(), token.clone());
         }
         token
     }

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -223,11 +223,7 @@ impl RegistryClient {
 
     fn http_for(&self, registry_url: &str) -> &reqwest::Client {
         let uri_key = crate::config::registry_uri_key_pub(registry_url);
-        if let Some(client) = self.http_by_uri.get(&uri_key) {
-            return client;
-        }
-        let trimmed = uri_key.trim_end_matches('/');
-        self.http_by_uri.get(trimmed).unwrap_or(&self.http)
+        crate::config::lookup_by_uri_prefix(&self.http_by_uri, &uri_key).unwrap_or(&self.http)
     }
 
     /// Send an HTTP request with transient-failure retry. Invoked from
@@ -705,11 +701,12 @@ impl RegistryClient {
             return Err(Error::Offline(format!("tarball {url}")));
         }
         // Tarball URLs may point to any registry, try to match auth.
-        // Retries cover transient 5xx / 429 / connection errors; see
-        // [`Self::send_with_retry`].
-        let tarball_registry = tarball_registry_url(url);
+        // Pass the full tarball URL through so longest-prefix matching
+        // in `registry_config_for` can find path-scoped auth entries
+        // (e.g. `//host/artifactory/npm/`). Retries cover transient
+        // 5xx / 429 / connection errors; see [`Self::send_with_retry`].
         let resp = self
-            .send_with_retry(|| self.authed_get(url, &tarball_registry))
+            .send_with_retry(|| self.authed_get(url, url))
             .await?
             .error_for_status()?;
         let started = std::time::Instant::now();
@@ -1125,19 +1122,6 @@ fn write_cached_full_packument(path: &Path, cached: &CachedFullPackument) -> std
     }
     let json = serde_json::to_vec(cached).map_err(std::io::Error::other)?;
     std::fs::write(path, json)
-}
-
-/// Extract a registry base URL from a tarball URL for auth lookup.
-/// "https://registry.example.com/foo/-/foo-1.0.0.tgz" -> "https://registry.example.com/"
-fn tarball_registry_url(url: &str) -> String {
-    // Find the scheme + host portion
-    if let Some(scheme_end) = url.find("://") {
-        let after_scheme = &url[scheme_end + 3..];
-        if let Some(slash) = after_scheme.find('/') {
-            return format!("{}://{}/", &url[..scheme_end], &after_scheme[..slash]);
-        }
-    }
-    url.to_string()
 }
 
 /// Emit a `fetchMinSpeedKiBps` warning if the tarball downloaded slower

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -304,11 +304,7 @@ impl NpmConfig {
 
     pub fn registry_config_for(&self, registry_url: &str) -> Option<&AuthConfig> {
         let uri_key = registry_uri_key(registry_url);
-        if let Some(auth) = self.auth_by_uri.get(&uri_key) {
-            return Some(auth);
-        }
-        let trimmed = uri_key.trim_end_matches('/');
-        self.auth_by_uri.get(trimmed)
+        lookup_by_uri_prefix(&self.auth_by_uri, &uri_key)
     }
 
     /// Test-only compatibility shim. Production code must go through
@@ -367,7 +363,14 @@ impl NpmConfig {
             } else if key.starts_with("//") {
                 // URI-specific config: //registry.url/:_authToken=TOKEN
                 if let Some((uri, suffix)) = key.rsplit_once(':') {
-                    let entry = self.auth_by_uri.entry(uri.to_string()).or_default();
+                    // Normalize so `//host:443/x/` and `//host/x/` collapse
+                    // to the same key — matches what `registry_uri_key`
+                    // produces on the lookup side after stripping the
+                    // scheme's default port.
+                    let entry = self
+                        .auth_by_uri
+                        .entry(normalize_npmrc_uri_key(uri))
+                        .or_default();
                     match suffix {
                         "_authToken" => entry.auth_token = Some(value),
                         "_auth" => entry.auth = Some(value),
@@ -851,14 +854,78 @@ fn package_scope(name: &str) -> Option<&str> {
 
 /// Convert a registry URL to the URI key used in .npmrc for auth lookup.
 /// "https://registry.example.com/" -> "//registry.example.com/"
+///
+/// Strips the scheme's default port (`:443` for https, `:80` for http) so
+/// `https://host:443/x/` collapses to the same key as `https://host/x/`,
+/// matching npm's nerf-dart behavior. Auth keys in `.npmrc` are stored
+/// after the same normalization (see [`normalize_npmrc_uri_key`]).
 fn registry_uri_key(url: &str) -> String {
-    if let Some(rest) = url.strip_prefix("https:") {
-        rest.to_string()
+    let rest = if let Some(rest) = url.strip_prefix("https:") {
+        rest
     } else if let Some(rest) = url.strip_prefix("http:") {
-        rest.to_string()
+        rest
     } else {
-        url.to_string()
+        return url.to_string();
+    };
+    normalize_npmrc_uri_key(rest)
+}
+
+/// Strip a trailing `:443` or `:80` from the authority of an
+/// `//host[:port]/path...` key. Used both when ingesting `.npmrc` URI
+/// entries and when computing the lookup key for a registry URL, so
+/// the two paths converge on the same canonical form.
+fn normalize_npmrc_uri_key(key: &str) -> String {
+    let Some(after) = key.strip_prefix("//") else {
+        return key.to_string();
+    };
+    let (authority, path) = match after.find('/') {
+        Some(idx) => (&after[..idx], &after[idx..]),
+        None => (after, ""),
+    };
+    let normalized = authority
+        .strip_suffix(":443")
+        .or_else(|| authority.strip_suffix(":80"))
+        .unwrap_or(authority);
+    format!("//{normalized}{path}")
+}
+
+/// Look up `key` in `map`, falling back to longest-prefix matching by
+/// trimming path segments from the right. Mirrors npm/pnpm's auth
+/// resolution: a tarball at `//host/a/b/c-1.0.0.tgz` finds an auth
+/// entry registered at `//host/a/`, while `//other/` does not match a
+/// `//host/` entry. Stops before falling all the way to the bare `//`
+/// host-less prefix.
+pub(crate) fn lookup_by_uri_prefix<'a, V>(
+    map: &'a BTreeMap<String, V>,
+    key: &str,
+) -> Option<&'a V> {
+    if let Some(v) = map.get(key) {
+        return Some(v);
     }
+    let trimmed = key.trim_end_matches('/');
+    if !trimmed.is_empty()
+        && trimmed != key
+        && let Some(v) = map.get(trimmed)
+    {
+        return Some(v);
+    }
+    let mut cursor = trimmed;
+    while let Some(idx) = cursor.rfind('/') {
+        cursor = &cursor[..idx];
+        // Stop at the leading "//" — anything shorter would be a
+        // host-less prefix that could match arbitrary registries.
+        if cursor.len() < 2 {
+            break;
+        }
+        let with_slash = format!("{cursor}/");
+        if let Some(v) = map.get(&with_slash) {
+            return Some(v);
+        }
+        if let Some(v) = map.get(cursor) {
+            return Some(v);
+        }
+    }
+    None
 }
 
 /// Public wrapper for normalize_registry_url.
@@ -1042,6 +1109,96 @@ mod tests {
         assert_eq!(
             registry_uri_key("http://localhost:4873/"),
             "//localhost:4873/"
+        );
+    }
+
+    #[test]
+    fn test_registry_uri_key_strips_default_port() {
+        // https default port collapses
+        assert_eq!(
+            registry_uri_key("https://registry.example.com:443/"),
+            "//registry.example.com/"
+        );
+        // http default port collapses
+        assert_eq!(
+            registry_uri_key("http://registry.example.com:80/artifactory/npm/"),
+            "//registry.example.com/artifactory/npm/"
+        );
+        // Non-default port is preserved
+        assert_eq!(
+            registry_uri_key("https://registry.example.com:8443/"),
+            "//registry.example.com:8443/"
+        );
+    }
+
+    #[test]
+    fn test_lookup_by_uri_prefix_longest_match() {
+        // Path-scoped auth entry. A tarball URL that lives under the
+        // same path should resolve, while an unrelated path should not.
+        let mut map: BTreeMap<String, &'static str> = BTreeMap::new();
+        map.insert("//host/artifactory/npm/".to_string(), "scoped-token");
+        map.insert("//host/".to_string(), "root-token");
+
+        // Full tarball path finds the path-scoped key.
+        assert_eq!(
+            lookup_by_uri_prefix(&map, "//host/artifactory/npm/lodash/-/lodash-4.17.21.tgz"),
+            Some(&"scoped-token"),
+        );
+        // A request outside the scope falls through to the host root.
+        assert_eq!(
+            lookup_by_uri_prefix(&map, "//host/other/pkg.tgz"),
+            Some(&"root-token"),
+        );
+        // Different host does not leak root-token.
+        assert_eq!(lookup_by_uri_prefix(&map, "//other/foo"), None);
+    }
+
+    #[test]
+    fn auth_token_resolves_for_path_scoped_registry_with_default_port() {
+        // End-to-end: `.npmrc` configures path-scoped auth under a
+        // reverse-proxy path, tarball URLs carry an explicit `:443`.
+        // Before the fix this 401'd because the lookup key
+        // `//host:443/artifactory/npm/lodash/-/lodash-4.17.21.tgz`
+        // never matched the stored `//host/artifactory/npm/` key.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".npmrc"),
+            "registry=https://registry.example.com/artifactory/npm/\n\
+             //registry.example.com/artifactory/npm/:_authToken=scoped-secret\n",
+        )
+        .unwrap();
+
+        let config = NpmConfig::load_isolated(dir.path());
+
+        assert_eq!(
+            config.auth_token_for(
+                "https://registry.example.com:443/artifactory/npm/lodash/-/lodash-4.17.21.tgz"
+            ),
+            Some("scoped-secret"),
+        );
+        assert_eq!(
+            config.auth_token_for(
+                "https://registry.example.com/artifactory/npm/lodash/-/lodash-4.17.21.tgz"
+            ),
+            Some("scoped-secret"),
+        );
+    }
+
+    #[test]
+    fn npmrc_key_with_default_port_is_normalized_on_ingest() {
+        // User wrote `:443` explicitly in `.npmrc`. Lookups that don't
+        // carry the port must still resolve.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".npmrc"),
+            "//registry.example.com:443/:_authToken=via-443\n",
+        )
+        .unwrap();
+
+        let config = NpmConfig::load_isolated(dir.path());
+        assert_eq!(
+            config.auth_token_for("https://registry.example.com/"),
+            Some("via-443"),
         );
     }
 

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -855,26 +855,43 @@ fn package_scope(name: &str) -> Option<&str> {
 /// Convert a registry URL to the URI key used in .npmrc for auth lookup.
 /// "https://registry.example.com/" -> "//registry.example.com/"
 ///
-/// Strips the scheme's default port (`:443` for https, `:80` for http) so
-/// `https://host:443/x/` collapses to the same key as `https://host/x/`,
-/// matching npm's nerf-dart behavior. Auth keys in `.npmrc` are stored
-/// after the same normalization (see [`normalize_npmrc_uri_key`]).
+/// Strips *only the scheme's own default port* (`:443` for https, `:80`
+/// for http) so `https://host:443/x/` collapses to the same key as
+/// `https://host/x/`, matching npm's nerf-dart behavior. The unusual
+/// case of `https://host:80/` (https on the http default port) is
+/// deliberately *not* collapsed — that's a different server.
 fn registry_uri_key(url: &str) -> String {
-    let rest = if let Some(rest) = url.strip_prefix("https:") {
-        rest
+    let (rest, default_port) = if let Some(rest) = url.strip_prefix("https:") {
+        (rest, ":443")
     } else if let Some(rest) = url.strip_prefix("http:") {
-        rest
+        (rest, ":80")
     } else {
         return url.to_string();
     };
-    normalize_npmrc_uri_key(rest)
+    strip_authority_port_suffix(rest, default_port)
 }
 
-/// Strip a trailing `:443` or `:80` from the authority of an
-/// `//host[:port]/path...` key. Used both when ingesting `.npmrc` URI
-/// entries and when computing the lookup key for a registry URL, so
-/// the two paths converge on the same canonical form.
+/// Normalize an `//host[:port]/path...` key from `.npmrc` so it matches
+/// what `registry_uri_key` produces on the lookup side.
+///
+/// Ingest can't know the scheme the user intended (`.npmrc` keys are
+/// scheme-less), so we strip both `:443` and `:80` — in practice
+/// nobody writes either explicitly unless they meant the default for
+/// the corresponding scheme. The lookup side is stricter: it only
+/// strips the matching default, so an `//host:80/x/` key will still
+/// not authenticate an `https://host:80/x/` request, and vice versa.
 fn normalize_npmrc_uri_key(key: &str) -> String {
+    let stripped = strip_authority_port_suffix(key, ":443");
+    if stripped != key {
+        return stripped;
+    }
+    strip_authority_port_suffix(key, ":80")
+}
+
+/// Strip a trailing `:N` from the authority of an `//host[:N]/path...`
+/// key. Returns the key unchanged when the prefix isn't `//` or the
+/// authority doesn't end with the requested port suffix.
+fn strip_authority_port_suffix(key: &str, port_suffix: &str) -> String {
     let Some(after) = key.strip_prefix("//") else {
         return key.to_string();
     };
@@ -882,11 +899,10 @@ fn normalize_npmrc_uri_key(key: &str) -> String {
         Some(idx) => (&after[..idx], &after[idx..]),
         None => (after, ""),
     };
-    let normalized = authority
-        .strip_suffix(":443")
-        .or_else(|| authority.strip_suffix(":80"))
-        .unwrap_or(authority);
-    format!("//{normalized}{path}")
+    let Some(authority) = authority.strip_suffix(port_suffix) else {
+        return key.to_string();
+    };
+    format!("//{authority}{path}")
 }
 
 /// Look up `key` in `map`, falling back to longest-prefix matching by
@@ -912,9 +928,9 @@ pub(crate) fn lookup_by_uri_prefix<'a, V>(
     let mut cursor = trimmed;
     while let Some(idx) = cursor.rfind('/') {
         cursor = &cursor[..idx];
-        // Stop at the leading "//" — anything shorter would be a
+        // Stop at or before the leading "//" — anything that short is a
         // host-less prefix that could match arbitrary registries.
-        if cursor.len() < 2 {
+        if cursor.len() <= 2 {
             break;
         }
         let with_slash = format!("{cursor}/");
@@ -1129,6 +1145,15 @@ mod tests {
             registry_uri_key("https://registry.example.com:8443/"),
             "//registry.example.com:8443/"
         );
+    }
+
+    #[test]
+    fn test_registry_uri_key_only_strips_matching_default_port() {
+        // https on the http default port (rare but valid) is a *different
+        // server* from https on its own default — don't collapse them.
+        assert_eq!(registry_uri_key("https://host:80/x/"), "//host:80/x/",);
+        // Symmetric case: http on https default port stays distinct.
+        assert_eq!(registry_uri_key("http://host:443/x/"), "//host:443/x/",);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes [#126](https://github.com/endevco/aube/discussions/126) — path-scoped registries (Artifactory, Nexus, Verdaccio behind a reverse proxy) returned 401 on every tarball fetch because aube did exact-match auth lookups against a host-only key, while `.npmrc` entries are scoped to a path like `//host/artifactory/npm/`.

## What changed

`crates/aube-registry/src/config.rs`:
- `registry_uri_key` strips the scheme's default port (`:443` https, `:80` http) so `https://host:443/x/` and `https://host/x/` collapse to the same key.
- New `normalize_npmrc_uri_key` applies the same stripping when ingesting `//host[:port]/path/:_authToken=...` entries — keeps the storage and lookup sides consistent regardless of whether the user wrote `:443` explicitly.
- New `lookup_by_uri_prefix` walks parent path segments after exact match (npm-style nerf-dart resolution). Stops before the host-less `//` prefix so a key like `//host/` cannot match an unrelated host.
- `registry_config_for` routes through the prefix-walking lookup.

`crates/aube-registry/src/client.rs`:
- `RegistryClient::http_for` uses the same prefix-walking lookup (TLS clients are keyed by the same shape).
- `fetch_tarball_bytes` passes the full tarball URL through (path included) instead of stripping to host-only, so prefix matching can find the path-scoped entry. Removes the now-dead `tarball_registry_url` helper.

Four new unit tests cover default-port stripping, longest-prefix ordering (including the negative case where an unrelated host doesn't match), end-to-end auth resolution for a path-scoped registry with `:443`, and ingest-side normalization of `:443` keys.

## Test plan

- [x] `cargo test -p aube-registry` (92 tests, includes 4 new)
- [x] `cargo test --workspace` (no regressions)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes registry auth resolution and per-registry HTTP client selection, which could affect which credentials/TLS settings are applied to requests if the new prefix/port normalization logic has edge-case mismatches.
> 
> **Overview**
> Fixes tarball authentication for *path-scoped* registry configs by switching `.npmrc` auth resolution from exact match to **longest-prefix URI matching**, and by stripping scheme-default ports (`:443`/`:80`) when generating lookup keys.
> 
> Updates `RegistryClient` to (1) use the same prefix lookup for per-registry HTTP clients, (2) pass the full tarball URL into auth lookup so path-scoped entries can match, and (3) cache `tokenHelper` results by helper command (not tarball URL) to avoid re-spawning during large installs. Adds unit tests covering default-port handling, prefix match behavior, and end-to-end auth resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6952e6276ed7c72a65bc8f972cfca048b5002ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->