### PR TITLE
resolver: treat empty version range as `*`

### DIFF
--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -2647,7 +2647,7 @@ fn pick_version<'a>(
         range_str.to_string()
     };
 
-    let range = match node_semver::Range::parse(&effective_range) {
+    let range = match node_semver::Range::parse(normalize_range(&effective_range)) {
         Ok(r) => r,
         Err(_) => return PickResult::NoMatch,
     };
@@ -3169,10 +3169,24 @@ pub(crate) fn version_satisfies(version: &str, range_str: &str) -> bool {
     let Ok(v) = node_semver::Version::parse(version) else {
         return false;
     };
-    with_cached_range(range_str, |r| match r {
+    with_cached_range(normalize_range(range_str), |r| match r {
         Some(r) => v.satisfies(r),
         None => false,
     })
+}
+
+/// npm / pnpm / yarn all treat an empty or whitespace-only version
+/// range as equivalent to `"*"` (match any). `node_semver` rejects it
+/// with `No valid ranges could be parsed`. Normalize here so the
+/// resolver and every `version_satisfies` caller agree with the
+/// upstream registry semantics. Real-world case: `hashring@0.0.8`
+/// declares `"bisection": ""` in its dependencies.
+fn normalize_range(range_str: &str) -> &str {
+    if range_str.trim().is_empty() {
+        "*"
+    } else {
+        range_str
+    }
 }
 
 /// Thread-local `node_semver::Range` parse cache.
@@ -3350,6 +3364,16 @@ mod tests {
     fn test_version_satisfies_invalid() {
         assert!(!version_satisfies("notaversion", "^1.0.0"));
         assert!(!version_satisfies("1.0.0", "notarange"));
+    }
+
+    #[test]
+    fn test_version_satisfies_empty_range_is_any() {
+        // `hashring@0.0.8` in the wild declares `"bisection": ""`.
+        // npm / pnpm / yarn treat empty and whitespace-only ranges as
+        // `"*"`; aube must match.
+        assert!(version_satisfies("0.0.3", ""));
+        assert!(version_satisfies("99.99.99", ""));
+        assert!(version_satisfies("1.2.3", "   "));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `hashring@0.0.8` declares `"bisection": ""` in its dependencies. npm, pnpm and yarn all treat an empty (or whitespace-only) version range as `*`; aube surfaced `no version of bisection matches range \`\`` because `node_semver::Range::parse("")` errors.
- Normalize at both parse sites: `pick_version` (registry path) and `with_cached_range` (used by `version_satisfies`).
- Added a unit test covering `""` and `"   "`.

## Reproducer

```json
{
  "name": "aube-exotic-bug",
  "dependencies": { "express-brute-redis": "0.0.1" }
}
```

Chain: `express-brute-redis@0.0.1 > express-brute@0.4.2 > memcached@0.2.8 > hashring@0.0.8 > bisection` (empty range).

Before: `Error: no version of bisection matches range \`\``
After: installs cleanly.

## Test plan

- [x] `cargo test -p aube-resolver --release`
- [x] `cargo clippy -p aube-resolver --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] End-to-end install of the reproducer package.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-scoped normalization that only changes behavior for empty/whitespace ranges, plus a targeted unit test.
> 
> **Overview**
> Aligns resolver semantics with npm/pnpm/yarn by treating empty or whitespace-only version ranges as `"*"` (match any), avoiding `node_semver` parse failures seen in real-world packages.
> 
> This normalization is applied both when selecting a version from a packument (`pick_version`) and when checking constraints via `version_satisfies`/range cache, and adds a unit test covering `""` and whitespace ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340b771f6eddb2ff1f654d3878f92c9a34b9bd7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->