### PR TITLE
install: wipe node_modules when global virtual store toggles

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -18,9 +18,9 @@ pub(crate) use side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_r
 use settings::{
     ResolverConfigInputs, check_unmet_peers, configure_resolver,
     default_lockfile_network_concurrency, default_streaming_network_concurrency,
-    find_gvs_incompatible_trigger, maybe_cleanup_unused_catalogs, resolve_dedupe_peer_dependents,
-    resolve_dedupe_peers, resolve_git_shallow_hosts, resolve_link_concurrency,
-    resolve_network_concurrency, resolve_peers_from_workspace_root,
+    detect_aube_dir_gvs_mode, find_gvs_incompatible_trigger, maybe_cleanup_unused_catalogs,
+    resolve_dedupe_peer_dependents, resolve_dedupe_peers, resolve_git_shallow_hosts,
+    resolve_link_concurrency, resolve_network_concurrency, resolve_peers_from_workspace_root,
     resolve_peers_suffix_max_length, resolve_side_effects_cache,
     resolve_side_effects_cache_readonly, resolve_strict_peer_dependencies,
     resolve_strict_store_pkg_content_check, resolve_symlink, resolve_use_running_store_server,
@@ -2256,6 +2256,43 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             graph.packages.len()
         );
         return Ok(());
+    }
+
+    // Global-virtual-store transition guard. The linker can't reconcile
+    // a mode switch in place — a non-gvs pass landing on a gvs tree
+    // silently re-uses stale symlinks into the shared store, and a gvs
+    // pass landing on a per-project tree fails to unlink the populated
+    // directories before creating its symlinks. When the existing
+    // `.aube/` tree's layout disagrees with the mode this install will
+    // produce, wipe `node_modules/` (and, if `virtualStoreDir` points
+    // outside it, the standalone `.aube/` tree) so the linker rebuilds
+    // from scratch. Matches pnpm's behavior modulo the prompt: pnpm
+    // asks, aube warns and proceeds. `state` goes too so an interrupted
+    // wipe can't leave a half-rebuilt tree behind a stale warm-path
+    // "up to date" verdict. Skipped in `--lockfile-only` /
+    // `enableModulesDir=false` mode (the return above already handled
+    // that case — no node_modules to reconcile).
+    let planned_gvs = use_global_virtual_store_override.unwrap_or_else(|| {
+        // Match `Linker::new`'s default: `CI` unset → gvs on. Reads the
+        // same env snapshot `find_gvs_incompatible_trigger` checked
+        // above, so the two sites can't disagree mid-install.
+        !opts.env_snapshot.iter().any(|(k, _)| k == "CI")
+    });
+    if let Some(existing_gvs) = detect_aube_dir_gvs_mode(&aube_dir)
+        && existing_gvs != planned_gvs
+    {
+        let from = if existing_gvs { "enabled" } else { "disabled" };
+        let to = if planned_gvs { "enabled" } else { "disabled" };
+        let modules_dir_path = cwd.join(&modules_dir_name);
+        tracing::warn!(
+            "global virtual store {from} → {to}; removing {} and reinstalling from scratch",
+            modules_dir_path.display()
+        );
+        let _ = std::fs::remove_dir_all(&modules_dir_path);
+        if !aube_dir.starts_with(&modules_dir_path) {
+            let _ = std::fs::remove_dir_all(&aube_dir);
+        }
+        let _ = state::remove_state(&cwd);
     }
 
     // 3. Parse or resolve lockfile, streaming tarball fetches during resolution

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2288,10 +2288,35 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             "global virtual store {from} → {to}; removing {} and reinstalling from scratch",
             modules_dir_path.display()
         );
-        let _ = std::fs::remove_dir_all(&modules_dir_path);
-        if !aube_dir.starts_with(&modules_dir_path) {
-            let _ = std::fs::remove_dir_all(&aube_dir);
+        // Hard-fail the install on a wipe failure instead of swallowing
+        // the error. We've already told the user a wipe was happening,
+        // so proceeding past a half-complete removal would land on the
+        // exact stale mixed-mode tree this guard exists to prevent —
+        // worse than aborting with a clear error the user can act on
+        // (locked file on Windows, permissions, busy mount). A
+        // `NotFound` race (concurrent removal, user deleted the tree
+        // between our classification and the wipe) is benign and stays
+        // silent so the install can proceed.
+        if let Err(e) = std::fs::remove_dir_all(&modules_dir_path)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(miette!(
+                "global virtual store transition: failed to remove {}: {e}",
+                modules_dir_path.display()
+            ));
         }
+        if !aube_dir.starts_with(&modules_dir_path)
+            && let Err(e) = std::fs::remove_dir_all(&aube_dir)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(miette!(
+                "global virtual store transition: failed to remove {}: {e}",
+                aube_dir.display()
+            ));
+        }
+        // State-file removal is best-effort: a stale sidecar the next
+        // install can't read just degrades to a fresh-install verdict,
+        // which is exactly what we want here anyway.
         let _ = state::remove_state(&cwd);
     }
 

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -137,6 +137,56 @@ pub(super) fn find_gvs_incompatible_trigger<'a>(
     None
 }
 
+/// Classify the existing `.aube/` tree as built with the global virtual
+/// store (entries are symlinks into the shared store) or with
+/// per-project materialization (entries are real directories holding
+/// the package files). Returns `None` when the tree is missing or has
+/// no inspectable package entries — a fresh checkout or a prior
+/// `--lockfile-only` run.
+///
+/// The linker can't reconcile a mode switch in place: a non-gvs install
+/// that lands on a gvs tree silently re-uses stale symlinks into the
+/// shared store, and a gvs install that lands on a per-project tree
+/// fails to unlink the populated directories before creating its
+/// symlinks. Callers use this to detect the transition and wipe
+/// `node_modules/` before the linker runs.
+///
+/// Assumes a consistent `.aube/` tree (every entry the same type),
+/// which is what a successful install produces. A crash mid-link
+/// during a transition could leave a mixed tree; we classify from the
+/// first entry `read_dir` yields and let the next install self-heal
+/// — worst case is one extra wipe, which is identical to the cost of
+/// the transition we're already handling.
+pub(super) fn detect_aube_dir_gvs_mode(aube_dir: &std::path::Path) -> Option<bool> {
+    let entries = std::fs::read_dir(aube_dir).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // Skip the hidden hoist tree and sidecar dotfiles
+        // (`.modules.yaml`, etc.). Scoped packages are encoded as
+        // `@scope+name@version` on disk, so `@`-prefixed entries are
+        // real package entries and must not be skipped.
+        if name_str == "node_modules" || name_str.starts_with('.') {
+            continue;
+        }
+        // Classify via `read_link`, not `file_type().is_symlink()`.
+        // On Windows, `sys::create_dir_link` produces an NTFS junction
+        // whose `is_symlink()` is `false` and `is_dir()` is `true`,
+        // making a gvs-on entry indistinguishable from a per-project
+        // real directory via the file-type bit. `read_link` succeeds on
+        // both Unix symlinks and Windows junction reparse points, and
+        // returns `Err(InvalidInput)` on a regular directory — exactly
+        // the signal we need. Non-link IO errors just skip the entry
+        // and move on to the next candidate.
+        match std::fs::read_link(entry.path()) {
+            Ok(_) => return Some(true),
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => return Some(false),
+            Err(_) => continue,
+        }
+    }
+    None
+}
+
 /// Honor `cleanupUnusedCatalogs` by pruning declared-but-unreferenced
 /// catalog entries from the workspace yaml. No-op when the setting is
 /// off, when there is no workspace yaml file on disk, or when every

--- a/test/gvs_toggle_wipe.bats
+++ b/test/gvs_toggle_wipe.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+# Toggling `enableGlobalVirtualStore` across installs must wipe
+# `node_modules/` before the linker runs. The linker can't reconcile
+# the switch in place — stale symlinks survive the non-gvs pass, and
+# populated directories block the gvs pass — so the install driver
+# detects the mismatch up front, warns, and rebuilds from scratch.
+# Matches pnpm's behavior modulo the prompt.
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "disabling gvs via .npmrc wipes the previous gvs tree on next install" {
+	_setup_basic_fixture
+
+	run aube install
+	assert_success
+	# Initial state: gvs on, `.aube/<pkg>` is a symlink into the
+	# shared store.
+	[ -L node_modules/.aube/is-odd@3.0.1 ]
+
+	cat >.npmrc <<'RC'
+enableGlobalVirtualStore=false
+RC
+
+	run aube install
+	assert_success
+	assert_output --partial "global virtual store enabled → disabled"
+	assert_output --partial "removing"
+	# After the wipe + re-link: `.aube/<pkg>` is a real directory.
+	[ -d node_modules/.aube/is-odd@3.0.1 ]
+	[ ! -L node_modules/.aube/is-odd@3.0.1 ]
+}
+
+@test "re-enabling gvs via .npmrc wipes the previous per-project tree on next install" {
+	_setup_basic_fixture
+
+	cat >.npmrc <<'RC'
+enableGlobalVirtualStore=false
+RC
+	run aube install
+	assert_success
+	[ -d node_modules/.aube/is-odd@3.0.1 ]
+	[ ! -L node_modules/.aube/is-odd@3.0.1 ]
+
+	rm .npmrc
+
+	run aube install
+	assert_success
+	assert_output --partial "global virtual store disabled → enabled"
+	assert_output --partial "removing"
+	[ -L node_modules/.aube/is-odd@3.0.1 ]
+}
+
+@test "gvs setting unchanged across reinstalls does not emit the transition warning" {
+	_setup_basic_fixture
+
+	run aube install
+	assert_success
+
+	run aube install
+	assert_success
+	refute_output --partial "global virtual store"
+}


### PR DESCRIPTION
## Summary

- When the effective global virtual store (gvs) setting flips between installs, `aube install` now wipes `node_modules/` and rebuilds from scratch, matching pnpm's behavior modulo the prompt.
- Transition is detected by sampling the existing `.aube/<pkg>@<ver>` layout: symlinks → gvs was on, real directories → gvs was off. Planned mode comes from `use_global_virtual_store_override` (explicit setting + auto-disable trigger) falling back to the linker's CI default.
- On mismatch we emit a `tracing::warn!` (`global virtual store enabled → disabled; removing <path>…`), `remove_dir_all` on `modulesDir` (plus the standalone `.aube/` tree if `virtualStoreDir` points outside it), and clear the install state sidecar.

## Why

The linker can't reconcile a gvs mode switch in place: a non-gvs pass landing on a gvs tree silently re-uses stale symlinks into the shared store, and a gvs pass landing on a per-project tree fails to unlink the populated directories before creating its symlinks. Users who toggle `enableGlobalVirtualStore` in `.npmrc` would previously get a half-rebuilt tree with no indication anything was wrong.

## Notes for reviewer

- The check runs after the `--lockfile-only` / `enableModulesDir=false` early-return, so those paths never trigger a wipe (no `node_modules` to reconcile).
- The warm-path short-circuit already includes `enable_gvs` in its `settings_hash`, so explicit toggles invalidate the fast path and reach the new check. Auto-disable transitions (adding/removing `next` etc.) are caught via the package.json hash.
- `DirEntry::file_type()` uses lstat semantics on Unix, so we correctly see the entry itself rather than what it points at.

## Test plan

- [x] `cargo build -p aube`
- [x] `cargo clippy -p aube --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p aube` (230 unit + 4 e2e)
- [x] `mise run test:bats test/gvs_toggle_wipe.bats` (3 new cases: off→on, on→off, no-op)
- [x] `mise run test:bats test/nextjs_gvs_autodisable.bats test/virtual_store_hash.bats test/install.bats` (no regressions; 9 + 3 + 53)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces automatic, recursive deletion of `node_modules`/`virtualStoreDir` during `aube install`; incorrect mode detection or path handling could cause unexpected wipes or install failures.
> 
> **Overview**
> Prevents mixed `enableGlobalVirtualStore` layouts by detecting when an existing `.aube/` tree was created with a different global-virtual-store mode than the upcoming install, then warning and wiping `node_modules/` (and the standalone `virtualStoreDir` when outside it) plus clearing install state before linking.
> 
> Adds `detect_aube_dir_gvs_mode` to classify `.aube` entries via `read_link` (handles Windows junctions), and introduces Bats coverage for gvs on→off, off→on, and no-change reinstalls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e97b6b774d8e3de6daa8b259fdb93c30eed3b54b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->