### PR TITLE
install: honor pnpm-workspace.yaml supportedArchitectures, ignoredOptionalDependencies, pnpmfilePath

### DIFF
--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -849,6 +849,12 @@ impl LockfileGraph {
     /// otherwise a lockfile written with a workspace override
     /// immediately looks stale on the next `--frozen-lockfile` run.
     ///
+    /// `workspace_ignored_optional` is the same idea for
+    /// `pnpm-workspace.yaml`'s `ignoredOptionalDependencies` block:
+    /// the resolver unions it with the manifest's list, so the drift
+    /// check has to see the same union or a freshly-written lockfile
+    /// immediately reads as stale.
+    ///
     /// Lockfile formats that don't record specifiers (npm, yarn, bun) always
     /// return `Fresh` since we have no way to detect drift without re-resolving.
     ///
@@ -857,15 +863,17 @@ impl LockfileGraph {
         &self,
         manifest: &aube_manifest::PackageJson,
         workspace_overrides: &BTreeMap<String, String>,
+        workspace_ignored_optional: &[String],
     ) -> DriftStatus {
         let effective = merge_manifest_and_workspace_overrides(manifest, workspace_overrides);
         if let Some(reason) = overrides_drift_reason(&self.overrides, &effective) {
             return DriftStatus::Stale { reason };
         }
-        if let Some(reason) = ignored_optional_drift_reason(
-            &self.ignored_optional_dependencies,
-            &manifest.pnpm_ignored_optional_dependencies(),
-        ) {
+        let mut effective_ignored = manifest.pnpm_ignored_optional_dependencies();
+        effective_ignored.extend(workspace_ignored_optional.iter().cloned());
+        if let Some(reason) =
+            ignored_optional_drift_reason(&self.ignored_optional_dependencies, &effective_ignored)
+        {
             return DriftStatus::Stale { reason };
         }
         self.check_drift_for_importer(".", manifest)
@@ -885,6 +893,7 @@ impl LockfileGraph {
         &self,
         manifests: &[(String, aube_manifest::PackageJson)],
         workspace_overrides: &BTreeMap<String, String>,
+        workspace_ignored_optional: &[String],
     ) -> DriftStatus {
         // Override drift is checked once at the workspace level, against
         // the root manifest. Workspace-package manifests may declare
@@ -896,9 +905,11 @@ impl LockfileGraph {
             if let Some(reason) = overrides_drift_reason(&self.overrides, &effective) {
                 return DriftStatus::Stale { reason };
             }
+            let mut effective_ignored = root_manifest.pnpm_ignored_optional_dependencies();
+            effective_ignored.extend(workspace_ignored_optional.iter().cloned());
             if let Some(reason) = ignored_optional_drift_reason(
                 &self.ignored_optional_dependencies,
-                &root_manifest.pnpm_ignored_optional_dependencies(),
+                &effective_ignored,
             ) {
                 return DriftStatus::Stale { reason };
             }
@@ -1853,7 +1864,7 @@ mod drift_tests {
         let manifest = make_manifest(&[("lodash", "^4.17.0")]);
         let graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
         assert_eq!(
-            graph.check_drift(&manifest, &BTreeMap::new()),
+            graph.check_drift(&manifest, &BTreeMap::new(), &[]),
             DriftStatus::Fresh
         );
     }
@@ -1862,7 +1873,7 @@ mod drift_tests {
     fn stale_when_specifier_changes() {
         let manifest = make_manifest(&[("lodash", "^4.18.0")]);
         let graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => assert!(reason.contains("lodash")),
             DriftStatus::Fresh => panic!("expected Stale"),
         }
@@ -1872,7 +1883,7 @@ mod drift_tests {
     fn stale_when_manifest_adds_dep() {
         let manifest = make_manifest(&[("lodash", "^4.17.0"), ("express", "^4.18.0")]);
         let graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => assert!(reason.contains("express")),
             DriftStatus::Fresh => panic!("expected Stale"),
         }
@@ -1885,7 +1896,7 @@ mod drift_tests {
             ("lodash", "^4.17.0", "lodash@4.17.21"),
             ("express", "^4.18.0", "express@4.18.0"),
         ]);
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => assert!(reason.contains("express")),
             DriftStatus::Fresh => panic!("expected Stale"),
         }
@@ -1924,7 +1935,7 @@ mod drift_tests {
             .insert("use-sync-external-store@1.2.0".into(), declaring_pkg);
 
         assert_eq!(
-            graph.check_drift(&manifest, &BTreeMap::new()),
+            graph.check_drift(&manifest, &BTreeMap::new(), &[]),
             DriftStatus::Fresh
         );
     }
@@ -1967,7 +1978,7 @@ mod drift_tests {
             .packages
             .insert("use-sync-external-store@1.2.0".into(), consumer);
 
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => assert!(reason.contains("react")),
             DriftStatus::Fresh => panic!(
                 "drift check should flag a removed user-pinned dep as stale, \
@@ -1985,7 +1996,7 @@ mod drift_tests {
             ("lodash", "^4.17.0", "lodash@4.17.21"),
             ("chalk", "^5.0.0", "chalk@5.0.0"),
         ]);
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => assert!(reason.contains("chalk")),
             DriftStatus::Fresh => panic!("expected Stale"),
         }
@@ -2014,7 +2025,7 @@ mod drift_tests {
             ..Default::default()
         };
         assert_eq!(
-            graph.check_drift(&manifest, &BTreeMap::new()),
+            graph.check_drift(&manifest, &BTreeMap::new(), &[]),
             DriftStatus::Fresh
         );
     }
@@ -2029,7 +2040,7 @@ mod drift_tests {
             .extra
             .insert("overrides".into(), serde_json::json!({"lodash": "4.17.21"}));
         let graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => assert!(reason.contains("overrides")),
             DriftStatus::Fresh => panic!("expected Stale"),
         }
@@ -2046,7 +2057,7 @@ mod drift_tests {
             .insert("overrides".into(), serde_json::json!({"lodash": "5.0.0"}));
         let mut graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
         graph.overrides.insert("lodash".into(), "4.17.21".into());
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => {
                 assert!(reason.contains("lodash"), "expected key in: {reason}");
                 assert!(
@@ -2064,7 +2075,7 @@ mod drift_tests {
         let manifest = make_manifest(&[("lodash", "^4.17.0")]);
         let mut graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
         graph.overrides.insert("lodash".into(), "4.17.21".into());
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => {
                 assert!(reason.contains("removes"));
                 assert!(reason.contains("lodash"));
@@ -2082,7 +2093,7 @@ mod drift_tests {
         let mut graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
         graph.overrides.insert("lodash".into(), "4.17.21".into());
         assert_eq!(
-            graph.check_drift(&manifest, &BTreeMap::new()),
+            graph.check_drift(&manifest, &BTreeMap::new(), &[]),
             DriftStatus::Fresh
         );
     }
@@ -2100,7 +2111,7 @@ mod drift_tests {
         let mut ws_overrides = BTreeMap::new();
         ws_overrides.insert("semver".into(), "7.7.1".into());
         assert_eq!(
-            graph.check_drift(&manifest, &ws_overrides),
+            graph.check_drift(&manifest, &ws_overrides, &[]),
             DriftStatus::Fresh,
         );
     }
@@ -2120,7 +2131,27 @@ mod drift_tests {
         let mut ws_overrides = BTreeMap::new();
         ws_overrides.insert("semver".into(), "7.7.1".into());
         assert_eq!(
-            graph.check_drift(&manifest, &ws_overrides),
+            graph.check_drift(&manifest, &ws_overrides, &[]),
+            DriftStatus::Fresh,
+        );
+    }
+
+    #[test]
+    fn fresh_when_workspace_yaml_ignored_optional_matches_lockfile() {
+        // Same drift-shaped bug as overrides: the resolver unions
+        // `ignoredOptionalDependencies` from package.json and
+        // pnpm-workspace.yaml, so the lockfile's
+        // `ignored_optional_dependencies` carries the union, and the
+        // drift check has to see the same union or the next
+        // `--frozen-lockfile` run fails with "manifest removes".
+        let manifest = make_manifest(&[("lodash", "^4.17.0")]);
+        let mut graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
+        graph
+            .ignored_optional_dependencies
+            .insert("fsevents".to_string());
+        let ws_ignored = vec!["fsevents".to_string()];
+        assert_eq!(
+            graph.check_drift(&manifest, &BTreeMap::new(), &ws_ignored),
             DriftStatus::Fresh,
         );
     }
@@ -2142,7 +2173,7 @@ mod drift_tests {
             .skipped_optional_dependencies
             .insert(".".to_string(), inner);
         assert_eq!(
-            graph.check_drift(&manifest, &BTreeMap::new()),
+            graph.check_drift(&manifest, &BTreeMap::new(), &[]),
             DriftStatus::Fresh
         );
     }
@@ -2159,7 +2190,7 @@ mod drift_tests {
             .optional_dependencies
             .insert("fsevents".into(), "^2.3.0".into());
         let graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => assert!(reason.contains("fsevents"), "{reason}"),
             DriftStatus::Fresh => panic!("expected Stale on new optional dep"),
         }
@@ -2180,7 +2211,7 @@ mod drift_tests {
         graph
             .skipped_optional_dependencies
             .insert(".".to_string(), inner);
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => assert!(reason.contains("fsevents"), "{reason}"),
             DriftStatus::Fresh => panic!("expected Stale on skipped optional spec change"),
         }
@@ -2203,7 +2234,7 @@ mod drift_tests {
         graph
             .skipped_optional_dependencies
             .insert(".".to_string(), inner);
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => assert!(reason.contains("fsevents"), "{reason}"),
             DriftStatus::Fresh => {
                 panic!("expected Stale: skipped-optional exemption must not apply to required deps")
@@ -2226,7 +2257,7 @@ mod drift_tests {
             dep_type: DepType::Optional,
             specifier: Some("^2.3.0".into()),
         });
-        match graph.check_drift(&manifest, &BTreeMap::new()) {
+        match graph.check_drift(&manifest, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => assert!(reason.contains("fsevents"), "{reason}"),
             DriftStatus::Fresh => panic!("expected Stale on optional spec change"),
         }
@@ -2237,7 +2268,7 @@ mod drift_tests {
         let manifest = make_manifest(&[]);
         let graph = make_graph(&[]);
         assert_eq!(
-            graph.check_drift(&manifest, &BTreeMap::new()),
+            graph.check_drift(&manifest, &BTreeMap::new(), &[]),
             DriftStatus::Fresh
         );
     }
@@ -2274,7 +2305,7 @@ mod drift_tests {
             (".".to_string(), root_manifest.clone()),
             ("packages/app".to_string(), app_manifest),
         ];
-        match graph.check_drift_workspace(&workspace_manifests, &BTreeMap::new()) {
+        match graph.check_drift_workspace(&workspace_manifests, &BTreeMap::new(), &[]) {
             DriftStatus::Stale { reason } => {
                 assert!(reason.contains("packages/app"));
                 assert!(reason.contains("express"));
@@ -2284,7 +2315,7 @@ mod drift_tests {
 
         // Single-importer check_drift on root only would say Fresh.
         assert_eq!(
-            graph.check_drift(&root_manifest, &BTreeMap::new()),
+            graph.check_drift(&root_manifest, &BTreeMap::new(), &[]),
             DriftStatus::Fresh
         );
     }
@@ -2700,7 +2731,7 @@ mod drift_tests {
             ),
         ];
         assert_eq!(
-            graph.check_drift_workspace(&workspace_manifests, &BTreeMap::new()),
+            graph.check_drift_workspace(&workspace_manifests, &BTreeMap::new(), &[]),
             DriftStatus::Fresh
         );
     }

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -740,6 +740,48 @@ fn push_unique_strs(dst: &mut Vec<String>, arr: &[serde_json::Value]) {
     }
 }
 
+/// Union of `package.json`'s `{pnpm,aube}.supportedArchitectures.*` and
+/// `pnpm-workspace.yaml`'s `supportedArchitectures.*`. pnpm v10 treats
+/// the workspace yaml as the canonical home for shared platform
+/// widening — a team generating a cross-platform lockfile on Linux CI
+/// sets it there once rather than in every importer's manifest.
+/// Insertion order: manifest first, workspace appended, duplicates
+/// dropped (same dedupe rule `pnpm_supported_architectures` already
+/// uses between the `pnpm.*` and `aube.*` namespaces).
+pub fn effective_supported_architectures(
+    manifest: &PackageJson,
+    workspace: &workspace::WorkspaceConfig,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let (mut os, mut cpu, mut libc) = manifest.pnpm_supported_architectures();
+    if let Some(ws) = &workspace.supported_architectures {
+        let extend_unique = |dst: &mut Vec<String>, src: &[String]| {
+            for s in src {
+                if !dst.iter().any(|existing| existing == s) {
+                    dst.push(s.clone());
+                }
+            }
+        };
+        extend_unique(&mut os, &ws.os);
+        extend_unique(&mut cpu, &ws.cpu);
+        extend_unique(&mut libc, &ws.libc);
+    }
+    (os, cpu, libc)
+}
+
+/// Union of `package.json`'s `{pnpm,aube}.ignoredOptionalDependencies`
+/// and `pnpm-workspace.yaml`'s `ignoredOptionalDependencies`. Same
+/// layering rule as [`effective_supported_architectures`]: workspace
+/// yaml is pnpm v10's canonical location for shared settings, so the
+/// two sources union rather than override.
+pub fn effective_ignored_optional_dependencies(
+    manifest: &PackageJson,
+    workspace: &workspace::WorkspaceConfig,
+) -> BTreeSet<String> {
+    let mut out = manifest.pnpm_ignored_optional_dependencies();
+    out.extend(workspace.ignored_optional_dependencies.iter().cloned());
+    out
+}
+
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum Error {
     #[error("failed to read {0}: {1}")]
@@ -1545,6 +1587,63 @@ mod tests {
             p.pnpm_peer_dependency_rules_allow_any(),
             vec!["@types/a".to_string(), "@types/b".to_string()],
         );
+    }
+
+    #[test]
+    fn effective_supported_architectures_unions_manifest_and_workspace() {
+        let p = parse(
+            r#"{
+                "pnpm": {
+                    "supportedArchitectures": {
+                        "os": ["current", "linux"],
+                        "cpu": ["x64"]
+                    }
+                }
+            }"#,
+        );
+        let ws: workspace::WorkspaceConfig = serde_yaml::from_str(
+            r#"
+supportedArchitectures:
+  os: ["win32"]
+  cpu: ["x64", "arm64"]
+  libc: ["glibc"]
+"#,
+        )
+        .unwrap();
+        let (os, cpu, libc) = effective_supported_architectures(&p, &ws);
+        // Manifest first, workspace appended, duplicates dropped.
+        assert_eq!(os, vec!["current", "linux", "win32"]);
+        assert_eq!(cpu, vec!["x64", "arm64"]);
+        assert_eq!(libc, vec!["glibc"]);
+    }
+
+    #[test]
+    fn effective_supported_architectures_works_without_either_source() {
+        let p = parse(r#"{}"#);
+        let ws = workspace::WorkspaceConfig::default();
+        let (os, cpu, libc) = effective_supported_architectures(&p, &ws);
+        assert!(os.is_empty() && cpu.is_empty() && libc.is_empty());
+    }
+
+    #[test]
+    fn effective_ignored_optional_dependencies_unions_manifest_and_workspace() {
+        let p = parse(
+            r#"{
+                "pnpm": { "ignoredOptionalDependencies": ["fsevents"] }
+            }"#,
+        );
+        let ws: workspace::WorkspaceConfig = serde_yaml::from_str(
+            r#"
+ignoredOptionalDependencies:
+  - dtrace-provider
+  - fsevents
+"#,
+        )
+        .unwrap();
+        let merged = effective_ignored_optional_dependencies(&p, &ws);
+        assert!(merged.contains("fsevents"));
+        assert!(merged.contains("dtrace-provider"));
+        assert_eq!(merged.len(), 2);
     }
 
     #[test]

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -142,6 +142,28 @@ pub struct WorkspaceConfig {
     #[serde(default, rename = "patchedDependencies")]
     pub patched_dependencies: BTreeMap<String, String>,
 
+    /// os/cpu/libc widening set. pnpm v10 moved this alongside
+    /// `overrides` — users generating a cross-platform lockfile on
+    /// Linux CI want to widen in the workspace yaml (where the rest
+    /// of their shared config lives) rather than `package.json`.
+    /// Merged with `package.json`'s `pnpm.supportedArchitectures` /
+    /// `aube.supportedArchitectures` at install time.
+    #[serde(default, rename = "supportedArchitectures")]
+    pub supported_architectures: Option<SupportedArchitectures>,
+
+    /// Optional-dep names that should always be skipped, even when
+    /// their platform matches. Merged with `package.json`'s
+    /// `pnpm.ignoredOptionalDependencies` / `aube.*` at install time.
+    /// Distinct from `--no-optional`, which drops *all* optional deps.
+    #[serde(default, rename = "ignoredOptionalDependencies")]
+    pub ignored_optional_dependencies: Vec<String>,
+
+    /// Override for the `.pnpmfile.cjs` path. pnpm v10 lets users
+    /// point at a non-default location; aube's default is `cwd/.pnpmfile.cjs`.
+    /// Relative paths resolve against the workspace root.
+    #[serde(default, rename = "pnpmfilePath")]
+    pub pnpmfile_path: Option<String>,
+
     /// Extend package metadata during resolution.
     #[serde(default)]
     pub package_extensions: BTreeMap<String, serde_yaml::Value>,
@@ -344,6 +366,26 @@ pub struct WorkspaceConfig {
     /// Capture unknown fields for forward compatibility.
     #[serde(flatten)]
     pub extra: BTreeMap<String, serde_yaml::Value>,
+}
+
+/// `supportedArchitectures.{os,cpu,libc}` arrays from
+/// pnpm-workspace.yaml. Same three-axis shape pnpm uses; each entry
+/// can be a concrete token (`"linux"`) or the literal `"current"`,
+/// which the resolver expands to the host triple.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SupportedArchitectures {
+    #[serde(default)]
+    pub os: Vec<String>,
+    #[serde(default)]
+    pub cpu: Vec<String>,
+    #[serde(default)]
+    pub libc: Vec<String>,
+}
+
+impl SupportedArchitectures {
+    pub fn is_empty(&self) -> bool {
+        self.os.is_empty() && self.cpu.is_empty() && self.libc.is_empty()
+    }
 }
 
 impl WorkspaceConfig {
@@ -658,6 +700,45 @@ overrides:
         let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.overrides.get("foo").unwrap(), "1.0.0");
         assert_eq!(config.overrides.get("bar").unwrap(), "npm:baz@^2");
+    }
+
+    #[test]
+    fn test_supported_architectures() {
+        let yaml = r#"
+supportedArchitectures:
+  os: ["current", "linux"]
+  cpu: ["current", "x64"]
+  libc: ["glibc"]
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let sa = config.supported_architectures.as_ref().unwrap();
+        assert_eq!(sa.os, vec!["current", "linux"]);
+        assert_eq!(sa.cpu, vec!["current", "x64"]);
+        assert_eq!(sa.libc, vec!["glibc"]);
+        assert!(!sa.is_empty());
+    }
+
+    #[test]
+    fn test_ignored_optional_dependencies() {
+        let yaml = r#"
+ignoredOptionalDependencies:
+  - fsevents
+  - dtrace-provider
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.ignored_optional_dependencies,
+            vec!["fsevents", "dtrace-provider"]
+        );
+    }
+
+    #[test]
+    fn test_pnpmfile_path() {
+        let yaml = r#"
+pnpmfilePath: config/pnpmfile.cjs
+"#;
+        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.pnpmfile_path.as_deref(), Some("config/pnpmfile.cjs"));
     }
 
     #[test]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -126,7 +126,13 @@ different from the host.
 sources.cli = []
 sources.env = []
 sources.npmrc = ["supportedArchitectures"]
+sources.workspaceYaml = ["supportedArchitectures"]
 examples = []
+# Read directly off the typed `WorkspaceConfig.supported_architectures`
+# field and unioned with `{pnpm,aube}.supportedArchitectures` from
+# `package.json` via `aube_manifest::effective_supported_architectures`.
+# The typed accessor would only surface the `.npmrc` spelling.
+typedAccessorUnused = true
 
 [ignoredOptionalDependencies]
 description = "Skip optional dependencies by name."
@@ -139,11 +145,12 @@ from `--no-optional`, which drops *all* optional deps at install time.
 sources.cli = []
 sources.env = []
 sources.npmrc = ["ignoredOptionalDependencies"]
+sources.workspaceYaml = ["ignoredOptionalDependencies"]
 examples = []
-# Read as a list out of the `package.json` pnpm block and the
-# workspace config in `aube-manifest`; the resolver consumes that list
-# directly. The typed accessor would only surface the `.npmrc`
-# spelling, which nobody uses in practice.
+# Read as a list out of the `package.json` pnpm/aube block and the
+# typed `WorkspaceConfig.ignored_optional_dependencies` field;
+# `aube_manifest::effective_ignored_optional_dependencies` unions
+# them. The typed accessor would only surface the `.npmrc` spelling.
 typedAccessorUnused = true
 
 [minimumReleaseAge]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -153,6 +153,26 @@ examples = []
 # them. The typed accessor would only surface the `.npmrc` spelling.
 typedAccessorUnused = true
 
+[pnpmfilePath]
+description = "Location of the pnpmfile.cjs hook file."
+type = "string"
+default = "undefined"
+docs = """
+Workspace-scoped override for the `.pnpmfile.cjs` discovery path.
+Defaults to `<project>/.pnpmfile.cjs`. Relative paths resolve against
+the workspace root; absolute paths are used as-is. A path that points
+at a missing file is a hard miss — aube emits a warning and runs with
+no pnpmfile rather than silently falling back to the default.
+"""
+sources.cli = []
+sources.env = []
+sources.npmrc = []
+sources.workspaceYaml = ["pnpmfilePath"]
+examples = []
+# Read directly off `WorkspaceConfig.pnpmfile_path` in `pnpmfile::detect`.
+# Inherently workspace-scoped, so no other sources.
+typedAccessorUnused = true
+
 [minimumReleaseAge]
 description = "Delay installation of newly published versions (minutes)."
 type = "int"

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2158,7 +2158,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 parsed,
                 Ok((g, _))
                     if matches!(
-                        g.check_drift_workspace(&manifests, &ws_config_shared.overrides),
+                        g.check_drift_workspace(&manifests, &ws_config_shared.overrides, &ws_config_shared.ignored_optional_dependencies),
                         DriftStatus::Fresh,
                     )
                         && matches!(g.check_catalogs_drift(&workspace_catalogs), DriftStatus::Fresh)
@@ -2383,9 +2383,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                          help: run without --frozen-lockfile to update the lockfile"
                         ));
                     }
-                    if let DriftStatus::Stale { reason } =
-                        graph.check_drift_workspace(&manifests, &ws_config_shared.overrides)
-                    {
+                    if let DriftStatus::Stale { reason } = graph.check_drift_workspace(
+                        &manifests,
+                        &ws_config_shared.overrides,
+                        &ws_config_shared.ignored_optional_dependencies,
+                    ) {
                         return Err(miette!(
                             "lockfile is out of date with package.json: {reason}\n\
                          help: run without --frozen-lockfile to update the lockfile, \
@@ -2408,9 +2410,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             );
                             Err(aube_lockfile::Error::NotFound(cwd.clone()))
                         } else {
-                            match graph
-                                .check_drift_workspace(&manifests, &ws_config_shared.overrides)
-                            {
+                            match graph.check_drift_workspace(
+                                &manifests,
+                                &ws_config_shared.overrides,
+                                &ws_config_shared.ignored_optional_dependencies,
+                            ) {
                                 DriftStatus::Fresh => Ok((graph, kind)),
                                 DriftStatus::Stale { reason } => {
                                     tracing::debug!(

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2176,7 +2176,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         }
         let client = std::sync::Arc::new(make_client(&cwd).with_network_mode(opts.network_mode));
         let pnpmfile_path = (!opts.ignore_pnpmfile)
-            .then(|| crate::pnpmfile::detect(&cwd))
+            .then(|| crate::pnpmfile::detect(&cwd, ws_config_shared.pnpmfile_path.as_deref()))
             .flatten();
         let read_package_host = match pnpmfile_path.as_deref() {
             Some(p) => crate::pnpmfile::ReadPackageHost::spawn(p)
@@ -2192,6 +2192,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             &manifest,
             ResolverConfigInputs {
                 settings_ctx: &settings_ctx,
+                workspace_config: &ws_config_shared,
                 workspace_catalogs: &workspace_catalogs,
                 opts: &opts,
                 // `lockfile=false` collapses to `None` so the resolver
@@ -2441,17 +2442,18 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // start fetching tarballs. The resolver's inline filter
             // never runs on the lockfile-happy path, so this pass is
             // what makes cross-platform lockfile installs work.
-            let (sup_os, sup_cpu, sup_libc) = manifest.pnpm_supported_architectures();
+            let (sup_os, sup_cpu, sup_libc) =
+                aube_manifest::effective_supported_architectures(&manifest, &ws_config_shared);
             let supported_architectures = aube_resolver::SupportedArchitectures {
                 os: sup_os,
                 cpu: sup_cpu,
                 libc: sup_libc,
                 ..Default::default()
             };
-            let ignored_optional_deps: std::collections::BTreeSet<String> = manifest
-                .pnpm_ignored_optional_dependencies()
-                .into_iter()
-                .collect();
+            let ignored_optional_deps = aube_manifest::effective_ignored_optional_dependencies(
+                &manifest,
+                &ws_config_shared,
+            );
             aube_resolver::platform::filter_graph(
                 &mut graph,
                 &supported_architectures,
@@ -2594,7 +2596,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // `--lockfile-only` short-circuit produces an identical lockfile.
             let (resolver, mut resolved_rx) = aube_resolver::Resolver::with_stream(client);
             let pnpmfile_path = (!opts.ignore_pnpmfile)
-                .then(|| crate::pnpmfile::detect(&cwd))
+                .then(|| crate::pnpmfile::detect(&cwd, ws_config_shared.pnpmfile_path.as_deref()))
                 .flatten();
             let read_package_host = match pnpmfile_path.as_deref() {
                 Some(p) => crate::pnpmfile::ReadPackageHost::spawn(p)
@@ -2610,6 +2612,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 &manifest,
                 ResolverConfigInputs {
                     settings_ctx: &settings_ctx,
+                    workspace_config: &ws_config_shared,
                     workspace_catalogs: &workspace_catalogs,
                     opts: &opts,
                     // Same disambiguation as the `--lockfile-only` path:
@@ -2656,7 +2659,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // set, so a deferred package that survives the trim is
             // exactly one the catch-up must fetch.
             let (fetch_sup_os, fetch_sup_cpu, fetch_sup_libc) =
-                manifest.pnpm_supported_architectures();
+                aube_manifest::effective_supported_architectures(&manifest, &ws_config_shared);
             let fetch_supported_arch = aube_resolver::SupportedArchitectures {
                 os: fetch_sup_os,
                 cpu: fetch_sup_cpu,
@@ -3215,17 +3218,18 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // filter pass the lockfile-happy branch above runs against a
             // parsed lockfile. A no-op when the manifest didn't trigger
             // widening (graph was already host-only).
-            let (sup_os, sup_cpu, sup_libc) = manifest.pnpm_supported_architectures();
+            let (sup_os, sup_cpu, sup_libc) =
+                aube_manifest::effective_supported_architectures(&manifest, &ws_config_shared);
             let install_supported_architectures = aube_resolver::SupportedArchitectures {
                 os: sup_os,
                 cpu: sup_cpu,
                 libc: sup_libc,
                 ..Default::default()
             };
-            let install_ignored_optional: std::collections::BTreeSet<String> = manifest
-                .pnpm_ignored_optional_dependencies()
-                .into_iter()
-                .collect();
+            let install_ignored_optional = aube_manifest::effective_ignored_optional_dependencies(
+                &manifest,
+                &ws_config_shared,
+            );
             aube_resolver::platform::filter_graph(
                 &mut graph,
                 &install_supported_architectures,

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -540,6 +540,7 @@ fn read_peer_dependencies_meta(
 /// option should land here rather than only in one branch.
 pub(super) struct ResolverConfigInputs<'a> {
     pub(super) settings_ctx: &'a aube_settings::ResolveCtx<'a>,
+    pub(super) workspace_config: &'a aube_manifest::workspace::WorkspaceConfig,
     pub(super) workspace_catalogs:
         &'a std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
     pub(super) opts: &'a InstallOptions,
@@ -566,6 +567,7 @@ pub(super) fn configure_resolver(
 ) -> aube_resolver::Resolver {
     let ResolverConfigInputs {
         settings_ctx,
+        workspace_config,
         workspace_catalogs,
         opts,
         target_lockfile_kind,
@@ -577,7 +579,8 @@ pub(super) fn configure_resolver(
     let dedupe_peers = resolve_dedupe_peers(settings_ctx);
     let resolve_peers_from_workspace_root_opt = resolve_peers_from_workspace_root(settings_ctx);
     let registry_supports_time_field = resolve_registry_supports_time_field(settings_ctx);
-    let (sup_os, sup_cpu, sup_libc) = manifest.pnpm_supported_architectures();
+    let (sup_os, sup_cpu, sup_libc) =
+        aube_manifest::effective_supported_architectures(manifest, workspace_config);
     // aube-lock.yaml and pnpm-lock.yaml are both committed,
     // cross-platform artifacts: if the user hasn't declared
     // `pnpm.supportedArchitectures` we widen the resolver's platform
@@ -630,7 +633,8 @@ pub(super) fn configure_resolver(
             dependency_policy.package_extensions.len()
         );
     }
-    let ignored_optional = manifest.pnpm_ignored_optional_dependencies();
+    let ignored_optional =
+        aube_manifest::effective_ignored_optional_dependencies(manifest, workspace_config);
     if !ignored_optional.is_empty() {
         tracing::debug!(
             "ignoring {} optional dependencies (pnpm.ignoredOptionalDependencies)",

--- a/crates/aube/src/pnpmfile.rs
+++ b/crates/aube/src/pnpmfile.rs
@@ -37,9 +37,22 @@ use tokio::process::{Child, ChildStdin, ChildStdout};
 pub const PNPMFILE_NAME: &str = ".pnpmfile.cjs";
 
 /// Return the path to the project's pnpmfile if one exists.
-pub fn detect(cwd: &Path) -> Option<PathBuf> {
+///
+/// `workspace_pnpmfile_path` is the `pnpmfilePath` override from
+/// `pnpm-workspace.yaml` (pnpm v10 lets users keep the hook file
+/// outside the project root). When set, it wins over the default
+/// `cwd/.pnpmfile.cjs`; relative paths resolve against `cwd`. An
+/// override that points at a missing file is a hard miss (returns
+/// `None`) rather than silently falling back — that way a typo
+/// surfaces as "pnpmfile not loaded" instead of silently running
+/// the wrong hooks.
+pub fn detect(cwd: &Path, workspace_pnpmfile_path: Option<&str>) -> Option<PathBuf> {
+    if let Some(rel) = workspace_pnpmfile_path {
+        let p = cwd.join(rel);
+        return p.is_file().then_some(p);
+    }
     let p = cwd.join(PNPMFILE_NAME);
-    if p.is_file() { Some(p) } else { None }
+    p.is_file().then_some(p)
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -444,4 +457,50 @@ async fn has_read_package_hook(pnpmfile: &Path) -> Result<bool> {
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to read pnpmfile at {}", pnpmfile.display()))?;
     Ok(contents.contains("readPackage"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_returns_default_when_present_and_no_override() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(PNPMFILE_NAME), "").unwrap();
+        let found = detect(dir.path(), None);
+        assert_eq!(
+            found.as_deref(),
+            Some(dir.path().join(PNPMFILE_NAME).as_path())
+        );
+    }
+
+    #[test]
+    fn detect_returns_none_when_default_missing_and_no_override() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(detect(dir.path(), None).is_none());
+    }
+
+    #[test]
+    fn detect_honors_workspace_pnpmfile_path_override() {
+        // pnpm v10 allows `pnpmfilePath: config/hooks.cjs` in
+        // pnpm-workspace.yaml to keep hooks outside the project root.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("config")).unwrap();
+        let custom = dir.path().join("config/hooks.cjs");
+        std::fs::write(&custom, "").unwrap();
+        // Even though .pnpmfile.cjs doesn't exist at the default
+        // location, the workspace override points at the real file.
+        let found = detect(dir.path(), Some("config/hooks.cjs"));
+        assert_eq!(found.as_deref(), Some(custom.as_path()));
+    }
+
+    #[test]
+    fn detect_workspace_override_returns_none_when_target_missing() {
+        // A typo in `pnpmfilePath` must surface as "not loaded" rather
+        // than silently falling back to `.pnpmfile.cjs` — otherwise the
+        // user thinks their hooks are running when they aren't.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(PNPMFILE_NAME), "").unwrap();
+        assert!(detect(dir.path(), Some("typo/missing.cjs")).is_none());
+    }
 }

--- a/crates/aube/src/pnpmfile.rs
+++ b/crates/aube/src/pnpmfile.rs
@@ -43,13 +43,21 @@ pub const PNPMFILE_NAME: &str = ".pnpmfile.cjs";
 /// outside the project root). When set, it wins over the default
 /// `cwd/.pnpmfile.cjs`; relative paths resolve against `cwd`. An
 /// override that points at a missing file is a hard miss (returns
-/// `None`) rather than silently falling back — that way a typo
-/// surfaces as "pnpmfile not loaded" instead of silently running
-/// the wrong hooks.
+/// `None`) rather than silently falling back, and emits a warning —
+/// without the log the user can't tell their typo from "no pnpmfile
+/// configured at all". The missing-default case stays silent because
+/// "no .pnpmfile.cjs" is the common case, not a misconfiguration.
 pub fn detect(cwd: &Path, workspace_pnpmfile_path: Option<&str>) -> Option<PathBuf> {
     if let Some(rel) = workspace_pnpmfile_path {
         let p = cwd.join(rel);
-        return p.is_file().then_some(p);
+        if !p.is_file() {
+            tracing::warn!(
+                "pnpmfilePath override {:?} (from pnpm-workspace.yaml) points at a missing file — hooks will not run",
+                p.display().to_string(),
+            );
+            return None;
+        }
+        return Some(p);
     }
     let p = cwd.join(PNPMFILE_NAME);
     p.is_file().then_some(p)

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -17,6 +17,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
 | [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
 | [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
+| [`pnpmfilePath`](#setting-pnpmfilepath) | `string` | Location of the pnpmfile.cjs hook file. |
 | [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
 | [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
 | [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
@@ -236,6 +237,21 @@ Skip optional dependencies by name.
 
 Named entries are skipped even if their platform/arch matches. Distinct
 from `--no-optional`, which drops *all* optional deps at install time.
+
+### `pnpmfilePath` {#setting-pnpmfilepath}
+
+Location of the pnpmfile.cjs hook file.
+
+- Type: `string`
+- Default: `undefined`
+- Environment: `npm_config_pnpmfile_path`, `NPM_CONFIG_PNPMFILE_PATH`
+- Workspace YAML keys: `pnpmfilePath`
+
+Workspace-scoped override for the `.pnpmfile.cjs` discovery path.
+Defaults to `<project>/.pnpmfile.cjs`. Relative paths resolve against
+the workspace root; absolute paths are used as-is. A path that points
+at a missing file is a hard miss — aube emits a warning and runs with
+no pnpmfile rather than silently falling back to the default.
 
 ### `minimumReleaseAge` {#setting-minimumreleaseage}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -218,6 +218,7 @@ Specify architectures for optional dependency installation.
 - Default: `undefined`
 - Environment: `npm_config_supported_architectures`, `NPM_CONFIG_SUPPORTED_ARCHITECTURES`
 - .npmrc keys: `supportedArchitectures`, `supported-architectures`
+- Workspace YAML keys: `supportedArchitectures`
 
 Override the current platform/arch/libc triple used to filter optional
 dependencies. Useful when generating a lockfile for a target platform
@@ -231,6 +232,7 @@ Skip optional dependencies by name.
 - Default: `undefined`
 - Environment: `npm_config_ignored_optional_dependencies`, `NPM_CONFIG_IGNORED_OPTIONAL_DEPENDENCIES`
 - .npmrc keys: `ignoredOptionalDependencies`, `ignored-optional-dependencies`
+- Workspace YAML keys: `ignoredOptionalDependencies`
 
 Named entries are skipped even if their platform/arch matches. Distinct
 from `--no-optional`, which drops *all* optional deps at install time.

--- a/test/optional_platform.bats
+++ b/test/optional_platform.bats
@@ -135,6 +135,52 @@ teardown() {
 	assert_exists node_modules/aube-test-optional-win32
 }
 
+@test "pnpm-workspace.yaml supportedArchitectures widens the match set" {
+	# pnpm v10 lets users declare `supportedArchitectures` in
+	# pnpm-workspace.yaml so one shared config spans every importer.
+	cat >package.json <<-'JSON'
+		{
+		  "name": "supported-arch-ws-test",
+		  "version": "0.0.0",
+		  "optionalDependencies": {
+		    "aube-test-optional-win32": "1.0.0"
+		  }
+		}
+	JSON
+	cat >pnpm-workspace.yaml <<-'YAML'
+		packages: []
+		supportedArchitectures:
+		  os: ["current", "win32"]
+	YAML
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_exists node_modules/aube-test-optional-win32
+}
+
+@test "pnpm-workspace.yaml ignoredOptionalDependencies drops a named optional dep" {
+	cat >package.json <<-'JSON'
+		{
+		  "name": "ignored-optional-ws-test",
+		  "version": "0.0.0",
+		  "optionalDependencies": {
+		    "aube-test-optional-win32": "1.0.0"
+		  }
+		}
+	JSON
+	cat >pnpm-workspace.yaml <<-'YAML'
+		packages: []
+		supportedArchitectures:
+		  os: ["current", "win32"]
+		ignoredOptionalDependencies:
+		  - aube-test-optional-win32
+	YAML
+	run aube install --no-frozen-lockfile
+	assert_success
+	# ignoredOptionalDependencies from the workspace yaml wins even
+	# though the platform filter would otherwise let the dep through.
+	assert_not_exists node_modules/aube-test-optional-win32
+}
+
 @test "aube.supportedArchitectures widens the match set" {
 	cat >package.json <<-'JSON'
 		{

--- a/test/pnpmfile.bats
+++ b/test/pnpmfile.bats
@@ -164,3 +164,37 @@ EOF
 	assert_failure
 	assert_output --partial 'boom from pnpmfile'
 }
+
+@test "pnpmfile: pnpm-workspace.yaml pnpmfilePath override loads hook from a custom location" {
+	# pnpm v10 lets `pnpmfilePath` in pnpm-workspace.yaml point at a
+	# non-default hook file. Put the hook somewhere the default
+	# resolver wouldn't find it, and prove the install still loaded
+	# it via the workspace override.
+	cat >package.json <<'EOF2'
+{
+  "name": "test-ws-pnpmfile-path",
+  "version": "0.0.0",
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}
+EOF2
+
+	cat >pnpm-workspace.yaml <<'EOF2'
+packages: []
+pnpmfilePath: hooks/custom-pnpmfile.cjs
+EOF2
+
+	mkdir -p hooks
+	cat >hooks/custom-pnpmfile.cjs <<'EOF2'
+function afterAllResolved(lockfile, context) {
+  context.log('hello from custom pnpmfile path');
+  return lockfile;
+}
+module.exports = { hooks: { afterAllResolved } };
+EOF2
+
+	run aube install
+	assert_success
+	assert_output --partial 'hello from custom pnpmfile path'
+}


### PR DESCRIPTION
## Summary

Follow-up to #175 — three more pnpm-workspace.yaml keys that `WorkspaceConfig` either didn't parse or parsed-but-didn't-wire to any consumer. Spotted during the compat audit in discussion [#174](https://github.com/endevco/aube/discussions/174#discussioncomment-16642880).

All three have `package.json` equivalents aube already honors; the workspace-yaml versions now merge with them the same way `overrides` does.

### `supportedArchitectures`
Before: only readable from `package.json`. A team declaring widening in `pnpm-workspace.yaml` got host-only behavior with no warning, even though pnpm v10 treats the yaml as the canonical location.

- New typed field on `WorkspaceConfig` mirroring pnpm's `{os, cpu, libc}` shape.
- `aube_manifest::effective_supported_architectures(manifest, workspace)` unions both sources (manifest first, workspace appended, dedupe).
- Every `manifest.pnpm_supported_architectures()` call site in the install pipeline migrated.
- `settings.toml` gains `sources.workspaceYaml = ["supportedArchitectures"]`.

### `ignoredOptionalDependencies`
Same shape. The inline comment in `settings.toml` claimed "reads from the workspace config in `aube-manifest`" — but no such field existed, so workspace-yaml entries were silently dropped.

- New `ignored_optional_dependencies: Vec<String>` on `WorkspaceConfig`.
- `effective_ignored_optional_dependencies` unions both sides.
- Stale comment fixed, `sources.workspaceYaml` declared.

### `pnpmfilePath`
Before: `pnpmfile::detect` hardcoded `cwd/.pnpmfile.cjs`. pnpm v10 lets users keep the hook file outside the project root via `pnpmfilePath:` in the workspace yaml.

- New `pnpmfile_path: Option<String>` on `WorkspaceConfig`.
- `pnpmfile::detect` takes the override as a second argument; when set, it wins (relative paths resolve against cwd).
- A typo in the override surfaces as "not loaded" rather than silently falling back — otherwise users think their hooks are running when they aren't.

### Dropped: `peerDependencyRules.{ignoreMissing, allowAny}` merge normalization

I originally flagged these as inconsistent with `allowedVersions` (which merges per-key), but re-reading the code the list-shaped vs map-shaped distinction is deliberate and mirrors pnpm's own "most specific source wins" for list config. False-positive in the audit — kept as-is.

## Test plan

- [x] `cargo test --release --workspace` — all green, new unit tests for the three fields + the two `effective_*` helpers + four `pnpmfile::detect` cases
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `test/optional_platform.bats` — new cases: `pnpm-workspace.yaml supportedArchitectures widens the match set` and `pnpm-workspace.yaml ignoredOptionalDependencies drops a named optional dep`
- [x] `test/pnpmfile.bats` — new case: `pnpm-workspace.yaml pnpmfilePath override loads hook from a custom location`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies install-time resolution inputs and lockfile drift detection, which can change which optional deps are installed and when a lockfile is treated as stale.
> 
> **Overview**
> Adds support for pnpm v10 workspace-level configuration by parsing `supportedArchitectures`, `ignoredOptionalDependencies`, and `pnpmfilePath` from `pnpm-workspace.yaml` and wiring them into the install pipeline.
> 
> Install now uses *effective* unions of manifest + workspace values for platform filtering and ignored optionals, and drift checks compare against the same merged inputs to avoid false stale lockfiles. `pnpmfile::detect` now accepts a workspace override path (with warning-on-missing behavior), and settings/docs/tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ebd2e694ef2d9f8b1ade34418d62d6d1af198ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->