### PR TITLE
install: silence peer-dep mismatches by default (bun parity)

### DIFF
--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -4664,7 +4664,7 @@ mod tests {
 
     // Peer declared but completely absent from `pkg.dependencies` —
     // exercises the `found: None` branch that drives the "missing
-    // required peer" display path in `warn_unmet_peers`. Rare in
+    // required peer" display path in `check_unmet_peers`. Rare in
     // practice because the BFS peer walk usually drags *some* version
     // in, but possible for corner cases (registry fetch failure, etc).
     #[test]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1242,11 +1242,9 @@ default = "false"
 docs = """
 When true, any unmet peer dependency (missing, or resolved to a version
 outside the declared range) fails the install with a miette diagnostic
-instead of only surfacing as a warning. Mirrors pnpm's
-`strict-peer-dependencies` behavior. Combines with
-`autoInstallPeers`: peers the resolver auto-installs are never
-reported, so enabling strict mode only catches peers the resolver
-couldn't satisfy from an existing version in the graph.
+listing every mismatch. This is also the only way aube surfaces peer
+mismatches — by default aube is silent, matching bun/npm/yarn. Set
+this to `false` (the default) to disable.
 """
 sources.cli = []
 sources.env = []
@@ -1277,13 +1275,14 @@ description = "Suppress warnings for specific missing peer dependencies."
 type = "list<string>"
 default = "undefined"
 docs = """
-Glob list of peer dependency names whose "missing required peer" warning
-should be silenced. Only silences peers that are missing entirely — a peer
-present at the wrong version still warns (use `allowedVersions` or
-`allowAny` for that). Read from the root `package.json`
-(`pnpm.peerDependencyRules.ignoreMissing`), `pnpm-workspace.yaml`, and
-`.npmrc`. Later sources fully replace the previous source's list — values
-do not concatenate across sources.
+Glob list of peer dependency names to exclude from the
+`strict-peer-dependencies` check when they're missing entirely. A peer
+present at the wrong version is still reported (use `allowedVersions`
+or `allowAny` for that). Has no effect on the default install — aube
+is silent about peer mismatches unless strict mode is on. Read from
+the root `package.json` (`pnpm.peerDependencyRules.ignoreMissing`),
+`pnpm-workspace.yaml`, and `.npmrc`; later sources fully replace the
+previous source's list.
 """
 sources.cli = []
 sources.env = []
@@ -1318,10 +1317,12 @@ default = "undefined"
 docs = """
 Glob list of peer dependency names whose semver check should be
 bypassed entirely — any resolved version counts as satisfying the
-declared range. Also silences missing-peer warnings for matching names.
-Escape hatch for packages with incompatible peer declarations. Read
-from the root `package.json`, `pnpm-workspace.yaml`, and `.npmrc`.
-Later sources fully replace the previous source's list.
+declared range. Also excludes missing peers for matching names. Escape
+hatch for packages with incompatible peer declarations. Has no effect
+on the default install — aube is silent about peer mismatches unless
+`strict-peer-dependencies` is on. Read from the root `package.json`,
+`pnpm-workspace.yaml`, and `.npmrc`; later sources fully replace the
+previous source's list.
 """
 sources.cli = []
 sources.env = []

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1191,7 +1191,7 @@ docs = """
 When true (the default), missing peer dependencies are auto-installed
 during resolution and hoisted into the importer. Set to `false` to
 match pnpm's opt-out behavior: peers are left alone and unmet peers
-surface as warnings.
+are silent (set `strict-peer-dependencies=true` for diagnostics).
 """
 sources.cli = ["auto-install-peers"]
 sources.env = []

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -16,14 +16,15 @@ pub(crate) use settings::PeerDependencyRules;
 pub(crate) use side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root};
 
 use settings::{
-    ResolverConfigInputs, configure_resolver, default_lockfile_network_concurrency,
-    default_streaming_network_concurrency, find_gvs_incompatible_trigger,
-    maybe_cleanup_unused_catalogs, resolve_dedupe_peer_dependents, resolve_dedupe_peers,
-    resolve_git_shallow_hosts, resolve_link_concurrency, resolve_network_concurrency,
-    resolve_peers_from_workspace_root, resolve_peers_suffix_max_length, resolve_side_effects_cache,
+    ResolverConfigInputs, check_unmet_peers, configure_resolver,
+    default_lockfile_network_concurrency, default_streaming_network_concurrency,
+    find_gvs_incompatible_trigger, maybe_cleanup_unused_catalogs, resolve_dedupe_peer_dependents,
+    resolve_dedupe_peers, resolve_git_shallow_hosts, resolve_link_concurrency,
+    resolve_network_concurrency, resolve_peers_from_workspace_root,
+    resolve_peers_suffix_max_length, resolve_side_effects_cache,
     resolve_side_effects_cache_readonly, resolve_strict_peer_dependencies,
     resolve_strict_store_pkg_content_check, resolve_symlink, resolve_use_running_store_server,
-    resolve_verify_store_integrity, warn_unmet_peers,
+    resolve_verify_store_integrity,
 };
 use side_effects_cache::{SideEffectsCacheEntry, SideEffectsCacheRestore};
 
@@ -3206,15 +3207,18 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // `graph.catalogs`.
     maybe_cleanup_unused_catalogs(&cwd, &settings_ctx, &workspace_catalogs, &graph.catalogs)?;
 
-    // 5a. Scan the resolved graph for unmet required peer dependencies
-    //     and surface them as warnings. Matches pnpm's behavior of
-    //     printing unmet peers but never failing the install over them.
-    //     Optional peers (peerDependenciesMeta.optional) are
-    //     deliberately skipped — `auto-install-peers=true` installs
-    //     them but suppresses the warning.
+    // 5a. Under `strict-peer-dependencies=true`, scan the resolved
+    //     graph for unmet required peers and fail the install with the
+    //     list. Default (strict=false) is silent, matching bun/npm/yarn
+    //     — the previous pnpm-style warn-on-every-mismatch default
+    //     produced a lot of noise on real-world trees and buried the
+    //     genuinely actionable ones. Optional peers
+    //     (peerDependenciesMeta.optional) are skipped either way, and
+    //     `peerDependencyRules` escape hatches filter out matches
+    //     before the strict check fires.
     let strict_peer_deps = resolve_strict_peer_dependencies(&settings_ctx);
     let peer_rules = PeerDependencyRules::resolve(&manifest, &settings_ctx);
-    warn_unmet_peers(&graph, strict_peer_deps, &peer_rules)?;
+    check_unmet_peers(&graph, strict_peer_deps, &peer_rules)?;
 
     // 5b. Apply --prod / --dev / --no-optional filters. Drops the corresponding
     //     direct dep roots from every importer and prunes transitive packages

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3216,9 +3216,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     //     (peerDependenciesMeta.optional) are skipped either way, and
     //     `peerDependencyRules` escape hatches filter out matches
     //     before the strict check fires.
-    let strict_peer_deps = resolve_strict_peer_dependencies(&settings_ctx);
-    let peer_rules = PeerDependencyRules::resolve(&manifest, &settings_ctx);
-    check_unmet_peers(&graph, strict_peer_deps, &peer_rules)?;
+    //
+    //     The `PeerDependencyRules::resolve` call is gated on strict
+    //     because it reads across package.json / .npmrc /
+    //     pnpm-workspace.yaml to build the three escape-hatch lists —
+    //     allocation + file-source iteration nobody consumes on the
+    //     silent default path.
+    if resolve_strict_peer_dependencies(&settings_ctx) {
+        let peer_rules = PeerDependencyRules::resolve(&manifest, &settings_ctx);
+        check_unmet_peers(&graph, &peer_rules)?;
+    }
 
     // 5b. Apply --prod / --dev / --no-optional filters. Drops the corresponding
     //     direct dep roots from every importer and prunes transitive packages

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -602,29 +602,19 @@ pub(super) fn configure_resolver(
 
 /// Check the resolved graph for declared required peer deps whose
 /// version doesn't satisfy the declared range, or that aren't in the
-/// tree at all. When `strict` is true (pnpm's
-/// `strict-peer-dependencies`), prints the list of unmet peers and
-/// returns an `Err` so the install fails. When `strict` is false
-/// (the default), this is silent — matching bun's default behavior.
-/// npm and yarn Classic are similarly quiet; pnpm is the outlier
-/// that warns on every mismatch. Users who need the list without
-/// failing the install can flip `strict-peer-dependencies=true`,
-/// which emits the same diagnostic and exits non-zero.
+/// tree at all. Prints the list of unmet peers and returns an `Err`
+/// so the install fails.
 ///
-/// Peers that match one of the `PeerDependencyRules` escape hatches
-/// (`ignoreMissing`, `allowAny`, `allowedVersions`) are filtered out
-/// before the strict check — same as pnpm.
+/// Only called under `strict-peer-dependencies=true`. The default
+/// install path skips this entirely — aube is silent about peer
+/// mismatches by default, matching bun/npm/yarn. Peers that match one
+/// of the `PeerDependencyRules` escape hatches (`ignoreMissing`,
+/// `allowAny`, `allowedVersions`) are filtered out before the check,
+/// same as pnpm.
 pub(super) fn check_unmet_peers(
     graph: &aube_lockfile::LockfileGraph,
-    strict: bool,
     rules: &PeerDependencyRules,
 ) -> miette::Result<()> {
-    if !strict {
-        // Silent default. Matches bun/npm/yarn; pnpm is the outlier.
-        // Skip the full peer walk too — detect_unmet_peers isn't free
-        // on a large graph and nobody's reading its output.
-        return Ok(());
-    }
     let unmet: Vec<_> = aube_resolver::detect_unmet_peers(graph)
         .into_iter()
         .filter(|u| !rules.silences(u))

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -600,19 +600,31 @@ pub(super) fn configure_resolver(
     resolver
 }
 
-/// Emit pnpm-style warnings for every declared required peer dep whose
-/// resolved version doesn't satisfy the declared range, or that isn't
-/// in the tree at all. When `strict` is true (pnpm's
-/// `strict-peer-dependencies`), returns an `Err` after printing the
-/// same lines so the install fails. Peers that match one of the
-/// `PeerDependencyRules` escape hatches (`ignoreMissing`, `allowAny`,
-/// `allowedVersions`) are filtered out before either warn or error —
-/// same as pnpm.
-pub(super) fn warn_unmet_peers(
+/// Check the resolved graph for declared required peer deps whose
+/// version doesn't satisfy the declared range, or that aren't in the
+/// tree at all. When `strict` is true (pnpm's
+/// `strict-peer-dependencies`), prints the list of unmet peers and
+/// returns an `Err` so the install fails. When `strict` is false
+/// (the default), this is silent — matching bun's default behavior.
+/// npm and yarn Classic are similarly quiet; pnpm is the outlier
+/// that warns on every mismatch. Users who need the list without
+/// failing the install can flip `strict-peer-dependencies=true`,
+/// which emits the same diagnostic and exits non-zero.
+///
+/// Peers that match one of the `PeerDependencyRules` escape hatches
+/// (`ignoreMissing`, `allowAny`, `allowedVersions`) are filtered out
+/// before the strict check — same as pnpm.
+pub(super) fn check_unmet_peers(
     graph: &aube_lockfile::LockfileGraph,
     strict: bool,
     rules: &PeerDependencyRules,
 ) -> miette::Result<()> {
+    if !strict {
+        // Silent default. Matches bun/npm/yarn; pnpm is the outlier.
+        // Skip the full peer walk too — detect_unmet_peers isn't free
+        // on a large graph and nobody's reading its output.
+        return Ok(());
+    }
     let unmet: Vec<_> = aube_resolver::detect_unmet_peers(graph)
         .into_iter()
         .filter(|u| !rules.silences(u))
@@ -620,17 +632,11 @@ pub(super) fn warn_unmet_peers(
     if unmet.is_empty() {
         return Ok(());
     }
-    let header = if strict {
-        "error: Issues with peer dependencies found"
-    } else {
-        "warn: Issues with peer dependencies found"
-    };
-    let prefix = if strict { "error:" } else { "warn:" };
-    eprintln!("{header}");
+    eprintln!("error: Issues with peer dependencies found");
     for u in &unmet {
         match &u.found {
             Some(found) => eprintln!(
-                "{prefix}   {}@{}: expected peer {}@{}, found {}",
+                "error:   {}@{}: expected peer {}@{}, found {}",
                 u.from_name,
                 version_from_dep_path(&u.from_dep_path, &u.from_name),
                 u.peer_name,
@@ -638,7 +644,7 @@ pub(super) fn warn_unmet_peers(
                 found,
             ),
             None => eprintln!(
-                "{prefix}   {}@{}: missing required peer {}@{}",
+                "error:   {}@{}: missing required peer {}@{}",
                 u.from_name,
                 version_from_dep_path(&u.from_dep_path, &u.from_name),
                 u.peer_name,
@@ -646,14 +652,11 @@ pub(super) fn warn_unmet_peers(
             ),
         }
     }
-    if strict {
-        return Err(miette!(
-            "{} unmet peer dependenc{} (strict-peer-dependencies is enabled)",
-            unmet.len(),
-            if unmet.len() == 1 { "y" } else { "ies" }
-        ));
-    }
-    Ok(())
+    Err(miette!(
+        "{} unmet peer dependenc{} (strict-peer-dependencies is enabled)",
+        unmet.len(),
+        if unmet.len() == 1 { "y" } else { "ies" }
+    ))
 }
 
 /// Resolved `pnpm.peerDependencyRules` — the three escape hatches pnpm

--- a/docs/settings/cli.md
+++ b/docs/settings/cli.md
@@ -209,7 +209,7 @@ Automatically install missing peer dependencies.
 When true (the default), missing peer dependencies are auto-installed
 during resolution and hoisted into the importer. Set to `false` to
 match pnpm's opt-out behavior: peers are left alone and unmet peers
-surface as warnings.
+are silent (set `strict-peer-dependencies=true` for diagnostics).
 
 ## CLI
 

--- a/docs/settings/env.md
+++ b/docs/settings/env.md
@@ -1197,11 +1197,9 @@ Fail if peer dependencies are missing or invalid.
 
 When true, any unmet peer dependency (missing, or resolved to a version
 outside the declared range) fails the install with a miette diagnostic
-instead of only surfacing as a warning. Mirrors pnpm's
-`strict-peer-dependencies` behavior. Combines with
-`autoInstallPeers`: peers the resolver auto-installs are never
-reported, so enabling strict mode only catches peers the resolver
-couldn't satisfy from an existing version in the graph.
+listing every mismatch. This is also the only way aube surfaces peer
+mismatches — by default aube is silent, matching bun/npm/yarn. Set
+this to `false` (the default) to disable.
 
 ### `resolvePeersFromWorkspaceRoot` {#setting-resolvepeersfromworkspaceroot}
 
@@ -1226,13 +1224,14 @@ Suppress warnings for specific missing peer dependencies.
 - Default: `undefined`
 - Environment: `npm_config_peer_dependency_rules_ignore_missing`, `NPM_CONFIG_PEER_DEPENDENCY_RULES_IGNORE_MISSING`
 
-Glob list of peer dependency names whose "missing required peer" warning
-should be silenced. Only silences peers that are missing entirely — a peer
-present at the wrong version still warns (use `allowedVersions` or
-`allowAny` for that). Read from the root `package.json`
-(`pnpm.peerDependencyRules.ignoreMissing`), `pnpm-workspace.yaml`, and
-`.npmrc`. Later sources fully replace the previous source's list — values
-do not concatenate across sources.
+Glob list of peer dependency names to exclude from the
+`strict-peer-dependencies` check when they're missing entirely. A peer
+present at the wrong version is still reported (use `allowedVersions`
+or `allowAny` for that). Has no effect on the default install — aube
+is silent about peer mismatches unless strict mode is on. Read from
+the root `package.json` (`pnpm.peerDependencyRules.ignoreMissing`),
+`pnpm-workspace.yaml`, and `.npmrc`; later sources fully replace the
+previous source's list.
 
 ### `peerDependencyRules.allowedVersions` {#setting-peerdependencyrules-allowedversions}
 
@@ -1261,10 +1260,12 @@ Allow any peer version to resolve, bypassing semver checks.
 
 Glob list of peer dependency names whose semver check should be
 bypassed entirely — any resolved version counts as satisfying the
-declared range. Also silences missing-peer warnings for matching names.
-Escape hatch for packages with incompatible peer declarations. Read
-from the root `package.json`, `pnpm-workspace.yaml`, and `.npmrc`.
-Later sources fully replace the previous source's list.
+declared range. Also excludes missing peers for matching names. Escape
+hatch for packages with incompatible peer declarations. Has no effect
+on the default install — aube is silent about peer mismatches unless
+`strict-peer-dependencies` is on. Read from the root `package.json`,
+`pnpm-workspace.yaml`, and `.npmrc`; later sources fully replace the
+previous source's list.
 
 ## CLI
 

--- a/docs/settings/env.md
+++ b/docs/settings/env.md
@@ -1155,7 +1155,7 @@ Automatically install missing peer dependencies.
 When true (the default), missing peer dependencies are auto-installed
 during resolution and hoisted into the importer. Set to `false` to
 match pnpm's opt-out behavior: peers are left alone and unmet peers
-surface as warnings.
+are silent (set `strict-peer-dependencies=true` for diagnostics).
 
 ### `dedupePeerDependents` {#setting-dedupepeerdependents}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1255,7 +1255,7 @@ Automatically install missing peer dependencies.
 When true (the default), missing peer dependencies are auto-installed
 during resolution and hoisted into the importer. Set to `false` to
 match pnpm's opt-out behavior: peers are left alone and unmet peers
-surface as warnings.
+are silent (set `strict-peer-dependencies=true` for diagnostics).
 
 ### `dedupePeerDependents` {#setting-dedupepeerdependents}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1303,11 +1303,9 @@ Fail if peer dependencies are missing or invalid.
 
 When true, any unmet peer dependency (missing, or resolved to a version
 outside the declared range) fails the install with a miette diagnostic
-instead of only surfacing as a warning. Mirrors pnpm's
-`strict-peer-dependencies` behavior. Combines with
-`autoInstallPeers`: peers the resolver auto-installs are never
-reported, so enabling strict mode only catches peers the resolver
-couldn't satisfy from an existing version in the graph.
+listing every mismatch. This is also the only way aube surfaces peer
+mismatches — by default aube is silent, matching bun/npm/yarn. Set
+this to `false` (the default) to disable.
 
 ### `resolvePeersFromWorkspaceRoot` {#setting-resolvepeersfromworkspaceroot}
 
@@ -1336,13 +1334,14 @@ Suppress warnings for specific missing peer dependencies.
 - .npmrc keys: `peerDependencyRules.ignoreMissing`, `peer-dependency-rules.ignore-missing`
 - Workspace YAML keys: `peerDependencyRules.ignoreMissing`
 
-Glob list of peer dependency names whose "missing required peer" warning
-should be silenced. Only silences peers that are missing entirely — a peer
-present at the wrong version still warns (use `allowedVersions` or
-`allowAny` for that). Read from the root `package.json`
-(`pnpm.peerDependencyRules.ignoreMissing`), `pnpm-workspace.yaml`, and
-`.npmrc`. Later sources fully replace the previous source's list — values
-do not concatenate across sources.
+Glob list of peer dependency names to exclude from the
+`strict-peer-dependencies` check when they're missing entirely. A peer
+present at the wrong version is still reported (use `allowedVersions`
+or `allowAny` for that). Has no effect on the default install — aube
+is silent about peer mismatches unless strict mode is on. Read from
+the root `package.json` (`pnpm.peerDependencyRules.ignoreMissing`),
+`pnpm-workspace.yaml`, and `.npmrc`; later sources fully replace the
+previous source's list.
 
 ### `peerDependencyRules.allowedVersions` {#setting-peerdependencyrules-allowedversions}
 
@@ -1375,10 +1374,12 @@ Allow any peer version to resolve, bypassing semver checks.
 
 Glob list of peer dependency names whose semver check should be
 bypassed entirely — any resolved version counts as satisfying the
-declared range. Also silences missing-peer warnings for matching names.
-Escape hatch for packages with incompatible peer declarations. Read
-from the root `package.json`, `pnpm-workspace.yaml`, and `.npmrc`.
-Later sources fully replace the previous source's list.
+declared range. Also excludes missing peers for matching names. Escape
+hatch for packages with incompatible peer declarations. Has no effect
+on the default install — aube is silent about peer mismatches unless
+`strict-peer-dependencies` is on. Read from the root `package.json`,
+`pnpm-workspace.yaml`, and `.npmrc`; later sources fully replace the
+previous source's list.
 
 ## CLI
 

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -1155,7 +1155,7 @@ Automatically install missing peer dependencies.
 When true (the default), missing peer dependencies are auto-installed
 during resolution and hoisted into the importer. Set to `false` to
 match pnpm's opt-out behavior: peers are left alone and unmet peers
-surface as warnings.
+are silent (set `strict-peer-dependencies=true` for diagnostics).
 
 ### `dedupePeerDependents` {#setting-dedupepeerdependents}
 

--- a/docs/settings/npmrc.md
+++ b/docs/settings/npmrc.md
@@ -1197,11 +1197,9 @@ Fail if peer dependencies are missing or invalid.
 
 When true, any unmet peer dependency (missing, or resolved to a version
 outside the declared range) fails the install with a miette diagnostic
-instead of only surfacing as a warning. Mirrors pnpm's
-`strict-peer-dependencies` behavior. Combines with
-`autoInstallPeers`: peers the resolver auto-installs are never
-reported, so enabling strict mode only catches peers the resolver
-couldn't satisfy from an existing version in the graph.
+listing every mismatch. This is also the only way aube surfaces peer
+mismatches — by default aube is silent, matching bun/npm/yarn. Set
+this to `false` (the default) to disable.
 
 ### `resolvePeersFromWorkspaceRoot` {#setting-resolvepeersfromworkspaceroot}
 
@@ -1226,13 +1224,14 @@ Suppress warnings for specific missing peer dependencies.
 - Default: `undefined`
 - .npmrc keys: `peerDependencyRules.ignoreMissing`, `peer-dependency-rules.ignore-missing`
 
-Glob list of peer dependency names whose "missing required peer" warning
-should be silenced. Only silences peers that are missing entirely — a peer
-present at the wrong version still warns (use `allowedVersions` or
-`allowAny` for that). Read from the root `package.json`
-(`pnpm.peerDependencyRules.ignoreMissing`), `pnpm-workspace.yaml`, and
-`.npmrc`. Later sources fully replace the previous source's list — values
-do not concatenate across sources.
+Glob list of peer dependency names to exclude from the
+`strict-peer-dependencies` check when they're missing entirely. A peer
+present at the wrong version is still reported (use `allowedVersions`
+or `allowAny` for that). Has no effect on the default install — aube
+is silent about peer mismatches unless strict mode is on. Read from
+the root `package.json` (`pnpm.peerDependencyRules.ignoreMissing`),
+`pnpm-workspace.yaml`, and `.npmrc`; later sources fully replace the
+previous source's list.
 
 ### `peerDependencyRules.allowedVersions` {#setting-peerdependencyrules-allowedversions}
 
@@ -1261,10 +1260,12 @@ Allow any peer version to resolve, bypassing semver checks.
 
 Glob list of peer dependency names whose semver check should be
 bypassed entirely — any resolved version counts as satisfying the
-declared range. Also silences missing-peer warnings for matching names.
-Escape hatch for packages with incompatible peer declarations. Read
-from the root `package.json`, `pnpm-workspace.yaml`, and `.npmrc`.
-Later sources fully replace the previous source's list.
+declared range. Also excludes missing peers for matching names. Escape
+hatch for packages with incompatible peer declarations. Has no effect
+on the default install — aube is silent about peer mismatches unless
+`strict-peer-dependencies` is on. Read from the root `package.json`,
+`pnpm-workspace.yaml`, and `.npmrc`; later sources fully replace the
+previous source's list.
 
 ## CLI
 

--- a/docs/settings/workspace-yaml.md
+++ b/docs/settings/workspace-yaml.md
@@ -702,7 +702,7 @@ Automatically install missing peer dependencies.
 When true (the default), missing peer dependencies are auto-installed
 during resolution and hoisted into the importer. Set to `false` to
 match pnpm's opt-out behavior: peers are left alone and unmet peers
-surface as warnings.
+are silent (set `strict-peer-dependencies=true` for diagnostics).
 
 ### `dedupePeerDependents` {#setting-dedupepeerdependents}
 

--- a/docs/settings/workspace-yaml.md
+++ b/docs/settings/workspace-yaml.md
@@ -744,11 +744,9 @@ Fail if peer dependencies are missing or invalid.
 
 When true, any unmet peer dependency (missing, or resolved to a version
 outside the declared range) fails the install with a miette diagnostic
-instead of only surfacing as a warning. Mirrors pnpm's
-`strict-peer-dependencies` behavior. Combines with
-`autoInstallPeers`: peers the resolver auto-installs are never
-reported, so enabling strict mode only catches peers the resolver
-couldn't satisfy from an existing version in the graph.
+listing every mismatch. This is also the only way aube surfaces peer
+mismatches — by default aube is silent, matching bun/npm/yarn. Set
+this to `false` (the default) to disable.
 
 ### `resolvePeersFromWorkspaceRoot` {#setting-resolvepeersfromworkspaceroot}
 
@@ -773,13 +771,14 @@ Suppress warnings for specific missing peer dependencies.
 - Default: `undefined`
 - Workspace YAML keys: `peerDependencyRules.ignoreMissing`
 
-Glob list of peer dependency names whose "missing required peer" warning
-should be silenced. Only silences peers that are missing entirely — a peer
-present at the wrong version still warns (use `allowedVersions` or
-`allowAny` for that). Read from the root `package.json`
-(`pnpm.peerDependencyRules.ignoreMissing`), `pnpm-workspace.yaml`, and
-`.npmrc`. Later sources fully replace the previous source's list — values
-do not concatenate across sources.
+Glob list of peer dependency names to exclude from the
+`strict-peer-dependencies` check when they're missing entirely. A peer
+present at the wrong version is still reported (use `allowedVersions`
+or `allowAny` for that). Has no effect on the default install — aube
+is silent about peer mismatches unless strict mode is on. Read from
+the root `package.json` (`pnpm.peerDependencyRules.ignoreMissing`),
+`pnpm-workspace.yaml`, and `.npmrc`; later sources fully replace the
+previous source's list.
 
 ### `peerDependencyRules.allowedVersions` {#setting-peerdependencyrules-allowedversions}
 
@@ -808,10 +807,12 @@ Allow any peer version to resolve, bypassing semver checks.
 
 Glob list of peer dependency names whose semver check should be
 bypassed entirely — any resolved version counts as satisfying the
-declared range. Also silences missing-peer warnings for matching names.
-Escape hatch for packages with incompatible peer declarations. Read
-from the root `package.json`, `pnpm-workspace.yaml`, and `.npmrc`.
-Later sources fully replace the previous source's list.
+declared range. Also excludes missing peers for matching names. Escape
+hatch for packages with incompatible peer declarations. Has no effect
+on the default install — aube is silent about peer mismatches unless
+`strict-peer-dependencies` is on. Read from the root `package.json`,
+`pnpm-workspace.yaml`, and `.npmrc`; later sources fully replace the
+previous source's list.
 
 ## Build
 

--- a/test/peer_deps.bats
+++ b/test/peer_deps.bats
@@ -126,12 +126,13 @@ JSON
 	assert_output --partial "react@17.0.2"
 }
 
-@test "user pin outside declared peer range stays pinned and warns" {
+@test "user pin outside declared peer range stays pinned" {
 	# react@19.0.0 does NOT satisfy use-sync-external-store's declared
 	# peer range (^16.8.0 || ^17.0.0 || ^18.0.0). pnpm keeps the user's
 	# direct pin authoritative, wires that version into the peer context,
-	# and reports the mismatch instead of installing a second satisfying
-	# react@18 tree.
+	# and we do the same instead of installing a second satisfying
+	# react@18 tree. The default install stays silent about the mismatch
+	# (bun parity); strict-peer-dependencies is tested separately.
 	cat >package.json <<'JSON'
 {
   "name": "per-range-auto-resolve",
@@ -144,8 +145,7 @@ JSON
 JSON
 	run aube install
 	assert_success
-	assert_output --partial "Issues with peer dependencies found"
-	assert_output --partial "expected peer react@^16.8.0 || ^17.0.0 || ^18.0.0, found 19.0.0"
+	refute_output --partial "Issues with peer dependencies"
 
 	# Only the user's pinned react version lives in the lockfile.
 	run bash -c 'grep -q "^  react@19.0.0:" aube-lock.yaml'
@@ -163,11 +163,12 @@ JSON
 	assert_output --partial "react@19.0.0"
 }
 
-@test "auto-install-peers=false leaves peers alone and warns they're missing" {
+@test "auto-install-peers=false leaves peers alone" {
 	# With auto-install disabled, the resolver must NOT drag in any peer
 	# version on its own: no top-level node_modules/react, no hoisted
 	# react entry in the lockfile importers section, no peer-context
-	# suffix on use-sync-external-store. The unmet warning still fires.
+	# suffix on use-sync-external-store. Default install is silent
+	# about the mismatch (bun parity).
 	cat >.npmrc <<'RC'
 auto-install-peers=false
 RC
@@ -182,8 +183,7 @@ RC
 JSON
 	run aube install
 	assert_success
-	assert_output --partial "Issues with peer dependencies found"
-	assert_output --partial "missing required peer react@"
+	refute_output --partial "Issues with peer dependencies"
 
 	# No top-level react symlink.
 	run test -e node_modules/react
@@ -231,11 +231,13 @@ JSON
 	refute_output --partial "expected peer"
 }
 
-@test "conflicting peer ranges keep user pins and warn" {
+@test "conflicting peer ranges keep user pins" {
 	# Pin react@17 at the root while pulling in @testing-library/react@14,
-	# which declares peers react: ^18 and react-dom: ^18. pnpm keeps the
-	# user's direct pins authoritative and reports unmet peer ranges
-	# instead of installing parallel react@18/react-dom@18 trees.
+	# which declares peers react: ^18 and react-dom: ^18. We keep the
+	# user's direct pins authoritative and record the mismatch in the
+	# peer-context dep_path instead of installing parallel
+	# react@18/react-dom@18 trees. Default install stays silent about
+	# the mismatch (bun parity).
 	cat >package.json <<'JSON'
 {
   "name": "per-range-peer",
@@ -249,9 +251,7 @@ JSON
 JSON
 	run aube install
 	assert_success
-	assert_output --partial "Issues with peer dependencies found"
-	assert_output --partial "expected peer react@^18.0.0, found 17.0.2"
-	assert_output --partial "expected peer react-dom@^18.0.0, found 17.0.2"
+	refute_output --partial "Issues with peer dependencies"
 
 	# Only the user's pinned react version should exist in the lockfile.
 	run bash -c 'grep -q "^  react@17.0.2:" aube-lock.yaml'
@@ -319,9 +319,12 @@ JSON
 	assert_output --partial "strict-peer-dependencies is enabled"
 }
 
-@test "strict-peer-dependencies is off by default — unmet peers warn only" {
+@test "default install is silent about unmet peers (bun parity)" {
 	# Same setup as the strict test but without the strict flag. Must
-	# succeed and emit the plain warn: prefix, not error:.
+	# succeed and emit no peer-dependency output at all — bun/npm/yarn
+	# are silent here, and pnpm is the outlier that warns on every
+	# mismatch. strict-peer-dependencies=true is the escape hatch for
+	# users who want the list.
 	cat >.npmrc <<'RC'
 auto-install-peers=false
 RC
@@ -336,18 +339,22 @@ RC
 JSON
 	run aube install
 	assert_success
-	assert_output --partial "warn: Issues with peer dependencies found"
+	refute_output --partial "Issues with peer dependencies"
+	refute_output --partial "missing required peer"
+	refute_output --partial "expected peer"
 	refute_output --partial "strict-peer-dependencies is enabled"
 }
 
-@test "peerDependencyRules.ignoreMissing silences missing-peer warning" {
+@test "peerDependencyRules.ignoreMissing silences strict check on matching name" {
 	# pnpm.peerDependencyRules.ignoreMissing in package.json should
-	# suppress the unmet-peer warning for matching names. The underlying
-	# condition (auto-install-peers=false + declared required peer) is
-	# identical to the plain-warn test above; the escape hatch is what
-	# differs.
+	# suppress the missing-peer error under strict mode. Without the
+	# rule, the same setup would fail (see
+	# "strict-peer-dependencies fails install on unmet required peer").
+	# Non-strict installs are silent regardless — this test drives the
+	# rule through strict mode so a regression actually surfaces.
 	cat >.npmrc <<'RC'
 auto-install-peers=false
+strict-peer-dependencies=true
 RC
 	cat >package.json <<'JSON'
 {
@@ -366,6 +373,7 @@ JSON
 	run aube install
 	assert_success
 	refute_output --partial "Issues with peer dependencies found"
+	refute_output --partial "strict-peer-dependencies is enabled"
 }
 
 @test "peerDependencyRules.ignoreMissing also silences strict-peer-dependencies error" {
@@ -397,10 +405,13 @@ JSON
 
 @test "peerDependencyRules.ignoreMissing respects glob patterns" {
 	# `react*` should catch `react` but NOT an unrelated missing peer.
-	# Verified here by pointing ignoreMissing at a non-matching pattern
-	# and confirming the warning still fires.
+	# Non-strict installs are silent either way, so drive this through
+	# strict-peer-dependencies: with a non-matching pattern the unmet
+	# peer still fails the install, proving the glob filter didn't
+	# accept `vue*` as a match for `react`.
 	cat >.npmrc <<'RC'
 auto-install-peers=false
+strict-peer-dependencies=true
 RC
 	cat >package.json <<'JSON'
 {
@@ -417,16 +428,20 @@ RC
 }
 JSON
 	run aube install
-	assert_success
-	assert_output --partial "warn: Issues with peer dependencies found"
+	assert_failure
+	assert_output --partial "error: Issues with peer dependencies found"
 	assert_output --partial "missing required peer react@"
+	assert_output --partial "strict-peer-dependencies is enabled"
 }
 
 @test "peerDependencyRules.ignoreMissing is read from pnpm-workspace.yaml" {
 	# Same behavior as the package.json case above, but sourced from
-	# pnpm-workspace.yaml. Covers the settings-generator path.
+	# pnpm-workspace.yaml. Covers the settings-generator path. Driven
+	# through strict mode so the silence is meaningful — non-strict
+	# installs are silent regardless.
 	cat >.npmrc <<'RC'
 auto-install-peers=false
+strict-peer-dependencies=true
 RC
 	cat >pnpm-workspace.yaml <<'YAML'
 peerDependencyRules:
@@ -445,16 +460,18 @@ JSON
 	run aube install
 	assert_success
 	refute_output --partial "Issues with peer dependencies found"
+	refute_output --partial "strict-peer-dependencies is enabled"
 }
 
 @test "peerDependencyRules.allowAny bypasses semver mismatch on resolved peer" {
 	# auto-install-peers=false + react@19 pinned at root means
 	# use-sync-external-store resolves its peer to react@19, which is
-	# outside its declared range (^16.8 || ^17 || ^18). That fires the
-	# "expected peer react@..., found 19" warning normally; allowAny
-	# silences it.
+	# outside its declared range (^16.8 || ^17 || ^18). Under strict
+	# mode that would fail with "expected peer react@..., found 19";
+	# allowAny silences it so the install succeeds.
 	cat >.npmrc <<'RC'
 auto-install-peers=false
+strict-peer-dependencies=true
 RC
 	cat >package.json <<'JSON'
 {
@@ -474,15 +491,17 @@ JSON
 	run aube install
 	assert_success
 	refute_output --partial "Issues with peer dependencies found"
+	refute_output --partial "strict-peer-dependencies is enabled"
 }
 
-@test "peerDependencyRules.allowAny also silences missing-peer warnings" {
+@test "peerDependencyRules.allowAny also silences missing peers" {
 	# allowAny is a strict superset of ignoreMissing: it bypasses the
 	# semver check and also silences missing peers for matching names.
 	# Verified here without pinning react — the peer is literally
-	# missing and allowAny: react silences it.
+	# missing and allowAny: react silences the strict-mode failure.
 	cat >.npmrc <<'RC'
 auto-install-peers=false
+strict-peer-dependencies=true
 RC
 	cat >package.json <<'JSON'
 {
@@ -501,4 +520,5 @@ JSON
 	run aube install
 	assert_success
 	refute_output --partial "Issues with peer dependencies found"
+	refute_output --partial "strict-peer-dependencies is enabled"
 }

--- a/test/peer_deps.bats
+++ b/test/peer_deps.bats
@@ -296,7 +296,7 @@ JSON
 
 @test "strict-peer-dependencies fails install on unmet required peer" {
 	# With auto-install-peers off, use-sync-external-store's required
-	# react peer is unresolvable. Plain install warns but succeeds;
+	# react peer is unresolvable. Plain install is silent and succeeds;
 	# strict-peer-dependencies should flip the same condition into a
 	# hard failure with the error-level diagnostic lines.
 	cat >.npmrc <<'RC'


### PR DESCRIPTION
## Summary

Stop emitting pnpm-style `warn: Issues with peer dependencies found` lines on every install. Real-world trees (React 19 against libraries pinned to `^16||^17||^18`, for example) fan one bad peer into a dozen warnings that drown the actionable ones. bun/npm/yarn are all silent here by default; pnpm is the outlier. This aligns aube with the quiet majority.

**Before**

```
warn: Issues with peer dependencies found
warn:   @textea/json-viewer@4.0.1: expected peer react@^17 || ^18, found 19.2.4
warn:   @textea/json-viewer@4.0.1: expected peer react-dom@^17 || ^18, found 19.2.4
warn:   react-datepicker@4.14.0: expected peer react@^16.9.0 || ^17 || ^18, found 19.2.4
... 10 more ...
```

**After**

(nothing)

## Escape hatch

Users who want the list flip `strict-peer-dependencies=true` in `.npmrc` or `pnpm-workspace.yaml`. Same diagnostic as before, except it fails the install (pnpm's existing strict-mode semantics, unchanged). `peerDependencyRules.{ignoreMissing,allowAny,allowedVersions}` still filter out matches before the strict check.

## What changed

- `warn_unmet_peers` → `check_unmet_peers` in `crates/aube/src/commands/install/settings.rs`. Non-strict path short-circuits before the peer walk — it's not free on a large graph and nothing consumes the output.
- `strict-peer-dependencies` doc in `settings.toml` explains that it's now the only surface for the diagnostic.
- `peerDependencyRules.ignoreMissing` / `allowAny` docs clarify the escape hatches are inert when strict mode is off.
- Regenerated `docs/settings/*.md` from the updated `settings.toml`.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `mise run test:bats test/peer_deps.bats` — all 15 tests pass, including the new `default install is silent about unmet peers (bun parity)` and existing strict-mode tests
- [x] Tests that previously asserted the warn output have been either rewritten to exercise strict mode (so the filter logic still gets meaningfully tested) or converted to refute the output entirely
- [ ] Reviewer: confirm we're OK making this a behavior change in a beta — users relying on the warn output as a CI signal need to switch to `strict-peer-dependencies=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change in install output and failure conditions: CI/workflows that relied on peer warnings will now see no output unless strict mode is enabled. The code path is straightforward but touches install-time validation and related settings/tests.
> 
> **Overview**
> Aube `install` no longer prints pnpm-style peer-dependency mismatch warnings on the default path; peer issues are now **silent unless** `strict-peer-dependencies=true` is set.
> 
> The previous `warn_unmet_peers` logic is renamed/reshaped into `check_unmet_peers`, is only executed in strict mode, and always fails the install with an error diagnostic after applying `peerDependencyRules` filters. Settings/docs/tests are updated to reflect that `autoInstallPeers`/`peerDependencyRules` only affect visibility under strict mode and that strict mode is the primary diagnostics escape hatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 543f518703a4ba9ed9c3e91af80331f82440ab50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->