### PR TITLE
packaging(copr): escape $XDG_DATA_HOME in spec description

### DIFF
--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -208,7 +208,7 @@ BuildRequires:  pkgconf-pkg-config
 Aube is a fast Node.js package manager written in Rust. It mirrors
 pnpm's CLI surface and isolated symlink layout so users can swap it
 in, with its own aube-owned on-disk state (global store under
-$XDG_DATA_HOME/aube/store/, per-project virtual store in
+\$XDG_DATA_HOME/aube/store/, per-project virtual store in
 node_modules/.aube/).
 Aube reads and writes pnpm-lock.yaml, package-lock.json,
 npm-shrinkwrap.json, yarn.lock, and bun.lock in addition to its


### PR DESCRIPTION
## Summary

- The COPR publish workflow for v1.0.0-beta.9 failed at the "Build and submit to COPR" step with `./packaging/copr/build-copr.sh: line 185: XDG_DATA_HOME: unbound variable` ([run 24676006103](https://github.com/endevco/aube/actions/runs/24676006103)).
- `build-copr.sh` emits the RPM spec via an unquoted heredoc (`<<EOF`), so `$XDG_DATA_HOME` in the package description gets shell-expanded. It is unset in the COPR container, and `set -u` aborts before the spec is written.
- Escape it as `\$XDG_DATA_HOME` so bash passes the literal `$XDG_DATA_HOME` string through to the spec file, which is what the description intends to show the reader.

## Test plan

- [ ] Re-run the `copr-publish` workflow (or tag a fresh release) and confirm it proceeds past spec generation.
- [ ] Inspect the emitted `SPECS/aube.spec` and verify the `%description` contains the literal `$XDG_DATA_HOME/aube/store/` text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to packaging text that only affects RPM spec generation in the COPR build script.
> 
> **Overview**
> Fixes COPR RPM spec generation by escaping `$XDG_DATA_HOME` in the `%description` heredoc emitted by `packaging/copr/build-copr.sh`, preventing `set -u` failures when the variable is unset and preserving the intended literal path in the package description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 924b7d22632f40deea2845a6973c7dbcb5e950e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->