### PR TITLE
manifest: tolerate non-string entries in scripts map

### DIFF
--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -54,6 +54,31 @@ where
     })
 }
 
+/// Deserialize `scripts` tolerant to non-string values. `firefox-profile`
+/// (and a handful of other legacy packages) ships junk like
+/// `"scripts": { "blanket": { "pattern": [...] } }` — tool-specific
+/// config that npm's CLI treats as "not a runnable script" and ignores.
+/// A strict `Record<string, string>` deserialization trips on the object
+/// entry and fails the whole install. Drop non-string entries so the
+/// real scripts still round-trip.
+pub fn scripts_tolerant<'de, D>(de: D) -> Result<BTreeMap<String, String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: Option<serde_json::Value> = Option::deserialize(de)?;
+    Ok(match value {
+        None | Some(serde_json::Value::Null) => BTreeMap::new(),
+        Some(serde_json::Value::Object(m)) => m
+            .into_iter()
+            .filter_map(|(k, v)| match v {
+                serde_json::Value::String(s) => Some((k, s)),
+                _ => None,
+            })
+            .collect(),
+        Some(_) => BTreeMap::new(),
+    })
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateConfig {
@@ -89,7 +114,11 @@ pub struct PackageJson {
         skip_serializing_if = "Option::is_none"
     )]
     pub bundled_dependencies: Option<BundledDependencies>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "scripts_tolerant",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     pub scripts: BTreeMap<String, String>,
     /// `engines` field — declared runtime version constraints, e.g.
     /// `{"node": ">=18.0.0"}`. Checked against the current runtime during
@@ -710,6 +739,43 @@ mod tests {
         assert_eq!(p.engines.get("node").unwrap(), ">=18");
         assert!(!p.engines.contains_key("weird"));
         assert!(!p.engines.contains_key("n"));
+    }
+
+    /// `firefox-profile@4.7.0` (and other legacy packages) ship tool
+    /// config nested under `scripts`, e.g. `scripts.blanket = {...}`.
+    /// npm ignores non-string entries instead of failing the install,
+    /// and so do we — drop them and keep the real scripts.
+    #[test]
+    fn scripts_non_string_entries_are_dropped() {
+        let p = parse(
+            r#"{
+                "name":"firefox-profile",
+                "scripts": {
+                    "test": "grunt travis",
+                    "blanket": { "pattern": ["/lib/firefox_profile"] }
+                }
+            }"#,
+        );
+        assert_eq!(
+            p.scripts.get("test").map(String::as_str),
+            Some("grunt travis")
+        );
+        assert!(!p.scripts.contains_key("blanket"));
+    }
+
+    #[test]
+    fn scripts_null_is_treated_as_empty() {
+        let p = parse(r#"{"name":"x","scripts":null}"#);
+        assert!(p.scripts.is_empty());
+    }
+
+    #[test]
+    fn scripts_non_object_value_is_treated_as_empty() {
+        // Mirrors `engines_tolerant`'s legacy-shape handling: if the
+        // field exists but isn't a map, treat it as absent rather than
+        // failing the parse.
+        let p = parse(r#"{"name":"x","scripts":"oops"}"#);
+        assert!(p.scripts.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`firefox-profile@4.7.0` ships:

```json
"scripts": {
  "test": "grunt travis",
  "blanket": { "pattern": ["/lib/firefox_profile"] }
}
```

The `blanket` entry is legacy tool config — npm's CLI treats non-string values as "not a runnable script" and ignores them. Our strict `Record<string, string>` deserialization was failing the whole install with `invalid type: map, expected a string at line 12 column 15`.

This mirrors the existing `engines_tolerant` pattern: accept the field, drop non-string entries, keep the real scripts.

## Test plan

- [x] `cargo test -p aube-manifest` — 3 new `scripts_*` tests pass alongside the existing 43
- [x] `cargo clippy -p aube-manifest --all-targets -- -D warnings` clean
- [ ] Install a project that depends on `firefox-profile` and confirm it completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to manifest deserialization and only broadens acceptance by dropping malformed `scripts` entries rather than erroring, with added tests covering edge cases.
> 
> **Overview**
> Updates `PackageJson.scripts` deserialization to use a new `scripts_tolerant` parser that **ignores non-string script values** (and treats `null`/non-object shapes as empty) to avoid failing installs on legacy packages.
> 
> Adds focused tests ensuring non-string `scripts` entries are dropped while valid string scripts still parse and round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c6aac3b65c1d53807c4d89fd3990514d6fffba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->