### PR TITLE
registry: tolerate legacy array engines shape in packuments

### DIFF
--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -161,7 +161,15 @@ pub struct VersionMetadata {
     /// Round-tripped into the lockfile so pnpm-compatible output can
     /// emit `engines: {node: '>=8'}` on package entries without a
     /// packument re-fetch.
-    #[serde(default, deserialize_with = "non_string_tolerant_map")]
+    ///
+    /// Uses `aube_manifest::engines_tolerant` so the legacy pre-npm-2.x
+    /// array shape (e.g. `madge@0.0.1` and `html-entities@1.x` ship
+    /// `"engines": ["node >= 0.8.0"]`) doesn't blow up the whole
+    /// packument — one such version would otherwise block install of
+    /// any range that touches the packument, even when the user's
+    /// selector doesn't pick that version. Array normalizes to an
+    /// empty map, matching the manifest and lockfile parsers.
+    #[serde(default, deserialize_with = "aube_manifest::engines_tolerant")]
     pub engines: BTreeMap<String, String>,
     /// `license:` field from the package manifest. npm's lockfile
     /// keeps this per-package; other formats don't. Stored as
@@ -573,5 +581,31 @@ mod tests {
     fn packument_time_null_whole_field_is_empty() {
         let p = parse_packument(r#"{"name":"pkg","time":null}"#);
         assert!(p.time.is_empty());
+    }
+
+    /// Pre-npm-2.x publishes (e.g. `madge@0.0.1`, `html-entities@1.x`)
+    /// ship `"engines": ["node >= 0.8.0"]` as an array, and npmjs.org
+    /// serves that shape verbatim in the packument. A strict map-only
+    /// deserializer fails the whole packument parse with
+    /// `invalid type: sequence, expected a map`, blocking install of
+    /// any range that even lists an affected version. Normalize the
+    /// array to an empty map — same tolerance the manifest and
+    /// lockfile parsers already apply.
+    #[test]
+    fn engines_accepts_legacy_array_shape() {
+        let v = parse(r#"{"name":"madge","version":"0.0.1","engines":["node >= 0.8.0"]}"#);
+        assert!(v.engines.is_empty());
+    }
+
+    #[test]
+    fn engines_accepts_map_shape() {
+        let v = parse(r#"{"name":"x","version":"1.0.0","engines":{"node":">=18"}}"#);
+        assert_eq!(v.engines.get("node"), Some(&">=18".to_string()));
+    }
+
+    #[test]
+    fn engines_null_is_empty() {
+        let v = parse(r#"{"name":"x","version":"1.0.0","engines":null}"#);
+        assert!(v.engines.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Pre-npm-2.x publishes ship `"engines": ["node >= 0.8.0"]` as an array, and npmjs.org serves that shape verbatim in the packument. `VersionMetadata.engines` used `non_string_tolerant_map`, which expects a map, so parsing bailed with `invalid type: sequence, expected a map` and aborted the whole packument — blocking `aube install` of any range that merely *lists* an affected version.
- Real-world hits: `madge@0.0.1`–`0.5.5`, `html-entities@1.0.0`–`1.2.1` (many more). Reported in #136 with a minimal `madge ^8.0.0` repro that has nothing to do with the user's selected range.
- Swap `non_string_tolerant_map` for `aube_manifest::engines_tolerant` on `VersionMetadata.engines`. Same helper the manifest parser (d3e1b39) and npm lockfile parser (#132) already use. Array normalizes to an empty map — matches modern npm's behavior for engine-strict on the legacy shape.

Closes #136.

## Test plan

- [x] `cargo test -p aube-registry --lib` (100 pass, including three new: `engines_accepts_legacy_array_shape`, `engines_accepts_map_shape`, `engines_null_is_empty`)
- [x] `cargo clippy -p aube-registry --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] End-to-end repro from #136: built release binary, ran `aube install` against `{"devDependencies":{"madge":"^8.0.0"}}` — resolves 135 packages in 1.2s, exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only relaxes packument JSON deserialization for `VersionMetadata.engines`, and adds tests to lock in behavior for array/map/null inputs.
> 
> **Overview**
> Packument parsing now tolerates legacy pre-npm-2.x `"engines": [...]` array shapes by switching `VersionMetadata.engines` to deserialize via `aube_manifest::engines_tolerant`, normalizing arrays (and `null`) to an empty map instead of failing the entire packument parse.
> 
> Adds targeted unit tests to cover `engines` parsing for legacy array, normal map, and `null` cases, preventing installs from being blocked by unrelated historical versions listed in a packument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e01f2512dd65580cb06b1d5f847fc60b0fb589d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->