### PR TITLE
linker: prune stale .aube/<dep_path> entries on reinstall

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -665,6 +665,50 @@ impl Linker {
         dep_path_to_filename(dep_path, self.virtual_store_dir_max_length)
     }
 
+    /// Remove `.aube/<dep_path>` entries no longer in the resolved
+    /// graph, so a package dropped from package.json doesn't linger
+    /// and keep satisfying phantom imports reached through nested
+    /// `node_modules/` walks. Preserves the hidden hoist tree at
+    /// `.aube/node_modules/` and any dotfile/`.tmp-*` sidecars; those
+    /// are owned by `link_hidden_hoist` and `sweep_stale_tmp_dirs`.
+    /// In gvs mode each entry is a symlink into the shared store, so
+    /// `file_type` drives the unlink to keep `remove_dir_all` from
+    /// recursing through the link and wiping another project's data.
+    fn prune_stale_virtual_store_entries(&self, aube_dir: &Path, graph: &LockfileGraph) {
+        let current: std::collections::HashSet<String> = graph
+            .packages
+            .keys()
+            .map(|dp| self.aube_dir_entry_name(dp))
+            .collect();
+        let Ok(entries) = std::fs::read_dir(aube_dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            // Membership check first: warm re-installs hit `current`
+            // for every package entry, so this skips the reserved-name
+            // compares in the overwhelming common case.
+            if current.contains(name_str.as_ref()) {
+                continue;
+            }
+            if name_str == "node_modules" || name_str.starts_with('.') {
+                continue;
+            }
+            let path = entry.path();
+            let is_symlink = entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(false);
+            if is_symlink {
+                // `remove_dir` before `remove_file` to match the
+                // stale-symlink cleanup in Step 1. Windows NTFS
+                // junctions look like directories and `remove_file`
+                // can't unlink them; Unix symlinks fall through.
+                let _ = std::fs::remove_dir(&path).or_else(|_| std::fs::remove_file(&path));
+            } else {
+                let _ = remove_dir_all_with_retry(&path);
+            }
+        }
+    }
+
     /// Whether this linker populates the project's `.aube/` entries as
     /// symlinks into the shared virtual store (true) or materializes a
     /// per-project copy (false). Callers that want to mutate package
@@ -899,6 +943,8 @@ impl Linker {
                 self.virtual_store_dir_max_length,
             );
         }
+
+        self.prune_stale_virtual_store_entries(&aube_dir, graph);
 
         // Step 1: Populate .aube virtual store
         //
@@ -1341,6 +1387,8 @@ impl Linker {
                 self.virtual_store_dir_max_length,
             );
         }
+
+        self.prune_stale_virtual_store_entries(&aube_dir, graph);
 
         // Step 1a: Materialize local (`file:` dir/tarball) packages
         // straight into the shared per-project `.aube/`. They never
@@ -3346,6 +3394,58 @@ mod tests {
             "module.exports = 'foo@2';",
             "install 2 should repoint the hoisted symlink to foo@2.0.0"
         );
+    }
+
+    /// Regression: removing a package from package.json between
+    /// installs must drop its `.aube/<dep_path>/` entry. Previously
+    /// the linker only swept the top-level `node_modules/<name>`
+    /// symlink, leaving the virtual-store dir behind where it could
+    /// keep satisfying phantom imports reached through a nested
+    /// `node_modules/` walk. Exercise both the per-project and
+    /// global-virtual-store modes because the entry type differs
+    /// (directory vs. symlink into the shared store).
+    #[test]
+    fn test_link_all_prunes_removed_package_from_virtual_store() {
+        for use_gvs in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let project_dir = dir.path().join("project");
+            std::fs::create_dir_all(&project_dir).unwrap();
+
+            let (store, indices) = setup_store_with_files(dir.path());
+            let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, use_gvs);
+
+            linker
+                .link_all(&project_dir, &make_graph(), &indices)
+                .unwrap();
+            let aube_foo = project_dir.join("node_modules/.aube/foo@1.0.0");
+            let aube_bar = project_dir.join("node_modules/.aube/bar@2.0.0");
+            assert!(
+                aube_foo.symlink_metadata().is_ok(),
+                "gvs={use_gvs}: foo should be materialized after install 1"
+            );
+            assert!(
+                aube_bar.symlink_metadata().is_ok(),
+                "gvs={use_gvs}: bar should be materialized after install 1"
+            );
+
+            let empty = LockfileGraph::default();
+            linker
+                .link_all(&project_dir, &empty, &BTreeMap::new())
+                .unwrap();
+
+            assert!(
+                aube_foo.symlink_metadata().is_err(),
+                "gvs={use_gvs}: foo@1.0.0 should be pruned from .aube after removal"
+            );
+            assert!(
+                aube_bar.symlink_metadata().is_err(),
+                "gvs={use_gvs}: bar@2.0.0 should be pruned from .aube after removal"
+            );
+            assert!(
+                project_dir.join("node_modules/.aube").exists(),
+                "gvs={use_gvs}: the .aube dir itself must survive the sweep"
+            );
+        }
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a bug where removing a package from `package.json` and rerunning `aube install` left the package's directory behind under `node_modules/.aube/<name>@<ver>/`. The top-level `node_modules/<pkg>` symlink was correctly swept, but the virtual-store entry kept satisfying phantom imports reached through nested `node_modules/` walks and wasted disk on every warm install thereafter.

## Root cause

`link_all` / `link_workspace` only ever *added* `.aube/<dep_path>` entries in Step 1. The existing top-level sweep at [lib.rs:804-877](crates/aube-linker/src/lib.rs#L804) handled `node_modules/<pkg>`, and `wipe_changed_patched_entries` at [lib.rs:2519](crates/aube-linker/src/lib.rs#L2519) fired only on patch-fingerprint churn — nothing reconciled `.aube/` against the resolved graph.

## Fix

New `Linker::prune_stale_virtual_store_entries` method, called before Step 1 in both `link_all` and `link_workspace`. It walks `aube_dir`, computes the set difference against `graph.packages` keyed by `aube_dir_entry_name(dep_path)`, and unlinks the stragglers.

Invariants preserved:

- `.aube/node_modules/` (hidden hoist tree, owned by `link_hidden_hoist`) — skipped by name.
- `.tmp-*` and `.aube-applied-patches.json` and any future dotfile sidecar — skipped by `starts_with('.')`.
- gvs-mode symlinks into the shared global store — unlinked via `remove_dir`/`remove_file`, never recursed through with `remove_dir_all` (which would wipe another project's data).
- Per-project mode directories — `remove_dir_all_with_retry` (matches existing Windows junction retry pattern).

The check order puts `current.contains(...)` first: warm re-installs hit membership for 100% of package entries, so the reserved-name compares are only paid on removals.

## Commands covered

Every path that drives the install pipeline — `aube install`, `remove`, `update`, `dedupe`, `add`, `ci`, `deploy`, `patch-commit`, `patch-remove`, `dlx`, auto-install from `run`/`exec`. The warm-path short-circuit at [install/mod.rs:1711](crates/aube/src/commands/install/mod.rs#L1711) correctly invalidates on dep removal (state hash covers package.json + lockfile), so the linker still runs and the fix kicks in. Hoisted mode (`node-linker=hoisted`) is unaffected — it returns early before the virtual store is touched.

## Test plan

- [x] New parameterized regression test `test_link_all_prunes_removed_package_from_virtual_store` covers both `use_gvs={false, true}` so both directory and symlink entry types are exercised.
- [x] Asserts `.aube/` itself survives the sweep.
- [x] `cargo test -p aube-linker --release` — 62/62 pass.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## Notes for reviewers

- Latent bug spotted but **not touched** in this PR: [`wipe_changed_patched_entries`](crates/aube-linker/src/lib.rs#L2519) calls `remove_dir_all` directly on `.aube/<dep_path>`, which would recurse through a gvs-mode symlink on Unix. Worth a follow-up.
- Only `link_all` is covered by the regression test; `link_workspace` uses the same helper but isn't exercised end-to-end. Low risk since the call sites are identical one-liners, but a monorepo fixture test would add belt-and-suspenders coverage.