### PR TITLE
fix: pnpm-workspace.yaml overrides/patches, npm: alias overrides, cross-platform pnpm-lock

### DIFF
--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -841,12 +841,25 @@ impl LockfileGraph {
     /// For workspace projects, use [`check_drift_workspace`] instead — this
     /// method only inspects the root importer.
     ///
+    /// `workspace_overrides` is the `overrides:` block from
+    /// `pnpm-workspace.yaml` (pnpm v10 moved overrides there). Pass an
+    /// empty map when the project has no workspace-yaml overrides. Keys
+    /// are merged on top of `manifest.overrides_map()` before the drift
+    /// comparison, matching the resolver's effective-override set —
+    /// otherwise a lockfile written with a workspace override
+    /// immediately looks stale on the next `--frozen-lockfile` run.
+    ///
     /// Lockfile formats that don't record specifiers (npm, yarn, bun) always
     /// return `Fresh` since we have no way to detect drift without re-resolving.
     ///
     /// [`check_drift_workspace`]: Self::check_drift_workspace
-    pub fn check_drift(&self, manifest: &aube_manifest::PackageJson) -> DriftStatus {
-        if let Some(reason) = overrides_drift_reason(&self.overrides, &manifest.overrides_map()) {
+    pub fn check_drift(
+        &self,
+        manifest: &aube_manifest::PackageJson,
+        workspace_overrides: &BTreeMap<String, String>,
+    ) -> DriftStatus {
+        let effective = merge_manifest_and_workspace_overrides(manifest, workspace_overrides);
+        if let Some(reason) = overrides_drift_reason(&self.overrides, &effective) {
             return DriftStatus::Stale { reason };
         }
         if let Some(reason) = ignored_optional_drift_reason(
@@ -864,18 +877,23 @@ impl LockfileGraph {
     /// `(".", root_manifest), ("packages/app", app_manifest), ...`. Every
     /// importer is checked against its own manifest; the first stale importer
     /// determines the result.
+    ///
+    /// See [`check_drift`] for the `workspace_overrides` contract.
+    ///
+    /// [`check_drift`]: Self::check_drift
     pub fn check_drift_workspace(
         &self,
         manifests: &[(String, aube_manifest::PackageJson)],
+        workspace_overrides: &BTreeMap<String, String>,
     ) -> DriftStatus {
         // Override drift is checked once at the workspace level, against
         // the root manifest. Workspace-package manifests may declare
         // their own `overrides` blocks but pnpm only honors the root's,
         // so we mirror that here.
         if let Some((_, root_manifest)) = manifests.iter().find(|(p, _)| p == ".") {
-            if let Some(reason) =
-                overrides_drift_reason(&self.overrides, &root_manifest.overrides_map())
-            {
+            let effective =
+                merge_manifest_and_workspace_overrides(root_manifest, workspace_overrides);
+            if let Some(reason) = overrides_drift_reason(&self.overrides, &effective) {
                 return DriftStatus::Stale { reason };
             }
             if let Some(reason) = ignored_optional_drift_reason(
@@ -1110,6 +1128,22 @@ impl LockfileGraph {
 
         DriftStatus::Fresh
     }
+}
+
+/// Merge `pnpm-workspace.yaml` overrides on top of the manifest's
+/// `overrides_map()`. Workspace entries win on key conflict, matching
+/// pnpm v10's behavior where the workspace yaml is the canonical
+/// home for overrides. Callers pass this into `overrides_drift_reason`
+/// so the drift check sees the same effective map the resolver used.
+fn merge_manifest_and_workspace_overrides(
+    manifest: &aube_manifest::PackageJson,
+    workspace_overrides: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut out = manifest.overrides_map();
+    for (k, v) in workspace_overrides {
+        out.insert(k.clone(), v.clone());
+    }
+    out
 }
 
 /// Compare two override maps and return a human-readable reason
@@ -1818,14 +1852,17 @@ mod drift_tests {
     fn fresh_when_specifiers_match() {
         let manifest = make_manifest(&[("lodash", "^4.17.0")]);
         let graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
-        assert_eq!(graph.check_drift(&manifest), DriftStatus::Fresh);
+        assert_eq!(
+            graph.check_drift(&manifest, &BTreeMap::new()),
+            DriftStatus::Fresh
+        );
     }
 
     #[test]
     fn stale_when_specifier_changes() {
         let manifest = make_manifest(&[("lodash", "^4.18.0")]);
         let graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => assert!(reason.contains("lodash")),
             DriftStatus::Fresh => panic!("expected Stale"),
         }
@@ -1835,7 +1872,7 @@ mod drift_tests {
     fn stale_when_manifest_adds_dep() {
         let manifest = make_manifest(&[("lodash", "^4.17.0"), ("express", "^4.18.0")]);
         let graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => assert!(reason.contains("express")),
             DriftStatus::Fresh => panic!("expected Stale"),
         }
@@ -1848,7 +1885,7 @@ mod drift_tests {
             ("lodash", "^4.17.0", "lodash@4.17.21"),
             ("express", "^4.18.0", "express@4.18.0"),
         ]);
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => assert!(reason.contains("express")),
             DriftStatus::Fresh => panic!("expected Stale"),
         }
@@ -1886,7 +1923,10 @@ mod drift_tests {
             .packages
             .insert("use-sync-external-store@1.2.0".into(), declaring_pkg);
 
-        assert_eq!(graph.check_drift(&manifest), DriftStatus::Fresh);
+        assert_eq!(
+            graph.check_drift(&manifest, &BTreeMap::new()),
+            DriftStatus::Fresh
+        );
     }
 
     // Regression: when a user explicitly pinned a dep that also happens
@@ -1927,7 +1967,7 @@ mod drift_tests {
             .packages
             .insert("use-sync-external-store@1.2.0".into(), consumer);
 
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => assert!(reason.contains("react")),
             DriftStatus::Fresh => panic!(
                 "drift check should flag a removed user-pinned dep as stale, \
@@ -1945,7 +1985,7 @@ mod drift_tests {
             ("lodash", "^4.17.0", "lodash@4.17.21"),
             ("chalk", "^5.0.0", "chalk@5.0.0"),
         ]);
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => assert!(reason.contains("chalk")),
             DriftStatus::Fresh => panic!("expected Stale"),
         }
@@ -1973,7 +2013,10 @@ mod drift_tests {
             packages: BTreeMap::new(),
             ..Default::default()
         };
-        assert_eq!(graph.check_drift(&manifest), DriftStatus::Fresh);
+        assert_eq!(
+            graph.check_drift(&manifest, &BTreeMap::new()),
+            DriftStatus::Fresh
+        );
     }
 
     #[test]
@@ -1986,7 +2029,7 @@ mod drift_tests {
             .extra
             .insert("overrides".into(), serde_json::json!({"lodash": "4.17.21"}));
         let graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => assert!(reason.contains("overrides")),
             DriftStatus::Fresh => panic!("expected Stale"),
         }
@@ -2003,7 +2046,7 @@ mod drift_tests {
             .insert("overrides".into(), serde_json::json!({"lodash": "5.0.0"}));
         let mut graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
         graph.overrides.insert("lodash".into(), "4.17.21".into());
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => {
                 assert!(reason.contains("lodash"), "expected key in: {reason}");
                 assert!(
@@ -2021,7 +2064,7 @@ mod drift_tests {
         let manifest = make_manifest(&[("lodash", "^4.17.0")]);
         let mut graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
         graph.overrides.insert("lodash".into(), "4.17.21".into());
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => {
                 assert!(reason.contains("removes"));
                 assert!(reason.contains("lodash"));
@@ -2038,7 +2081,48 @@ mod drift_tests {
             .insert("overrides".into(), serde_json::json!({"lodash": "4.17.21"}));
         let mut graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
         graph.overrides.insert("lodash".into(), "4.17.21".into());
-        assert_eq!(graph.check_drift(&manifest), DriftStatus::Fresh);
+        assert_eq!(
+            graph.check_drift(&manifest, &BTreeMap::new()),
+            DriftStatus::Fresh
+        );
+    }
+
+    #[test]
+    fn fresh_when_workspace_yaml_overrides_match_lockfile() {
+        // pnpm v10 moved `overrides` to pnpm-workspace.yaml. When the
+        // resolver wrote them into `self.overrides`, the drift check
+        // must see the same map — otherwise the second install run
+        // rejects the lockfile as stale with "manifest removes ..."
+        // (reported in discussion #174).
+        let manifest = make_manifest(&[("semver", "^7.5.0")]);
+        let mut graph = make_graph(&[("semver", "^7.5.0", "semver@7.7.1")]);
+        graph.overrides.insert("semver".into(), "7.7.1".into());
+        let mut ws_overrides = BTreeMap::new();
+        ws_overrides.insert("semver".into(), "7.7.1".into());
+        assert_eq!(
+            graph.check_drift(&manifest, &ws_overrides),
+            DriftStatus::Fresh,
+        );
+    }
+
+    #[test]
+    fn workspace_yaml_overrides_win_over_package_json() {
+        // When both pnpm-workspace.yaml and package.json declare an
+        // override for the same key, the workspace yaml wins — pnpm
+        // v10's precedence. The drift check must apply the merged
+        // effective map.
+        let mut manifest = make_manifest(&[("semver", "^7.5.0")]);
+        manifest
+            .extra
+            .insert("overrides".into(), serde_json::json!({"semver": "7.0.0"}));
+        let mut graph = make_graph(&[("semver", "^7.5.0", "semver@7.7.1")]);
+        graph.overrides.insert("semver".into(), "7.7.1".into());
+        let mut ws_overrides = BTreeMap::new();
+        ws_overrides.insert("semver".into(), "7.7.1".into());
+        assert_eq!(
+            graph.check_drift(&manifest, &ws_overrides),
+            DriftStatus::Fresh,
+        );
     }
 
     #[test]
@@ -2057,7 +2141,10 @@ mod drift_tests {
         graph
             .skipped_optional_dependencies
             .insert(".".to_string(), inner);
-        assert_eq!(graph.check_drift(&manifest), DriftStatus::Fresh);
+        assert_eq!(
+            graph.check_drift(&manifest, &BTreeMap::new()),
+            DriftStatus::Fresh
+        );
     }
 
     #[test]
@@ -2072,7 +2159,7 @@ mod drift_tests {
             .optional_dependencies
             .insert("fsevents".into(), "^2.3.0".into());
         let graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => assert!(reason.contains("fsevents"), "{reason}"),
             DriftStatus::Fresh => panic!("expected Stale on new optional dep"),
         }
@@ -2093,7 +2180,7 @@ mod drift_tests {
         graph
             .skipped_optional_dependencies
             .insert(".".to_string(), inner);
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => assert!(reason.contains("fsevents"), "{reason}"),
             DriftStatus::Fresh => panic!("expected Stale on skipped optional spec change"),
         }
@@ -2116,7 +2203,7 @@ mod drift_tests {
         graph
             .skipped_optional_dependencies
             .insert(".".to_string(), inner);
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => assert!(reason.contains("fsevents"), "{reason}"),
             DriftStatus::Fresh => {
                 panic!("expected Stale: skipped-optional exemption must not apply to required deps")
@@ -2139,7 +2226,7 @@ mod drift_tests {
             dep_type: DepType::Optional,
             specifier: Some("^2.3.0".into()),
         });
-        match graph.check_drift(&manifest) {
+        match graph.check_drift(&manifest, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => assert!(reason.contains("fsevents"), "{reason}"),
             DriftStatus::Fresh => panic!("expected Stale on optional spec change"),
         }
@@ -2149,7 +2236,10 @@ mod drift_tests {
     fn fresh_for_empty_manifest_and_lockfile() {
         let manifest = make_manifest(&[]);
         let graph = make_graph(&[]);
-        assert_eq!(graph.check_drift(&manifest), DriftStatus::Fresh);
+        assert_eq!(
+            graph.check_drift(&manifest, &BTreeMap::new()),
+            DriftStatus::Fresh
+        );
     }
 
     #[test]
@@ -2184,7 +2274,7 @@ mod drift_tests {
             (".".to_string(), root_manifest.clone()),
             ("packages/app".to_string(), app_manifest),
         ];
-        match graph.check_drift_workspace(&workspace_manifests) {
+        match graph.check_drift_workspace(&workspace_manifests, &BTreeMap::new()) {
             DriftStatus::Stale { reason } => {
                 assert!(reason.contains("packages/app"));
                 assert!(reason.contains("express"));
@@ -2193,7 +2283,10 @@ mod drift_tests {
         }
 
         // Single-importer check_drift on root only would say Fresh.
-        assert_eq!(graph.check_drift(&root_manifest), DriftStatus::Fresh);
+        assert_eq!(
+            graph.check_drift(&root_manifest, &BTreeMap::new()),
+            DriftStatus::Fresh
+        );
     }
 
     #[test]
@@ -2607,7 +2700,7 @@ mod drift_tests {
             ),
         ];
         assert_eq!(
-            graph.check_drift_workspace(&workspace_manifests),
+            graph.check_drift_workspace(&workspace_manifests, &BTreeMap::new()),
             DriftStatus::Fresh
         );
     }

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -134,6 +134,14 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub overrides: BTreeMap<String, String>,
 
+    /// `name@version` → patch-file-path map. pnpm v10 moved this out
+    /// of `package.json`'s `pnpm.patchedDependencies` so users can
+    /// document *why* a patch exists with YAML comments; aube merges
+    /// both locations, with workspace-yaml entries winning on key
+    /// conflict (same precedence as `overrides`).
+    #[serde(default, rename = "patchedDependencies")]
+    pub patched_dependencies: BTreeMap<String, String>,
+
     /// Extend package metadata during resolution.
     #[serde(default)]
     pub package_extensions: BTreeMap<String, serde_yaml::Value>,
@@ -650,6 +658,31 @@ overrides:
         let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.overrides.get("foo").unwrap(), "1.0.0");
         assert_eq!(config.overrides.get("bar").unwrap(), "npm:baz@^2");
+    }
+
+    #[test]
+    fn test_patched_dependencies() {
+        // pnpm v10 lets users declare patches in pnpm-workspace.yaml so
+        // they can annotate each patch with YAML comments explaining
+        // WHY the patch exists — something package.json's JSON syntax
+        // can't host. Parse shape matches `pnpm.patchedDependencies`.
+        let yaml = r#"
+patchedDependencies:
+  "is-positive@3.1.0": patches/is-positive@3.1.0.patch
+  "@scope/pkg@1.0.0": patches/scope-pkg.patch
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            config
+                .patched_dependencies
+                .get("is-positive@3.1.0")
+                .unwrap(),
+            "patches/is-positive@3.1.0.patch"
+        );
+        assert_eq!(
+            config.patched_dependencies.get("@scope/pkg@1.0.0").unwrap(),
+            "patches/scope-pkg.patch"
+        );
     }
 
     #[test]

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -3019,6 +3019,15 @@ fn pick_override_spec(
     task_range: &str,
     ancestors: &[(String, String)],
 ) -> Option<String> {
+    // When the task range is an `npm:`/`jsr:` alias, the trailing
+    // `@<version>` — not the raw alias string — is what should
+    // participate in a selector's version-range check. Without this
+    // normalization, the matcher's `range_could_satisfy` never
+    // parses the raw `npm:@scope/pkg@6.0.9-patched.1` as a semver,
+    // hits its "probably matches" fallback, and fires overrides
+    // whose version req (`>=7 <9`) the real version doesn't satisfy.
+    // Reported in #174.
+    let effective_range = strip_alias_prefix(task_range);
     let frames: Vec<override_rule::AncestorFrame<'_>> = ancestors
         .iter()
         .map(|(n, v)| override_rule::AncestorFrame {
@@ -3028,12 +3037,27 @@ fn pick_override_spec(
         .collect();
     rules
         .iter()
-        .filter(|r| override_rule::matches(r, task_name, task_range, &frames))
+        .filter(|r| override_rule::matches(r, task_name, effective_range, &frames))
         .max_by_key(|r| {
             let named_parents = r.parents.iter().filter(|p| !p.is_wildcard()).count();
             named_parents * 2 + usize::from(r.target.version_req.is_some())
         })
         .map(|r| r.replacement.clone())
+}
+
+/// Extract the trailing `@<version>` from an `npm:<name>@<version>`
+/// or `jsr:<name>@<version>` alias spec. Returns the input unchanged
+/// when the spec isn't an alias or doesn't carry a version tail.
+fn strip_alias_prefix(range: &str) -> &str {
+    for prefix in ["npm:", "jsr:"] {
+        if let Some(rest) = range.strip_prefix(prefix) {
+            return match rest.rfind('@') {
+                Some(at) if at > 0 => &rest[at + 1..],
+                _ => rest,
+            };
+        }
+    }
+    range
 }
 
 pub(crate) fn version_satisfies(version: &str, range_str: &str) -> bool {
@@ -3199,6 +3223,41 @@ mod tests {
     #[test]
     fn dependency_policy_default_blocks_exotic_subdeps() {
         assert!(DependencyPolicy::default().block_exotic_subdeps);
+    }
+
+    #[test]
+    fn strip_alias_prefix_extracts_version_tail() {
+        assert_eq!(strip_alias_prefix("npm:bar@1.2.3"), "1.2.3");
+        assert_eq!(
+            strip_alias_prefix("npm:@descript/immer@6.0.9-patched.1"),
+            "6.0.9-patched.1"
+        );
+        assert_eq!(strip_alias_prefix("jsr:@std/fmt@1.0.0"), "1.0.0");
+        assert_eq!(strip_alias_prefix("^1.2.3"), "^1.2.3");
+        // Edge cases: alias without a version tail falls through.
+        assert_eq!(strip_alias_prefix("npm:bar"), "bar");
+        assert_eq!(strip_alias_prefix("jsr:^1.0.0"), "^1.0.0");
+    }
+
+    #[test]
+    fn pick_override_spec_respects_aliased_version_tail() {
+        use override_rule::compile;
+        // Override `immer@>=7.0.0 <9.0.6`, real dep is
+        // `npm:@descript/immer@6.0.9-patched.1`. The version tail is
+        // outside the selector's range, so the override must NOT fire
+        // (pnpm parity). Regression for #174.
+        let mut raw = BTreeMap::new();
+        raw.insert("immer@>=7.0.0 <9.0.6".to_string(), "11.1.4".to_string());
+        let rules = compile(&raw);
+        assert_eq!(
+            pick_override_spec(&rules, "immer", "npm:@descript/immer@6.0.9-patched.1", &[]),
+            None,
+        );
+        // A matching version tail still fires.
+        assert_eq!(
+            pick_override_spec(&rules, "immer", "npm:@descript/immer@8.0.0", &[]),
+            Some("11.1.4".to_string()),
+        );
     }
 
     #[test]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2157,7 +2157,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             && matches!(
                 parsed,
                 Ok((g, _))
-                    if matches!(g.check_drift_workspace(&manifests), DriftStatus::Fresh)
+                    if matches!(
+                        g.check_drift_workspace(&manifests, &ws_config_shared.overrides),
+                        DriftStatus::Fresh,
+                    )
                         && matches!(g.check_catalogs_drift(&workspace_catalogs), DriftStatus::Fresh)
             );
         if fresh {
@@ -2379,7 +2382,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                          help: run without --frozen-lockfile to update the lockfile"
                         ));
                     }
-                    if let DriftStatus::Stale { reason } = graph.check_drift_workspace(&manifests) {
+                    if let DriftStatus::Stale { reason } =
+                        graph.check_drift_workspace(&manifests, &ws_config_shared.overrides)
+                    {
                         return Err(miette!(
                             "lockfile is out of date with package.json: {reason}\n\
                          help: run without --frozen-lockfile to update the lockfile, \
@@ -2402,7 +2407,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             );
                             Err(aube_lockfile::Error::NotFound(cwd.clone()))
                         } else {
-                            match graph.check_drift_workspace(&manifests) {
+                            match graph
+                                .check_drift_workspace(&manifests, &ws_config_shared.overrides)
+                            {
                                 DriftStatus::Fresh => Ok((graph, kind)),
                                 DriftStatus::Stale { reason } => {
                                     tracing::debug!(

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -578,21 +578,29 @@ pub(super) fn configure_resolver(
     let resolve_peers_from_workspace_root_opt = resolve_peers_from_workspace_root(settings_ctx);
     let registry_supports_time_field = resolve_registry_supports_time_field(settings_ctx);
     let (sup_os, sup_cpu, sup_libc) = manifest.pnpm_supported_architectures();
-    // aube-lock.yaml is a committed, cross-platform artifact: if the
-    // user hasn't declared `pnpm.supportedArchitectures` we widen the
-    // resolver's platform filter to cover every common OS/CPU/libc so
-    // Linux-native optionals (e.g. `@rollup/rollup-linux-x64-gnu`)
-    // land in the lockfile even when `aube install` is run on macOS.
-    // Install-time filtering (see `filter_graph` call on the lockfile
-    // branch) still runs against the unmodified manifest setting, so
-    // `node_modules` stays trimmed to the host. For foreign lockfiles
-    // (pnpm-lock.yaml, yarn.lock, package-lock.json, bun.lock) we keep
-    // pnpm's host-only default — aube shouldn't silently bake in more
-    // packages than the native tool would have produced.
+    // aube-lock.yaml and pnpm-lock.yaml are both committed,
+    // cross-platform artifacts: if the user hasn't declared
+    // `pnpm.supportedArchitectures` we widen the resolver's platform
+    // filter to cover every common OS/CPU/libc so Linux-native
+    // optionals (e.g. `@rollup/rollup-linux-x64-gnu`) land in the
+    // lockfile even when `aube install` is run on macOS, and
+    // macOS-native optionals (`@esbuild/darwin-arm64`) land in a
+    // Linux-CI-generated lockfile. pnpm does the same — it records
+    // every optional-dep variant regardless of host — so withholding
+    // them from `pnpm-lock.yaml` leaves cross-platform teammates with
+    // "Cannot find native binding" on install. Install-time filtering
+    // (see `filter_graph` call on the lockfile branch) still runs
+    // against the unmodified manifest setting, so `node_modules`
+    // stays trimmed to the host. Yarn / npm / bun lockfiles don't
+    // carry per-package os/cpu metadata, so widening there would only
+    // bloat the lockfile — keep pnpm's host-only default for those.
     let manifest_set_supported_arch =
         !(sup_os.is_empty() && sup_cpu.is_empty() && sup_libc.is_empty());
-    let writes_aube_lock = target_lockfile_kind == Some(aube_lockfile::LockfileKind::Aube);
-    let supported_architectures = if !manifest_set_supported_arch && writes_aube_lock {
+    let writes_cross_platform_lock = matches!(
+        target_lockfile_kind,
+        Some(aube_lockfile::LockfileKind::Aube | aube_lockfile::LockfileKind::Pnpm)
+    );
+    let supported_architectures = if !manifest_set_supported_arch && writes_cross_platform_lock {
         aube_resolver::SupportedArchitectures::aube_lock_default()
     } else {
         aube_resolver::SupportedArchitectures {

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -65,20 +65,29 @@ pub fn split_patch_key(key: &str) -> Result<(String, String)> {
 }
 
 /// Read every patch declared in the project's `package.json` and
-/// return them keyed by `name@version`. Missing patch files become a
-/// hard error — that matches pnpm, which refuses to install with a
+/// `pnpm-workspace.yaml` and return them keyed by `name@version`.
+/// Workspace-yaml entries (pnpm v10+ canonical location) win over
+/// `package.json` on key conflict. Missing patch files become a hard
+/// error — that matches pnpm, which refuses to install with a
 /// declared-but-missing patch.
 pub fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
+    let mut entries: BTreeMap<String, String> = BTreeMap::new();
+
     let manifest_path = cwd.join("package.json");
-    if !manifest_path.exists() {
-        return Ok(BTreeMap::new());
+    if manifest_path.exists() {
+        let manifest = aube_manifest::PackageJson::from_path(&manifest_path)
+            .map_err(miette::Report::new)
+            .wrap_err("failed to read package.json")?;
+        entries.extend(manifest.pnpm_patched_dependencies());
     }
-    let manifest = aube_manifest::PackageJson::from_path(&manifest_path)
+
+    let ws_config = aube_manifest::workspace::WorkspaceConfig::load(cwd)
         .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+        .wrap_err("failed to read pnpm-workspace.yaml")?;
+    entries.extend(ws_config.patched_dependencies);
 
     let mut out = BTreeMap::new();
-    for (key, rel) in manifest.pnpm_patched_dependencies() {
+    for (key, rel) in entries {
         let (name, version) = split_patch_key(&key)?;
         let path = cwd.join(&rel);
         let content = std::fs::read_to_string(&path)

--- a/test/optional_platform.bats
+++ b/test/optional_platform.bats
@@ -84,17 +84,16 @@ teardown() {
 	assert_exists node_modules/aube-test-optional-win32/package.json
 }
 
-@test "pnpm-lock.yaml keeps pnpm's host-only default" {
-	# Aube preserves whatever lockfile format was already on disk. For
-	# pnpm-lock.yaml that means matching pnpm's default: optionals for
-	# other platforms are NOT baked in unless the user opts in with
-	# `pnpm.supportedArchitectures`. Otherwise aube would silently
-	# diverge from what `pnpm install` would have produced in the same
-	# repo.
+@test "pnpm-lock.yaml captures cross-platform optionals like pnpm does" {
+	# pnpm itself records every optional-dep variant in pnpm-lock.yaml
+	# regardless of the host running the resolve — that's how teammates
+	# on other platforms install from a Linux-generated lockfile without
+	# "Cannot find native binding" errors on macOS. aube matches.
+	# Reported in discussion #174.
 	: >pnpm-lock.yaml
 	cat >package.json <<-'JSON'
 		{
-		  "name": "pnpm-lock-host-only",
+		  "name": "pnpm-lock-cross-platform",
 		  "version": "0.0.0",
 		  "optionalDependencies": {
 		    "aube-test-optional-win32": "1.0.0"
@@ -105,13 +104,13 @@ teardown() {
 	assert_success
 	assert_exists pnpm-lock.yaml
 	assert_not_exists aube-lock.yaml
-	# The manifest's `optionalDependencies:` block round-trips into the
-	# importer record regardless of platform (pnpm does the same), so
-	# don't grep for the bare name. What we actually care about is the
-	# resolved `packages:` entry — that's what a subsequent install on a
-	# matching platform would use, and what we want aube to have skipped.
+	# The win32-only optional must not land in node_modules on non-win32
+	# hosts…
+	assert_not_exists node_modules/aube-test-optional-win32
+	# …but it MUST land in the lockfile's `packages:` block so a Windows
+	# CI run resolving from this file picks it up.
 	run grep -F 'aube-test-optional-win32@1.0.0:' pnpm-lock.yaml
-	assert_failure
+	assert_success
 }
 
 @test "pnpm.supportedArchitectures widens the match set" {

--- a/test/overrides.bats
+++ b/test/overrides.bats
@@ -389,6 +389,34 @@ teardown() {
 	assert_failure
 }
 
+@test "pnpm-workspace.yaml overrides survive --frozen-lockfile" {
+	# pnpm v10 moved overrides to pnpm-workspace.yaml. The resolver has
+	# always read them, but the lockfile drift check used to compare
+	# against `package.json`'s overrides only — so the second run (with
+	# --frozen-lockfile) rejected the lockfile with "manifest removes".
+	# Regression for #174.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-ws-overrides",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "3.0.1" }
+		}
+	EOF
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages: []
+		overrides:
+		  is-number: 7.0.0
+	EOF
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_dir_exists node_modules/.aube/is-number@7.0.0
+
+	# Same project, --frozen-lockfile. Must NOT claim drift.
+	run aube install --frozen-lockfile
+	assert_success
+	assert_dir_exists node_modules/.aube/is-number@7.0.0
+}
+
 @test "changing overrides re-resolves the lockfile on next install" {
 	# First install with no override.
 	cat >package.json <<-'EOF'


### PR DESCRIPTION
## Summary

Three bug fixes from https://github.com/endevco/aube/discussions/174, bundled as one PR per the reporter's repro layout.

### 1. `resolver:` npm:/jsr: alias + version-range override (5daa52e)

Overrides keyed `foo@<range>` were firing on aliased deps like `"foo": "npm:@scope/foo@<version>"` even when the alias version was outside the range. `range_could_satisfy` couldn't parse the raw `npm:@scope/pkg@6.0.9-patched.1` spec as a semver, fell back to "probably matches", and the override replaced the alias. Now the matcher sees just the trailing `@<version>`.

### 2. `install:` widen platform filter for pnpm-lock.yaml writes (27bc5a3)

pnpm records every optional-dep variant in `pnpm-lock.yaml` regardless of the host — that's how teammates on other platforms install from a Linux-generated lockfile without "Cannot find native binding" on macOS. Extend the `aube_lock_default` widening (previously only for `aube-lock.yaml`) to `pnpm-lock.yaml` writes too. Install-time `filter_graph` still trims `node_modules` to the host.

### 3. `install:` honor pnpm-workspace.yaml overrides + patchedDependencies (759fd32)

- **Overrides:** the resolver already merged workspace-yaml overrides, but the drift check only looked at `package.json`, so the next `--frozen-lockfile` run rejected the lockfile with "manifest removes …". Thread workspace overrides into `check_drift` / `check_drift_workspace`.
- **Patches:** add `patched_dependencies` to `WorkspaceConfig` and have `load_patches` merge both locations (workspace wins on key conflict, matching pnpm v10).

## Test plan

- [x] `cargo test --release --workspace` — all green, added unit tests for each fix
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `test/overrides.bats` — new case: `pnpm-workspace.yaml overrides survive --frozen-lockfile`
- [x] `test/optional_platform.bats` — updated the `pnpm-lock.yaml keeps pnpm's host-only default` case (was asserting the bug) to assert the pnpm-matching cross-platform behavior
- [x] Manual verification against the three repro dirs in [stevelandeydescript/aube-bug-repros](https://github.com/stevelandeydescript/aube-bug-repros): all three now install correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes dependency resolution/override matching, lockfile drift detection, and the platform filter used when writing `pnpm-lock.yaml`, which can affect what gets locked and when installs re-resolve.
> 
> **Overview**
> Fixes pnpm v10 parity issues around **overrides**, **patches**, and **cross-platform lockfile output**.
> 
> Drift detection now takes `pnpm-workspace.yaml` `overrides` into account (merged with `package.json`, with workspace entries winning) so `--frozen-lockfile` no longer incorrectly rejects a lockfile written with workspace-level overrides.
> 
> Patch loading now merges `pnpm.patchedDependencies` from `package.json` with `patchedDependencies` from `pnpm-workspace.yaml` (workspace wins), and override selection now correctly handles `npm:`/`jsr:` alias specs by matching version-range selectors against the alias’s version tail.
> 
> When writing `pnpm-lock.yaml`, installs now widen supported-architecture defaults (like `aube-lock.yaml`) so cross-platform optional-dep variants are recorded in the lockfile while still keeping `node_modules` filtered to the host at install time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 759fd324aea75062a416ca8db99178ee519fd1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->