### PR TITLE
chore: release v1.0.0-beta.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 dependencies = [
  "miette",
  "serde",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 dependencies = [
  "base64",
  "blake3",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ strip = "debuginfo"
 panic = "abort"
 
 [workspace.package]
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -97,13 +97,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.9" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.9" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.9" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.9" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.9" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.9" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.9" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.9" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.9" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.9" }
+aube = { path = "crates/aube", version = "1.0.0-beta.10" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.10" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.10" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.10" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.10" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.10" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.10" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.10" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.10" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.10" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.9"
+version "1.0.0-beta.10"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.9...aube-linker-v1.0.0-beta.10) - 2026-04-21
+
+### Fixed
+
+- close remaining audit findings across registry, store, and linker ([#164](https://github.com/endevco/aube/pull/164))
+
 ## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.8...aube-linker-v1.0.0-beta.9) - 2026-04-20
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.9...aube-lockfile-v1.0.0-beta.10) - 2026-04-21
+
+### Fixed
+
+- pnpm-workspace.yaml overrides/patches, npm: alias overrides, cross-platform pnpm-lock ([#175](https://github.com/endevco/aube/pull/175))
+
+### Other
+
+- honor pnpm-workspace.yaml supportedArchitectures, ignoredOptionalDependencies, pnpmfilePath ([#181](https://github.com/endevco/aube/pull/181))
+- render parse errors with miette source span ([#166](https://github.com/endevco/aube/pull/166))
+- *(bun)* emit version, bin, optionalPeers on non-root workspaces ([#169](https://github.com/endevco/aube/pull/169))
+
 ## [1.0.0-beta.8](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.7...aube-lockfile-v1.0.0-beta.8) - 2026-04-20
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.9...aube-manifest-v1.0.0-beta.10) - 2026-04-21
+
+### Fixed
+
+- pnpm-workspace.yaml overrides/patches, npm: alias overrides, cross-platform pnpm-lock ([#175](https://github.com/endevco/aube/pull/175))
+- close remaining audit findings across registry, store, and linker ([#164](https://github.com/endevco/aube/pull/164))
+
+### Other
+
+- honor pnpm-workspace.yaml supportedArchitectures, ignoredOptionalDependencies, pnpmfilePath ([#181](https://github.com/endevco/aube/pull/181))
+- support $name references in overrides ([#180](https://github.com/endevco/aube/pull/180))
+- scope deprecation warnings + add `aube deprecations` ([#170](https://github.com/endevco/aube/pull/170))
+- read top-level trustedDependencies as allow-source ([#172](https://github.com/endevco/aube/pull/172))
+- render parse errors with miette source span ([#166](https://github.com/endevco/aube/pull/166))
+
 ## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.8...aube-manifest-v1.0.0-beta.9) - 2026-04-20
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.9...aube-registry-v1.0.0-beta.10) - 2026-04-21
+
+### Fixed
+
+- close remaining audit findings across registry, store, and linker ([#164](https://github.com/endevco/aube/pull/164))
+
+### Other
+
+- strip matched surrounding quotes from .npmrc values ([#182](https://github.com/endevco/aube/pull/182))
+- parse cached full packuments directly ([#184](https://github.com/endevco/aube/pull/184))
+- increase packument cache ttl for repeat installs ([#173](https://github.com/endevco/aube/pull/173))
+
 ## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.8...aube-registry-v1.0.0-beta.9) - 2026-04-20
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.9...aube-resolver-v1.0.0-beta.10) - 2026-04-21
+
+### Fixed
+
+- pnpm-workspace.yaml overrides/patches, npm: alias overrides, cross-platform pnpm-lock ([#175](https://github.com/endevco/aube/pull/175))
+
+### Other
+
+- avoid sorting packument versions during picks ([#176](https://github.com/endevco/aube/pull/176))
+- scope deprecation warnings + add `aube deprecations` ([#170](https://github.com/endevco/aube/pull/170))
+- collapse install bool bags into enums, FxHashMap in resolver ([#165](https://github.com/endevco/aube/pull/165))
+
 ## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.8...aube-resolver-v1.0.0-beta.9) - 2026-04-20
 
 ### Other

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0-beta.9...aube-scripts-v1.0.0-beta.10) - 2026-04-21
+
+### Fixed
+
+- close remaining audit findings across registry, store, and linker ([#164](https://github.com/endevco/aube/pull/164))
+
 ## [1.0.0-beta.7](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0-beta.6...aube-scripts-v1.0.0-beta.7) - 2026-04-19
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.9...aube-settings-v1.0.0-beta.10) - 2026-04-21
+
+### Fixed
+
+- close remaining audit findings across registry, store, and linker ([#164](https://github.com/endevco/aube/pull/164))
+
+### Other
+
+- honor pnpm-workspace.yaml supportedArchitectures, ignoredOptionalDependencies, pnpmfilePath ([#181](https://github.com/endevco/aube/pull/181))
+- scope deprecation warnings + add `aube deprecations` ([#170](https://github.com/endevco/aube/pull/170))
+
 ## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.8...aube-settings-v1.0.0-beta.9) - 2026-04-20
 
 ### Other

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.9...aube-store-v1.0.0-beta.10) - 2026-04-21
+
+### Fixed
+
+- close remaining audit findings across registry, store, and linker ([#164](https://github.com/endevco/aube/pull/164))
+
 ## [1.0.0-beta.8](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.7...aube-store-v1.0.0-beta.8) - 2026-04-20
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.10](https://github.com/endevco/aube/compare/v1.0.0-beta.9...v1.0.0-beta.10) - 2026-04-21
+
+### Fixed
+
+- pnpm-workspace.yaml overrides/patches, npm: alias overrides, cross-platform pnpm-lock ([#175](https://github.com/endevco/aube/pull/175))
+- close remaining audit findings across registry, store, and linker ([#164](https://github.com/endevco/aube/pull/164))
+
+### Other
+
+- honor pnpm-workspace.yaml supportedArchitectures, ignoredOptionalDependencies, pnpmfilePath ([#181](https://github.com/endevco/aube/pull/181))
+- hint at `aube deprecations --transitive` when transitives exist ([#183](https://github.com/endevco/aube/pull/183))
+- support $name references in overrides ([#180](https://github.com/endevco/aube/pull/180))
+- scope deprecation warnings + add `aube deprecations` ([#170](https://github.com/endevco/aube/pull/170))
+- read top-level trustedDependencies as allow-source ([#172](https://github.com/endevco/aube/pull/172))
+- collapse install bool bags into enums, FxHashMap in resolver ([#165](https://github.com/endevco/aube/pull/165))
+- render parse errors with miette source span ([#166](https://github.com/endevco/aube/pull/166))
+
 ## [1.0.0-beta.9](https://github.com/endevco/aube/compare/v1.0.0-beta.8...v1.0.0-beta.9) - 2026-04-20
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5734,7 +5734,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.9
+**Version**: 1.0.0-beta.10
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.9",
-  "releasedAt": "2026-04-20T15:24:06Z"
+  "version": "1.0.0-beta.10",
+  "releasedAt": "2026-04-21T00:14:34Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.10`

This PR bumps the workspace to `v1.0.0-beta.10` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version bump and regenerated release metadata/docs (no functional code changes in this diff). Main risk is accidental publish/doc/version mismatches across crates.
> 
> **Overview**
> Updates the workspace and all `aube-*` crate versions from `1.0.0-beta.9` to `1.0.0-beta.10`, including `Cargo.lock` and the internal dependency pins in `Cargo.toml`.
> 
> Regenerates release outputs: per-crate `CHANGELOG.md` entries for `beta.10`, updates `aube.usage.kdl` and generated CLI docs (`docs/cli/*`) to reflect the new version, and bumps `release.json` metadata (version + timestamp).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5d03b31324aad2c01a75914c6957b16bc15ec22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->