### PR TITLE
chore: release v1.0.0-beta.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 dependencies = [
  "base64",
  "blake3",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "1.0.0-beta.7"
+version = "1.0.0-beta.8"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -85,13 +85,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.7" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.7" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.7" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.7" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.7" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.7" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.7" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.7" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.7" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.7" }
+aube = { path = "crates/aube", version = "1.0.0-beta.8" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.8" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.8" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.8" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.8" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.8" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.8" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.8" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.8" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.8" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.7"
+version "1.0.0-beta.8"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.8](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.7...aube-lockfile-v1.0.0-beta.8) - 2026-04-20
+
+### Other
+
+- default to ~/.local/share/aube/store per XDG spec ([#129](https://github.com/endevco/aube/pull/129))
+- *(npm)* tolerate legacy array engines field ([#132](https://github.com/endevco/aube/pull/132))
+- *(npm)* accept string and array funding shapes ([#133](https://github.com/endevco/aube/pull/133))
+
 ## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.6...aube-lockfile-v1.0.0-beta.7) - 2026-04-19
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.8](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.7...aube-manifest-v1.0.0-beta.8) - 2026-04-20
+
+### Other
+
+- *(npm)* tolerate legacy array engines field ([#132](https://github.com/endevco/aube/pull/132))
+
 ## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.6...aube-manifest-v1.0.0-beta.7) - 2026-04-19
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.8](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.7...aube-registry-v1.0.0-beta.8) - 2026-04-20
+
+### Other
+
+- quiet retry warnings; settings: kebab-case gvs npmrc aliases ([#139](https://github.com/endevco/aube/pull/139))
+- tolerate legacy array engines shape in packuments ([#138](https://github.com/endevco/aube/pull/138))
+- *(auth)* longest-prefix .npmrc lookup with default-port stripping ([#131](https://github.com/endevco/aube/pull/131))
+- honor NPM_CONFIG_USERCONFIG for user-level .npmrc path ([#130](https://github.com/endevco/aube/pull/130))
+
 ## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.6...aube-registry-v1.0.0-beta.7) - 2026-04-19
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.8](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.7...aube-settings-v1.0.0-beta.8) - 2026-04-20
+
+### Other
+
+- quiet retry warnings; settings: kebab-case gvs npmrc aliases ([#139](https://github.com/endevco/aube/pull/139))
+- default to ~/.local/share/aube/store per XDG spec ([#129](https://github.com/endevco/aube/pull/129))
+
 ## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.6...aube-settings-v1.0.0-beta.7) - 2026-04-19
 
 ### Other

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.8](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.7...aube-store-v1.0.0-beta.8) - 2026-04-20
+
+### Other
+
+- default to ~/.local/share/aube/store per XDG spec ([#129](https://github.com/endevco/aube/pull/129))
+
 ## [1.0.0-beta.6](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.5...aube-store-v1.0.0-beta.6) - 2026-04-19
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.8](https://github.com/endevco/aube/compare/v1.0.0-beta.7...v1.0.0-beta.8) - 2026-04-20
+
+### Other
+
+- rewrite gvs auto-disable warning in plain English ([#140](https://github.com/endevco/aube/pull/140))
+- default to ~/.local/share/aube/store per XDG spec ([#129](https://github.com/endevco/aube/pull/129))
+
 ## [1.0.0-beta.7](https://github.com/endevco/aube/compare/v1.0.0-beta.6...v1.0.0-beta.7) - 2026-04-19
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5546,7 +5546,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.7
+**Version**: 1.0.0-beta.8
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.7",
-  "releasedAt": "2026-04-19T22:39:20Z"
+  "version": "1.0.0-beta.8",
+  "releasedAt": "2026-04-20T02:36:51Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.8`

This PR bumps the workspace to `v1.0.0-beta.8` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR is a version/release metadata bump (Cargo workspace + lockfile, generated CLI spec/docs, and changelogs) with no functional code changes in the diff.
> 
> **Overview**
> Bumps the workspace and all internal crates from `1.0.0-beta.7` to `1.0.0-beta.8`, updating `Cargo.toml` and `Cargo.lock` accordingly.
> 
> Regenerates release artifacts for the new version: updates `aube.usage.kdl`, CLI docs (`docs/cli/*`), per-crate `CHANGELOG.md` entries, and `release.json` timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0940250a09f62052c65b52778d5a533bba6319f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->