### PR TITLE
cli: recognize package.json#workspaces as a workspace-root marker

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -95,10 +95,10 @@ cmd add help="Add a dependency" {
         long_help "Add as a peer dependency (written to `peerDependencies` in package.json).\n\nBy convention you usually pair this with `--save-dev` so the peer is also installed for local development; that's what pnpm does."
     }
     flag "-w --workspace" help="Add the dependency to the workspace root's `package.json`, regardless of the current working directory" {
-        long_help "Add the dependency to the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml` / `pnpm-workspace.yaml` and runs the add against that directory."
+        long_help "Add the dependency to the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the add against that directory."
     }
     flag "-W --ignore-workspace-root-check" help="Allow `add` to run in a workspace root" {
-        long_help "Allow `add` to run in a workspace root.\n\nBy default aube refuses to add dependencies to the root `package.json` of a workspace (a directory containing `aube-workspace.yaml` or `pnpm-workspace.yaml`) because deps added there end up shared by every package and usually reflect a mistake. Pass this flag to opt in. Mirrors `pnpm add -W`."
+        long_help "Allow `add` to run in a workspace root.\n\nBy default aube refuses to add dependencies to the root `package.json` of a workspace (a directory containing `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field) because deps added there end up shared by every package and usually reflect a mistake. Pass this flag to opt in. Mirrors `pnpm add -W`."
     }
     arg "[PACKAGES]…" help="Package(s) to add" required=#false var=#true
 }
@@ -637,7 +637,7 @@ cmd remove help="Remove a dependency" {
     flag "-g --global" help="Remove from the global install directory instead of the project"
     flag --ignore-scripts help="Skip root lifecycle scripts during the chained reinstall"
     flag "-w --workspace" help="Remove the dependency from the workspace root's `package.json`, regardless of the current working directory" {
-        long_help "Remove the dependency from the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml` / `pnpm-workspace.yaml` and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`)."
+        long_help "Remove the dependency from the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`)."
     }
     arg "[PACKAGES]…" help="Package(s) to remove" required=#false var=#true
 }

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -274,9 +274,19 @@ pub async fn run(
     // catalog-only yaml is not a workspace root, and a `package.json`
     // without a `workspaces` field isn't either.
     if !ignore_workspace_root_check && !workspace {
-        let yaml_has_packages = aube_manifest::WorkspaceConfig::load(&cwd)
-            .map(|ws| !ws.packages.is_empty())
-            .unwrap_or(false);
+        // `WorkspaceConfig::load` already returns an empty `packages`
+        // list when no yaml exists, so propagating errors here only
+        // surfaces genuine yaml problems (permission denied, malformed
+        // YAML) instead of silently letting `add` proceed against what
+        // might actually be a workspace root.
+        let ws = aube_manifest::WorkspaceConfig::load(&cwd)
+            .into_diagnostic()
+            .wrap_err("failed to read workspace config")?;
+        let yaml_has_packages = !ws.packages.is_empty();
+        // `package.json` read errors fall through intentionally: the
+        // install pipeline below re-reads and parses the same file and
+        // surfaces a richer miette diagnostic pointing at the offending
+        // byte. Duplicating that error here would double-report.
         let pkg_json_has_workspaces =
             aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
                 .ok()

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -770,11 +770,17 @@ async fn run_filtered(
         return Err(miette!("no packages specified"));
     }
     let cwd = crate::dirs::cwd()?;
-    let (_root, matched) = super::select_workspace_packages(&cwd, filter, "add")?;
-    let _lock = super::take_project_lock(&cwd)?;
+    // The workspace root — not the child `cwd` — is what owns the
+    // lockfile and the project lock in yarn / npm / bun monorepos.
+    // Taking the lock or snapshotting the lockfile against `cwd` would
+    // target a stale subpackage path, letting `install::run` (which
+    // walks up) mutate the real root lockfile and then silently skip
+    // the restore under `--no-save`.
+    let (root, matched) = super::select_workspace_packages(&cwd, filter, "add")?;
+    let _lock = super::take_project_lock(&root)?;
 
     let mut snapshots = Vec::new();
-    let lockfile_path = lockfile_path_for_project(&cwd);
+    let lockfile_path = lockfile_path_for_project(&root);
     let root_lockfile_snapshot = if args.no_save {
         match std::fs::read(&lockfile_path) {
             Ok(bytes) => Some(bytes),

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -268,15 +268,21 @@ pub async fn run(
     // package and usually reflect a mistake. `-W` /
     // `--ignore-workspace-root-check` bypasses the check, and `-w` /
     // `--workspace` implies the bypass since the user explicitly
-    // targeted the root. We only trip on a workspace root that
-    // actually declares package patterns — bare catalog-only yaml is
-    // not a workspace root, and a `package.json` without a
-    // `workspaces` field isn't either.
+    // targeted the root. We trip on a *declared* package-pattern list,
+    // not on the materialized glob — an empty `packages/*` directory
+    // is still a workspace root the user should opt into. Bare
+    // catalog-only yaml is not a workspace root, and a `package.json`
+    // without a `workspaces` field isn't either.
     if !ignore_workspace_root_check && !workspace {
-        let has_packages = aube_workspace::find_workspace_packages(&cwd)
-            .map(|pkgs| !pkgs.is_empty())
+        let yaml_has_packages = aube_manifest::WorkspaceConfig::load(&cwd)
+            .map(|ws| !ws.packages.is_empty())
             .unwrap_or(false);
-        if has_packages {
+        let pkg_json_has_workspaces =
+            aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
+                .ok()
+                .and_then(|m| m.workspaces)
+                .is_some_and(|w| !w.patterns().is_empty());
+        if yaml_has_packages || pkg_json_has_workspaces {
             return Err(miette!(
                 "refusing to add dependencies to the workspace root. \
                  If this is intentional, pass --ignore-workspace-root-check (-W)."

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -49,17 +49,19 @@ pub struct AddArgs {
     /// Add the dependency to the workspace root's `package.json`,
     /// regardless of the current working directory.
     ///
-    /// Walks up from cwd looking for `aube-workspace.yaml` /
-    /// `pnpm-workspace.yaml` and runs the add against that directory.
+    /// Walks up from cwd looking for `aube-workspace.yaml`,
+    /// `pnpm-workspace.yaml`, or a `package.json` with a `workspaces`
+    /// field and runs the add against that directory.
     #[arg(short = 'w', long, conflicts_with = "global")]
     pub workspace: bool,
     /// Allow `add` to run in a workspace root.
     ///
     /// By default aube refuses to add dependencies to the root
     /// `package.json` of a workspace (a directory containing
-    /// `aube-workspace.yaml` or `pnpm-workspace.yaml`) because deps
-    /// added there end up shared by every package and usually reflect
-    /// a mistake. Pass this flag to opt in. Mirrors `pnpm add -W`.
+    /// `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json`
+    /// with a `workspaces` field) because deps added there end up
+    /// shared by every package and usually reflect a mistake. Pass
+    /// this flag to opt in. Mirrors `pnpm add -W`.
     #[arg(short = 'W', long)]
     pub ignore_workspace_root_check: bool,
 }
@@ -266,14 +268,15 @@ pub async fn run(
     // package and usually reflect a mistake. `-W` /
     // `--ignore-workspace-root-check` bypasses the check, and `-w` /
     // `--workspace` implies the bypass since the user explicitly
-    // targeted the root. We only trip on a workspace file that
-    // actually declares `packages:` — a bare catalog-only file is
-    // not a workspace root.
+    // targeted the root. We only trip on a workspace root that
+    // actually declares package patterns — bare catalog-only yaml is
+    // not a workspace root, and a `package.json` without a
+    // `workspaces` field isn't either.
     if !ignore_workspace_root_check && !workspace {
-        let ws = aube_manifest::WorkspaceConfig::load(&cwd)
-            .into_diagnostic()
-            .wrap_err("failed to read workspace config")?;
-        if !ws.packages.is_empty() {
+        let has_packages = aube_workspace::find_workspace_packages(&cwd)
+            .map(|pkgs| !pkgs.is_empty())
+            .unwrap_or(false);
+        if has_packages {
             return Err(miette!(
                 "refusing to add dependencies to the workspace root. \
                  If this is intentional, pass --ignore-workspace-root-check (-W)."

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -770,7 +770,7 @@ async fn run_filtered(
         return Err(miette!("no packages specified"));
     }
     let cwd = crate::dirs::cwd()?;
-    let matched = super::select_workspace_packages(&cwd, filter, "add")?;
+    let (_root, matched) = super::select_workspace_packages(&cwd, filter, "add")?;
     let _lock = super::take_project_lock(&cwd)?;
 
     let mut snapshots = Vec::new();

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -101,7 +101,7 @@ pub async fn run(
     if workspace_pkgs.is_empty() {
         return Err(miette!(
             "aube deploy: no workspace packages found. \
-             `deploy` requires a pnpm-workspace.yaml at {}",
+             `deploy` requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at {}",
             source_root.display()
         ));
     }

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -101,7 +101,7 @@ async fn run_filtered(
     parallel: bool,
     filter: &aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<()> {
-    let matched = super::select_workspace_packages(cwd, filter, "exec")?;
+    let (_root, matched) = super::select_workspace_packages(cwd, filter, "exec")?;
     if parallel {
         if !shell_mode {
             for pkg in &matched {

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -254,7 +254,7 @@ fn run_filtered(
         ListFormat::Json => {
             let mut values = Vec::new();
             for pkg in &selected {
-                let importer = super::workspace_importer_path(cwd, &pkg.dir)?;
+                let importer = super::workspace_importer_path(&root, &pkg.dir)?;
                 values.push(json_importer_value(
                     &pkg.dir,
                     &pkg.manifest,
@@ -276,7 +276,7 @@ fn run_filtered(
                 if idx > 0 {
                     println!();
                 }
-                let importer = super::workspace_importer_path(cwd, &pkg.dir)?;
+                let importer = super::workspace_importer_path(&root, &pkg.dir)?;
                 render_default_for_importer(
                     &pkg.dir,
                     &pkg.manifest,
@@ -291,7 +291,7 @@ fn run_filtered(
         }
         ListFormat::Parseable => {
             for pkg in &selected {
-                let importer = super::workspace_importer_path(cwd, &pkg.dir)?;
+                let importer = super::workspace_importer_path(&root, &pkg.dir)?;
                 render_parseable_for_importer(graph, args, dep_filter, &importer)?;
             }
         }

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -129,16 +129,27 @@ pub async fn run(
     }
 
     let cwd = crate::dirs::project_root()?;
+    // In yarn / npm / bun monorepos the lockfile lives only at the
+    // workspace root, not in the subpackage. When the caller asks for
+    // `--filter` we read manifest + lockfile from the root so
+    // `run_filtered` sees the real graph — otherwise `parse_lockfile`
+    // returns `NotFound` from the child and we exit before ever
+    // iterating the workspace.
+    let read_from = if !filter.is_empty() {
+        crate::dirs::find_workspace_root(&cwd).unwrap_or_else(|| cwd.clone())
+    } else {
+        cwd.clone()
+    };
 
     // Read manifest (needed even for `list` — we print the project name/version
     // at the top, and the lockfile parser needs it for non-pnpm formats).
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
+    let manifest = aube_manifest::PackageJson::from_path(&read_from.join("package.json"))
         .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
 
     // Lockfile may be absent in a brand-new project — treat that as "nothing
     // installed yet" rather than a hard error, and print an empty tree.
-    let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
+    let graph = match aube_lockfile::parse_lockfile(&read_from, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
             eprintln!("No lockfile found. Run `aube install` to populate node_modules.");
@@ -177,7 +188,7 @@ pub async fn run(
 
     if !filter.is_empty() {
         return run_filtered(
-            &cwd,
+            &read_from,
             &manifest,
             &graph,
             &args,
@@ -209,7 +220,7 @@ use super::DepFilter;
 
 #[allow(clippy::too_many_arguments)]
 fn run_filtered(
-    cwd: &std::path::Path,
+    root: &std::path::Path,
     root_manifest: &aube_manifest::PackageJson,
     graph: &LockfileGraph,
     args: &ListArgs,
@@ -218,20 +229,16 @@ fn run_filtered(
     vstore_max_len: usize,
     vstore_prefix: &str,
 ) -> miette::Result<()> {
-    // Walk up to the workspace root so `--filter` works from a
-    // subpackage in a yarn / npm / bun monorepo (where only the root
-    // carries `package.json#workspaces`).
-    let root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
-    let workspace_pkgs = aube_workspace::find_workspace_packages(&root)
+    let workspace_pkgs = aube_workspace::find_workspace_packages(root)
         .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
     if workspace_pkgs.is_empty() {
         return Err(miette!(
             "aube list: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
-            cwd.display()
+            root.display()
         ));
     }
     let selected = aube_workspace::selector::select_workspace_packages(
-        &root,
+        root,
         &workspace_pkgs,
         workspace_filter,
     )
@@ -254,7 +261,7 @@ fn run_filtered(
         ListFormat::Json => {
             let mut values = Vec::new();
             for pkg in &selected {
-                let importer = super::workspace_importer_path(&root, &pkg.dir)?;
+                let importer = super::workspace_importer_path(root, &pkg.dir)?;
                 values.push(json_importer_value(
                     &pkg.dir,
                     &pkg.manifest,
@@ -276,7 +283,7 @@ fn run_filtered(
                 if idx > 0 {
                     println!();
                 }
-                let importer = super::workspace_importer_path(&root, &pkg.dir)?;
+                let importer = super::workspace_importer_path(root, &pkg.dir)?;
                 render_default_for_importer(
                     &pkg.dir,
                     &pkg.manifest,
@@ -291,7 +298,7 @@ fn run_filtered(
         }
         ListFormat::Parseable => {
             for pkg in &selected {
-                let importer = super::workspace_importer_path(&root, &pkg.dir)?;
+                let importer = super::workspace_importer_path(root, &pkg.dir)?;
                 render_parseable_for_importer(graph, args, dep_filter, &importer)?;
             }
         }

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -174,16 +174,19 @@ pub async fn run(
     // Resolve `virtualStoreDirMaxLength` once so `--long` mode prints
     // the same `.aube/<name>` filename the linker actually wrote.
     // Passing the default would mis-report long dep_paths on projects
-    // that customize the cap via `.npmrc`.
-    let vstore_max_len = super::resolve_virtual_store_dir_max_length_for_cwd(&cwd);
+    // that customize the cap via `.npmrc`. Read from `read_from` so
+    // a yarn / npm / bun subpackage inherits the root's settings
+    // instead of falling back to defaults when the child has no
+    // `.npmrc` / `pnpm-workspace.yaml`.
+    let vstore_max_len = super::resolve_virtual_store_dir_max_length_for_cwd(&read_from);
     // Resolve `virtualStoreDir` too — without this, `--long` would
     // always print `./node_modules/.aube/...` even when the user has
     // relocated the virtual store (e.g. `virtualStoreDir=node_modules/vstore`
     // or an out-of-tree absolute path), pointing at a path that
     // doesn't exist.
     let vstore_prefix = super::format_virtual_store_display_prefix(
-        &super::resolve_virtual_store_dir_for_cwd(&cwd),
-        &cwd,
+        &super::resolve_virtual_store_dir_for_cwd(&read_from),
+        &read_from,
     );
 
     if !filter.is_empty() {

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -218,17 +218,24 @@ fn run_filtered(
     vstore_max_len: usize,
     vstore_prefix: &str,
 ) -> miette::Result<()> {
-    let workspace_pkgs = aube_workspace::find_workspace_packages(cwd)
+    // Walk up to the workspace root so `--filter` works from a
+    // subpackage in a yarn / npm / bun monorepo (where only the root
+    // carries `package.json#workspaces`).
+    let root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+    let workspace_pkgs = aube_workspace::find_workspace_packages(&root)
         .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
     if workspace_pkgs.is_empty() {
         return Err(miette!(
-            "aube list: --filter requires a pnpm-workspace.yaml at {}",
+            "aube list: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
             cwd.display()
         ));
     }
-    let selected =
-        aube_workspace::selector::select_workspace_packages(cwd, &workspace_pkgs, workspace_filter)
-            .map_err(|e| miette!("invalid --filter selector: {e}"))?;
+    let selected = aube_workspace::selector::select_workspace_packages(
+        &root,
+        &workspace_pkgs,
+        workspace_filter,
+    )
+    .map_err(|e| miette!("invalid --filter selector: {e}"))?;
     if selected.is_empty() {
         return Err(miette!(
             "aube list: filter {workspace_filter:?} did not match any workspace package"

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -615,27 +615,6 @@ fn merge_manifest_catalogs(out: &mut CatalogMap, manifest: &aube_manifest::Packa
     merge_catalog_source(out, &manifest.pnpm_catalog(), &manifest.pnpm_catalogs());
 }
 
-/// Walk upward from `start` looking for the nearest ancestor whose
-/// `package.json` declares a `workspaces` field. bun / npm / yarn mark
-/// the workspace root that way (no separate `pnpm-workspace.yaml`), so
-/// when `aube install` runs from a subpackage of one of those projects
-/// this is the only handle we have on the workspace root.
-///
-/// `start` itself is included in the walk; the closest ancestor wins
-/// (nested workspaces aren't a thing in any of pnpm / bun / npm /
-/// yarn).
-fn find_workspaces_field_root(start: &std::path::Path) -> Option<std::path::PathBuf> {
-    start.ancestors().find_map(|dir| {
-        let pkg = dir.join("package.json");
-        if !pkg.is_file() {
-            return None;
-        }
-        let manifest = aube_manifest::PackageJson::from_path(&pkg).ok()?;
-        manifest.workspaces.as_ref()?;
-        Some(dir.to_path_buf())
-    })
-}
-
 /// Discover catalog entries from every supported source and merge them
 /// into a single map for the resolver.
 ///
@@ -676,10 +655,8 @@ pub(crate) fn discover_catalogs(project_root: &std::path::Path) -> miette::Resul
     // either marker — yaml first (pnpm convention), then `workspaces`
     // field (bun / npm / yarn convention) — so a subpackage install in
     // a non-pnpm monorepo still picks up the root catalog.
-    let workspace_yaml_dir = crate::dirs::find_workspace_root(project_root);
-    let workspace_root_dir = workspace_yaml_dir
-        .clone()
-        .or_else(|| find_workspaces_field_root(project_root));
+    let workspace_yaml_dir = crate::dirs::find_workspace_yaml_root(project_root);
+    let workspace_root_dir = crate::dirs::find_workspace_root(project_root);
     if let Some(dir) = &workspace_root_dir
         && dir != project_root
         && let Ok(m) = aube_manifest::PackageJson::from_path(&dir.join("package.json"))
@@ -705,12 +682,13 @@ pub(crate) fn load_workspace_catalogs(cwd: &std::path::Path) -> miette::Result<C
     discover_catalogs(cwd)
 }
 
-/// Walk up from `start` looking for a directory that contains an
-/// `aube-workspace.yaml` or `pnpm-workspace.yaml` file and return it.
+/// Walk up from `start` looking for a directory that marks a workspace
+/// root — either an `aube-workspace.yaml` / `pnpm-workspace.yaml` file
+/// or a `package.json` with a `workspaces` field.
 pub(crate) fn find_workspace_root(start: &std::path::Path) -> miette::Result<std::path::PathBuf> {
     crate::dirs::find_workspace_root(start).ok_or_else(|| {
         miette!(
-            "no aube-workspace.yaml or pnpm-workspace.yaml found above {}",
+            "no workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) found above {}",
             start.display()
         )
     })

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -699,16 +699,22 @@ pub(crate) fn select_workspace_packages(
     filter: &aube_workspace::selector::EffectiveFilter,
     command: &str,
 ) -> miette::Result<Vec<aube_workspace::selector::SelectedPackage>> {
-    let workspace_pkgs = aube_workspace::find_workspace_packages(cwd)
+    // `cwd` is the nearest ancestor with a `package.json`, which in a
+    // monorepo subpackage is the child — not the workspace root. Walk
+    // up so discovery sees every sibling package in yarn / npm / bun
+    // layouts where only the root carries `package.json#workspaces`.
+    let root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+    let workspace_pkgs = aube_workspace::find_workspace_packages(&root)
         .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
     if workspace_pkgs.is_empty() {
         return Err(miette!(
-            "aube {command}: --filter requires a pnpm-workspace.yaml at {}",
+            "aube {command}: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
             cwd.display()
         ));
     }
-    let matched = aube_workspace::selector::select_workspace_packages(cwd, &workspace_pkgs, filter)
-        .map_err(|e| miette!("invalid --filter selector: {e}"))?;
+    let matched =
+        aube_workspace::selector::select_workspace_packages(&root, &workspace_pkgs, filter)
+            .map_err(|e| miette!("invalid --filter selector: {e}"))?;
     if matched.is_empty() {
         return Err(miette!(
             "aube {command}: filter {filter:?} did not match any workspace package"

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -694,15 +694,19 @@ pub(crate) fn find_workspace_root(start: &std::path::Path) -> miette::Result<std
     })
 }
 
+/// Resolve `--filter` to the matching workspace packages, returning the
+/// workspace root alongside the matches. Callers need the root to
+/// compute importer paths, resolve the lockfile, etc., and `cwd`
+/// alone isn't it in yarn / npm / bun subpackage installs where only
+/// the monorepo root carries `package.json#workspaces`.
 pub(crate) fn select_workspace_packages(
     cwd: &std::path::Path,
     filter: &aube_workspace::selector::EffectiveFilter,
     command: &str,
-) -> miette::Result<Vec<aube_workspace::selector::SelectedPackage>> {
-    // `cwd` is the nearest ancestor with a `package.json`, which in a
-    // monorepo subpackage is the child — not the workspace root. Walk
-    // up so discovery sees every sibling package in yarn / npm / bun
-    // layouts where only the root carries `package.json#workspaces`.
+) -> miette::Result<(
+    std::path::PathBuf,
+    Vec<aube_workspace::selector::SelectedPackage>,
+)> {
     let root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
     let workspace_pkgs = aube_workspace::find_workspace_packages(&root)
         .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
@@ -720,7 +724,7 @@ pub(crate) fn select_workspace_packages(
             "aube {command}: filter {filter:?} did not match any workspace package"
         ));
     }
-    Ok(matched)
+    Ok((root, matched))
 }
 
 /// Resolve a version spec against a full packument. Returns the concrete

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -130,11 +130,11 @@ async fn run_filtered(
     args: OutdatedArgs,
     filter: &aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<()> {
-    let matched = super::select_workspace_packages(cwd, filter, "outdated")?;
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
+    let (root, matched) = super::select_workspace_packages(cwd, filter, "outdated")?;
+    let manifest = aube_manifest::PackageJson::from_path(&root.join("package.json"))
         .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
-    let graph = match aube_lockfile::parse_lockfile(cwd, &manifest) {
+    let graph = match aube_lockfile::parse_lockfile(&root, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
             eprintln!("No lockfile found. Run `aube install` first.");
@@ -148,13 +148,21 @@ async fn run_filtered(
             .name
             .clone()
             .unwrap_or_else(|| pkg.dir.display().to_string());
-        let importer_path = super::workspace_importer_path(cwd, &pkg.dir)?;
+        let importer_path = super::workspace_importer_path(&root, &pkg.dir)?;
         let roots = graph
             .importers
             .get(&importer_path)
             .map(Vec::as_slice)
             .unwrap_or(&[]);
-        if run_graph(cwd, args.clone_for_fanout(), &graph, roots, Some(importer)).await? {
+        if run_graph(
+            &root,
+            args.clone_for_fanout(),
+            &graph,
+            roots,
+            Some(importer),
+        )
+        .await?
+        {
             any_drift = true;
         }
     }

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -234,7 +234,7 @@ async fn run_recursive(
     if workspace_pkgs.is_empty() {
         return Err(miette!(
             "aube publish: no workspace packages found. \
-             `--recursive` / `--filter` requires a pnpm-workspace.yaml at {}",
+             `--recursive` / `--filter` requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at {}",
             source_root.display()
         ));
     }

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -149,7 +149,7 @@ pub async fn run(
 
 async fn run_filtered(filter: &aube_workspace::selector::EffectiveFilter) -> miette::Result<()> {
     let cwd = crate::dirs::cwd()?;
-    let matched = super::select_workspace_packages(&cwd, filter, "rebuild")?;
+    let (_root, matched) = super::select_workspace_packages(&cwd, filter, "rebuild")?;
     let result = async {
         for pkg in matched {
             super::retarget_cwd(&pkg.dir)?;

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -142,7 +142,7 @@ async fn run_filtered(
     filter: &aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<()> {
     let cwd = crate::dirs::cwd()?;
-    let matched = super::select_workspace_packages(&cwd, filter, "remove")?;
+    let (_root, matched) = super::select_workspace_packages(&cwd, filter, "remove")?;
     let result = async {
         for pkg in matched {
             super::retarget_cwd(&pkg.dir)?;

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -18,10 +18,11 @@ pub struct RemoveArgs {
     /// Remove the dependency from the workspace root's `package.json`,
     /// regardless of the current working directory.
     ///
-    /// Walks up from cwd looking for `aube-workspace.yaml` /
-    /// `pnpm-workspace.yaml` and runs the remove against that
-    /// directory. Takes precedence over `--filter` when both are
-    /// supplied (same as `add --workspace`).
+    /// Walks up from cwd looking for `aube-workspace.yaml`,
+    /// `pnpm-workspace.yaml`, or a `package.json` with a `workspaces`
+    /// field and runs the remove against that directory. Takes
+    /// precedence over `--filter` when both are supplied (same as
+    /// `add --workspace`).
     #[arg(short = 'w', long, conflicts_with = "global")]
     pub workspace: bool,
 }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -277,27 +277,11 @@ async fn run_script_filtered(
     enable_pre_post_scripts: bool,
 ) -> miette::Result<()> {
     // `cwd` is the nearest ancestor with a `package.json`, which in a
-    // monorepo subpackage is the child — not the workspace root. Walk
-    // up to the workspace root so discovery sees every sibling package.
-    let root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
-    let workspace_pkgs = aube_workspace::find_workspace_packages(&root)
-        .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
-    if workspace_pkgs.is_empty() {
-        return Err(miette!(
-            "aube run: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
-            cwd.display()
-        ));
-    }
-
-    let matched =
-        aube_workspace::selector::select_workspace_packages(&root, &workspace_pkgs, filter)
-            .map_err(|e| miette!("invalid --filter selector: {e}"))?;
-
-    if matched.is_empty() {
-        return Err(miette!(
-            "aube run: filter {filter:?} did not match any workspace package"
-        ));
-    }
+    // monorepo subpackage is the child — not the workspace root. The
+    // shared helper walks up to the real workspace root before
+    // enumerating packages, so yarn / npm / bun monorepos work from a
+    // subpackage.
+    let (_root, matched) = super::select_workspace_packages(cwd, filter, "run")?;
 
     // Install once at the workspace root before fanning out — the
     // isolated linker already materializes every workspace package's

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -276,17 +276,22 @@ async fn run_script_filtered(
     filter: &aube_workspace::selector::EffectiveFilter,
     enable_pre_post_scripts: bool,
 ) -> miette::Result<()> {
-    let workspace_pkgs = aube_workspace::find_workspace_packages(cwd)
+    // `cwd` is the nearest ancestor with a `package.json`, which in a
+    // monorepo subpackage is the child — not the workspace root. Walk
+    // up to the workspace root so discovery sees every sibling package.
+    let root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+    let workspace_pkgs = aube_workspace::find_workspace_packages(&root)
         .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
     if workspace_pkgs.is_empty() {
         return Err(miette!(
-            "aube run: --filter requires a pnpm-workspace.yaml at {}",
+            "aube run: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
             cwd.display()
         ));
     }
 
-    let matched = aube_workspace::selector::select_workspace_packages(cwd, &workspace_pkgs, filter)
-        .map_err(|e| miette!("invalid --filter selector: {e}"))?;
+    let matched =
+        aube_workspace::selector::select_workspace_packages(&root, &workspace_pkgs, filter)
+            .map_err(|e| miette!("invalid --filter selector: {e}"))?;
 
     if matched.is_empty() {
         return Err(miette!(

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -364,7 +364,7 @@ async fn run_filtered(
     filter: &aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<()> {
     let cwd = crate::dirs::cwd()?;
-    let matched = super::select_workspace_packages(&cwd, filter, "update")?;
+    let (_root, matched) = super::select_workspace_packages(&cwd, filter, "update")?;
     let result = async {
         for pkg in matched {
             super::retarget_cwd(&pkg.dir)?;

--- a/crates/aube/src/commands/why.rs
+++ b/crates/aube/src/commands/why.rs
@@ -144,7 +144,7 @@ fn run_filtered(
         .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
     if workspace_pkgs.is_empty() {
         return Err(miette!(
-            "aube why: --filter requires a pnpm-workspace.yaml at {}",
+            "aube why: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at {}",
             workspace_root.display()
         ));
     }

--- a/crates/aube/src/commands/why.rs
+++ b/crates/aube/src/commands/why.rs
@@ -120,7 +120,7 @@ fn run_filtered(
 ) -> miette::Result<()> {
     let workspace_root = crate::dirs::find_workspace_root(cwd).ok_or_else(|| {
         miette!(
-            "aube why: --filter requires a pnpm-workspace.yaml at or above {}",
+            "aube why: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
             cwd.display()
         )
     })?;

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -45,10 +45,33 @@ pub fn find_project_root(start: &Path) -> Option<PathBuf> {
 
 /// Walk upward from `start` looking for the nearest workspace root.
 ///
-/// A workspace root is any ancestor containing `aube-workspace.yaml` or
-/// `pnpm-workspace.yaml`. The aube-owned name wins at read time elsewhere,
-/// but discovery only needs to know whether either file marks the root.
+/// A workspace root is any ancestor that either:
+/// - contains `aube-workspace.yaml` or `pnpm-workspace.yaml`, or
+/// - has a `package.json` with a `workspaces` field (yarn / npm / bun).
+///
+/// The aube-owned yaml name wins at read time elsewhere, but discovery
+/// only needs to know whether any of those markers fixes the root.
 pub fn find_workspace_root(start: &Path) -> Option<PathBuf> {
+    start.ancestors().find_map(|dir| {
+        if dir.join("aube-workspace.yaml").exists() || dir.join("pnpm-workspace.yaml").exists() {
+            return Some(dir.to_path_buf());
+        }
+        let pkg = dir.join("package.json");
+        if !pkg.is_file() {
+            return None;
+        }
+        let manifest = aube_manifest::PackageJson::from_path(&pkg).ok()?;
+        manifest.workspaces.as_ref()?;
+        Some(dir.to_path_buf())
+    })
+}
+
+/// Walk upward from `start` looking for the nearest ancestor that
+/// contains `aube-workspace.yaml` or `pnpm-workspace.yaml`. Unlike
+/// [`find_workspace_root`], this ignores `package.json#workspaces`
+/// because it feeds callers that specifically need the yaml file path
+/// (catalog loader, settings loader).
+pub fn find_workspace_yaml_root(start: &Path) -> Option<PathBuf> {
     start.ancestors().find_map(|dir| {
         if dir.join("aube-workspace.yaml").exists() || dir.join("pnpm-workspace.yaml").exists() {
             Some(dir.to_path_buf())
@@ -93,4 +116,105 @@ pub fn set_cwd(path: &Path) -> miette::Result<()> {
     };
     *CWD.write().expect("cwd lock poisoned") = Some(path);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn find_workspace_root_finds_pnpm_workspace_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'\n",
+        );
+        write(&dir.path().join("packages/a/package.json"), "{}");
+
+        let child = dir.path().join("packages/a");
+        assert_eq!(find_workspace_root(&child).unwrap(), dir.path());
+    }
+
+    #[test]
+    fn find_workspace_root_finds_package_json_workspaces_array() {
+        // yarn / npm / bun: no yaml, just a `workspaces` field in the
+        // root package.json. Running aube from a subpackage must still
+        // resolve to the monorepo root.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("package.json"),
+            r#"{"name":"root","workspaces":["packages/*"]}"#,
+        );
+        write(
+            &dir.path().join("packages/a/package.json"),
+            r#"{"name":"a"}"#,
+        );
+
+        let child = dir.path().join("packages/a");
+        assert_eq!(find_workspace_root(&child).unwrap(), dir.path());
+    }
+
+    #[test]
+    fn find_workspace_root_finds_package_json_workspaces_object() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("package.json"),
+            r#"{"name":"root","workspaces":{"packages":["apps/*"]}}"#,
+        );
+        write(&dir.path().join("apps/a/package.json"), r#"{"name":"a"}"#);
+
+        let child = dir.path().join("apps/a");
+        assert_eq!(find_workspace_root(&child).unwrap(), dir.path());
+    }
+
+    #[test]
+    fn find_workspace_root_ignores_package_json_without_workspaces() {
+        // A child package.json with no `workspaces` field must not
+        // short-circuit the walk — otherwise nested single packages
+        // inside a monorepo would each be treated as a workspace root.
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("package.json"),
+            r#"{"name":"root","workspaces":["packages/*"]}"#,
+        );
+        write(
+            &dir.path().join("packages/a/package.json"),
+            r#"{"name":"a"}"#,
+        );
+
+        let child = dir.path().join("packages/a");
+        let root = find_workspace_root(&child).unwrap();
+        assert_eq!(root, dir.path());
+        assert_ne!(root, child);
+    }
+
+    #[test]
+    fn find_workspace_yaml_root_ignores_package_json_workspaces() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("package.json"),
+            r#"{"name":"root","workspaces":["packages/*"]}"#,
+        );
+        write(
+            &dir.path().join("packages/a/package.json"),
+            r#"{"name":"a"}"#,
+        );
+
+        let child = dir.path().join("packages/a");
+        assert!(find_workspace_yaml_root(&child).is_none());
+    }
+
+    #[test]
+    fn find_workspace_root_returns_none_without_markers() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join("package.json"), r#"{"name":"solo"}"#);
+        assert!(find_workspace_root(dir.path()).is_none());
+    }
 }

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -51,10 +51,10 @@ By convention you usually pair this with `--save-dev` so the peer is also instal
 
 Add the dependency to the workspace root's `package.json`, regardless of the current working directory.
 
-Walks up from cwd looking for `aube-workspace.yaml` / `pnpm-workspace.yaml` and runs the add against that directory.
+Walks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the add against that directory.
 
 ### `-W --ignore-workspace-root-check`
 
 Allow `add` to run in a workspace root.
 
-By default aube refuses to add dependencies to the root `package.json` of a workspace (a directory containing `aube-workspace.yaml` or `pnpm-workspace.yaml`) because deps added there end up shared by every package and usually reflect a mistake. Pass this flag to opt in. Mirrors `pnpm add -W`.
+By default aube refuses to add dependencies to the root `package.json` of a workspace (a directory containing `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field) because deps added there end up shared by every package and usually reflect a mistake. Pass this flag to opt in. Mirrors `pnpm add -W`.

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -123,7 +123,7 @@
             "name": "workspace",
             "usage": "-w --workspace",
             "help": "Add the dependency to the workspace root's `package.json`, regardless of the current working directory",
-            "help_long": "Add the dependency to the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml` / `pnpm-workspace.yaml` and runs the add against that directory.",
+            "help_long": "Add the dependency to the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the add against that directory.",
             "help_first_line": "Add the dependency to the workspace root's `package.json`, regardless of the current working directory",
             "short": [
               "w"
@@ -138,7 +138,7 @@
             "name": "ignore-workspace-root-check",
             "usage": "-W --ignore-workspace-root-check",
             "help": "Allow `add` to run in a workspace root",
-            "help_long": "Allow `add` to run in a workspace root.\n\nBy default aube refuses to add dependencies to the root `package.json` of a workspace (a directory containing `aube-workspace.yaml` or `pnpm-workspace.yaml`) because deps added there end up shared by every package and usually reflect a mistake. Pass this flag to opt in. Mirrors `pnpm add -W`.",
+            "help_long": "Allow `add` to run in a workspace root.\n\nBy default aube refuses to add dependencies to the root `package.json` of a workspace (a directory containing `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field) because deps added there end up shared by every package and usually reflect a mistake. Pass this flag to opt in. Mirrors `pnpm add -W`.",
             "help_first_line": "Allow `add` to run in a workspace root",
             "short": [
               "W"
@@ -3889,7 +3889,7 @@
             "name": "workspace",
             "usage": "-w --workspace",
             "help": "Remove the dependency from the workspace root's `package.json`, regardless of the current working directory",
-            "help_long": "Remove the dependency from the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml` / `pnpm-workspace.yaml` and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`).",
+            "help_long": "Remove the dependency from the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`).",
             "help_first_line": "Remove the dependency from the workspace root's `package.json`, regardless of the current working directory",
             "short": [
               "w"

--- a/docs/cli/remove.md
+++ b/docs/cli/remove.md
@@ -30,4 +30,4 @@ Skip root lifecycle scripts during the chained reinstall
 
 Remove the dependency from the workspace root's `package.json`, regardless of the current working directory.
 
-Walks up from cwd looking for `aube-workspace.yaml` / `pnpm-workspace.yaml` and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`).
+Walks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`).

--- a/test/guardrails.bats
+++ b/test/guardrails.bats
@@ -74,7 +74,7 @@ _setup_workspace_fixture() {
 
 	NPM_CONFIG_COLOR=false run aube --workspace-root run env
 	assert_failure
-	[[ "$output" == *"no aube-workspace.yaml or pnpm-workspace.yaml found"* ]]
+	[[ "$output" == *"no workspace root"* ]]
 	[[ "$output" != *$'\033['* ]]
 }
 


### PR DESCRIPTION
## Summary

- `find_workspace_root` now walks up to an ancestor `package.json` with a `workspaces` field, not just `aube-workspace.yaml` / `pnpm-workspace.yaml`. Yarn / npm / bun monorepos (no yaml) work with `--workspace-root`, `add -w / -W`, `remove -w`, `why --filter`, `run --filter`, and the `packageManagerStrict` guard when invoked from a subpackage.
- `aube run --filter` used to enumerate workspace packages from the child project root, which is always empty in a yarn subpackage — it now walks up to the workspace root first.
- Consolidated the duplicate `find_workspaces_field_root` helper into `dirs::find_workspace_root`; catalog discovery keeps a narrower `find_workspace_yaml_root` for the yaml-specific load path.
- `add`'s workspace-root guard (`-W` / `ignore-workspace-root-check`) now trips on yarn roots too.
- Error messages and long-help strings mention all three markers; `aube.usage.kdl` regenerated.

Closes the ask in https://github.com/endevco/aube/discussions/178. `package.json#workspaces` discovery for `find_workspace_packages` was already supported — this PR fixes the remaining call sites.

## Test plan

- [x] `cargo test --release` (240+ unit tests pass, including 6 new `dirs::tests`)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual: `aube run foo` from a yarn-monorepo subpackage resolves to the root's `workspaces` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace root detection and lockfile/manifest targeting across multiple commands, which could alter behavior in existing monorepos and affect where installs/lockfile operations apply.
> 
> **Overview**
> Adds support for treating `package.json#workspaces` as a workspace-root marker (in addition to `aube-workspace.yaml`/`pnpm-workspace.yaml`), enabling yarn/npm/bun-style monorepos to work correctly when invoked from a subpackage.
> 
> Refactors workspace selection to return the resolved workspace root alongside matched packages and updates `add`, `run`, `exec`, `list`, `outdated`, `rebuild`, `remove`, and other `--filter`/`-w` paths to use the root for lockfiles, importer paths, and project locking (fixing issues like `add --no-save` restoring the wrong lockfile from a subpackage). Updates CLI docs/usage/error messages accordingly and adds unit tests for the new workspace-root discovery logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 330daf1f0be4f6e15a47413b509803c0f42271dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->