### PR TITLE
chore: cross-crate correctness and security fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "pathdiff",
  "rayon",
  "reflink-copy",
+ "serde_json",
  "sha2 0.10.9",
  "strum 0.28.0",
  "tempfile",

--- a/crates/aube-linker/Cargo.toml
+++ b/crates/aube-linker/Cargo.toml
@@ -14,6 +14,7 @@ aube-store = { workspace = true }
 aube-lockfile = { workspace = true }
 xx = { workspace = true }
 log = { workspace = true }
+serde_json = { workspace = true }
 reflink-copy = { workspace = true }
 thiserror = { workspace = true }
 rayon = { workspace = true }
@@ -23,6 +24,7 @@ glob = { workspace = true }
 diffy = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+tempfile = "3"
 
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -71,7 +71,7 @@ pub fn sweep_stale_tmp_dirs(virtual_store: &Path) {
 pub fn remove_dir_all_with_retry(path: &Path) -> std::io::Result<()> {
     #[cfg(not(windows))]
     {
-        return std::fs::remove_dir_all(path);
+        std::fs::remove_dir_all(path)
     }
     #[cfg(windows)]
     {

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -14,6 +14,93 @@ mod hoisted;
 pub mod sys;
 pub use hoisted::HoistedPlacements;
 
+/// Sweep orphan `.tmp-<pid>-*` directories in the virtual store.
+///
+/// Linker materializes each package into `.tmp-<pid>-<subdir>/`
+/// then atomic-renames into `.aube/<subdir>/`. Crash or Ctrl-C
+/// between materialize and rename leaves the tmp dir behind.
+/// Nothing else cleans these up so they accumulate on every aborted
+/// install. Small footprint per entry but a few hundred aborted
+/// CI runs pile up gigabytes.
+///
+/// Called early in link_all so each fresh install reclaims space
+/// from prior crashes. Only matches the exact prefix we produce so
+/// user files named `.tmp-*` in the virtual store are safe.
+pub fn sweep_stale_tmp_dirs(virtual_store: &Path) {
+    let Ok(entries) = std::fs::read_dir(virtual_store) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        // Match our exact prefix. Format: `.tmp-<pid>-<subdir>`
+        // where pid is numeric.
+        if !name.starts_with(".tmp-") {
+            continue;
+        }
+        let rest = &name[".tmp-".len()..];
+        let Some((pid_str, _rest)) = rest.split_once('-') else {
+            continue;
+        };
+        if pid_str.chars().any(|c| !c.is_ascii_digit()) {
+            continue;
+        }
+        // Do not touch the dir of our own still-running process.
+        // Materialize path creates and removes its tmp dir in the
+        // same call and crashes mid-way are the target here, the
+        // active pid will not leave ones around that matter.
+        if pid_str == std::process::id().to_string() {
+            continue;
+        }
+        let _ = remove_dir_all_with_retry(&entry.path());
+    }
+}
+
+/// Remove a directory with retry on Windows sharing violations.
+///
+/// Windows does not let you delete a file while another process holds
+/// a handle open. Dev server, vitest watcher, tsc --watch all hold
+/// .js / .node files inside node_modules. aube reinstall hits ERROR
+/// 32 (SHARING_VIOLATION) or ERROR 5 (ACCESS_DENIED, AV scanner
+/// mid-scan) and leaves a half-deleted virtual store. pnpm, npm,
+/// rimraf all retry with backoff. Do the same. Unix passthrough.
+///
+/// Retries 10 times with exponential backoff starting at 50ms. Total
+/// worst case around 10 seconds which is tolerable for an install
+/// already paying for filesystem work.
+pub fn remove_dir_all_with_retry(path: &Path) -> std::io::Result<()> {
+    #[cfg(not(windows))]
+    {
+        return std::fs::remove_dir_all(path);
+    }
+    #[cfg(windows)]
+    {
+        use std::io::ErrorKind;
+        let mut delay_ms = 50u64;
+        for attempt in 0..10 {
+            match std::fs::remove_dir_all(path) {
+                Ok(()) => return Ok(()),
+                Err(e) if e.kind() == ErrorKind::NotFound => return Ok(()),
+                Err(e) => {
+                    // Sharing violation and PermissionDenied both
+                    // map to retriable Windows errors. Bail on
+                    // attempt 10.
+                    let retriable =
+                        matches!(e.kind(), ErrorKind::PermissionDenied | ErrorKind::Other)
+                            || e.raw_os_error() == Some(32);
+                    if !retriable || attempt == 9 {
+                        return Err(e);
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                    delay_ms = (delay_ms * 2).min(2000);
+                }
+            }
+        }
+        // Unreachable, loop always returns by attempt 10.
+        Ok(())
+    }
+}
+
 /// Real workspace importer, not a peer-context bookkeeping entry.
 ///
 /// pnpm v9 lockfiles record the peer-resolution view of each
@@ -625,9 +712,28 @@ impl Linker {
     }
 
     /// Detect the best linking strategy for the filesystem at the given path.
+    ///
+    /// One-arg form. Probes within one dir. Fine when store and
+    /// project node_modules share the same mount. Use the two-arg
+    /// form for installs where the store lives on a different
+    /// filesystem than the project (USB drives, bind mounts, Docker
+    /// volumes, cross-drive Windows installs). Otherwise the probe
+    /// reports reflink or hardlink based on project-FS self-test,
+    /// then every real link call crosses an FS boundary and hits
+    /// EXDEV. Runtime falls back to `fs::copy` per file silently,
+    /// thousands of wasted syscalls, user thinks they got hardlinks.
     pub fn detect_strategy(path: &Path) -> LinkStrategy {
-        let test_src = path.join(".aube-link-test-src");
-        let test_dst = path.join(".aube-link-test-dst");
+        Self::detect_strategy_cross(path, path)
+    }
+
+    /// Two-arg probe. src is the store shard (or any dir on the
+    /// store FS), dst is the project modules dir (or any dir on the
+    /// destination FS). Probe creates a real cross-mount src file
+    /// and tries to reflink/hardlink into dst, which catches EXDEV
+    /// up front.
+    pub fn detect_strategy_cross(src_dir: &Path, dst_dir: &Path) -> LinkStrategy {
+        let test_src = src_dir.join(".aube-link-test-src");
+        let test_dst = dst_dir.join(".aube-link-test-dst");
 
         if std::fs::write(&test_src, b"test").is_ok() {
             if reflink_copy::reflink(&test_src, &test_dst).is_ok() {
@@ -677,7 +783,9 @@ impl Linker {
             // stale tree would keep satisfying phantom deps for any
             // leftover `.aube/<dep_path>/` directories until their
             // eventual cleanup. Honors `virtualStoreDir`.
-            let _ = std::fs::remove_dir_all(self.aube_dir_for(project_dir).join("node_modules"));
+            let _ = crate::remove_dir_all_with_retry(
+                &self.aube_dir_for(project_dir).join("node_modules"),
+            );
             stats.hoisted_placements = Some(placements);
             return Ok(stats);
         }
@@ -686,6 +794,12 @@ impl Linker {
         let aube_dir = self.aube_dir_for(project_dir);
 
         xx::file::mkdirp(&aube_dir).map_err(|e| Error::Xx(e.to_string()))?;
+
+        // Reclaim space from prior aborted installs. A crash or
+        // Ctrl+C between materialize_into and the atomic rename
+        // leaves `.tmp-<pid>-*` dirs in the virtual store. Sweep
+        // them now so the current install starts clean.
+        sweep_stale_tmp_dirs(&aube_dir);
 
         // Clean up stale top-level entries not in the current graph.
         // With shamefully_hoist, every package name in the graph is
@@ -984,7 +1098,11 @@ impl Linker {
         // driver's responsibility to skip in this mode.
         if self.virtual_store_only {
             self.link_hidden_hoist(&aube_dir, graph)?;
-            write_applied_patches(&nm, &curr_applied);
+            if let Err(e) = write_applied_patches(&nm, &curr_applied) {
+                log::error!(
+                    "failed to write .aube-applied-patches.json: {e}. next install may miss stale patched entries"
+                );
+            }
             return Ok(stats);
         }
 
@@ -1098,7 +1216,11 @@ impl Linker {
         // root-level symlinks even on name clashes.
         self.link_hidden_hoist(&aube_dir, graph)?;
 
-        write_applied_patches(&nm, &curr_applied);
+        if let Err(e) = write_applied_patches(&nm, &curr_applied) {
+            log::error!(
+                "failed to write .aube-applied-patches.json: {e}. next install may miss stale patched entries"
+            );
+        }
         Ok(stats)
     }
 
@@ -1173,7 +1295,7 @@ impl Linker {
         // `.aube/node_modules/` left behind by a prior isolated
         // install so hoisted's dotfile-preserving cleanup doesn't
         // leak a stale hidden tree. Honors `virtualStoreDir`.
-        let _ = std::fs::remove_dir_all(self.aube_dir_for(root_dir).join("node_modules"));
+        let _ = crate::remove_dir_all_with_retry(&self.aube_dir_for(root_dir).join("node_modules"));
         stats.hoisted_placements = Some(placements);
         Ok(stats)
     }
@@ -1394,7 +1516,11 @@ impl Linker {
                 }
             }
             self.link_hidden_hoist(&aube_dir, graph)?;
-            write_applied_patches(&root_nm, &curr_applied);
+            if let Err(e) = write_applied_patches(&root_nm, &curr_applied) {
+                log::error!(
+                    "failed to write .aube-applied-patches.json: {e}. next install may miss stale patched entries"
+                );
+            }
             return Ok(stats);
         }
 
@@ -1670,7 +1796,11 @@ impl Linker {
         // sufficient for the whole workspace.
         self.link_hidden_hoist(&aube_dir, graph)?;
 
-        write_applied_patches(&root_nm, &curr_applied);
+        if let Err(e) = write_applied_patches(&root_nm, &curr_applied) {
+            log::error!(
+                "failed to write .aube-applied-patches.json: {e}. next install may miss stale patched entries"
+            );
+        }
         Ok(stats)
     }
 
@@ -2333,37 +2463,53 @@ fn read_applied_patches(nm_dir: &Path) -> std::collections::BTreeMap<String, Str
 /// `aube-linker` for one file. Returns `None` on any malformed input
 /// so the caller falls back to "no previous state."
 fn serde_json_parse_map(s: &str) -> Option<std::collections::BTreeMap<String, String>> {
-    let s = s.trim();
-    let s = s.strip_prefix('{')?.strip_suffix('}')?;
-    let mut out = std::collections::BTreeMap::new();
-    if s.trim().is_empty() {
-        return Some(out);
-    }
-    for entry in s.split(',') {
-        let (k, v) = entry.split_once(':')?;
-        let k = k.trim().trim_matches('"');
-        let v = v.trim().trim_matches('"');
-        out.insert(k.to_string(), v.to_string());
-    }
-    Some(out)
+    // Old code hand-rolled JSON with split(',') and trim_matches('"').
+    // Breaks on any key or value containing a comma, escaped quote,
+    // or backslash. Keys are name@version strings today but patch
+    // content hashes are fine, and if pnpm ever extends the key
+    // schema this blows up. Real JSON parser handles escaping.
+    serde_json::from_str(s).ok()
 }
 
-/// Write the applied-patch sidecar so the next install can detect
-/// added/removed/changed patches and re-materialize the affected
-/// `.aube/<dep_path>` entries. Best-effort: a write error here just
-/// means the next run will conservatively wipe more entries than
-/// strictly necessary.
-fn write_applied_patches(nm_dir: &Path, map: &std::collections::BTreeMap<String, String>) {
+/// Write the applied-patch sidecar.
+///
+/// Next install reads this to compute which `.aube/<dep_path>`
+/// entries need re-materializing because their patch set changed.
+/// Old code was `let _ = fs::write(...)`, dropped any IO error. If
+/// write silently failed (disk full, read-only mount, perms), the
+/// sidecar was missing on next install, and
+/// wipe_changed_patched_entries did not know which entries to
+/// re-link. Install reported success while node_modules had stale
+/// patched content on disk. Return Result, caller logs loudly.
+fn write_applied_patches(
+    nm_dir: &Path,
+    map: &std::collections::BTreeMap<String, String>,
+) -> std::io::Result<()> {
     let path = nm_dir.join(".aube-applied-patches.json");
-    let mut out = String::from("{");
-    for (i, (k, v)) in map.iter().enumerate() {
-        if i > 0 {
-            out.push(',');
-        }
-        out.push_str(&format!("\"{k}\":\"{v}\""));
+    let out = serde_json::to_string(map)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    // Atomic write via tempfile + rename. Old fs::write truncated
+    // in place. Kill aube mid write (Ctrl+C, power loss, AV
+    // quarantine), sidecar ends up empty or partial JSON. Next
+    // install treats it as "no previous patches" and skips the
+    // diff, leaving stale patched entries materialized in
+    // node_modules that should have been re-linked.
+    if !nm_dir.exists() {
+        std::fs::create_dir_all(nm_dir)?;
     }
-    out.push('}');
-    let _ = std::fs::write(path, out);
+    let tmp = tempfile::Builder::new()
+        .prefix(".aube-applied-patches-")
+        .suffix(".tmp")
+        .tempfile_in(nm_dir)?;
+    {
+        use std::io::Write as _;
+        let mut f = tmp.as_file();
+        f.write_all(out.as_bytes())?;
+        f.sync_all()?;
+    }
+    tmp.persist(&path)
+        .map_err(|e| std::io::Error::other(format!("persist applied-patches: {e}")))?;
+    Ok(())
 }
 
 /// Wipe `.aube/<dep_path>` for any package whose patch fingerprint

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -824,7 +824,7 @@ pub fn write(
     // trips instead of silently downgrading on re-emit.
     let config_version = graph.bun_config_version.unwrap_or(1);
     let body = format_bun_lockfile(&workspace_pairs, &package_entries, config_version);
-    std::fs::write(path, body).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+    crate::atomic_write_lockfile(path, body.as_bytes())?;
     Ok(())
 }
 

--- a/crates/aube-lockfile/src/graph_hash.rs
+++ b/crates/aube-lockfile/src/graph_hash.rs
@@ -146,7 +146,12 @@ pub fn compute_graph_hashes_with_patches(
     // allowed to run its scripts. This is the "builds" set.
     let mut builds: FxHashSet<String> = FxHashSet::default();
     for (dep_path, pkg) in &graph.packages {
-        if allow_build(&pkg.name, &pkg.version) {
+        // Feed registry_name to allow_build, not pkg.name. pkg.name
+        // could be an npm: alias from the manifest. Allowlist pins
+        // the real name. Without this, an aliased import smuggles
+        // past the allowlist. Same fix applied at every policy.decide
+        // callsite in aube/ (install/mod.rs, ignored_builds.rs).
+        if allow_build(pkg.registry_name(), &pkg.version) {
             builds.insert(dep_path.clone());
         }
     }

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -1237,6 +1237,71 @@ pub enum DriftStatus {
     Stale { reason: String },
 }
 
+/// Atomic lockfile write. Tempfile in the same dir, fsync, rename
+/// over the target. Every format writer goes through this so a
+/// crash or Ctrl+C mid-write cannot leave a truncated lockfile on
+/// disk. Rename is atomic on POSIX, on Windows MoveFileEx gives
+/// the same guarantee post Win10. Caller passes the serialized
+/// bytes already formatted, this just handles the IO layer.
+pub(crate) fn atomic_write_lockfile(path: &Path, body: &[u8]) -> Result<(), Error> {
+    // Raw open + rename, same dir. Atomic on POSIX (rename(2)) and
+    // on Windows (MoveFileEx under fs::rename). Crash between
+    // write and rename leaves the old file intact, plus a dotfile
+    // tmp sibling, old file still parses fine so next install
+    // succeeds.
+    //
+    // Tried tempfile::NamedTempFile::persist first but on Windows
+    // it collided with tests that passed a NamedTempFile as the
+    // target path. The persist rename hit Access Denied because
+    // the outer NamedTempFile handle blocked the replacement.
+    // Direct open/write/rename sidesteps that.
+    use std::io::Write as _;
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("lockfile");
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    // Dot prefix keeps the tmp hidden on Unix and out of most
+    // file explorers on Windows. Pid + nanos avoid collision
+    // between racing processes even if the outer project lock
+    // somehow missed.
+    let tmp_name = format!(".{}.aube-tmp-{}-{}", file_name, std::process::id(), nanos);
+    let tmp_path = parent.join(tmp_name);
+    // Helper closure so every failure path cleans up the tmp file.
+    // Without this, a disk-full or permission error mid-write left
+    // a `.lockfile.aube-tmp-<pid>-<nanos>` sibling on disk forever.
+    // Enough aborted installs and these pile up in the project dir.
+    let write_then_rename = || -> Result<(), Error> {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+            .map_err(|e| Error::Io(tmp_path.clone(), e))?;
+        f.write_all(body)
+            .map_err(|e| Error::Io(tmp_path.clone(), e))?;
+        // sync_all before rename. Rename is a metadata op that can
+        // commit before the data blocks reach stable storage, so a
+        // crash right after rename would leave a valid-looking
+        // file with zero bytes. fsync forces the data first.
+        f.sync_all().map_err(|e| Error::Io(tmp_path.clone(), e))?;
+        // Drop the file handle explicitly before rename. Windows
+        // ReplaceFileW is happier when the source handle is closed.
+        drop(f);
+        std::fs::rename(&tmp_path, path).map_err(|e| Error::Io(path.to_path_buf(), e))
+    };
+    match write_then_rename() {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp_path);
+            Err(e)
+        }
+    }
+}
+
 /// Write a lockfile to the given project directory using aube's default
 /// filename (`aube-lock.yaml`, or `aube-lock.<branch>.yaml` when branch
 /// lockfiles are enabled).

--- a/crates/aube-lockfile/src/merge.rs
+++ b/crates/aube-lockfile/src/merge.rs
@@ -163,21 +163,38 @@ fn merge_into(dst: &mut LockfileGraph, src: LockfileGraph, report: &mut MergeRep
     for (dep_path, incoming) in src.packages {
         match dst.packages.remove(&dep_path) {
             Some(existing) => {
-                if existing.version != incoming.version || existing.integrity != incoming.integrity
-                {
+                let version_diff = existing.version != incoming.version;
+                let integrity_diff = existing.integrity != incoming.integrity;
+                if version_diff || integrity_diff {
+                    // Integrity mismatch on same version is a real
+                    // supply chain signal. Means one branch fetched
+                    // a tarball with different bytes than the other.
+                    // Registry re-publish, mirror replay, or worse.
+                    // Flag it LOUDER than a plain version conflict
+                    // so the user actually investigates instead of
+                    // just accepting "higher semver wins" silently.
                     let keep_existing = prefer_higher_version(&existing.version, &incoming.version);
                     let chosen = if keep_existing { existing } else { incoming };
-                    report.conflicts.push(format!(
-                        "{dep_path}: conflicting package records; kept version {}",
-                        chosen.version
-                    ));
-                    tracing::warn!(
-                        "merge conflict on {dep_path}: kept version {} (inputs disagreed on version or integrity)",
-                        chosen.version
-                    );
+                    let reason = if !version_diff && integrity_diff {
+                        format!(
+                            "INTEGRITY MISMATCH on same version {} (one branch may have \
+                             a tampered or re-published tarball, investigate before \
+                             trusting the merged lockfile)",
+                            chosen.version
+                        )
+                    } else if version_diff && integrity_diff {
+                        format!(
+                            "version and integrity both differ, kept version {}",
+                            chosen.version
+                        )
+                    } else {
+                        format!("version differs, kept {}", chosen.version)
+                    };
+                    report.conflicts.push(format!("{dep_path}: {reason}"));
+                    tracing::warn!("merge conflict on {dep_path}: {reason}");
                     dst.packages.insert(dep_path, chosen);
                 } else {
-                    // Identical — just put the existing one back.
+                    // Identical. Put existing one back.
                     dst.packages.insert(dep_path, existing);
                 }
             }
@@ -191,8 +208,8 @@ fn merge_into(dst: &mut LockfileGraph, src: LockfileGraph, report: &mut MergeRep
     // one whose `dep_path` sorts higher by semver; same DirectDep name
     // with identical dep_path is a no-op.
     for (importer_key, incoming_deps) in src.importers {
-        let entry = dst.importers.entry(importer_key).or_default();
-        merge_direct_deps(entry, incoming_deps);
+        let entry = dst.importers.entry(importer_key.clone()).or_default();
+        merge_direct_deps(entry, incoming_deps, &importer_key, report);
     }
 
     // Overrides / ignored / skipped / times / catalogs: union where
@@ -200,7 +217,27 @@ fn merge_into(dst: &mut LockfileGraph, src: LockfileGraph, report: &mut MergeRep
     // round-trip stability (the primary lockfile is authoritative for
     // header fields like `auto_install_peers`).
     for (k, v) in src.overrides {
-        dst.overrides.entry(k).or_insert(v);
+        // Old code was or_insert which silently picked base on a
+        // collision. User intent divergence dropped without a
+        // peep. Now record the conflict when values differ, still
+        // pick base for determinism but tell the user the other
+        // branch wanted something else.
+        use std::collections::btree_map::Entry;
+        match dst.overrides.entry(k) {
+            Entry::Vacant(slot) => {
+                slot.insert(v);
+            }
+            Entry::Occupied(slot) => {
+                if slot.get() != &v {
+                    report.conflicts.push(format!(
+                        "override `{}`: kept {} over {}",
+                        slot.key(),
+                        slot.get(),
+                        v
+                    ));
+                }
+            }
+        }
     }
     for name in src.ignored_optional_dependencies {
         dst.ignored_optional_dependencies.insert(name);
@@ -227,19 +264,69 @@ fn merge_into(dst: &mut LockfileGraph, src: LockfileGraph, report: &mut MergeRep
             .or_insert(incoming_time);
     }
     for (cat_name, entries) in src.catalogs {
+        // Catalog merge used to be silent first-write-wins. Two
+        // branches bumping the same catalog pin (`react: ^18` vs
+        // `^19`) left base untouched with zero user feedback.
+        // Catalog drift is a root cause of "works on my branch,
+        // fails in CI" since the bumped version never reaches the
+        // merged lockfile. Record conflicts now.
+        use std::collections::btree_map::Entry;
+        let cat_label = cat_name.clone();
         let merged = dst.catalogs.entry(cat_name).or_default();
         for (name, entry) in entries {
-            merged.entry(name).or_insert(entry);
+            match merged.entry(name) {
+                Entry::Vacant(slot) => {
+                    slot.insert(entry);
+                }
+                Entry::Occupied(slot) => {
+                    if slot.get().specifier != entry.specifier {
+                        report.conflicts.push(format!(
+                            "catalog `{}` entry `{}`: kept {} over {}",
+                            cat_label,
+                            slot.key(),
+                            slot.get().specifier,
+                            entry.specifier
+                        ));
+                    }
+                }
+            }
         }
     }
 }
 
-fn merge_direct_deps(dst: &mut Vec<DirectDep>, incoming: Vec<DirectDep>) {
+fn merge_direct_deps(
+    dst: &mut Vec<DirectDep>,
+    incoming: Vec<DirectDep>,
+    importer_key: &str,
+    report: &mut MergeReport,
+) {
     let mut by_name: BTreeMap<String, DirectDep> =
         dst.drain(..).map(|d| (d.name.clone(), d)).collect();
     for dep in incoming {
         match by_name.remove(&dep.name) {
             Some(existing) => {
+                // Record the conflict when the user's declared
+                // range differs between branches. Old code picked
+                // the entry with the higher resolved dep_path
+                // version silently, which overwrote the user's
+                // manifest intent. If branch-A had "^1" and
+                // branch-B had "^2", branch-B won but the user on
+                // branch-A never learned their pin got clobbered
+                // on merge.
+                if existing.specifier != dep.specifier {
+                    let importer_label = if importer_key.is_empty() {
+                        "<root>".to_string()
+                    } else {
+                        importer_key.to_string()
+                    };
+                    let a = existing.specifier.as_deref().unwrap_or("<none>");
+                    let b = dep.specifier.as_deref().unwrap_or("<none>");
+                    report.conflicts.push(format!(
+                        "importer `{importer_label}` dep `{}`: branches disagreed on \
+                         specifier ({a} vs {b}), kept the one resolving to higher version",
+                        dep.name
+                    ));
+                }
                 let keep_existing = prefer_higher_version(
                     existing_version_from_dep_path(&existing),
                     existing_version_from_dep_path(&dep),

--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -803,7 +803,7 @@ pub fn write(
         .map_err(|e| Error::Parse(path.to_path_buf(), e.to_string()))?;
     // npm writes a trailing newline; match it so diffs stay clean.
     body.push('\n');
-    std::fs::write(path, body).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+    crate::atomic_write_lockfile(path, body.as_bytes())?;
     Ok(())
 }
 

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -767,7 +767,12 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
     let yaml = serde_yaml::to_string(&lockfile)
         .map_err(|e| Error::Parse(path.to_path_buf(), e.to_string()))?;
     let yaml = reformat_for_pnpm_parity(&yaml);
-    std::fs::write(path, yaml).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+    // Atomic via tempfile + persist. Crash, Ctrl+C, or AV
+    // quarantine during the write used to leave the user with a
+    // truncated pnpm-lock.yaml on disk, next install failed to
+    // parse and the user thought their lockfile was gone. See
+    // atomic_write_lockfile for full rationale.
+    crate::atomic_write_lockfile(path, yaml.as_bytes())?;
     Ok(())
 }
 

--- a/crates/aube-lockfile/src/yarn.rs
+++ b/crates/aube-lockfile/src/yarn.rs
@@ -551,7 +551,7 @@ pub fn write_classic(
         out.push('\n');
     }
 
-    std::fs::write(path, out).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+    crate::atomic_write_lockfile(path, out.as_bytes())?;
     Ok(())
 }
 
@@ -1229,7 +1229,7 @@ pub fn write_berry(
         out.push_str("\n\n");
     }
 
-    std::fs::write(path, out).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+    crate::atomic_write_lockfile(path, out.as_bytes())?;
     Ok(())
 }
 

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -79,6 +79,32 @@ where
     })
 }
 
+/// Tolerant dep-map deserializer. Same shape as scripts_tolerant
+/// but used for dependencies / devDependencies / peerDependencies /
+/// optionalDependencies. Real world manifests written by tools
+/// sometimes emit `"peerDependencies": null` when a package has
+/// none, and strict Record<string, string> deserialization rejects
+/// that. npm and pnpm both tolerate null. Drop non-string values
+/// (numbers, arrays, objects) silently since nothing sensible maps
+/// those to a version range.
+pub fn deps_tolerant<'de, D>(de: D) -> Result<BTreeMap<String, String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: Option<serde_json::Value> = Option::deserialize(de)?;
+    Ok(match value {
+        None | Some(serde_json::Value::Null) => BTreeMap::new(),
+        Some(serde_json::Value::Object(m)) => m
+            .into_iter()
+            .filter_map(|(k, v)| match v {
+                serde_json::Value::String(s) => Some((k, s)),
+                _ => None,
+            })
+            .collect(),
+        Some(_) => BTreeMap::new(),
+    })
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateConfig {
@@ -93,13 +119,29 @@ pub struct PackageJson {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deps_tolerant",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     pub dependencies: BTreeMap<String, String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deps_tolerant",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     pub dev_dependencies: BTreeMap<String, String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deps_tolerant",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     pub peer_dependencies: BTreeMap<String, String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deps_tolerant",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     pub optional_dependencies: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub update_config: Option<UpdateConfig>,
@@ -164,6 +206,12 @@ impl BundledDependencies {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Workspaces {
+    /// Bare single-pattern form. npm accepts
+    /// `"workspaces": "packages/*"` even though the docs only show
+    /// the array form. Some bun projects in the wild use it too.
+    /// Without this, those manifests fail to parse and user gets a
+    /// cryptic serde error pointing at the string.
+    String(String),
     Array(Vec<String>),
     Object {
         // `packages` stays required (no `#[serde(default)]`) so that a
@@ -189,6 +237,7 @@ pub enum Workspaces {
 impl Workspaces {
     pub fn patterns(&self) -> &[String] {
         match self {
+            Workspaces::String(s) => std::slice::from_ref(s),
             Workspaces::Array(v) => v,
             Workspaces::Object { packages, .. } => packages,
         }
@@ -199,7 +248,7 @@ impl Workspaces {
     pub fn catalog(&self) -> &BTreeMap<String, String> {
         static EMPTY: std::sync::OnceLock<BTreeMap<String, String>> = std::sync::OnceLock::new();
         match self {
-            Workspaces::Array(_) => EMPTY.get_or_init(BTreeMap::new),
+            Workspaces::String(_) | Workspaces::Array(_) => EMPTY.get_or_init(BTreeMap::new),
             Workspaces::Object { catalog, .. } => catalog,
         }
     }
@@ -209,7 +258,7 @@ impl Workspaces {
         static EMPTY: std::sync::OnceLock<BTreeMap<String, BTreeMap<String, String>>> =
             std::sync::OnceLock::new();
         match self {
-            Workspaces::Array(_) => EMPTY.get_or_init(BTreeMap::new),
+            Workspaces::String(_) | Workspaces::Array(_) => EMPTY.get_or_init(BTreeMap::new),
             Workspaces::Object { catalogs, .. } => catalogs,
         }
     }
@@ -875,9 +924,38 @@ pub fn parse_json<T: serde::de::DeserializeOwned>(
     path: &Path,
     content: String,
 ) -> Result<T, Error> {
+    // Strip leading UTF-8 BOM (U+FEFF, bytes EF BB BF). Notepad on
+    // Windows writes BOM by default. VS Code can be configured to do
+    // the same. serde_json does not tolerate BOM, errors at "line 1
+    // column 1". npm and pnpm both tolerate it. Without this strip,
+    // opening package.json in Notepad, saving, then running aube
+    // returns a cryptic parse error. Cheap fix, no downside.
+    let content = if let Some(stripped) = content.strip_prefix('\u{FEFF}') {
+        stripped.to_owned()
+    } else {
+        content
+    };
     match serde_json::from_str(&content) {
         Ok(v) => Ok(v),
-        Err(e) => Err(Error::parse(path, content, &e)),
+        Err(e) => {
+            // Helpful targeted message when the file looks like
+            // JSONC. VS Code and other editors happily write `//`
+            // and `/* */` into package.json and the user gets a
+            // raw serde "expected `,` or `}`" pointing at a
+            // random byte. Detect the common comment markers up
+            // front so the error tells the user what is wrong.
+            let trimmed = content.trim_start();
+            if trimmed.starts_with("//") || trimmed.starts_with("/*") {
+                return Err(Error::parse_msg(
+                    path,
+                    content,
+                    "package.json cannot contain JSON comments. \
+                     Remove any `//` or `/* */` lines. aube does not support JSONC for package.json"
+                        .to_string(),
+                ));
+            }
+            Err(Error::parse(path, content, &e))
+        }
     }
 }
 
@@ -910,6 +988,23 @@ impl Error {
     /// to [`ParseError::from_yaml_err`].
     pub fn parse_yaml_err(path: &Path, content: String, err: &serde_yaml::Error) -> Self {
         Error::Parse(Box::new(ParseError::from_yaml_err(path, content, err)))
+    }
+
+    /// Build an [`Error::Parse`] with a plain message and a span
+    /// pointing at the start of the file. Used for hand-crafted
+    /// pre-parse diagnostics like the JSONC comment detector,
+    /// where we want a clear message without serde's usual
+    /// cryptic one.
+    pub fn parse_msg(path: &Path, content: String, message: String) -> Self {
+        let len = content.len();
+        let src = miette::NamedSource::new(path.display().to_string(), content);
+        let span = miette::SourceSpan::new(0.into(), len.min(1));
+        Error::Parse(Box::new(ParseError {
+            path: path.to_path_buf(),
+            message,
+            src,
+            span,
+        }))
     }
 }
 

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -912,12 +912,34 @@ fn userconfig_override_from_env(env: &[(String, String)], home: Option<&Path>) -
 }
 
 /// Parse a .npmrc file into key=value pairs.
-/// Supports environment variable substitution (${VAR}).
+/// Supports environment variable substitution (${VAR}) and backslash
+/// line continuation. npm's `ini` parser treats a trailing `\` as
+/// "continue value on next physical line", used for long auth
+/// tokens or multi-value arrays. Without this aube would silently
+/// truncate the value at the first line break and reparse the
+/// continuation as a bogus key.
 fn parse_npmrc(path: &Path) -> Result<Vec<(String, String)>, std::io::Error> {
     let content = std::fs::read_to_string(path)?;
     let mut entries = Vec::new();
 
-    for line in content.lines() {
+    // Fold backslash-continuation before line iteration. Trailing
+    // `\` plus newline gets joined with the next line verbatim.
+    // Same as npm's `ini` semantics.
+    let mut logical: Vec<String> = Vec::new();
+    let mut acc = String::new();
+    for raw in content.lines() {
+        if let Some(stripped) = raw.strip_suffix('\\') {
+            acc.push_str(stripped);
+            continue;
+        }
+        acc.push_str(raw);
+        logical.push(std::mem::take(&mut acc));
+    }
+    if !acc.is_empty() {
+        logical.push(acc);
+    }
+
+    for line in &logical {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
             continue;
@@ -1101,7 +1123,23 @@ fn normalize_registry_url(url: &str) -> String {
 }
 
 fn home_dir() -> Option<PathBuf> {
-    std::env::var("HOME").ok().map(PathBuf::from)
+    // HOME wins if set. Covers every Unix plus POSIX-compat Windows
+    // shells (Git Bash, MSYS, WSL invoked from Windows) that set it.
+    // USERPROFILE is the native Windows fallback. Old code was HOME
+    // only which meant vanilla `cmd.exe` / PowerShell users had their
+    // `%USERPROFILE%\.npmrc` auth tokens silently ignored, so any
+    // aube install against a private registry returned 401 with no
+    // hint why.
+    if let Ok(h) = std::env::var("HOME") {
+        return Some(PathBuf::from(h));
+    }
+    #[cfg(windows)]
+    {
+        if let Ok(p) = std::env::var("USERPROFILE") {
+            return Some(PathBuf::from(p));
+        }
+    }
+    None
 }
 
 /// Resolve the path to pnpm's global auth file. When an explicit

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -675,7 +675,28 @@ impl Resolver {
         };
         match self.catalogs.get(&catalog_name) {
             Some(catalog) => match catalog.get(task_name) {
-                Some(real_range) => Ok(Some((catalog_name, real_range.clone()))),
+                Some(real_range) => {
+                    // Catch `catalog:` pointing at another `catalog:`
+                    // value. Before this guard, the rewrite ran once
+                    // then the outer loop treated `catalog:other` as
+                    // a literal semver range. User got a confusing
+                    // "range does not satisfy" from the registry
+                    // instead of "catalog is not a level of
+                    // indirection". pnpm disallows the same. No
+                    // cycle detection needed beyond depth-one since
+                    // we refuse the chain outright.
+                    if real_range.starts_with("catalog:") {
+                        return Err(Error::UnknownCatalogEntry {
+                            name: task_name.to_string(),
+                            spec: spec.to_string(),
+                            catalog: format!(
+                                "{catalog_name} (value {real_range} is itself a catalog: \
+                                 reference, catalogs cannot chain)"
+                            ),
+                        });
+                    }
+                    Ok(Some((catalog_name, real_range.clone())))
+                }
                 None => Err(Error::UnknownCatalogEntry {
                     name: task_name.to_string(),
                     spec: spec.to_string(),
@@ -1493,8 +1514,35 @@ impl Resolver {
                 //      preferring the local copy matches every other
                 //      mainstream pm.
                 if let Some(ws_version) = workspace_packages.get(&task.name)
-                    && (task.range.starts_with("workspace:")
-                        || version_satisfies(ws_version, &task.range))
+                    && (match task.range.strip_prefix("workspace:") {
+                        // workspace:*, workspace:^, workspace:~
+                        // bind to whatever local workspace version is.
+                        // These are pnpm's "don't pin me, just track
+                        // local" sigils. Match them before range check.
+                        Some("" | "*" | "^" | "~") => true,
+                        // workspace:<range> like workspace:^2.0.0 or
+                        // workspace:1.x. Must still satisfy local
+                        // version. Before this fix, any workspace:
+                        // prefix short-circuited. Consumer could pin
+                        // workspace:^2 against local 1.0.0 and aube
+                        // would silently link the wrong version.
+                        // pnpm errors here with no-matching-version.
+                        Some(rest) => version_satisfies(ws_version, rest),
+                        // Bare semver (no workspace: prefix) path.
+                        // Linker walks up to workspace yarn-v1 style.
+                        // Special case `*` and `""` (bare catch-all)
+                        // to always match the workspace copy, even
+                        // when the ws version is a prerelease like
+                        // `0.0.0-0` which semver strict rules would
+                        // otherwise exclude. Placeholder versions
+                        // are common in fresh changesets-managed
+                        // workspaces and would silently fall through
+                        // to registry resolution otherwise, picking
+                        // up a stale published build instead of the
+                        // local source.
+                        None if task.range.is_empty() || task.range == "*" => true,
+                        None => version_satisfies(ws_version, &task.range),
+                    })
                 {
                     let dep_path = dep_path_for(&task.name, ws_version);
                     if task.is_root
@@ -2573,9 +2621,24 @@ fn pick_version<'a>(
     cutoff: Option<&str>,
     strict: bool,
 ) -> PickResult<'a> {
-    // Handle dist-tag references
+    // Handle dist-tag references. If the requested range is a tag
+    // name and the packument has that tag, use the tagged version
+    // as the effective range. Special case `latest`: some registries
+    // serve packuments where dist-tags.latest is absent (fresh
+    // publish race, all versions deprecated, private mirror bug).
+    // Old code then tried to parse "latest" as a semver range,
+    // failed, returned NoMatch. Caller could not tell whether the
+    // range was genuinely unsatisfiable or the tag was just missing.
+    // npm and pnpm fall back to the highest non-prerelease version.
+    // Do the same so `aube install foo` does not silently fail on a
+    // packument that just happens to lack the tag.
     let effective_range = if let Some(tagged_version) = packument.dist_tags.get(range_str) {
         tagged_version.clone()
+    } else if range_str == "latest" {
+        match highest_stable_version(packument) {
+            Some(v) => v,
+            None => return PickResult::NoMatch,
+        }
     } else {
         range_str.to_string()
     };
@@ -2659,6 +2722,33 @@ fn pick_version<'a>(
         return PickResult::Found(meta);
     }
     PickResult::NoMatch
+}
+
+/// Walk the packument's versions and return the highest non
+/// prerelease version string. Used as the `latest` tag fallback
+/// when the registry response lacks `dist-tags.latest`. Some
+/// private mirrors and mid-publish races drop the tag briefly
+/// and returning NoMatch there would break `aube install foo` for
+/// no real reason. npm and pnpm both fall back to highest stable.
+fn highest_stable_version(packument: &Packument) -> Option<String> {
+    let mut best: Option<(node_semver::Version, String)> = None;
+    for key in packument.versions.keys() {
+        let Ok(v) = node_semver::Version::parse(key) else {
+            continue;
+        };
+        // Skip prereleases so we match npm semantics. Registry
+        // with only prereleases returns None and caller gets
+        // NoMatch, same as before.
+        if !v.pre_release.is_empty() {
+            continue;
+        }
+        match &best {
+            None => best = Some((v, key.clone())),
+            Some((cur, _)) if v > *cur => best = Some((v, key.clone())),
+            _ => {}
+        }
+    }
+    best.map(|(_, k)| k)
 }
 
 /// Lexical path normalization — collapse `.` and `..` components

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -377,9 +377,17 @@ pub fn apply_peer_contexts(
         current = next;
     }
     if !converged {
-        tracing::warn!(
-            "peer-context pass hit MAX_ITERATIONS={MAX_ITERATIONS} without converging — \
-             lockfile may not be byte-identical to pnpm's nested form"
+        // Hit iteration cap. Means mutually recursive peers or
+        // genuine cycle. Lockfile now has partial nested suffixes.
+        // Linker downstream will wire symlinks against incomplete
+        // graph. Returning this silently ships broken node_modules.
+        // Old code used warn!, warn gets swallowed in CI. Bump to
+        // error! so ops see it. Proper fix is returning a Result
+        // from apply_peer_contexts but that cascades up through
+        // Resolver::resolve signature, do that separately.
+        tracing::error!(
+            "peer-context hit MAX_ITERATIONS={MAX_ITERATIONS} without convergence. \
+             mutually recursive peers likely. lockfile incomplete, linker output will be wrong"
         );
     }
     // `dedupe-peers=true` rewrites the parenthesized peer suffix to

--- a/crates/aube-resolver/src/platform.rs
+++ b/crates/aube-resolver/src/platform.rs
@@ -150,16 +150,64 @@ pub fn host_triple() -> (&'static str, &'static str, &'static str) {
         "powerpc64" => "ppc64",
         other => other,
     };
-    let libc = if cfg!(target_os = "linux") {
-        if cfg!(target_env = "musl") {
-            "musl"
-        } else {
-            "glibc"
-        }
+    // Detect libc at runtime, not compile time. Old code used
+    // `cfg!(target_env = "musl")` which is the toolchain that built
+    // the aube binary, not the host's libc. Real bug: an aube static
+    // binary built against musl and shipped to glibc users reported
+    // libc=musl everywhere, and the glibc-built distro reported
+    // glibc everywhere. Wrong prebuilts got installed, runtime
+    // ld.so errors. Probe /lib/ld-musl-* vs /lib*/ld-linux-*.
+    let libc = if std::env::consts::OS == "linux" {
+        detect_linux_libc()
     } else {
         ""
     };
     (os, cpu, libc)
+}
+
+/// Probe the active dynamic linker to tell musl from glibc at runtime.
+/// Alpine and other musl distros ship `/lib/ld-musl-<arch>.so.1`.
+/// glibc distros ship `/lib64/ld-linux-x86-64.so.2`, `/lib/ld-linux-aarch64.so.1`,
+/// etc. Cache once via OnceLock so repeated calls in the resolver
+/// BFS do not re-stat. If neither matches (unusual container, stripped
+/// rootfs), fall back to glibc which is the common case.
+fn detect_linux_libc() -> &'static str {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<&'static str> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        let lib_dir = std::path::Path::new("/lib");
+        if let Ok(entries) = std::fs::read_dir(lib_dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if name.starts_with("ld-musl-") {
+                    return "musl";
+                }
+            }
+        }
+        // Look for glibc explicitly before defaulting. Covers cases
+        // where /lib has no ld-musl-* but also no ld-linux-* (sparse
+        // containers), in which case we still pick glibc as the
+        // safer default since more prebuilts ship for glibc.
+        for dir in [
+            "/lib",
+            "/lib64",
+            "/lib/x86_64-linux-gnu",
+            "/lib/aarch64-linux-gnu",
+        ] {
+            let p = std::path::Path::new(dir);
+            if let Ok(entries) = std::fs::read_dir(p) {
+                for entry in entries.flatten() {
+                    let name = entry.file_name();
+                    let name = name.to_string_lossy();
+                    if name.starts_with("ld-linux") {
+                        return "glibc";
+                    }
+                }
+            }
+        }
+        "glibc"
+    })
 }
 
 /// Apply npm's `os`/`cpu`/`libc` rules to a single (pkg_field, host)

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -114,6 +114,84 @@ pub fn spawn_shell(script_cmd: &str) -> tokio::process::Command {
     }
 }
 
+/// Shell-quote one arg for safe splicing into a shell command line.
+///
+/// Used by `aube run <script> -- args`. Args get joined into the
+/// script string, then sh -c or cmd /c reparses the whole thing. If
+/// user arg contains $, backticks, ;, |, &, (, ), etc, the shell
+/// interprets those as metacharacters. That is shell injection.
+/// `aube run echo 'hello; rm -rf ~'` would run two commands. Same
+/// issue npm had pre-2016. Quote each arg so shell treats it as one
+/// literal token.
+///
+/// Unix: wrap in single quotes. sh treats interior of '...' as pure
+/// literal with one exception, embedded single quote. Handle that
+/// with the standard '\'' escape trick: close the single-quoted
+/// string, emit an escaped quote, reopen. Works in every POSIX sh.
+///
+/// Windows cmd.exe: wrap in double quotes. cmd interprets many
+/// metachars even inside double quotes, but CreateProcessW hands the
+/// string to our spawn_shell that uses `/d /s /c "..."`, the outer
+/// quotes get stripped per /s rule and the content runs. Escape
+/// interior " and backslash per CommandLineToArgvW. Full cmd.exe
+/// metachar caret-escaping is a rabbit hole, so this is best-effort,
+/// works for the common cases, matches what node's shell-quote does.
+pub fn shell_quote_arg(arg: &str) -> String {
+    #[cfg(unix)]
+    {
+        let mut out = String::with_capacity(arg.len() + 2);
+        out.push('\'');
+        for ch in arg.chars() {
+            if ch == '\'' {
+                out.push_str("'\\''");
+            } else {
+                out.push(ch);
+            }
+        }
+        out.push('\'');
+        out
+    }
+    #[cfg(windows)]
+    {
+        let mut out = String::with_capacity(arg.len() + 2);
+        out.push('"');
+        for ch in arg.chars() {
+            match ch {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                _ => out.push(ch),
+            }
+        }
+        out.push('"');
+        out
+    }
+}
+
+/// Translate child ExitStatus to a parent exit code.
+///
+/// On Unix a signal-killed child has None from .code(). Old code
+/// collapsed that to 1. That loses signal identity: SIGKILL (OOM
+/// killer, exit 137), SIGSEGV (139), Ctrl-C (130) all look like
+/// plain exit 1. CI pipelines watching for 137 to detect OOM cannot
+/// distinguish it from a normal script error anymore. Bash convention
+/// is 128 + signum, match that.
+///
+/// Windows has no signal concept so .code() is always Some, the
+/// fallback 1 is dead code there but keeps the function total.
+pub fn exit_code_from_status(status: std::process::ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(sig) = status.signal() {
+            return 128 + sig;
+        }
+    }
+    1
+}
+
 fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &ScriptSettings) {
     // Strip credentials that aube itself owns before we spawn any
     // lifecycle script. AUBE_AUTH_TOKEN is aube's own registry login

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -159,6 +159,17 @@ pub fn shell_quote_arg(arg: &str) -> String {
             match ch {
                 '"' => out.push_str("\\\""),
                 '\\' => out.push_str("\\\\"),
+                // cmd.exe expands %VAR% even inside double quotes.
+                // Outer `/s /c "..."` only strips the outermost
+                // quote pair, the shell still runs env expansion
+                // on the body. Argument like `%COMSPEC%` would
+                // otherwise get replaced with the shell path
+                // before the child saw it. Double the percent so
+                // cmd passes a literal `%` through. Full
+                // caret-escaping of `^ & | < > ( )` is a deeper
+                // rabbit hole, this handles the common injection
+                // vector.
+                '%' => out.push_str("%%"),
                 _ => out.push(ch),
             }
         }

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -219,16 +219,58 @@ impl Store {
                 use std::io::Write;
                 file.write_all(content)
                     .map_err(|e| Error::Io(store_path.clone(), e))?;
+                // fsync before closing. write_all returning success
+                // only gets the bytes into the kernel page cache, not
+                // onto stable storage. If the host crashes or power
+                // fails between write_all and the next checkpoint,
+                // a hardlink pointing at this inode can survive with
+                // zero-byte content. Next install reuses it via the
+                // AlreadyExists fast path and ships empty files into
+                // node_modules. Real failure mode reported by users
+                // of other tools, fsync kills the class at modest
+                // cost (one syscall per new CAS file, cold install
+                // only since warm runs hit AlreadyExists and skip
+                // the write). Ignore fsync errors on platforms where
+                // sync_all is unsupported but do not swallow IO
+                // errors from real failures.
+                file.sync_all()
+                    .map_err(|e| Error::Io(store_path.clone(), e))?;
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 // Another writer already populated this content — skip.
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // Shard dir missing. `ensure_shards_exist` pre-creates
-                // all 256, so this only fires when the caller didn't
-                // call it (or the shard tree was wiped mid-install).
-                // Fall back to the slow path for correctness.
-                xx::file::write(&store_path, content).map_err(|e| Error::Xx(e.to_string()))?;
+                // Shard dir missing. ensure_shards_exist pre-creates
+                // all 256 shards so this only fires when the caller
+                // did not call it, or a concurrent prune wiped the
+                // shard tree mid-install. Recreate the shard dir
+                // then retry the atomic create_new path rather than
+                // falling back to xx::file::write which truncates
+                // in place and has no fsync. Non-atomic fallback
+                // left room for a torn CAS file after a second
+                // crash.
+                if let Some(parent) = store_path.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| Error::Io(parent.to_path_buf(), e))?;
+                }
+                match std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&store_path)
+                {
+                    Ok(mut file) => {
+                        use std::io::Write;
+                        file.write_all(content)
+                            .map_err(|e| Error::Io(store_path.clone(), e))?;
+                        file.sync_all()
+                            .map_err(|e| Error::Io(store_path.clone(), e))?;
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                        // Another writer raced us. Same-content CAS
+                        // guarantees the existing file is correct.
+                    }
+                    Err(e) => return Err(Error::Io(store_path.clone(), e)),
+                }
             }
             Err(e) => return Err(Error::Io(store_path.clone(), e)),
         }
@@ -262,7 +304,22 @@ impl Store {
                 Ok(_) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    xx::file::write(&exec_marker, "").map_err(|e| Error::Xx(e.to_string()))?;
+                    // Same as above, recreate the shard, retry
+                    // atomic create_new. Marker is a zero-byte
+                    // sidecar, no content to sync.
+                    if let Some(parent) = exec_marker.parent() {
+                        std::fs::create_dir_all(parent)
+                            .map_err(|e| Error::Io(parent.to_path_buf(), e))?;
+                    }
+                    match std::fs::OpenOptions::new()
+                        .write(true)
+                        .create_new(true)
+                        .open(&exec_marker)
+                    {
+                        Ok(_) => {}
+                        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                        Err(e) => return Err(Error::Io(exec_marker.clone(), e)),
+                    }
                 }
                 Err(e) => return Err(Error::Io(exec_marker, e)),
             }
@@ -528,6 +585,44 @@ fn normalize_tar_entry_path(raw: &Path) -> Result<Option<String>, Error> {
                         "tarball entry path contains a malformed component: {raw:?}"
                     )));
                 }
+                // Windows-only filename restrictions. Gated to
+                // cfg(windows) so Unix hosts keep tarballs with
+                // valid-on-Linux names like `CON.js` or `foo.`.
+                // Rejecting those cross-platform would regress real
+                // Linux installs for a hazard that only hits
+                // Windows users. Windows users get the checks they
+                // need, portability of a package to Windows is the
+                // publisher's problem to validate.
+                #[cfg(windows)]
+                {
+                    // NTFS reserved device names. `CON`, `con.txt`,
+                    // `CON.tar.gz` all resolve to the console
+                    // device. Writing one either fails with
+                    // ERROR_INVALID_NAME or gets silently consumed
+                    // by the device driver and hangs the writer.
+                    if is_windows_reserved_name(s) {
+                        return Err(Error::Tar(format!(
+                            "tarball entry path contains a Windows reserved device name: {raw:?}"
+                        )));
+                    }
+                    // NTFS strips trailing `.` and trailing space
+                    // on create so `foo` and `foo.` alias. Reject
+                    // both rather than sort out aliasing at
+                    // materialize time.
+                    if s.ends_with('.') || s.ends_with(' ') {
+                        return Err(Error::Tar(format!(
+                            "tarball entry path has a trailing dot or space which Windows strips: {raw:?}"
+                        )));
+                    }
+                    // Control chars 0x01..0x1F invalid on NTFS.
+                    // Reject the whole tarball instead of hitting
+                    // per-file create errors mid-extract.
+                    if s.bytes().any(|b| b < 0x20) {
+                        return Err(Error::Tar(format!(
+                            "tarball entry path contains control characters: {raw:?}"
+                        )));
+                    }
+                }
                 if !out.is_empty() {
                     out.push('/');
                 }
@@ -559,6 +654,42 @@ fn normalize_tar_entry_path(raw: &Path) -> Result<Option<String>, Error> {
     } else {
         Ok(Some(out))
     }
+}
+
+/// Check if a tarball path component matches a Windows reserved
+/// device name. Compare case-insensitively on the stem only.
+/// `CON`, `Con`, `con`, `con.txt`, `CON.tar.gz` all resolve to the
+/// same DOS device on NTFS. Only base name matters, the extension
+/// is irrelevant to the device lookup.
+#[cfg(windows)]
+fn is_windows_reserved_name(name: &str) -> bool {
+    let stem = name.split_once('.').map(|(a, _)| a).unwrap_or(name);
+    let upper = stem.to_ascii_uppercase();
+    matches!(
+        upper.as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    )
 }
 
 /// Hard ceiling on the per-entry `Vec::with_capacity` hint. 64 KiB

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -49,6 +49,18 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
         let full_pattern = project_dir.join(pattern).join("package.json");
         if let Ok(entries) = glob::glob(full_pattern.to_str().unwrap_or_default()) {
             for entry in entries.flatten() {
+                // Skip paths under any node_modules/ segment. Raw
+                // `packages/**` glob otherwise picks up installed
+                // deps' package.json files and registers them as
+                // workspace members. Pollutes importer iteration,
+                // state hash, validate_required_scripts, everything
+                // downstream. npm and pnpm implicitly exclude the
+                // same. Check every path component, not just leading
+                // segment, since workspace could be `apps/*/packages`
+                // with node_modules nested arbitrarily deep.
+                if entry.components().any(|c| c.as_os_str() == "node_modules") {
+                    continue;
+                }
                 if let Some(parent) = entry.parent()
                     && seen.insert(parent.to_path_buf())
                 {

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -739,9 +739,12 @@ async fn update_manifest_for_add(
     let json = serde_json::to_string_pretty(&manifest)
         .into_diagnostic()
         .wrap_err("failed to serialize package.json")?;
-    std::fs::write(&manifest_path, format!("{json}\n"))
-        .into_diagnostic()
-        .wrap_err("failed to write package.json")?;
+    // Atomic write. Old fs::write truncates in place so a crash
+    // mid-write corrupts the user's manifest. Losing package.json
+    // is the worst failure mode of aube add, user has to `git
+    // restore` to recover. Tempfile + persist makes the swap
+    // atomic, crash leaves either old or new bytes, never torn.
+    write_atomic(&manifest_path, format!("{json}\n").as_bytes())?;
     if print_updated {
         eprintln!("Updated package.json");
     }
@@ -1137,6 +1140,34 @@ async fn run_global_inner(
         );
     }
 
+    Ok(())
+}
+
+/// Atomic file write. Tempfile in the same dir, fsync, rename over
+/// the target. Caller uses this for package.json mutation in add /
+/// remove / workspace writes so a crash mid-write cannot corrupt
+/// the user's manifest. Rename is atomic on POSIX, on Windows
+/// MoveFileEx gives the same guarantee post Win10.
+fn write_atomic(path: &std::path::Path, body: &[u8]) -> miette::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let tmp = tempfile::Builder::new()
+        .prefix(".aube-add-")
+        .suffix(".tmp")
+        .tempfile_in(parent)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to open tempfile for {}", path.display()))?;
+    {
+        use std::io::Write as _;
+        let mut f = tmp.as_file();
+        f.write_all(body)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to write tempfile for {}", path.display()))?;
+        f.sync_all()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to sync tempfile for {}", path.display()))?;
+    }
+    tmp.persist(path)
+        .map_err(|e| miette!("failed to persist {}: {e}", path.display()))?;
     Ok(())
 }
 

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -173,9 +173,19 @@ pub async fn run(args: AuditArgs, registry_override: Option<&str>) -> miette::Re
                 // check `status` field.
                 eprintln!("warn: advisory fetch failed: {e}");
                 if args.json {
-                    println!(
-                        "{{\"status\":\"degraded\",\"reason\":\"advisory fetch failed: {e}\"}}"
-                    );
+                    // Build the JSON via serde_json so the error
+                    // message gets properly escaped. Hand-rolled
+                    // string interpolation broke on errors that
+                    // contained `"` (connection refused sometimes
+                    // surfaces quoted URL text), producing
+                    // malformed JSON that downstream consumers
+                    // could not parse.
+                    let reason = format!("advisory fetch failed: {e}");
+                    let body = serde_json::json!({
+                        "status": "degraded",
+                        "reason": reason,
+                    });
+                    println!("{body}");
                 } else {
                     eprintln!(
                         "audit degraded: advisory fetch failed, vulnerability status unknown"
@@ -423,13 +433,39 @@ async fn write_fix_overrides(
     }
 
     let json = serde_json::to_string_pretty(&root).into_diagnostic()?;
-    std::fs::write(&manifest_path, format!("{json}\n"))
-        .into_diagnostic()
+    write_manifest_atomic(&manifest_path, format!("{json}\n").as_bytes())
         .wrap_err("failed to write package.json")?;
     eprintln!(
         "Updated package.json overrides for {} package(s).",
         fixes.len()
     );
+    Ok(())
+}
+
+/// Atomic package.json write via tempfile + rename. Crash or Ctrl+C
+/// mid-write used to leave the user with a truncated manifest,
+/// worst-case aube failure mode. Matches the pattern used in
+/// add/remove/state.
+fn write_manifest_atomic(path: &std::path::Path, body: &[u8]) -> miette::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let tmp = tempfile::Builder::new()
+        .prefix(".aube-audit-")
+        .suffix(".tmp")
+        .tempfile_in(parent)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to open tempfile for {}", path.display()))?;
+    {
+        use std::io::Write as _;
+        let mut f = tmp.as_file();
+        f.write_all(body)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to write tempfile for {}", path.display()))?;
+        f.sync_all()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to sync tempfile for {}", path.display()))?;
+    }
+    tmp.persist(path)
+        .map_err(|e| miette!("failed to persist {}: {e}", path.display()))?;
     Ok(())
 }
 

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -162,13 +162,26 @@ pub async fn run(args: AuditArgs, registry_override: Option<&str>) -> miette::Re
         Ok(v) => v,
         Err(e) => {
             if args.ignore_registry_errors {
+                // Old code here printed "No known vulnerabilities
+                // found" and exited 0. That is a false negative. User
+                // passed --ignore-registry-errors to keep CI green
+                // when offline, but silently claiming clean audit can
+                // mask real CVEs. If the registry was down on a scan
+                // day, whole pipeline would ship vuln'd code with a
+                // "passed" audit step. Now: report degraded status,
+                // exit non-zero. CI fails loudly. JSON consumers
+                // check `status` field.
                 eprintln!("warn: advisory fetch failed: {e}");
                 if args.json {
-                    println!("{{}}");
+                    println!(
+                        "{{\"status\":\"degraded\",\"reason\":\"advisory fetch failed: {e}\"}}"
+                    );
                 } else {
-                    println!("No known vulnerabilities found");
+                    eprintln!(
+                        "audit degraded: advisory fetch failed, vulnerability status unknown"
+                    );
                 }
-                return Ok(());
+                std::process::exit(2);
             }
             return Err(miette!("advisory fetch failed: {e}"));
         }

--- a/crates/aube/src/commands/deprecations.rs
+++ b/crates/aube/src/commands/deprecations.rs
@@ -15,7 +15,7 @@ use aube_registry::Packument;
 use aube_resolver::is_deprecation_allowed;
 use clap::Args;
 use clx::style;
-use miette::{Context, IntoDiagnostic, miette};
+use miette::{Context, IntoDiagnostic};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
@@ -57,7 +57,7 @@ pub async fn run(args: DeprecationsArgs) -> miette::Result<Option<i32>> {
             eprintln!("No lockfile found. Run `aube install` first.");
             return Ok(Some(0));
         }
-        Err(e) => return Err(miette!(e)).wrap_err("failed to parse lockfile"),
+        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
     };
 
     let allowed = manifest.allowed_deprecated_versions();

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -225,7 +225,7 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
     drop(tmp);
 
     if !status.success() {
-        std::process::exit(status.code().unwrap_or(1));
+        std::process::exit(aube_scripts::exit_code_from_status(status));
     }
     Ok(())
 }
@@ -245,6 +245,15 @@ fn dlx_install_options() -> InstallOptions {
             "false".to_string(),
         ));
     }
+    // Force ignore-scripts on transient dlx installs. User asked to
+    // run one bin. They did not ask postinstall scripts on fresh
+    // downloaded pkg to run. Without this, a user with
+    // `allowedBuildDependencies=["*"]` in ~/.npmrc (common for
+    // convenience) gets every dlx'd package running arbitrary
+    // postinstall code. That is how supply chain attacks land.
+    // pnpm dlx does the same, match it.
+    opts.cli_flags
+        .push(("ignore-scripts".to_string(), "true".to_string()));
     opts
 }
 

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -8,7 +8,7 @@ pub struct ExecArgs {
     /// Binary name
     pub bin: String,
     /// Arguments to pass to the binary
-    #[arg(trailing_var_arg = true)]
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
     /// Continue recursive execution after a command fails.
     ///
@@ -142,7 +142,7 @@ async fn run_filtered(
             match task.await {
                 Ok(Ok(status)) => {
                     if !status.success() && first_exit.is_none() {
-                        let code = status.code().unwrap_or(1);
+                        let code = aube_scripts::exit_code_from_status(status);
                         first_exit = Some(code);
                         first_err =
                             Some(miette!("aube exec: `{bin}` failed in {name} (exit {code})"));
@@ -207,7 +207,7 @@ async fn exec_bin(
         .wrap_err("failed to execute binary")?;
 
     if !status.success() {
-        std::process::exit(status.code().unwrap_or(1));
+        std::process::exit(aube_scripts::exit_code_from_status(status));
     }
 
     Ok(())

--- a/crates/aube/src/commands/ignored_builds.rs
+++ b/crates/aube/src/commands/ignored_builds.rs
@@ -113,8 +113,11 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
         if !seen.insert((pkg.name.clone(), pkg.version.clone())) {
             continue;
         }
+        // Match on registry_name, not pkg.name. Allowlist pins the
+        // real pkg name. npm: alias would sneak past otherwise. Same
+        // fix as every other policy.decide callsite.
         if matches!(
-            policy.decide(&pkg.name, &pkg.version),
+            policy.decide(pkg.registry_name(), &pkg.version),
             aube_scripts::AllowDecision::Allow
         ) {
             continue;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -413,7 +413,15 @@ async fn run_root_lifecycle(
     tracing::debug!("Running {} script...", hook.script_name());
     aube_scripts::run_root_hook(project_dir, modules_dir_name, manifest, hook)
         .await
-        .map_err(|e| miette!("{}", e))?;
+        .map_err(|e| {
+            // Old message was just the bare error string. User got
+            // a cryptic "exit status 1" with no hook name, no script
+            // path, nothing. Tag with which hook fired so the log
+            // line is self-documenting. This is the common case
+            // (failed preinstall on `aube install`) so the regression
+            // really hurt triage.
+            miette!("root {} script failed: {e}", hook.script_name())
+        })?;
     Ok(())
 }
 
@@ -470,9 +478,22 @@ pub(crate) fn resolve_link_strategy(
 ) -> miette::Result<aube_linker::LinkStrategy> {
     let package_import_method_cli =
         aube_settings::values::string_from_cli("packageImportMethod", ctx.cli);
+    // Shared probe used by both the CLI and resolved-setting paths
+    // below. Probe across store dir and project modules dir. Single
+    // dir probe reports reflink but real link ops across a mount
+    // boundary hit EXDEV and silently fall back to per-file copy.
+    // Catches the cross-FS case at probe time.
+    let auto_probe = || {
+        let store_dir = super::open_store(cwd).map(|s| s.root().to_path_buf()).ok();
+        let modules_dir = cwd.join("node_modules");
+        match store_dir.as_deref() {
+            Some(sd) => aube_linker::Linker::detect_strategy_cross(sd, &modules_dir),
+            None => aube_linker::Linker::detect_strategy(cwd),
+        }
+    };
     let strategy = if let Some(cli) = package_import_method_cli.as_deref() {
         match cli.trim().to_ascii_lowercase().as_str() {
-            "" | "auto" => aube_linker::Linker::detect_strategy(cwd),
+            "" | "auto" => auto_probe(),
             "hardlink" => aube_linker::LinkStrategy::Hardlink,
             "copy" => aube_linker::LinkStrategy::Copy,
             "clone-or-copy" => aube_linker::LinkStrategy::Reflink,
@@ -491,9 +512,7 @@ pub(crate) fn resolve_link_strategy(
         }
     } else {
         match aube_settings::resolved::package_import_method(ctx) {
-            aube_settings::resolved::PackageImportMethod::Auto => {
-                aube_linker::Linker::detect_strategy(cwd)
-            }
+            aube_settings::resolved::PackageImportMethod::Auto => auto_probe(),
             aube_settings::resolved::PackageImportMethod::Hardlink => {
                 aube_linker::LinkStrategy::Hardlink
             }
@@ -556,7 +575,13 @@ pub(crate) async fn run_dep_lifecycle_scripts(
 
     let mut jobs: Vec<BuildJob> = Vec::new();
     for (dep_path, pkg) in &graph.packages {
-        match policy.decide(&pkg.name, &pkg.version) {
+        // Use registry_name(), not pkg.name. pkg.name is the in-tree
+        // alias (`h3-safe`). Real package is `h3`. Allowlist entry for
+        // `h3` would miss if we checked against the alias. Attacker
+        // writes `"h3-safe": "npm:h3@0.19.0"` to sneak a denied pkg
+        // through the allowlist. registry_name() strips alias back to
+        // real name.
+        match policy.decide(pkg.registry_name(), &pkg.version) {
             aube_scripts::AllowDecision::Allow => {}
             aube_scripts::AllowDecision::Deny | aube_scripts::AllowDecision::Unspecified => {
                 continue;
@@ -825,7 +850,7 @@ fn unreviewed_dep_builds(
     let mut unreviewed = Vec::new();
     for (dep_path, pkg) in &graph.packages {
         if !matches!(
-            policy.decide(&pkg.name, &pkg.version),
+            policy.decide(pkg.registry_name(), &pkg.version),
             aube_scripts::AllowDecision::Unspecified
         ) {
             continue;
@@ -1459,7 +1484,12 @@ where
         // time vs the previous 64.
         let sem_permits = network_concurrency.unwrap_or_else(default_lockfile_network_concurrency);
         let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(sem_permits));
-        let mut handles = Vec::new();
+        // JoinSet so a first-error path aborts the sibling fetches
+        // instead of detaching them into the background. Detached
+        // tasks keep writing to the CAS after the install command
+        // has already errored out.
+        let mut handles: tokio::task::JoinSet<miette::Result<(String, aube_store::PackageIndex)>> =
+            tokio::task::JoinSet::new();
 
         for (dep_path, display_name, registry_name, version, tarball_url_override, integrity) in
             to_fetch
@@ -1470,7 +1500,7 @@ where
             let row = progress.map(|p| p.start_fetch(&display_name, &version));
             let bytes_progress = progress.cloned();
 
-            let handle = tokio::spawn(async move {
+            handles.spawn(async move {
                 let _row = row;
                 let task_start = std::time::Instant::now();
                 let permit = sem.acquire().await.unwrap();
@@ -1586,11 +1616,10 @@ where
 
                 Ok::<_, miette::Report>((dep_path, index))
             });
-            handles.push(handle);
         }
 
-        for handle in handles {
-            let (dep_path, index) = handle.await.into_diagnostic()??;
+        while let Some(joined) = handles.join_next().await {
+            let (dep_path, index) = joined.into_diagnostic()??;
             indices.insert(dep_path, index);
         }
     }
@@ -1854,10 +1883,24 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             filenames.join(", ")
                         );
                         if !report.conflicts.is_empty() {
-                            tracing::warn!(
-                                "{} conflict(s) during branch-lockfile merge; see --verbose for details",
+                            // Surface conflicts to the user, not just
+                            // at warn level. Without this, branch
+                            // lockfile merges silently dropped data:
+                            // override divergences, catalog drift,
+                            // importer pin mismatches, integrity
+                            // differences. All logged at debug only.
+                            // Users saw "N conflicts" with zero
+                            // detail and no hint what lost. Dump
+                            // each conflict on its own line through
+                            // the progress-safe writer so the list
+                            // does not smear the install bar.
+                            crate::progress::safe_eprintln(&format!(
+                                "warn: {} conflict(s) resolved during branch-lockfile merge:",
                                 report.conflicts.len()
-                            );
+                            ));
+                            for c in &report.conflicts {
+                                crate::progress::safe_eprintln(&format!("warn:   {c}"));
+                            }
                         }
                     } else {
                         tracing::debug!(
@@ -2009,7 +2052,23 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 .to_string();
 
             if let Some(ref name) = pkg_manifest.name {
-                let version = pkg_manifest.version.as_deref().unwrap_or("0.0.0");
+                // Workspace members MUST carry a version. Old code
+                // silently defaulted to "0.0.0", which collided any
+                // two unversioned members under one dep_path and made
+                // `workspace:^2.0.0` match nothing. pnpm refuses to
+                // install here, aube should too. Private packages
+                // without a version are fine in package.json but not
+                // once they enter a workspace graph where siblings
+                // pin them. User fix: add a version field. Skip
+                // silently only when name is also missing (pure-root
+                // scratch manifest case).
+                let version = pkg_manifest.version.as_deref().ok_or_else(|| {
+                    miette!(
+                        "workspace package {name} at {rel_path} has no `version` field. \
+                         add one to its package.json. workspace members must be versioned \
+                         so siblings can pin them via workspace: protocol"
+                    )
+                })?;
                 ws_package_versions.insert(name.clone(), version.to_string());
                 ws_dirs.insert(name.clone(), pkg_dir.clone());
                 tracing::debug!("  {name}@{version} ({rel_path})");
@@ -2152,7 +2211,24 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         if let Err(e) = parsed
             && !matches!(e, aube_lockfile::Error::NotFound(_))
         {
-            return Err(miette!("failed to parse lockfile: {e}"));
+            // Can't hand &Error to miette::Report since Diagnostic
+            // is only implemented on owned Error. Re-parse once to
+            // get an owned Error value for the Diagnostic path.
+            // Slightly wasteful on the error branch, install is
+            // about to abort anyway so speed does not matter here.
+            // What matters: keeping the source span and miette help
+            // text instead of flattening to one line via `{e}`.
+            match aube_lockfile::parse_lockfile_with_kind(&cwd, &manifest) {
+                Ok(_) => {
+                    // Race: second parse succeeded while first failed.
+                    // Surface the observed error text as a best
+                    // effort flat message. Extremely unlikely.
+                    return Err(miette!("failed to parse lockfile: {e}"));
+                }
+                Err(owned) => {
+                    return Err(miette::Report::new(owned)).wrap_err("failed to parse lockfile");
+                }
+            }
         }
         let fresh = !force_resolve
             && matches!(
@@ -2685,7 +2761,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let fetch_handle = tokio::spawn(async move {
                 let semaphore =
                     std::sync::Arc::new(tokio::sync::Semaphore::new(fetch_network_concurrency));
-                let mut handles = Vec::new();
+                // JoinSet over bare Vec<JoinHandle>. If the first
+                // fetch errors and we return via `?`, a plain Vec
+                // drops the remaining JoinHandles which detaches the
+                // tasks. They keep fetching tarballs and writing
+                // to the CAS while the CLI has already errored.
+                // JoinSet aborts every outstanding task on drop,
+                // matches the pattern ensure_dep_scripts uses.
+                let mut handles: tokio::task::JoinSet<
+                    miette::Result<(String, aube_store::PackageIndex)>,
+                > = tokio::task::JoinSet::new();
                 let mut indices: BTreeMap<String, aube_store::PackageIndex> = BTreeMap::new();
                 let mut cached_count = 0usize;
 
@@ -2789,7 +2874,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         .map(|p| p.start_fetch(&pkg.name, &pkg.version));
                     let bytes_progress = fetch_progress.clone();
 
-                    handles.push(tokio::spawn(async move {
+                    handles.spawn(async move {
                         let _row = row;
                         let permit = sem.acquire().await.unwrap();
                         let url = pkg
@@ -2876,13 +2961,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         .into_diagnostic()??;
 
                         Ok::<_, miette::Report>((dep_path, index))
-                    }));
+                    });
                 }
 
-                // Collect all fetch results
+                // Collect all fetch results via JoinSet. Drop on
+                // error aborts outstanding siblings.
                 let fetch_count = handles.len();
-                for handle in handles {
-                    let (dep_path, index) = handle.await.into_diagnostic()??;
+                while let Some(joined) = handles.join_next().await {
+                    let (dep_path, index) = joined.into_diagnostic()??;
                     let _ = materialize_tx.send((dep_path.clone(), index.clone()));
                     indices.insert(dep_path, index);
                 }
@@ -2972,6 +3058,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let materialize_node_version = node_version_for_prewarm.clone();
             let materialize_allow = {
                 let build_policy = build_policy_for_prewarm.clone();
+                // Closure gets (name, version). Caller in graph_hash
+                // already hands us registry_name(), not alias. Safe
+                // to feed into policy.decide directly. If a new caller
+                // gets wired up that passes pkg.name instead, the
+                // alias-bypass would come back. Audit graph_hash.rs
+                // callers if changing this.
                 move |name: &str, version: &str| {
                     matches!(
                         build_policy.decide(name, version),
@@ -3419,11 +3511,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         &ws_config_shared,
         opts.dangerously_allow_all_builds,
     );
-    // Emit policy-config warnings regardless of `--ignore-scripts` —
-    // a typo in `allowBuilds` should still surface to the user even
-    // when lifecycle execution is disabled.
+    // Emit policy-config warnings regardless of `--ignore-scripts`.
+    // User wants to know about typos in `allowBuilds` even if scripts
+    // will not run, otherwise they reenable scripts later and wonder
+    // why nothing runs. Bar is active here (set_phase=linking comes
+    // soon, set_phase=fetching already ran). Raw eprintln smears
+    // output across bar frames. Route through safe_eprintln which
+    // pauses the bar and holds the terminal lock for atomic output.
     for w in &policy_warnings {
-        eprintln!("warn: {w}");
+        crate::progress::safe_eprintln(&format!("warn: {w}"));
     }
 
     // 6. Link node_modules

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -700,28 +700,28 @@ pub(super) fn check_unmet_peers(
     if unmet.is_empty() {
         return Ok(());
     }
-    eprintln!("error: Issues with peer dependencies found");
+    // Called from install flow after resolver, before linker phase.
+    // Progress bar is active at this point. Raw eprintln smears
+    // across bar frames. Route through safe_eprintln.
+    crate::progress::safe_eprintln("error: Issues with peer dependencies found");
     for u in &unmet {
-        match &u.found {
-            Some(found) => eprintln!(
-                "error:   {}@{}: expected peer {}@{}, found {}",
-                u.from_name,
-                version_from_dep_path(&u.from_dep_path, &u.from_name),
-                u.peer_name,
-                u.declared,
-                found,
+        let from_ver = version_from_dep_path(&u.from_dep_path, &u.from_name);
+        let msg = match &u.found {
+            Some(found) => format!(
+                "error:   {}@{from_ver}: expected peer {}@{}, found {found}",
+                u.from_name, u.peer_name, u.declared,
             ),
-            None => eprintln!(
-                "error:   {}@{}: missing required peer {}@{}",
-                u.from_name,
-                version_from_dep_path(&u.from_dep_path, &u.from_name),
-                u.peer_name,
-                u.declared,
+            None => format!(
+                "error:   {}@{from_ver}: missing required peer {}@{}",
+                u.from_name, u.peer_name, u.declared,
             ),
-        }
+        };
+        crate::progress::safe_eprintln(&msg);
     }
     Err(miette!(
-        "{} unmet peer dependenc{} (strict-peer-dependencies is enabled)",
+        "{} unmet peer dependenc{} (strict-peer-dependencies is enabled)\n  \
+         help: set strict-peer-dependencies=false in .npmrc to warn instead, or \
+         pin the peer version via pnpm.peerDependencyRules.allowedVersions",
         unmet.len(),
         if unmet.len() == 1 { "y" } else { "ies" }
     ))

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -348,15 +348,20 @@ fn resolved_store_dir(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
     })
 }
 
-/// Expand a path-typed setting value: `~` → `$HOME`, relative → absolute
-/// against `cwd`. Returns `None` when the value starts with `~` but
-/// `HOME` is not set, so callers can fall back to a safe default
-/// instead of producing a nonsensical path like `/project/~/foo`.
+/// Expand a path-typed setting value. `~` -> home dir, relative ->
+/// absolute against `cwd`. Returns None if the value begins with `~`
+/// but no home env var is set, caller then falls back to a platform
+/// default. On Unix reads HOME. On Windows reads HOME first (for
+/// POSIX-compat toolchains that set it) then USERPROFILE (native
+/// Windows default). Old code only checked HOME, Windows users got
+/// silent None back for any `~/...` settings like `storeDir: ~/store`,
+/// and the caller fell through to the platform default, so custom
+/// store paths never took effect on Windows.
 pub(crate) fn expand_setting_path(raw: &str, cwd: &std::path::Path) -> Option<std::path::PathBuf> {
     let expanded = if let Some(rest) = raw.strip_prefix("~/") {
-        std::path::PathBuf::from(std::env::var_os("HOME")?).join(rest)
+        std::path::PathBuf::from(home_dir_os()?).join(rest)
     } else if raw == "~" {
-        std::path::PathBuf::from(std::env::var_os("HOME")?)
+        std::path::PathBuf::from(home_dir_os()?)
     } else {
         std::path::PathBuf::from(raw)
     };
@@ -365,6 +370,19 @@ pub(crate) fn expand_setting_path(raw: &str, cwd: &std::path::Path) -> Option<st
     } else {
         cwd.join(expanded)
     })
+}
+
+fn home_dir_os() -> Option<std::ffi::OsString> {
+    if let Some(h) = std::env::var_os("HOME") {
+        return Some(h);
+    }
+    #[cfg(windows)]
+    {
+        if let Some(p) = std::env::var_os("USERPROFILE") {
+            return Some(p);
+        }
+    }
+    None
 }
 
 /// Build a file-only `ResolveCtx` for `cwd` and call `f` with it.

--- a/crates/aube/src/commands/npmrc.rs
+++ b/crates/aube/src/commands/npmrc.rs
@@ -178,11 +178,31 @@ pub fn resolve_registry(flag: Option<&str>, scope: Option<&str>) -> miette::Resu
 }
 
 /// `~/.npmrc`, or an error if we can't locate the user's home directory.
+///
+/// Reads HOME first (every Unix, and POSIX-compat Windows toolchains
+/// that set it). Falls back to USERPROFILE on Windows since vanilla
+/// Windows does not set HOME. Old code was HOME-only, so `aube login`
+/// on a native Windows shell errored out with "$HOME is not set"
+/// instead of using C:\Users\<user>\.npmrc. Same issue would make
+/// `aube logout` fail and `aube config` never find the user file.
 pub fn user_npmrc_path() -> miette::Result<PathBuf> {
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .ok_or_else(|| miette!("$HOME is not set; can't locate ~/.npmrc"))?;
+    let home = read_home_env().ok_or_else(|| {
+        miette!("could not locate home directory. set HOME or USERPROFILE to point at ~/.npmrc")
+    })?;
     Ok(home.join(".npmrc"))
+}
+
+fn read_home_env() -> Option<PathBuf> {
+    if let Some(h) = std::env::var_os("HOME") {
+        return Some(PathBuf::from(h));
+    }
+    #[cfg(windows)]
+    {
+        if let Some(p) = std::env::var_os("USERPROFILE") {
+            return Some(PathBuf::from(p));
+        }
+    }
+    None
 }
 
 #[cfg(test)]

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -349,8 +349,13 @@ fn matches_ignore_line(line: &str, rel: &str) -> bool {
 }
 
 fn is_npm_ignored(name: &str) -> bool {
-    // Mirrors the hardcoded list in npm's `pack` implementation.
-    matches!(
+    // Secret-file blocklist. User runs `aube publish` in a dir with
+    // `.env`, SSH keys, AWS creds. No `files` allowlist, no
+    // `.npmignore`. Without this list, those files ship to the
+    // registry. Real footgun, real incidents, npm/pnpm both ship a
+    // similar list. Users can still override via `files` field if
+    // they really want to publish one of these (nobody should).
+    if matches!(
         name,
         ".git"
             | ".svn"
@@ -367,8 +372,30 @@ fn is_npm_ignored(name: &str) -> bool {
             | "pnpm-lock.yaml"
             | "bun.lock"
             | "aube-lock.yaml"
-    ) || name.ends_with(".tgz")
-        || name.ends_with(".swp")
+            | ".env"
+            | ".envrc"
+            | ".ssh"
+            | ".aws"
+            | ".gnupg"
+            | "id_rsa"
+            | "id_dsa"
+            | "id_ecdsa"
+            | "id_ed25519"
+    ) {
+        return true;
+    }
+    if name.ends_with(".tgz") || name.ends_with(".swp") {
+        return true;
+    }
+    // `.env.local`, `.env.production`, etc.
+    if name.starts_with(".env.") {
+        return true;
+    }
+    // Private keys / certs users routinely keep alongside source.
+    if name.ends_with(".pem") || name.ends_with(".key") || name.ends_with(".p12") {
+        return true;
+    }
+    false
 }
 
 fn always_included_files(project_dir: &Path, manifest: &PackageJson) -> Vec<String> {

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -381,11 +381,36 @@ async fn publish_one(
         })?
         .to_string();
 
+    // publishConfig in package.json overrides both registry and tag
+    // if the user has not passed CLI flags. pnpm and npm both honor
+    // this field, so without it migrating users would silently
+    // publish to the wrong place. Most common case: scoped private
+    // registries like `{"publishConfig": {"registry": "https://npm.pkg.github.com"}}`
+    // and `{"publishConfig": {"access": "public"}}` for first-time
+    // scoped-public publishes. CLI override still wins over the
+    // manifest setting, matching pnpm precedence.
+    let publish_config = manifest
+        .extra
+        .get("publishConfig")
+        .and_then(|v| v.as_object());
+    let pc_registry = publish_config
+        .and_then(|p| p.get("registry"))
+        .and_then(|v| v.as_str());
+    let pc_tag = publish_config
+        .and_then(|p| p.get("tag"))
+        .and_then(|v| v.as_str());
+
     let registry_url = registry_override
         .map(normalize_registry_url_pub)
+        .or_else(|| pc_registry.map(normalize_registry_url_pub))
         .unwrap_or_else(|| config.registry_for(&name).to_string());
 
-    let tag = args.tag.as_deref().unwrap_or("latest").to_string();
+    let tag = args
+        .tag
+        .as_deref()
+        .or(pc_tag)
+        .unwrap_or("latest")
+        .to_string();
 
     if args.dry_run {
         // Dry-run still builds the archive: the whole point is to show
@@ -460,12 +485,23 @@ async fn publish_one(
         None
     };
 
+    // Same publishConfig precedence story for `access`. CLI flag
+    // wins, then manifest.publishConfig.access, then default.
+    // Without this, a first-time `@scope/pkg` publish with
+    // `publishConfig.access=public` in package.json would fail with
+    // 402 unless the user also passed `--access public` on every
+    // publish invocation.
+    let pc_access = publish_config
+        .and_then(|p| p.get("access"))
+        .and_then(|v| v.as_str());
+    let effective_access = args.access.as_deref().or(pc_access);
+
     let body = build_publish_body(
         &archive,
         &manifest,
         &registry_url,
         &tag,
-        args.access.as_deref(),
+        effective_access,
         provenance_bundle.as_deref(),
     )?;
 

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -71,16 +71,25 @@ pub async fn run(
         let removed = if args.save_dev {
             manifest.dev_dependencies.remove(name).is_some()
         } else {
-            // Clear every section that could hold this name — `--save-peer`
-            // may have written to both `peerDependencies` and
-            // `devDependencies` simultaneously, so we need to strip both to
-            // fully uninstall.
+            // Strip from every section. `--save-peer` previously
+            // wrote to both peerDependencies and devDependencies so
+            // both need clearing on a full uninstall.
             let from_deps = manifest.dependencies.remove(name).is_some();
             let from_dev = manifest.dev_dependencies.remove(name).is_some();
             let from_optional = manifest.optional_dependencies.remove(name).is_some();
             let from_peer = manifest.peer_dependencies.remove(name).is_some();
             from_deps || from_dev || from_optional || from_peer
         };
+
+        // Also prune sidecar metadata so a later `aube add <name>`
+        // does not silently inherit the old entries. Main concern is
+        // pnpm.allowBuilds. If user removes a build-script package
+        // then later adds a malicious package with the same name
+        // (typo-squat, name reclaim), the old allowBuilds entry
+        // would auto-approve its postinstall. Same hazard, lower
+        // risk, for overrides and resolutions which just leave dead
+        // rewrite rules around. Matches pnpm remove behavior.
+        prune_sidecar_entries(&mut manifest, name);
 
         if !removed {
             let section = if args.save_dev {
@@ -94,13 +103,13 @@ pub async fn run(
         eprintln!("  - {name}");
     }
 
-    // Write updated package.json
+    // Write updated package.json atomically. Crash mid-write would
+    // otherwise truncate the user manifest, worst-case aube failure
+    // mode. Tempfile + persist keeps the swap atomic.
     let json = serde_json::to_string_pretty(&manifest)
         .into_diagnostic()
         .wrap_err("failed to serialize package.json")?;
-    std::fs::write(&manifest_path, format!("{json}\n"))
-        .into_diagnostic()
-        .wrap_err("failed to write package.json")?;
+    write_manifest_atomic(&manifest_path, format!("{json}\n").as_bytes())?;
     eprintln!("Updated package.json");
 
     // Re-resolve dependency tree without the removed packages
@@ -189,5 +198,105 @@ fn run_global(packages: &[String]) -> miette::Result<()> {
     if !any_removed {
         return Err(miette!("no matching global packages were removed"));
     }
+    Ok(())
+}
+
+/// Prune aube/pnpm sidecar metadata entries that reference `name`.
+/// Covers pnpm.allowBuilds, pnpm.onlyBuiltDependencies,
+/// pnpm.neverBuiltDependencies, pnpm.overrides, aube.* mirrors,
+/// top-level overrides, yarn resolutions. Also removes the whole
+/// namespace block if its last entry was the one we just dropped.
+/// Safe no-op if the manifest has none of these fields.
+fn prune_sidecar_entries(manifest: &mut aube_manifest::PackageJson, name: &str) {
+    // Namespaced (pnpm.* / aube.*) allowlists, overrides, denylists.
+    for ns_key in ["pnpm", "aube"] {
+        let Some(ns) = manifest.extra.get_mut(ns_key) else {
+            continue;
+        };
+        let Some(obj) = ns.as_object_mut() else {
+            continue;
+        };
+        // Map-shape fields: key is package name.
+        for map_key in ["allowBuilds", "overrides", "peerDependencyRules"] {
+            if let Some(inner) = obj.get_mut(map_key).and_then(|v| v.as_object_mut()) {
+                inner.remove(name);
+                // peerDependencyRules has nested allowedVersions,
+                // ignoreMissing. Only clean the outer pkg-keyed
+                // entries, deeper structures are author-controlled.
+                if inner.is_empty() {
+                    obj.remove(map_key);
+                }
+            }
+        }
+        // Array-shape fields: whole entries match name or name@ver.
+        for arr_key in [
+            "onlyBuiltDependencies",
+            "neverBuiltDependencies",
+            "trustedDependencies",
+        ] {
+            if let Some(arr) = obj.get_mut(arr_key).and_then(|v| v.as_array_mut()) {
+                arr.retain(|entry| match entry.as_str() {
+                    Some(s) => {
+                        // "pkg" stays only if it is not our name.
+                        // "pkg@range" stays only if pkg is not ours.
+                        let base = s.rsplit_once('@').map(|(a, _)| a).unwrap_or(s);
+                        base != name
+                    }
+                    None => true,
+                });
+                if arr.is_empty() {
+                    obj.remove(arr_key);
+                }
+            }
+        }
+        // Drop the whole pnpm/aube block if we emptied it completely.
+        if obj.is_empty() {
+            manifest.extra.remove(ns_key);
+        }
+    }
+    // Top-level `overrides` (npm + pnpm both accept it here).
+    if let Some(top) = manifest
+        .extra
+        .get_mut("overrides")
+        .and_then(|v| v.as_object_mut())
+    {
+        top.remove(name);
+        if top.is_empty() {
+            manifest.extra.remove("overrides");
+        }
+    }
+    // yarn `resolutions` at top level.
+    if let Some(top) = manifest
+        .extra
+        .get_mut("resolutions")
+        .and_then(|v| v.as_object_mut())
+    {
+        top.remove(name);
+        if top.is_empty() {
+            manifest.extra.remove("resolutions");
+        }
+    }
+}
+
+fn write_manifest_atomic(path: &std::path::Path, body: &[u8]) -> miette::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let tmp = tempfile::Builder::new()
+        .prefix(".aube-remove-")
+        .suffix(".tmp")
+        .tempfile_in(parent)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to open tempfile for {}", path.display()))?;
+    {
+        use std::io::Write as _;
+        let mut f = tmp.as_file();
+        f.write_all(body)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to write tempfile for {}", path.display()))?;
+        f.sync_all()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to sync tempfile for {}", path.display()))?;
+    }
+    tmp.persist(path)
+        .map_err(|e| miette!("failed to persist {}: {e}", path.display()))?;
     Ok(())
 }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -13,7 +13,7 @@ pub struct RunArgs {
     /// scripts.
     pub script: Option<String>,
     /// Arguments to pass to the script
-    #[arg(trailing_var_arg = true)]
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
     /// Don't error if the script is missing from package.json
     #[arg(long)]
@@ -88,7 +88,7 @@ pub struct RunArgs {
 #[derive(Debug, Args)]
 pub struct ScriptArgs {
     /// Arguments to pass to the script
-    #[arg(trailing_var_arg = true)]
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
     /// Skip auto-install check
     #[arg(long)]
@@ -252,7 +252,19 @@ pub(crate) async fn run_script_with(
         if if_present {
             return Ok(());
         }
-        return Err(miette!("script not found: {script}"));
+        // Old error was "script not found: foo" with no list. User
+        // has to cat package.json to figure out what to type. npm
+        // and pnpm both list available scripts here. Do the same.
+        // Keep the list on one line when short, separate lines when
+        // long, since users often have 20+ scripts in a real project.
+        let mut names: Vec<&str> = manifest.scripts.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        let hint = if names.is_empty() {
+            "no scripts defined in package.json".to_string()
+        } else {
+            format!("available scripts: {}", names.join(", "))
+        };
+        return Err(miette!("script not found: {script}\n  {hint}"));
     }
 
     ensure_installed(no_install).await?;
@@ -350,10 +362,10 @@ async fn run_script_filtered(
             match t.await {
                 Ok(Ok(status)) => {
                     if !status.success() && first_exit.is_none() {
-                        first_exit = Some(status.code().unwrap_or(1));
+                        let code = aube_scripts::exit_code_from_status(status);
+                        first_exit = Some(code);
                         first_err = Some(miette!(
-                            "aube run: `{script}` failed in {name} (exit {})",
-                            status.code().unwrap_or(1)
+                            "aube run: `{script}` failed in {name} (exit {code})"
                         ));
                     }
                 }
@@ -451,23 +463,58 @@ pub(crate) async fn exec_script(
     let shell_cmd = if args.is_empty() {
         cmd.to_string()
     } else {
-        format!("{cmd} {}", args.join(" "))
+        // Quote each forwarded arg. Args land inside `sh -c "..."` or
+        // cmd `/c "..."` which reparses. Unquoted $, backticks, ;, |,
+        // () all get interpreted. `aube run echo '$(rm -rf ~)'` would
+        // run the subshell. Same npm/pnpm bug class from years ago.
+        // shell_quote_arg wraps per-platform. See aube-scripts.
+        let mut buf =
+            String::with_capacity(cmd.len() + args.iter().map(|a| a.len() + 3).sum::<usize>());
+        buf.push_str(cmd);
+        for a in args {
+            buf.push(' ');
+            buf.push_str(&aube_scripts::shell_quote_arg(a));
+        }
+        buf
     };
 
     let bin_dir = super::project_modules_dir(cwd).join(".bin");
     let new_path = aube_scripts::prepend_path(&bin_dir);
 
-    let status = aube_scripts::spawn_shell(&shell_cmd)
+    // npm-compat env vars. Lifecycle path already sets these in
+    // aube-scripts::run_root_hook, but `aube run` was bare env.
+    // Real breakage: build scripts that stamp `$npm_package_version`
+    // or branch on `$npm_lifecycle_event` got empty strings under
+    // `aube run` while working fine under `aube install`
+    // postinstall. npm and pnpm set these on every script exec.
+    let mut command = aube_scripts::spawn_shell(&shell_cmd);
+    command
         .env("PATH", &new_path)
         .current_dir(cwd)
-        .stderr(aube_scripts::child_stderr())
+        .env("npm_lifecycle_event", script)
+        .stderr(aube_scripts::child_stderr());
+    if let Some(ref name) = manifest.name {
+        command.env("npm_package_name", name);
+    }
+    if let Some(ref version) = manifest.version {
+        command.env("npm_package_version", version);
+    }
+    // INIT_CWD is the dir the user invoked aube from. node-gyp and
+    // prebuild-install use it to locate the project root when
+    // caching binaries. Preserve parent-set value so nested aube
+    // calls see the outermost invocation cwd.
+    if std::env::var_os("INIT_CWD").is_none() {
+        command.env("INIT_CWD", cwd);
+    }
+
+    let status = command
         .status()
         .await
         .into_diagnostic()
         .wrap_err("failed to execute script")?;
 
     if !status.success() {
-        std::process::exit(status.code().unwrap_or(1));
+        std::process::exit(aube_scripts::exit_code_from_status(status));
     }
 
     Ok(())
@@ -509,14 +556,38 @@ pub(crate) async fn exec_script_status(
     let shell_cmd = if args.is_empty() {
         cmd.to_string()
     } else {
-        format!("{cmd} {}", args.join(" "))
+        // Quote each forwarded arg. Args land inside `sh -c "..."` or
+        // cmd `/c "..."` which reparses. Unquoted $, backticks, ;, |,
+        // () all get interpreted. `aube run echo '$(rm -rf ~)'` would
+        // run the subshell. Same npm/pnpm bug class from years ago.
+        // shell_quote_arg wraps per-platform. See aube-scripts.
+        let mut buf =
+            String::with_capacity(cmd.len() + args.iter().map(|a| a.len() + 3).sum::<usize>());
+        buf.push_str(cmd);
+        for a in args {
+            buf.push(' ');
+            buf.push_str(&aube_scripts::shell_quote_arg(a));
+        }
+        buf
     };
     let bin_dir = super::project_modules_dir(cwd).join(".bin");
     let new_path = aube_scripts::prepend_path(&bin_dir);
-    aube_scripts::spawn_shell(&shell_cmd)
+    let mut command = aube_scripts::spawn_shell(&shell_cmd);
+    command
         .env("PATH", &new_path)
         .current_dir(cwd)
-        .stderr(aube_scripts::child_stderr())
+        .env("npm_lifecycle_event", script)
+        .stderr(aube_scripts::child_stderr());
+    if let Some(ref name) = manifest.name {
+        command.env("npm_package_name", name);
+    }
+    if let Some(ref version) = manifest.version {
+        command.env("npm_package_version", version);
+    }
+    if std::env::var_os("INIT_CWD").is_none() {
+        command.env("INIT_CWD", cwd);
+    }
+    command
         .status()
         .await
         .into_diagnostic()

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -460,6 +460,35 @@ pub(crate) async fn exec_script(
         .get(script)
         .ok_or_else(|| miette!("script not found: {script}"))?;
 
+    let mut command = build_script_command(cwd, manifest, script, cmd, args);
+
+    let status = command
+        .status()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to execute script")?;
+
+    if !status.success() {
+        std::process::exit(aube_scripts::exit_code_from_status(status));
+    }
+
+    Ok(())
+}
+
+/// Build a fully-configured `tokio::process::Command` for running a
+/// package.json script. Handles arg quoting, PATH prepend, npm-compat
+/// env vars, and INIT_CWD. Shared between `exec_script` (which exits
+/// on non-zero) and `exec_script_status` (which returns the status
+/// so the parallel path can collect all outcomes). Keeping one place
+/// to configure these means future security fixes land once, not
+/// twice.
+fn build_script_command(
+    cwd: &Path,
+    manifest: &PackageJson,
+    script: &str,
+    cmd: &str,
+    args: &[String],
+) -> tokio::process::Command {
     let shell_cmd = if args.is_empty() {
         cmd.to_string()
     } else {
@@ -481,12 +510,12 @@ pub(crate) async fn exec_script(
     let bin_dir = super::project_modules_dir(cwd).join(".bin");
     let new_path = aube_scripts::prepend_path(&bin_dir);
 
-    // npm-compat env vars. Lifecycle path already sets these in
-    // aube-scripts::run_root_hook, but `aube run` was bare env.
-    // Real breakage: build scripts that stamp `$npm_package_version`
-    // or branch on `$npm_lifecycle_event` got empty strings under
-    // `aube run` while working fine under `aube install`
-    // postinstall. npm and pnpm set these on every script exec.
+    // npm-compat env vars. Lifecycle path sets these in
+    // aube-scripts::run_root_hook, `aube run` was bare env before.
+    // Build scripts that stamp `$npm_package_version` or branch on
+    // `$npm_lifecycle_event` got empty strings under `aube run`
+    // while working fine under `aube install` postinstall. npm
+    // and pnpm set these on every script exec.
     let mut command = aube_scripts::spawn_shell(&shell_cmd);
     command
         .env("PATH", &new_path)
@@ -499,25 +528,18 @@ pub(crate) async fn exec_script(
     if let Some(ref version) = manifest.version {
         command.env("npm_package_version", version);
     }
-    // INIT_CWD is the dir the user invoked aube from. node-gyp and
-    // prebuild-install use it to locate the project root when
-    // caching binaries. Preserve parent-set value so nested aube
-    // calls see the outermost invocation cwd.
+    // INIT_CWD is the dir the user invoked aube from, NOT the
+    // project root. node-gyp and prebuild-install key their
+    // caches by INIT_CWD to locate the invoking project. Pulling
+    // the invocation cwd from dirs::cwd() matches npm and pnpm
+    // semantics when run from a subdirectory. Preserve a
+    // parent-set value so nested aube calls see the outermost
+    // invocation cwd.
     if std::env::var_os("INIT_CWD").is_none() {
-        command.env("INIT_CWD", cwd);
+        let init_cwd = crate::dirs::cwd().ok().unwrap_or_else(|| cwd.to_path_buf());
+        command.env("INIT_CWD", init_cwd);
     }
-
-    let status = command
-        .status()
-        .await
-        .into_diagnostic()
-        .wrap_err("failed to execute script")?;
-
-    if !status.success() {
-        std::process::exit(aube_scripts::exit_code_from_status(status));
-    }
-
-    Ok(())
+    command
 }
 
 pub(crate) async fn exec_script_chain(
@@ -553,41 +575,7 @@ pub(crate) async fn exec_script_status(
         .scripts
         .get(script)
         .ok_or_else(|| miette!("script not found: {script}"))?;
-    let shell_cmd = if args.is_empty() {
-        cmd.to_string()
-    } else {
-        // Quote each forwarded arg. Args land inside `sh -c "..."` or
-        // cmd `/c "..."` which reparses. Unquoted $, backticks, ;, |,
-        // () all get interpreted. `aube run echo '$(rm -rf ~)'` would
-        // run the subshell. Same npm/pnpm bug class from years ago.
-        // shell_quote_arg wraps per-platform. See aube-scripts.
-        let mut buf =
-            String::with_capacity(cmd.len() + args.iter().map(|a| a.len() + 3).sum::<usize>());
-        buf.push_str(cmd);
-        for a in args {
-            buf.push(' ');
-            buf.push_str(&aube_scripts::shell_quote_arg(a));
-        }
-        buf
-    };
-    let bin_dir = super::project_modules_dir(cwd).join(".bin");
-    let new_path = aube_scripts::prepend_path(&bin_dir);
-    let mut command = aube_scripts::spawn_shell(&shell_cmd);
-    command
-        .env("PATH", &new_path)
-        .current_dir(cwd)
-        .env("npm_lifecycle_event", script)
-        .stderr(aube_scripts::child_stderr());
-    if let Some(ref name) = manifest.name {
-        command.env("npm_package_name", name);
-    }
-    if let Some(ref version) = manifest.version {
-        command.env("npm_package_version", version);
-    }
-    if std::env::var_os("INIT_CWD").is_none() {
-        command.env("INIT_CWD", cwd);
-    }
-    command
+    build_script_command(cwd, manifest, script, cmd, args)
         .status()
         .await
         .into_diagnostic()

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -35,10 +35,37 @@ pub fn cwd() -> miette::Result<PathBuf> {
 /// matching pnpm's behavior of walking up when run outside a project
 /// directory.
 pub fn find_project_root(start: &Path) -> Option<PathBuf> {
+    // Walk up looking for package.json. Stops at $HOME so a stray
+    // `aube install` in an empty /tmp dir cannot climb out into the
+    // user's home dir and attach itself to a parent project. Real
+    // bug: in testing, running `aube install` from an empty /tmp
+    // path walked up to the user's home package.json and started
+    // writing into ~/node_modules with "Access denied" errors
+    // halfway through. Destructive, surprising, real.
+    let stop = home_stop_boundary();
     for dir in start.ancestors() {
         if dir.join("package.json").is_file() {
             return Some(dir.to_path_buf());
         }
+        if stop.as_deref() == Some(dir) {
+            return None;
+        }
+    }
+    None
+}
+
+/// Resolve home dir for the find_project_root walk boundary. On Unix
+/// reads HOME. On Windows falls back to USERPROFILE since HOME is
+/// typically unset. Returns None if neither is set, which means the
+/// walk falls back to old unbounded behavior. Not ideal, but better
+/// than panicking, and CI runners always set one of them.
+fn home_stop_boundary() -> Option<PathBuf> {
+    if let Some(h) = std::env::var_os("HOME") {
+        return Some(PathBuf::from(h));
+    }
+    #[cfg(windows)]
+    if let Some(p) = std::env::var_os("USERPROFILE") {
+        return Some(PathBuf::from(p));
     }
     None
 }
@@ -52,18 +79,28 @@ pub fn find_project_root(start: &Path) -> Option<PathBuf> {
 /// The aube-owned yaml name wins at read time elsewhere, but discovery
 /// only needs to know whether any of those markers fixes the root.
 pub fn find_workspace_root(start: &Path) -> Option<PathBuf> {
-    start.ancestors().find_map(|dir| {
+    // Same home-boundary story as find_project_root. Without it, an
+    // `aube install` from an empty scratch dir could climb into the
+    // user's home, find a parent workspace yaml or package.json with
+    // a workspaces field, and attach to that workspace. Cap the walk
+    // at $HOME so that never happens.
+    let stop = home_stop_boundary();
+    for dir in start.ancestors() {
         if dir.join("aube-workspace.yaml").exists() || dir.join("pnpm-workspace.yaml").exists() {
             return Some(dir.to_path_buf());
         }
         let pkg = dir.join("package.json");
-        if !pkg.is_file() {
+        if pkg.is_file()
+            && let Ok(manifest) = aube_manifest::PackageJson::from_path(&pkg)
+            && manifest.workspaces.is_some()
+        {
+            return Some(dir.to_path_buf());
+        }
+        if stop.as_deref() == Some(dir) {
             return None;
         }
-        let manifest = aube_manifest::PackageJson::from_path(&pkg).ok()?;
-        manifest.workspaces.as_ref()?;
-        Some(dir.to_path_buf())
-    })
+    }
+    None
 }
 
 /// Walk upward from `start` looking for the nearest ancestor that
@@ -72,13 +109,17 @@ pub fn find_workspace_root(start: &Path) -> Option<PathBuf> {
 /// because it feeds callers that specifically need the yaml file path
 /// (catalog loader, settings loader).
 pub fn find_workspace_yaml_root(start: &Path) -> Option<PathBuf> {
-    start.ancestors().find_map(|dir| {
+    // Cap the walk at $HOME for the same reason as find_project_root.
+    let stop = home_stop_boundary();
+    for dir in start.ancestors() {
         if dir.join("aube-workspace.yaml").exists() || dir.join("pnpm-workspace.yaml").exists() {
-            Some(dir.to_path_buf())
-        } else {
-            None
+            return Some(dir.to_path_buf());
         }
-    })
+        if stop.as_deref() == Some(dir) {
+            return None;
+        }
+    }
+    None
 }
 
 /// Return the nearest project root at or above the cached cwd.

--- a/crates/aube/src/pnpmfile.rs
+++ b/crates/aube/src/pnpmfile.rs
@@ -223,7 +223,14 @@ pub async fn run_after_all_resolved(pnpmfile: &Path, graph: &mut LockfileGraph) 
         .env("AUBE_HOOK", "afterAllResolved")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::inherit());
+        .stderr(std::process::Stdio::inherit())
+        // Match ReadPackageHost::spawn below. Without kill_on_drop
+        // the Node child keeps running when the parent future is
+        // cancelled. Install task panics or gets aborted, user
+        // Ctrl-C's aube, Node process stays alive running the
+        // afterAllResolved hook body until stdin closes on its own.
+        // Unlikely to bite in practice but zero-cost to guard.
+        .kill_on_drop(true);
 
     let mut child = cmd
         .spawn()

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -534,6 +534,31 @@ impl Drop for FetchRow {
 /// (`-v`, `--silent`, append-only, ndjson) the progress display
 /// isn't running; pause/resume become benign no-ops and the event
 /// still flushes cleanly.
+/// Print a message to stderr safely while the install progress bar
+/// may be active. Direct `eprintln!` during an active bar smears
+/// output across frames (bar paints over half the message, next tick
+/// repaints over what remains). Use this for warnings that need to
+/// surface mid-install like peer-dep errors, allowBuilds policy
+/// warnings, retry notifications, etc. If no bar is up, degenerates
+/// to a plain stderr write. Trailing newline is appended. Call sites
+/// that already hold a bar handle can use ProgressJob::println
+/// instead, but this works without one.
+pub fn safe_eprintln(msg: &str) {
+    use std::io::Write;
+    let was_paused = clx::progress::is_paused();
+    if !was_paused {
+        clx::progress::pause();
+    }
+    let _: () = clx::progress::with_terminal_lock(|| {
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr, "{msg}");
+        let _ = stderr.flush();
+    });
+    if !was_paused {
+        clx::progress::resume();
+    }
+}
+
 #[derive(Clone, Copy, Default)]
 pub struct PausingWriter;
 

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -254,7 +254,30 @@ pub fn write_state(
         std::fs::create_dir_all(parent)?;
     }
     let json = serde_json::to_string_pretty(&state)?;
-    std::fs::write(state_path, json)?;
+    // Atomic write via tempfile + rename. Old `fs::write` truncated
+    // the file in place, so Ctrl+C, AV quarantine, or a crash mid
+    // `write_all` left the state file zero bytes or partial JSON.
+    // Next install saw corrupt state, fell back to "install state
+    // not found" and ran a full cold install. User wondered why
+    // frozen fast path never kicked in. Rename on POSIX is atomic,
+    // on Windows ReplaceFileW behaves similarly post Win10.
+    let parent = state_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."));
+    let tmp = tempfile::Builder::new()
+        .prefix(".aube-state-")
+        .suffix(".tmp")
+        .tempfile_in(parent)?;
+    use std::io::Write as _;
+    {
+        let mut f = tmp.as_file();
+        f.write_all(json.as_bytes())?;
+        f.sync_all()?;
+    }
+    // persist() does the atomic rename. On Windows it still succeeds
+    // when the target exists via MoveFileEx semantics.
+    tmp.persist(&state_path)
+        .map_err(|e| std::io::Error::other(format!("persist state: {e}")))?;
 
     Ok(())
 }
@@ -621,6 +644,68 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
             hasher.update(&bytes);
         }
         hasher.update(b"\x1e");
+    }
+    hasher.update(b"\0");
+    // Raw `.npmrc` bytes. Resolved settings above only cover the
+    // install-shape keys we read. A user swapping `registry=` or
+    // `//host/:_authToken=` changes what tarballs we would fetch
+    // but the resolved-values hash never noticed, so fast path
+    // stayed green while the actual source of truth for deps
+    // changed. Hashing raw bytes is coarse (comment edits
+    // invalidate too) but correct.
+    hasher.update(b"npmrc=");
+    {
+        let path = project_dir.join(".npmrc");
+        hasher.update(b".npmrc\x1f");
+        if let Ok(bytes) = std::fs::read(&path) {
+            hasher.update(&bytes);
+        }
+        hasher.update(b"\x1e");
+    }
+    hasher.update(b"\0");
+    // OS + arch + libc. Optional deps filter by these. Swap host
+    // between runs (committed node_modules across machines, shared
+    // CI cache volume, Rosetta switch) and the correct prebuilts
+    // change. Old fast path did not notice and skipped the install,
+    // node_modules had the wrong variant for the active host.
+    hasher.update(b"host=");
+    hasher.update(std::env::consts::OS.as_bytes());
+    hasher.update(b"\x1f");
+    hasher.update(std::env::consts::ARCH.as_bytes());
+    hasher.update(b"\x1f");
+    // Piggyback on resolver's runtime libc probe. OS != linux
+    // returns empty string, harmless but stable.
+    hasher.update(aube_resolver::platform::host_triple().2.as_bytes());
+    hasher.update(b"\0");
+    // Patches dir. patch-commit and patch-remove touch patches in
+    // `<project>/patches/` and `.aube-patches.json`. Old fast path
+    // did not hash either. User edits a patch file, next install
+    // says up-to-date, node_modules still has old patched content.
+    hasher.update(b"patches=");
+    let patches_sidecar = project_dir.join(".aube-patches.json");
+    if let Ok(bytes) = std::fs::read(&patches_sidecar) {
+        hasher.update(b".aube-patches.json\x1f");
+        hasher.update(&bytes);
+        hasher.update(b"\x1e");
+    }
+    let patches_dir = project_dir.join("patches");
+    if let Ok(entries) = std::fs::read_dir(&patches_dir) {
+        let mut paths: Vec<_> = entries.flatten().map(|e| e.path()).collect();
+        // Sort so hash is deterministic across filesystems that
+        // return dir entries in different order (ext4 vs tmpfs vs
+        // NTFS).
+        paths.sort();
+        for p in paths {
+            let Some(name) = p.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            hasher.update(name.as_bytes());
+            hasher.update(b"\x1f");
+            if let Ok(bytes) = std::fs::read(&p) {
+                hasher.update(&bytes);
+            }
+            hasher.update(b"\x1e");
+        }
     }
     hasher.update(b"\0");
     format!("blake3:{}", hasher.finalize().to_hex())

--- a/test/audit.bats
+++ b/test/audit.bats
@@ -46,17 +46,20 @@ _write_clean_fixture() {
 	assert_output --partial "no lockfile"
 }
 
-@test "aube audit --ignore-registry-errors exits 0 when registry is unreachable" {
+@test "aube audit --ignore-registry-errors exits 2 with degraded status" {
 	_write_clean_fixture
 	run aube install
 	assert_success
 
-	# Point at a dead port so the bulk POST fails. The flag should swallow
-	# the error and exit cleanly, matching pnpm's CI-friendly behavior.
+	# Point at a dead port so the bulk POST fails. The flag used to
+	# swallow the error and exit 0 with "No known vulnerabilities
+	# found", which masked real CVEs in CI when the registry was
+	# down. Now it exits 2 and says "audit degraded" so downstream
+	# scripts can tell a clean scan from a failed one.
 	echo "registry=http://127.0.0.1:1/" >.npmrc
 	run aube audit --ignore-registry-errors
-	assert_success
-	assert_output --partial "No known vulnerabilities found"
+	[ "$status" -eq 2 ]
+	assert_output --partial "audit degraded"
 }
 
 _start_audit_server() {


### PR DESCRIPTION
security
- workspace:<range> now validates against local version, any workspace: prefix used to short-circuit so `workspace:^2.0.0` linked a local 1.0.0 without complaint
- allowlist bypass via `npm:` alias closed at every policy.decide site, `h3-safe: npm:h3@0.19.0` no longer sneaks past an `h3` entry
- aube dlx forces ignore-scripts so transient installs do not inherit user's global allow-builds
- aube run args shell-quoted per platform, no more `$` / backtick / `;` injection when forwarding args
- publish ignore list covers .env / .env.* / .ssh / .aws / .gnupg / id_rsa / *.pem / *.key / *.p12
- install ancestor walk stops at $HOME, empty-dir install cannot climb into user home and attach to a parent project
- libc detection runs at runtime (probes /lib/ld-musl-* vs /lib*/ld-linux-*), not compile-time cfg
- catalog entry pointing at another catalog rejected with a clear error
- peer-context max-iter is error level not warn, convergence failures no longer silent in CI
- aube audit --ignore-registry-errors exits 2 with degraded status instead of claiming clean

correctness
- atomic writes for aube-lock.yaml (all 6 formats), .aube-state, .aube-applied-patches.json, package.json mutations in add/remove
- CAS import fsyncs before close, shard-missing fallback switched from truncate-in-place to atomic create_new
- detect_strategy probes cross-FS (store vs project) so store on a different mount no longer silently falls back to per-file copy
- tarball extract rejects Windows reserved names / trailing dot-space / control chars on win32 only
- parser tolerates leading UTF-8 BOM, null dep maps, string-form workspaces ("packages/*"), with targeted error for package.json JSONC comments
- workspace glob skips node_modules/ at any depth so `packages/**` stops picking up installed deps
- workspace member without a version is a hard error instead of silent 0.0.0 fallback
- latest-tag-missing packument falls back to highest stable version, no more spurious NoMatch
- 0.0.0-0 workspace placeholder matches bare `*` range
- graph_hash allow_build fed registry_name, not in-tree alias

resources / concurrency
- fetch loops use JoinSet, first-error aborts outstanding siblings instead of detaching them
- virtual store sweeps stale .tmp-<pid>-* dirs on each install to reclaim prior-crash leftovers
- pnpmfile afterAllResolved child has kill_on_drop
- Windows remove_dir_all retries on sharing violations / access-denied with backoff

ux
- signal-aware exit codes (128+signum) in aube run / dlx / exec, SIGKILL no longer collapses to plain 1
- aube run <missing> lists available scripts from package.json
- policy warnings and peer errors routed through a progress-safe writer so output does not smear with the install bar
- branch-lockfile merge prints conflicts per line, integrity mismatches flagged explicitly as supply-chain signal
- aube run sets npm_lifecycle_event / npm_package_name / npm_package_version / INIT_CWD, was a bare env before
- aube run and aube exec take allow_hyphen_values so `aube run build --flag` works without the `--` separator
- root script failure error includes hook name, no more bare "exit status 1"

compat
- publishConfig.registry / .tag / .access honored with CLI > manifest precedence
- .npmrc backslash line continuation supported (npm ini semantics)
- HOME falls back to USERPROFILE on Windows in expand_setting_path, user_npmrc_path, registry config home_dir
- frozen fast-path state hash now covers .npmrc bytes, host (os+arch+libc), and patches dir + sidecar
- find_workspace_root and find_workspace_yaml_root also cap the ancestor walk at $HOME