### PR TITLE
ci: tune autofix and cargo meta checks

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          shared-key: autofix
+          shared-key: test-linux
+          save-if: false
       - run: "mise run render ::: lint-fix"
       - uses: autofix-ci/action@7a166d7532b277f34e16238930461bf77f9d7ed8 # v1.3.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,30 +65,12 @@ jobs:
         with:
           shared-key: test-linux
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-      # cargo-msrv and cargo-machete (both needed by `hk check --all`)
-      # are declared in mise.toml with the `cargo:` backend. Since
-      # cargo-binstall is also declared there, mise-action fetches
-      # prebuilt binaries rather than compiling from source — no extra
-      # step needed here.
       - run: mise run test
       - run: mise run lint
+      - run: cargo-machete
+      - run: cargo msrv --manifest-path crates/aube/Cargo.toml verify --output-format minimal
       - run: mise run render
       - run: mise run docs:build
-
-  # macOS build+test mirror. Upload the binary so the macos BATS shards
-  # can consume it via download-artifact rather than rebuilding.
-  test-macos:
-    runs-on: macos-latest
-    timeout-minutes: 30
-    env:
-      RUSTFLAGS: "-D warnings"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: test-macos
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-      - run: mise run test
 
   # BATS integration shards. Linux runs 4 shards (matches Buildkite),
   # macOS runs 2 (GitHub-hosted macOS runners are slower + fewer cores).
@@ -192,7 +174,6 @@ jobs:
     needs:
       - build
       - test-linux
-      - test-macos
       - bats
       - bats-serial
       - windows

--- a/hk.pkl
+++ b/hk.pkl
@@ -24,14 +24,6 @@ local linters = new Mapping<String, Step> {
         glob = "*.pkl"
         check = "pkl eval {{files}} >/dev/null"
     }
-    ["cargo-machete"] {
-        glob = List("**/Cargo.toml")
-        check = "cargo-machete"
-    }
-    ["cargo-msrv"] {
-        glob = List("**/Cargo.toml")
-        check = "cargo msrv --manifest-path crates/aube/Cargo.toml verify --output-format minimal"
-    }
 }
 
 fail_fast = false


### PR DESCRIPTION
## Summary

Remove the `cargo-machete` and `cargo-msrv` steps from `hk.pkl` so local `hk check` and autofix lint runs do not invoke slower Cargo metadata checks as part of the generic hook set.

Keep both checks enforced in CI by running `cargo-machete` and `cargo msrv --manifest-path crates/aube/Cargo.toml verify --output-format minimal` explicitly in the Linux test job after `mise run lint`.

Have `autofix.ci` restore from the Linux `test-linux` Rust cache while setting `save-if: false` so autofix never writes that cache.

Remove the standalone `test-macos` job from CI. The macOS build artifact and macOS BATS shards remain covered by the existing `build` and `bats` jobs.

## Validation

- `pkl eval hk.pkl >/dev/null`
- `actionlint .github/workflows/autofix.yml .github/workflows/ci.yml`

_Written with Claude._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes (including removing the macOS test job) could reduce platform coverage and lead to missed regressions or unexpected workflow failures; runtime code is untouched.
> 
> **Overview**
> Moves `cargo-machete` and `cargo msrv` out of `hk.pkl`’s generic linter set, so local `hk`/autofix hook runs no longer pay the cost of Cargo metadata verification.
> 
> Updates CI to keep these checks enforced by running `cargo-machete` and `cargo msrv ... verify` explicitly in `test-linux`, and adjusts the autofix workflow to restore from the `test-linux` Rust cache while disabling cache writes (`save-if: false`). Also removes the standalone `test-macos` job and drops it from the `final` aggregator’s required needs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5534a0283fbf2d6db8a24ac7f8da98bb5f887d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->