### PR TITLE
registry: parse cached full packuments directly

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -1150,24 +1150,17 @@ fn read_cached_full_packument(path: &Path) -> Option<CachedFullPackument> {
 /// `Value` path.
 fn read_cached_full_packument_typed(path: &Path, force_cache: bool) -> Option<Packument> {
     #[derive(Deserialize)]
-    struct Borrowed<'a> {
+    struct Typed {
         fetched_at: u64,
-        #[serde(borrow)]
-        packument: &'a serde_json::value::RawValue,
+        packument: Packument,
     }
 
-    let content = std::fs::read(path).ok()?;
-    let head: Borrowed = serde_json::from_slice(&content).ok()?;
-    if !force_cache && now_secs().saturating_sub(head.fetched_at) >= PACKUMENT_TTL_SECS {
+    let mut content = std::fs::read(path).ok()?;
+    let typed: Typed = simd_json::serde::from_slice(&mut content).ok()?;
+    if !force_cache && now_secs().saturating_sub(typed.fetched_at) >= PACKUMENT_TTL_SECS {
         return None;
     }
-    // simd-json for the body parse — it's 2–3× faster than serde_json
-    // on dense packument JSON. It mutates its input, so we own a
-    // mutable Vec by copying the raw slice out of the `RawValue`.
-    // The copy is cheap (~tens of GB/s memcpy) and amortized against
-    // the parse that follows.
-    let mut buf = head.packument.get().as_bytes().to_vec();
-    simd_json::serde::from_slice(&mut buf).ok()
+    Some(typed.packument)
 }
 
 fn write_cached_full_packument(path: &Path, cached: &CachedFullPackument) -> std::io::Result<()> {


### PR DESCRIPTION
## Summary
- parse cached full-packument files directly into the typed `Packument` shape with a single `simd_json` pass
- remove the extra wrapper parse + raw-value extraction + second parse from the resolver's warm-cache full-packument path
- keep the cache format unchanged

## Benchmark
Controlled A/B against current `main` on stale packument cache installs (`fetched_at` aged to 10 minutes old), no lockfile, and the same project-state cleanup before each run.

### next
- baseline avg: 983.3ms
- patched avg: 835.3ms
- improvement: 15.1%

Runs:
- baseline: 989.0ms, 980.0ms, 981.0ms
- patched: 830.0ms, 856.6ms, 819.2ms

### svelte
- baseline avg: 222.6ms
- patched avg: 190.1ms
- improvement: 14.6%

Runs:
- baseline: 227.2ms, 221.1ms, 219.5ms
- patched: 195.1ms, 185.7ms, 189.6ms

### large
- baseline avg: 544.3ms
- patched avg: 482.7ms
- improvement: 11.3%

Runs:
- baseline: 550.8ms, 535.8ms, 546.3ms
- patched: 484.4ms, 483.5ms, 480.1ms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to the warm-cache read path and preserves the on-disk cache format, but could surface as cache parse failures that fall back to the network path.
> 
> **Overview**
> Speeds up `fetch_packument_with_time_cached` warm-cache reads by deserializing cached full-packument files directly into a typed `Packument` using a single `simd_json` pass.
> 
> This removes the prior wrapper parse + `RawValue` extraction + second parse, while keeping the cache freshness check and cache file format unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 284e077e619001f162b208144320c5a9ad5a049a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->