### PR TITLE
lockfile(npm): tolerate legacy array engines field

### DIFF
--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -72,7 +72,15 @@ struct RawNpmPackage {
     /// package entry; dropping them on re-emit is one of the
     /// remaining sources of `aube install --no-frozen-lockfile`
     /// churn against native npm output.
-    #[serde(default)]
+    ///
+    /// Uses `aube_manifest::engines_tolerant` so the legacy array
+    /// shape (e.g. `ansi-html-community@0.0.8` ships
+    /// `"engines": ["node >= 0.8.0"]` and npm preserves it verbatim
+    /// in the lockfile) doesn't blow up the whole parse. We normalize
+    /// the array to an empty map — same behavior modern npm gives the
+    /// shape for engine-strict checks, and the same tolerance the
+    /// manifest parser already applies.
+    #[serde(default, deserialize_with = "aube_manifest::engines_tolerant")]
     engines: BTreeMap<String, String>,
     #[serde(default)]
     bin: BTreeMap<String, String>,
@@ -1536,6 +1544,42 @@ mod tests {
 
         let err = parse(tmp.path()).unwrap_err();
         assert!(matches!(err, Error::Parse(_, msg) if msg.contains("lockfileVersion 1")));
+    }
+
+    /// Pre-npm-2.x packages (e.g. `ansi-html-community@0.0.8`) ship
+    /// `"engines": ["node >= 0.8.0"]` as an array; npm preserves that
+    /// shape verbatim in v2/v3 lockfiles. Without tolerant parsing, a
+    /// single such entry blows up the whole `aube ci`. Normalize to an
+    /// empty map (matches what modern npm does for engine-strict on
+    /// the array shape) so the install proceeds.
+    #[test]
+    fn test_parse_legacy_array_engines() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+            "name": "test",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "test",
+                    "version": "1.0.0",
+                    "dependencies": { "ansi-html-community": "0.0.8" }
+                },
+                "node_modules/ansi-html-community": {
+                    "version": "0.0.8",
+                    "integrity": "sha512-aaa",
+                    "engines": ["node >= 0.8.0"]
+                }
+            }
+        }"#;
+        std::fs::write(tmp.path(), content).unwrap();
+
+        let graph = parse(tmp.path()).unwrap();
+        let pkg = &graph.packages["ansi-html-community@0.0.8"];
+        // Array shape gets normalized to an empty map — same as the
+        // manifest parser, and same as what modern npm honors for the
+        // engine-strict check on the array form.
+        assert!(pkg.engines.is_empty());
     }
 
     /// npm writes `"h3-v2": "npm:h3@..."` aliases as a packages entry

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -16,7 +16,12 @@ use std::path::Path;
 ///
 /// An explicit `null` is also tolerated (same as "field absent"),
 /// matching the tolerance our other dep-map parsers apply.
-fn engines_tolerant<'de, D>(de: D) -> Result<BTreeMap<String, String>, D::Error>
+///
+/// Exposed (`pub`) so the lockfile parser can apply the same tolerance
+/// — npm v2/v3 lockfiles preserve the array shape verbatim from the
+/// originating `package.json`, so a strict map-only deserializer there
+/// trips on the same ancient packages and blocks `aube ci` outright.
+pub fn engines_tolerant<'de, D>(de: D) -> Result<BTreeMap<String, String>, D::Error>
 where
     D: Deserializer<'de>,
 {


### PR DESCRIPTION
## Summary

- Pre-npm-2.x packages like `ansi-html-community@0.0.8` ship `"engines": ["node >= 0.8.0"]` as an array. npm preserves that shape verbatim in v2/v3 lockfiles, so a single such entry triggered `invalid type: sequence, expected a map` and blew up `aube ci` outright.
- Promotes the existing `engines_tolerant` deserializer in `aube-manifest` to `pub` and applies it on `RawNpmPackage.engines` in `aube-lockfile`. Array shape normalizes to an empty map — same behavior modern npm gives the array form for the engine-strict check, and the same tolerance the manifest parser already applies (added in d3e1b39).
- Round-trip note: the array entry won't survive a re-write (we normalize to empty map, then the writer skips empty maps). That's a deliberate trade — the alternative is parse failure that blocks the whole install, and modern npm itself ignores the array form.

Closes #125.

## Test plan

- [x] `cargo test -p aube-lockfile` (156 pass, including new `test_parse_legacy_array_engines`)
- [x] `cargo test -p aube-manifest` (42 pass — `engines_tolerant` visibility change doesn't affect existing callers)
- [x] `cargo clippy -p aube-lockfile -p aube-manifest --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm lockfile parsing behavior to accept a previously-failing `engines` shape, which could subtly affect lockfile round-tripping (legacy array normalizes away) but is otherwise localized to deserialization.
> 
> **Overview**
> Prevents `aube ci` from failing on npm v2/v3 lockfiles that contain legacy pre-npm-2.x `"engines": [...]` array entries by switching `RawNpmPackage.engines` to a tolerant deserializer that normalizes arrays/`null` to an empty map.
> 
> Promotes `aube-manifest`’s `engines_tolerant` helper to `pub` for reuse and adds a regression test covering lockfile parsing of the legacy array form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5366184894d73ed52dbc59741211ff8465ba32f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->