### PR TITLE
install(filter): keep root importer deps in workspace selects

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -4028,6 +4028,9 @@ fn filter_graph_to_workspace_selection(
         ));
     }
     let mut keep_importers = std::collections::BTreeSet::new();
+    if graph.importers.contains_key(".") {
+        keep_importers.insert(".".to_string());
+    }
     for pkg in selected {
         keep_importers.insert(super::workspace_importer_path(workspace_root, &pkg.dir)?);
     }

--- a/test/filter.bats
+++ b/test/filter.bats
@@ -155,6 +155,40 @@ _setup_filter_workspace() {
 	refute_output --partial "lib-a-ran"
 }
 
+@test "aube install --filter keeps root devDependencies" {
+	cat >pnpm-workspace.yaml <<-EOF
+		packages:
+		  - packages/*
+	EOF
+	cat >package.json <<-'EOF'
+		{
+		  "name": "root",
+		  "version": "1.0.0",
+		  "private": true,
+		  "devDependencies": {
+		    "is-odd": "^3.0.1"
+		  }
+		}
+	EOF
+	mkdir -p packages/app
+	cat >packages/app/package.json <<-'EOF'
+		{
+		  "name": "@scope/app",
+		  "version": "1.0.0",
+		  "dependencies": {
+		    "is-even": "^1.0.0"
+		  }
+		}
+	EOF
+
+	run aube install --filter '@scope/app...'
+	assert_success
+	assert_link_exists node_modules/is-odd
+	run node -e 'console.log(require.resolve("is-odd"))'
+	assert_success
+	assert_output --partial "node_modules/is-odd"
+}
+
 @test "aube -F run: unmatched selector errors" {
 	_setup_filter_workspace
 	run aube -F no-such-pkg run hello


### PR DESCRIPTION
## Summary
- keep the root importer when `aube install --filter ...` narrows a workspace install so root package dependencies and devDependencies still get linked
- add a regression test covering a filtered workspace install that still needs a root `devDependency`
- verify the external repro from `stevelandeydescript/aube-bug-repros` now resolves the root tool after a filtered install

## Repro
- `aube install --filter '@repro/app...'`
- `node test.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to workspace install graph filtering that ensures the root importer is retained, with a focused regression test; low risk aside from potentially linking additional root deps during filtered installs.
> 
> **Overview**
> Filtered workspace installs (`aube install --filter ...`) now **always retain the root importer (`"."`)** when it exists in the lockfile graph, so root-level `dependencies`/`devDependencies` continue to be linked even when the install graph is narrowed to selected workspace packages.
> 
> Adds a regression test covering a filtered install that still requires a root `devDependency` to be present in `node_modules`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b386f157cde8976d729c08b6a6b042f14ce1779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->