### PR TITLE
registry: tolerate legacy array engines shape in packuments

### DIFF
--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -161,7 +161,16 @@ pub struct VersionMetadata {
     /// Round-tripped into the lockfile so pnpm-compatible output can
     /// emit `engines: {node: '>=8'}` on package entries without a
     /// packument re-fetch.
-    #[serde(default, deserialize_with = "non_string_tolerant_map")]
+    ///
+    /// Uses `aube_manifest::engines_tolerant` rather than
+    /// `non_string_tolerant_map` so the packument parser tolerates the
+    /// pre-npm-2.x legacy array shape (`"engines": ["node >= 0.4.0"]`,
+    /// still present on `html-entities@1.0.0` and other ancient
+    /// publishes). A strict map-only deserializer there aborts the
+    /// whole resolve for any transitive dep whose packument merely
+    /// *lists* an affected version — even when the user's range
+    /// wouldn't have selected it.
+    #[serde(default, deserialize_with = "aube_manifest::engines_tolerant")]
     pub engines: BTreeMap<String, String>,
     /// `license:` field from the package manifest. npm's lockfile
     /// keeps this per-package; other formats don't. Stored as
@@ -515,6 +524,31 @@ mod tests {
         );
         assert_eq!(v.dev_dependencies.len(), 1);
         assert_eq!(v.dev_dependencies["lodash"], "0.9.2");
+    }
+
+    /// `html-entities@1.0.0` (and other pre-npm-2.x publishes) ship
+    /// `"engines": ["node >= 0.4.0"]` — a legacy array shape. A strict
+    /// map-only deserializer fails the whole packument with
+    /// "invalid type: sequence, expected a map", aborting resolve for
+    /// every dependent. Tolerate the array (same behavior as
+    /// `aube-manifest::engines_tolerant`) by dropping it to an empty
+    /// map, matching what modern npm does with that field.
+    #[test]
+    fn engines_tolerates_legacy_array_shape() {
+        let v = parse(
+            r#"{
+                "name": "html-entities",
+                "version": "1.0.0",
+                "engines": ["node >= 0.4.0"]
+            }"#,
+        );
+        assert!(v.engines.is_empty());
+    }
+
+    #[test]
+    fn engines_map_is_preserved() {
+        let v = parse(r#"{"name":"x","version":"1.0.0","engines":{"node":">=18"}}"#);
+        assert_eq!(v.engines["node"], ">=18");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `html-entities@1.0.0` and other pre-npm-2.x publishes ship `"engines": ["node >= 0.4.0"]` in the packument. The packument parser used `non_string_tolerant_map` for `engines`, which failed with `invalid type: sequence, expected a map` and aborted resolve for every dependent (`registry error for html-entities: I/O error: invalid type: sequence, expected a map`).
- Swap to `aube_manifest::engines_tolerant`, which already normalizes the legacy array shape to an empty map on the manifest / lockfile paths (added in #120 / #132). Modern npm likewise ignores the array form — engine-strict only consults the map — so dropping it matches observed behavior.
- Added two regression tests: one for the `html-entities`-style array shape, one confirming the map shape still round-trips.

## Test plan
- [x] `cargo test -p aube-registry --lib`
- [x] `cargo clippy -p aube-registry --all-targets -- -D warnings`
- [ ] `aube i` against a project depending on `html-entities@1.x` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes packument deserialization for `VersionMetadata.engines`, which can affect parsing behavior and downstream engine handling, but is narrowly scoped and adds regression coverage for both legacy and map shapes.
> 
> **Overview**
> Fixes npm packument parsing to **tolerate legacy pre-npm-2.x `engines` array shape** (e.g. `"engines": ["node >= 0.4.0"]`) by switching `VersionMetadata.engines` deserialization from `non_string_tolerant_map` to `aube_manifest::engines_tolerant`, preventing installs from failing on ancient transitive versions.
> 
> Adds regression tests ensuring the array form is dropped to an empty map while the normal map form is still preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47594c9dc209c2cebff200e0c95f40e98f90b276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->