### PR TITLE
registry: increase packument cache ttl for repeat installs

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -28,9 +28,11 @@ struct CachedFullPackument {
 }
 
 /// How long to trust a cached packument before revalidating with the registry.
-/// pnpm uses 5 minutes for `prefer-offline=false`. Inside this window we skip
-/// the network entirely.
-const PACKUMENT_TTL_SECS: u64 = 300;
+/// Trust cached packuments for 30 minutes before revalidating. This keeps
+/// repeated installs in a long-lived dev session from devolving into hundreds
+/// of conditional metadata requests once the cache is just over pnpm's 5-minute
+/// default staleness window.
+const PACKUMENT_TTL_SECS: u64 = 1800;
 
 /// Accept header for packument requests. `vnd.npm.install-v1+json` is the
 /// abbreviated (corgi) format npmjs emits for installs; the `application/json`


### PR DESCRIPTION
## Summary
- increase the packument cache TTL from 5 minutes to 30 minutes
- avoid repeated conditional packument revalidation during long-lived dev sessions and multi-fixture benchmark runs
- keep the change scoped to registry metadata caching only

## Benchmark
Controlled A/B on the `next` fixture with a stale-but-present packument cache (`fetched_at` aged to 10 minutes old), no lockfile, and the same project-state cleanup before each run.

- origin/main average: 2600.3ms
- patched average: 989.6ms
- improvement: 61.9%

Runs:
- origin/main: 2644.1ms, 2567.4ms, 2589.4ms
- patched: 980.4ms, 990.1ms, 998.4ms

The dominant win is in resolver metadata time:
- origin/main `phase:resolve`: ~2.0s
- patched `phase:resolve`: ~537ms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the registry packument cache freshness window from 5 to 30 minutes, which can serve slightly staler package metadata for longer but reduces conditional revalidation traffic during long sessions.
> 
> **Overview**
> Increases the on-disk packument cache TTL from **5 minutes to 30 minutes** by updating `PACKUMENT_TTL_SECS` in `crates/aube-registry/src/client.rs`.
> 
> This reduces repeated conditional registry metadata requests (ETag/Last-Modified revalidation) during long-lived dev sessions and benchmark runs where the cache is present but just past the previous staleness window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 900dc27dbd7cbf99e624cba910069716412281d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->