### PR TITLE
install: detect missing top-level node_modules entries on warm path

### DIFF
--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -93,6 +93,17 @@ pub fn check_needs_install(project_dir: &Path) -> Option<String> {
         }
     }
 
+    // Spot check that direct deps still have their top-level entries.
+    // `rm node_modules/<dep>` (or nuking its `.aube/` target so the
+    // top-level symlink dangles) leaves every hash above matching, so
+    // without this stat sweep the warm path declares "Already up to
+    // date" and never relinks. Skip optional/peer deps — those may
+    // legitimately not be on disk (platform-skipped optionals,
+    // `auto-install-peers=false`).
+    if let Some(reason) = missing_top_level_dep(project_dir, &modules_dir) {
+        return Some(reason);
+    }
+
     if state.section_filtered {
         return Some(
             "previous install omitted dependency sections; auto-installing full graph".into(),
@@ -242,6 +253,30 @@ fn active_lockfile(project_dir: &Path) -> (String, Option<PathBuf>) {
         }
     }
     (preferred, None)
+}
+
+/// Return `Some(reason)` if any direct dep in the root `package.json`
+/// has no top-level entry under `modules_dir`. `try_exists` follows
+/// symlinks, so a dangling top-level symlink (its `.aube/` target was
+/// deleted) also counts as missing — both kinds of corruption need a
+/// real install pass to heal.
+fn missing_top_level_dep(project_dir: &Path, modules_dir: &Path) -> Option<String> {
+    let manifest = aube_manifest::PackageJson::from_path(&project_dir.join("package.json")).ok()?;
+    let modules_name = modules_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("node_modules");
+    for name in manifest
+        .dependencies
+        .keys()
+        .chain(manifest.dev_dependencies.keys())
+    {
+        let entry = modules_dir.join(name);
+        if !entry.try_exists().unwrap_or(false) {
+            return Some(format!("{modules_name}/{name} is missing"));
+        }
+    }
+    None
 }
 
 fn read_state(path: &PathBuf) -> Option<InstallState> {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -93,21 +93,24 @@ pub fn check_needs_install(project_dir: &Path) -> Option<String> {
         }
     }
 
-    // Spot check that direct deps still have their top-level entries.
-    // `rm node_modules/<dep>` (or nuking its `.aube/` target so the
-    // top-level symlink dangles) leaves every hash above matching, so
-    // without this stat sweep the warm path declares "Already up to
-    // date" and never relinks. Skip optional/peer deps — those may
-    // legitimately not be on disk (platform-skipped optionals,
-    // `auto-install-peers=false`).
-    if let Some(reason) = missing_top_level_dep(project_dir, &modules_dir) {
-        return Some(reason);
-    }
-
     if state.section_filtered {
         return Some(
             "previous install omitted dependency sections; auto-installing full graph".into(),
         );
+    }
+
+    // Spot check that direct deps still have their top-level entries.
+    // `rm node_modules/<dep>` (or nuking its `.aube/` target so the
+    // top-level symlink dangles) leaves every hash above matching, so
+    // without this stat sweep the warm path declares "Already up to
+    // date" and never relinks. Must run after the `section_filtered`
+    // guard — a `--prod`/`--dev` install legitimately omits the other
+    // section, and the filtered-install message is more informative
+    // than a generic "<dep> is missing". Skip optional/peer deps —
+    // those may legitimately not be on disk (platform-skipped
+    // optionals, `auto-install-peers=false`).
+    if let Some(reason) = missing_top_level_dep(project_dir, &modules_dir) {
+        return Some(reason);
     }
 
     // no settings_hash check here. this path feeds ensure_installed

--- a/test/install.bats
+++ b/test/install.bats
@@ -43,6 +43,25 @@ teardown() {
 	refute_output --partial "Already up to date"
 }
 
+@test "aube install heals a top-level entry deleted from node_modules" {
+	# Regression: the warm-path freshness check only stat'd node_modules
+	# itself, so `rm node_modules/<dep>` between installs left every
+	# hash matching and the second install printed "Already up to date"
+	# without re-creating the symlink. bun catches this case; aube must too.
+	_setup_basic_fixture
+	run aube install
+	assert_success
+	assert_file_exists node_modules/is-odd/package.json
+
+	rm node_modules/is-odd
+	assert [ ! -e node_modules/is-odd ]
+
+	run aube install
+	assert_success
+	refute_output --partial "Already up to date"
+	assert_file_exists node_modules/is-odd/package.json
+}
+
 @test "aube install --dev installs only devDependencies" {
 	cat >package.json <<'JSON'
 {


### PR DESCRIPTION
## Summary

- Warm-path freshness check only stat'd `node_modules` itself, so `rm node_modules/<dep>` between installs left every hash matching and the second install printed "Already up to date" without recreating the symlink. bun catches this corruption; aube now does too.
- Added `missing_top_level_dep` to `crates/aube/src/state.rs` that reads the root `package.json` and `try_exists`-checks `<modulesDir>/<name>` for every entry in `dependencies` ∪ `devDependencies`. `try_exists` follows symlinks, so a dangling top-level symlink (its `.aube/` target deleted) also counts as missing.
- `optionalDependencies` and `peerDependencies` are intentionally skipped — those may legitimately not be on disk (platform-skipped optionals, `auto-install-peers=false`).

## Test plan

- [x] `cargo clippy -p aube --all-targets -- -D warnings`
- [x] New bats regression: `aube install heals a top-level entry deleted from node_modules` in `test/install.bats` — installs, `rm node_modules/is-odd`, re-installs, asserts the entry is back and "Already up to date" is **not** printed.
- [ ] CI: full `mise run test:bats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the install freshness logic on a hot path, so mistakes could cause unnecessary reinstalls or missed healing in edge cases, but the change is scoped to a simple existence check of direct deps.
> 
> **Overview**
> Prevents false "Already up to date" no-ops when the install tree is partially corrupted (e.g., a direct dependency folder/symlink under `node_modules` is deleted while the state file and hashes still match).
> 
> `check_needs_install` now reads the root `package.json` and `try_exists`-checks top-level entries for all `dependencies` and `devDependencies`, triggering a reinstall when any are missing (while preserving the existing `--prod/--dev` filtered-install behavior). Adds a bats regression test that deletes `node_modules/is-odd` between installs and asserts the second install relinks it and does not print "Already up to date".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3304b1735257c83ff88392009d3fa67573b0b64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->