### PR TITLE
chore: add communique 1.0.1

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -71,6 +71,40 @@ url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/ca
 checksum = "sha256:89706aa5215c164d8d091597a470fee72308ac87e8553af395ea77db844a888c"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-pc-windows-msvc.zip"
 
+[[tools.communique]]
+version = "1.0.1"
+backend = "github:jdx/communique"
+
+[tools.communique."platforms.linux-arm64"]
+checksum = "sha256:7be8c2a327212b41e7d39c9866f49c09c26beddfcdfbde1289804c836c45797b"
+url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318499"
+
+[tools.communique."platforms.linux-arm64-musl"]
+checksum = "sha256:7be8c2a327212b41e7d39c9866f49c09c26beddfcdfbde1289804c836c45797b"
+url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318499"
+
+[tools.communique."platforms.linux-x64"]
+checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
+url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+
+[tools.communique."platforms.linux-x64-musl"]
+checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
+url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+
+[tools.communique."platforms.macos-arm64"]
+checksum = "sha256:9adcd413f3377b98aa12df003ffa4c24f084e7bea549104e29088a3b79892dd8"
+url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318491"
+
+[tools.communique."platforms.windows-x64"]
+checksum = "sha256:2474f4ed704c9a94bb9dd357452275b8efe92df132ab81b642055c858441a905"
+url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400319696"
+
 [[tools."github:bnjbvr/cargo-machete"]]
 version = "0.9.2"
 backend = "github:bnjbvr/cargo-machete"

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@ _.path = ["./bin"]
 [tools]
 actionlint = "latest"
 cargo-binstall = "latest"
+communique = "latest"
 "github:bnjbvr/cargo-machete" = "latest"
 "github:foresterre/cargo-msrv" = "latest"
 hk = "latest"


### PR DESCRIPTION
## Summary
- Add communique tool for editorialized release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new pinned dev tool (`communique`) to `mise` configuration/lockfiles and does not change application/runtime code.
> 
> **Overview**
> Adds `communique` to `mise.toml` and updates `mise.lock` to pin `communique` v1.0.1 with platform-specific download URLs and checksums, enabling consistent installation of the release-notes tool across environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a928d9388e2afb6bad77422a4dead2c445e1c32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->