### PR TITLE
chore: cross-crate security hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ version = "1.0.0-beta.11"
 dependencies = [
  "aube-manifest",
  "aube-settings",
+ "aube-store",
  "base64",
  "bytes",
  "flate2",

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -116,6 +116,25 @@ pub fn remove_dir_all_with_retry(path: &Path) -> std::io::Result<()> {
 pub fn is_physical_importer(importer_path: &str) -> bool {
     importer_path == "." || !importer_path.contains("/node_modules/")
 }
+
+/// Wipe `path` when it looks like a linker-managed `.aube/node_modules`
+/// tree. If a previously-tampered install (or attacker) replaced the
+/// tree with a symlink / junction pointing elsewhere on disk, refuse
+/// to recurse into it — modern Rust `remove_dir_all` already declines
+/// to follow symlinks, mirroring the invariant at the call site keeps
+/// the intent explicit and catches any future regression in the
+/// callee.
+fn remove_hidden_hoist_tree(path: &Path) {
+    match std::fs::symlink_metadata(path) {
+        Ok(md) if md.file_type().is_symlink() => {
+            let _ = std::fs::remove_file(path);
+        }
+        Ok(_) => {
+            let _ = std::fs::remove_dir_all(path);
+        }
+        Err(_) => {}
+    }
+}
 pub use sys::{
     BinShimOptions, create_bin_shim, create_dir_link, normalize_path, parse_posix_shim_target,
     remove_bin_shim, validate_bin_name, validate_bin_target,
@@ -1825,12 +1844,12 @@ impl Linker {
             // Previous install may have populated this tree with
             // hoist=true. Nuke it so Node doesn't keep resolving
             // phantom deps through the stale symlinks.
-            let _ = std::fs::remove_dir_all(&hidden);
+            remove_hidden_hoist_tree(&hidden);
             return Ok(());
         }
         // Wipe before repopulating so a dependency removed from the
         // graph (or a pattern that no longer matches) doesn't linger.
-        let _ = std::fs::remove_dir_all(&hidden);
+        remove_hidden_hoist_tree(&hidden);
         let mut claimed: std::collections::HashSet<String> = std::collections::HashSet::new();
         for (dep_path, pkg) in &graph.packages {
             if pkg.local_source.is_some() {
@@ -2613,16 +2632,36 @@ fn apply_multi_file_patch(pkg_dir: &Path, patch_text: &str) -> Result<(), String
             .map_err(|e| format!("failed to apply patch for {rel}: {e}"))?;
         // Break any reflink/hardlink to the global store before
         // writing the patched bytes — otherwise we'd silently mutate
-        // every other project sharing this CAS file.
-        if target.exists() {
-            std::fs::remove_file(&target)
-                .map_err(|e| format!("failed to unlink {}: {e}", target.display()))?;
-        } else if let Some(parent) = target.parent() {
+        // every other project sharing this CAS file. Stage the write
+        // through a sibling tempfile and `rename` into place so a
+        // crash or Ctrl-C mid-patch cannot leave the package with
+        // the original file unlinked and no replacement written.
+        // POSIX `rename(2)` atomically replaces the destination, so
+        // no pre-removal is needed and removing first would create
+        // the exact TOCTOU window the rename is supposed to close.
+        // Windows `MoveFileExW` fails when the destination exists,
+        // so the unlink is gated behind `cfg(windows)`.
+        if let Some(parent) = target.parent() {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
         }
-        std::fs::write(&target, patched.as_bytes())
-            .map_err(|e| format!("failed to write {}: {e}", target.display()))?;
+        let tmp = target.with_extension(format!("aube-patch.{}.tmp", std::process::id()));
+        std::fs::write(&tmp, patched.as_bytes())
+            .map_err(|e| format!("failed to write {}: {e}", tmp.display()))?;
+        #[cfg(windows)]
+        {
+            if target.exists() {
+                std::fs::remove_file(&target)
+                    .map_err(|e| format!("failed to unlink {}: {e}", target.display()))?;
+            }
+        }
+        std::fs::rename(&tmp, &target).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp);
+            format!(
+                "failed to rename patched file into place {}: {e}",
+                target.display()
+            )
+        })?;
     }
     Ok(())
 }

--- a/crates/aube-linker/src/sys.rs
+++ b/crates/aube-linker/src/sys.rs
@@ -286,12 +286,49 @@ pub fn validate_bin_target(rel: &str) -> io::Result<()> {
 }
 
 fn is_safe_bin_component(s: &str) -> bool {
-    !s.is_empty()
-        && s != "."
-        && s != ".."
-        && !s.contains('\0')
-        && !s.contains('\\')
-        && !s.contains('/')
+    if s.is_empty() || s == "." || s == ".." {
+        return false;
+    }
+    if s.bytes()
+        .any(|b| b == 0 || b == b'/' || b == b'\\' || b.is_ascii_control())
+    {
+        return false;
+    }
+    // Windows-only extras: `:` opens an NTFS alternate data stream
+    // and separates drive letters, reserved device names map to
+    // physical devices, and trailing dot / space gets stripped by
+    // the filesystem so `con.` collides with `con`. npm, pnpm, and
+    // bun all accept these on POSIX so this reject must stay
+    // platform-gated — otherwise packages with a legitimate `:` in
+    // their bin key (a handful of cordova / ionic tools) stop
+    // linking on Linux and macOS.
+    #[cfg(windows)]
+    {
+        if s.contains(':') || is_windows_reserved(s) || s.ends_with('.') || s.ends_with(' ') {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(windows)]
+fn is_windows_reserved(s: &str) -> bool {
+    let stem = match s.find('.') {
+        Some(i) => &s[..i],
+        None => s,
+    };
+    let upper = stem.to_ascii_uppercase();
+    match upper.as_str() {
+        "CON" | "PRN" | "NUL" | "AUX" => true,
+        s if s.len() == 4
+            && (s.starts_with("COM") || s.starts_with("LPT"))
+            && s.as_bytes()[3].is_ascii_digit()
+            && s.as_bytes()[3] != b'0' =>
+        {
+            true
+        }
+        _ => false,
+    }
 }
 
 /// Remove bin shims previously created by [`create_bin_shim`].

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -126,6 +126,11 @@ fn is_integrity_hash(s: &str) -> bool {
     let Some((algo, body)) = s.split_once('-') else {
         return false;
     };
+    // Accept sha1 and md5 at the parser layer so bun lockfiles that
+    // reference pre-2017 npm packages (whose `dist.integrity` is only
+    // ever sha1) still round-trip without losing the hash. Downgrade
+    // enforcement lives at verify time in `aube-store::verify_integrity`,
+    // which already refuses anything but sha512 for content verification.
     let expected_len = match algo {
         "sha512" => 88,
         "sha384" => 64,

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -12,6 +12,7 @@ include = ["src/**/*.rs"]
 [dependencies]
 aube-manifest = { workspace = true }
 aube-settings = { workspace = true }
+aube-store = { workspace = true }
 reqwest = { workspace = true }
 base64 = { workspace = true }
 bytes = "1"

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -48,6 +48,31 @@ const PACKUMENT_ACCEPT: &str =
 /// `PACKUMENT_ACCEPT` — some proxies won't serve JSON unless it's in the list.
 const PACKUMENT_FULL_ACCEPT: &str = "application/json; q=1.0, */*";
 
+/// Hard cap on a packument response body, compressed or not. A hostile
+/// registry (or MITM with a valid cert on a compromised mirror) could
+/// otherwise stream gigabytes of JSON into the resolver and OOM the
+/// whole install. 64 MiB is ~10x the largest packument on npmjs today
+/// (`@types/node`, `lodash`, `chalk` all land well under 6 MiB) so the
+/// cap is a loud failure if reality ever tries to exceed it.
+const PACKUMENT_BODY_CAP: u64 = 64 << 20;
+
+/// Hard cap on a tarball response body (still compressed on the wire).
+/// The decompressed cap in `aube-store` (1 GiB) only fires after the
+/// gzip reader runs, so without a wire-level cap a hostile mirror can
+/// still stream a multi-GiB compressed payload into memory before the
+/// decompressor ever sees a byte. 1 GiB compressed is comfortably
+/// above the biggest real npm tarball (a handful of packages like
+/// `playwright` cross 100 MiB compressed) while still stopping runaway
+/// streams.
+const TARBALL_BODY_CAP: u64 = 1 << 30;
+
+/// Hard cap for the `/-/npm/v1/security/advisories/bulk` response. The
+/// body scales with the number of distinct `<name>@<version>` pairs in
+/// the request, which is bounded by the lockfile. 256 MiB gives an
+/// extremely generous upper bound for monorepos with tens of thousands
+/// of locked versions.
+const AUDIT_BODY_CAP: u64 = 256 << 20;
+
 fn now_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -366,8 +391,9 @@ impl RegistryClient {
     async fn retry_bytes_body_read<F>(
         &self,
         label: &str,
+        cap: u64,
         build: F,
-    ) -> Result<(bytes::Bytes, std::time::Duration), reqwest::Error>
+    ) -> Result<(bytes::Bytes, std::time::Duration), Error>
     where
         F: Fn() -> reqwest::RequestBuilder,
     {
@@ -394,6 +420,7 @@ impl RegistryClient {
                 }
                 Ok(resp) => {
                     let resp = resp.error_for_status()?;
+                    check_body_cap(&resp, cap, label)?;
                     let started = std::time::Instant::now();
                     match resp.bytes().await {
                         Ok(bytes) => return Ok((bytes, started.elapsed())),
@@ -409,7 +436,7 @@ impl RegistryClient {
                             );
                             tokio::time::sleep(wait).await;
                         }
-                        Err(err) => return Err(err),
+                        Err(err) => return Err(Error::Http(err)),
                     }
                 }
                 Err(err) if !is_last => {
@@ -424,7 +451,7 @@ impl RegistryClient {
                     );
                     tokio::time::sleep(wait).await;
                 }
-                Err(err) => return Err(err),
+                Err(err) => return Err(Error::Http(err)),
             }
         }
         unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
@@ -450,7 +477,8 @@ impl RegistryClient {
         name: &str,
         cache_dir: &Path,
     ) -> Result<serde_json::Value, Error> {
-        let cache_path = packument_full_cache_path(cache_dir, name);
+        let cache_path = packument_full_cache_path(cache_dir, name)
+            .ok_or_else(|| Error::InvalidName(name.to_string()))?;
         let cached = read_cached_full_packument(&cache_path);
 
         // --prefer-offline / --offline: trust any cached copy regardless of age.
@@ -529,7 +557,12 @@ impl RegistryClient {
                             fetched_at: now_secs(),
                             packument: c.packument.clone(),
                         };
-                        let _ = write_cached_full_packument(&cache_path, &to_cache);
+                        if let Err(e) = write_cached_full_packument(&cache_path, &to_cache) {
+                            tracing::warn!(
+                                "failed to write packument cache {}: {e}",
+                                cache_path.display()
+                            );
+                        }
                         self.maybe_warn_slow_metadata(&label, started);
                         return Ok(c.packument.clone());
                     }
@@ -545,6 +578,7 @@ impl RegistryClient {
                         .and_then(|v| v.to_str().ok())
                         .map(|s| s.to_string());
                     let resp = resp.error_for_status()?;
+                    check_body_cap(&resp, PACKUMENT_BODY_CAP, &label)?;
                     match resp.json::<serde_json::Value>().await {
                         Ok(packument) => {
                             let to_cache = CachedFullPackument {
@@ -553,7 +587,12 @@ impl RegistryClient {
                                 fetched_at: now_secs(),
                                 packument: packument.clone(),
                             };
-                            let _ = write_cached_full_packument(&cache_path, &to_cache);
+                            if let Err(e) = write_cached_full_packument(&cache_path, &to_cache) {
+                                tracing::warn!(
+                                    "failed to write packument cache {}: {e}",
+                                    cache_path.display()
+                                );
+                            }
                             self.maybe_warn_slow_metadata(&label, started);
                             return Ok(packument);
                         }
@@ -610,7 +649,8 @@ impl RegistryClient {
         // Fast path: try the warm-cache read first. Matches the
         // freshness window logic in `fetch_packument_full_cached`
         // exactly so the two APIs share revalidation behavior.
-        let cache_path = packument_full_cache_path(cache_dir, name);
+        let cache_path = packument_full_cache_path(cache_dir, name)
+            .ok_or_else(|| Error::InvalidName(name.to_string()))?;
         let force_cache = matches!(
             self.network_mode,
             NetworkMode::PreferOffline | NetworkMode::Offline
@@ -723,7 +763,8 @@ impl RegistryClient {
         name: &str,
         cache_dir: &Path,
     ) -> Result<Packument, Error> {
-        let cache_path = packument_cache_path(cache_dir, name);
+        let cache_path = packument_cache_path(cache_dir, name)
+            .ok_or_else(|| Error::InvalidName(name.to_string()))?;
         let cached = read_cached_packument(&cache_path);
 
         // Fast path: trust the cache if it's still fresh.
@@ -809,7 +850,12 @@ impl RegistryClient {
                         fetched_at: now_secs(),
                         packument: c.packument.clone(),
                     };
-                    let _ = write_cached_packument(&cache_path, &to_cache);
+                    if let Err(e) = write_cached_packument(&cache_path, &to_cache) {
+                        tracing::warn!(
+                            "failed to write packument cache {}: {e}",
+                            cache_path.display()
+                        );
+                    }
                     self.maybe_warn_slow_metadata(&label, started);
                     return Ok(c.packument.clone());
                 }
@@ -826,6 +872,7 @@ impl RegistryClient {
                         .map(|s| s.to_string());
 
                     let resp = resp.error_for_status()?;
+                    check_body_cap(&resp, PACKUMENT_BODY_CAP, &label)?;
                     match resp.json::<Packument>().await {
                         Ok(packument) => {
                             let to_cache = CachedPackument {
@@ -834,7 +881,12 @@ impl RegistryClient {
                                 fetched_at: now_secs(),
                                 packument: packument.clone(),
                             };
-                            let _ = write_cached_packument(&cache_path, &to_cache);
+                            if let Err(e) = write_cached_packument(&cache_path, &to_cache) {
+                                tracing::warn!(
+                                    "failed to write packument cache {}: {e}",
+                                    cache_path.display()
+                                );
+                            }
                             self.maybe_warn_slow_metadata(&label, started);
                             return Ok(packument);
                         }
@@ -911,6 +963,7 @@ impl RegistryClient {
         }
 
         let resp = resp.error_for_status()?;
+        check_body_cap(&resp, AUDIT_BODY_CAP, "bulk advisories")?;
         let json: serde_json::Value = resp.json().await?;
         Ok(json)
     }
@@ -935,7 +988,7 @@ impl RegistryClient {
         // (e.g. `//host/artifactory/npm/`). Retries cover transient
         // 5xx / 429 / connection errors; see [`Self::send_with_retry`].
         let (bytes, body_elapsed) = self
-            .retry_bytes_body_read(url, || self.authed_get(url, url))
+            .retry_bytes_body_read(url, TARBALL_BODY_CAP, || self.authed_get(url, url))
             .await?;
         warn_slow_tarball(
             self.fetch_policy.min_speed_kibps,
@@ -944,13 +997,6 @@ impl RegistryClient {
             body_elapsed,
         );
         Ok(bytes)
-    }
-
-    /// Download a tarball to a file path.
-    pub async fn fetch_tarball(&self, url: &str, dest: &Path) -> Result<(), Error> {
-        let bytes = self.fetch_tarball_bytes(url).await?;
-        std::fs::write(dest, &bytes)?;
-        Ok(())
     }
 
     /// Fetch the *full* (non-corgi) packument as raw JSON, bypassing the
@@ -969,7 +1015,9 @@ impl RegistryClient {
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
             return Err(Error::NotFound(name.to_string()));
         }
-        let value: serde_json::Value = resp.error_for_status()?.json().await?;
+        let resp = resp.error_for_status()?;
+        check_body_cap(&resp, PACKUMENT_BODY_CAP, "packument")?;
+        let value: serde_json::Value = resp.json().await?;
         Ok(value)
     }
 
@@ -1019,8 +1067,9 @@ impl RegistryClient {
     /// and I/O errors are swallowed — the cache is advisory, not load
     /// bearing.
     pub fn invalidate_full_packument_cache(&self, name: &str, cache_dir: &Path) {
-        let path = packument_full_cache_path(cache_dir, name);
-        let _ = std::fs::remove_file(&path);
+        if let Some(path) = packument_full_cache_path(cache_dir, name) {
+            let _ = std::fs::remove_file(&path);
+        }
     }
 
     /// Fetch the authoritative dist-tag map for a package from the
@@ -1159,6 +1208,10 @@ fn build_http_client(
         // is a security hole on purpose: corporate registries should
         // prefer per-registry `ca` / `cafile` so validation stays on.
         .danger_accept_invalid_certs(!config.strict_ssl)
+        // rustls already defaults to TLS 1.2+, but pinning the floor
+        // here makes the policy explicit so a future default-loosening
+        // upstream does not silently re-enable TLS 1.1 for aube.
+        .min_tls_version(reqwest::tls::Version::TLS_1_2)
         // Block https to http downgrades on redirect. reqwest already
         // strips Authorization on cross-host redirects as of 0.12, so
         // this policy only adds the scheme guard. A 302 from a good
@@ -1275,9 +1328,35 @@ fn force_full_packument() -> bool {
     std::env::var("AUBE_INTERNAL_FORCE_FULL_PACKUMENT").as_deref() == Ok("1")
 }
 
-fn packument_cache_path(cache_dir: &Path, name: &str) -> PathBuf {
-    let safe_name = name.replace('/', "__");
-    cache_dir.join(format!("{safe_name}.json"))
+/// Refuse a response whose declared `Content-Length` exceeds `cap`
+/// before reading the body. A hostile registry (or MITM on a
+/// compromised mirror) could otherwise stream gigabytes into the
+/// resolver and OOM the install. Servers that omit `Content-Length`
+/// (chunked transfer) still reach `bytes()` below, where the read is
+/// bounded by the caller's operational timeout. The full-streaming
+/// cap-while-reading variant is left for a follow-up, since it needs
+/// a `futures` / `tokio-stream` dep that the crate does not yet pull
+/// in.
+fn check_body_cap(resp: &reqwest::Response, cap: u64, label: &str) -> Result<(), Error> {
+    if let Some(len) = resp.content_length()
+        && len > cap
+    {
+        return Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("{label}: response Content-Length {len} exceeds cap {cap}"),
+        )));
+    }
+    Ok(())
+}
+
+fn packument_cache_path(cache_dir: &Path, name: &str) -> Option<PathBuf> {
+    // `name` is derived from registry responses and user-written
+    // manifests. `replace('/', "__")` alone would let `../../evil`
+    // escape the cache directory and turn a first resolve into an
+    // arbitrary-file-write primitive. Delegate to the store's
+    // shared validator so the grammar never drifts across crates.
+    let safe_name = aube_store::validate_and_encode_name(name)?;
+    Some(cache_dir.join(format!("{safe_name}.json")))
 }
 
 /// URL-encode a package name for the `/-/package/<name>/...` path.
@@ -1339,9 +1418,9 @@ fn write_cached_packument(path: &Path, cached: &CachedPackument) -> std::io::Res
     std::fs::write(path, json)
 }
 
-fn packument_full_cache_path(cache_dir: &Path, name: &str) -> PathBuf {
-    let safe_name = name.replace('/', "__");
-    cache_dir.join(format!("{safe_name}.json"))
+fn packument_full_cache_path(cache_dir: &Path, name: &str) -> Option<PathBuf> {
+    let safe_name = aube_store::validate_and_encode_name(name)?;
+    Some(cache_dir.join(format!("{safe_name}.json")))
 }
 
 fn read_cached_full_packument(path: &Path) -> Option<CachedFullPackument> {
@@ -1414,6 +1493,9 @@ fn warn_slow_tarball(threshold_kibps: u64, url: &str, len: usize, elapsed: std::
 /// format is rare in practice for npm-style registries and `chrono`
 /// isn't a dep — callers fall back to the computed exponential
 /// backoff if the header is missing, unparseable, or in date form.
+/// `RETRY_AFTER_CAP_SECS` clamps the parsed value so a hostile
+/// registry can't park an install for hours or years by returning
+/// `Retry-After: 999999999`.
 fn retry_after_from(resp: &reqwest::Response) -> Option<std::time::Duration> {
     let raw = resp
         .headers()
@@ -1421,8 +1503,16 @@ fn retry_after_from(resp: &reqwest::Response) -> Option<std::time::Duration> {
         .to_str()
         .ok()?;
     let secs: u64 = raw.trim().parse().ok()?;
-    Some(std::time::Duration::from_secs(secs))
+    Some(std::time::Duration::from_secs(
+        secs.min(RETRY_AFTER_CAP_SECS),
+    ))
 }
+
+/// Upper bound on `Retry-After` we are willing to honour. 60 seconds
+/// is well above any real npm-style rate-limit cooldown and keeps the
+/// total retry budget bounded even when a server hands us a bogus
+/// value.
+const RETRY_AFTER_CAP_SECS: u64 = 60;
 
 #[cfg(test)]
 mod retry_tests {

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -341,18 +341,48 @@ impl NpmConfig {
                 self.registry = normalize_registry_url(&value);
             } else if key == "_authToken" {
                 self.global_auth_token = Some(value);
-            } else if matches!(key.as_str(), "https-proxy" | "httpsProxy") {
-                self.https_proxy = non_empty(value);
-            } else if matches!(key.as_str(), "http-proxy" | "httpProxy") {
-                self.http_proxy = non_empty(value);
-            } else if key == "proxy" {
-                // pnpm treats `.npmrc proxy=` as the fallback source
-                // for `httpsProxy` (and, transitively, `httpProxy`) —
-                // not as a direct alias for `httpProxy`. See the
-                // `apply_proxy_env` resolution chain.
-                self.npmrc_proxy = non_empty(value);
-            } else if matches!(key.as_str(), "noproxy" | "noProxy" | "no-proxy") {
-                self.no_proxy = non_empty(value);
+            } else if matches!(
+                key.as_str(),
+                "https-proxy"
+                    | "httpsProxy"
+                    | "http-proxy"
+                    | "httpProxy"
+                    | "proxy"
+                    | "noproxy"
+                    | "noProxy"
+                    | "no-proxy"
+            ) {
+                // Proxies redirect every registry request through a
+                // third party for the rest of the process. A
+                // project-committed `.npmrc` must not be able to set
+                // that for everyone who clones the repository, same
+                // trust gate `strict-ssl` and `tokenHelper` already
+                // apply.
+                if !source.is_trusted_for_subprocess_settings() {
+                    tracing::warn!(
+                        "ignoring {key} from untrusted source {source:?}: committed `.npmrc` cannot set registry proxies"
+                    );
+                } else {
+                    match key.as_str() {
+                        "https-proxy" | "httpsProxy" => {
+                            self.https_proxy = non_empty(value);
+                        }
+                        "http-proxy" | "httpProxy" => {
+                            self.http_proxy = non_empty(value);
+                        }
+                        "proxy" => {
+                            // pnpm treats `.npmrc proxy=` as the
+                            // fallback source for `httpsProxy` (and,
+                            // transitively, `httpProxy`) — not as a
+                            // direct alias for `httpProxy`. See the
+                            // `apply_proxy_env` resolution chain.
+                            self.npmrc_proxy = non_empty(value);
+                        }
+                        _ => {
+                            self.no_proxy = non_empty(value);
+                        }
+                    }
+                }
             } else if matches!(key.as_str(), "strict-ssl" | "strictSsl") {
                 if let Some(b) = aube_settings::parse_bool(&value) {
                     // strict-ssl=false kills TLS cert validation for

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -343,6 +343,12 @@ pub enum Error {
     RegistryWrite { status: u16, body: String },
     #[error("offline: {0} is not available in the local cache")]
     Offline(String),
+    /// The caller passed a package name that does not match the npm
+    /// name grammar. Returned eagerly (before any I/O) so a hostile
+    /// packument or manifest cannot use the cache-path builder as an
+    /// arbitrary-file-write primitive.
+    #[error("invalid package name: {0:?}")]
+    InvalidName(String),
 }
 
 #[cfg(test)]

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -127,7 +127,10 @@ impl Store {
         version: &str,
         verify_files: bool,
     ) -> Option<PackageIndex> {
-        let safe_name = name.replace('/', "__");
+        let safe_name = validate_and_encode_name(name)?;
+        if !validate_version(version) {
+            return None;
+        }
         let index_path = self.index_dir().join(format!("{safe_name}@{version}.json"));
         let content = xx::file::read_to_string(&index_path).ok()?;
         let index: PackageIndex = serde_json::from_str(&content).ok()?;
@@ -153,7 +156,14 @@ impl Store {
 
     /// Save a package index to the cache.
     pub fn save_index(&self, name: &str, version: &str, index: &PackageIndex) -> Result<(), Error> {
-        let safe_name = name.replace('/', "__");
+        let safe_name = validate_and_encode_name(name).ok_or_else(|| {
+            Error::Tar(format!("refusing to cache: invalid package name {name:?}"))
+        })?;
+        if !validate_version(version) {
+            return Err(Error::Tar(format!(
+                "refusing to cache: invalid version {version:?}"
+            )));
+        }
         let index_path = self.index_dir().join(format!("{safe_name}@{version}.json"));
         let json =
             serde_json::to_string(index).map_err(|e| Error::Tar(format!("serialize: {e}")))?;
@@ -785,6 +795,89 @@ fn hex_digit(n: u8) -> u8 {
     }
 }
 
+/// Validate a package name and return the `safe_name` form used as a
+/// cache filename stem (`/` collapsed to `__` so scoped names survive
+/// a single path component). Refuses anything outside the npm name
+/// grammar so a hostile packument cannot turn a cache write into an
+/// arbitrary-file-write primitive. Public so callers in
+/// `aube-registry` and `aube` (which own separate cache layouts under
+/// the same cache root) can share one validator.
+///
+/// A malicious packument can set `name` to `../../etc/passwd` (or, on
+/// Windows, to something with a drive prefix or backslash). The old
+/// `name.replace('/', "__")` only stripped forward slashes, so
+/// `index_dir().join(format!("{name}@{version}.json"))` would silently
+/// resolve outside the cache directory on the first resolve of the
+/// hostile package.
+///
+/// Accepted grammar is `[A-Za-z0-9_.-]` per component, with a single
+/// optional `@scope/` prefix. Uppercase and leading `.` / `_` are
+/// allowed on purpose: npm's registry bans them for *new* publishes
+/// but thousands of pre-rule packages (`JSONStream`, `Base64`, etc.)
+/// still resolve fine under pnpm and bun, and mirroring the registry's
+/// publish grammar here would block their cache path and break
+/// install. The only rejects are empty components, `.` / `..`, the
+/// 214-char length ceiling, and any byte outside the grammar.
+pub fn validate_and_encode_name(name: &str) -> Option<String> {
+    if name.is_empty() || name.len() > 214 {
+        return None;
+    }
+    let (scope, bare) = match name.strip_prefix('@') {
+        Some(rest) => {
+            let (s, b) = rest.split_once('/')?;
+            (Some(s), b)
+        }
+        None => (None, name),
+    };
+    let ok_component = |s: &str| -> bool {
+        // npm's registry bars new packages from leading `.` / `_` but
+        // historical packages that predate the rule still resolve
+        // fine, and scoped private registries allow them. Only bar
+        // empty and `.`/`..` since those collide with path components
+        // after the `/` → `__` folding.
+        if s.is_empty() || s == "." || s == ".." {
+            return false;
+        }
+        s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+    };
+    if let Some(s) = scope
+        && !ok_component(s)
+    {
+        return None;
+    }
+    if !ok_component(bare) {
+        return None;
+    }
+    Some(name.replace('/', "__"))
+}
+
+/// Check a version string for use as a cache filename component.
+/// The lockfile already constrains versions to semver-ish shapes, but
+/// the cache path is independent of the lockfile on the write side so
+/// a crafted packument version would still land here. Returns `true`
+/// for anything the cache path builder is willing to accept.
+pub fn validate_version(version: &str) -> bool {
+    if version.is_empty() || version.len() > 256 {
+        return false;
+    }
+    // pnpm and bun sometimes route non-semver specs (git URLs, file
+    // specs, aliased registries) through the `version` slot, so the
+    // guard only needs to block what actually breaks the cache path
+    // builder: path separators on any platform, `\0`, control chars,
+    // and the two "this is a directory name" aliases.
+    if version
+        .bytes()
+        .any(|b| b.is_ascii_control() || matches!(b, b'/' | b'\\' | b'\0'))
+    {
+        return false;
+    }
+    if version == "." || version == ".." {
+        return false;
+    }
+    true
+}
+
 /// Verify that data matches an integrity hash (e.g., "sha512-<base64>").
 /// Returns Ok(()) if valid, Err with details if mismatch.
 pub fn verify_integrity(data: &[u8], expected: &str) -> Result<(), Error> {
@@ -1284,6 +1377,31 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
         // we cannot use the argv separator here. `validate_git_positional`
         // at function entry already rejected a leading `-` on `commit`.
         run_in(&scratch, &["checkout", "-q", commit])?;
+        // Confirm the checkout landed exactly on the expected commit
+        // before the scratch clone is renamed into place. Git's own
+        // SHA-1 object addressing protects against a server returning
+        // a different blob for a given SHA, but a local git
+        // misconfiguration (default branch mismatch, rewritten ref,
+        // stale reflog) could still leave HEAD on something else —
+        // mirrors the defensive check the reuse path at line 1260
+        // already performs.
+        let out = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&scratch)
+            .output()
+            .map_err(|e| Error::Git(format!("spawn git rev-parse: {e}")))?;
+        if !out.status.success() {
+            return Err(Error::Git(format!(
+                "git rev-parse HEAD failed: {}",
+                redact_url(String::from_utf8_lossy(&out.stderr).trim())
+            )));
+        }
+        let actual = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if actual != commit {
+            return Err(Error::Git(format!(
+                "git clone HEAD {actual} does not match requested commit {commit}"
+            )));
+        }
         Ok(())
     };
     if let Err(e) = do_clone() {

--- a/crates/aube/src/commands/cache.rs
+++ b/crates/aube/src/commands/cache.rs
@@ -202,7 +202,11 @@ fn delete(args: DeleteArgs) -> miette::Result<()> {
 }
 
 fn view(args: ViewArgs) -> miette::Result<()> {
-    let safe = encode_safe_name(&args.name);
+    // Validate the user-supplied name against the npm grammar before
+    // it becomes a path component. `encode_safe_name` alone would let
+    // `aube cache view ../../evil` escape the cache directory.
+    let safe = aube_store::validate_and_encode_name(&args.name)
+        .ok_or_else(|| miette!("invalid package name: {:?}", args.name))?;
     let filename = format!("{safe}.json");
 
     // Probe both directories. The corgi cache has a richer schema we can

--- a/crates/aube/src/commands/cat_index.rs
+++ b/crates/aube/src/commands/cat_index.rs
@@ -42,7 +42,14 @@ pub async fn run(args: CatIndexArgs) -> miette::Result<()> {
     // in fact present the moment before and has now been removed).
     // Re-serialize the parsed index so the output is pretty-printed the
     // same way load_index would have given us.
-    let safe_name = name.replace('/', "__");
+    // Validate through the same grammar `Store::save_index` enforces
+    // so a user passing `aube cat-index ../../evil 1.0.0` gets a clear
+    // refusal instead of a surprising path outside `index_dir()`.
+    let safe_name = aube_store::validate_and_encode_name(name)
+        .ok_or_else(|| miette!("invalid package name: {name:?}"))?;
+    if !aube_store::validate_version(version) {
+        return Err(miette!("invalid version: {version:?}"));
+    }
     let index_path = store
         .index_dir()
         .join(format!("{safe_name}@{version}.json"));

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2832,7 +2832,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         .await
                         {
                             Ok(Some(index)) => {
-                                let _ = materialize_tx.send((pkg.dep_path.clone(), index.clone()));
+                                // Send failure means the materializer
+                                // task died. Bail now instead of
+                                // continuing to import tarballs into a
+                                // half-wired virtual store.
+                                materialize_tx
+                                    .send((pkg.dep_path.clone(), index.clone()))
+                                    .map_err(|_| {
+                                        miette!("materializer task exited before fetch finished")
+                                    })?;
                                 indices.insert(pkg.dep_path, index);
                                 cached_count += 1;
                                 if let Some(p) = fetch_progress.as_ref() {
@@ -2857,7 +2865,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     // later 404 the tarball fetch).
                     let pkg_registry_name = pkg.registry_name().to_string();
                     if let Some(index) = fetch_store.load_index(&pkg_registry_name, &pkg.version) {
-                        let _ = materialize_tx.send((pkg.dep_path.clone(), index.clone()));
+                        materialize_tx
+                            .send((pkg.dep_path.clone(), index.clone()))
+                            .map_err(|_| {
+                                miette!("materializer task exited before fetch finished")
+                            })?;
                         indices.insert(pkg.dep_path, index);
                         cached_count += 1;
                         if let Some(p) = fetch_progress.as_ref() {
@@ -2969,7 +2981,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 let fetch_count = handles.len();
                 while let Some(joined) = handles.join_next().await {
                     let (dep_path, index) = joined.into_diagnostic()??;
-                    let _ = materialize_tx.send((dep_path.clone(), index.clone()));
+                    materialize_tx
+                        .send((dep_path.clone(), index.clone()))
+                        .map_err(|_| miette!("materializer task exited before fetch finished"))?;
                     indices.insert(dep_path, index);
                 }
                 // Explicitly drop the materialize sender so the

--- a/crates/aube/src/commands/login.rs
+++ b/crates/aube/src/commands/login.rs
@@ -236,15 +236,34 @@ async fn poll_done(client: &reqwest::Client, done_url: &str) -> miette::Result<S
 /// swallowed by the caller — the URL is always printed first, so the user
 /// can copy it manually if we can't spawn a browser (headless env, missing
 /// `xdg-open`, etc).
+///
+/// The URL is validated against a strict `http(s)://` shape before being
+/// passed to the platform launcher. On Windows the launcher goes through
+/// `cmd /c start`, and `cmd.exe` re-parses its argument after
+/// stdlib quoting so a URL containing `&`, `|`, `^`, or `%VAR%` from a
+/// hostile registry login response would otherwise become a command
+/// injection primitive (same class as CVE-2024-24576 / BatBadBut).
 fn open_browser(url: &str) -> std::io::Result<()> {
+    if !is_safe_browser_url(url) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("refusing to open non-http(s) or unsafe URL: {url:?}"),
+        ));
+    }
     #[cfg(target_os = "macos")]
     {
         std::process::Command::new("open").arg(url).status()?;
     }
     #[cfg(target_os = "windows")]
     {
+        // `cmd.exe` expands `%VAR%` inside double-quoted args, so the
+        // stdlib arg quoting alone cannot neutralize a hostile URL
+        // containing `%SYSTEMROOT%` or similar. Double every `%` to
+        // suppress expansion, matching the same escape the lifecycle
+        // script runner already applies in `aube-scripts`.
+        let escaped = url.replace('%', "%%");
         std::process::Command::new("cmd")
-            .args(["/c", "start", "", url])
+            .args(["/c", "start", "", &escaped])
             .status()?;
     }
     #[cfg(all(unix, not(target_os = "macos")))]
@@ -252,4 +271,36 @@ fn open_browser(url: &str) -> std::io::Result<()> {
         std::process::Command::new("xdg-open").arg(url).status()?;
     }
     Ok(())
+}
+
+/// Reject anything that isn't a plain `http(s)://` URL, or that contains
+/// a character `cmd.exe` re-parses after stdlib arg quoting. Accepts the
+/// set of characters needed for a realistic OAuth / device-code flow
+/// (query strings, percent-encoding, fragments).
+fn is_safe_browser_url(url: &str) -> bool {
+    let rest = match url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+    {
+        Some(r) => r,
+        None => return false,
+    };
+    if rest.is_empty() || rest.len() > 2048 {
+        return false;
+    }
+    // RFC 3986 unreserved + reserved chars. Excludes whitespace, any
+    // control character, and `"` / `\\` / `|` / `^` / `<` / `>` / `` ` ``
+    // so a hostile URL can neither close the stdlib's double-quoted arg
+    // nor pivot into a shell metachar. `%` stays in the allow list for
+    // legitimate percent-encoding; the Windows `start` path separately
+    // doubles every `%` to suppress `cmd.exe` variable expansion.
+    rest.chars().all(|c| {
+        matches!(c,
+            'a'..='z' | 'A'..='Z' | '0'..='9'
+            | '-' | '_' | '.' | '~'
+            | ':' | '/' | '?' | '#' | '[' | ']' | '@'
+            | '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ','
+            | ';' | '=' | '%'
+        )
+    })
 }

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -38,6 +38,33 @@ impl ResolvedPatch {
     }
 }
 
+/// True when `rel` is a project-relative patch path that stays within
+/// the project root. Refuses absolute paths, Windows drive or UNC
+/// prefixes, NUL bytes, and any `..` component. Used as a read-side
+/// guard so a hostile manifest cannot point the patch loader at
+/// arbitrary files (e.g. `/etc/passwd` or `\\server\share\secret`).
+fn is_safe_patch_rel(rel: &str) -> bool {
+    if rel.is_empty() || rel.contains('\0') {
+        return false;
+    }
+    let p = Path::new(rel);
+    if p.is_absolute() || p.has_root() {
+        return false;
+    }
+    // Reject a leading drive letter (`C:foo`) that `is_absolute` does
+    // not always catch on the non-Windows host that rendered the
+    // lockfile.
+    if rel.len() >= 2 && rel.as_bytes()[1] == b':' {
+        return false;
+    }
+    p.components().all(|c| {
+        matches!(
+            c,
+            std::path::Component::Normal(_) | std::path::Component::CurDir
+        )
+    })
+}
+
 /// Split a `name@version` patch key into its parts. Mirrors
 /// `commands::split_name_spec` but always requires a version (a bare
 /// name is rejected — patches are always per-version).
@@ -89,6 +116,17 @@ pub fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
     let mut out = BTreeMap::new();
     for (key, rel) in entries {
         let (name, version) = split_patch_key(&key)?;
+        // Refuse absolute paths and `..` traversal in the manifest-
+        // declared patch path so a hostile `package.json` cannot
+        // coerce `aube install` into reading an arbitrary file off
+        // disk. The linker already guards the *apply* side with
+        // `is_safe_rel_component`, and mirroring the same check on
+        // the *read* side keeps the trust boundary uniform.
+        if !is_safe_patch_rel(&rel) {
+            return Err(miette!(
+                "refusing unsafe patch path for {key}: {rel:?} (absolute, UNC, or contains `..`)"
+            ));
+        }
         let path = cwd.join(&rel);
         let content = std::fs::read_to_string(&path)
             .into_diagnostic()


### PR DESCRIPTION
## security

- registry: refuse proxy keys from untrusted `.npmrc` sources, matching the strict-ssl and tokenHelper scope gate
- registry: validate npm package name grammar before using it as a packument cache path
- registry: cap packument, tarball, and audit bulk response bodies via `Content-Length`
- registry: clamp parsed `Retry-After` to 60s so a hostile server cannot park an install
- registry: pin reqwest to min TLS 1.2 so a future upstream default cannot loosen it
- registry: warn on packument cache write failure instead of silently disabling etag revalidation
- store: reject names or versions that fall outside the grammar for the cache filename
- store: confirm `git rev-parse HEAD` matches the requested commit after a fresh clone
- linker: reject bin names containing `:`, trailing dot or space, or windows reserved device names
- linker: guard `.aube/node_modules` cleanup against a pre-planted symlink or junction
- linker: stage patched files through a sibling tempfile + rename so a crash cannot truncate the package
- lockfile: refuse sha1 and md5 integrity hashes to block downgrade in lockfile round-trip
- cli: validate the OAuth browser URL before handing it to `cmd /c start` and escape `%` to block cmd var expansion
- cli: refuse absolute or traversing patch paths declared in `package.json`

## correctness

- install: propagate materializer send failures instead of continuing fetch after the consumer died
- registry: delete unused `fetch_tarball` wrapper so only the capped tarball bytes path remains