### PR TITLE
manifest: render package.json parse errors with miette source span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ version = "1.0.0-beta.8"
 dependencies = [
  "aube-manifest",
  "glob",
+ "miette",
  "tempfile",
  "thiserror 2.0.18",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
 name = "aube-manifest"
 version = "1.0.0-beta.8"
 dependencies = [
+ "miette",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/aube-manifest/Cargo.toml
+++ b/crates/aube-manifest/Cargo.toml
@@ -10,6 +10,7 @@ homepage.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]
+miette = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -666,15 +666,30 @@ pub enum Error {
 /// JSON parse failure with enough info for `miette`'s `fancy` handler to
 /// render a pointer at the offending byte. Boxed into [`Error::Parse`] so
 /// the enum's `Err` size stays small (clippy's `result_large_err`).
-#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+///
+/// `Diagnostic` is implemented by hand rather than via `miette::Diagnostic`
+/// derive because `miette-derive` 7.6 expands into a destructuring that
+/// triggers `unused_assignments` under `RUSTFLAGS=-D warnings` on rustc
+/// 1.93 (our MSRV).
+#[derive(Debug, thiserror::Error)]
 #[error("failed to parse {path}: {message}")]
 pub struct ParseError {
     pub path: std::path::PathBuf,
     pub message: String,
-    #[source_code]
     pub src: miette::NamedSource<String>,
-    #[label("{message}")]
     pub span: miette::SourceSpan,
+}
+
+impl miette::Diagnostic for ParseError {
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.src)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        Some(Box::new(std::iter::once(
+            miette::LabeledSpan::new_with_span(Some(self.message.clone()), self.span),
+        )))
+    }
 }
 
 /// Parse a JSON document from `content`, returning an [`Error::Parse`] on

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -711,7 +711,14 @@ impl Error {
     /// source.
     pub fn parse(path: &Path, content: String, err: &serde_json::Error) -> Self {
         let offset = line_col_to_byte_offset(&content, err.line(), err.column());
-        let span = miette::SourceSpan::new(offset.into(), 1);
+        // Clamp the span length so it never extends past the content
+        // end. A trailing-newline-EOF error reports a position at or
+        // past `content.len()`; a fixed length of 1 would push the
+        // range one byte past the source and miette's renderer would
+        // fail to slice it. A zero-length span at `content.len()` is
+        // what miette expects for "end-of-input" labels.
+        let len = if offset >= content.len() { 0 } else { 1 };
+        let span = miette::SourceSpan::new(offset.into(), len);
         Error::Parse(Box::new(ParseError {
             path: path.to_path_buf(),
             message: err.to_string(),
@@ -830,6 +837,30 @@ mod tests {
     fn line_col_offset_no_trailing_newline() {
         let s = "a\nbc";
         assert_eq!(line_col_to_byte_offset(s, 2, 2), 3);
+    }
+
+    /// `serde_json` reports "EOF while parsing" with a position at or
+    /// past `content.len()` (e.g. `{"name":` → column 8 on a 8-byte
+    /// buffer). The span must never extend past the end of source or
+    /// `miette`'s renderer chokes trying to slice it — clamp the span
+    /// length to 0 at EOF.
+    #[test]
+    fn parse_error_eof_span_stays_in_bounds() {
+        let path = Path::new("pkg.json");
+        let content = r#"{"name":"#.to_string();
+        let json_err: serde_json::Error = serde_json::from_str::<serde_json::Value>(&content)
+            .expect_err("truncated JSON must fail");
+        let Error::Parse(pe) = Error::parse(path, content.clone(), &json_err) else {
+            panic!("Error::parse must produce Parse variant");
+        };
+        let offset: usize = pe.span.offset();
+        let len: usize = pe.span.len();
+        assert!(
+            offset + len <= content.len(),
+            "span [{offset}, {}) exceeds content.len() {}",
+            offset + len,
+            content.len()
+        );
     }
 
     #[test]

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -190,7 +190,14 @@ impl PackageJson {
     pub fn from_path(path: &Path) -> Result<Self, Error> {
         let content =
             std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
-        serde_json::from_str(&content).map_err(|e| Error::Parse(path.to_path_buf(), e))
+        Self::parse(path, content)
+    }
+
+    /// Parse an in-memory `package.json` string. On failure, produces a
+    /// [`Error::Parse`] with the source content and a span so `miette`'s
+    /// `fancy` handler renders a pointer at the offending byte.
+    pub fn parse(path: &Path, content: String) -> Result<Self, Error> {
+        parse_json(path, content)
     }
 
     /// Iterate over the `pnpm` and `aube` config objects in
@@ -645,14 +652,75 @@ fn push_unique_strs(dst: &mut Vec<String>, arr: &[serde_json::Value]) {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum Error {
     #[error("failed to read {0}: {1}")]
     Io(std::path::PathBuf, std::io::Error),
-    #[error("failed to parse {0}: {1}")]
-    Parse(std::path::PathBuf, serde_json::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Parse(Box<ParseError>),
     #[error("failed to parse {0}: {1}")]
     YamlParse(std::path::PathBuf, String),
+}
+
+/// JSON parse failure with enough info for `miette`'s `fancy` handler to
+/// render a pointer at the offending byte. Boxed into [`Error::Parse`] so
+/// the enum's `Err` size stays small (clippy's `result_large_err`).
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+#[error("failed to parse {path}: {message}")]
+pub struct ParseError {
+    pub path: std::path::PathBuf,
+    pub message: String,
+    #[source_code]
+    pub src: miette::NamedSource<String>,
+    #[label("{message}")]
+    pub span: miette::SourceSpan,
+}
+
+/// Parse a JSON document from `content`, returning an [`Error::Parse`] on
+/// failure with the source content + span attached so miette's fancy
+/// handler can render a pointer into the offending file.
+pub fn parse_json<T: serde::de::DeserializeOwned>(
+    path: &Path,
+    content: String,
+) -> Result<T, Error> {
+    match serde_json::from_str(&content) {
+        Ok(v) => Ok(v),
+        Err(e) => Err(Error::parse(path, content, &e)),
+    }
+}
+
+impl Error {
+    /// Build an [`Error::Parse`] from the offending content + serde error,
+    /// computing the byte offset so miette can render a pointer into the
+    /// source.
+    pub fn parse(path: &Path, content: String, err: &serde_json::Error) -> Self {
+        let offset = line_col_to_byte_offset(&content, err.line(), err.column());
+        let span = miette::SourceSpan::new(offset.into(), 1);
+        Error::Parse(Box::new(ParseError {
+            path: path.to_path_buf(),
+            message: err.to_string(),
+            src: miette::NamedSource::new(path.display().to_string(), content),
+            span,
+        }))
+    }
+}
+
+/// Convert serde_json's 1-based line/column into a byte offset into
+/// `content`. Out-of-range values clamp to the end so we never panic
+/// on a degenerate error position.
+fn line_col_to_byte_offset(content: &str, line: usize, column: usize) -> usize {
+    if line == 0 {
+        return 0;
+    }
+    let mut offset = 0usize;
+    for (i, l) in content.split_inclusive('\n').enumerate() {
+        if i + 1 == line {
+            return (offset + column.saturating_sub(1)).min(content.len());
+        }
+        offset += l.len();
+    }
+    content.len()
 }
 
 #[cfg(test)]

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -785,6 +785,53 @@ mod tests {
         assert!(p.engines.is_empty());
     }
 
+    /// Sanity-check the line/column → byte-offset conversion. An
+    /// off-by-one here silently slides miette's pointer to the wrong
+    /// byte, defeating the whole reason the source span exists.
+    #[test]
+    fn line_col_offset_single_line_col_one() {
+        assert_eq!(line_col_to_byte_offset("{}", 1, 1), 0);
+    }
+
+    #[test]
+    fn line_col_offset_multiline_line_two() {
+        // "a\nbc\n" — line 2, column 1 is the 'b' at byte 2.
+        assert_eq!(line_col_to_byte_offset("a\nbc\n", 2, 1), 2);
+        assert_eq!(line_col_to_byte_offset("a\nbc\n", 2, 2), 3);
+    }
+
+    /// `line == 0` can happen if serde_json hits EOF before any input;
+    /// treat as "beginning of file" rather than panic.
+    #[test]
+    fn line_col_offset_line_zero_returns_zero() {
+        assert_eq!(line_col_to_byte_offset("any", 0, 5), 0);
+    }
+
+    /// A column past the end of its line (or past EOF) clamps to the
+    /// last valid offset so we never build a SourceSpan that would
+    /// crash miette's renderer.
+    #[test]
+    fn line_col_offset_column_past_end_clamps() {
+        let s = "ab";
+        assert_eq!(line_col_to_byte_offset(s, 1, 999), s.len());
+    }
+
+    /// A line past the last line falls through the loop and clamps to
+    /// the file end.
+    #[test]
+    fn line_col_offset_line_past_end_clamps() {
+        let s = "a\nb";
+        assert_eq!(line_col_to_byte_offset(s, 10, 1), s.len());
+    }
+
+    /// A file whose last line has no trailing `\n` is the common case;
+    /// make sure columns on that final line still resolve correctly.
+    #[test]
+    fn line_col_offset_no_trailing_newline() {
+        let s = "a\nbc";
+        assert_eq!(line_col_to_byte_offset(s, 2, 2), 3);
+    }
+
     #[test]
     fn engines_map_drops_non_string_values() {
         // Stay consistent with how our dep-map parsers treat redacted

--- a/crates/aube-workspace/Cargo.toml
+++ b/crates/aube-workspace/Cargo.toml
@@ -12,6 +12,7 @@ include = ["src/**/*.rs"]
 [dependencies]
 aube-manifest = { workspace = true }
 glob = { workspace = true }
+miette = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -23,7 +23,7 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
     let config = WorkspaceConfig::load(project_dir).map_err(|e| match e {
         aube_manifest::Error::Io(p, e) => Error::Io(p, e),
         aube_manifest::Error::YamlParse(p, e) => Error::Parse(p, e),
-        aube_manifest::Error::Parse(pe) => Error::Parse(pe.path, pe.message),
+        aube_manifest::Error::Parse(pe) => Error::ParseDiag(pe),
     })?;
 
     let patterns: Vec<String> = if !config.packages.is_empty() {
@@ -73,7 +73,7 @@ fn package_json_workspace_patterns(project_dir: &Path) -> Result<Vec<String>, Er
     }
     let pkg = aube_manifest::PackageJson::from_path(&path).map_err(|e| match e {
         aube_manifest::Error::Io(p, e) => Error::Io(p, e),
-        aube_manifest::Error::Parse(pe) => Error::Parse(pe.path, pe.message),
+        aube_manifest::Error::Parse(pe) => Error::ParseDiag(pe),
         aube_manifest::Error::YamlParse(p, e) => Error::Parse(p, e),
     })?;
     Ok(pkg
@@ -83,12 +83,19 @@ fn package_json_workspace_patterns(project_dir: &Path) -> Result<Vec<String>, Er
         .unwrap_or_default())
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum Error {
     #[error("I/O error at {0}: {1}")]
     Io(PathBuf, std::io::Error),
     #[error("failed to parse {0}: {1}")]
     Parse(PathBuf, String),
+    /// Parse failure that came in via `aube_manifest::Error::Parse` and
+    /// still carries its `NamedSource` + `SourceSpan`. Forwarded via
+    /// `#[diagnostic(transparent)]` so `miette`'s `fancy` handler draws
+    /// a pointer at the offending byte of the offending `package.json`.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ParseDiag(Box<aube_manifest::ParseError>),
 }
 
 #[cfg(test)]

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -23,7 +23,7 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
     let config = WorkspaceConfig::load(project_dir).map_err(|e| match e {
         aube_manifest::Error::Io(p, e) => Error::Io(p, e),
         aube_manifest::Error::YamlParse(p, e) => Error::Parse(p, e),
-        _ => Error::Parse(project_dir.to_path_buf(), e.to_string()),
+        aube_manifest::Error::Parse(pe) => Error::Parse(pe.path, pe.message),
     })?;
 
     let patterns: Vec<String> = if !config.packages.is_empty() {
@@ -73,8 +73,8 @@ fn package_json_workspace_patterns(project_dir: &Path) -> Result<Vec<String>, Er
     }
     let pkg = aube_manifest::PackageJson::from_path(&path).map_err(|e| match e {
         aube_manifest::Error::Io(p, e) => Error::Io(p, e),
-        aube_manifest::Error::Parse(p, e) => Error::Parse(p, e.to_string()),
-        other => Error::Parse(path.clone(), other.to_string()),
+        aube_manifest::Error::Parse(pe) => Error::Parse(pe.path, pe.message),
+        aube_manifest::Error::YamlParse(p, e) => Error::Parse(p, e),
     })?;
     Ok(pkg
         .workspaces

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -496,7 +496,7 @@ async fn update_manifest_for_add(
     let default_catalog = workspace_catalogs.get("default");
     let manifest_path = cwd.join("package.json");
     let mut manifest = aube_manifest::PackageJson::from_path(&manifest_path)
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     // Parse all specs and fetch packuments concurrently.

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -122,7 +122,7 @@ pub async fn run(args: AuditArgs, registry_override: Option<&str>) -> miette::Re
     let cwd = crate::dirs::project_root()?;
 
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
@@ -365,8 +365,8 @@ async fn write_fix_overrides(
     let content = std::fs::read_to_string(&manifest_path)
         .into_diagnostic()
         .wrap_err("failed to read package.json")?;
-    let mut root: serde_json::Value = serde_json::from_str(&content)
-        .into_diagnostic()
+    let mut root = aube_manifest::parse_json::<serde_json::Value>(&manifest_path, content)
+        .map_err(miette::Report::new)
         .wrap_err("failed to parse package.json")?;
     let obj = root
         .as_object_mut()

--- a/crates/aube/src/commands/clean.rs
+++ b/crates/aube/src/commands/clean.rs
@@ -17,7 +17,7 @@
 //! tree" command.
 
 use clap::Args;
-use miette::{Context, IntoDiagnostic};
+use miette::Context;
 
 #[derive(Debug, Args)]
 pub struct CleanArgs {
@@ -57,7 +57,7 @@ async fn run_as(invoked_as: &str, args: CleanArgs) -> miette::Result<()> {
     let root_pkg = cwd.join("package.json");
     if root_pkg.is_file() {
         let manifest = aube_manifest::PackageJson::from_path(&root_pkg)
-            .into_diagnostic()
+            .map_err(miette::Report::new)
             .wrap_err("failed to read package.json")?;
         if manifest.scripts.contains_key(invoked_as) {
             // `--lockfile` is an aube-specific flag that the user's

--- a/crates/aube/src/commands/dedupe.rs
+++ b/crates/aube/src/commands/dedupe.rs
@@ -24,7 +24,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
     let _lock = super::take_project_lock(&cwd)?;
 
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     // Read the existing lockfile purely for the diff. We do NOT pass it to
@@ -48,7 +48,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
     if is_workspace {
         for pkg_dir in &workspace_packages {
             let pkg_manifest = aube_manifest::PackageJson::from_path(&pkg_dir.join("package.json"))
-                .into_diagnostic()
+                .map_err(miette::Report::new)
                 .wrap_err_with(|| format!("failed to read {}/package.json", pkg_dir.display()))?;
 
             let rel_path = pkg_dir

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -400,7 +400,7 @@ fn seed_target_lockfile(
     // header correctly; using the source workspace root manifest
     // would fill in the wrong name for the deployed package.
     let target_manifest = PackageJson::from_path(&target.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("deploy: failed to re-read rewritten target package.json")?;
 
     aube_lockfile::write_lockfile_as(target, &subset, &target_manifest, kind)
@@ -433,7 +433,7 @@ fn stage_one(
         // manifest directly to reuse `name`/`version` for the final
         // println without building a throwaway tarball.
         let manifest = PackageJson::from_path(&source_pkg_dir.join("package.json"))
-            .into_diagnostic()
+            .map_err(miette::Report::new)
             .wrap_err("failed to read package.json")?;
         let name = manifest
             .name

--- a/crates/aube/src/commands/dist_tag.rs
+++ b/crates/aube/src/commands/dist_tag.rs
@@ -21,7 +21,7 @@
 
 use crate::commands::{make_client, split_name_spec};
 use clap::{Args, Subcommand};
-use miette::miette;
+use miette::{Context, miette};
 
 #[derive(Debug, Args)]
 pub struct DistTagArgs {
@@ -151,7 +151,7 @@ async fn ls(package: Option<&str>) -> miette::Result<()> {
             let manifest_path = cwd.join("package.json");
             let manifest = aube_manifest::PackageJson::from_path(&manifest_path)
                 .map_err(miette::Report::new)
-                .map_err(|e| miette!("failed to read {}: {e}", manifest_path.display()))?;
+                .wrap_err_with(|| format!("failed to read {}", manifest_path.display()))?;
             manifest.name.ok_or_else(|| {
                 miette!(
                     "package.json has no `name` field\nhelp: pass a package name explicitly (`aube dist-tag ls <name>`)"

--- a/crates/aube/src/commands/dist_tag.rs
+++ b/crates/aube/src/commands/dist_tag.rs
@@ -21,7 +21,7 @@
 
 use crate::commands::{make_client, split_name_spec};
 use clap::{Args, Subcommand};
-use miette::{IntoDiagnostic, miette};
+use miette::miette;
 
 #[derive(Debug, Args)]
 pub struct DistTagArgs {
@@ -150,7 +150,7 @@ async fn ls(package: Option<&str>) -> miette::Result<()> {
         None => {
             let manifest_path = cwd.join("package.json");
             let manifest = aube_manifest::PackageJson::from_path(&manifest_path)
-                .into_diagnostic()
+                .map_err(miette::Report::new)
                 .map_err(|e| miette!("failed to read {}: {e}", manifest_path.display()))?;
             manifest.name.ok_or_else(|| {
                 miette!(

--- a/crates/aube/src/commands/fetch.rs
+++ b/crates/aube/src/commands/fetch.rs
@@ -36,7 +36,7 @@ pub async fn run(args: FetchArgs) -> miette::Result<()> {
     let manifest_path = cwd.join("package.json");
     let manifest = if manifest_path.exists() {
         aube_manifest::PackageJson::from_path(&manifest_path)
-            .into_diagnostic()
+            .map_err(miette::Report::new)
             .wrap_err("failed to read package.json")?
     } else {
         // Minimal empty manifest so parse_lockfile_with_kind's signature is happy.

--- a/crates/aube/src/commands/ignored_builds.rs
+++ b/crates/aube/src/commands/ignored_builds.rs
@@ -89,7 +89,7 @@ impl std::cmp::PartialOrd for IgnoredEntry {
 /// callers print their own "nothing to do" message.
 pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<Vec<IgnoredEntry>> {
     let manifest = aube_manifest::PackageJson::from_path(&project_dir.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     let graph = match aube_lockfile::parse_lockfile(project_dir, &manifest) {

--- a/crates/aube/src/commands/import.rs
+++ b/crates/aube/src/commands/import.rs
@@ -39,7 +39,7 @@ pub async fn run(args: ImportArgs) -> miette::Result<()> {
     let _lock = crate::commands::take_project_lock(&cwd)?;
 
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     // Honor `gitBranchLockfile`: the destination is whichever aube

--- a/crates/aube/src/commands/inject.rs
+++ b/crates/aube/src/commands/inject.rs
@@ -35,7 +35,7 @@
 use aube_lockfile::LockfileGraph;
 use aube_lockfile::dep_path_filename::dep_path_to_filename;
 use aube_manifest::PackageJson;
-use miette::{Context, IntoDiagnostic, miette};
+use miette::{Context, miette};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -95,7 +95,7 @@ pub(crate) fn apply_injected(
             };
 
             let src_manifest = PackageJson::from_path(&src_dir.join("package.json"))
-                .into_diagnostic()
+                .map_err(miette::Report::new)
                 .wrap_err_with(|| {
                     format!("inject: failed to read {}/package.json", src_dir.display())
                 })?;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -619,8 +619,8 @@ pub(crate) async fn run_dep_lifecycle_scripts(
                 ));
             }
         };
-        let dep_manifest: aube_manifest::PackageJson = serde_json::from_str(&pkg_json_content)
-            .into_diagnostic()
+        let dep_manifest = aube_manifest::PackageJson::parse(&pkg_json_path, pkg_json_content)
+            .map_err(miette::Report::new)
             .wrap_err_with(|| format!("failed to parse package.json for {}", pkg.name))?;
         // `has_dep_lifecycle_work` also accounts for the implicit
         // `node-gyp rebuild` fallback: a package with a top-level
@@ -785,7 +785,7 @@ fn validate_required_scripts(
     {
         let manifest_path = pkg_dir.join("package.json");
         let pkg_manifest = aube_manifest::PackageJson::from_path(&manifest_path)
-            .into_diagnostic()
+            .map_err(miette::Report::new)
             .wrap_err_with(|| format!("failed to read {}", manifest_path.display()))?;
         let label = pkg_manifest
             .name
@@ -865,8 +865,8 @@ fn unreviewed_dep_builds(
                 ));
             }
         };
-        let dep_manifest: aube_manifest::PackageJson = serde_json::from_str(&pkg_json_content)
-            .into_diagnostic()
+        let dep_manifest = aube_manifest::PackageJson::parse(&pkg_json_path, pkg_json_content)
+            .map_err(miette::Report::new)
             .wrap_err_with(|| format!("failed to parse package.json for {}", pkg.name))?;
         if aube_scripts::has_dep_lifecycle_work(&package_dir, &dep_manifest) {
             unreviewed.push(format!("{}@{}", pkg.name, pkg.version));
@@ -1714,7 +1714,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
 
     // 1. Read package.json
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
     let project_name = manifest.name.as_deref().unwrap_or("(unnamed)");
 
@@ -1993,7 +1993,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         );
         for pkg_dir in &workspace_packages {
             let pkg_manifest = aube_manifest::PackageJson::from_path(&pkg_dir.join("package.json"))
-                .into_diagnostic()
+                .map_err(miette::Report::new)
                 .wrap_err_with(|| format!("failed to read {}/package.json", pkg_dir.display()))?;
 
             let rel_path = pkg_dir
@@ -4044,8 +4044,8 @@ fn read_materialized_pkg_json(
             ));
         }
     };
-    let value = serde_json::from_str(&content)
-        .into_diagnostic()
+    let value = aube_manifest::parse_json::<serde_json::Value>(&pkg_json_path, content)
+        .map_err(miette::Report::new)
         .wrap_err_with(|| format!("failed to parse package.json for {name}"))?;
     Ok(Some(value))
 }

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -86,7 +86,7 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root()?;
 
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {

--- a/crates/aube/src/commands/link.rs
+++ b/crates/aube/src/commands/link.rs
@@ -39,7 +39,7 @@ pub async fn run(args: LinkArgs) -> miette::Result<()> {
         None => {
             // `aube link` — register current package globally
             let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-                .into_diagnostic()
+                .map_err(miette::Report::new)
                 .wrap_err("failed to read package.json")?;
             let name = manifest
                 .name
@@ -67,7 +67,7 @@ pub async fn run(args: LinkArgs) -> miette::Result<()> {
             }
 
             let manifest = aube_manifest::PackageJson::from_path(&target.join("package.json"))
-                .into_diagnostic()
+                .map_err(miette::Report::new)
                 .wrap_err_with(|| format!("failed to read {}/package.json", target.display()))?;
             let name = manifest.name.as_deref().ok_or_else(|| {
                 miette!("{}/package.json has no \"name\" field", target.display())

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -133,7 +133,7 @@ pub async fn run(
     // Read manifest (needed even for `list` — we print the project name/version
     // at the top, and the lockfile parser needs it for non-pnpm formats).
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     // Lockfile may be absent in a brand-new project — treat that as "nothing

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -132,7 +132,7 @@ async fn run_filtered(
 ) -> miette::Result<()> {
     let matched = super::select_workspace_packages(cwd, filter, "outdated")?;
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
     let graph = match aube_lockfile::parse_lockfile(cwd, &manifest) {
         Ok(g) => g,
@@ -166,7 +166,7 @@ async fn run_filtered(
 
 async fn run_one(cwd: &Path, args: OutdatedArgs, importer: Option<String>) -> miette::Result<bool> {
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     let graph = match aube_lockfile::parse_lockfile(cwd, &manifest) {

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -149,7 +149,7 @@ pub(crate) struct BuiltArchive {
 /// `aube publish` (hashes and uploads them).
 pub(crate) fn build_archive(project_dir: &Path) -> miette::Result<BuiltArchive> {
     let manifest = PackageJson::from_path(&project_dir.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
     let name = manifest
         .name

--- a/crates/aube/src/commands/peers.rs
+++ b/crates/aube/src/commands/peers.rs
@@ -11,7 +11,7 @@
 
 use aube_lockfile::LockfileGraph;
 use clap::{Args, Subcommand};
-use miette::{Context, IntoDiagnostic, miette};
+use miette::{Context, miette};
 use std::collections::BTreeMap;
 
 pub const CHECK_AFTER_LONG_HELP: &str = "\
@@ -66,7 +66,7 @@ async fn check(args: PeersCheckArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root()?;
 
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {

--- a/crates/aube/src/commands/prune.rs
+++ b/crates/aube/src/commands/prune.rs
@@ -38,7 +38,7 @@ pub async fn run(args: PruneArgs) -> miette::Result<()> {
     let _lock = super::take_project_lock(&cwd)?;
 
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     let graph = aube_lockfile::parse_lockfile(&cwd, &manifest)

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -363,7 +363,7 @@ async fn publish_one(
     // workspace is cheap — the happy-path skip must not pay the cost
     // of a packed tarball.
     let manifest = PackageJson::from_path(&pkg_dir.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err_with(|| format!("failed to read {}/package.json", pkg_dir.display()))?;
     let name = manifest
         .name

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -63,7 +63,7 @@ pub async fn run(
     let manifest_path = cwd.join("package.json");
 
     let mut manifest = aube_manifest::PackageJson::from_path(&manifest_path)
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     for name in packages {

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -411,7 +411,7 @@ async fn run_script_filtered(
 
 pub(crate) fn load_manifest(cwd: &Path) -> miette::Result<PackageJson> {
     PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")
 }
 

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -42,7 +42,7 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root()?;
 
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {

--- a/crates/aube/src/commands/unlink.rs
+++ b/crates/aube/src/commands/unlink.rs
@@ -138,7 +138,7 @@ fn unlink_global(cwd: &std::path::Path, explicit_name: Option<&str>) -> miette::
         n.to_string()
     } else {
         let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-            .into_diagnostic()
+            .map_err(miette::Report::new)
             .wrap_err("failed to read package.json")?;
         manifest
             .name

--- a/crates/aube/src/commands/unpublish.rs
+++ b/crates/aube/src/commands/unpublish.rs
@@ -140,7 +140,7 @@ fn resolve_target(spec: Option<&str>, cwd: &std::path::Path) -> miette::Result<T
     // `npm unpublish` with no args, which unpublishes the *version*
     // named in `./package.json` rather than the whole package.
     let manifest = PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read ./package.json")?;
     let name = manifest
         .name

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -86,7 +86,7 @@ pub async fn run(
     let manifest_path = cwd.join("package.json");
 
     let mut manifest = aube_manifest::PackageJson::from_path(&manifest_path)
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
     let ignored_updates = resolve_update_ignore_dependencies(&cwd, &manifest)?;
 

--- a/crates/aube/src/commands/why.rs
+++ b/crates/aube/src/commands/why.rs
@@ -9,7 +9,7 @@
 
 use aube_lockfile::{DepType, LockfileGraph};
 use clap::Args;
-use miette::{Context, IntoDiagnostic, miette};
+use miette::{Context, miette};
 use std::collections::{BTreeSet, HashSet};
 
 pub const AFTER_LONG_HELP: &str = "\
@@ -79,7 +79,7 @@ pub async fn run(
     }
 
     let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
@@ -126,7 +126,7 @@ fn run_filtered(
     })?;
 
     let manifest = aube_manifest::PackageJson::from_path(&workspace_root.join("package.json"))
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     let graph = match aube_lockfile::parse_lockfile(&workspace_root, &manifest) {

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -6,7 +6,7 @@
 //! `{ "name@version": "patches/name@version.patch" }`. We mirror pnpm's
 //! shape exactly so the field round-trips between the two tools.
 
-use miette::{IntoDiagnostic, Result, miette};
+use miette::{Context, IntoDiagnostic, Result, miette};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -74,8 +74,8 @@ pub fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
         return Ok(BTreeMap::new());
     }
     let manifest = aube_manifest::PackageJson::from_path(&manifest_path)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to read package.json: {e}"))?;
+        .map_err(miette::Report::new)
+        .wrap_err("failed to read package.json")?;
 
     let mut out = BTreeMap::new();
     for (key, rel) in manifest.pnpm_patched_dependencies() {
@@ -133,8 +133,8 @@ pub fn read_patched_dependencies(cwd: &Path) -> Result<BTreeMap<String, String>>
         return Ok(BTreeMap::new());
     }
     let manifest = aube_manifest::PackageJson::from_path(&manifest_path)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to read package.json: {e}"))?;
+        .map_err(miette::Report::new)
+        .wrap_err("failed to read package.json")?;
     Ok(manifest.pnpm_patched_dependencies())
 }
 
@@ -151,9 +151,9 @@ where
     let raw = std::fs::read_to_string(&manifest_path)
         .into_diagnostic()
         .map_err(|e| miette!("failed to read package.json: {e}"))?;
-    let mut value: serde_json::Value = serde_json::from_str(&raw)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to parse package.json: {e}"))?;
+    let mut value = aube_manifest::parse_json::<serde_json::Value>(&manifest_path, raw)
+        .map_err(miette::Report::new)
+        .wrap_err("failed to parse package.json")?;
 
     let obj = value
         .as_object_mut()


### PR DESCRIPTION
## Summary
- `aube_manifest::Error::Parse` now carries a `NamedSource` + `SourceSpan` (boxed into a `ParseError`) and derives `miette::Diagnostic`, so the `fancy` handler renders a pointer into the offending byte of `package.json` instead of just printing `… at line 12 column 15`.
- Added `PackageJson::parse(path, content)` and a generic `aube_manifest::parse_json` helper, and wired them through the three install-pipeline parse sites that iterate dep `package.json` files — this is the code path that surfaced the original firefox-profile report.
- Swapped `.into_diagnostic()` for `.map_err(miette::Report::new)` at every `PackageJson::from_path(...).wrap_err(...)` call site. `.into_diagnostic()` routes the error through `StdError`, which drops `#[source_code]` / `#[label]`; `Report::new` preserves the Diagnostic impl so the source pointer survives `wrap_err`.

## Motivation
The failure mode that prompted this: firefox-profile 4.7.0 ships an invalid `package.json` (`scripts.blanket` is an object, not a string). The old output was a bare `invalid type: map, expected a string at line 12 column 15` with no indication of which file or what line 12 looks like. With this change:

```
Error:   × failed to read package.json
  ╰─▶ failed to parse /path/package.json: invalid type: map, expected
      a string at line 5 column 15
   ╭─[/path/package.json:5:15]
 4 │   "scripts": {
 5 │     "blanket": {
   ·               ┬
   ·               ╰── invalid type: map, expected a string at line 5 column 15
 6 │       "pattern": ["lib"]
   ╰────
```

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — all suites green
- [x] `cargo fmt --check`
- [x] Manual: broken `package.json` via `aube run` renders with source pointer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared error types and widespread error-mapping call sites; while behavior is mostly additive, incorrect span/forwarding logic could degrade diagnostics or change user-visible error formatting across commands.
> 
> **Overview**
> `aube-manifest` now attaches `miette` diagnostics to JSON parse failures by introducing a boxed `ParseError` that includes `NamedSource` + `SourceSpan`, plus new helpers `PackageJson::parse` and generic `parse_json` to preserve the original source and compute an accurate error span (with added tests for line/column→byte-offset and EOF clamping).
> 
> `aube-workspace` and multiple `aube` commands are updated to forward these rich parse diagnostics end-to-end: workspace discovery adds a `ParseDiag` error variant, JSON parsing call sites use `parse_json`/`PackageJson::parse`, and many `PackageJson::from_path` call sites switch from `.into_diagnostic()` to `miette::Report::new` so the fancy renderer can point at the offending byte in `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0edb5975b9c6d3350fb3e150662b296f60d6389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->