### PR TITLE
store: skip pkg-content version check for URL-shaped lockfile entries

### DIFF
--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -856,7 +856,19 @@ pub fn validate_pkg_content(
         .strip_prefix('v')
         .filter(|rest| rest.starts_with(|c: char| c.is_ascii_digit()))
         .unwrap_or(actual_version);
-    if actual_name != expected_name || actual_version_normalized != expected_version {
+    // pnpm v9 lockfiles key git-hosted deps by the codeload tarball URL
+    // (or a `git+<url>#<commit>` form) in the `version` slot of the
+    // dep_path — that URL is what the resolver hands us as
+    // `expected_version`, and it can't meaningfully be compared to the
+    // tarball's real semver. pnpm scopes its equivalent check to
+    // registry sources; do the same by dropping the version comparison
+    // (but still checking the name) whenever `expected_version` isn't
+    // semver-shaped.
+    let expected_is_url_or_ref = expected_version.contains("://")
+        || expected_version.starts_with("git+")
+        || expected_version.starts_with("file:");
+    let version_matches = expected_is_url_or_ref || actual_version_normalized == expected_version;
+    if actual_name != expected_name || !version_matches {
         // Only carry the *actual* coordinate the tarball declared.
         // Every caller wraps the error with the expected
         // `{name}@{version}: ` prefix (mirroring the Error::Integrity
@@ -1547,6 +1559,22 @@ mod tests {
         let store = Store::at(dir.path().join("files"));
         let index = index_with_manifest(&store, "@upstash/ratelimit", "v2.0.8");
         assert!(validate_pkg_content(&index, "@upstash/ratelimit", "2.0.8").is_ok());
+    }
+
+    #[test]
+    fn test_validate_pkg_content_skips_version_for_url_shaped_expected() {
+        // pnpm v9 lockfiles key github-hosted deps by the codeload
+        // tarball URL in the version slot; the tarball's real semver
+        // will never match it. Skip the version comparison for
+        // non-semver expected values, but still enforce the name.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        let index = index_with_manifest(&store, "datejs", "1.0.0-rc3");
+        let url = "https://codeload.github.com/PruvoNet/datejs/tar.gz/e2cde1e";
+        assert!(validate_pkg_content(&index, "datejs", url).is_ok());
+        // Name mismatch still rejects.
+        let err = validate_pkg_content(&index, "evil", url).unwrap_err();
+        assert!(err.to_string().contains("content mismatch"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- pnpm v9 lockfiles encode git-hosted deps (e.g. `"datejs": "github:PruvoNet/datejs#v1.0.0-rc6"`) by putting the codeload tarball URL in the `version` slot of the snapshot's dep_path. aube parsed that URL out as `pkg.version` and fed it to `validate_pkg_content` as the expected version, which obviously never matches the tarball's real manifest semver — so `strictStorePkgContentCheck` rejected the install with `package.json content mismatch: tarball declares <pkg>@<real-version>`.
- pnpm scopes its equivalent check to registry sources. Mirror that: skip the version comparison (still enforce the name) whenever `expected_version` isn't semver-shaped — i.e. contains `://`, or starts with `git+` / `file:`.

## Reported via

User installed a project with `"datejs": "github:PruvoNet/datejs#v1.0.0-rc6"` and a pnpm v9 lockfile. aube errored with:

```
Error: datejs@https://codeload.github.com/PruvoNet/datejs/tar.gz/e2cde1e...:
  package.json content mismatch: tarball declares datejs@1.0.0-rc3
```

pnpm installs the same project without error because it doesn't run the check on non-semver expected versions.

## Test plan

- [x] `cargo test --release -p aube-store validate_pkg_content` (7 passed, including the new `test_validate_pkg_content_skips_version_for_url_shaped_expected` covering codeload URL + name-mismatch-still-rejects)
- [x] `cargo clippy -p aube-store --all-targets -- -D warnings` clean
- [x] Existing match / name-mismatch / version-mismatch / leading-`v` / missing-manifest / unparseable-manifest tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `strictStorePkgContentCheck` behavior by bypassing version validation for URL/ref-shaped expected versions (git/file/codeload), which could slightly reduce substitution detection for those sources but still enforces package name matching.
> 
> **Overview**
> Adjusts `validate_pkg_content` to **skip the `package.json` version comparison** when the expected version looks like a URL/ref (contains `://` or starts with `git+`/`file:`), matching pnpm v9 behavior for git-hosted dependencies whose lockfile “version” is actually a tarball URL.
> 
> Adds a unit test covering the URL-shaped expected case (accepts version mismatch but still rejects on name mismatch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 135e1c1c4ce5eff944a0159927665b4ddf450842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->