### PR TITLE
resolver: allow exotic subdeps from local parents

### DIFF
--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2905,11 +2905,10 @@ fn should_block_exotic_subdep(
     block_exotic_subdeps
         && !task.is_root
         && is_non_registry_specifier(&task.range)
-        && !task
+        && task
             .parent
             .as_ref()
-            .and_then(|parent| resolved.get(parent))
-            .is_some_and(|pkg| pkg.local_source.is_some())
+            .and_then(|parent| resolved.get(parent)).is_none_or(|pkg| pkg.local_source.is_none())
 }
 
 /// Turn a raw `GitSource` (committish parsed from the user's

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2908,7 +2908,8 @@ fn should_block_exotic_subdep(
         && task
             .parent
             .as_ref()
-            .and_then(|parent| resolved.get(parent)).is_none_or(|pkg| pkg.local_source.is_none())
+            .and_then(|parent| resolved.get(parent))
+            .is_none_or(|pkg| pkg.local_source.is_none())
 }
 
 /// Turn a raw `GitSource` (committish parsed from the user's

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1315,7 +1315,11 @@ impl Resolver {
                 // falls through to the normal resolver path and fails
                 // loudly there.
                 if is_non_registry_specifier(&task.range) {
-                    if !task.is_root && self.dependency_policy.block_exotic_subdeps {
+                    if should_block_exotic_subdep(
+                        &task,
+                        &resolved,
+                        self.dependency_policy.block_exotic_subdeps,
+                    ) {
                         return Err(Error::BlockedExoticSubdep {
                             name: task.name.clone(),
                             spec: task.range.clone(),
@@ -2893,6 +2897,21 @@ fn is_non_registry_specifier(s: &str) -> bool {
     s.starts_with("file:")
 }
 
+fn should_block_exotic_subdep(
+    task: &ResolveTask,
+    resolved: &BTreeMap<String, LockedPackage>,
+    block_exotic_subdeps: bool,
+) -> bool {
+    block_exotic_subdeps
+        && !task.is_root
+        && is_non_registry_specifier(&task.range)
+        && !task
+            .parent
+            .as_ref()
+            .and_then(|parent| resolved.get(parent))
+            .is_some_and(|pkg| pkg.local_source.is_some())
+}
+
 /// Turn a raw `GitSource` (committish parsed from the user's
 /// specifier, empty `resolved`) into a fully-resolved one by running
 /// `git ls-remote`, then shallow-cloning to read the package's own
@@ -3160,7 +3179,7 @@ pub enum Error {
         catalog: String,
     },
     #[error(
-        "blocked exotic transitive dependency {name}@{spec} from {parent} (blockExoticSubdeps=true)"
+        "blocked exotic transitive dependency {name}@{spec} from {parent} (blockExoticSubdeps=true; set blockExoticSubdeps=false to allow trusted git/file/tarball subdeps)"
     )]
     BlockedExoticSubdep {
         name: String,
@@ -3211,6 +3230,61 @@ mod tests {
     #[test]
     fn dependency_policy_default_blocks_exotic_subdeps() {
         assert!(DependencyPolicy::default().block_exotic_subdeps);
+    }
+
+    #[test]
+    fn exotic_subdeps_from_local_parents_are_allowed() {
+        let task = ResolveTask {
+            name: "xlsx".to_string(),
+            range: "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz".to_string(),
+            dep_type: DepType::Production,
+            is_root: false,
+            parent: Some("pi-web-ui@file+abc123".to_string()),
+            importer: ".".to_string(),
+            original_specifier: None,
+            real_name: None,
+            ancestors: Vec::new(),
+        };
+        let mut resolved = BTreeMap::new();
+        resolved.insert(
+            "pi-web-ui@file+abc123".to_string(),
+            LockedPackage {
+                name: "pi-web-ui".to_string(),
+                version: "0.68.1".to_string(),
+                dep_path: "pi-web-ui@file+abc123".to_string(),
+                local_source: Some(LocalSource::Directory(PathBuf::from("packages/web-ui"))),
+                ..Default::default()
+            },
+        );
+
+        assert!(!should_block_exotic_subdep(&task, &resolved, true));
+    }
+
+    #[test]
+    fn exotic_subdeps_from_registry_parents_stay_blocked() {
+        let task = ResolveTask {
+            name: "xlsx".to_string(),
+            range: "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz".to_string(),
+            dep_type: DepType::Production,
+            is_root: false,
+            parent: Some("pi-web-ui@0.68.1".to_string()),
+            importer: ".".to_string(),
+            original_specifier: None,
+            real_name: None,
+            ancestors: Vec::new(),
+        };
+        let mut resolved = BTreeMap::new();
+        resolved.insert(
+            "pi-web-ui@0.68.1".to_string(),
+            LockedPackage {
+                name: "pi-web-ui".to_string(),
+                version: "0.68.1".to_string(),
+                dep_path: "pi-web-ui@0.68.1".to_string(),
+                ..Default::default()
+            },
+        );
+
+        assert!(should_block_exotic_subdep(&task, &resolved, true));
     }
 
     #[test]

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2904,11 +2904,11 @@ fn should_block_exotic_subdep(
 ) -> bool {
     block_exotic_subdeps
         && !task.is_root
-        && task
+        && !task
             .parent
             .as_ref()
             .and_then(|parent| resolved.get(parent))
-            .is_none_or(|pkg| {
+            .is_some_and(|pkg| {
                 matches!(
                     pkg.local_source,
                     Some(LocalSource::Directory(_)) | Some(LocalSource::Link(_))

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2904,12 +2904,16 @@ fn should_block_exotic_subdep(
 ) -> bool {
     block_exotic_subdeps
         && !task.is_root
-        && is_non_registry_specifier(&task.range)
         && task
             .parent
             .as_ref()
             .and_then(|parent| resolved.get(parent))
-            .is_none_or(|pkg| pkg.local_source.is_none())
+            .is_none_or(|pkg| {
+                matches!(
+                    pkg.local_source,
+                    Some(LocalSource::Directory(_)) | Some(LocalSource::Link(_))
+                )
+            })
 }
 
 /// Turn a raw `GitSource` (committish parsed from the user's
@@ -3258,6 +3262,23 @@ mod tests {
         );
 
         assert!(!should_block_exotic_subdep(&task, &resolved, true));
+    }
+
+    #[test]
+    fn exotic_subdeps_from_unknown_parents_stay_blocked() {
+        let task = ResolveTask {
+            name: "xlsx".to_string(),
+            range: "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz".to_string(),
+            dep_type: DepType::Production,
+            is_root: false,
+            parent: Some("pi-web-ui@file+missing".to_string()),
+            importer: ".".to_string(),
+            original_specifier: None,
+            real_name: None,
+            ancestors: Vec::new(),
+        };
+
+        assert!(should_block_exotic_subdep(&task, &BTreeMap::new(), true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- stop treating exotic subdependencies declared by trusted local/workspace packages as blocked transitive deps under `blockExoticSubdeps`
- keep the existing block in place for registry-sourced transitive packages and improve the user-facing error with the config override to use when the strict policy is intentional
- add resolver tests covering the allowed-local and blocked-registry cases, and verify the `pi-mono` install path end-to-end

## Repro
- `git clone https://github.com/badlogic/pi-mono && cd pi-mono && aube install`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency policy enforcement for non-registry transitive dependencies, which can affect supply-chain restrictions and install behavior. Scope is small and covered by new unit tests, but policy changes warrant careful review.
> 
> **Overview**
> Adjusts `blockExoticSubdeps` enforcement to **allow** git/file/link/tarball dependencies when they are declared transitively by *trusted local* packages (i.e., parents resolved from `LocalSource::Directory` or `LocalSource::Link`), while keeping the block for registry-sourced or unknown parents.
> 
> Adds `should_block_exotic_subdep` helper plus focused unit tests for allowed-local vs blocked-registry/unknown cases, and updates the `BlockedExoticSubdep` error text to mention setting `blockExoticSubdeps=false` to override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5ecd3abd18e868bce544bfde1027440da96f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->