### PR TITLE
scripts: read top-level trustedDependencies as allow-source

### DIFF
--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -300,6 +300,24 @@ impl PackageJson {
         out
     }
 
+    /// Extract the top-level `trustedDependencies` array — Bun's
+    /// allowlist for lifecycle scripts. Treated as an additional
+    /// allow-source alongside `pnpm.onlyBuiltDependencies`, so bun
+    /// projects migrating to aube do not have to rewrite their manifest
+    /// to get scripts running. Non-string entries are dropped; a denylist
+    /// match in `neverBuiltDependencies` still wins at `decide()` time.
+    pub fn trusted_dependencies(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        if let Some(arr) = self
+            .extra
+            .get("trustedDependencies")
+            .and_then(|v| v.as_array())
+        {
+            push_unique_strs(&mut out, arr);
+        }
+        out
+    }
+
     /// Extract `pnpm.catalog` / `aube.catalog` — a default catalog
     /// defined inline in package.json under the `pnpm`/`aube` object.
     /// pnpm itself reads catalogs only from `pnpm-workspace.yaml`, but
@@ -1191,6 +1209,28 @@ mod tests {
             p.pnpm_allow_builds().get("esbuild"),
             Some(AllowBuildRaw::Bool(true)),
         ));
+    }
+
+    #[test]
+    fn trusted_dependencies_reads_top_level_bun_format() {
+        let p = parse(
+            r#"{
+                "trustedDependencies": ["esbuild", "sharp", "esbuild"]
+            }"#,
+        );
+        assert_eq!(p.trusted_dependencies(), vec!["esbuild", "sharp"]);
+    }
+
+    #[test]
+    fn trusted_dependencies_absent_returns_empty() {
+        let p = parse(r#"{}"#);
+        assert!(p.trusted_dependencies().is_empty());
+    }
+
+    #[test]
+    fn trusted_dependencies_wrong_shape_returns_empty() {
+        let p = parse(r#"{"trustedDependencies": {"esbuild": true}}"#);
+        assert!(p.trusted_dependencies().is_empty());
     }
 
     #[test]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -463,6 +463,10 @@ pub(crate) fn build_policy_from_sources(
     }
     let mut only_built = manifest.pnpm_only_built_dependencies();
     only_built.extend(workspace.only_built_dependencies.iter().cloned());
+    // Bun's top-level `trustedDependencies` feeds the same allowlist so
+    // bun projects migrating to aube keep running their install scripts
+    // without moving the list under `pnpm.onlyBuiltDependencies` first.
+    only_built.extend(manifest.trusted_dependencies());
     let mut never_built = manifest.pnpm_never_built_dependencies();
     never_built.extend(workspace.never_built_dependencies.iter().cloned());
     aube_scripts::BuildPolicy::from_config(

--- a/docs/bun-users.md
+++ b/docs/bun-users.md
@@ -41,11 +41,13 @@ future installs keep writing `aube-lock.yaml`.
   [mise](https://mise.jdx.dev) (`mise use node@22`) if you need a Node
   version alongside or in place of Bun.
 - Dependency lifecycle scripts (`preinstall`, `install`, `postinstall`)
-  follow the pnpm v11 allowlist rather than Bun's `trustedDependencies`
-  list. aube runs them only for packages you've explicitly allowlisted
-  via `pnpm.allowBuilds`, `pnpm.onlyBuiltDependencies`, or
-  `aube approve-builds`. aube does not read `trustedDependencies`, so
-  anything you had listed there needs to be moved to one of the pnpm
-  fields before aube will run its scripts.
+  are gated by an allowlist. aube reads Bun's top-level
+  `trustedDependencies` array in addition to pnpm's
+  `pnpm.allowBuilds` / `pnpm.onlyBuiltDependencies`, so an existing
+  Bun manifest keeps running its install scripts without edits.
+  `aube approve-builds` writes new entries into
+  `pnpm-workspace.yaml`'s `onlyBuiltDependencies`; a package in
+  `pnpm.neverBuiltDependencies` is denied even if it appears in
+  `trustedDependencies`.
 
 Reference: [bun install](https://bun.sh/docs/cli/install)

--- a/docs/package-manager/lifecycle-scripts.md
+++ b/docs/package-manager/lifecycle-scripts.md
@@ -80,5 +80,8 @@ it on future installs with the same input hash.
 ## Bun comparison
 
 Bun also treats dependency scripts as a security boundary and uses an allowlist
-model through `trustedDependencies`. aube uses pnpm-compatible policy fields so
-the same manifest can stay close to pnpm's model.
+model through `trustedDependencies`. aube reads the top-level
+`trustedDependencies` array as an additional allow-source alongside
+`pnpm.onlyBuiltDependencies`, so bun projects work without rewriting the
+manifest. `pnpm.neverBuiltDependencies` still wins when both sides list the
+same package.

--- a/test/allow_builds.bats
+++ b/test/allow_builds.bats
@@ -128,6 +128,43 @@ JSON
 	assert_output "ran:aube-test-builds-marker@1.0.0"
 }
 
+@test "top-level trustedDependencies (bun format) allows a dep script" {
+	cat >package.json <<'JSON'
+{
+  "name": "allow-builds-trusted-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "aube-test-builds-marker": "^1.0.0"
+  },
+  "trustedDependencies": ["aube-test-builds-marker"]
+}
+JSON
+	run aube install
+	assert_success
+	assert_file_exists aube-builds-marker.txt
+	run cat aube-builds-marker.txt
+	assert_output "ran:aube-test-builds-marker@1.0.0"
+}
+
+@test "trustedDependencies is overridden by neverBuiltDependencies" {
+	cat >package.json <<'JSON'
+{
+  "name": "allow-builds-trusted-denied-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "aube-test-builds-marker": "^1.0.0"
+  },
+  "trustedDependencies": ["aube-test-builds-marker"],
+  "pnpm": {
+    "neverBuiltDependencies": ["aube-test-builds-marker"]
+  }
+}
+JSON
+	run aube install
+	assert_success
+	assert_file_not_exists aube-builds-marker.txt
+}
+
 @test "pnpm.neverBuiltDependencies denies a dep already on the allowlist" {
 	# Cross-format precedence: an allow in `onlyBuiltDependencies`
 	# is overridden by a deny in `neverBuiltDependencies`, matching


### PR DESCRIPTION
## Summary

- `PackageJson::trusted_dependencies()` reads the top-level `trustedDependencies` array (Bun's lifecycle-script allowlist format)
- `build_policy_from_sources` merges those entries into the same pool as `pnpm.onlyBuiltDependencies`, so Bun projects migrating to aube no longer need to rewrite the manifest to get install scripts running
- `pnpm.neverBuiltDependencies` still wins at `BuildPolicy::decide` time, and `approve-builds` / `ignored-builds` pick up the new source through the shared policy path

Docs flipped from "aube does not read `trustedDependencies`" to the new behavior in `docs/bun-users.md` and `docs/package-manager/lifecycle-scripts.md`.

## Test plan

- [x] `cargo test -p aube-manifest trusted_dependencies` — 3 new unit tests for present / absent / wrong-shape
- [x] `test/allow_builds.bats` — 2 new cases: top-level `trustedDependencies` runs the postinstall, and `neverBuiltDependencies` overrides it
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Full `test/allow_builds.bats` + `test/approve_builds.bats` bats suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the lifecycle-script allowlist sources, which can change which dependency install scripts execute (a security-sensitive boundary), especially for Bun projects migrating to aube. Behavior is constrained by existing deny-wins semantics via `pnpm.neverBuiltDependencies` and covered by new unit/integration tests.
> 
> **Overview**
> aube now **reads Bun’s top-level `trustedDependencies`** from `package.json` and treats it as an additional allow-source for dependency lifecycle scripts, merged into the same pool as `pnpm.onlyBuiltDependencies` during install policy construction.
> 
> Docs are updated to reflect the new Bun migration behavior, and tests are added to verify `trustedDependencies` enables scripts while `pnpm.neverBuiltDependencies` still overrides it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfaf8ef889e21d1995ecb5a36f0ce8f649bea5d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->