### PR TITLE
docs: add star history chart to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,16 @@ Some pnpm commands are intentionally out of scope. Runtime-management commands s
 
 Thanks to [Buildkite](https://buildkite.com) for providing CI for aube.
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=endevco%2Faube&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=endevco/aube&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=endevco/aube&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=endevco/aube&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ## Contributors
 
 [![Contributors](https://contrib.rocks/image?repo=endevco/aube)](https://github.com/endevco/aube/graphs/contributors)


### PR DESCRIPTION
## Summary
- Adds a Star History section to `README.md` with a `<picture>` element that swaps between light and dark chart variants based on the viewer's `prefers-color-scheme`.
- Placed between the Buildkite CI block and Contributors.

## Test plan
- [ ] Preview README on GitHub in light and dark modes and confirm the chart renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that embeds an external star-history chart image/link in `README.md`. No runtime or build behavior is affected.
> 
> **Overview**
> Adds a new **Star History** section to `README.md`, embedding a star-history.com chart via a `<picture>` element that switches between light/dark variants using `prefers-color-scheme`.
> 
> The section is placed between the existing CI/Buildkite acknowledgment and the **Contributors** section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a6737cd9d789c3ff52cf42096da37044b618b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->