### PR TITLE
docs(home): remove beta warning

### DIFF
--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -279,14 +279,6 @@ watch(progressBarEl, (el, previousEl) => {
       </div>
 
       <div class="aube-stage" aria-label="Aube install preview">
-        <div class="aube-beta-note" role="note">
-          <span class="aube-beta-mark" aria-hidden="true">!</span>
-          <strong>Beta software.</strong>
-          <span>
-            Aube should have <a href="/pnpm-users">feature parity with pnpm</a>,
-            but it has not been tested in many projects yet. There will be bugs.
-          </span>
-        </div>
         <div class="aube-terminal" aria-label="Interactive install output">
           <div class="aube-terminal-bar">
             <span></span>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -334,57 +334,6 @@ body {
   max-width: 520px;
 }
 
-.aube-beta-note {
-  background: oklch(0.24 0.04 45 / 0.55);
-  border: 1px solid oklch(0.58 0.12 55 / 0.5);
-  border-radius: 8px;
-  box-sizing: border-box;
-  color: var(--aube-muted);
-}
-
-.aube-beta-note strong {
-  color: var(--aube-accent-2);
-  font-weight: 600;
-}
-
-.aube-beta-note {
-  display: grid;
-  gap: 4px 12px;
-  grid-template-columns: 28px minmax(0, 1fr);
-  line-height: 1.45;
-  margin: 0;
-  max-width: 560px;
-  padding: 14px 16px;
-  position: relative;
-  width: 100%;
-  z-index: 3;
-}
-
-.aube-beta-note span {
-  font-size: 14px;
-}
-
-.aube-beta-note a {
-  color: var(--aube-accent-2);
-  text-decoration-color: oklch(0.72 0.13 72 / 0.55);
-  text-underline-offset: 3px;
-}
-
-.aube-beta-mark {
-  align-items: center;
-  background: var(--aube-accent);
-  border-radius: 6px;
-  color: var(--aube-accent-ink);
-  display: inline-flex;
-  font-family: var(--aube-mono);
-  font-size: 14px !important;
-  font-weight: 700;
-  grid-row: span 2;
-  height: 28px;
-  justify-content: center;
-  width: 28px;
-}
-
 .custom-block {
   --aube-block-accent: var(--aube-muted);
   --aube-block-bg: oklch(0.24 0.018 45 / 0.55);
@@ -725,7 +674,6 @@ body {
 }
 
 .aube-stage {
-  min-height: 430px;
   min-width: 0;
   position: relative;
 }
@@ -738,17 +686,14 @@ body {
     0 1px 0 oklch(0.35 0.012 40 / 0.4) inset,
     0 40px 80px -30px oklch(0 0 0 / 0.6),
     0 0 0 1px oklch(0.28 0.012 40 / 0.4);
-  left: 0;
   overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 126px;
+  position: relative;
   z-index: 2;
 }
 
 @media (min-width: 961px) {
   .aube-terminal {
-    right: -28px;
+    margin-right: -28px;
   }
 }
 
@@ -1306,10 +1251,6 @@ body {
     font-size: 70px;
   }
 
-  .aube-stage {
-    min-height: 440px;
-  }
-
   .aube-proof {
     grid-template-columns: 1fr;
   }
@@ -1382,14 +1323,6 @@ body {
   .aube-stat-tip:hover [role="tooltip"],
   .aube-stat-tip:focus-within [role="tooltip"] {
     transform: translateY(0);
-  }
-
-  .aube-stage {
-    min-height: 500px;
-  }
-
-  .aube-terminal {
-    top: 146px;
   }
 
   .aube-clx {


### PR DESCRIPTION
## Summary

Remove the beta warning callout from the landing page hero and delete the now-unused styles that supported it.

Aube is still in beta, but it should be stable enough for the homepage to invite users to try it without warning language that scares them away.

## Validation

- `npm run docs:build` from `docs/`

_Written with Claude._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only markup/CSS changes; main risk is minor visual/layout regressions on different breakpoints.
> 
> **Overview**
> Removes the *beta software* warning callout from the landing page hero (`HomeLanding.vue`).
> 
> Cleans up now-unused styles in `custom.css` and slightly adjusts the hero install-preview layout by dropping fixed `min-height`/absolute positioning and using relative positioning with a desktop-only negative right margin for the terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 894d90d0f8d1cd2d2876a9d52866930897935fd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->