### PR TITLE
install: rewrite gvs auto-disable warning in plain English

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2004,7 +2004,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             && !virtual_store_only_setting
         {
             tracing::warn!(
-                "disabling global virtual store: `{name}` is in disableGlobalVirtualStoreForPackages (packages in that list have bundler-style module resolvers that follow symlinks and walk up, which can't reach the project root when `.aube/<pkg>` symlinks into the global store). To silence this warning while keeping the fallback, add `enableGlobalVirtualStore=false` to .npmrc; to opt out of the heuristic entirely, set `disableGlobalVirtualStoreForPackages=[]`."
+                "`{name}` isn't compatible with aube's global virtual store — \
+                 installing per-project instead. Install still succeeds; repeat \
+                 installs of this project just won't share materialized packages \
+                 across projects. Fixing this requires an upstream change in \
+                 `{name}` itself (please file it with that project, not aube). \
+                 To silence this warning, add `enableGlobalVirtualStore=false` to \
+                 .npmrc — or set `disableGlobalVirtualStoreForPackages=[]` to opt \
+                 out of this auto-detection entirely. \
+                 Details: https://aube.en.dev/package-manager/node-modules#global-virtual-store"
             );
             Some(false)
         } else {

--- a/docs/package-manager/node-modules.md
+++ b/docs/package-manager/node-modules.md
@@ -44,6 +44,56 @@ aube imports files from that store into the virtual store with reflinks,
 hardlinks, or copies depending on filesystem support and
 `package-import-method`.
 
+## Global virtual store
+
+aube has two "stores":
+
+- The **global content store** (`$XDG_DATA_HOME/aube/store/v1/files/`) holds
+  package *files* deduplicated by BLAKE3 hash. Every install reads from it.
+- The **global virtual store** (`~/.cache/aube/virtual-store/`) holds
+  materialized package *directories* keyed by dependency-graph hash.
+  `node_modules/.aube/<pkg>` is an absolute symlink into this shared location,
+  so repeat installs across projects reuse the same tree instead of
+  re-materializing it.
+
+The global virtual store is on by default outside CI and off under CI (where a
+warm cache is rarely available). Override per-project with
+`enableGlobalVirtualStore=true|false` in `.npmrc`, or per-invocation with
+`--enable-global-virtual-store` / `--disable-global-virtual-store`.
+
+### Why aube turns it off for some packages
+
+A few tools resolve modules by canonicalizing every `node_modules/<pkg>`
+symlink to its real path, then walking up the directory tree looking for
+configs, app-router roots, or hoisted deps. When `<pkg>` points into the
+global virtual store, the walk escapes the project and fails with errors
+like `Symlink ... is invalid, it points out of the filesystem root`.
+
+When any importer depends on a known-incompatible package, aube falls back
+to per-project materialization under `node_modules/.aube/` and prints a
+one-line warning:
+
+```text
+`next` isn't compatible with aube's global virtual store — installing
+per-project instead. Install still succeeds; repeat installs of this
+project just won't share materialized packages across projects.
+```
+
+- **How to fix it properly.** The package itself would need to stop
+  canonicalizing through symlinks (pnpm users hit the same class of issue).
+  That's an upstream change in the tool — please file it with the package
+  maintainers, not with aube.
+- **How to silence the warning.** Add `enableGlobalVirtualStore=false` to
+  `.npmrc`. The per-project fallback stays on; the warning just goes away.
+- **How to opt out of the heuristic entirely** (at your own risk — expect
+  the errors above): set `disableGlobalVirtualStoreForPackages=[]` in
+  `.npmrc`.
+
+The default trigger list is `next`, `nuxt`, `vite`, `vitepress`, `parcel` —
+the tools with concrete, reproducible walk-up failures. Add names to
+`disableGlobalVirtualStoreForPackages` if you hit the same class of error
+with another package.
+
 ## Coexistence with pnpm
 
 aube does not reuse `node_modules/.pnpm/` or `~/.pnpm-store/`. If a pnpm-built


### PR DESCRIPTION
## Summary

The auto-disable warning that fires when a project depends on Next.js / Vite / etc. has been a frequent source of confusion. The old text was a single jargon-heavy sentence that didn't tell users what actually happened, whether it was a problem, or what to do about it:

> disabling global virtual store: \`next\` is in disableGlobalVirtualStoreForPackages (packages in that list have bundler-style module resolvers that follow symlinks and walk up, which can't reach the project root when \`.aube/<pkg>\` symlinks into the global store). To silence this warning while keeping the fallback, add \`enableGlobalVirtualStore=false\` to .npmrc; to opt out of the heuristic entirely, set \`disableGlobalVirtualStoreForPackages=[]\`.

The rewrite states four things a user actually needs:

- **what aube did** — installing per-project instead of via the shared virtual store,
- **what that costs** — the install still succeeds, repeat installs just won't share materialized packages across projects,
- **how to fix it properly** — this is an upstream issue in the triggering package itself (Turbopack/Vite/etc. canonicalize through symlinks); file it with them, not aube,
- **how to silence** — `enableGlobalVirtualStore=false` in `.npmrc`, or `disableGlobalVirtualStoreForPackages=[]` to opt out of the auto-detection entirely.

The warning also now links to a new **Global virtual store** section in the node_modules layout docs, which explains the two stores (content store vs. virtual store), why the auto-disable exists, and the three user paths.

## Test plan

- [x] `cargo check -p aube` — clean build
- [x] `./test/bats/bin/bats test/nextjs_gvs_autodisable.bats` — all 9 tests pass (setting name and backticked package name are still present in the new message; previously-refuted `disabling global virtual store` phrase is gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to user-facing warning text and documentation, with no functional changes to install/link behavior.
> 
> **Overview**
> Rewrites the install-time warning emitted when aube auto-disables the global virtual store due to known incompatible packages, making it explicit that aube falls back to *per-project* materialization, installs still succeed, and how to silence/opt out; it also adds a link to the relevant docs.
> 
> Expands `docs/package-manager/node-modules.md` with a new **Global virtual store** section explaining the content store vs virtual store, when GVS is enabled, why the heuristic disables it for some tools, and the available user overrides (`enableGlobalVirtualStore` / `disableGlobalVirtualStoreForPackages`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6498173ec592d7113859d61f63597bd2a5f90872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->