### PR TITLE
install: hint at `aube deprecations --transitive` when transitives exist

### DIFF
--- a/crates/aube/src/deprecations.rs
+++ b/crates/aube/src/deprecations.rs
@@ -98,7 +98,7 @@ pub fn render_install_warnings(
     let (direct, transitive) = classify(records, graph);
     match mode {
         DeprecationWarnings::None => {}
-        DeprecationWarnings::Summary => write_count_line(records.len()),
+        DeprecationWarnings::Summary => write_count_line(records.len(), !transitive.is_empty()),
         DeprecationWarnings::Direct => {
             for r in &direct {
                 write_warn_line(r);
@@ -129,13 +129,20 @@ fn write_warn_line(r: &DeprecationRecord) {
 fn write_transitive_count_line(count: usize) {
     let pkgs = pluralizer::pluralize("transitive package", count as isize, true);
     let verb = if count == 1 { "has" } else { "have" };
-    let msg = format!("{pkgs} {verb} deprecation warnings. Run `aube deprecations` to see them.");
+    let msg = format!(
+        "{pkgs} {verb} deprecation warnings. Run `aube deprecations --transitive` to see them."
+    );
     let _ = writeln!(std::io::stderr(), "{}", style::edim(msg));
 }
 
-fn write_count_line(count: usize) {
+fn write_count_line(count: usize, has_transitive: bool) {
     let pkgs = pluralizer::pluralize("package", count as isize, true);
     let verb = if count == 1 { "has" } else { "have" };
-    let msg = format!("{pkgs} {verb} deprecation warnings. Run `aube deprecations` to see them.");
+    let cmd = if has_transitive {
+        "aube deprecations --transitive"
+    } else {
+        "aube deprecations"
+    };
+    let msg = format!("{pkgs} {verb} deprecation warnings. Run `{cmd}` to see them.");
     let _ = writeln!(std::io::stderr(), "{}", style::edim(msg));
 }


### PR DESCRIPTION
## Summary

The post-install summary ended with a transitive-count line that hinted at `aube deprecations` — but that command defaults to direct-only and then prints "Transitives weren't checked. Run with --transitive for the full view." So users had to walk through two progressive disclosures for one question.

This patch teaches both install-time hint lines to suggest `aube deprecations --transitive` when the summary actually contains transitive deprecations:

- **Transitive-count line** ([crates/aube/src/deprecations.rs:130](crates/aube/src/deprecations.rs)) — always points at `--transitive`, since by definition it only fires when transitives exist.
- **Summary-mode count line** ([crates/aube/src/deprecations.rs:140](crates/aube/src/deprecations.rs)) — picks `--transitive` only when transitives are present, so projects with only direct deprecations still get the simpler command.

## Test plan

- [x] `cargo build -p aube`
- [x] `cargo fmt --check` + `cargo clippy` (pre-commit hooks)
- [ ] Manual: install a project with a known transitive deprecation, confirm the hint matches the command that surfaces those deprecations on the first try.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts install-time deprecation warning messaging and function signatures, with no changes to dependency resolution or data handling.
> 
> **Overview**
> Improves the install-time deprecation summary hints so users are directed to the correct command when *transitive* deprecations exist.
> 
> `write_transitive_count_line` now explicitly suggests `aube deprecations --transitive`, and the summary-mode count line (`write_count_line`) conditionally suggests `--transitive` only when transitive deprecations were detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10235323ae552c0dfca3335437261065f453256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->