### PR TITLE
ci(release-plz): fail when communique notes fail

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -135,8 +135,8 @@ jobs:
           gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false
 
   # Replace the raw git-cliff-style body with a communique-generated
-  # narrative release note. Non-fatal: if communique fails for any
-  # reason the published release still has the release-plz body.
+  # narrative release note. If communique fails, fail the workflow so
+  # the broken release-note generation is visible and actionable.
   enhance-release:
     name: Enhance release notes
     needs: [release-plz-release, publish-release]
@@ -153,7 +153,6 @@ jobs:
         with:
           install_args: communique
       - name: Enhance GitHub release with communique
-        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- remove `continue-on-error: true` from the `Enhance GitHub release with communique` step
- update the workflow comment to match the new behavior
- make `communique` release-note generation failures visible in CI instead of silently leaving the workflow green

## Why
The `release-plz` run on April 21, 2026 hit a deterministic `communique` failure during both the original job and a retry:

```text
parse error: missing release_body in submission
```

Because the step was marked `continue-on-error`, GitHub still reported the `Enhance release notes` job as successful even though the command exited nonzero. That hid a real release automation failure in the raw logs.

This PR fixes the masking problem in aube. It does not fix the underlying `communique` bug or any misuse of `communique`; that follow-up still needs to happen separately.

## Validation
- parsed `.github/workflows/release-plz.yml` with Ruby YAML
- inspected the failing Actions job logs for both run attempt 1 and run attempt 2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens CI behavior in the release workflow so releases will now fail if `communique` errors, which could block publishing until the underlying note-generation issue is fixed.
> 
> **Overview**
> **Release automation now surfaces `communique` failures as CI failures.** The `Enhance GitHub release with communique` step in `release-plz.yml` no longer uses `continue-on-error`, so a broken narrative release-note generation run will fail the workflow instead of silently shipping the default `release-plz` body.
> 
> Updates the inline workflow comment to match the new fail-fast behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac4174c775659daaa98d1765680596625bad6af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->