### PR TITLE
lockfile: render parse errors with miette source span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "aube-settings",
  "glob",
  "hex",
+ "miette",
  "node-semver",
  "serde",
  "serde_json",

--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -13,6 +13,7 @@ include = ["src/**/*.rs"]
 aube-manifest = { workspace = true }
 aube-settings = { workspace = true }
 glob = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -162,8 +162,16 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     let raw_content =
         std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     let cleaned = strip_jsonc(&raw_content);
+    // `strip_jsonc` preserves byte offsets, so a serde_json error on
+    // `cleaned` points at the same byte in `raw_content`. Feed the
+    // raw file into the `NamedSource` so miette renders the user's
+    // actual bun.lock (including comments) under the pointer.
+    debug_assert_eq!(raw_content.len(), cleaned.len());
 
-    let raw: RawBunLockfile = crate::parse_json(path, cleaned)?;
+    let raw: RawBunLockfile = match serde_json::from_str(&cleaned) {
+        Ok(v) => v,
+        Err(e) => return Err(Error::parse_json_err(path, raw_content, &e)),
+    };
 
     if raw.lockfile_version != 1 {
         return Err(Error::Parse(
@@ -458,6 +466,14 @@ fn split_ident(ident: &str) -> Option<(String, String)> {
 
 /// Strip JSONC features (line comments, block comments, trailing commas)
 /// to produce valid JSON. Respects string literals.
+///
+/// Output length is byte-identical to the input — comment bytes and
+/// trailing commas become spaces (newlines inside block comments are
+/// preserved). That keeps every byte offset in `cleaned` pointing at
+/// the same byte in the original file, so a `serde_json` parse error
+/// on the stripped buffer lines up with the user's editor line/column
+/// when rendered against the original source via `miette`'s fancy
+/// handler.
 fn strip_jsonc(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();
@@ -481,31 +497,51 @@ fn strip_jsonc(input: &str) -> String {
             continue;
         }
 
-        // Line comment
+        // Line comment: replace every byte up to (not including) the
+        // newline with a space. The `\n` itself is kept.
         if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
             while i < bytes.len() && bytes[i] != b'\n' {
+                out.push(' ');
                 i += 1;
             }
             continue;
         }
 
-        // Block comment
+        // Block comment: replace every byte with a space, but keep
+        // embedded newlines so line numbers don't shift.
         if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            out.push(' ');
+            out.push(' ');
             i += 2;
             while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                out.push(if bytes[i] == b'\n' { '\n' } else { ' ' });
                 i += 1;
             }
-            i += 2.min(bytes.len() - i.min(bytes.len()));
+            if i + 1 < bytes.len() {
+                // consume the closing `*/`
+                out.push(' ');
+                out.push(' ');
+                i += 2;
+            } else {
+                // unterminated block comment — mirror every remaining
+                // byte to preserve length, keeping newlines intact.
+                while i < bytes.len() {
+                    out.push(if bytes[i] == b'\n' { '\n' } else { ' ' });
+                    i += 1;
+                }
+            }
             continue;
         }
 
-        // Trailing comma: drop `,` if the next non-whitespace char is `}` or `]`
+        // Trailing comma: replace `,` with a space when the next
+        // non-whitespace char is `}` or `]`.
         if c == b',' {
             let mut j = i + 1;
             while j < bytes.len() && (bytes[j] as char).is_whitespace() {
                 j += 1;
             }
             if j < bytes.len() && (bytes[j] == b'}' || bytes[j] == b']') {
+                out.push(' ');
                 i += 1;
                 continue;
             }
@@ -943,6 +979,36 @@ mod tests {
         let out = strip_jsonc(input);
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["url"], "http://example.com/path");
+    }
+
+    /// `strip_jsonc` must preserve byte offsets so a `serde_json` error
+    /// on the stripped buffer maps 1:1 onto the original file — that's
+    /// the only reason `parse()` can hand `raw_content` to miette's
+    /// `NamedSource` and trust the span.
+    #[test]
+    fn test_strip_jsonc_preserves_byte_offsets() {
+        let cases = [
+            "{ \"a\": 1 }",                    // no-op
+            "{ // line\n  \"a\": 1 }",         // line comment
+            "{ /* block */ \"a\": 1 }",        // block comment
+            "{ /* multi\nline */ \"a\": 1 }",  // block spans newline
+            "{ \"a\": 1, \"b\": 2, }",         // trailing comma
+            "{ \"a\": \"// not a comment\" }", // comment inside string
+            "{ \"a\": 1 /* trailing",          // unterminated block
+        ];
+        for input in cases {
+            let out = strip_jsonc(input);
+            assert_eq!(
+                out.len(),
+                input.len(),
+                "length mismatch stripping {input:?} -> {out:?}"
+            );
+            // Every `\n` must land at the same byte offset so line
+            // numbers stay stable between the raw and cleaned buffers.
+            let raw_nls: Vec<usize> = input.match_indices('\n').map(|(i, _)| i).collect();
+            let out_nls: Vec<usize> = out.match_indices('\n').map(|(i, _)| i).collect();
+            assert_eq!(raw_nls, out_nls, "newline drift stripping {input:?}");
+        }
     }
 
     /// Build a placeholder SRI hash of the right shape (88-char base64

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -163,8 +163,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     let cleaned = strip_jsonc(&raw_content);
 
-    let raw: RawBunLockfile = serde_json::from_str(&cleaned)
-        .map_err(|e| Error::Parse(path.to_path_buf(), e.to_string()))?;
+    let raw: RawBunLockfile = crate::parse_json(path, cleaned)?;
 
     if raw.lockfile_version != 1 {
         return Err(Error::Parse(

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -1479,7 +1479,7 @@ fn refine_yarn_kind(path: &Path, kind: LockfileKind) -> LockfileKind {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum Error {
     #[error("no lockfile found in {0}")]
     NotFound(std::path::PathBuf),
@@ -1487,8 +1487,167 @@ pub enum Error {
     UnsupportedFormat(String),
     #[error("failed to read lockfile {0}: {1}")]
     Io(std::path::PathBuf, std::io::Error),
+    /// Structural/serialization lockfile errors that have no source
+    /// location — shape checks (`must be a mapping`), version guards
+    /// (`lockfileVersion N unsupported`), and `serde_yaml::to_string`
+    /// failures during write.
     #[error("failed to parse lockfile {0}: {1}")]
     Parse(std::path::PathBuf, String),
+    /// Deserialization failure with a byte offset into the source
+    /// content, so miette's `fancy` handler can draw a pointer at the
+    /// offending byte of the lockfile.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ParseDiag(Box<ParseError>),
+}
+
+/// Parse failure carrying the source content + span. Shaped identically
+/// to `aube_manifest::ParseError` so the two crates render the same way
+/// through miette's fancy handler.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to parse {path}: {message}")]
+pub struct ParseError {
+    pub path: std::path::PathBuf,
+    pub message: String,
+    pub src: miette::NamedSource<String>,
+    pub span: miette::SourceSpan,
+}
+
+impl miette::Diagnostic for ParseError {
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.src)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        Some(Box::new(std::iter::once(
+            miette::LabeledSpan::new_with_span(Some(self.message.clone()), self.span),
+        )))
+    }
+}
+
+/// Parse a JSON lockfile document, attaching a miette source span on
+/// failure so the fancy handler can point at the offending byte.
+pub fn parse_json<T: serde::de::DeserializeOwned>(
+    path: &std::path::Path,
+    content: String,
+) -> Result<T, Error> {
+    match serde_json::from_str(&content) {
+        Ok(v) => Ok(v),
+        Err(e) => Err(Error::parse_json_err(path, content, &e)),
+    }
+}
+
+/// Parse a YAML lockfile document, attaching a miette source span on
+/// failure. `serde_yaml::Error::location` gives a byte offset directly,
+/// so no line/col conversion is needed.
+pub fn parse_yaml<T: serde::de::DeserializeOwned>(
+    path: &std::path::Path,
+    content: String,
+) -> Result<T, Error> {
+    match serde_yaml::from_str(&content) {
+        Ok(v) => Ok(v),
+        Err(e) => Err(Error::parse_yaml_err(path, content, &e)),
+    }
+}
+
+impl Error {
+    pub fn parse_json_err(
+        path: &std::path::Path,
+        content: String,
+        err: &serde_json::Error,
+    ) -> Self {
+        let offset = line_col_to_byte_offset(&content, err.line(), err.column());
+        let len = if offset >= content.len() { 0 } else { 1 };
+        Self::parse_at(path, content, err.to_string(), offset, len)
+    }
+
+    pub fn parse_yaml_err(
+        path: &std::path::Path,
+        content: String,
+        err: &serde_yaml::Error,
+    ) -> Self {
+        let (offset, len) = match err.location() {
+            Some(loc) => {
+                let idx = loc.index().min(content.len());
+                let len = if idx >= content.len() { 0 } else { 1 };
+                (idx, len)
+            }
+            None => (0, 0),
+        };
+        Self::parse_at(path, content, err.to_string(), offset, len)
+    }
+
+    fn parse_at(
+        path: &std::path::Path,
+        content: String,
+        message: String,
+        offset: usize,
+        len: usize,
+    ) -> Self {
+        let span = miette::SourceSpan::new(offset.into(), len);
+        Error::ParseDiag(Box::new(ParseError {
+            path: path.to_path_buf(),
+            message,
+            src: miette::NamedSource::new(path.display().to_string(), content),
+            span,
+        }))
+    }
+}
+
+/// serde_json's 1-based line/column → 0-based byte offset. Clamps to
+/// `content.len()` when the reported position is at EOF so the
+/// resulting span never runs past the buffer.
+fn line_col_to_byte_offset(content: &str, line: usize, column: usize) -> usize {
+    if line == 0 {
+        return 0;
+    }
+    let mut offset = 0usize;
+    for (i, l) in content.split_inclusive('\n').enumerate() {
+        if i + 1 == line {
+            return (offset + column.saturating_sub(1)).min(content.len());
+        }
+        offset += l.len();
+    }
+    content.len()
+}
+
+#[cfg(test)]
+mod parse_diag_tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Trailing `,` in an otherwise fine JSON lockfile — confirm the
+    /// helper attaches a `NamedSource` pointed at the lockfile path and
+    /// the span stays in bounds so miette can render a pointer.
+    #[test]
+    fn parse_json_attaches_span_for_bad_input() {
+        let path = Path::new("package-lock.json");
+        let content = r#"{"name":"x","#.to_string();
+        let Err(Error::ParseDiag(pe)) = parse_json::<serde_json::Value>(path, content.clone())
+        else {
+            panic!("parse_json must produce ParseDiag on malformed input");
+        };
+        let offset: usize = pe.span.offset();
+        let len: usize = pe.span.len();
+        assert!(offset + len <= content.len());
+        assert_eq!(pe.path, path);
+    }
+
+    /// Same story for YAML — serde_yaml reports a `Location` with a
+    /// byte index directly, so no line/col conversion is exercised here.
+    #[test]
+    fn parse_yaml_attaches_span_for_bad_input() {
+        let path = Path::new("yarn.lock");
+        let content = "packages:\n\t- pkg\n".to_string();
+        let Err(Error::ParseDiag(pe)) = parse_yaml::<serde_yaml::Value>(path, content.clone())
+        else {
+            panic!("parse_yaml must produce ParseDiag on malformed input");
+        };
+        let offset: usize = pe.span.offset();
+        let len: usize = pe.span.len();
+        assert!(offset + len <= content.len());
+        assert_eq!(pe.path, path);
+    }
 }
 
 #[cfg(test)]

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -1495,34 +1495,12 @@ pub enum Error {
     Parse(std::path::PathBuf, String),
     /// Deserialization failure with a byte offset into the source
     /// content, so miette's `fancy` handler can draw a pointer at the
-    /// offending byte of the lockfile.
+    /// offending byte of the lockfile. Reuses `aube_manifest`'s
+    /// `ParseError` — identical shape, identical rendering — via the
+    /// same `ParseDiag` pattern `aube-workspace` uses.
     #[error(transparent)]
     #[diagnostic(transparent)]
-    ParseDiag(Box<ParseError>),
-}
-
-/// Parse failure carrying the source content + span. Shaped identically
-/// to `aube_manifest::ParseError` so the two crates render the same way
-/// through miette's fancy handler.
-#[derive(Debug, thiserror::Error)]
-#[error("failed to parse {path}: {message}")]
-pub struct ParseError {
-    pub path: std::path::PathBuf,
-    pub message: String,
-    pub src: miette::NamedSource<String>,
-    pub span: miette::SourceSpan,
-}
-
-impl miette::Diagnostic for ParseError {
-    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        Some(&self.src)
-    }
-
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        Some(Box::new(std::iter::once(
-            miette::LabeledSpan::new_with_span(Some(self.message.clone()), self.span),
-        )))
-    }
+    ParseDiag(Box<aube_manifest::ParseError>),
 }
 
 /// Parse a JSON lockfile document, attaching a miette source span on
@@ -1543,9 +1521,9 @@ impl Error {
         content: String,
         err: &serde_json::Error,
     ) -> Self {
-        let offset = line_col_to_byte_offset(&content, err.line(), err.column());
-        let len = if offset >= content.len() { 0 } else { 1 };
-        Self::parse_at(path, content, err.to_string(), offset, len)
+        Error::ParseDiag(Box::new(aube_manifest::ParseError::from_json_err(
+            path, content, err,
+        )))
     }
 
     pub fn parse_yaml_err(
@@ -1553,49 +1531,10 @@ impl Error {
         content: String,
         err: &serde_yaml::Error,
     ) -> Self {
-        let (offset, len) = match err.location() {
-            Some(loc) => {
-                let idx = loc.index().min(content.len());
-                let len = if idx >= content.len() { 0 } else { 1 };
-                (idx, len)
-            }
-            None => (0, 0),
-        };
-        Self::parse_at(path, content, err.to_string(), offset, len)
+        Error::ParseDiag(Box::new(aube_manifest::ParseError::from_yaml_err(
+            path, content, err,
+        )))
     }
-
-    fn parse_at(
-        path: &std::path::Path,
-        content: String,
-        message: String,
-        offset: usize,
-        len: usize,
-    ) -> Self {
-        let span = miette::SourceSpan::new(offset.into(), len);
-        Error::ParseDiag(Box::new(ParseError {
-            path: path.to_path_buf(),
-            message,
-            src: miette::NamedSource::new(path.display().to_string(), content),
-            span,
-        }))
-    }
-}
-
-/// serde_json's 1-based line/column → 0-based byte offset. Clamps to
-/// `content.len()` when the reported position is at EOF so the
-/// resulting span never runs past the buffer.
-fn line_col_to_byte_offset(content: &str, line: usize, column: usize) -> usize {
-    if line == 0 {
-        return 0;
-    }
-    let mut offset = 0usize;
-    for (i, l) in content.split_inclusive('\n').enumerate() {
-        if i + 1 == line {
-            return (offset + column.saturating_sub(1)).min(content.len());
-        }
-        offset += l.len();
-    }
-    content.len()
 }
 
 #[cfg(test)]

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -1537,19 +1537,6 @@ pub fn parse_json<T: serde::de::DeserializeOwned>(
     }
 }
 
-/// Parse a YAML lockfile document, attaching a miette source span on
-/// failure. `serde_yaml::Error::location` gives a byte offset directly,
-/// so no line/col conversion is needed.
-pub fn parse_yaml<T: serde::de::DeserializeOwned>(
-    path: &std::path::Path,
-    content: String,
-) -> Result<T, Error> {
-    match serde_yaml::from_str(&content) {
-        Ok(v) => Ok(v),
-        Err(e) => Err(Error::parse_yaml_err(path, content, &e)),
-    }
-}
-
 impl Error {
     pub fn parse_json_err(
         path: &std::path::Path,
@@ -1634,14 +1621,19 @@ mod parse_diag_tests {
     }
 
     /// Same story for YAML — serde_yaml reports a `Location` with a
-    /// byte index directly, so no line/col conversion is exercised here.
+    /// byte index directly, so no line/col conversion is exercised
+    /// here. Both production sites (`pnpm.rs`, `yarn.rs`) call
+    /// `Error::parse_yaml_err` directly (one iterates multiple YAML
+    /// documents, the other has only borrowed content), so that's the
+    /// entry point this test locks down.
     #[test]
-    fn parse_yaml_attaches_span_for_bad_input() {
+    fn parse_yaml_err_attaches_span_for_bad_input() {
         let path = Path::new("yarn.lock");
         let content = "packages:\n\t- pkg\n".to_string();
-        let Err(Error::ParseDiag(pe)) = parse_yaml::<serde_yaml::Value>(path, content.clone())
-        else {
-            panic!("parse_yaml must produce ParseDiag on malformed input");
+        let yaml_err: serde_yaml::Error = serde_yaml::from_str::<serde_yaml::Value>(&content)
+            .expect_err("tab-indented YAML must fail");
+        let Error::ParseDiag(pe) = Error::parse_yaml_err(path, content.clone(), &yaml_err) else {
+            panic!("parse_yaml_err must produce ParseDiag");
         };
         let offset: usize = pe.span.offset();
         let len: usize = pe.span.len();

--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -190,8 +190,7 @@ struct RawNpmPeerDepMeta {
 /// Parse a package-lock.json or npm-shrinkwrap.json file into a LockfileGraph.
 pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     let content = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
-    let raw: RawNpmLockfile = serde_json::from_str(&content)
-        .map_err(|e| Error::Parse(path.to_path_buf(), e.to_string()))?;
+    let raw: RawNpmLockfile = crate::parse_json(path, content)?;
 
     if raw.lockfile_version < 2 {
         return Err(Error::Parse(

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     let content = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     let raw = parse_raw_lockfile(&content)
-        .map_err(|e| Error::Parse(path.to_path_buf(), e.to_string()))?;
+        .map_err(|e| Error::parse_yaml_err(path, content.clone(), &e))?;
 
     // Parse importers (direct deps of each workspace package).
     // We track synthesized LockedPackages for local (`file:` / `link:`)

--- a/crates/aube-lockfile/src/yarn.rs
+++ b/crates/aube-lockfile/src/yarn.rs
@@ -569,7 +569,7 @@ fn parse_berry_str(
     manifest: &aube_manifest::PackageJson,
 ) -> Result<LockfileGraph, Error> {
     let doc: serde_yaml::Value = serde_yaml::from_str(content)
-        .map_err(|e| Error::Parse(path.to_path_buf(), format!("yaml parse error: {e}")))?;
+        .map_err(|e| Error::parse_yaml_err(path, content.to_string(), &e))?;
     let map = doc.as_mapping().ok_or_else(|| {
         Error::Parse(
             path.to_path_buf(),

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -721,6 +721,52 @@ impl miette::Diagnostic for ParseError {
     }
 }
 
+impl ParseError {
+    /// Build a `ParseError` from a `serde_json::Error`, computing the
+    /// byte offset so miette can render a pointer into `content`.
+    /// Shared across crates (see `aube_lockfile::Error::parse_json_err`)
+    /// so there's a single implementation of the line/col → byte-offset
+    /// conversion and span clamping.
+    pub fn from_json_err(path: &Path, content: String, err: &serde_json::Error) -> Self {
+        let offset = line_col_to_byte_offset(&content, err.line(), err.column());
+        // Clamp the span length so it never extends past the content
+        // end. A trailing-newline-EOF error reports a position at or
+        // past `content.len()`; a fixed length of 1 would push the
+        // range one byte past the source and miette's renderer would
+        // fail to slice it. A zero-length span at `content.len()` is
+        // what miette expects for "end-of-input" labels.
+        let len = if offset >= content.len() { 0 } else { 1 };
+        Self::new(path, content, err.to_string(), offset, len)
+    }
+
+    /// Build a `ParseError` from a `serde_yaml::Error`.
+    /// `serde_yaml::Location::index` is already a byte offset, so no
+    /// line/col conversion is needed. Errors without a location
+    /// (notably those bubbling from `serde_yaml::from_value`) collapse
+    /// to an empty span at offset 0 — miette still renders the file
+    /// name + message, just without a pointer.
+    pub fn from_yaml_err(path: &Path, content: String, err: &serde_yaml::Error) -> Self {
+        let (offset, len) = match err.location() {
+            Some(loc) => {
+                let idx = loc.index().min(content.len());
+                let len = if idx >= content.len() { 0 } else { 1 };
+                (idx, len)
+            }
+            None => (0, 0),
+        };
+        Self::new(path, content, err.to_string(), offset, len)
+    }
+
+    fn new(path: &Path, content: String, message: String, offset: usize, len: usize) -> Self {
+        ParseError {
+            path: path.to_path_buf(),
+            message,
+            src: miette::NamedSource::new(path.display().to_string(), content),
+            span: miette::SourceSpan::new(offset.into(), len),
+        }
+    }
+}
+
 /// Parse a JSON document from `content`, returning an [`Error::Parse`] on
 /// failure with the source content + span attached so miette's fancy
 /// handler can render a pointer into the offending file.
@@ -751,47 +797,18 @@ pub fn parse_yaml<T: serde::de::DeserializeOwned>(
 }
 
 impl Error {
-    /// Build an [`Error::Parse`] from the offending content + serde error,
-    /// computing the byte offset so miette can render a pointer into the
-    /// source.
+    /// Build an [`Error::Parse`] from a `serde_json::Error`. Delegates
+    /// to [`ParseError::from_json_err`] — the crate-shared constructor
+    /// other crates (`aube-lockfile`) also reuse for their JSON parse
+    /// paths.
     pub fn parse(path: &Path, content: String, err: &serde_json::Error) -> Self {
-        let offset = line_col_to_byte_offset(&content, err.line(), err.column());
-        // Clamp the span length so it never extends past the content
-        // end. A trailing-newline-EOF error reports a position at or
-        // past `content.len()`; a fixed length of 1 would push the
-        // range one byte past the source and miette's renderer would
-        // fail to slice it. A zero-length span at `content.len()` is
-        // what miette expects for "end-of-input" labels.
-        let len = if offset >= content.len() { 0 } else { 1 };
-        Error::parse_at(path, content, err.to_string(), offset, len)
+        Error::Parse(Box::new(ParseError::from_json_err(path, content, err)))
     }
 
-    /// Build an [`Error::Parse`] from a `serde_yaml::Error`.
-    /// `serde_yaml::Location::index` is already a byte offset, so no
-    /// line/col conversion is needed. Errors without a location
-    /// (notably those bubbling from `serde_yaml::from_value`) collapse
-    /// to an empty span at offset 0 — miette still renders the file
-    /// name + message, just without a pointer.
+    /// Build an [`Error::Parse`] from a `serde_yaml::Error`. Delegates
+    /// to [`ParseError::from_yaml_err`].
     pub fn parse_yaml_err(path: &Path, content: String, err: &serde_yaml::Error) -> Self {
-        let (offset, len) = match err.location() {
-            Some(loc) => {
-                let idx = loc.index().min(content.len());
-                let len = if idx >= content.len() { 0 } else { 1 };
-                (idx, len)
-            }
-            None => (0, 0),
-        };
-        Error::parse_at(path, content, err.to_string(), offset, len)
-    }
-
-    fn parse_at(path: &Path, content: String, message: String, offset: usize, len: usize) -> Self {
-        let span = miette::SourceSpan::new(offset.into(), len);
-        Error::Parse(Box::new(ParseError {
-            path: path.to_path_buf(),
-            message,
-            src: miette::NamedSource::new(path.display().to_string(), content),
-            span,
-        }))
+        Error::Parse(Box::new(ParseError::from_yaml_err(path, content, err)))
     }
 }
 

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -734,6 +734,22 @@ pub fn parse_json<T: serde::de::DeserializeOwned>(
     }
 }
 
+/// Parse a YAML document from `content`, returning an [`Error::Parse`] on
+/// failure with the source content + span attached. `serde_yaml` reports
+/// errors with a `Location { index, line, column }` we can feed straight
+/// into a miette span; type-mismatch errors raised after `from_str`
+/// succeeds (e.g. via `from_value`) have no location and render without
+/// a pointer but still carry the file name.
+pub fn parse_yaml<T: serde::de::DeserializeOwned>(
+    path: &Path,
+    content: String,
+) -> Result<T, Error> {
+    match serde_yaml::from_str(&content) {
+        Ok(v) => Ok(v),
+        Err(e) => Err(Error::parse_yaml_err(path, content, &e)),
+    }
+}
+
 impl Error {
     /// Build an [`Error::Parse`] from the offending content + serde error,
     /// computing the byte offset so miette can render a pointer into the
@@ -747,10 +763,32 @@ impl Error {
         // fail to slice it. A zero-length span at `content.len()` is
         // what miette expects for "end-of-input" labels.
         let len = if offset >= content.len() { 0 } else { 1 };
+        Error::parse_at(path, content, err.to_string(), offset, len)
+    }
+
+    /// Build an [`Error::Parse`] from a `serde_yaml::Error`.
+    /// `serde_yaml::Location::index` is already a byte offset, so no
+    /// line/col conversion is needed. Errors without a location
+    /// (notably those bubbling from `serde_yaml::from_value`) collapse
+    /// to an empty span at offset 0 — miette still renders the file
+    /// name + message, just without a pointer.
+    pub fn parse_yaml_err(path: &Path, content: String, err: &serde_yaml::Error) -> Self {
+        let (offset, len) = match err.location() {
+            Some(loc) => {
+                let idx = loc.index().min(content.len());
+                let len = if idx >= content.len() { 0 } else { 1 };
+                (idx, len)
+            }
+            None => (0, 0),
+        };
+        Error::parse_at(path, content, err.to_string(), offset, len)
+    }
+
+    fn parse_at(path: &Path, content: String, message: String, offset: usize, len: usize) -> Self {
         let span = miette::SourceSpan::new(offset.into(), len);
         Error::Parse(Box::new(ParseError {
             path: path.to_path_buf(),
-            message: err.to_string(),
+            message,
             src: miette::NamedSource::new(path.display().to_string(), content),
             span,
         }))
@@ -890,6 +928,43 @@ mod tests {
             offset + len,
             content.len()
         );
+    }
+
+    /// A malformed YAML document should surface through `parse_yaml`
+    /// as an `Error::Parse` carrying a `NamedSource` pointed at the
+    /// supplied path and a span inside the content buffer.
+    #[test]
+    fn parse_yaml_attaches_source_span() {
+        let path = Path::new("pnpm-workspace.yaml");
+        // Tab as the first indent char is a spec-level YAML error;
+        // serde_yaml reports a location for it.
+        let content = "packages:\n\t- pkg\n".to_string();
+        let res: Result<serde_yaml::Value, Error> = parse_yaml(path, content.clone());
+        let Err(Error::Parse(pe)) = res else {
+            panic!("parse_yaml must produce Parse variant on malformed input");
+        };
+        let offset: usize = pe.span.offset();
+        let len: usize = pe.span.len();
+        assert!(offset + len <= content.len());
+        assert_eq!(pe.path, path);
+    }
+
+    /// `serde_yaml::from_value` errors have no `location()`. The helper
+    /// should still produce an `Error::Parse` (with a zero-length span)
+    /// so the file name survives into miette's render.
+    #[test]
+    fn parse_yaml_err_without_location_falls_back_to_empty_span() {
+        let path = Path::new("pnpm-workspace.yaml");
+        let content = String::new();
+        let yaml_err: serde_yaml::Error =
+            serde_yaml::from_value::<BTreeMap<String, String>>(serde_yaml::Value::Bool(true))
+                .expect_err("bool cannot coerce to a map");
+        assert!(yaml_err.location().is_none());
+        let Error::Parse(pe) = Error::parse_yaml_err(path, content, &yaml_err) else {
+            panic!("parse_yaml_err must produce Parse variant");
+        };
+        assert_eq!(pe.span.offset(), 0);
+        assert_eq!(pe.span.len(), 0);
     }
 
     #[test]

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -371,8 +371,7 @@ impl WorkspaceConfig {
                 if content.trim().is_empty() {
                     return Ok(Self::default());
                 }
-                return serde_yaml::from_str(&content)
-                    .map_err(|e| crate::Error::YamlParse(path.to_path_buf(), e.to_string()));
+                return crate::parse_yaml(&path, content);
             }
         }
         Ok(Self::default())
@@ -427,8 +426,7 @@ pub fn load_raw(project_dir: &Path) -> Result<BTreeMap<String, serde_yaml::Value
                 raw_cache_insert(project_dir, BTreeMap::new());
                 return Ok(BTreeMap::new());
             }
-            let parsed: BTreeMap<String, serde_yaml::Value> = serde_yaml::from_str(&content)
-                .map_err(|e| crate::Error::YamlParse(path.to_path_buf(), e.to_string()))?;
+            let parsed: BTreeMap<String, serde_yaml::Value> = crate::parse_yaml(&path, content)?;
             raw_cache_insert(project_dir, parsed.clone());
             return Ok(parsed);
         }
@@ -456,12 +454,11 @@ pub fn load_both(
                 raw_cache_insert(project_dir, BTreeMap::new());
                 return Ok((WorkspaceConfig::default(), BTreeMap::new()));
             }
-            let value: serde_yaml::Value = serde_yaml::from_str(&content)
-                .map_err(|e| crate::Error::YamlParse(path.to_path_buf(), e.to_string()))?;
+            let value: serde_yaml::Value = crate::parse_yaml(&path, content.clone())?;
             let typed: WorkspaceConfig = serde_yaml::from_value(value.clone())
-                .map_err(|e| crate::Error::YamlParse(path.to_path_buf(), e.to_string()))?;
+                .map_err(|e| crate::Error::parse_yaml_err(&path, content.clone(), &e))?;
             let raw: BTreeMap<String, serde_yaml::Value> = serde_yaml::from_value(value)
-                .map_err(|e| crate::Error::YamlParse(path.to_path_buf(), e.to_string()))?;
+                .map_err(|e| crate::Error::parse_yaml_err(&path, content, &e))?;
             raw_cache_insert(project_dir, raw.clone());
             return Ok((typed, raw));
         }
@@ -509,8 +506,7 @@ pub fn add_to_only_built_dependencies(
         if content.trim().is_empty() {
             Value::Mapping(Mapping::new())
         } else {
-            serde_yaml::from_str(&content)
-                .map_err(|e| crate::Error::YamlParse(path.clone(), e.to_string()))?
+            crate::parse_yaml(&path, content)?
         }
     } else {
         Value::Mapping(Mapping::new())

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -132,7 +132,7 @@ pub async fn run(args: AuditArgs, registry_override: Option<&str>) -> miette::Re
                 "no lockfile found — run `aube install` before `aube audit`"
             ));
         }
-        Err(e) => return Err(miette!(e)).wrap_err("failed to parse lockfile"),
+        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
     };
 
     let filter = DepFilter::from_flags(args.prod, args.dev);

--- a/crates/aube/src/commands/fetch.rs
+++ b/crates/aube/src/commands/fetch.rs
@@ -52,9 +52,7 @@ pub async fn run(args: FetchArgs) -> miette::Result<()> {
             ));
         }
         Err(e) => {
-            return Err(e)
-                .into_diagnostic()
-                .wrap_err("failed to parse lockfile");
+            return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile");
         }
     };
 

--- a/crates/aube/src/commands/ignored_builds.rs
+++ b/crates/aube/src/commands/ignored_builds.rs
@@ -95,7 +95,7 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
     let graph = match aube_lockfile::parse_lockfile(project_dir, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => return Ok(Vec::new()),
-        Err(e) => return Err(miette!(e)).wrap_err("failed to parse lockfile"),
+        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
     };
 
     let workspace = aube_manifest::WorkspaceConfig::load(project_dir)

--- a/crates/aube/src/commands/import.rs
+++ b/crates/aube/src/commands/import.rs
@@ -63,9 +63,7 @@ pub async fn run(args: ImportArgs) -> miette::Result<()> {
             ));
         }
         Err(e) => {
-            return Err(e)
-                .into_diagnostic()
-                .wrap_err("failed to parse source lockfile");
+            return Err(miette::Report::new(e)).wrap_err("failed to parse source lockfile");
         }
     };
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3252,9 +3252,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             ));
         }
         Err(e) => {
-            return Err(e)
-                .into_diagnostic()
-                .wrap_err("failed to parse lockfile");
+            return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile");
         }
     };
 

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -8,7 +8,7 @@
 use super::DepFilter;
 use aube_lockfile::LockfileGraph;
 use clap::Args;
-use miette::{Context, IntoDiagnostic, miette};
+use miette::{Context, IntoDiagnostic};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -95,7 +95,7 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
             eprintln!("No lockfile found. Run `aube install` first.");
             return Ok(());
         }
-        Err(e) => return Err(miette!(e)).wrap_err("failed to parse lockfile"),
+        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
     };
 
     let filter = DepFilter::from_flags(args.prod, args.dev);

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -145,7 +145,7 @@ pub async fn run(
             return Ok(());
         }
         Err(e) => {
-            return Err(miette!(e)).wrap_err("failed to parse lockfile");
+            return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile");
         }
     };
 

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -12,7 +12,7 @@ use super::{DepFilter, make_client, packument_cache_dir};
 use aube_lockfile::{DepType, DirectDep};
 use aube_registry::Packument;
 use clap::Args;
-use miette::{Context, IntoDiagnostic, miette};
+use miette::{Context, IntoDiagnostic};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -140,7 +140,7 @@ async fn run_filtered(
             eprintln!("No lockfile found. Run `aube install` first.");
             return Ok(());
         }
-        Err(e) => return Err(miette!(e)).wrap_err("failed to parse lockfile"),
+        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
     };
     let mut any_drift = false;
     for pkg in matched {
@@ -175,7 +175,7 @@ async fn run_one(cwd: &Path, args: OutdatedArgs, importer: Option<String>) -> mi
             eprintln!("No lockfile found. Run `aube install` first.");
             return Ok(false);
         }
-        Err(e) => return Err(miette!(e)).wrap_err("failed to parse lockfile"),
+        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
     };
 
     run_graph(cwd, args, &graph, graph.root_deps(), importer).await

--- a/crates/aube/src/commands/peers.rs
+++ b/crates/aube/src/commands/peers.rs
@@ -74,7 +74,7 @@ async fn check(args: PeersCheckArgs) -> miette::Result<()> {
         Err(aube_lockfile::Error::NotFound(_)) => {
             return Err(miette!("no lockfile found\nhelp: run `aube install` first"));
         }
-        Err(e) => return Err(miette!(e)).wrap_err("failed to parse lockfile"),
+        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
     };
 
     let issues = collect_issues(&graph);

--- a/crates/aube/src/commands/prune.rs
+++ b/crates/aube/src/commands/prune.rs
@@ -42,7 +42,7 @@ pub async fn run(args: PruneArgs) -> miette::Result<()> {
         .wrap_err("failed to read package.json")?;
 
     let graph = aube_lockfile::parse_lockfile(&cwd, &manifest)
-        .into_diagnostic()
+        .map_err(miette::Report::new)
         .wrap_err("failed to read lockfile — run `aube install` first")?;
 
     // Build the filtered graph via the existing BFS helper.

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -42,7 +42,7 @@ pub async fn run(
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
         Ok(graph) => Some(graph),
         Err(aube_lockfile::Error::NotFound(_)) => None,
-        Err(e) => return Err(miette!(e)).wrap_err("failed to parse lockfile"),
+        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
     };
 
     let modules_dir_name = aube_settings::resolved::modules_dir(&settings_ctx);

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -52,7 +52,7 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
                 "no lockfile found — run `aube install` before generating an SBOM"
             ));
         }
-        Err(e) => return Err(miette!(e)).wrap_err("failed to parse lockfile"),
+        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
     };
 
     let filter = DepFilter::from_flags(args.prod, args.dev);

--- a/crates/aube/src/commands/why.rs
+++ b/crates/aube/src/commands/why.rs
@@ -89,7 +89,7 @@ pub async fn run(
             return Ok(());
         }
         Err(e) => {
-            return Err(miette!(e)).wrap_err("failed to parse lockfile");
+            return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile");
         }
     };
 
@@ -136,7 +136,7 @@ fn run_filtered(
             return Ok(());
         }
         Err(e) => {
-            return Err(miette!(e)).wrap_err("failed to parse lockfile");
+            return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile");
         }
     };
 


### PR DESCRIPTION
## Summary

Extends [#157](https://github.com/endevco/aube/pull/157)'s `miette`-pointer rendering to every remaining file-backed parser. Lockfile and workspace-yaml parse failures now draw a pointer at the offending byte of the offending file instead of printing `… at line X column Y` with no file context.

Covered in this PR:

- [crates/aube-lockfile/src/npm.rs:193](../blob/HEAD/crates/aube-lockfile/src/npm.rs#L193) — `package-lock.json` / `npm-shrinkwrap.json`
- [crates/aube-lockfile/src/bun.rs:167](../blob/HEAD/crates/aube-lockfile/src/bun.rs#L167) — `bun.lock` (JSONC-stripped; span is valid against the stripped buffer)
- [crates/aube-lockfile/src/yarn.rs:571](../blob/HEAD/crates/aube-lockfile/src/yarn.rs#L571) — `yarn.lock` (berry)
- [crates/aube-lockfile/src/pnpm.rs:13](../blob/HEAD/crates/aube-lockfile/src/pnpm.rs#L13) — `pnpm-lock.yaml` (multi-document aware)
- [crates/aube-manifest/src/workspace.rs](../blob/HEAD/crates/aube-manifest/src/workspace.rs) — `aube-workspace.yaml` / `pnpm-workspace.yaml` across `load`, `load_raw`, `load_both` (typed + raw), and `add_to_only_built_dependencies`

## What changed

**`aube-manifest`** — new `parse_yaml<T>` helper + `Error::parse_yaml_err` constructor that reads `serde_yaml::Error::location()` for a direct byte offset. Structural errors (`must be a mapping`, serialize failures) stay on the existing `Error::YamlParse(PathBuf, String)` variant. Two new tests: one for a tab-indent YAML failure, one for the `from_value` no-location fallback.

**`aube-lockfile`** — mirrors the manifest shape. New `ParseError` struct with a hand-rolled `miette::Diagnostic` impl (same workaround PR #157 used to dodge the `miette-derive` 7.6 `unused_assignments` expansion). New `parse_json<T>` / `parse_yaml<T>` helpers and `Error::parse_json_err` / `parse_yaml_err` constructors on a new `Error::ParseDiag(Box<ParseError>)` variant. Non-span errors (dep-path validation, shape checks, `serde_yaml::to_string` failures) stay on the existing `Error::Parse(PathBuf, String)`. Two new tests covering JSON + YAML span attachment.

**CLI** — 13 call sites that previously erased the Diagnostic impl via `miette!(e)` or `.into_diagnostic()` switched to `miette::Report::new(e)` so `wrap_err` preserves the span. Touched: `audit.rs`, `fetch.rs`, `ignored_builds.rs`, `import.rs`, `install/mod.rs`, `licenses.rs`, `list.rs`, `outdated.rs`, `peers.rs`, `prune.rs`, `rebuild.rs`, `sbom.rs`, `why.rs`.

## Deliberately skipped

**Packuments** — `resp.json().await` consumes the response body before any parse error is raised, so attaching a `NamedSource` would need a `.text().await?` refactor across [crates/aube-registry/src/client.rs](../blob/HEAD/crates/aube-registry/src/client.rs) (lines 468, 548, 642, 752 + three `simd_json::serde::from_slice` cache-read sites). Packument parse failures are almost always registry breakage (unrecoverable), and the source would be a 5 MB blob from `registry.npmjs.org/<pkg>` that helps nobody — so the cost-benefit isn't there.

**[crates/aube/src/commands/install/mod.rs:2150](../blob/HEAD/crates/aube/src/commands/install/mod.rs#L2150)** — in the `--lockfile-only` bail path, the error is borrowed from a pre-parse cache that also gets reused on the success path, so preserving the Diagnostic here would need either a `LockfileGraph` clone or a larger control-flow restructure. Behavior is unchanged from before (same `miette!("failed to parse lockfile: {e}")`). The main install paths (around line 3254) and all read-only commands render the full diagnostic.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --release` — all suites green across all 13 crates
- [x] Manual: truncated `package-lock.json` via `aube install` renders with source pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches error types and parse error paths across multiple lockfile formats and CLI commands; functional behavior should be unchanged but regressions could affect how parse failures are reported or propagated.
> 
> **Overview**
> Lockfile and workspace file parsing errors now surface as `miette` diagnostics with an attached `NamedSource` and byte-accurate `SourceSpan`, so the CLI can render a pointer into the offending file instead of line/column-only messages.
> 
> This adds shared JSON/YAML parse helpers and new diagnostic error variants in `aube-lockfile` and `aube-manifest`, updates bun’s JSONC stripping to preserve byte offsets (with new tests), and switches multiple CLI commands to wrap lockfile parse failures via `miette::Report::new(e)` so spans aren’t lost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7acf6055a4555f6305537df4387a2cd9542578c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->