### PR TITLE
registry: tolerate string engines metadata

### DIFF
--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -6,8 +6,9 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-/// Deserialize `engines` tolerant to the pre-npm-2.x legacy array
-/// form, e.g. `extsprintf@1.4.1` ships `"engines": ["node >=0.6.0"]`.
+/// Deserialize `engines` tolerant to legacy non-map forms, e.g.
+/// `extsprintf@1.4.1` ships `"engines": ["node >=0.6.0"]` and some
+/// old packument entries (such as `qs`) ship a bare string.
 /// Modern npm ignores that shape (engine-strict only consults the map
 /// form), so normalize to an empty map rather than failing the whole
 /// manifest — a hard error there takes down every install that touches
@@ -27,7 +28,10 @@ where
 {
     let value: Option<serde_json::Value> = Option::deserialize(de)?;
     Ok(match value {
-        None | Some(serde_json::Value::Null) | Some(serde_json::Value::Array(_)) => BTreeMap::new(),
+        None
+        | Some(serde_json::Value::Null)
+        | Some(serde_json::Value::Array(_))
+        | Some(serde_json::Value::String(_)) => BTreeMap::new(),
         Some(serde_json::Value::Object(m)) => m
             .into_iter()
             .filter_map(|(k, v)| match v {
@@ -36,12 +40,11 @@ where
             })
             .collect(),
         Some(other) => {
-            // Null / Array / Object are handled above, so `other` can
-            // only be a scalar here.
+            // Null / Array / String / Object are handled above, so
+            // `other` can only be another scalar here.
             return Err(serde::de::Error::custom(format!(
                 "engines: expected a map, got {}",
                 match other {
-                    serde_json::Value::String(_) => "string",
                     serde_json::Value::Number(_) => "number",
                     serde_json::Value::Bool(_) => "boolean",
                     _ => unreachable!("engines: unexpected value variant"),
@@ -668,6 +671,15 @@ mod tests {
     #[test]
     fn engines_legacy_array_form_parses_as_empty_map() {
         let p = parse(r#"{"name":"x","engines":["node >=0.6.0"]}"#);
+        assert!(p.engines.is_empty());
+    }
+
+    /// Some old npm packument entries (e.g. `qs`) ship `engines` as a
+    /// bare string. There is no reliable key to preserve, so treat it
+    /// like the legacy array form and ignore it.
+    #[test]
+    fn engines_legacy_string_form_parses_as_empty_map() {
+        let p = parse(r#"{"name":"x","engines":"node >=0.6.0"}"#);
         assert!(p.engines.is_empty());
     }
 

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -584,16 +584,22 @@ mod tests {
     }
 
     /// Pre-npm-2.x publishes (e.g. `madge@0.0.1`, `html-entities@1.x`)
-    /// ship `"engines": ["node >= 0.8.0"]` as an array, and npmjs.org
-    /// serves that shape verbatim in the packument. A strict map-only
-    /// deserializer fails the whole packument parse with
-    /// `invalid type: sequence, expected a map`, blocking install of
-    /// any range that even lists an affected version. Normalize the
-    /// array to an empty map — same tolerance the manifest and
+    /// ship `"engines": ["node >= 0.8.0"]` as an array, and some old
+    /// entries (e.g. `qs`) ship a bare string. npmjs.org serves those
+    /// shapes verbatim in packuments. A strict map-only deserializer
+    /// fails the whole packument parse, blocking install of any range
+    /// that even lists an affected version. Normalize legacy non-map
+    /// forms to an empty map — same tolerance the manifest and
     /// lockfile parsers already apply.
     #[test]
     fn engines_accepts_legacy_array_shape() {
         let v = parse(r#"{"name":"madge","version":"0.0.1","engines":["node >= 0.8.0"]}"#);
+        assert!(v.engines.is_empty());
+    }
+
+    #[test]
+    fn engines_accepts_legacy_string_shape() {
+        let v = parse(r#"{"name":"qs","version":"0.6.0","engines":"node >= 0.4.0"}"#);
         assert!(v.engines.is_empty());
     }
 


### PR DESCRIPTION
## Summary

Treat bare string `engines` metadata as a legacy non-map shape and normalize it to an empty map instead of failing packument parsing.

This fixes dependency resolution failures like:

```text
registry error for qs: I/O error: engines: expected a map, got string
```

## Root Cause

`engines_tolerant` already accepted missing, null, array, and object forms, but string values still returned a hard deserialization error. Some old npm packument entries, including `qs`, contain `engines` as a bare string. Since there is no reliable key to preserve from that form, this follows the existing legacy-array behavior and ignores it.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-manifest`
- `cargo test -p aube-registry`
- `cargo test -p aube`
- Reproduced with a throwaway project depending on `qs`; `aube install` now resolves and installs successfully.

_Written with Claude._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only relaxes deserialization of `engines` to ignore legacy string values, with added tests to prevent regressions.
> 
> **Overview**
> Updates `aube_manifest::engines_tolerant` to also treat a bare string `engines` field as a legacy non-map shape and normalize it to an empty map instead of erroring.
> 
> Adds regression tests in `aube-manifest` and `aube-registry` to ensure packument/manifest parsing succeeds for both legacy array and legacy string `engines` forms while preserving modern map behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b91c80018291f837676a15a2c58629aa2069c5e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->