### PR TITLE
install: short-circuit bin linking on packages with no bin metadata

### DIFF
--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -629,6 +629,23 @@ impl LockfileGraph {
         self.packages.get(dep_path)
     }
 
+    /// `true` when at least one package in the graph carries a
+    /// non-empty `bin` map — a cheap signal that the source (lockfile
+    /// parser or fresh resolve) populated bin metadata. Bin-linking
+    /// passes use this to short-circuit the `package.json` read on
+    /// packages whose `bin` is empty (95%+ of a typical graph).
+    ///
+    /// The pnpm, bun, npm, and aube parsers all fill `bin`; a fresh
+    /// resolve fills it from packument data. The yarn-classic parser
+    /// leaves it empty, so a graph loaded exclusively from `yarn.lock`
+    /// returns `false` here and bin linking falls back to the full
+    /// `package.json` read. That's a correctness-over-speed choice:
+    /// misreading "empty" as "no bin" on yarn would silently drop
+    /// executables from `node_modules/.bin/`.
+    pub fn has_bin_metadata(&self) -> bool {
+        self.packages.values().any(|p| !p.bin.is_empty())
+    }
+
     /// BFS the transitive closure of `roots` through `self.packages`,
     /// returning every reachable dep_path (roots included). Missing
     /// roots are skipped silently — a root without a matching package
@@ -1579,6 +1596,59 @@ impl Error {
         Error::ParseDiag(Box::new(aube_manifest::ParseError::from_yaml_err(
             path, content, err,
         )))
+    }
+}
+
+#[cfg(test)]
+mod has_bin_metadata_tests {
+    use super::*;
+
+    fn pkg_with_bin(bin: BTreeMap<String, String>) -> LockedPackage {
+        LockedPackage {
+            name: "p".to_string(),
+            version: "1.0.0".to_string(),
+            dep_path: "p@1.0.0".to_string(),
+            bin,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn empty_graph_has_no_bin_metadata() {
+        let g = LockfileGraph::default();
+        assert!(!g.has_bin_metadata());
+    }
+
+    #[test]
+    fn graph_with_no_bins_returns_false() {
+        let mut g = LockfileGraph::default();
+        g.packages
+            .insert("a@1.0.0".to_string(), pkg_with_bin(BTreeMap::new()));
+        g.packages
+            .insert("b@2.0.0".to_string(), pkg_with_bin(BTreeMap::new()));
+        assert!(!g.has_bin_metadata());
+    }
+
+    #[test]
+    fn any_non_empty_bin_flips_to_true() {
+        let mut g = LockfileGraph::default();
+        g.packages
+            .insert("a@1.0.0".to_string(), pkg_with_bin(BTreeMap::new()));
+        let mut bin = BTreeMap::new();
+        bin.insert("tool".to_string(), "bin/tool.js".to_string());
+        g.packages.insert("b@2.0.0".to_string(), pkg_with_bin(bin));
+        assert!(g.has_bin_metadata());
+    }
+
+    /// pnpm parsers record `hasBin: true` as a one-entry placeholder
+    /// map (empty key + empty value). That still flips the flag.
+    #[test]
+    fn pnpm_placeholder_bin_counts() {
+        let mut g = LockfileGraph::default();
+        let mut bin = BTreeMap::new();
+        bin.insert(String::new(), String::new());
+        g.packages.insert("a@1.0.0".to_string(), pkg_with_bin(bin));
+        assert!(g.has_bin_metadata());
     }
 }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -4323,17 +4323,21 @@ pub(crate) fn link_dep_bins(
         // contributes nothing to a local `.bin/`. Skipping here avoids
         // both the `pkg_dir.exists()` stat and the per-child
         // `link_bins_for_dep` dispatch on ~95% of entries in a typical
-        // graph. Children with `local_source` bypass the lockfile's
-        // bin map, and `bundled_dependencies` can ship bins from child
-        // tarballs regardless of the parent's `bin` field, so both
-        // escape the fast path.
+        // graph. Escape hatches: a child with `local_source`
+        // (file:/link:) bypasses the lockfile's bin map; a child with
+        // its *own* `bundled_dependencies` can ship bins from its
+        // nested tarballs that `link_bins_for_dep` -> `link_bundled_bins`
+        // surfaces into the parent's `.bin/`, so we must dispatch
+        // normally for it.
         if has_bin_metadata
             && pkg.bundled_dependencies.is_empty()
             && pkg.dependencies.iter().all(|(child_name, child_version)| {
                 let child_dep_path = format!("{child_name}@{child_version}");
-                graph
-                    .get_package(&child_dep_path)
-                    .is_some_and(|c| c.bin.is_empty() && c.local_source.is_none())
+                graph.get_package(&child_dep_path).is_some_and(|c| {
+                    c.bin.is_empty()
+                        && c.local_source.is_none()
+                        && c.bundled_dependencies.is_empty()
+                })
             })
         {
             continue;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3612,6 +3612,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         prefer_symlinked_executables,
     };
     if !virtual_store_only {
+        // Computed once up front: scans the packages map (~1350 entries
+        // on the vlt `large` fixture) to see if any carry `bin` info.
+        // pnpm/bun/npm parsers and fresh resolves populate `bin`;
+        // yarn-classic leaves it empty. The bin-linking fast path
+        // trusts empty `bin` as "no bins" only when this flag is set.
+        let has_bin_metadata = graph_for_link.has_bin_metadata();
         link_bins(
             &cwd,
             &modules_dir_name,
@@ -3620,6 +3626,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             virtual_store_dir_max_length,
             placements_ref,
             shim_opts,
+            has_bin_metadata,
         )?;
         if has_workspace {
             for (importer_path, deps) in &graph_for_link.importers {
@@ -3639,6 +3646,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         virtual_store_dir_max_length,
                         placements_ref,
                         shim_opts,
+                        has_bin_metadata,
                     )?;
                 }
             }
@@ -3649,6 +3657,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             virtual_store_dir_max_length,
             placements_ref,
             shim_opts,
+            has_bin_metadata,
         )?;
         tracing::debug!("phase:link_bins {:.1?}", phase_start.elapsed());
     }
@@ -4188,6 +4197,7 @@ fn link_bins_for_dep(
     virtual_store_dir_max_length: usize,
     placements: Option<&aube_linker::HoistedPlacements>,
     shim_opts: aube_linker::BinShimOptions,
+    has_bin_metadata: bool,
 ) -> miette::Result<()> {
     let pkg_dir = materialized_pkg_dir(
         aube_dir,
@@ -4196,6 +4206,22 @@ fn link_bins_for_dep(
         virtual_store_dir_max_length,
         placements,
     );
+    // Fast path: when the lockfile carries bin metadata and says this
+    // package ships none, skip the package.json read + JSON parse.
+    // 95%+ of a typical graph falls into this bucket; the saving
+    // scales with every bin-linking caller (root, per-dep,
+    // per-workspace). `local_source` packages (file:/link:) bypass
+    // the lockfile's bin info so we still consult their on-disk
+    // manifest. Bundled dependencies contribute bins from child
+    // tarballs regardless of the parent's own `bin` field, so
+    // `link_bundled_bins` runs unconditionally below.
+    let skip_bin_read = has_bin_metadata
+        && graph
+            .get_package(dep_path)
+            .is_some_and(|p| p.bin.is_empty() && p.local_source.is_none());
+    if skip_bin_read {
+        return link_bundled_bins(bin_dir, &pkg_dir, graph, dep_path, shim_opts);
+    }
     if let Some(pkg_json) = read_materialized_pkg_json(
         aube_dir,
         dep_path,
@@ -4230,6 +4256,7 @@ fn link_bins_for_dep(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn link_bins(
     project_dir: &std::path::Path,
     modules_dir_name: &str,
@@ -4238,6 +4265,7 @@ fn link_bins(
     virtual_store_dir_max_length: usize,
     placements: Option<&aube_linker::HoistedPlacements>,
     shim_opts: aube_linker::BinShimOptions,
+    has_bin_metadata: bool,
 ) -> miette::Result<()> {
     let bin_dir = project_dir.join(modules_dir_name).join(".bin");
     std::fs::create_dir_all(&bin_dir).into_diagnostic()?;
@@ -4252,6 +4280,7 @@ fn link_bins(
             virtual_store_dir_max_length,
             placements,
             shim_opts,
+            has_bin_metadata,
         )?;
     }
 
@@ -4279,12 +4308,36 @@ pub(crate) fn link_dep_bins(
     virtual_store_dir_max_length: usize,
     placements: Option<&aube_linker::HoistedPlacements>,
     shim_opts: aube_linker::BinShimOptions,
+    has_bin_metadata: bool,
 ) -> miette::Result<()> {
     if placements.is_some() {
         // Hoisted — skip. See function doc.
         return Ok(());
     }
     for (dep_path, pkg) in &graph.packages {
+        if pkg.dependencies.is_empty() {
+            continue;
+        }
+        // Fast path: when lockfile bin metadata is trustworthy and
+        // none of this package's children declare bins, the whole dep
+        // contributes nothing to a local `.bin/`. Skipping here avoids
+        // both the `pkg_dir.exists()` stat and the per-child
+        // `link_bins_for_dep` dispatch on ~95% of entries in a typical
+        // graph. Children with `local_source` bypass the lockfile's
+        // bin map, and `bundled_dependencies` can ship bins from child
+        // tarballs regardless of the parent's `bin` field, so both
+        // escape the fast path.
+        if has_bin_metadata
+            && pkg.bundled_dependencies.is_empty()
+            && pkg.dependencies.iter().all(|(child_name, child_version)| {
+                let child_dep_path = format!("{child_name}@{child_version}");
+                graph
+                    .get_package(&child_dep_path)
+                    .is_some_and(|c| c.bin.is_empty() && c.local_source.is_none())
+            })
+        {
+            continue;
+        }
         let pkg_dir = materialized_pkg_dir(
             aube_dir,
             dep_path,
@@ -4296,9 +4349,6 @@ pub(crate) fn link_dep_bins(
             // Filtered by optional / platform guards, or a staging
             // hiccup. Skipping avoids blowing up the whole install on
             // a dep that was never materialized.
-            continue;
-        }
-        if pkg.dependencies.is_empty() {
             continue;
         }
         let dep_modules_dir = dep_modules_dir_for(&pkg_dir, &pkg.name);
@@ -4330,6 +4380,7 @@ pub(crate) fn link_dep_bins(
                 virtual_store_dir_max_length,
                 placements,
                 shim_opts,
+                has_bin_metadata,
             )?;
         }
     }

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -106,6 +106,7 @@ pub async fn run(
                 super::resolve_virtual_store_dir_max_length(&settings_ctx),
                 hoisted_placements.as_ref(),
                 shim_opts,
+                graph.has_bin_metadata(),
             )?;
             super::install::run_dep_lifecycle_scripts(
                 &cwd,


### PR DESCRIPTION
## Summary

Trim the bin-linking pass from ~40ms to ~9ms on the vlt benchmarks `large` fixture by trusting the lockfile's `bin` metadata. 95%+ of packages in a typical graph ship no executables, and the lockfile already knows which ones do — there's no need to open + JSON-parse every materialized `package.json` just to re-confirm.

- New `LockfileGraph::has_bin_metadata()` — true when any package in the graph carries a non-empty `bin` map. pnpm, bun, npm parsers and fresh resolves all populate `bin`; yarn-classic doesn't. When the flag is `false`, bin linking falls back to the full `package.json` read.
- `link_bins_for_dep` short-circuits when the flag is set and the package has no `bin` and no `local_source`.
- `link_dep_bins` has an outer short-circuit too: when none of a package's *children* declare bins, the whole dep contributes nothing to a local `.bin/` and we skip the `pkg_dir.exists()` stat plus the per-child dispatch.
- `bundled_dependencies` bypass the fast path entirely — bundled children can ship bins from their own tarballs regardless of the parent's `bin` field.

## Measured impact (vlt `large` fixture, cache+lockfile, wiped node_modules, local NVMe)

| phase | before | after |
|---|---|---|
| `link_bins` | 41.9 ms | **9.1 ms** (-78%) |
| total install | 130 ms | **102 ms** (-22%) |

On GHA (where vlt's bench runs at ~2.8s on this fixture), the win should be larger in absolute terms — per-read FS ops dominate there.

## Correctness

- yarn-classic lockfile loads: `has_bin_metadata()` returns `false`, so bin linking falls back to the pre-change code path. No silent drop of `.bin/` entries.
- `local_source` packages (file:/link:): the lockfile may not carry their bin info, so they always read the on-disk manifest.
- `bundled_dependencies`: `link_bundled_bins` runs unconditionally regardless of the parent's `bin`.
- Verified byte-identical `.bin/` output on:
  - vlt `large` fixture (14 top-level bins, 1 nested `.bin/` dir — same set before/after)
  - in-repo `fixtures/workspace/` (2-package workspace, per-workspace bins preserved)

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release -p aube-lockfile` (168 pass, 4 new for `has_bin_metadata`)
- [x] `cargo test --release -p aube --bin aube` (234 pass)
- [x] `cargo test --release -p aube --test e2e` (4 pass)
- [x] Manual byte-diff of `node_modules/.bin` before/after on the large + workspace fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the bin-linking logic during install/rebuild to conditionally skip `package.json` reads based on lockfile-provided `bin` metadata; mistakes here could silently omit executables from `.bin/` in some lockfile/edge cases.
> 
> **Overview**
> Speeds up the install bin-linking phase by trusting lockfile `bin` metadata when available, avoiding `package.json` reads/parses for packages that are known to ship no executables.
> 
> Adds `LockfileGraph::has_bin_metadata()` (with tests) and threads a `has_bin_metadata` flag through `link_bins`, `link_bins_for_dep`, and `link_dep_bins` to short-circuit work, while preserving correctness fallbacks for yarn-classic graphs, `local_source` packages, and `bundled_dependencies` bin hoisting (also used by `rebuild`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a56634c1742156d823ffe8b3fc911ca34e3cd00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->