### PR TITLE
resolver: support $name references in overrides

### DIFF
--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -500,6 +500,47 @@ impl PackageJson {
         out
     }
 
+    /// Look up a package name in `dependencies`, then `devDependencies`,
+    /// then `optionalDependencies`, returning the declared version range.
+    /// Mirrors the lookup order pnpm/npm use for `$name` override
+    /// references. `peerDependencies` is intentionally excluded — a peer
+    /// range isn't a dependency the root pins and reusing it as an
+    /// override target would confuse rather than help.
+    pub fn direct_dependency_range(&self, name: &str) -> Option<&str> {
+        self.dependencies
+            .get(name)
+            .or_else(|| self.dev_dependencies.get(name))
+            .or_else(|| self.optional_dependencies.get(name))
+            .map(String::as_str)
+    }
+
+    /// Resolve `$name` override values in place against this manifest's
+    /// direct dependencies, per pnpm/npm's documented sibling-reference
+    /// syntax. Entries whose `$name` target isn't declared in
+    /// `dependencies` / `devDependencies` / `optionalDependencies` are
+    /// removed from the map; their raw selector keys are returned so the
+    /// caller can surface a diagnostic. Non-`$` values pass through
+    /// unchanged.
+    pub fn resolve_override_refs(&self, overrides: &mut BTreeMap<String, String>) -> Vec<String> {
+        let mut unresolved = Vec::new();
+        overrides.retain(|key, value| {
+            let Some(name) = value.strip_prefix('$') else {
+                return true;
+            };
+            match self.direct_dependency_range(name) {
+                Some(range) => {
+                    *value = range.to_owned();
+                    true
+                }
+                None => {
+                    unresolved.push(key.clone());
+                    false
+                }
+            }
+        });
+        unresolved
+    }
+
     /// Extract `packageExtensions` from root package.json. Supports
     /// top-level `packageExtensions`, `pnpm.packageExtensions`, and
     /// `aube.packageExtensions`. Precedence (low → high):
@@ -1159,6 +1200,86 @@ mod tests {
         // so they should be silently dropped rather than panicking.
         let p = parse(r#"{"overrides": {"foo": {"bar": "1.0.0"}}}"#);
         assert!(p.overrides_map().is_empty());
+    }
+
+    #[test]
+    fn resolve_override_refs_substitutes_from_dependencies() {
+        let p = parse(
+            r#"{
+                "dependencies": {"semver": "^7.5.2"},
+                "overrides": {"semver@<7.5.2": "$semver"}
+            }"#,
+        );
+        let mut m = p.overrides_map();
+        let unresolved = p.resolve_override_refs(&mut m);
+        assert!(unresolved.is_empty());
+        assert_eq!(m.get("semver@<7.5.2").unwrap(), "^7.5.2");
+    }
+
+    #[test]
+    fn resolve_override_refs_checks_dev_and_optional() {
+        let p = parse(
+            r#"{
+                "devDependencies": {"a": "1.0.0"},
+                "optionalDependencies": {"b": "2.0.0"},
+                "overrides": {"a": "$a", "b": "$b"}
+            }"#,
+        );
+        let mut m = p.overrides_map();
+        let unresolved = p.resolve_override_refs(&mut m);
+        assert!(unresolved.is_empty());
+        assert_eq!(m.get("a").unwrap(), "1.0.0");
+        assert_eq!(m.get("b").unwrap(), "2.0.0");
+    }
+
+    #[test]
+    fn resolve_override_refs_drops_unresolved() {
+        let p = parse(
+            r#"{
+                "dependencies": {"semver": "^7.5.2"},
+                "overrides": {
+                    "semver@<7.5.2": "$semver",
+                    "cacheable-request@<10": "$cacheable-request"
+                }
+            }"#,
+        );
+        let mut m = p.overrides_map();
+        let unresolved = p.resolve_override_refs(&mut m);
+        assert_eq!(unresolved, vec!["cacheable-request@<10".to_string()]);
+        assert_eq!(m.get("semver@<7.5.2").unwrap(), "^7.5.2");
+        assert!(!m.contains_key("cacheable-request@<10"));
+    }
+
+    #[test]
+    fn resolve_override_refs_passes_non_dollar_through() {
+        let p = parse(
+            r#"{
+                "dependencies": {"foo": "1.0.0"},
+                "overrides": {"foo": "2.0.0", "bar": "3.0.0"}
+            }"#,
+        );
+        let mut m = p.overrides_map();
+        let unresolved = p.resolve_override_refs(&mut m);
+        assert!(unresolved.is_empty());
+        assert_eq!(m.get("foo").unwrap(), "2.0.0");
+        assert_eq!(m.get("bar").unwrap(), "3.0.0");
+    }
+
+    #[test]
+    fn resolve_override_refs_ignores_peer_dependencies() {
+        // npm/pnpm resolve `$name` against direct deps only. Peer
+        // dependency ranges are contracts, not pins, so they shouldn't
+        // silently flow into override values.
+        let p = parse(
+            r#"{
+                "peerDependencies": {"react": "^18"},
+                "overrides": {"react": "$react"}
+            }"#,
+        );
+        let mut m = p.overrides_map();
+        let unresolved = p.resolve_override_refs(&mut m);
+        assert_eq!(unresolved, vec!["react".to_string()]);
+        assert!(m.is_empty());
     }
 
     #[test]

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -610,9 +610,16 @@ pub(super) fn configure_resolver(
             ..Default::default()
         }
     };
-    let effective_overrides = manifest.overrides_map();
-    let mut effective_overrides = effective_overrides;
+    let mut effective_overrides = manifest.overrides_map();
     merge_string_map_setting(settings_ctx, "overrides", &mut effective_overrides);
+    let unresolved_refs = manifest.resolve_override_refs(&mut effective_overrides);
+    for key in &unresolved_refs {
+        tracing::warn!(
+            "override {key:?} uses a $ reference to a package that is not in \
+             dependencies, devDependencies, or optionalDependencies — \
+             dropping the override"
+        );
+    }
     if !effective_overrides.is_empty() {
         tracing::debug!("applying {} overrides", effective_overrides.len());
     }


### PR DESCRIPTION
## Summary

pnpm and npm let override values reference a version declared in the root manifest via `$name`. For example:

```json
{
  "dependencies": { "semver": "^7.5.2" },
  "overrides": { "semver@<7.5.2": "$semver" }
}
```

aube was passing the literal `$semver` through to the resolver, which failed to parse it as a version spec. This pattern is common — Renovate's own `package.json` uses it heavily to keep transitive pins tracking the primary dependency range — and was the missing feature flagged while testing aube against [renovatebot/renovate](https://github.com/renovatebot/renovate).

## What changed

- `PackageJson::direct_dependency_range` — look up a name in `dependencies` → `devDependencies` → `optionalDependencies`. `peerDependencies` is intentionally excluded: peer ranges are contracts, not pins, and silently flowing them into override values would surprise more than help.
- `PackageJson::resolve_override_refs` — rewrite `$name` values in place; return the raw selector keys whose references couldn't be resolved.
- `configure_resolver` calls the resolver after workspace / npmrc / env / cli overrides have merged on top of the manifest map, so `pnpm-workspace.yaml` overrides can use `$name` too (resolved against the root manifest, matching pnpm's behavior).
- Unresolved references are dropped with a `tracing::warn!`, consistent with how `override_rule` already drops unparseable selector keys rather than failing the install.

## References

- pnpm: https://pnpm.io/settings#overrides
- npm: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides

## Test plan

- [x] `cargo test -p aube-manifest` — 5 new unit tests cover substitution from each dep map, unresolved drop behavior, non-`$` passthrough, and peer-dep exclusion
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] e2e smoke: `aube install` on a fixture with `"overrides": { "foo@<2": "\$foo" }` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes override processing during installs by rewriting `$name` values to direct dependency ranges and dropping unresolved override entries, which can alter the resolved dependency graph for projects relying on overrides.
> 
> **Overview**
> Adds support for pnpm/npm-style `$name` references in `overrides` by resolving them against the root manifest’s direct `dependencies`/`devDependencies`/`optionalDependencies` and excluding `peerDependencies`.
> 
> During `install` resolver configuration, overrides are now post-processed after settings/workspace merges to substitute `$` references, and any unresolved references are dropped with a `tracing::warn!`. Includes new unit tests covering substitution, passthrough, unresolved-drop behavior, and peer-dep exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f5ab35dfef0e99930990c067de091c4eb3761c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->