### PR TITLE
registry: retry cold fetch body decode errors

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -480,7 +480,7 @@ impl RegistryClient {
         let max_attempts = self.fetch_policy.retries.saturating_add(1);
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
-            match (|| {
+            match {
                 let mut req = self
                     .authed_get(&url, registry_url)
                     .header("Accept", PACKUMENT_FULL_ACCEPT);
@@ -493,7 +493,7 @@ impl RegistryClient {
                     }
                 }
                 req
-            })()
+            }
             .send()
             .await
             {
@@ -643,14 +643,14 @@ impl RegistryClient {
         let started = std::time::Instant::now();
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
-            match (|| {
+            match {
                 let req = self.authed_get(&url, registry_url);
                 if force_full_packument() {
                     req
                 } else {
                     req.header("Accept", PACKUMENT_ACCEPT)
                 }
-            })()
+            }
             .send()
             .await
             {
@@ -760,7 +760,7 @@ impl RegistryClient {
         let started = std::time::Instant::now();
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
-            match (|| {
+            match {
                 let mut req = self.authed_get(&url, registry_url);
                 if !force_full_packument() {
                     req = req.header("Accept", PACKUMENT_ACCEPT);
@@ -774,7 +774,7 @@ impl RegistryClient {
                     }
                 }
                 req
-            })()
+            }
             .send()
             .await
             {

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -239,39 +239,6 @@ impl RegistryClient {
         crate::config::lookup_by_uri_prefix(&self.http_by_uri, &uri_key).unwrap_or(&self.http)
     }
 
-    /// Send an HTTP request with transient-failure retry. Invoked from
-    /// every GET path (packument fetches, tarball downloads, dist-tag
-    /// reads) so the `fetchRetries` / `fetchRetryFactor` /
-    /// `fetchRetryMintimeout` / `fetchRetryMaxtimeout` settings take
-    /// effect without each call site open-coding backoff math.
-    ///
-    /// `build` is called once per attempt — it has to rebuild the
-    /// [`reqwest::RequestBuilder`] from scratch because a builder is
-    /// consumed by `.send()`. That matches how the existing call sites
-    /// already compose conditional headers (`If-None-Match`, `Accept`,
-    /// `npm-otp`) on a fresh request, so the closure just wraps those
-    /// few lines.
-    ///
-    /// Retry policy (matches pnpm / `make-fetch-happen`):
-    /// - Transport errors (`reqwest::Error`) are always retriable.
-    /// - `5xx` and `429` responses are retriable.
-    /// - Everything else (2xx, 3xx, 4xx other than 429) short-circuits
-    ///   and is returned immediately — we don't retry 404s or auth
-    ///   failures because the next attempt will just fail the same
-    ///   way, and for mutation endpoints a retry could double-apply.
-    ///
-    /// Writes do *not* route through this helper; only idempotent GETs
-    /// do. See `put_packument` / `put_dist_tag` for the write-path
-    /// contract.
-    async fn send_with_retry<F>(&self, build: F) -> Result<reqwest::Response, reqwest::Error>
-    where
-        F: Fn() -> reqwest::RequestBuilder,
-    {
-        self.send_with_retry_timed(build)
-            .await
-            .map(|(resp, _)| resp)
-    }
-
     /// Same as [`Self::send_with_retry`] but also returns wall-clock
     /// elapsed from the first `.send()` to the returned response. Used
     /// by metadata call sites to compare against `fetchWarnTimeoutMs`
@@ -383,21 +350,68 @@ impl RegistryClient {
         Ok(resp)
     }
 
+    fn maybe_warn_slow_metadata(&self, label: &str, started: std::time::Instant) {
+        let threshold = self.fetch_policy.warn_timeout_ms;
+        let elapsed_ms = started.elapsed().as_millis() as u64;
+        if threshold > 0 && elapsed_ms > threshold {
+            tracing::warn!(
+                elapsed_ms,
+                threshold_ms = threshold,
+                label,
+                "slow registry metadata request exceeded fetchWarnTimeoutMs",
+            );
+        }
+    }
+
     async fn retry_bytes_body_read<F>(
         &self,
         label: &str,
         build: F,
-    ) -> Result<bytes::Bytes, reqwest::Error>
+    ) -> Result<(bytes::Bytes, std::time::Duration), reqwest::Error>
     where
         F: Fn() -> reqwest::RequestBuilder,
     {
         let max_attempts = self.fetch_policy.retries.saturating_add(1);
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
-            let resp = self.send_with_retry(&build).await?;
-            let resp = resp.error_for_status()?;
-            match resp.bytes().await {
-                Ok(bytes) => return Ok(bytes),
+            match build().send().await {
+                Ok(resp)
+                    if (resp.status().is_server_error()
+                        || resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS)
+                        && !is_last =>
+                {
+                    let wait = retry_after_from(&resp)
+                        .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
+                    tracing::debug!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        status = resp.status().as_u16(),
+                        label,
+                        "retrying HTTP request after transient failure",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Ok(resp) => {
+                    let resp = resp.error_for_status()?;
+                    let started = std::time::Instant::now();
+                    match resp.bytes().await {
+                        Ok(bytes) => return Ok((bytes, started.elapsed())),
+                        Err(err) if !is_last => {
+                            let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                            tracing::debug!(
+                                attempt = attempt + 1,
+                                max_attempts,
+                                backoff_ms = wait.as_millis() as u64,
+                                error = %err,
+                                label,
+                                "retrying HTTP request after response body read error",
+                            );
+                            tokio::time::sleep(wait).await;
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
                 Err(err) if !is_last => {
                     let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
                     tracing::debug!(
@@ -406,7 +420,7 @@ impl RegistryClient {
                         backoff_ms = wait.as_millis() as u64,
                         error = %err,
                         label,
-                        "retrying HTTP request after response body read error",
+                        "retrying HTTP request after transport error",
                     );
                     tokio::time::sleep(wait).await;
                 }
@@ -455,14 +469,18 @@ impl RegistryClient {
         }
 
         let (url, registry_url) = self.packument_url(name);
+        let started = std::time::Instant::now();
 
         // Rebuild the conditional request on each retry. Held in a
         // closure so the revalidation headers are consistent across
         // attempts — a 503 retry with stale `If-None-Match` would be
         // a caching bug.
         let cached_ref = cached.as_ref();
-        let resp = self
-            .send_metadata_with_retry(&format!("packument {name}"), || {
+        let label = format!("packument {name}");
+        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        for attempt in 0..max_attempts {
+            let is_last = attempt + 1 >= max_attempts;
+            match (|| {
                 let mut req = self
                     .authed_get(&url, registry_url)
                     .header("Accept", PACKUMENT_FULL_ACCEPT);
@@ -475,48 +493,101 @@ impl RegistryClient {
                     }
                 }
                 req
-            })
-            .await?;
+            })()
+            .send()
+            .await
+            {
+                Ok(resp)
+                    if (resp.status().is_server_error()
+                        || resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS)
+                        && !is_last =>
+                {
+                    let wait = retry_after_from(&resp)
+                        .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
+                    tracing::debug!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        status = resp.status().as_u16(),
+                        label,
+                        "retrying HTTP request after transient failure",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Ok(resp) => {
+                    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+                        self.maybe_warn_slow_metadata(&label, started);
+                        return Err(Error::NotFound(name.to_string()));
+                    }
 
-        if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            return Err(Error::NotFound(name.to_string()));
+                    if resp.status() == reqwest::StatusCode::NOT_MODIFIED
+                        && let Some(c) = cached.as_ref()
+                    {
+                        let to_cache = CachedFullPackument {
+                            etag: c.etag.clone(),
+                            last_modified: c.last_modified.clone(),
+                            fetched_at: now_secs(),
+                            packument: c.packument.clone(),
+                        };
+                        let _ = write_cached_full_packument(&cache_path, &to_cache);
+                        self.maybe_warn_slow_metadata(&label, started);
+                        return Ok(c.packument.clone());
+                    }
+
+                    let etag = resp
+                        .headers()
+                        .get(reqwest::header::ETAG)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+                    let last_modified = resp
+                        .headers()
+                        .get(reqwest::header::LAST_MODIFIED)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+                    let resp = resp.error_for_status()?;
+                    match resp.json::<serde_json::Value>().await {
+                        Ok(packument) => {
+                            let to_cache = CachedFullPackument {
+                                etag,
+                                last_modified,
+                                fetched_at: now_secs(),
+                                packument: packument.clone(),
+                            };
+                            let _ = write_cached_full_packument(&cache_path, &to_cache);
+                            self.maybe_warn_slow_metadata(&label, started);
+                            return Ok(packument);
+                        }
+                        Err(err) if !is_last => {
+                            let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                            tracing::debug!(
+                                attempt = attempt + 1,
+                                max_attempts,
+                                backoff_ms = wait.as_millis() as u64,
+                                error = %err,
+                                label,
+                                "retrying HTTP request after response body decode error",
+                            );
+                            tokio::time::sleep(wait).await;
+                        }
+                        Err(err) => return Err(err.into()),
+                    }
+                }
+                Err(err) if !is_last => {
+                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                    tracing::debug!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        error = %err,
+                        label,
+                        "retrying HTTP request after transport error",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Err(err) => return Err(err.into()),
+            }
         }
-
-        if resp.status() == reqwest::StatusCode::NOT_MODIFIED
-            && let Some(c) = cached
-        {
-            let to_cache = CachedFullPackument {
-                etag: c.etag.clone(),
-                last_modified: c.last_modified.clone(),
-                fetched_at: now_secs(),
-                packument: c.packument.clone(),
-            };
-            let _ = write_cached_full_packument(&cache_path, &to_cache);
-            return Ok(c.packument);
-        }
-
-        let etag = resp
-            .headers()
-            .get(reqwest::header::ETAG)
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
-        let last_modified = resp
-            .headers()
-            .get(reqwest::header::LAST_MODIFIED)
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
-
-        let packument: serde_json::Value = resp.error_for_status()?.json().await?;
-
-        let to_cache = CachedFullPackument {
-            etag,
-            last_modified,
-            fetched_at: now_secs(),
-            packument: packument.clone(),
-        };
-        let _ = write_cached_full_packument(&cache_path, &to_cache);
-
-        Ok(packument)
+        unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
     }
 
     /// Fetch the full (non-corgi) packument for a package and parse it
@@ -569,26 +640,60 @@ impl RegistryClient {
         let (url, registry_url) = self.packument_url(name);
         let label = format!("packument {name}");
         let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        let started = std::time::Instant::now();
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
-            let resp = self
-                .send_metadata_with_retry(&label, || {
-                    let req = self.authed_get(&url, registry_url);
-                    if force_full_packument() {
-                        req
-                    } else {
-                        req.header("Accept", PACKUMENT_ACCEPT)
+            match (|| {
+                let req = self.authed_get(&url, registry_url);
+                if force_full_packument() {
+                    req
+                } else {
+                    req.header("Accept", PACKUMENT_ACCEPT)
+                }
+            })()
+            .send()
+            .await
+            {
+                Ok(resp)
+                    if (resp.status().is_server_error()
+                        || resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS)
+                        && !is_last =>
+                {
+                    let wait = retry_after_from(&resp)
+                        .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
+                    tracing::debug!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        status = resp.status().as_u16(),
+                        label,
+                        "retrying HTTP request after transient failure",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => {
+                    self.maybe_warn_slow_metadata(&label, started);
+                    return Err(Error::NotFound(name.to_string()));
+                }
+                Ok(resp) => match resp.error_for_status()?.json().await {
+                    Ok(packument) => {
+                        self.maybe_warn_slow_metadata(&label, started);
+                        return Ok(packument);
                     }
-                })
-                .await?;
-
-            if resp.status() == reqwest::StatusCode::NOT_FOUND {
-                return Err(Error::NotFound(name.to_string()));
-            }
-
-            let resp = resp.error_for_status()?;
-            match resp.json().await {
-                Ok(packument) => return Ok(packument),
+                    Err(err) if !is_last => {
+                        let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                        tracing::debug!(
+                            attempt = attempt + 1,
+                            max_attempts,
+                            backoff_ms = wait.as_millis() as u64,
+                            error = %err,
+                            label,
+                            "retrying HTTP request after response body decode error",
+                        );
+                        tokio::time::sleep(wait).await;
+                    }
+                    Err(err) => return Err(err.into()),
+                },
                 Err(err) if !is_last => {
                     let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
                     tracing::debug!(
@@ -652,66 +757,101 @@ impl RegistryClient {
         let cached_ref = cached.as_ref();
         let label = format!("packument {name}");
         let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        let started = std::time::Instant::now();
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
-            let resp = self
-                .send_metadata_with_retry(&label, || {
-                    let mut req = self.authed_get(&url, registry_url);
-                    if !force_full_packument() {
-                        req = req.header("Accept", PACKUMENT_ACCEPT);
+            match (|| {
+                let mut req = self.authed_get(&url, registry_url);
+                if !force_full_packument() {
+                    req = req.header("Accept", PACKUMENT_ACCEPT);
+                }
+                if let Some(c) = cached_ref {
+                    if let Some(ref etag) = c.etag {
+                        req = req.header("If-None-Match", etag);
                     }
-                    if let Some(c) = cached_ref {
-                        if let Some(ref etag) = c.etag {
-                            req = req.header("If-None-Match", etag);
-                        }
-                        if let Some(ref lm) = c.last_modified {
-                            req = req.header("If-Modified-Since", lm);
-                        }
+                    if let Some(ref lm) = c.last_modified {
+                        req = req.header("If-Modified-Since", lm);
                     }
-                    req
-                })
-                .await?;
-
-            if resp.status() == reqwest::StatusCode::NOT_FOUND {
-                return Err(Error::NotFound(name.to_string()));
-            }
-
-            if resp.status() == reqwest::StatusCode::NOT_MODIFIED
-                && let Some(c) = cached.as_ref()
+                }
+                req
+            })()
+            .send()
+            .await
             {
-                // Refresh the timestamp so we can skip the network next time
-                let to_cache = CachedPackument {
-                    etag: c.etag.clone(),
-                    last_modified: c.last_modified.clone(),
-                    fetched_at: now_secs(),
-                    packument: c.packument.clone(),
-                };
-                let _ = write_cached_packument(&cache_path, &to_cache);
-                return Ok(c.packument.clone());
-            }
-
-            let etag = resp
-                .headers()
-                .get(reqwest::header::ETAG)
-                .and_then(|v| v.to_str().ok())
-                .map(|s| s.to_string());
-            let last_modified = resp
-                .headers()
-                .get(reqwest::header::LAST_MODIFIED)
-                .and_then(|v| v.to_str().ok())
-                .map(|s| s.to_string());
-
-            let resp = resp.error_for_status()?;
-            match resp.json::<Packument>().await {
-                Ok(packument) => {
+                Ok(resp)
+                    if (resp.status().is_server_error()
+                        || resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS)
+                        && !is_last =>
+                {
+                    let wait = retry_after_from(&resp)
+                        .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
+                    tracing::debug!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        status = resp.status().as_u16(),
+                        label,
+                        "retrying HTTP request after transient failure",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => {
+                    self.maybe_warn_slow_metadata(&label, started);
+                    return Err(Error::NotFound(name.to_string()));
+                }
+                Ok(resp)
+                    if resp.status() == reqwest::StatusCode::NOT_MODIFIED && cached.is_some() =>
+                {
+                    let c = cached.as_ref().unwrap();
                     let to_cache = CachedPackument {
-                        etag,
-                        last_modified,
+                        etag: c.etag.clone(),
+                        last_modified: c.last_modified.clone(),
                         fetched_at: now_secs(),
-                        packument: packument.clone(),
+                        packument: c.packument.clone(),
                     };
                     let _ = write_cached_packument(&cache_path, &to_cache);
-                    return Ok(packument);
+                    self.maybe_warn_slow_metadata(&label, started);
+                    return Ok(c.packument.clone());
+                }
+                Ok(resp) => {
+                    let etag = resp
+                        .headers()
+                        .get(reqwest::header::ETAG)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+                    let last_modified = resp
+                        .headers()
+                        .get(reqwest::header::LAST_MODIFIED)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+
+                    let resp = resp.error_for_status()?;
+                    match resp.json::<Packument>().await {
+                        Ok(packument) => {
+                            let to_cache = CachedPackument {
+                                etag,
+                                last_modified,
+                                fetched_at: now_secs(),
+                                packument: packument.clone(),
+                            };
+                            let _ = write_cached_packument(&cache_path, &to_cache);
+                            self.maybe_warn_slow_metadata(&label, started);
+                            return Ok(packument);
+                        }
+                        Err(err) if !is_last => {
+                            let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                            tracing::debug!(
+                                attempt = attempt + 1,
+                                max_attempts,
+                                backoff_ms = wait.as_millis() as u64,
+                                error = %err,
+                                label,
+                                "retrying HTTP request after response body decode error",
+                            );
+                            tokio::time::sleep(wait).await;
+                        }
+                        Err(err) => return Err(err.into()),
+                    }
                 }
                 Err(err) if !is_last => {
                     let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
@@ -794,12 +934,15 @@ impl RegistryClient {
         // in `registry_config_for` can find path-scoped auth entries
         // (e.g. `//host/artifactory/npm/`). Retries cover transient
         // 5xx / 429 / connection errors; see [`Self::send_with_retry`].
-        let started = std::time::Instant::now();
-        let bytes = self
+        let (bytes, body_elapsed) = self
             .retry_bytes_body_read(url, || self.authed_get(url, url))
             .await?;
-        let elapsed = started.elapsed();
-        warn_slow_tarball(self.fetch_policy.min_speed_kibps, url, bytes.len(), elapsed);
+        warn_slow_tarball(
+            self.fetch_policy.min_speed_kibps,
+            url,
+            bytes.len(),
+            body_elapsed,
+        );
         Ok(bytes)
     }
 
@@ -1597,6 +1740,87 @@ mod retry_tests {
 
         let requests = server.received_requests().await.unwrap();
         assert_eq!(requests.len(), 2, "expected retry after decode error");
+    }
+
+    #[tokio::test]
+    async fn full_packument_cached_retries_on_body_decode_error_then_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/demo"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw("{not valid json", "application/json"),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/demo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "name": "demo",
+                "versions": {},
+                "dist-tags": {},
+                "time": {},
+            })))
+            .mount(&server)
+            .await;
+
+        let policy = FetchPolicy {
+            timeout_ms: 5_000,
+            retries: 2,
+            retry_factor: 1,
+            retry_min_timeout_ms: 1,
+            retry_max_timeout_ms: 1,
+            ..FetchPolicy::default()
+        };
+        let client = client_with(&server, policy);
+        let temp = tempfile::tempdir().unwrap();
+        let packument = client
+            .fetch_packument_full_cached("demo", temp.path())
+            .await
+            .expect("decode error should be retried on full packument path");
+        assert_eq!(packument["name"], "demo");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2, "expected retry after decode error");
+    }
+
+    #[tokio::test]
+    async fn body_decode_retry_does_not_multiply_total_attempt_count() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/demo"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw("{not valid json", "application/json"),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/demo"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let policy = FetchPolicy {
+            timeout_ms: 5_000,
+            retries: 1,
+            retry_factor: 1,
+            retry_min_timeout_ms: 1,
+            retry_max_timeout_ms: 1,
+            ..FetchPolicy::default()
+        };
+        let client = client_with(&server, policy);
+        let err = client
+            .fetch_packument("demo")
+            .await
+            .expect_err("retry budget should be exhausted after two total attempts");
+        match err {
+            Error::Http(inner) => assert_eq!(inner.status().map(|s| s.as_u16()), Some(503)),
+            other => panic!("unexpected error: {other}"),
+        }
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2, "expected total attempts to stay capped");
     }
 
     #[tokio::test]

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -383,6 +383,39 @@ impl RegistryClient {
         Ok(resp)
     }
 
+    async fn retry_bytes_body_read<F>(
+        &self,
+        label: &str,
+        build: F,
+    ) -> Result<bytes::Bytes, reqwest::Error>
+    where
+        F: Fn() -> reqwest::RequestBuilder,
+    {
+        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        for attempt in 0..max_attempts {
+            let is_last = attempt + 1 >= max_attempts;
+            let resp = self.send_with_retry(&build).await?;
+            let resp = resp.error_for_status()?;
+            match resp.bytes().await {
+                Ok(bytes) => return Ok(bytes),
+                Err(err) if !is_last => {
+                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                    tracing::debug!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        error = %err,
+                        label,
+                        "retrying HTTP request after response body read error",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
+    }
+
     /// Fetch the *full* (non-corgi) packument for a package as raw JSON
     /// with disk caching + ETag revalidation, mirroring
     /// [`Self::fetch_packument_cached`]. Returns `serde_json::Value` so
@@ -534,24 +567,44 @@ impl RegistryClient {
             return Err(Error::Offline(format!("packument for {name}")));
         }
         let (url, registry_url) = self.packument_url(name);
+        let label = format!("packument {name}");
+        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        for attempt in 0..max_attempts {
+            let is_last = attempt + 1 >= max_attempts;
+            let resp = self
+                .send_metadata_with_retry(&label, || {
+                    let req = self.authed_get(&url, registry_url);
+                    if force_full_packument() {
+                        req
+                    } else {
+                        req.header("Accept", PACKUMENT_ACCEPT)
+                    }
+                })
+                .await?;
 
-        let resp = self
-            .send_metadata_with_retry(&format!("packument {name}"), || {
-                let req = self.authed_get(&url, registry_url);
-                if force_full_packument() {
-                    req
-                } else {
-                    req.header("Accept", PACKUMENT_ACCEPT)
+            if resp.status() == reqwest::StatusCode::NOT_FOUND {
+                return Err(Error::NotFound(name.to_string()));
+            }
+
+            let resp = resp.error_for_status()?;
+            match resp.json().await {
+                Ok(packument) => return Ok(packument),
+                Err(err) if !is_last => {
+                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                    tracing::debug!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        error = %err,
+                        label,
+                        "retrying HTTP request after response body decode error",
+                    );
+                    tokio::time::sleep(wait).await;
                 }
-            })
-            .await?;
-
-        if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            return Err(Error::NotFound(name.to_string()));
+                Err(err) => return Err(err.into()),
+            }
         }
-
-        let packument: Packument = resp.error_for_status()?.json().await?;
-        Ok(packument)
+        unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
     }
 
     /// Fetch a packument using a disk-backed cache:
@@ -597,64 +650,85 @@ impl RegistryClient {
         // using the correct `If-None-Match` / `If-Modified-Since`
         // without silently stripping cache hints.
         let cached_ref = cached.as_ref();
-        let resp = self
-            .send_metadata_with_retry(&format!("packument {name}"), || {
-                let mut req = self.authed_get(&url, registry_url);
-                if !force_full_packument() {
-                    req = req.header("Accept", PACKUMENT_ACCEPT);
-                }
-                if let Some(c) = cached_ref {
-                    if let Some(ref etag) = c.etag {
-                        req = req.header("If-None-Match", etag);
+        let label = format!("packument {name}");
+        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        for attempt in 0..max_attempts {
+            let is_last = attempt + 1 >= max_attempts;
+            let resp = self
+                .send_metadata_with_retry(&label, || {
+                    let mut req = self.authed_get(&url, registry_url);
+                    if !force_full_packument() {
+                        req = req.header("Accept", PACKUMENT_ACCEPT);
                     }
-                    if let Some(ref lm) = c.last_modified {
-                        req = req.header("If-Modified-Since", lm);
+                    if let Some(c) = cached_ref {
+                        if let Some(ref etag) = c.etag {
+                            req = req.header("If-None-Match", etag);
+                        }
+                        if let Some(ref lm) = c.last_modified {
+                            req = req.header("If-Modified-Since", lm);
+                        }
                     }
+                    req
+                })
+                .await?;
+
+            if resp.status() == reqwest::StatusCode::NOT_FOUND {
+                return Err(Error::NotFound(name.to_string()));
+            }
+
+            if resp.status() == reqwest::StatusCode::NOT_MODIFIED
+                && let Some(c) = cached.as_ref()
+            {
+                // Refresh the timestamp so we can skip the network next time
+                let to_cache = CachedPackument {
+                    etag: c.etag.clone(),
+                    last_modified: c.last_modified.clone(),
+                    fetched_at: now_secs(),
+                    packument: c.packument.clone(),
+                };
+                let _ = write_cached_packument(&cache_path, &to_cache);
+                return Ok(c.packument.clone());
+            }
+
+            let etag = resp
+                .headers()
+                .get(reqwest::header::ETAG)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+            let last_modified = resp
+                .headers()
+                .get(reqwest::header::LAST_MODIFIED)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+
+            let resp = resp.error_for_status()?;
+            match resp.json::<Packument>().await {
+                Ok(packument) => {
+                    let to_cache = CachedPackument {
+                        etag,
+                        last_modified,
+                        fetched_at: now_secs(),
+                        packument: packument.clone(),
+                    };
+                    let _ = write_cached_packument(&cache_path, &to_cache);
+                    return Ok(packument);
                 }
-                req
-            })
-            .await?;
-
-        if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            return Err(Error::NotFound(name.to_string()));
+                Err(err) if !is_last => {
+                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                    tracing::debug!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        error = %err,
+                        label,
+                        "retrying HTTP request after response body decode error",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Err(err) => return Err(err.into()),
+            }
         }
-
-        if resp.status() == reqwest::StatusCode::NOT_MODIFIED
-            && let Some(c) = cached
-        {
-            // Refresh the timestamp so we can skip the network next time
-            let to_cache = CachedPackument {
-                etag: c.etag.clone(),
-                last_modified: c.last_modified.clone(),
-                fetched_at: now_secs(),
-                packument: c.packument.clone(),
-            };
-            let _ = write_cached_packument(&cache_path, &to_cache);
-            return Ok(c.packument);
-        }
-
-        let etag = resp
-            .headers()
-            .get(reqwest::header::ETAG)
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
-        let last_modified = resp
-            .headers()
-            .get(reqwest::header::LAST_MODIFIED)
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
-
-        let packument: Packument = resp.error_for_status()?.json().await?;
-
-        let to_cache = CachedPackument {
-            etag,
-            last_modified,
-            fetched_at: now_secs(),
-            packument: packument.clone(),
-        };
-        let _ = write_cached_packument(&cache_path, &to_cache);
-
-        Ok(packument)
+        unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
     }
 
     /// POST to the npm bulk security advisories endpoint used by `npm audit`
@@ -720,12 +794,10 @@ impl RegistryClient {
         // in `registry_config_for` can find path-scoped auth entries
         // (e.g. `//host/artifactory/npm/`). Retries cover transient
         // 5xx / 429 / connection errors; see [`Self::send_with_retry`].
-        let resp = self
-            .send_with_retry(|| self.authed_get(url, url))
-            .await?
-            .error_for_status()?;
         let started = std::time::Instant::now();
-        let bytes = resp.bytes().await?;
+        let bytes = self
+            .retry_bytes_body_read(url, || self.authed_get(url, url))
+            .await?;
         let elapsed = started.elapsed();
         warn_slow_tarball(self.fetch_policy.min_speed_kibps, url, bytes.len(), elapsed);
         Ok(bytes)
@@ -1489,6 +1561,42 @@ mod retry_tests {
             .await
             .expect("warn-threshold is advisory — request must still succeed");
         assert_eq!(packument.name, "demo");
+    }
+
+    #[tokio::test]
+    async fn retries_on_packument_body_decode_error_then_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/demo"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw("{not valid json", "application/json"),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/demo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_packument_json()))
+            .mount(&server)
+            .await;
+
+        let policy = FetchPolicy {
+            timeout_ms: 5_000,
+            retries: 2,
+            retry_factor: 1,
+            retry_min_timeout_ms: 1,
+            retry_max_timeout_ms: 1,
+            ..FetchPolicy::default()
+        };
+        let client = client_with(&server, policy);
+        let packument = client
+            .fetch_packument("demo")
+            .await
+            .expect("decode error should be retried");
+        assert_eq!(packument.name, "demo");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2, "expected retry after decode error");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed
Retry install-time registry GETs when the response body itself fails during decode/read, not just when the request/send/status phase fails.

This wires retry-on-body-failure into:
- abbreviated packument fetches
- cached packument refreshes
- tarball byte downloads

It also adds a regression test covering a packument request whose first `200 OK` body is invalid JSON and whose second attempt succeeds.

## Why
The cold benchmark failures were not primarily a linker or resolver speed problem. The reproduced failure mode was a cold install aborting with a registry body decode error after the server had already returned a successful response.

Before this change, `aube` retried transport errors, `5xx`, and `429`, but a truncated/corrupt response body from a `200 OK` response failed immediately. In the published `benchmarks.vlt.sh` data, that was enough to mark `aube` as `DNF` on cold install variations.

## Impact
Cold installs are more resilient to transient registry/proxy body corruption and truncated responses.

This keeps the existing non-retriable behavior for real terminal states like `404` package misses and auth failures.

## Root cause
`RegistryClient` handled retries around `send()` and status codes, but the body consumption paths still did a single `resp.json().await?` or `resp.bytes().await?`. Any failure after headers arrived bypassed the retry policy.

## Validation
- `cargo fmt --check`
- `cargo test -p aube-registry retry_tests --release`
- Mock clean-style benchmark run against the upstream `vltpkg/benchmarks` `next` fixture with isolated `HOME` / `XDG_CACHE_HOME` / `XDG_DATA_HOME` and a fresh project per run via `hyperfine`
- Result: `3.455s ± 0.231s` across 2 cold runs, with no command failure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core registry network retry behavior on hot install paths; incorrect retry conditions or accounting could increase load or alter error surfacing, though retries remain limited and still avoid retrying terminal 4xx states.
> 
> **Overview**
> Improves registry fetch resilience by **extending retry behavior beyond `.send()`/status handling to include response body consumption failures** (JSON decode errors and tarball body read errors) for install-time GET paths.
> 
> Packument fetches (`fetch_packument`, `fetch_packument_cached`, `fetch_packument_full_cached`) now run a unified attempt loop that retries on `5xx`/`429` *and* on JSON decode failures, while still short-circuiting terminal states like `404` and preserving cache revalidation semantics (ETag/Last-Modified). Tarball downloads (`fetch_tarball_bytes`) now retry when `resp.bytes()` fails via a new `retry_bytes_body_read` helper, and metadata slow warnings are emitted via a centralized `maybe_warn_slow_metadata`.
> 
> Adds regression tests covering retries on invalid JSON bodies and ensuring decode retries do not exceed the configured total retry budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cebf6bffbd0c1059f8636850c54ce27a735edd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->