### PR TITLE
chore: release v1.0.0-beta.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "miette",
  "serde",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "base64",
  "blake3",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -1914,9 +1914,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc89deee4af0429081d2a518c0431ae068222a5a262a3bc6ff4d8535ec2e02fe"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
 ]
@@ -2013,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca3c01a711f395b4257b81674c0e90e8dd1f1e62c4b7db45f684cc7a4fcb18a"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -2876,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ strip = "debuginfo"
 panic = "abort"
 
 [workspace.package]
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -103,13 +103,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.11" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.11" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.11" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.11" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.11" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.11" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.11" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.11" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.11" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.11" }
+aube = { path = "crates/aube", version = "1.0.0-beta.12" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.12" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.12" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.12" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.12" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.12" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.12" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.12" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.12" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.12" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.11"
+version "1.0.0-beta.12"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.11...aube-linker-v1.0.0-beta.12) - 2026-04-22
+
+### Other
+
+- include integrity in package index cache key ([#209](https://github.com/endevco/aube/pull/209))
+- cross-crate dedup pass ([#208](https://github.com/endevco/aube/pull/208))
+- cross-crate security hardening ([#202](https://github.com/endevco/aube/pull/202))
+- cross-crate correctness and security fixes ([#196](https://github.com/endevco/aube/pull/196))
+
 ## [1.0.0-beta.11](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.10...aube-linker-v1.0.0-beta.11) - 2026-04-21
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.11...aube-lockfile-v1.0.0-beta.12) - 2026-04-22
+
+### Other
+
+- *(pnpm)* strip peer-context suffix from URL importer versions ([#214](https://github.com/endevco/aube/pull/214))
+- cross-crate dedup pass ([#208](https://github.com/endevco/aube/pull/208))
+- *(pnpm)* prefer pnpm version field for url-keyed transitives ([#204](https://github.com/endevco/aube/pull/204))
+- cross-crate security hardening ([#202](https://github.com/endevco/aube/pull/202))
+- *(npm)* parse workspace link entries ([#198](https://github.com/endevco/aube/pull/198))
+- cross-crate correctness and security fixes ([#196](https://github.com/endevco/aube/pull/196))
+
 ## [1.0.0-beta.11](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.10...aube-lockfile-v1.0.0-beta.11) - 2026-04-21
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.11...aube-manifest-v1.0.0-beta.12) - 2026-04-22
+
+### Other
+
+- cross-crate correctness and security fixes ([#196](https://github.com/endevco/aube/pull/196))
+
 ## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.9...aube-manifest-v1.0.0-beta.10) - 2026-04-21
 
 ### Fixed

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.11...aube-registry-v1.0.0-beta.12) - 2026-04-22
+
+### Other
+
+- cross-crate dedup pass ([#208](https://github.com/endevco/aube/pull/208))
+- cross-crate security hardening ([#202](https://github.com/endevco/aube/pull/202))
+- cross-crate correctness and security fixes ([#196](https://github.com/endevco/aube/pull/196))
+
 ## [1.0.0-beta.11](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.10...aube-registry-v1.0.0-beta.11) - 2026-04-21
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.11...aube-resolver-v1.0.0-beta.12) - 2026-04-22
+
+### Other
+
+- cross-crate dedup pass ([#208](https://github.com/endevco/aube/pull/208))
+- enrich NoMatch error with importer, chain, available versions ([#205](https://github.com/endevco/aube/pull/205))
+- treat empty version range as `*` ([#206](https://github.com/endevco/aube/pull/206))
+- allow exotic subdeps from local parents ([#201](https://github.com/endevco/aube/pull/201))
+- cross-crate correctness and security fixes ([#196](https://github.com/endevco/aube/pull/196))
+
 ## [1.0.0-beta.11](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.10...aube-resolver-v1.0.0-beta.11) - 2026-04-21
 
 ### Other

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0-beta.11...aube-scripts-v1.0.0-beta.12) - 2026-04-22
+
+### Other
+
+- bootstrap node-gyp when absent from PATH ([#210](https://github.com/endevco/aube/pull/210))
+- cross-crate dedup pass ([#208](https://github.com/endevco/aube/pull/208))
+- cross-crate correctness and security fixes ([#196](https://github.com/endevco/aube/pull/196))
+
 ## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0-beta.9...aube-scripts-v1.0.0-beta.10) - 2026-04-21
 
 ### Fixed

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.11...aube-settings-v1.0.0-beta.12) - 2026-04-22
+
+### Other
+
+- make packageManagerStrict a tri-state, default warn ([#213](https://github.com/endevco/aube/pull/213))
+
 ## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.9...aube-settings-v1.0.0-beta.10) - 2026-04-21
 
 ### Fixed

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.11...aube-store-v1.0.0-beta.12) - 2026-04-22
+
+### Other
+
+- include integrity in package index cache key ([#209](https://github.com/endevco/aube/pull/209))
+- cross-crate dedup pass ([#208](https://github.com/endevco/aube/pull/208))
+- skip pkg-content version check for URL-shaped lockfile entries ([#203](https://github.com/endevco/aube/pull/203))
+- cross-crate security hardening ([#202](https://github.com/endevco/aube/pull/202))
+- cross-crate correctness and security fixes ([#196](https://github.com/endevco/aube/pull/196))
+
 ## [1.0.0-beta.10](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.9...aube-store-v1.0.0-beta.10) - 2026-04-21
 
 ### Fixed

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.11...aube-workspace-v1.0.0-beta.12) - 2026-04-22
+
+### Other
+
+- cross-crate correctness and security fixes ([#196](https://github.com/endevco/aube/pull/196))
+
 ## [1.0.0-beta.9](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.8...aube-workspace-v1.0.0-beta.9) - 2026-04-20
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.12](https://github.com/endevco/aube/compare/v1.0.0-beta.11...v1.0.0-beta.12) - 2026-04-22
+
+### Other
+
+- anchor aube install at workspace root from member subdir ([#217](https://github.com/endevco/aube/pull/217))
+- apply dependency policy in add/remove/update/dedupe resolver ([#218](https://github.com/endevco/aube/pull/218))
+- compare packageManagerStrictVersion against user-facing version ([#216](https://github.com/endevco/aube/pull/216))
+- anchor auto-install freshness check at workspace root ([#215](https://github.com/endevco/aube/pull/215))
+- make packageManagerStrict a tri-state, default warn ([#213](https://github.com/endevco/aube/pull/213))
+- append -DEBUG to version on non-release builds ([#212](https://github.com/endevco/aube/pull/212))
+- include integrity in package index cache key ([#209](https://github.com/endevco/aube/pull/209))
+- bootstrap node-gyp when absent from PATH ([#210](https://github.com/endevco/aube/pull/210))
+- cross-crate dedup pass ([#208](https://github.com/endevco/aube/pull/208))
+- enrich NoMatch error with importer, chain, available versions ([#205](https://github.com/endevco/aube/pull/205))
+- raise RLIMIT_NOFILE soft limit at startup ([#207](https://github.com/endevco/aube/pull/207))
+- cross-crate security hardening ([#202](https://github.com/endevco/aube/pull/202))
+- *(filter)* keep root importer deps in workspace selects ([#199](https://github.com/endevco/aube/pull/199))
+- cross-crate correctness and security fixes ([#196](https://github.com/endevco/aube/pull/196))
+
 ## [1.0.0-beta.11](https://github.com/endevco/aube/compare/v1.0.0-beta.10...v1.0.0-beta.11) - 2026-04-21
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5734,7 +5734,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.11
+**Version**: 1.0.0-beta.12
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.11",
-  "releasedAt": "2026-04-21T15:46:20Z"
+  "version": "1.0.0-beta.12",
+  "releasedAt": "2026-04-22T22:31:24Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.12`

This PR bumps the workspace to `v1.0.0-beta.12` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a release/version bump with regenerated documentation and lockfile updates, with no source code changes in the diff.
> 
> **Overview**
> Updates the workspace/package versions (and all internal crate dependency pins) from `1.0.0-beta.11` to `1.0.0-beta.12`.
> 
> Regenerates release artifacts: per-crate `CHANGELOG.md` entries for `1.0.0-beta.12`, bumps the CLI usage spec/docs version (`aube.usage.kdl`, `docs/cli/*`), and refreshes `Cargo.lock`/`release.json` (including minor dependency lock bumps like `rustls` and `mimalloc`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d0ff63a61401ea2b375916ccf57bfbebfee99f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->