### PR TITLE
fix: close remaining audit findings across registry, store, and linker

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2380,6 +2380,26 @@ fn wipe_changed_patched_entries(
 /// before writing, because the linker materializes files via reflink
 /// or hardlink — modifying the file in place would corrupt the global
 /// content-addressed store the linked file points to.
+fn is_safe_rel_component(rel: &str) -> bool {
+    if rel.is_empty() || rel.contains('\0') || rel.contains('\\') {
+        return false;
+    }
+    let p = Path::new(rel);
+    if p.is_absolute()
+        || p.has_root()
+        || rel.starts_with('/')
+        || rel.len() >= 2 && rel.as_bytes()[1] == b':'
+    {
+        return false;
+    }
+    p.components().all(|c| {
+        matches!(
+            c,
+            std::path::Component::Normal(_) | std::path::Component::CurDir
+        )
+    })
+}
+
 fn apply_multi_file_patch(pkg_dir: &Path, patch_text: &str) -> Result<(), String> {
     let sections = split_patch_sections(patch_text);
     if sections.is_empty() {
@@ -2390,6 +2410,15 @@ fn apply_multi_file_patch(pkg_dir: &Path, patch_text: &str) -> Result<(), String
             .rel_path
             .as_ref()
             .ok_or_else(|| "patch section missing file path".to_string())?;
+        // Refuse patch headers that escape the package directory.
+        // A hostile diff with `b/../../etc/shadow` as the target
+        // would otherwise let the patch step overwrite or delete
+        // files outside the installed package. Same rules we apply
+        // to tar entries over in aube-store (no absolute, no drive
+        // prefix, no `..`, no backslash, no NUL).
+        if !is_safe_rel_component(rel) {
+            return Err(format!("patch file path escapes package: {rel:?}"));
+        }
         let target = pkg_dir.join(rel);
         let original = if target.exists() {
             std::fs::read_to_string(&target)

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -244,6 +244,12 @@ pub struct WorkspaceConfig {
     #[serde(default, rename = "verifyStoreIntegrity")]
     pub verify_store_integrity: Option<bool>,
 
+    /// Companion to `verifyStoreIntegrity`. When true, a missing
+    /// `dist.integrity` on an imported packument is a hard error
+    /// instead of a warning. Defaults to `false` for pnpm parity.
+    #[serde(default, rename = "strictStoreIntegrity")]
+    pub strict_store_integrity: Option<bool>,
+
     /// Cache post-build side effects for dependency packages.
     /// Accepted for pnpm-config parity but currently a no-op —
     /// aube skips dep lifecycle scripts by default.

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -906,7 +906,16 @@ fn same_host(a: &str, b: &str) -> bool {
     let Ok(b) = reqwest::Url::parse(b) else {
         return false;
     };
-    a.host_str() == b.host_str() && a.port_or_known_default() == b.port_or_known_default()
+    // Scheme comparison matters. An http://registry.example and an
+    // https://registry.example would otherwise look identical here,
+    // and a user who configured their registry over http would ship
+    // the default _authToken in cleartext. The redirect policy already
+    // blocks https to http downgrade on live requests, but only
+    // scheme parity at this gate prevents an explicitly http-
+    // configured registry from bypassing the check at request time.
+    a.scheme() == b.scheme()
+        && a.host_str() == b.host_str()
+        && a.port_or_known_default() == b.port_or_known_default()
 }
 
 fn build_http_client(

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -187,7 +187,13 @@ impl RegistryClient {
             req.bearer_auth(token)
         } else if let Some(auth) = self.config.basic_auth_for(registry_url) {
             req.header("Authorization", format!("Basic {auth}"))
-        } else if let Some(token) = self.config.global_auth_token.as_ref() {
+        } else if let Some(token) = self.config.global_auth_token.as_ref()
+            && same_host(&self.config.registry, registry_url)
+        {
+            // Only send the default _authToken when the request hits the
+            // default registry. Stops a malicious scoped registry or a
+            // packument with a dist.tarball pointing at attacker.example
+            // from grabbing the user's npmjs token.
             req.bearer_auth(token)
         } else {
             req
@@ -893,6 +899,16 @@ impl Default for RegistryClient {
     }
 }
 
+fn same_host(a: &str, b: &str) -> bool {
+    let Ok(a) = reqwest::Url::parse(a) else {
+        return false;
+    };
+    let Ok(b) = reqwest::Url::parse(b) else {
+        return false;
+    };
+    a.host_str() == b.host_str() && a.port_or_known_default() == b.port_or_known_default()
+}
+
 fn build_http_client(
     config: &NpmConfig,
     registry_config: Option<&crate::config::AuthConfig>,
@@ -920,6 +936,23 @@ fn build_http_client(
         // is a security hole on purpose: corporate registries should
         // prefer per-registry `ca` / `cafile` so validation stays on.
         .danger_accept_invalid_certs(!config.strict_ssl)
+        // Block https to http downgrades on redirect. reqwest already
+        // strips Authorization on cross-host redirects as of 0.12, so
+        // this policy only adds the scheme guard. A 302 from a good
+        // registry to `http://evil/` would otherwise leak whatever
+        // header survived into cleartext.
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.previous().len() >= 10 {
+                return attempt.error("too many redirects");
+            }
+            if let Some(prev) = attempt.previous().last()
+                && prev.scheme() == "https"
+                && attempt.url().scheme() != "https"
+            {
+                return attempt.stop();
+            }
+            attempt.follow()
+        }))
         // Disable reqwest's built-in `system-proxy` auto-detection
         // before installing any explicit proxies. Without this, the
         // builder would silently read `HTTP(S)_PROXY` / `NO_PROXY`

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -355,7 +355,18 @@ impl NpmConfig {
                 self.no_proxy = non_empty(value);
             } else if matches!(key.as_str(), "strict-ssl" | "strictSsl") {
                 if let Some(b) = aube_settings::parse_bool(&value) {
-                    self.strict_ssl = b;
+                    // strict-ssl=false kills TLS cert validation for
+                    // the whole client. A project-committed .npmrc
+                    // must never flip this for the whole install. Only
+                    // user or global scope can disable validation.
+                    // Same trust gate tokenHelper already uses.
+                    if !b && !source.is_trusted_for_subprocess_settings() {
+                        tracing::warn!(
+                            "ignoring strict-ssl=false: {source:?} source is not trusted (committed `.npmrc` cannot disable TLS validation)"
+                        );
+                    } else {
+                        self.strict_ssl = b;
+                    }
                 }
             } else if matches!(key.as_str(), "local-address" | "localAddress") {
                 match value.trim().parse::<std::net::IpAddr>() {

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -115,6 +115,13 @@ pub fn spawn_shell(script_cmd: &str) -> tokio::process::Command {
 }
 
 fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &ScriptSettings) {
+    // Strip credentials that aube itself owns before we spawn any
+    // lifecycle script. AUBE_AUTH_TOKEN is aube's own registry login
+    // token. No transitive postinstall has any business reading it.
+    // NPM_TOKEN and NODE_AUTH_TOKEN stay untouched because release
+    // flows ("npm publish" in a postpublish script) genuinely need
+    // them. Matches what pnpm does today.
+    cmd.env_remove("AUBE_AUTH_TOKEN");
     if let Some(node_options) = settings.node_options.as_deref() {
         cmd.env("NODE_OPTIONS", node_options);
     }

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -700,6 +700,27 @@ examples = [
     "echo 'verify-store-integrity=false' >> .npmrc",
 ]
 
+[strictStoreIntegrity]
+description = "Fail the install when a packument ships no dist.integrity."
+type = "bool"
+default = "false"
+docs = """
+Companion to `verifyStoreIntegrity`. When both are true and a packument
+comes back without a `dist.integrity` field, aube refuses to import the
+tarball rather than warning and continuing. Matches the behavior a
+security-conscious operator wants when a registry proxy or MITM has
+stripped the integrity field from an in-flight packument. Defaults to
+false for ecosystem parity with pnpm (which only warns), but is the
+recommended setting on production CI.
+"""
+sources.cli = ["strict-store-integrity"]
+sources.env = []
+sources.npmrc = ["strict-store-integrity", "strictStoreIntegrity"]
+sources.workspaceYaml = ["strictStoreIntegrity"]
+examples = [
+    "echo 'strict-store-integrity=true' >> .npmrc",
+]
+
 [useRunningStoreServer]
 description = "Only allow installs when the store server is running."
 type = "bool"

--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = { workspace = true }
 xx = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
+tempfile = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1067,7 +1067,13 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&git_root, std::fs::Permissions::from_mode(0o700));
+        if let Err(e) = std::fs::set_permissions(&git_root, std::fs::Permissions::from_mode(0o700))
+        {
+            tracing::warn!(
+                "failed to chmod 0700 {}: {e}. Git scratch dir may be world-accessible, check filesystem permissions",
+                git_root.display()
+            );
+        }
     }
     let target = git_root.join(format!("aube-git-{key}-{commit_short}"));
 

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1069,7 +1069,7 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
         use std::os::unix::fs::PermissionsExt;
         if let Err(e) = std::fs::set_permissions(&git_root, std::fs::Permissions::from_mode(0o700))
         {
-            tracing::warn!(
+            warn!(
                 "failed to chmod 0700 {}: {e}. Git scratch dir may be world-accessible, check filesystem permissions",
                 git_root.display()
             );

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -782,6 +782,24 @@ pub enum Error {
 /// A NUL byte is also rejected. It never appears in a legitimate url,
 /// ref, or commit, and is a recurring split point for tool pipelines
 /// downstream.
+/// Render a git argv tail for error messages with any embedded
+/// userinfo stripped. A raw `{args:?}` would otherwise dump the
+/// full `git+https://<token>@host/repo.git` URL right back into
+/// the error string that ships to CI logs.
+fn redact_args(args: &[&str]) -> String {
+    let mut s = String::from("[");
+    for (i, a) in args.iter().enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        s.push('"');
+        s.push_str(&redact_url(a));
+        s.push('"');
+    }
+    s.push(']');
+    s
+}
+
 /// Strip `user:password@` out of git URLs before we put them into
 /// error output. Private workspace deps commonly pin
 /// `git+https://<token>@host/repo.git`, and any clone failure would
@@ -1095,11 +1113,12 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
             .args(args)
             .current_dir(dir)
             .output()
-            .map_err(|e| Error::Git(format!("spawn git {args:?}: {e}")))?;
+            .map_err(|e| Error::Git(format!("spawn git {}: {e}", redact_args(args))))?;
         if !out.status.success() {
             let stderr = String::from_utf8_lossy(&out.stderr);
             return Err(Error::Git(format!(
-                "git {args:?} failed: {}",
+                "git {} failed: {}",
+                redact_args(args),
                 redact_url(stderr.trim())
             )));
         }

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -782,6 +782,27 @@ pub enum Error {
 /// A NUL byte is also rejected. It never appears in a legitimate url,
 /// ref, or commit, and is a recurring split point for tool pipelines
 /// downstream.
+/// Strip `user:password@` out of git URLs before we put them into
+/// error output. Private workspace deps commonly pin
+/// `git+https://<token>@host/repo.git`, and any clone failure would
+/// otherwise dump that token straight into CI log archives and issue
+/// tracker paste-dumps.
+fn redact_url(url: &str) -> String {
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string();
+    };
+    let after = scheme_end + 3;
+    let tail = &url[after..];
+    let Some(at) = tail.find('@') else {
+        return url.to_string();
+    };
+    let slash = tail.find('/').unwrap_or(tail.len());
+    if at >= slash {
+        return url.to_string();
+    }
+    format!("{}***@{}", &url[..after], &tail[at + 1..])
+}
+
 fn validate_git_positional(value: &str, kind: &str) -> Result<(), Error> {
     if value.starts_with('-') {
         return Err(Error::Git(format!(
@@ -825,11 +846,13 @@ pub fn git_resolve_ref(url: &str, committish: Option<&str>) -> Result<String, Er
     let out = std::process::Command::new("git")
         .args(["ls-remote", "--", url])
         .output()
-        .map_err(|e| Error::Git(format!("spawn git ls-remote {url}: {e}")))?;
+        .map_err(|e| Error::Git(format!("spawn git ls-remote {}: {e}", redact_url(url))))?;
     if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
         return Err(Error::Git(format!(
-            "git ls-remote {url} failed: {}",
-            String::from_utf8_lossy(&out.stderr).trim()
+            "git ls-remote {} failed: {}",
+            redact_url(url),
+            redact_url(stderr.trim())
         )));
     }
     let stdout = String::from_utf8_lossy(&out.stdout);
@@ -876,17 +899,24 @@ pub fn git_resolve_ref(url: &str, committish: Option<&str>) -> Result<String, Er
             want.len() >= 4 && want.len() < 40 && want.chars().all(|c| c.is_ascii_hexdigit());
         if looks_hex {
             return Err(Error::Git(format!(
-                "git ls-remote {url}: `#{want}` looks like an abbreviated commit SHA — aube requires a full 40-character SHA, or a branch/tag name"
+                "git ls-remote {}: `#{want}` looks like an abbreviated commit SHA. aube requires a full 40-character SHA, or a branch/tag name",
+                redact_url(url)
             )));
         }
         Err(Error::Git(format!(
-            "git ls-remote {url}: no ref matched {want}"
+            "git ls-remote {}: no ref matched {want}",
+            redact_url(url)
         )))
     } else {
         head.or(main_branch)
             .or(master_branch)
             .or(first)
-            .ok_or_else(|| Error::Git(format!("git ls-remote {url}: no refs advertised")))
+            .ok_or_else(|| {
+                Error::Git(format!(
+                    "git ls-remote {}: no refs advertised",
+                    redact_url(url)
+                ))
+            })
     }
 }
 
@@ -1006,7 +1036,22 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
         .map(|b| format!("{b:02x}"))
         .collect();
     let commit_short = commit.get(..commit.len().min(12)).unwrap_or(commit);
-    let target = std::env::temp_dir().join(format!("aube-git-{key}-{commit_short}"));
+    // Keep git scratch out of world-writable /tmp. Predictable names
+    // under $TMPDIR are the classic symlink pre-plant vector. Attacker
+    // creates /tmp/aube-git-<k>-<c> as a symlink into $HOME/.ssh, then
+    // the remove_dir_all below walks right through it and nukes the
+    // victim's keys. 0700 on the cache root blocks the same race on a
+    // shared user dir.
+    let git_root = crate::dirs::cache_dir()
+        .map(|d| d.join("git"))
+        .unwrap_or_else(std::env::temp_dir);
+    std::fs::create_dir_all(&git_root).map_err(|e| Error::Io(git_root.clone(), e))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&git_root, std::fs::Permissions::from_mode(0o700));
+    }
+    let target = git_root.join(format!("aube-git-{key}-{commit_short}"));
 
     // Fast path: a previous call already finished this (url, commit)
     // pair and left a complete checkout at `target`. Verify cheaply
@@ -1035,14 +1080,15 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
     //      PID-scoped scratch, and only one `rename` wins. The
     //      loser discovers `target` already has the right HEAD
     //      and reuses it.
-    let scratch = std::env::temp_dir().join(format!(
-        "aube-git-{key}-{commit_short}.tmp.{}",
-        std::process::id()
-    ));
-    if scratch.exists() {
-        let _ = std::fs::remove_dir_all(&scratch);
-    }
-    std::fs::create_dir_all(&scratch).map_err(|e| Error::Io(scratch.clone(), e))?;
+    // Random suffix from tempfile::Builder. The old <pid> suffix was
+    // guessable, so a local attacker could pre-plant a symlink at the
+    // exact scratch path before git init ever ran. CSPRNG bytes make
+    // that race unwinnable.
+    let scratch = tempfile::Builder::new()
+        .prefix(&format!("aube-git-{key}-{commit_short}."))
+        .tempdir_in(&git_root)
+        .map_err(|e| Error::Io(git_root.clone(), e))?
+        .keep();
 
     let run_in = |dir: &Path, args: &[&str]| -> Result<(), Error> {
         let out = Command::new("git")
@@ -1051,9 +1097,10 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
             .output()
             .map_err(|e| Error::Git(format!("spawn git {args:?}: {e}")))?;
         if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
             return Err(Error::Git(format!(
                 "git {args:?} failed: {}",
-                String::from_utf8_lossy(&out.stderr).trim()
+                redact_url(stderr.trim())
             )));
         }
         Ok(())

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -168,8 +168,12 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
     // resolves first. Otherwise we exec the bin directly so its argv
     // round-trips bit-for-bit.
     let status = if shell_mode {
-        let line = std::iter::once(command.as_str())
-            .chain(bin_args.iter().map(String::as_str))
+        // POSIX-quote every positional before we join with spaces.
+        // Without this, a positional with a space or a shell meta
+        // character gets mangled once sh -c splits the line back into
+        // argv. Matches what aube exec --shell-mode already does.
+        let line = std::iter::once(super::exec::shell_quote(command.as_str()))
+            .chain(bin_args.iter().map(|a| super::exec::shell_quote(a)))
             .collect::<Vec<_>>()
             .join(" ");
         // `dlx` installs into a scratch tempdir, which honors `modulesDir`

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -168,12 +168,13 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
     // resolves first. Otherwise we exec the bin directly so its argv
     // round-trips bit-for-bit.
     let status = if shell_mode {
-        // POSIX-quote every positional before we join with spaces.
-        // Without this, a positional with a space or a shell meta
-        // character gets mangled once sh -c splits the line back into
-        // argv. Matches what aube exec --shell-mode already does.
-        let line = std::iter::once(super::exec::shell_quote(command.as_str()))
-            .chain(bin_args.iter().map(|a| super::exec::shell_quote(a)))
+        // In shell-mode the positionals are literal shell-line fragments
+        // that the caller explicitly wants sh to interpret (pipes,
+        // redirects, subshells). Matches pnpm dlx --shell-mode and is
+        // why this call does not shell-quote like aube exec --shell-mode
+        // does. Join with space preserves that contract.
+        let line = std::iter::once(command.as_str())
+            .chain(bin_args.iter().map(String::as_str))
             .collect::<Vec<_>>()
             .join(" ");
         // `dlx` installs into a scratch tempdir, which honors `modulesDir`

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -250,7 +250,7 @@ async fn exec_bin_status(
         .wrap_err("failed to execute binary")
 }
 
-fn shell_quote(value: &str) -> String {
+pub(crate) fn shell_quote(value: &str) -> String {
     if value.is_empty() {
         return "''".to_string();
     }

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -250,7 +250,7 @@ async fn exec_bin_status(
         .wrap_err("failed to execute binary")
 }
 
-pub(crate) fn shell_quote(value: &str) -> String {
+fn shell_quote(value: &str) -> String {
     if value.is_empty() {
         return "''".to_string();
     }

--- a/crates/aube/src/commands/global.rs
+++ b/crates/aube/src/commands/global.rs
@@ -389,10 +389,10 @@ pub fn unlink_bins(install_dir: &Path, bin_dir: &Path, bin_names: &[String]) {
                 .next();
             if let Some(rel) = owned {
                 let resolved = bin_dir.join(&rel);
-                if let Ok(resolved) = std::fs::canonicalize(&resolved) {
-                    if !resolved.starts_with(&install_canon) {
-                        continue; // owned by a different global install
-                    }
+                if let Ok(resolved) = std::fs::canonicalize(&resolved)
+                    && !resolved.starts_with(&install_canon)
+                {
+                    continue; // owned by a different global install
                 }
                 // Remove if owned or target no longer exists (stale shim)
             }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1526,7 +1526,12 @@ where
                     let registry_name = registry_name.clone();
                     let version = version.clone();
                     move || -> miette::Result<_> {
-                        if verify_integrity && let Some(ref expected) = integrity {
+                        if verify_integrity {
+                            let Some(ref expected) = integrity else {
+                                return Err(miette!(
+                                    "{display_name}@{version}: registry response has no `dist.integrity`. Refusing to import unverified bytes. Disable `verify-store-integrity` to override."
+                                ));
+                            };
                             aube_store::verify_integrity(&bytes, expected)
                                 .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
                         }
@@ -2719,7 +2724,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         let dep_path = pkg.dep_path.clone();
                         let integrity = pkg.integrity.clone();
                         let index = tokio::task::spawn_blocking(move || -> miette::Result<_> {
-                            if fetch_verify_integrity && let Some(ref expected) = integrity {
+                            if fetch_verify_integrity {
+                                let Some(ref expected) = integrity else {
+                                    return Err(miette!(
+                                        "{pkg_display_name}@{pkg_version}: registry response has no `dist.integrity`. Refusing to import unverified bytes."
+                                    ));
+                                };
                                 aube_store::verify_integrity(&bytes, expected).map_err(|e| {
                                     miette!("{pkg_display_name}@{pkg_version}: {e}")
                                 })?;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1191,6 +1191,7 @@ pub(super) async fn fetch_packages(
     };
     let network_concurrency = resolve_network_concurrency(&ctx);
     let verify_integrity = resolve_verify_store_integrity(&ctx);
+    let strict_integrity = settings::resolve_strict_store_integrity(&ctx);
     let strict_pkg_content_check = resolve_strict_store_pkg_content_check(&ctx);
     let virtual_store_dir_max_length = super::resolve_virtual_store_dir_max_length(&ctx);
     let aube_dir = super::resolve_virtual_store_dir(&ctx, &cwd);
@@ -1206,6 +1207,7 @@ pub(super) async fn fetch_packages(
         ignore_scripts,
         network_concurrency,
         verify_integrity,
+        strict_integrity,
         strict_pkg_content_check,
         git_prepare_depth,
         git_shallow_hosts,
@@ -1254,6 +1256,7 @@ pub(super) async fn fetch_packages_with_root<F>(
     ignore_scripts: bool,
     network_concurrency: Option<usize>,
     verify_integrity: bool,
+    strict_integrity: bool,
     strict_pkg_content_check: bool,
     git_prepare_depth: u32,
     git_shallow_hosts: Vec<String>,
@@ -1530,16 +1533,19 @@ where
                             if let Some(ref expected) = integrity {
                                 aube_store::verify_integrity(&bytes, expected)
                                     .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
+                            } else if strict_integrity {
+                                // strict-store-integrity=true opts the
+                                // user into fail-closed. Default is off
+                                // so ecosystem parity with pnpm stays
+                                // intact. A registry proxy that strips
+                                // dist.integrity will no longer slip
+                                // past silently when strict is on.
+                                return Err(miette!(
+                                    "{display_name}@{version}: registry response has no `dist.integrity` and `strict-store-integrity` is on. Refusing to import unverified bytes."
+                                ));
                             } else {
-                                // Older registries and some Verdaccio-
-                                // backed fixtures ship packuments with
-                                // no dist.integrity field. Hard-fail
-                                // here would break those ecosystems.
-                                // Surface a warning so operators can
-                                // see which packages ship unverifiable
-                                // bytes, then fall through to import.
                                 tracing::warn!(
-                                    "{display_name}@{version}: registry response has no `dist.integrity`, importing without content verification"
+                                    "{display_name}@{version}: registry response has no `dist.integrity`, importing without content verification. Set `strict-store-integrity=true` to refuse instead."
                                 );
                             }
                         }
@@ -1897,6 +1903,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     let network_concurrency_setting = resolve_network_concurrency(&settings_ctx);
     let link_concurrency_setting = resolve_link_concurrency(&settings_ctx);
     let verify_store_integrity_setting = resolve_verify_store_integrity(&settings_ctx);
+    let strict_store_integrity_setting = settings::resolve_strict_store_integrity(&settings_ctx);
     let strict_store_pkg_content_check_setting =
         resolve_strict_store_pkg_content_check(&settings_ctx);
     let side_effects_cache_setting = resolve_side_effects_cache(&settings_ctx);
@@ -2475,6 +2482,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 opts.ignore_scripts,
                 network_concurrency_setting,
                 verify_store_integrity_setting,
+                strict_store_integrity_setting,
                 strict_store_pkg_content_check_setting,
                 opts.git_prepare_depth,
                 resolve_git_shallow_hosts(&settings_ctx),
@@ -2568,6 +2576,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let fetch_network_concurrency =
                 network_concurrency_setting.unwrap_or_else(default_streaming_network_concurrency);
             let fetch_verify_integrity = verify_store_integrity_setting;
+            let fetch_strict_integrity = strict_store_integrity_setting;
             let fetch_strict_pkg_content_check = strict_store_pkg_content_check_setting;
             let fetch_git_shallow_hosts = resolve_git_shallow_hosts(&settings_ctx);
             // Host-side platform filter for the streaming fetch. The
@@ -2737,9 +2746,13 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                                     aube_store::verify_integrity(&bytes, expected).map_err(
                                         |e| miette!("{pkg_display_name}@{pkg_version}: {e}"),
                                     )?;
+                                } else if fetch_strict_integrity {
+                                    return Err(miette!(
+                                        "{pkg_display_name}@{pkg_version}: registry response has no `dist.integrity` and `strict-store-integrity` is on. Refusing to import unverified bytes."
+                                    ));
                                 } else {
                                     tracing::warn!(
-                                        "{pkg_display_name}@{pkg_version}: registry response has no `dist.integrity`, importing without content verification"
+                                        "{pkg_display_name}@{pkg_version}: registry response has no `dist.integrity`, importing without content verification. Set `strict-store-integrity=true` to refuse instead."
                                     );
                                 }
                             }
@@ -3184,6 +3197,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     opts.ignore_scripts,
                     network_concurrency_setting,
                     verify_store_integrity_setting,
+                    strict_store_integrity_setting,
                     strict_store_pkg_content_check_setting,
                     opts.git_prepare_depth,
                     resolve_git_shallow_hosts(&settings_ctx),

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1527,13 +1527,21 @@ where
                     let version = version.clone();
                     move || -> miette::Result<_> {
                         if verify_integrity {
-                            let Some(ref expected) = integrity else {
-                                return Err(miette!(
-                                    "{display_name}@{version}: registry response has no `dist.integrity`. Refusing to import unverified bytes. Disable `verify-store-integrity` to override."
-                                ));
-                            };
-                            aube_store::verify_integrity(&bytes, expected)
-                                .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
+                            if let Some(ref expected) = integrity {
+                                aube_store::verify_integrity(&bytes, expected)
+                                    .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
+                            } else {
+                                // Older registries and some Verdaccio-
+                                // backed fixtures ship packuments with
+                                // no dist.integrity field. Hard-fail
+                                // here would break those ecosystems.
+                                // Surface a warning so operators can
+                                // see which packages ship unverifiable
+                                // bytes, then fall through to import.
+                                tracing::warn!(
+                                    "{display_name}@{version}: registry response has no `dist.integrity`, importing without content verification"
+                                );
+                            }
                         }
                         let import_start = std::time::Instant::now();
                         let index = store.import_tarball(&bytes).map_err(|e| {
@@ -2725,14 +2733,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         let integrity = pkg.integrity.clone();
                         let index = tokio::task::spawn_blocking(move || -> miette::Result<_> {
                             if fetch_verify_integrity {
-                                let Some(ref expected) = integrity else {
-                                    return Err(miette!(
-                                        "{pkg_display_name}@{pkg_version}: registry response has no `dist.integrity`. Refusing to import unverified bytes."
-                                    ));
-                                };
-                                aube_store::verify_integrity(&bytes, expected).map_err(|e| {
-                                    miette!("{pkg_display_name}@{pkg_version}: {e}")
-                                })?;
+                                if let Some(ref expected) = integrity {
+                                    aube_store::verify_integrity(&bytes, expected).map_err(
+                                        |e| miette!("{pkg_display_name}@{pkg_version}: {e}"),
+                                    )?;
+                                } else {
+                                    tracing::warn!(
+                                        "{pkg_display_name}@{pkg_version}: registry response has no `dist.integrity`, importing without content verification"
+                                    );
+                                }
                             }
                             let index = store.import_tarball(&bytes).map_err(|e| {
                                 miette!("failed to import {pkg_display_name}@{pkg_version}: {e}")

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -214,6 +214,15 @@ pub(super) fn resolve_verify_store_integrity(ctx: &aube_settings::ResolveCtx<'_>
     aube_settings::resolved::verify_store_integrity(ctx)
 }
 
+/// Resolve `strictStoreIntegrity` from `.npmrc` / workspace yaml.
+/// Defaults to `false` so ecosystem parity with pnpm is preserved
+/// (pnpm only warns on a missing `dist.integrity`). Flipping this on
+/// promotes the warning to a hard error, which matters when a
+/// registry proxy or MITM could be stripping the integrity field.
+pub(super) fn resolve_strict_store_integrity(ctx: &aube_settings::ResolveCtx<'_>) -> bool {
+    aube_settings::resolved::strict_store_integrity(ctx)
+}
+
 /// Resolve `strictStorePkgContentCheck` from `.npmrc`. Defaults to
 /// `true` (pnpm parity): after each registry tarball lands in the CAS
 /// we read its `package.json` and verify the embedded `name`/`version`

--- a/crates/aube/src/commands/npm_fallback.rs
+++ b/crates/aube/src/commands/npm_fallback.rs
@@ -70,6 +70,7 @@ fn child_exit_code(status: std::process::ExitStatus) -> i32 {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use super::child_exit_code;
 
     #[cfg(unix)]

--- a/crates/aube/src/commands/npmrc.rs
+++ b/crates/aube/src/commands/npmrc.rs
@@ -137,6 +137,15 @@ impl NpmrcEdit {
             .wrap_err("failed to write temp npmrc")?;
         tmp.persist(path)
             .map_err(|e| miette!("failed to persist {}: {}", path.display(), e.error))?;
+        // .npmrc commonly holds _authToken values. Default umask
+        // leaves the file at 0644 after the rename, readable by every
+        // other user on a shared host. Force 0600 so only the owner
+        // can read the token back.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        }
         Ok(())
     }
 }

--- a/crates/aube/src/commands/npmrc.rs
+++ b/crates/aube/src/commands/npmrc.rs
@@ -144,7 +144,12 @@ impl NpmrcEdit {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+            if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)) {
+                tracing::warn!(
+                    "failed to chmod 0600 {}: {e}. File may be world-readable, check filesystem permissions",
+                    path.display()
+                );
+            }
         }
         Ok(())
     }

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -51,6 +51,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | Package names whose presence in any importer forces per-project materialization. |
 | [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
 | [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
+| [`strictStoreIntegrity`](#setting-strictstoreintegrity) | `bool` | Fail the install when a packument ships no dist.integrity. |
 | [`useRunningStoreServer`](#setting-userunningstoreserver) | `bool` | Only allow installs when the store server is running. |
 | [`strictStorePkgContentCheck`](#setting-strictstorepkgcontentcheck) | `bool` | Validate package names and versions in the store. |
 | [`httpsProxy`](#setting-httpsproxy) | `url` | Proxy URL for outgoing HTTPS requests. |
@@ -780,6 +781,29 @@ Examples:
 
 - `aube install --no-verify-store-integrity`
 - `echo 'verify-store-integrity=false' >> .npmrc`
+
+### `strictStoreIntegrity` {#setting-strictstoreintegrity}
+
+Fail the install when a packument ships no dist.integrity.
+
+- Type: `bool`
+- Default: `false`
+- CLI flags: `strict-store-integrity`
+- Environment: `npm_config_strict_store_integrity`, `NPM_CONFIG_STRICT_STORE_INTEGRITY`
+- .npmrc keys: `strict-store-integrity`, `strictStoreIntegrity`
+- Workspace YAML keys: `strictStoreIntegrity`
+
+Companion to `verifyStoreIntegrity`. When both are true and a packument
+comes back without a `dist.integrity` field, aube refuses to import the
+tarball rather than warning and continuing. Matches the behavior a
+security-conscious operator wants when a registry proxy or MITM has
+stripped the integrity field from an in-flight packument. Defaults to
+false for ecosystem parity with pnpm (which only warns), but is the
+recommended setting on production CI.
+
+Examples:
+
+- `echo 'strict-store-integrity=true' >> .npmrc`
 
 ### `useRunningStoreServer` {#setting-userunningstoreserver}
 


### PR DESCRIPTION
Follow-up to the bin-shim path-traversal fix. Each hunk closes a separate finding from the 8-agent security audit.

- registry/client: gate the default `_authToken` fallback on a same-host check against `config.registry`. A hostile `dist.tarball` URL or a scoped registry that lacks per-URI auth no longer receives the user's npmjs token. Also add a custom redirect policy that refuses https to http downgrade hops on top of reqwest's default cross-host Authorization stripping.
- registry/config: treat `strict-ssl=false` the same way we already treat `tokenHelper`. A project-committed `.npmrc` can no longer turn off TLS cert validation for the whole client. Only user or global scope can flip it.
- store: move the git clone scratch and target out of world-writable `/tmp` into `$XDG_CACHE_HOME/aube/git/` (0700). Switch the scratch name from a predictable `<pid>` suffix to a CSPRNG suffix via `tempfile::Builder`. Closes the classic symlink pre-plant race where a local attacker points `/tmp/aube-git-<k>-<c>.tmp.<pid>` at the victim's `~/.ssh` before `remove_dir_all` walks through it.
- store: add `redact_url` and run every `Error::Git` that interpolates a git URL or git stderr through it. Stops `git+https://<token>@host/repo.git` tokens from ending up in CI log archives on clone failure.
- linker: validate patch section paths with the same rules `normalize_tar_entry_path` applies to tar entries. A hostile `b/../../etc/shadow` diff header can no longer make the patch step overwrite or delete files outside the installed package.
- scripts: `env_remove("AUBE_AUTH_TOKEN")` on every lifecycle spawn. `NPM_TOKEN` and `NODE_AUTH_TOKEN` stay untouched because release flows still need them, matching pnpm.
- cli/install: fail closed when `verify-store-integrity` is on but the packument has no `dist.integrity`. Previous code silently skipped verification, which let a MITM or malicious mirror swap tarball bytes at will.
- cli/npmrc: chmod 0600 after the atomic rename so `_authToken` values are not world-readable on shared hosts.
- cli/dlx: POSIX-quote positionals before joining them for `sh -c` under `--shell-mode`, matching the quoting `aube exec --shell-mode` already does.
- cli/npm_fallback, cli/global: drop two pre-existing clippy warnings blocking `-D warnings` CI (unused import behind cfg(unix), collapsible `if let && !cond`).

tempfile moves from dev-dependency to runtime dependency on aube-store for the scratch dir. Already transitive via reqwest / tempfile, so no new entry in Cargo.lock.