### PR TITLE
docs(claude-md): require agent attribution on maintainer-authored posts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,14 +82,12 @@ somewhere to get help, link Discussions and do **not** write phrases like
 
 ### Agent-authored replies
 
-When posting a reply, comment, or any other message on behalf of a
-maintainer to a public venue (GitHub Discussions, PR reviews, issue
-comments on other repos, etc.), disclose that it was written by an
-agent. Prefix the message with a short italicized attribution line such
-as `_(Posted by Claude on @jdx's behalf.)_` so readers know they're
-talking to an AI and can calibrate accordingly. This applies to any
-agent-authored external communication — do not post anonymously as the
-maintainer.
+When posting a reply, comment, or any other message as a maintainer to
+a public venue (GitHub Discussions, PR reviews, issue comments on other
+repos, etc.), disclose that it was written by an agent. End the message
+with a short italicized attribution line on its own trailing paragraph,
+verbatim: `_Written with Claude._`. This applies to any agent-authored
+external communication — do not post without the attribution.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,17 @@ writing docs, error messages, or any user-facing copy that points people
 somewhere to get help, link Discussions and do **not** write phrases like
 "file an issue" or "open an issue."
 
+### Agent-authored replies
+
+When posting a reply, comment, or any other message on behalf of a
+maintainer to a public venue (GitHub Discussions, PR reviews, issue
+comments on other repos, etc.), disclose that it was written by an
+agent. Prefix the message with a short italicized attribution line such
+as `_(Posted by Claude on @jdx's behalf.)_` so readers know they're
+talking to an AI and can calibrate accordingly. This applies to any
+agent-authored external communication — do not post anonymously as the
+maintainer.
+
 ## Architecture
 
 Cargo workspace with 9 crates under `crates/`. The binary entry point is `crates/aube/src/main.rs`.


### PR DESCRIPTION
## Summary
- When an agent posts on a maintainer's behalf to a public venue (GitHub Discussions, PR reviews, cross-repo comments, etc.), it must prefix the message with a short italicized attribution line, e.g. `_(Posted by Claude on @jdx's behalf.)_`
- Keeps readers honest about who they're actually talking to and lets them calibrate trust accordingly

## Test plan
- [x] N/A — docs-only change to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds a communication guideline; no runtime or build behavior is affected.
> 
> **Overview**
> Adds a new `CLAUDE.md` guideline requiring any maintainer-facing, agent-authored public communication (e.g., Discussions/PR reviews/cross-repo comments) to include a trailing italic attribution line: `_Written with Claude._`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faba17599c75eb13a2a934a0213b1b1f5a6b3392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->