### PR TITLE
cli: raise RLIMIT_NOFILE soft limit at startup

### DIFF
--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -641,6 +641,7 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
     let settings = load_startup_settings()?;
     let effective_level = resolve_loglevel(&cli, settings.loglevel.as_deref());
     init_logging(&cli, effective_level);
+    raise_nofile_limit();
 
     // `--silent` suppresses non-error stderr output from every command,
     // including the ~230 direct `eprintln!` calls in command bodies. The
@@ -1175,6 +1176,53 @@ fn parse_color_mode(raw: &str) -> Option<ColorMode> {
         _ => None,
     }
 }
+
+/// Raise the `RLIMIT_NOFILE` soft limit toward the hard limit on Unix.
+/// macOS defaults this to ~256 on some setups, which installs blow past
+/// during concurrent fetch + tarball-extract + materialize (one FD per
+/// CAS file open, multiplied across the tokio blocking pool and rayon
+/// linker threads). Silent no-op on Windows.
+///
+/// First try `soft = hard`. If that fails (macOS reports `rlim_max` as
+/// `RLIM_INFINITY` but the kernel still caps at `kern.maxfilesperproc`,
+/// usually 24576), retry with `OPEN_MAX = 10240` which is accepted on
+/// every stock macOS.
+#[cfg(unix)]
+fn raise_nofile_limit() {
+    // SAFETY: get/setrlimit are sync syscalls that read/write our own
+    // process's resource table. No aliasing. Failure is reported as a
+    // non-zero return and handled by the caller.
+    unsafe {
+        let mut rlim = std::mem::zeroed::<libc::rlimit>();
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
+            tracing::trace!("getrlimit(RLIMIT_NOFILE) failed; keeping default FD limit");
+            return;
+        }
+        let before = rlim.rlim_cur;
+        if before >= rlim.rlim_max {
+            tracing::trace!("RLIMIT_NOFILE soft={before} already at hard limit");
+            return;
+        }
+        let hard = rlim.rlim_max;
+        rlim.rlim_cur = hard;
+        if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) == 0 {
+            tracing::trace!("raised RLIMIT_NOFILE soft {before} -> {hard}");
+            return;
+        }
+        rlim.rlim_cur = before.max(10240).min(hard);
+        if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) == 0 {
+            tracing::trace!(
+                "raised RLIMIT_NOFILE soft {before} -> {} (hard={hard}, fallback cap)",
+                rlim.rlim_cur
+            );
+        } else {
+            tracing::trace!("setrlimit(RLIMIT_NOFILE) failed; keeping soft={before}");
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn raise_nofile_limit() {}
 
 fn init_logging(cli: &Cli, effective_level: LogLevel) {
     let log_level = effective_level.filter();


### PR DESCRIPTION
## Summary

- Installs on macOS can hit `Too many open files (os error 24)` mid-fetch when the graph is in the thousands of packages. Reproduced via the `ret@0.1.15` import failure reported by a user on `v1.0.0-beta.11`.
- macOS often ships a soft `RLIMIT_NOFILE` of 256 while the hard limit is much higher. Concurrent tarball fetch + tokio blocking-pool extract (one CAS file open per entry in [`aube-store::import_bytes`](https://github.com/endevco/aube/blob/main/crates/aube-store/src/lib.rs#L211)) + rayon materialize share the same FD table and blow through 256 fast.
- Bump soft to hard in [`async_main`](https://github.com/endevco/aube/blob/main/crates/aube/src/main.rs#L613) right after `init_logging`, before any install work runs. `trace!` logs the before/after so it's diagnosable.
- macOS gotcha handled: `getrlimit` reports `rlim_max = RLIM_INFINITY` but the kernel still caps at `kern.maxfilesperproc` (default 24576). If the `soft = hard` attempt is rejected, fall back to `OPEN_MAX = 10240`, which is accepted on every stock macOS.
- Windows is a `#[cfg(not(unix))]` no-op.

## Test plan

- [x] `cargo build -p aube`
- [x] `cargo clippy -p aube --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Smoke: `AUBE_LOG=aube=trace aube doctor` on a system with `ulimit -Sn 256` — traces `raised RLIMIT_NOFILE soft 256 -> <hard>` before any install work.
- [x] Smoke: same on a system already at the hard limit — traces `already at hard limit` and no-ops.
- [ ] Follow-up: reproduce the original `ret@0.1.15` failure on a macOS box with default `ulimit` on `v1.0.0-beta.11`, confirm it passes on this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-level Unix resource limits at startup; while guarded and best-effort, it could have OS-specific behavior differences (especially on macOS) that affect runtime in unexpected environments.
> 
> **Overview**
> Preemptively increases the process file-descriptor soft limit on Unix during startup (right after `init_logging`) to better handle large, highly concurrent install workloads.
> 
> Adds `raise_nofile_limit()` which best-effort bumps `RLIMIT_NOFILE` to the hard limit, with a macOS-specific fallback target (`10240`) when `soft=hard` is rejected, and no-ops on non-Unix platforms while emitting `trace!` diagnostics when enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e0cb1983e6bf3686b756ab0bb82859387ec949d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->