### PR TITLE
cli: emit colored stderr under CI even when not a TTY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "aube-workspace",
  "base64",
  "blake3",
+ "ci_info",
  "clap",
  "clap-sort",
  "clap_usage",
@@ -592,6 +593,15 @@ dependencies = [
  "parse-zoneinfo",
  "phf",
  "phf_codegen",
+]
+
+[[package]]
+name = "ci_info"
+version = "0.14.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d502ead02cc105c33a87aa76817cdca915a7576b59caba5eeb4e7abdd633f23"
+dependencies = [
+ "envmnt",
 ]
 
 [[package]]
@@ -1022,6 +1032,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "envmnt"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73999a2b8871e74c8b8bc23759ee9f3d85011b24fafc91a4b3b5c8cc8185501"
+dependencies = [
+ "fsio",
+ "indexmap 1.9.3",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1137,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsio"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4944f16eb6a05b4b2b79986b4786867bb275f52882adea798f17cc2588f25b2"
+dependencies = [
+ "dunce",
+]
 
 [[package]]
 name = "fslock"
@@ -1324,7 +1353,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1340,6 +1369,12 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1670,6 +1705,16 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2987,7 +3032,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3022,7 +3067,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3798,7 +3843,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4028,7 +4073,7 @@ checksum = "1851c9ddbc3a428af152852227363e7f66b73ca2ce732c8db3c2d4ab37eb63d2"
 dependencies = [
  "clap",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools",
  "kdl",
  "log",
@@ -4214,7 +4259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4240,7 +4285,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4826,7 +4871,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4857,7 +4902,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4876,7 +4921,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -73,6 +73,7 @@ diffy = { workspace = true }
 libc = "0.2"
 pathdiff = "0.2"
 is_ci = "1"
+ci_info = "0.14"
 pluralizer = "0.5.0"
 
 [dev-dependencies]

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -533,13 +533,14 @@ fn main() -> miette::Result<()> {
             std::env::set_var("CLICOLOR_FORCE", "1");
             std::env::remove_var("NO_COLOR");
         }
-    } else if ci_renders_ansi() {
-        // Auto + a CI runner whose log viewer renders ANSI: stderr
-        // isn't a TTY so console/clx would default to plain text. Flip
-        // color on for stderr only via console's per-stream override —
-        // that's the stream the install progress heartbeat writes to.
-        // Deliberately *not* setting FORCE_COLOR / CLICOLOR_FORCE: those
-        // are process-wide and would also colorize stdout (e.g.
+    } else if ci_renders_ansi() && !env_disables_color() {
+        // Auto + a CI runner whose log viewer renders ANSI, and the
+        // user hasn't opted out via NO_COLOR / CLICOLOR=0: stderr isn't
+        // a TTY so console/clx would default to plain text. Flip color
+        // on for stderr only via console's per-stream override — that's
+        // the stream the install progress heartbeat writes to.
+        // Deliberately *not* setting FORCE_COLOR / CLICOLOR_FORCE:
+        // those are process-wide and would also colorize stdout (e.g.
         // `aube view --json > out.json` baking escapes into the file)
         // and propagate into lifecycle scripts.
         console::set_colors_enabled_stderr(true);
@@ -1021,6 +1022,13 @@ fn resolve_color_mode(cli: &Cli) -> ColorMode {
 /// on the list (Heroku build, Netlify, AWS CodeBuild, generic `CI=true`
 /// from a script that captures stderr to a log file, …) keeps the
 /// default no-color behavior to avoid baking escapes into log artifacts.
+///
+/// Deliberately narrower than `is_ci::cached()` (used elsewhere to pick
+/// the CI heartbeat over the animated TTY bar): "are we in CI?" is a
+/// broader question than "does this CI render ANSI?", and forcing
+/// color on a runner that captures stderr to a plain log file is worse
+/// than leaving it off. New entries here should be vendors whose web
+/// log viewer is documented to render ANSI; expand as confirmed.
 fn ci_renders_ansi() -> bool {
     use ci_info::types::Vendor;
     matches!(
@@ -1034,8 +1042,21 @@ fn ci_renders_ansi() -> bool {
                 | Vendor::Drone
                 | Vendor::AppVeyor
                 | Vendor::AzurePipelines
+                | Vendor::BitbucketPipelines
+                | Vendor::TeamCity
+                | Vendor::WoodpeckerCI
         )
     )
+}
+
+/// True when the user has asked for no color via the cross-tool
+/// conventions (https://no-color.org/, the CLICOLOR convention). Lets
+/// the CI auto-color branch back off without disturbing the explicit
+/// `--color` / `color=always` paths, which already win earlier in
+/// `resolve_color_mode`.
+fn env_disables_color() -> bool {
+    std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty())
+        || std::env::var_os("CLICOLOR").is_some_and(|v| v == "0")
 }
 
 fn startup_cwd(cli: &Cli) -> miette::Result<PathBuf> {

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -533,6 +533,17 @@ fn main() -> miette::Result<()> {
             std::env::set_var("CLICOLOR_FORCE", "1");
             std::env::remove_var("NO_COLOR");
         }
+    } else if is_ci::cached() {
+        // Auto + CI: most modern runners (GitHub Actions, GitLab,
+        // Buildkite, CircleCI, …) render ANSI in their log viewers, but
+        // their stderr isn't a TTY so console/clx default to plain
+        // text. Flip color on for stderr only via console's per-stream
+        // override — that's the stream the install progress heartbeat
+        // writes to. Deliberately *not* setting FORCE_COLOR /
+        // CLICOLOR_FORCE: those are process-wide and would also
+        // colorize stdout (e.g. `aube view --json > out.json` baking
+        // escapes into the file) and propagate into lifecycle scripts.
+        console::set_colors_enabled_stderr(true);
     }
 
     // `--use-stderr` / `.npmrc` `useStderr=true`: redirect stdout to stderr
@@ -996,23 +1007,13 @@ fn resolve_color_mode(cli: &Cli) -> ColorMode {
     {
         return mode;
     }
-    if let Ok(cwd) = startup_cwd(cli) {
-        let npmrc = aube_registry::config::load_npmrc_entries(&cwd);
-        if let Some(mode) = aube_settings::values::string_from_npmrc("color", &npmrc)
-            .and_then(|raw| parse_color_mode(&raw))
-        {
-            return mode;
-        }
-    }
-    // Force color when running on a CI that renders ANSI in its log
-    // viewer (GitHub Actions, GitLab, Buildkite, CircleCI, …) — without
-    // this the install progress UI ships a plain non-TTY heartbeat
-    // because clx and miette both fall back to no-color when stderr
-    // isn't a real terminal.
-    if is_ci::cached() {
-        return ColorMode::Always;
-    }
-    ColorMode::Auto
+    let Ok(cwd) = startup_cwd(cli) else {
+        return ColorMode::Auto;
+    };
+    let npmrc = aube_registry::config::load_npmrc_entries(&cwd);
+    aube_settings::values::string_from_npmrc("color", &npmrc)
+        .and_then(|raw| parse_color_mode(&raw))
+        .unwrap_or(ColorMode::Auto)
 }
 
 fn startup_cwd(cli: &Cli) -> miette::Result<PathBuf> {

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -1022,17 +1022,20 @@ fn resolve_color_mode(cli: &Cli) -> ColorMode {
 /// from a script that captures stderr to a log file, …) keeps the
 /// default no-color behavior to avoid baking escapes into log artifacts.
 fn ci_renders_ansi() -> bool {
-    [
-        "GITHUB_ACTIONS",
-        "GITLAB_CI",
-        "BUILDKITE",
-        "CIRCLECI",
-        "TRAVIS",
-        "DRONE",
-        "APPVEYOR",
-    ]
-    .iter()
-    .any(|var| std::env::var_os(var).is_some_and(|v| !v.is_empty() && v != "false" && v != "0"))
+    use ci_info::types::Vendor;
+    matches!(
+        ci_info::get().vendor,
+        Some(
+            Vendor::GitHubActions
+                | Vendor::GitLabCI
+                | Vendor::Buildkite
+                | Vendor::CircleCI
+                | Vendor::TravisCI
+                | Vendor::Drone
+                | Vendor::AppVeyor
+                | Vendor::AzurePipelines
+        )
+    )
 }
 
 fn startup_cwd(cli: &Cli) -> miette::Result<PathBuf> {

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -996,13 +996,23 @@ fn resolve_color_mode(cli: &Cli) -> ColorMode {
     {
         return mode;
     }
-    let Ok(cwd) = startup_cwd(cli) else {
-        return ColorMode::Auto;
-    };
-    let npmrc = aube_registry::config::load_npmrc_entries(&cwd);
-    aube_settings::values::string_from_npmrc("color", &npmrc)
-        .and_then(|raw| parse_color_mode(&raw))
-        .unwrap_or(ColorMode::Auto)
+    if let Ok(cwd) = startup_cwd(cli) {
+        let npmrc = aube_registry::config::load_npmrc_entries(&cwd);
+        if let Some(mode) = aube_settings::values::string_from_npmrc("color", &npmrc)
+            .and_then(|raw| parse_color_mode(&raw))
+        {
+            return mode;
+        }
+    }
+    // Force color when running on a CI that renders ANSI in its log
+    // viewer (GitHub Actions, GitLab, Buildkite, CircleCI, …) — without
+    // this the install progress UI ships a plain non-TTY heartbeat
+    // because clx and miette both fall back to no-color when stderr
+    // isn't a real terminal.
+    if is_ci::cached() {
+        return ColorMode::Always;
+    }
+    ColorMode::Auto
 }
 
 fn startup_cwd(cli: &Cli) -> miette::Result<PathBuf> {

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -533,16 +533,15 @@ fn main() -> miette::Result<()> {
             std::env::set_var("CLICOLOR_FORCE", "1");
             std::env::remove_var("NO_COLOR");
         }
-    } else if is_ci::cached() {
-        // Auto + CI: most modern runners (GitHub Actions, GitLab,
-        // Buildkite, CircleCI, …) render ANSI in their log viewers, but
-        // their stderr isn't a TTY so console/clx default to plain
-        // text. Flip color on for stderr only via console's per-stream
-        // override — that's the stream the install progress heartbeat
-        // writes to. Deliberately *not* setting FORCE_COLOR /
-        // CLICOLOR_FORCE: those are process-wide and would also
-        // colorize stdout (e.g. `aube view --json > out.json` baking
-        // escapes into the file) and propagate into lifecycle scripts.
+    } else if ci_renders_ansi() {
+        // Auto + a CI runner whose log viewer renders ANSI: stderr
+        // isn't a TTY so console/clx would default to plain text. Flip
+        // color on for stderr only via console's per-stream override —
+        // that's the stream the install progress heartbeat writes to.
+        // Deliberately *not* setting FORCE_COLOR / CLICOLOR_FORCE: those
+        // are process-wide and would also colorize stdout (e.g.
+        // `aube view --json > out.json` baking escapes into the file)
+        // and propagate into lifecycle scripts.
         console::set_colors_enabled_stderr(true);
     }
 
@@ -1014,6 +1013,26 @@ fn resolve_color_mode(cli: &Cli) -> ColorMode {
     aube_settings::values::string_from_npmrc("color", &npmrc)
         .and_then(|raw| parse_color_mode(&raw))
         .unwrap_or(ColorMode::Auto)
+}
+
+/// Conservative allowlist of CI vendors whose log viewers are known to
+/// render ANSI escape sequences. We force color on stderr for these so
+/// the install progress UI keeps its styling under CI; everything not
+/// on the list (Heroku build, Netlify, AWS CodeBuild, generic `CI=true`
+/// from a script that captures stderr to a log file, …) keeps the
+/// default no-color behavior to avoid baking escapes into log artifacts.
+fn ci_renders_ansi() -> bool {
+    [
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "BUILDKITE",
+        "CIRCLECI",
+        "TRAVIS",
+        "DRONE",
+        "APPVEYOR",
+    ]
+    .iter()
+    .any(|var| std::env::var_os(var).is_some_and(|v| !v.is_empty() && v != "false" && v != "0"))
 }
 
 fn startup_cwd(cli: &Cli) -> miette::Result<PathBuf> {


### PR DESCRIPTION
## Summary

`aube install` (and any other command using the `clx::progress` UI) was shipping plain, uncolored output on CI runners like GitHub Actions, GitLab, Buildkite, and CircleCI even though their log viewers render ANSI just fine. The progress code path uses `clx::style::e*`, which delegates to `console::colors_enabled_stderr()` — and that returns `false` whenever stderr isn't a TTY (which it never is on a CI runner). The result: the colored magenta header / green status the user sees locally collapsed to plain text in CI logs.

The fix is in `resolve_color_mode`'s Auto branch in [crates/aube/src/main.rs](crates/aube/src/main.rs): when `is_ci::cached()` is true and the user hasn't explicitly pinned a color mode, call `console::set_colors_enabled_stderr(true)` so console/clx emit ANSI on stderr regardless of TTY status.

## Why per-stream and not `FORCE_COLOR`

The first cut of this used `ColorMode::Always`, which goes through the existing `FORCE_COLOR=1` / `CLICOLOR_FORCE=1` env-var plumbing. That's process-wide and has two unwanted side effects:

1. It also colorizes **stdout**, so things like `aube view --json > out.json` running in CI would bake ANSI escape codes into the file.
2. It propagates to lifecycle scripts via the environment, changing third-party child-process behavior.

Using `console::set_colors_enabled_stderr(true)` confines the override to a single process-internal flag on the stream we actually care about. `console::colors_enabled()` (stdout) is untouched, no env vars are mutated, and child processes inherit the same environment they would have without this change.

`is_ci` was already in the dep tree (it's also what `supports-color` itself delegates to for vendor detection), so no new dependency.

Explicit opt-outs (`--no-color`, `--color`, `NO_COLOR`, `color=…` in env or `.npmrc`) all continue to win because they're checked before the CI auto-branch fires.

## Test plan

- [x] `cargo build -p aube` clean
- [x] `cargo clippy -p aube --all-targets -- -D warnings` clean
- [x] Smoke test: pipe stderr without `CI` set → plain text (`a u b e ...`)
- [x] Smoke test: pipe stderr with `CI=true` → starts with `\e[35m\e[1m` (magenta+bold install header), `\e[32m` (green status)
- [x] Smoke test: `CI=true aube view is-odd --json | head -1` → plain `{`, no escapes baked in
- [ ] Eyeball the colored heartbeat in a real GitHub Actions run after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI output coloring behavior, gated behind `ColorMode::Auto` plus a CI vendor allowlist and honoring `NO_COLOR`/`CLICOLOR=0`. Primary risk is unexpected ANSI escapes in some CI log pipelines if vendor detection is wrong.
> 
> **Overview**
> Improves CI log readability by **enabling ANSI colors on stderr** (without requiring a TTY) when `--color/--no-color` aren’t set and the runner is a known ANSI-capable CI.
> 
> Adds `ci_info` and a conservative vendor allowlist (`ci_renders_ansi`) plus an opt-out check (`env_disables_color`), and uses `console::set_colors_enabled_stderr(true)` to avoid forcing color on stdout or propagating `FORCE_COLOR` to child processes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07fc6255d71b91de44de73291c2b3bdd169e9dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->