### PR TITLE
install: verify warm-path deps from install state

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -4205,7 +4205,7 @@ fn filter_graph_to_importers<const N: usize>(
 /// truncate-and-hash fallback inside `dep_path_to_filename` will
 /// encode to a different filename than the one the linker wrote,
 /// and this function will return a path that doesn't exist.
-fn materialized_pkg_dir(
+pub(crate) fn materialized_pkg_dir(
     aube_dir: &std::path::Path,
     dep_path: &str,
     name: &str,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3879,11 +3879,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             package_content_hashes,
             graph_lthash,
             package_subtree_hashes,
-            &graph_for_link,
-            node_linker,
-            &aube_dir,
-            virtual_store_dir_max_length,
-            placements_ref,
+            state::WriteStateLayout {
+                graph: &graph_for_link,
+                node_linker,
+                modules_dir_name: &modules_dir_name,
+                aube_dir: &aube_dir,
+                virtual_store_dir_max_length,
+                placements: placements_ref,
+            },
         )
         .into_diagnostic()
         .wrap_err("failed to write install state")?;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3879,6 +3879,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             package_content_hashes,
             graph_lthash,
             package_subtree_hashes,
+            &graph_for_link,
+            node_linker,
+            &aube_dir,
+            virtual_store_dir_max_length,
+            placements_ref,
         )
         .into_diagnostic()
         .wrap_err("failed to write install state")?;

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -65,6 +65,36 @@ pub struct InstallState {
     /// leaf-only diff.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub package_subtree_hashes: BTreeMap<String, String>,
+    #[serde(default)]
+    pub layout: Option<InstallLayoutState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallLayoutState {
+    pub linker: InstallLayoutMode,
+    pub direct_entries: BTreeMap<String, Vec<String>>,
+    pub packages: BTreeMap<String, InstalledPackageState>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InstallLayoutMode {
+    Isolated,
+    Hoisted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledPackageState {
+    pub name: String,
+    pub version: String,
+    pub package_json_path: String,
+    pub package_json_fingerprint: InstalledFileFingerprint,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstalledFileFingerprint {
+    pub len: u64,
+    pub modified_unix_ms: u128,
 }
 
 /// Check if install is needed. Returns None if up-to-date, or Some(reason) if stale.
@@ -122,6 +152,10 @@ pub fn check_needs_install(project_dir: &Path) -> Option<String> {
         );
     }
 
+    if let Some(reason) = verify_install_layout(project_dir, &state) {
+        return Some(reason);
+    }
+
     // no settings_hash check here. this path feeds ensure_installed
     // (aube run / exec / test). those commands do not care about
     // install-shape settings changing because the tree is still the tree
@@ -168,16 +202,12 @@ pub fn write_state(
     package_content_hashes: BTreeMap<String, String>,
     graph_lthash: String,
     package_subtree_hashes: BTreeMap<String, String>,
+    graph: &aube_lockfile::LockfileGraph,
+    node_linker: aube_linker::NodeLinker,
+    aube_dir: &Path,
+    virtual_store_dir_max_length: usize,
+    placements: Option<&aube_linker::HoistedPlacements>,
 ) -> Result<(), std::io::Error> {
-    let mut package_json_hashes = BTreeMap::new();
-
-    let pkg_path = project_dir.join("package.json");
-    if pkg_path.exists() {
-        package_json_hashes.insert(".".to_string(), hash_file(&pkg_path));
-    }
-
-    // TODO: hash workspace package.json files
-
     let lockfile_hash = match active_lockfile(project_dir).1 {
         Some(path) => hash_file(&path),
         None => String::new(),
@@ -185,13 +215,21 @@ pub fn write_state(
 
     let state = InstallState {
         lockfile_hash,
-        package_json_hashes,
+        package_json_hashes: collect_package_json_hashes(project_dir),
         aube_version: env!("CARGO_PKG_VERSION").to_string(),
         section_filtered,
         settings_hash: hash_settings(project_dir, cli_flags),
         package_content_hashes,
         graph_lthash,
         package_subtree_hashes,
+        layout: Some(InstallLayoutState::from_graph(
+            project_dir,
+            graph,
+            node_linker,
+            aube_dir,
+            virtual_store_dir_max_length,
+            placements,
+        )),
     };
 
     let state_path = state_file(project_dir);
@@ -310,6 +348,228 @@ fn active_lockfile(project_dir: &Path) -> (String, Option<PathBuf>) {
 fn read_state(path: &PathBuf) -> Option<InstallState> {
     let content = std::fs::read_to_string(path).ok()?;
     serde_json::from_str(&content).ok()
+}
+
+impl InstallLayoutState {
+    fn from_graph(
+        project_dir: &Path,
+        graph: &aube_lockfile::LockfileGraph,
+        node_linker: aube_linker::NodeLinker,
+        aube_dir: &Path,
+        virtual_store_dir_max_length: usize,
+        placements: Option<&aube_linker::HoistedPlacements>,
+    ) -> Self {
+        let linker = match node_linker {
+            aube_linker::NodeLinker::Isolated => InstallLayoutMode::Isolated,
+            aube_linker::NodeLinker::Hoisted => InstallLayoutMode::Hoisted,
+        };
+        let mut direct_entries = BTreeMap::new();
+        if let Some(deps) = graph.importers.get(".") {
+            let mut entries = Vec::with_capacity(deps.len());
+            for dep in deps {
+                entries.push(project_dir.join("node_modules").join(&dep.name));
+            }
+            direct_entries.insert(
+                ".".to_string(),
+                entries
+                    .into_iter()
+                    .map(|p| {
+                        pathdiff::diff_paths(&p, project_dir)
+                            .unwrap_or(p)
+                            .to_string_lossy()
+                            .replace('\\', "/")
+                    })
+                    .collect(),
+            );
+        }
+
+        let mut packages = BTreeMap::new();
+        let direct_dep_paths: std::collections::BTreeSet<String> = graph
+            .importers
+            .get(".")
+            .into_iter()
+            .flat_map(|deps| deps.iter().map(|dep| dep.dep_path.clone()))
+            .collect();
+        for dep_path in direct_dep_paths {
+            let Some(pkg) = graph.packages.get(&dep_path) else {
+                continue;
+            };
+            let package_json_path = match pkg.local_source.as_ref() {
+                Some(aube_lockfile::LocalSource::Link(path)) => {
+                    project_dir.join(path).join("package.json")
+                }
+                _ => materialized_pkg_dir(
+                    aube_dir,
+                    &dep_path,
+                    &pkg.name,
+                    virtual_store_dir_max_length,
+                    placements,
+                )
+                .join("package.json"),
+            };
+            let rel = pathdiff::diff_paths(&package_json_path, project_dir)
+                .unwrap_or_else(|| PathBuf::from("package.json"));
+            packages.insert(
+                dep_path,
+                InstalledPackageState {
+                    name: pkg.name.clone(),
+                    version: pkg.version.clone(),
+                    package_json_path: rel.to_string_lossy().replace('\\', "/"),
+                    package_json_fingerprint: file_fingerprint(&package_json_path).unwrap_or(
+                        InstalledFileFingerprint {
+                            len: 0,
+                            modified_unix_ms: 0,
+                        },
+                    ),
+                },
+            );
+        }
+
+        Self {
+            linker,
+            direct_entries,
+            packages,
+        }
+    }
+}
+
+fn verify_install_layout(project_dir: &Path, state: &InstallState) -> Option<String> {
+    let layout = state.layout.as_ref()?;
+
+    for entries in layout.direct_entries.values() {
+        for rel in entries {
+            let path = project_dir.join(rel);
+            if !path.exists() {
+                return Some(format!("installed entry missing: {rel}"));
+            }
+        }
+    }
+
+    for pkg in layout.packages.values() {
+        let pkg_json_path = project_dir.join(&pkg.package_json_path);
+        let fingerprint = match file_fingerprint(&pkg_json_path) {
+            Ok(fingerprint) => fingerprint,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Some(format!(
+                    "installed package metadata missing: {}",
+                    pkg.package_json_path
+                ));
+            }
+            Err(_) => {
+                return Some(format!(
+                    "installed package metadata unreadable: {}",
+                    pkg.package_json_path
+                ));
+            }
+        };
+        if fingerprint == pkg.package_json_fingerprint {
+            continue;
+        }
+        let manifest = match read_installed_package_manifest(&pkg_json_path) {
+            Ok(Some(manifest)) => manifest,
+            Ok(None) => {
+                return Some(format!(
+                    "installed package metadata missing: {}",
+                    pkg.package_json_path
+                ));
+            }
+            Err(_) => {
+                return Some(format!(
+                    "installed package metadata unreadable: {}",
+                    pkg.package_json_path
+                ));
+            }
+        };
+        if manifest.name != pkg.name
+            || manifest.version != pkg.version
+            || fingerprint.len != pkg.package_json_fingerprint.len
+        {
+            return Some(format!(
+                "installed package metadata changed: {}",
+                pkg.package_json_path
+            ));
+        }
+    }
+
+    None
+}
+
+#[derive(Deserialize)]
+struct InstalledManifest {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    version: String,
+}
+
+fn read_installed_package_manifest(
+    path: &Path,
+) -> Result<Option<InstalledManifest>, std::io::Error> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let parsed = serde_json::from_str(&content)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    Ok(Some(parsed))
+}
+
+fn file_fingerprint(path: &Path) -> Result<InstalledFileFingerprint, std::io::Error> {
+    let meta = std::fs::metadata(path)?;
+    let modified = meta
+        .modified()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(std::io::Error::other)?
+        .as_millis();
+    Ok(InstalledFileFingerprint {
+        len: meta.len(),
+        modified_unix_ms: modified,
+    })
+}
+
+fn collect_package_json_hashes(project_dir: &Path) -> BTreeMap<String, String> {
+    let mut hashes = BTreeMap::new();
+    let pkg_path = project_dir.join("package.json");
+    if pkg_path.exists() {
+        hashes.insert(".".to_string(), hash_file(&pkg_path));
+    }
+    if let Ok(workspaces) = aube_workspace::find_workspace_packages(project_dir) {
+        for pkg_dir in workspaces {
+            let pkg_json = pkg_dir.join("package.json");
+            if !pkg_json.is_file() {
+                continue;
+            }
+            let rel =
+                pathdiff::diff_paths(&pkg_json, project_dir).unwrap_or_else(|| pkg_json.clone());
+            hashes.insert(
+                rel.to_string_lossy().replace('\\', "/"),
+                hash_file(&pkg_json),
+            );
+        }
+    }
+    hashes
+}
+
+fn materialized_pkg_dir(
+    aube_dir: &Path,
+    dep_path: &str,
+    name: &str,
+    virtual_store_dir_max_length: usize,
+    placements: Option<&aube_linker::HoistedPlacements>,
+) -> PathBuf {
+    if let Some(placements) = placements
+        && let Some(p) = placements.package_dir(dep_path)
+    {
+        return p.to_path_buf();
+    }
+    aube_dir
+        .join(aube_lockfile::dep_path_filename::dep_path_to_filename(
+            dep_path,
+            virtual_store_dir_max_length,
+        ))
+        .join("node_modules")
+        .join(name)
 }
 
 fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -33,6 +33,13 @@ fn state_file(project_dir: &Path) -> PathBuf {
     resolve_paths(project_dir).1
 }
 
+fn relative_path_or_original(path: &Path, base: &Path) -> String {
+    pathdiff::diff_paths(path, base)
+        .unwrap_or_else(|| path.to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InstallState {
     pub lockfile_hash: String,
@@ -383,12 +390,7 @@ impl InstallLayoutState {
                 ".".to_string(),
                 entries
                     .into_iter()
-                    .map(|p| {
-                        pathdiff::diff_paths(&p, project_dir)
-                            .unwrap_or(p)
-                            .to_string_lossy()
-                            .replace('\\', "/")
-                    })
+                    .map(|p| relative_path_or_original(&p, project_dir))
                     .collect(),
             );
         }
@@ -417,14 +419,12 @@ impl InstallLayoutState {
                 )
                 .join("package.json"),
             };
-            let rel = pathdiff::diff_paths(&package_json_path, project_dir)
-                .unwrap_or_else(|| PathBuf::from("package.json"));
             packages.insert(
                 dep_path,
                 InstalledPackageState {
                     name: pkg.name.clone(),
                     version: pkg.version.clone(),
-                    package_json_path: rel.to_string_lossy().replace('\\', "/"),
+                    package_json_path: relative_path_or_original(&package_json_path, project_dir),
                     package_json_hash: hash_file(&package_json_path),
                 },
             );
@@ -515,15 +515,30 @@ fn collect_package_json_hashes(project_dir: &Path) -> BTreeMap<String, String> {
             if !pkg_json.is_file() {
                 continue;
             }
-            let rel =
-                pathdiff::diff_paths(&pkg_json, project_dir).unwrap_or_else(|| pkg_json.clone());
             hashes.insert(
-                rel.to_string_lossy().replace('\\', "/"),
+                relative_path_or_original(&pkg_json, project_dir),
                 hash_file(&pkg_json),
             );
         }
     }
     hashes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::relative_path_or_original;
+    use std::path::Path;
+
+    #[test]
+    fn relative_path_helper_keeps_original_path_when_diff_fails() {
+        let original = Path::new("/tmp/aube-test/package.json");
+        let base = Path::new("project/../project");
+
+        assert_eq!(
+            relative_path_or_original(original, base),
+            original.to_string_lossy()
+        );
+    }
 }
 
 fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -88,13 +88,7 @@ pub struct InstalledPackageState {
     pub name: String,
     pub version: String,
     pub package_json_path: String,
-    pub package_json_fingerprint: InstalledFileFingerprint,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct InstalledFileFingerprint {
-    pub len: u64,
-    pub modified_unix_ms: u128,
+    pub package_json_hash: String,
 }
 
 /// Check if install is needed. Returns None if up-to-date, or Some(reason) if stale.
@@ -195,6 +189,15 @@ pub fn check_needs_install_with_flags(
 /// that expect the whole graph. `cli_flags` is the install's `opts.cli_flags`
 /// bag — threaded through so the stored `settings_hash` reflects CLI overrides
 /// (e.g. `--node-linker=hoisted`) that shaped the tree on disk.
+pub struct WriteStateLayout<'a> {
+    pub graph: &'a aube_lockfile::LockfileGraph,
+    pub node_linker: aube_linker::NodeLinker,
+    pub modules_dir_name: &'a str,
+    pub aube_dir: &'a Path,
+    pub virtual_store_dir_max_length: usize,
+    pub placements: Option<&'a aube_linker::HoistedPlacements>,
+}
+
 pub fn write_state(
     project_dir: &Path,
     section_filtered: bool,
@@ -202,11 +205,7 @@ pub fn write_state(
     package_content_hashes: BTreeMap<String, String>,
     graph_lthash: String,
     package_subtree_hashes: BTreeMap<String, String>,
-    graph: &aube_lockfile::LockfileGraph,
-    node_linker: aube_linker::NodeLinker,
-    aube_dir: &Path,
-    virtual_store_dir_max_length: usize,
-    placements: Option<&aube_linker::HoistedPlacements>,
+    layout: WriteStateLayout<'_>,
 ) -> Result<(), std::io::Error> {
     let lockfile_hash = match active_lockfile(project_dir).1 {
         Some(path) => hash_file(&path),
@@ -224,11 +223,12 @@ pub fn write_state(
         package_subtree_hashes,
         layout: Some(InstallLayoutState::from_graph(
             project_dir,
-            graph,
-            node_linker,
-            aube_dir,
-            virtual_store_dir_max_length,
-            placements,
+            layout.graph,
+            layout.node_linker,
+            layout.modules_dir_name,
+            layout.aube_dir,
+            layout.virtual_store_dir_max_length,
+            layout.placements,
         )),
     };
 
@@ -355,6 +355,7 @@ impl InstallLayoutState {
         project_dir: &Path,
         graph: &aube_lockfile::LockfileGraph,
         node_linker: aube_linker::NodeLinker,
+        modules_dir_name: &str,
         aube_dir: &Path,
         virtual_store_dir_max_length: usize,
         placements: Option<&aube_linker::HoistedPlacements>,
@@ -367,7 +368,7 @@ impl InstallLayoutState {
         if let Some(deps) = graph.importers.get(".") {
             let mut entries = Vec::with_capacity(deps.len());
             for dep in deps {
-                entries.push(project_dir.join("node_modules").join(&dep.name));
+                entries.push(project_dir.join(modules_dir_name).join(&dep.name));
             }
             direct_entries.insert(
                 ".".to_string(),
@@ -415,12 +416,7 @@ impl InstallLayoutState {
                     name: pkg.name.clone(),
                     version: pkg.version.clone(),
                     package_json_path: rel.to_string_lossy().replace('\\', "/"),
-                    package_json_fingerprint: file_fingerprint(&package_json_path).unwrap_or(
-                        InstalledFileFingerprint {
-                            len: 0,
-                            modified_unix_ms: 0,
-                        },
-                    ),
+                    package_json_hash: hash_file(&package_json_path),
                 },
             );
         }
@@ -447,8 +443,8 @@ fn verify_install_layout(project_dir: &Path, state: &InstallState) -> Option<Str
 
     for pkg in layout.packages.values() {
         let pkg_json_path = project_dir.join(&pkg.package_json_path);
-        let fingerprint = match file_fingerprint(&pkg_json_path) {
-            Ok(fingerprint) => fingerprint,
+        let current_hash = match std::fs::metadata(&pkg_json_path) {
+            Ok(_) => hash_file(&pkg_json_path),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 return Some(format!(
                     "installed package metadata missing: {}",
@@ -462,7 +458,7 @@ fn verify_install_layout(project_dir: &Path, state: &InstallState) -> Option<Str
                 ));
             }
         };
-        if fingerprint == pkg.package_json_fingerprint {
+        if current_hash == pkg.package_json_hash {
             continue;
         }
         let manifest = match read_installed_package_manifest(&pkg_json_path) {
@@ -480,10 +476,7 @@ fn verify_install_layout(project_dir: &Path, state: &InstallState) -> Option<Str
                 ));
             }
         };
-        if manifest.name != pkg.name
-            || manifest.version != pkg.version
-            || fingerprint.len != pkg.package_json_fingerprint.len
-        {
+        if manifest.name != pkg.name || manifest.version != pkg.version {
             return Some(format!(
                 "installed package metadata changed: {}",
                 pkg.package_json_path
@@ -513,19 +506,6 @@ fn read_installed_package_manifest(
     let parsed = serde_json::from_str(&content)
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
     Ok(Some(parsed))
-}
-
-fn file_fingerprint(path: &Path) -> Result<InstalledFileFingerprint, std::io::Error> {
-    let meta = std::fs::metadata(path)?;
-    let modified = meta
-        .modified()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_err(std::io::Error::other)?
-        .as_millis();
-    Ok(InstalledFileFingerprint {
-        len: meta.len(),
-        modified_unix_ms: modified,
-    })
 }
 
 fn collect_package_json_hashes(project_dir: &Path) -> BTreeMap<String, String> {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -130,13 +130,22 @@ pub fn check_needs_install(project_dir: &Path) -> Option<String> {
         return Some("no lockfile found".into());
     }
 
-    // Check root package.json hash
-    let pkg_path = project_dir.join("package.json");
-    if pkg_path.exists() {
-        let current_hash = hash_file(&pkg_path);
-        let stored_hash = state.package_json_hashes.get(".");
-        if stored_hash != Some(&current_hash) {
-            return Some("package.json has changed".into());
+    // Check root + workspace package.json hashes.
+    for (rel, stored_hash) in &state.package_json_hashes {
+        let path = if rel == "." {
+            project_dir.join("package.json")
+        } else {
+            project_dir.join(rel)
+        };
+        if !path.exists() {
+            return Some(format!("{rel} is missing"));
+        }
+        if hash_file(&path) != *stored_hash {
+            return Some(if rel == "." {
+                "package.json has changed".into()
+            } else {
+                format!("{rel} has changed")
+            });
         }
     }
 
@@ -399,7 +408,7 @@ impl InstallLayoutState {
                 Some(aube_lockfile::LocalSource::Link(path)) => {
                     project_dir.join(path).join("package.json")
                 }
-                _ => materialized_pkg_dir(
+                _ => crate::commands::install::materialized_pkg_dir(
                     aube_dir,
                     &dep_path,
                     &pkg.name,
@@ -443,21 +452,7 @@ fn verify_install_layout(project_dir: &Path, state: &InstallState) -> Option<Str
 
     for pkg in layout.packages.values() {
         let pkg_json_path = project_dir.join(&pkg.package_json_path);
-        let current_hash = match std::fs::metadata(&pkg_json_path) {
-            Ok(_) => hash_file(&pkg_json_path),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                return Some(format!(
-                    "installed package metadata missing: {}",
-                    pkg.package_json_path
-                ));
-            }
-            Err(_) => {
-                return Some(format!(
-                    "installed package metadata unreadable: {}",
-                    pkg.package_json_path
-                ));
-            }
-        };
+        let current_hash = hash_file(&pkg_json_path);
         if current_hash == pkg.package_json_hash {
             continue;
         }
@@ -529,27 +524,6 @@ fn collect_package_json_hashes(project_dir: &Path) -> BTreeMap<String, String> {
         }
     }
     hashes
-}
-
-fn materialized_pkg_dir(
-    aube_dir: &Path,
-    dep_path: &str,
-    name: &str,
-    virtual_store_dir_max_length: usize,
-    placements: Option<&aube_linker::HoistedPlacements>,
-) -> PathBuf {
-    if let Some(placements) = placements
-        && let Some(p) = placements.package_dir(dep_path)
-    {
-        return p.to_path_buf();
-    }
-    aube_dir
-        .join(aube_lockfile::dep_path_filename::dep_path_to_filename(
-            dep_path,
-            virtual_store_dir_max_length,
-        ))
-        .join("node_modules")
-        .join(name)
 }
 
 fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -95,6 +95,7 @@ pub struct InstalledPackageState {
     pub name: String,
     pub version: String,
     pub package_json_path: String,
+    #[serde(default)]
     pub package_json_hash: String,
 }
 
@@ -425,7 +426,7 @@ impl InstallLayoutState {
                     name: pkg.name.clone(),
                     version: pkg.version.clone(),
                     package_json_path: relative_path_or_original(&package_json_path, project_dir),
-                    package_json_hash: hash_file(&package_json_path),
+                    package_json_hash: hash_file_if_exists(&package_json_path).unwrap_or_default(),
                 },
             );
         }
@@ -452,8 +453,12 @@ fn verify_install_layout(project_dir: &Path, state: &InstallState) -> Option<Str
 
     for pkg in layout.packages.values() {
         let pkg_json_path = project_dir.join(&pkg.package_json_path);
-        let current_hash = hash_file(&pkg_json_path);
-        if current_hash == pkg.package_json_hash {
+        let current_hash = hash_file_if_exists(&pkg_json_path);
+        if let Some(current_hash) = current_hash
+            && !pkg.package_json_hash.is_empty()
+            && pkg.package_json_hash != empty_blake3_hash()
+            && current_hash == pkg.package_json_hash
+        {
             continue;
         }
         let manifest = match read_installed_package_manifest(&pkg_json_path) {
@@ -522,23 +527,6 @@ fn collect_package_json_hashes(project_dir: &Path) -> BTreeMap<String, String> {
         }
     }
     hashes
-}
-
-#[cfg(test)]
-mod tests {
-    use super::relative_path_or_original;
-    use std::path::Path;
-
-    #[test]
-    fn relative_path_helper_keeps_original_path_when_diff_fails() {
-        let original = Path::new("/tmp/aube-test/package.json");
-        let base = Path::new("project/../project");
-
-        assert_eq!(
-            relative_path_or_original(original, base),
-            original.to_string_lossy()
-        );
-    }
 }
 
 fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
@@ -645,4 +633,82 @@ fn hash_file(path: &Path) -> String {
     let content = std::fs::read(path).unwrap_or_default();
     let hash = blake3::hash(&content);
     format!("blake3:{}", hash.to_hex())
+}
+
+fn hash_file_if_exists(path: &Path) -> Option<String> {
+    std::fs::read(path).ok().map(|content| {
+        let hash = blake3::hash(&content);
+        format!("blake3:{}", hash.to_hex())
+    })
+}
+
+fn empty_blake3_hash() -> &'static str {
+    "blake3:af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
+        empty_blake3_hash, relative_path_or_original, verify_install_layout,
+    };
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn relative_path_helper_keeps_original_path_when_diff_fails() {
+        let original = Path::new("/tmp/aube-test/package.json");
+        let base = Path::new("project/../project");
+
+        assert_eq!(
+            relative_path_or_original(original, base),
+            original.to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn verify_install_layout_treats_legacy_empty_hash_as_cache_miss() {
+        let project_dir = temp_project_dir("legacy-empty-hash");
+        let state = InstallState {
+            lockfile_hash: String::new(),
+            package_json_hashes: BTreeMap::new(),
+            aube_version: String::new(),
+            section_filtered: false,
+            settings_hash: String::new(),
+            package_content_hashes: BTreeMap::new(),
+            graph_lthash: String::new(),
+            package_subtree_hashes: BTreeMap::new(),
+            layout: Some(InstallLayoutState {
+                linker: InstallLayoutMode::Isolated,
+                direct_entries: BTreeMap::new(),
+                packages: BTreeMap::from([(
+                    "is-odd@3.0.1".to_string(),
+                    InstalledPackageState {
+                        name: "is-odd".to_string(),
+                        version: "3.0.1".to_string(),
+                        package_json_path:
+                            "node_modules/.aube/missing/node_modules/is-odd/package.json"
+                                .to_string(),
+                        package_json_hash: empty_blake3_hash().to_string(),
+                    },
+                )]),
+            }),
+        };
+
+        assert_eq!(
+            verify_install_layout(&project_dir, &state),
+            Some(
+                "installed package metadata missing: node_modules/.aube/missing/node_modules/is-odd/package.json"
+                    .to_string()
+            )
+        );
+    }
+
+    fn temp_project_dir(name: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("aube-state-tests-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir should be creatable");
+        dir
+    }
 }

--- a/test/install.bats
+++ b/test/install.bats
@@ -248,6 +248,46 @@ JSON
 	assert_output --partial "Already up to date"
 }
 
+@test "aube install warm path notices workspace package.json drift" {
+	cat >package.json <<'JSON'
+{
+  "name": "workspace-root",
+  "version": "1.0.0",
+  "private": true
+}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	mkdir -p packages/a
+	cat >packages/a/package.json <<'JSON'
+{
+  "name": "a",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-odd": "3.0.1"
+  }
+}
+JSON
+
+	run aube install
+	assert_success
+	assert_link_exists packages/a/node_modules/is-odd
+
+	node -e '
+		const fs = require("fs");
+		const pkg = JSON.parse(fs.readFileSync("packages/a/package.json", "utf8"));
+		pkg.dependencies["is-even"] = "1.0.0";
+		fs.writeFileSync("packages/a/package.json", JSON.stringify(pkg, null, 2));
+	'
+
+	run aube install
+	assert_success
+	refute_output --partial "Already up to date"
+	assert_link_exists packages/a/node_modules/is-even
+}
+
 @test "aube run auto-installs when installed package metadata is missing" {
 	cat >package.json <<'JSON'
 {

--- a/test/install.bats
+++ b/test/install.bats
@@ -246,6 +246,13 @@ JSON
 	run aube install
 	assert_success
 	assert_output --partial "Already up to date"
+
+	rm .modules/is-odd
+
+	run aube install
+	assert_success
+	refute_output --partial "Already up to date"
+	assert_link_exists .modules/is-odd
 }
 
 @test "aube install warm path notices workspace package.json drift" {

--- a/test/install.bats
+++ b/test/install.bats
@@ -235,6 +235,19 @@ JSON
 	assert_link_exists node_modules/is-odd
 }
 
+@test "aube install warm path respects custom modulesDir" {
+	_setup_basic_fixture
+	echo "modulesDir=.modules" >.npmrc
+
+	run aube install
+	assert_success
+	assert_link_exists .modules/is-odd
+
+	run aube install
+	assert_success
+	assert_output --partial "Already up to date"
+}
+
 @test "aube run auto-installs when installed package metadata is missing" {
 	cat >package.json <<'JSON'
 {

--- a/test/install.bats
+++ b/test/install.bats
@@ -216,6 +216,48 @@ JSON
 	run cat node_modules/.aube-state
 	assert_output --partial "lockfile_hash"
 	assert_output --partial "package_json_hashes"
+	assert_output --partial "\"layout\""
+	assert_output --partial "\"direct_entries\""
+	assert_output --partial "\"packages\""
+}
+
+@test "aube install does not treat missing top-level entry as up to date" {
+	_setup_basic_fixture
+
+	run aube install
+	assert_success
+
+	rm node_modules/is-odd
+
+	run aube install
+	assert_success
+	refute_output --partial "Already up to date"
+	assert_link_exists node_modules/is-odd
+}
+
+@test "aube run auto-installs when installed package metadata is missing" {
+	cat >package.json <<'JSON'
+{
+  "name": "missing-installed-metadata",
+  "version": "1.0.0",
+  "scripts": {
+    "check": "node -e 'console.log(require(\"is-odd\")(3))'"
+  },
+  "dependencies": {
+    "is-odd": "3.0.1"
+  }
+}
+JSON
+
+	run aube install
+	assert_success
+
+	rm node_modules/.aube/is-odd@3.0.1/node_modules/is-odd/package.json
+
+	run aube run check
+	assert_success
+	assert_output --partial "Auto-installing"
+	assert_output --partial "true"
 }
 
 @test "installed packages are requireable by node" {


### PR DESCRIPTION
## Summary

Teach the warm install path to verify a lightweight install-layout manifest from `.aube-state` instead of trusting only lockfile and manifest hashes.

## What changed

- extend `.aube-state` with install-layout metadata for the root importer
- record direct dependency `package.json` fingerprints so the warm path can cheaply detect missing or swapped installs
- hash workspace `package.json` files into install state
- re-run install when a root `node_modules/<name>` entry disappears or a direct dependency's installed `package.json` goes missing
- add BATS coverage for the new state contents and the missing-entry / missing-metadata cases

## Why

The previous state file only tracked inputs such as the lockfile, root `package.json`, and settings. That let warm installs report up to date even when the installed tree had drifted on disk. This change makes the warm-path check validate the bits that actually matter for a fast correctness guard without turning it into a full package-content checksum sweep.

## Validation

- `cargo build`
- `cargo build --release -p aube`
- `mise run test:bats test/install.bats`
- warm-path benchmark on a warmed `vercel/turborepo` checkout versus `origin/main`: ~5.41 ms on this branch vs ~5.55 ms on `main` across 30 runs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the criteria for skipping installs by adding new state fields and on-disk verification, which could cause unexpected extra installs or missed edge cases if the layout manifest is incorrect.
> 
> **Overview**
> Improves the warm install/auto-install freshness check by **recording and validating an install-layout manifest** in `.aube-state`, so the CLI no longer reports “Already up to date” when the on-disk tree has drifted.
> 
> State writing now hashes **workspace `package.json` files** (not just the root) and persists layout details (direct `node_modules` entries plus direct-dependency `package.json` name/version/hash and path) computed from the lockfile graph for both isolated/hoisted linkers. The warm path now re-runs install when a top-level entry is missing or when an installed direct dependency’s `package.json` is missing/unreadable or has mismatched name/version; BATS coverage is added for the new state fields and these drift scenarios (including custom `modulesDir`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab258f64a71225038208240b40554462d17a7d74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->