### PR TITLE
resolver: avoid sorting packument versions during picks

### DIFF
--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2623,9 +2623,9 @@ fn pick_version<'a>(
         }
 
         if passes_cutoff(ver_str) {
-            let replace = best.as_ref().is_none_or(|(cur, _)| {
-                if pick_lowest { v < *cur } else { v > *cur }
-            });
+            let replace =
+                best.as_ref()
+                    .is_none_or(|(cur, _)| if pick_lowest { v < *cur } else { v > *cur });
             if replace {
                 best = Some((v, meta));
             }

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2606,32 +2606,36 @@ fn pick_version<'a>(
     // related, not a real "no match in range".
     let mut had_satisfying_but_age_gated = false;
 
-    let mut versions: Vec<(&String, &aube_registry::VersionMetadata)> =
-        packument.versions.iter().collect();
-    versions.sort_by(|(a, _), (b, _)| {
-        let va = node_semver::Version::parse(a);
-        let vb = node_semver::Version::parse(b);
-        match (va, vb) {
-            (Ok(va), Ok(vb)) => {
-                if pick_lowest {
-                    va.cmp(&vb)
-                } else {
-                    vb.cmp(&va)
-                }
-            }
-            _ => std::cmp::Ordering::Equal,
-        }
-    });
+    let mut best: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> = None;
+    let mut fallback_lowest: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> =
+        None;
 
-    for (ver_str, meta) in &versions {
-        if let Ok(v) = node_semver::Version::parse(ver_str)
-            && v.satisfies(&range)
-        {
-            if passes_cutoff(ver_str) {
-                return PickResult::Found(meta);
+    for (ver_str, meta) in &packument.versions {
+        let Ok(v) = node_semver::Version::parse(ver_str) else {
+            continue;
+        };
+        if !v.satisfies(&range) {
+            continue;
+        }
+
+        if fallback_lowest.as_ref().is_none_or(|(cur, _)| v < *cur) {
+            fallback_lowest = Some((v.clone(), meta));
+        }
+
+        if passes_cutoff(ver_str) {
+            let replace = best.as_ref().is_none_or(|(cur, _)| {
+                if pick_lowest { v < *cur } else { v > *cur }
+            });
+            if replace {
+                best = Some((v, meta));
             }
+        } else {
             had_satisfying_but_age_gated = true;
         }
+    }
+
+    if let Some((_, meta)) = best {
+        return PickResult::Found(meta);
     }
 
     // Strict mode (or no cutoff active): give up. Distinguish age-gate
@@ -2646,25 +2650,9 @@ fn pick_version<'a>(
     }
 
     // Lenient fallback: pnpm's `pickPackageFromMetaUsingTime` ignores
-    // the cutoff and picks the *lowest* satisfying version. We have to
-    // re-sort because the primary scan above may have been
-    // highest-first.
-    let mut ascending: Vec<(&String, &aube_registry::VersionMetadata)> =
-        packument.versions.iter().collect();
-    ascending.sort_by(|(a, _), (b, _)| {
-        let va = node_semver::Version::parse(a);
-        let vb = node_semver::Version::parse(b);
-        match (va, vb) {
-            (Ok(va), Ok(vb)) => va.cmp(&vb),
-            _ => std::cmp::Ordering::Equal,
-        }
-    });
-    for (ver_str, meta) in ascending {
-        if let Ok(v) = node_semver::Version::parse(ver_str)
-            && v.satisfies(&range)
-        {
-            return PickResult::Found(meta);
-        }
+    // the cutoff and picks the *lowest* satisfying version.
+    if let Some((_, meta)) = fallback_lowest {
+        return PickResult::Found(meta);
     }
     PickResult::NoMatch
 }

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2623,9 +2623,9 @@ fn pick_version<'a>(
         }
 
         if passes_cutoff(ver_str) {
-            let replace =
-                best.as_ref()
-                    .is_none_or(|(cur, _)| if pick_lowest { v < *cur } else { v > *cur });
+            let replace = best
+                .as_ref()
+                .is_none_or(|(cur, _)| if pick_lowest { v < *cur } else { v > *cur });
             if replace {
                 best = Some((v, meta));
             }


### PR DESCRIPTION
## Summary
- replace `pick_version`'s collect-and-sort approach with a single pass over packument versions
- remove the extra sort for the lenient lowest-satisfying fallback path
- keep the existing locked-version preference and age-gate semantics intact

## Benchmark
Controlled A/B on the `next` fixture with a stale packument cache (`fetched_at` aged to 10 minutes old), no lockfile, and the same project-state cleanup before each run.

### Wall clock
- origin/main average: 968.5ms
- patched average: 908.6ms
- improvement: 6.2%

Runs:
- origin/main: 965.1ms, 962.0ms, 978.3ms
- patched: 908.2ms, 906.8ms, 910.7ms

### Phase timings
One representative run on the same scenario:
- origin/main `phase:resolve`: 508.9ms
- patched `phase:resolve`: 453.7ms
- total install: 978ms -> 925ms

The win is concentrated in resolver metadata/version-pick work. Fetch and link timings stayed effectively flat.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core version-selection logic in `pick_version` to a single-pass algorithm, which could subtly affect which package version is chosen in edge cases (semver parsing, cutoff/strict handling). Functional intent appears preserved, but resolver correctness regressions would impact installs broadly.
> 
> **Overview**
> Refactors `pick_version` to avoid collecting and sorting all packument versions on each pick, replacing it with a single pass that tracks the best satisfying version (honoring `pick_lowest` and cutoff) and the lowest satisfying version for lenient fallback.
> 
> Keeps existing behaviors around locked-version preference and age-gate (`cutoff` + `strict`) semantics, but removes the extra re-sort previously used for the lenient “lowest satisfying” fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dadead8262983b4405e822ba2e1264038f97584e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->