### PR TITLE
chore: release v1.0.0-beta.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "miette",
  "serde",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "base64",
  "blake3",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ strip = "debuginfo"
 panic = "abort"
 
 [workspace.package]
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -91,13 +91,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.8" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.8" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.8" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.8" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.8" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.8" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.8" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.8" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.8" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.8" }
+aube = { path = "crates/aube", version = "1.0.0-beta.9" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.9" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.9" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.9" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.9" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.9" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.9" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.9" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.9" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.9" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.8"
+version "1.0.0-beta.9"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.8...aube-linker-v1.0.0-beta.9) - 2026-04-20
+
+### Other
+
+- reject path-traversing bin names and targets ([#162](https://github.com/endevco/aube/pull/162))
+- create scoped bin shim parents ([#149](https://github.com/endevco/aube/pull/149))
+
 ## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.6...aube-linker-v1.0.0-beta.7) - 2026-04-19
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.8...aube-manifest-v1.0.0-beta.9) - 2026-04-20
+
+### Other
+
+- render package.json parse errors with miette source span ([#157](https://github.com/endevco/aube/pull/157))
+- tolerate non-string entries in scripts map ([#155](https://github.com/endevco/aube/pull/155))
+- short-circuit warm path when install-state matches ([#127](https://github.com/endevco/aube/pull/127))
+- tolerate string engines metadata ([#150](https://github.com/endevco/aube/pull/150))
+
 ## [1.0.0-beta.8](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.7...aube-manifest-v1.0.0-beta.8) - 2026-04-20
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.8...aube-registry-v1.0.0-beta.9) - 2026-04-20
+
+### Other
+
+- short-circuit warm path when install-state matches ([#127](https://github.com/endevco/aube/pull/127))
+- tolerate string engines metadata ([#150](https://github.com/endevco/aube/pull/150))
+
 ## [1.0.0-beta.8](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.7...aube-registry-v1.0.0-beta.8) - 2026-04-20
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.8...aube-resolver-v1.0.0-beta.9) - 2026-04-20
+
+### Other
+
+- silence peer-dep mismatches by default (bun parity) ([#158](https://github.com/endevco/aube/pull/158))
+
 ## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.6...aube-resolver-v1.0.0-beta.7) - 2026-04-19
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.8...aube-settings-v1.0.0-beta.9) - 2026-04-20
+
+### Other
+
+- *(settings)* collapse per-source pages into single reference ([#159](https://github.com/endevco/aube/pull/159))
+- silence peer-dep mismatches by default (bun parity) ([#158](https://github.com/endevco/aube/pull/158))
+
 ## [1.0.0-beta.8](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.7...aube-settings-v1.0.0-beta.8) - 2026-04-20
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.8...aube-workspace-v1.0.0-beta.9) - 2026-04-20
+
+### Other
+
+- render package.json parse errors with miette source span ([#157](https://github.com/endevco/aube/pull/157))
+
 ## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.6...aube-workspace-v1.0.0-beta.7) - 2026-04-19
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.9](https://github.com/endevco/aube/compare/v1.0.0-beta.8...v1.0.0-beta.9) - 2026-04-20
+
+### Other
+
+- reject path-traversing bin names and targets ([#162](https://github.com/endevco/aube/pull/162))
+- wipe node_modules when global virtual store toggles ([#160](https://github.com/endevco/aube/pull/160))
+- render package.json parse errors with miette source span ([#157](https://github.com/endevco/aube/pull/157))
+- *(config)* add --local shortcut for --location project ([#161](https://github.com/endevco/aube/pull/161))
+- silence peer-dep mismatches by default (bun parity) ([#158](https://github.com/endevco/aube/pull/158))
+- *(troubleshooting)* lead with disable-gvs as first step ([#156](https://github.com/endevco/aube/pull/156))
+- short-circuit warm path when install-state matches ([#127](https://github.com/endevco/aube/pull/127))
+- create scoped bin shim parents ([#149](https://github.com/endevco/aube/pull/149))
+- emit colored stderr under CI even when not a TTY ([#146](https://github.com/endevco/aube/pull/146))
+
 ## [1.0.0-beta.8](https://github.com/endevco/aube/compare/v1.0.0-beta.7...v1.0.0-beta.8) - 2026-04-20
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5681,7 +5681,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.8
+**Version**: 1.0.0-beta.9
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.8",
-  "releasedAt": "2026-04-20T02:36:51Z"
+  "version": "1.0.0-beta.9",
+  "releasedAt": "2026-04-20T15:24:06Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.9`

This PR bumps the workspace to `v1.0.0-beta.9` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR is a release metadata bump (versions, lockfile, generated CLI docs, and changelogs) with no functional code changes.
> 
> **Overview**
> Bumps the workspace and all internal `aube-*` crates from `1.0.0-beta.8` to `1.0.0-beta.9`, updating `Cargo.toml` and `Cargo.lock` accordingly.
> 
> Regenerates release artifacts: per-crate `CHANGELOG.md` entries for `beta.9`, the `aube.usage.kdl` spec, generated CLI docs (`docs/cli/*`) version string, and `release.json` timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c389bf86352c8618364788909d504d1bee799231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->