### PR TITLE
registry: quiet retry warnings; settings: kebab-case gvs npmrc aliases

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -301,7 +301,12 @@ impl RegistryClient {
                     let wait = retry_after_from(&resp)
                         .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
                     drop(resp);
-                    tracing::warn!(
+                    // Recoverable: the retry succeeds in the common
+                    // case, and the final failure propagates up as a
+                    // user-facing error. Emitting a WARN on every
+                    // transient blip turns a healthy retry loop into
+                    // install-time noise.
+                    tracing::debug!(
                         attempt = attempt + 1,
                         max_attempts,
                         backoff_ms = wait.as_millis() as u64,
@@ -315,7 +320,7 @@ impl RegistryClient {
                         return Err(e);
                     }
                     let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
-                    tracing::warn!(
+                    tracing::debug!(
                         attempt = attempt + 1,
                         max_attempts,
                         backoff_ms = wait.as_millis() as u64,

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -603,7 +603,7 @@ compatibility heuristics would normally disable it.
 """
 sources.cli = ["enable-global-virtual-store", "disable-global-virtual-store"]
 sources.env = []
-sources.npmrc = ["enableGlobalVirtualStore"]
+sources.npmrc = ["enableGlobalVirtualStore", "enable-global-virtual-store"]
 sources.workspaceYaml = ["enableGlobalVirtualStore"]
 examples = [
   "echo 'enableGlobalVirtualStore=false' >> .npmrc",
@@ -644,7 +644,7 @@ warning suppresses itself in that case.
 """
 sources.cli = []
 sources.env = []
-sources.npmrc = ["disableGlobalVirtualStoreForPackages"]
+sources.npmrc = ["disableGlobalVirtualStoreForPackages", "disable-global-virtual-store-for-packages"]
 sources.workspaceYaml = ["disableGlobalVirtualStoreForPackages"]
 examples = []
 


### PR DESCRIPTION
## Summary

Two small fixes carried over from a three-bug install report; the third (engines-array packument crash) already landed in #138, so this PR has been rebased onto main and that commit dropped as a duplicate.

- **registry: demote retry logs to debug.** Transient 5xx/429s and transport errors that recover on retry don't need operator attention. The retry loop is working as designed, and a final exhausted attempt still propagates as a user-facing error. Reporter saw three WARN lines on a clean resolve; both paths now log at `debug!`.
- **settings: accept kebab-case `.npmrc` keys for global-virtual-store.** Most settings list both camelCase and kebab-case aliases, but `enableGlobalVirtualStore` and `disableGlobalVirtualStoreForPackages` only accepted camelCase. Add the kebab forms to `sources.npmrc`; `pnpm-workspace.yaml` stays camelCase-only since that matches YAML convention.

## Test plan

- [x] `cargo build -p aube-registry -p aube-settings`
- [x] `cargo test -p aube-registry --lib`
- [x] `cargo test -p aube-settings`
- [x] `cargo clippy -p aube-registry -p aube-settings --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)