### PR TITLE
ci(release-plz): fetch communique via mise

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -149,9 +149,7 @@ jobs:
         with:
           ref: refs/tags/${{ needs.release-plz-release.outputs.tag }}
           submodules: recursive
-      - uses: Swatinem/rust-cache@v2
-      - name: Install communique
-        run: cargo install communique --locked
+      - uses: jdx/mise-action@v2
       - name: Enhance GitHub release with communique
         continue-on-error: true
         env:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -150,6 +150,8 @@ jobs:
           ref: refs/tags/${{ needs.release-plz-release.outputs.tag }}
           submodules: recursive
       - uses: jdx/mise-action@v2
+        with:
+          install_args: communique
       - name: Enhance GitHub release with communique
         continue-on-error: true
         env:


### PR DESCRIPTION
## Summary
- The `enhance-release` job was running `cargo install communique --locked`, which compiled from source on every release (~5+ min, see [run 24675235947](https://github.com/endevco/aube/actions/runs/24675235947/job/72160012243)).
- [mise.toml](mise.toml) already pins `communique = "latest"`, so swapping in `jdx/mise-action@v2` fetches a prebuilt binary in seconds.
- Dropped the `Swatinem/rust-cache@v2` step since nothing compiles Rust here anymore.

## Test plan
- [ ] Next release run completes the `Enhance release notes` job without a `cargo install` step
- [ ] Release body is still replaced with communique-generated notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change limited to the release notes enhancement job; main risk is a workflow failure if `mise`/tool resolution differs from the prior Cargo install.
> 
> **Overview**
> Speeds up the `enhance-release` GitHub Actions job by switching `communique` installation from `cargo install` (source build) to `jdx/mise-action@v2` fetching the pinned tool, and drops the Rust cache step since no compilation is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd91699dae5a7bc7917ab956f53b4fc31ba0e975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->