### PR TITLE
publish: tag 1.0 betas as latest on npm

### DIFF
--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -63,6 +63,10 @@ function versionFromTag(tag) {
 }
 
 function defaultNpmTag(version) {
+    // During the 1.0.0 beta series, npm is still one of the documented
+    // install paths, so `npm install -g @endevco/aube` should track the
+    // current beta. Future prerelease trains can use `next` again.
+    if (version.startsWith('1.0.0-')) return 'latest';
     return version.includes('-') ? 'next' : 'latest';
 }
 


### PR DESCRIPTION
## Summary

- publish `1.0.0-*` prereleases to the npm `latest` dist-tag
- keep later prerelease trains on `next`

## Why

The README documents `npm install -g @endevco/aube` as an install path while Aube is still in the 1.0 beta series. The current generic prerelease behavior publishes betas to `next`, leaving `latest` stuck on an older beta. That causes consumers and external benchmarks that follow the documented npm command to install stale bits.

This keeps the exception narrow: only `1.0.0-*` uses `latest`; future prereleases such as `1.1.0-beta.1` continue to use `next`.

## Validation

Ran a local behavior check for the default tag helper:

- `1.0.0-beta.8` -> `latest`
- `1.0.0-rc.1` -> `latest`
- `1.0.0` -> `latest`
- `1.1.0-beta.1` -> `next`
- `2.0.0-alpha.1` -> `next`
- `1.1.0` -> `latest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to release tagging logic that only affects which npm dist-tag is used during publishing. Main risk is accidental mis-tagging of prereleases, impacting which version users install.
> 
> **Overview**
> Updates npm publish tagging so `1.0.0-*` prereleases are published under the `latest` dist-tag (to keep `npm install -g @endevco/aube` tracking the current 1.0 beta), while other prereleases continue to default to `next`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e92760a4818753762da955a412b2a5ffe20e304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->