### PR TITLE
chore: release v1.0.0-beta.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "miette",
  "serde",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "base64",
  "blake3",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -2937,9 +2937,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ strip = "debuginfo"
 panic = "abort"
 
 [workspace.package]
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -103,13 +103,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.10" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.10" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.10" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.10" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.10" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.10" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.10" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.10" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.10" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.10" }
+aube = { path = "crates/aube", version = "1.0.0-beta.11" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.11" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.11" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.11" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.11" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.11" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.11" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.11" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.11" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.11" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.10"
+version "1.0.0-beta.11"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.11](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.10...aube-linker-v1.0.0-beta.11) - 2026-04-21
+
+### Other
+
+- skip pnpm v9 virtual importers in workspace link passes ([#190](https://github.com/endevco/aube/pull/190))
+
 ## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.9...aube-linker-v1.0.0-beta.10) - 2026-04-21
 
 ### Fixed

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.11](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.10...aube-lockfile-v1.0.0-beta.11) - 2026-04-21
+
+### Other
+
+- warm-install speedup ([#177](https://github.com/endevco/aube/pull/177))
+- short-circuit bin linking on packages with no bin metadata ([#192](https://github.com/endevco/aube/pull/192))
+
 ## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.9...aube-lockfile-v1.0.0-beta.10) - 2026-04-21
 
 ### Fixed

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.11](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.10...aube-registry-v1.0.0-beta.11) - 2026-04-21
+
+### Other
+
+- retry cold fetch body decode errors ([#189](https://github.com/endevco/aube/pull/189))
+
 ## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.9...aube-registry-v1.0.0-beta.10) - 2026-04-21
 
 ### Fixed

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.11](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.10...aube-resolver-v1.0.0-beta.11) - 2026-04-21
+
+### Other
+
+- warm-install speedup ([#177](https://github.com/endevco/aube/pull/177))
+
 ## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.9...aube-resolver-v1.0.0-beta.10) - 2026-04-21
 
 ### Fixed

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.11](https://github.com/endevco/aube/compare/v1.0.0-beta.10...v1.0.0-beta.11) - 2026-04-21
+
+### Other
+
+- recognize package.json#workspaces as a workspace-root marker ([#194](https://github.com/endevco/aube/pull/194))
+- verify warm-path deps from install state ([#188](https://github.com/endevco/aube/pull/188))
+- warm-install speedup ([#177](https://github.com/endevco/aube/pull/177))
+- short-circuit bin linking on packages with no bin metadata ([#192](https://github.com/endevco/aube/pull/192))
+- warn instead of erroring on packageManager mismatch for run ([#191](https://github.com/endevco/aube/pull/191))
+- skip pnpm v9 virtual importers in workspace link passes ([#190](https://github.com/endevco/aube/pull/190))
+
 ## [1.0.0-beta.10](https://github.com/endevco/aube/compare/v1.0.0-beta.9...v1.0.0-beta.10) - 2026-04-21
 
 ### Fixed

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5734,7 +5734,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.10
+**Version**: 1.0.0-beta.11
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.10",
-  "releasedAt": "2026-04-21T00:14:34Z"
+  "version": "1.0.0-beta.11",
+  "releasedAt": "2026-04-21T15:46:20Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.11`

This PR bumps the workspace to `v1.0.0-beta.11` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is primarily a version bump with regenerated changelogs/CLI docs and an updated lockfile; no functional source changes are included in the diff.
> 
> **Overview**
> Bumps the workspace and all internal crates from `1.0.0-beta.10` to `1.0.0-beta.11`, updating `Cargo.toml`, `Cargo.lock`, and `release.json`.
> 
> Regenerates release artifacts: per-crate `CHANGELOG.md` entries for `beta.11`, plus the CLI usage spec (`aube.usage.kdl`) and generated docs (`docs/cli/*`) to reflect the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21467ab57b0b327893104f24332f3466fe42ca0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->