### PR TITLE
docs(troubleshooting): lead with disable-gvs as first step

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2065,9 +2065,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                  installs of this project just won't share materialized packages \
                  across projects. Fixing this requires an upstream change in \
                  `{name}` itself (please file it with that project, not aube). \
-                 To silence this warning, add `enableGlobalVirtualStore=false` to \
-                 .npmrc — or set `disableGlobalVirtualStoreForPackages=[]` to opt \
-                 out of this auto-detection entirely. \
+                 To silence this warning, run `aube config set \
+                 enableGlobalVirtualStore false --location project` — or set \
+                 `disableGlobalVirtualStoreForPackages=[]` to opt out of this \
+                 auto-detection entirely. \
                  Details: https://aube.en.dev/package-manager/node-modules#global-virtual-store"
             );
             Some(false)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,8 +21,13 @@ Symptoms that usually point here:
 - `ERR_INVALID_PACKAGE_TARGET` or exports-resolution failures for a
   package that resolves fine under pnpm/npm
 
-To make it stick for a project, add `enableGlobalVirtualStore=false` to
-`.npmrc`. See [Global virtual store](/package-manager/node-modules#global-virtual-store)
+To make it stick for a project:
+
+```sh
+aube config set enableGlobalVirtualStore false --location project
+```
+
+See [Global virtual store](/package-manager/node-modules#global-virtual-store)
 for what this changes.
 
 ## A package is missing from `node_modules`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,6 +9,18 @@ store off before digging further:
 aube install --disable-gvs
 ```
 
+Symptoms that usually point here:
+
+- `Symlink ... is invalid, it points out of the filesystem root`
+- `ENOENT: no such file or directory` for a module that clearly exists
+  under `node_modules/.aube/`
+- `Cannot find module '<pkg>'` from Next.js / Turbopack, Vite,
+  VitePress, Nuxt, or Parcel during dev or build
+- Plugin config discovery (PostCSS, Tailwind, Vite) silently misses a
+  config file that lives at the project root
+- `ERR_INVALID_PACKAGE_TARGET` or exports-resolution failures for a
+  package that resolves fine under pnpm/npm
+
 To make it stick for a project, add `enableGlobalVirtualStore=false` to
 `.npmrc`. See [Global virtual store](/package-manager/node-modules#global-virtual-store)
 for what this changes.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,11 +2,11 @@
 
 ## Try disabling the global virtual store first
 
-If an install or build is behaving oddly, retry with the global virtual
-store off before digging further:
+If an install or build is behaving oddly, turn the global virtual
+store off for the project before digging further:
 
 ```sh
-aube install --disable-gvs
+aube config set enableGlobalVirtualStore false --location project
 ```
 
 Symptoms that usually point here:
@@ -20,12 +20,6 @@ Symptoms that usually point here:
   config file that lives at the project root
 - `ERR_INVALID_PACKAGE_TARGET` or exports-resolution failures for a
   package that resolves fine under pnpm/npm
-
-To make it stick for a project:
-
-```sh
-aube config set enableGlobalVirtualStore false --location project
-```
 
 See [Global virtual store](/package-manager/node-modules#global-virtual-store)
 for what this changes.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,18 @@
 # Troubleshooting
 
+## Try disabling the global virtual store first
+
+If an install or build is behaving oddly, retry with the global virtual
+store off before digging further:
+
+```sh
+aube install --disable-gvs
+```
+
+To make it stick for a project, add `enableGlobalVirtualStore=false` to
+`.npmrc`. See [Global virtual store](/package-manager/node-modules#global-virtual-store)
+for what this changes.
+
 ## A package is missing from `node_modules`
 
 Run:


### PR DESCRIPTION
## Summary
- Add a top-of-page section to [docs/troubleshooting.md](docs/troubleshooting.md) telling users to try `aube install --disable-gvs` (or `enableGlobalVirtualStore=false` in `.npmrc`) before digging into more specific troubleshooting sections.
- Links out to the existing Global virtual store explainer for context on what the flag changes.

## Test plan
- [ ] Docs site renders the new section and the `/package-manager/node-modules#global-virtual-store` anchor link resolves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and warning-message text changes only; no behavior or data flow is modified.
> 
> **Overview**
> Updates the global-virtual-store incompatibility warning during `aube install` to recommend silencing it via `aube config set enableGlobalVirtualStore false --location project` (instead of editing `.npmrc`).
> 
> Adds a new top section to `docs/troubleshooting.md` that advises disabling the global virtual store as the first troubleshooting step, lists common failure symptoms, and links to the existing global virtual store docs for details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216540fd281c938140a3d3ea60376f9ee5c01ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->