### PR TITLE
refactor: cross-crate dedup pass

### DIFF
--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -295,51 +295,17 @@ pub(crate) fn link_hoisted_importer(
     placements: &mut HoistedPlacements,
 ) -> Result<(), Error> {
     let nm = importer_dir.join(linker.modules_dir_name());
-    xx::file::mkdirp(&nm).map_err(|e| Error::Xx(e.to_string()))?;
+    crate::mkdirp(&nm)?;
 
     let plan = plan_importer(&nm, root_deps, graph);
 
     // Sweep any top-level entries that are no longer claimed by the
-    // plan. Dotfiles (`.aube`, `.bin`, …) are
-    // preserved — .aube in particular may hold a previous isolated
-    // tree that the user hasn't switched off; we leave it alone
-    // rather than wiping bytes the other layout owns.
+    // plan. Dotfiles (`.aube`, `.bin`, …) are preserved — .aube in
+    // particular may hold a previous isolated tree that the user
+    // hasn't switched off; we leave it alone rather than wiping
+    // bytes the other layout owns.
     let keep_root: std::collections::HashSet<&str> = plan.root_names().collect();
-    let keep_scopes: std::collections::HashSet<&str> = keep_root
-        .iter()
-        .filter_map(|n| n.split_once('/').map(|(scope, _)| scope))
-        .collect();
-    if let Ok(entries) = std::fs::read_dir(&nm) {
-        for entry in entries.flatten() {
-            let raw = entry.file_name();
-            let name_str = raw.to_string_lossy();
-            if name_str.starts_with('.') {
-                continue;
-            }
-            if keep_root.contains(name_str.as_ref()) {
-                continue;
-            }
-            if keep_scopes.contains(name_str.as_ref()) {
-                // Scoped dir: prune stale members but keep surviving siblings.
-                let scope_dir = entry.path();
-                if let Ok(inner) = std::fs::read_dir(&scope_dir) {
-                    for inner_entry in inner.flatten() {
-                        let full =
-                            format!("{}/{}", name_str, inner_entry.file_name().to_string_lossy());
-                        if !keep_root.contains(full.as_str()) {
-                            let p = inner_entry.path();
-                            let _ = std::fs::remove_dir_all(&p);
-                            let _ = std::fs::remove_file(&p);
-                        }
-                    }
-                }
-                continue;
-            }
-            let p = entry.path();
-            let _ = std::fs::remove_dir_all(&p);
-            let _ = std::fs::remove_file(&p);
-        }
-    }
+    crate::sweep_stale_top_level_entries(&nm, &keep_root, None);
 
     // Materialize every non-root node. Order doesn't matter for
     // correctness (each package's files are written into its own
@@ -370,10 +336,9 @@ pub(crate) fn link_hoisted_importer(
         // normalized the relative path to be importer-relative.
         if let Some(LocalSource::Link(rel)) = pkg.local_source.as_ref() {
             if let Some(parent) = pkg_dir.parent() {
-                xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                crate::mkdirp(parent)?;
             }
-            let _ = std::fs::remove_dir_all(&pkg_dir);
-            let _ = std::fs::remove_file(&pkg_dir);
+            crate::try_remove_entry(&pkg_dir);
             let abs_target = importer_dir.join(rel);
             let link_parent = pkg_dir.parent().unwrap_or(&nm);
             let rel_target = pathdiff::diff_paths(&abs_target, link_parent).unwrap_or(abs_target);
@@ -410,8 +375,7 @@ pub(crate) fn link_hoisted_importer(
         // changing versions doesn't leave stale files behind, then
         // batch-create every intermediate parent directory the index
         // will write into.
-        let _ = std::fs::remove_dir_all(&pkg_dir);
-        let _ = std::fs::remove_file(&pkg_dir);
+        crate::try_remove_entry(&pkg_dir);
         let mut parents: BTreeSet<PathBuf> = BTreeSet::new();
         parents.insert(pkg_dir.clone());
         // Validate every key once here. The file-linking loop below
@@ -440,7 +404,7 @@ pub(crate) fn link_hoisted_importer(
             }
         }
 
-        let patch_key = format!("{}@{}", pkg.name, pkg.version);
+        let patch_key = pkg.spec_key();
         if let Some(patch_text) = linker.patches.get(&patch_key) {
             apply_multi_file_patch(&pkg_dir, patch_text)
                 .map_err(|msg| Error::Patch(patch_key.clone(), msg))?;

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -135,6 +135,123 @@ fn remove_hidden_hoist_tree(path: &Path) {
         Err(_) => {}
     }
 }
+
+/// Best-effort unlink of `path` regardless of whether it's a file,
+/// symlink, junction, or directory. Errors are intentionally ignored
+/// because this is a "clear the slot" operation — the caller is about
+/// to place something else here and any residual entry that survives
+/// will surface as a downstream error.
+pub(crate) fn try_remove_entry(path: &Path) {
+    let _ = std::fs::remove_dir_all(path);
+    let _ = std::fs::remove_file(path);
+}
+
+/// `xx::file::mkdirp` wrapped with the linker's `Error::Xx` conversion.
+/// Every materialize pass calls this before creating a symlink /
+/// junction, so the lossy `.to_string()` wrap lives in exactly one
+/// place.
+pub(crate) fn mkdirp(dir: &Path) -> Result<(), Error> {
+    xx::file::mkdirp(dir).map_err(|e| Error::Xx(e.to_string()))
+}
+
+/// Classification of a `.aube/<dep_path>` symlink relative to the
+/// current hashed global entry the linker wants to point at.
+#[derive(Copy, Clone)]
+pub(crate) enum EntryState {
+    /// The symlink already points at `expected` and the target exists —
+    /// nothing to do. Caller can bump a `packages_cached` counter and
+    /// move on.
+    Fresh,
+    /// No entry at `link_path` yet. Caller needs to materialize and
+    /// create the symlink, but there's nothing to unlink first.
+    Missing,
+    /// An entry exists but is stale (different target, dangling link,
+    /// or an `Err` read that isn't NotFound). Caller must unlink
+    /// before resymlinking.
+    Stale,
+}
+
+/// Sweep stale entries out of a `node_modules/` directory while
+/// preserving everything in `preserve` (bare names like `lodash` and
+/// scope prefixes like `@babel`), dotfiles, and — if set — the
+/// virtual-store leaf (`aube_dir_leaf`) sitting right under `nm`
+/// with a non-dotfile name (the `virtualStoreDir=node_modules/vstore`
+/// case). For `@scope` entries we recurse one level and drop any
+/// `@scope/<pkg>` whose full `@scope/pkg` name is not in `preserve`;
+/// an empty scope directory left behind by the sweep is removed so
+/// the next install doesn't trip over a phantom scope tombstone.
+pub(crate) fn sweep_stale_top_level_entries(
+    nm: &Path,
+    preserve: &std::collections::HashSet<&str>,
+    aube_dir_leaf: Option<&std::ffi::OsStr>,
+) {
+    let scope_prefixes: std::collections::HashSet<&str> = preserve
+        .iter()
+        .filter_map(|n| n.split_once('/').map(|(scope, _)| scope))
+        .collect();
+    let Ok(entries) = std::fs::read_dir(nm) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with('.') {
+            continue;
+        }
+        if aube_dir_leaf == Some(name.as_os_str()) {
+            continue;
+        }
+        if preserve.contains(name_str.as_ref()) {
+            continue;
+        }
+        if scope_prefixes.contains(name_str.as_ref()) {
+            let scope_dir = entry.path();
+            if let Ok(inner) = std::fs::read_dir(&scope_dir) {
+                for inner_entry in inner.flatten() {
+                    let inner_name = inner_entry.file_name();
+                    let full = format!("{}/{}", name_str, inner_name.to_string_lossy());
+                    if !preserve.contains(full.as_str()) {
+                        try_remove_entry(&inner_entry.path());
+                    }
+                }
+            }
+            // If the scope dir is now empty (every member was stale),
+            // drop the tombstone directory too.
+            if std::fs::read_dir(&scope_dir)
+                .map(|mut d| d.next().is_none())
+                .unwrap_or(false)
+            {
+                let _ = std::fs::remove_dir(&scope_dir);
+            }
+            continue;
+        }
+        try_remove_entry(&entry.path());
+    }
+}
+
+/// Classify `link_path` against `expected` without the double-check
+/// (`read_link` then `exists`) that ate ~1.4k ENOENT syscalls per
+/// install on the medium fixture. Fresh means "points at expected
+/// AND the target still exists"; everything else is Missing or
+/// Stale. The fast path returns without touching disk a second time.
+pub(crate) fn classify_entry_state(link_path: &Path, expected: &Path) -> EntryState {
+    match std::fs::read_link(link_path) {
+        Ok(existing) if existing == expected => {
+            if link_path.exists() {
+                EntryState::Fresh
+            } else {
+                EntryState::Stale
+            }
+        }
+        Ok(_) => EntryState::Stale,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => EntryState::Missing,
+        // Some other error (permission, etc.): treat as Stale and
+        // let the removal/recreate path try its best-effort cleanup
+        // + surface the real error on symlink creation if unlucky.
+        Err(_) => EntryState::Stale,
+    }
+}
+
 pub use sys::{
     BinShimOptions, create_bin_shim, create_dir_link, normalize_path, parse_posix_shim_target,
     remove_bin_shim, validate_bin_name, validate_bin_target,
@@ -812,7 +929,7 @@ impl Linker {
         let nm = project_dir.join(&self.modules_dir_name);
         let aube_dir = self.aube_dir_for(project_dir);
 
-        xx::file::mkdirp(&aube_dir).map_err(|e| Error::Xx(e.to_string()))?;
+        mkdirp(&aube_dir)?;
 
         // Reclaim space from prior aborted installs. A crash or
         // Ctrl+C between materialize_into and the atomic rename
@@ -840,13 +957,9 @@ impl Linker {
                 }
             }
         }
-        let scope_prefixes: std::collections::HashSet<&str> = root_dep_names
-            .iter()
-            .filter_map(|n| n.split_once('/').map(|(scope, _)| scope))
-            .collect();
         // Preserve the virtual-store leaf name when `aube_dir` sits
         // directly under `nm`. With the default `.aube` the dotfile
-        // check below covers it, but a user who sets
+        // check inside the sweep covers it, but a user who sets
         // `virtualStoreDir=node_modules/vstore` would otherwise see
         // the sweep delete the freshly-`mkdirp`d virtual store on
         // every install because `vstore` isn't a dotfile and isn't
@@ -856,44 +969,7 @@ impl Linker {
         } else {
             None
         };
-        if let Ok(entries) = std::fs::read_dir(&nm) {
-            for entry in entries.flatten() {
-                let name = entry.file_name();
-                let name_str = name.to_string_lossy();
-                // Skip .aube, .bin, and other dotfiles
-                if name_str.starts_with('.') {
-                    continue;
-                }
-                if aube_dir_leaf.as_deref() == Some(name.as_os_str()) {
-                    continue;
-                }
-                if root_dep_names.contains(name_str.as_ref()) {
-                    continue;
-                }
-                // Preserved `@scope` directory: keep the directory
-                // itself, but recurse and drop any `@scope/<pkg>`
-                // whose full name is no longer in the graph. Without
-                // this, a scoped dep removed from package.json would
-                // linger as a phantom symlink (its `.aube/` entry
-                // also persists) and still resolve successfully.
-                if scope_prefixes.contains(name_str.as_ref()) {
-                    let scope_dir = entry.path();
-                    if let Ok(inner) = std::fs::read_dir(&scope_dir) {
-                        for inner_entry in inner.flatten() {
-                            let inner_name = inner_entry.file_name();
-                            let full = format!("{}/{}", name_str, inner_name.to_string_lossy());
-                            if !root_dep_names.contains(full.as_str()) {
-                                let _ = std::fs::remove_dir_all(inner_entry.path());
-                                let _ = std::fs::remove_file(inner_entry.path());
-                            }
-                        }
-                    }
-                    continue;
-                }
-                let _ = std::fs::remove_dir_all(entry.path());
-                let _ = std::fs::remove_file(entry.path());
-            }
-        }
+        sweep_stale_top_level_entries(&nm, &root_dep_names, aube_dir_leaf.as_deref());
 
         let mut stats = LinkStats::default();
 
@@ -975,40 +1051,7 @@ impl Linker {
                             // `remove_dir`/`remove_file` pair on cold installs,
                             // which strace showed as ~1.4k ENOENT syscalls per
                             // install on the medium fixture.
-                            enum EntryState {
-                                /// `.aube/<dep_path>` already points at the
-                                /// current hashed global entry — nothing to do.
-                                Fresh,
-                                /// `.aube/<dep_path>` doesn't exist yet. We need
-                                /// to materialize + create the symlink, but
-                                /// there's nothing to remove first.
-                                Missing,
-                                /// `.aube/<dep_path>` exists and points somewhere
-                                /// else (stale hash, patch change, etc.). Must
-                                /// unlink before resymlinking.
-                                Stale,
-                            }
-                            let state = match std::fs::read_link(&local_aube_entry) {
-                                Ok(existing) if existing == global_entry => {
-                                    // Verify the target actually exists — a
-                                    // dangling link needs to fall through to
-                                    // the materialize path.
-                                    if local_aube_entry.exists() {
-                                        EntryState::Fresh
-                                    } else {
-                                        EntryState::Stale
-                                    }
-                                }
-                                Ok(_) => EntryState::Stale,
-                                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                                    EntryState::Missing
-                                }
-                                // Some other error (permission, etc.): treat as
-                                // Stale and let the removal/recreate path try
-                                // its best-effort cleanup + surface the real
-                                // error on symlink creation if unlucky.
-                                Err(_) => EntryState::Stale,
-                            };
+                            let state = classify_entry_state(&local_aube_entry, &global_entry);
 
                             if matches!(state, EntryState::Fresh) {
                                 local_stats.packages_cached += 1;
@@ -1051,7 +1094,7 @@ impl Linker {
                                     .or_else(|_| std::fs::remove_file(&local_aube_entry));
                             }
                             if let Some(parent) = local_aube_entry.parent() {
-                                xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                                mkdirp(parent)?;
                             }
                             sys::create_dir_link(&global_entry, &local_aube_entry)
                                 .map_err(|e| Error::Io(local_aube_entry.clone(), e))?;
@@ -1155,7 +1198,7 @@ impl Linker {
                             return Ok(false);
                         }
                         if let Some(parent) = target_dir.parent() {
-                            xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                            mkdirp(parent)?;
                         }
                         sys::create_dir_link(&rel_target, &target_dir)
                             .map_err(|e| Error::Io(target_dir.clone(), e))?;
@@ -1186,7 +1229,7 @@ impl Linker {
                         return Ok(false);
                     }
                     if let Some(parent) = target_dir.parent() {
-                        xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                        mkdirp(parent)?;
                     }
 
                     sys::create_dir_link(&rel_target, &target_dir)
@@ -1299,10 +1342,9 @@ impl Linker {
                 };
                 let link_path = nm.join(&dep.name);
                 if let Some(parent) = link_path.parent() {
-                    xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                    mkdirp(parent)?;
                 }
-                let _ = std::fs::remove_dir_all(&link_path);
-                let _ = std::fs::remove_file(&link_path);
+                try_remove_entry(&link_path);
                 let link_parent = link_path.parent().unwrap_or(&nm);
                 let target = pathdiff::diff_paths(ws_dir, link_parent).unwrap_or(ws_dir.clone());
                 sys::create_dir_link(&target, &link_path)
@@ -1338,8 +1380,8 @@ impl Linker {
         let root_nm = root_dir.join(&self.modules_dir_name);
         let aube_dir = self.aube_dir_for(root_dir);
 
-        xx::file::mkdirp(&aube_dir).map_err(|e| Error::Xx(e.to_string()))?;
-        xx::file::mkdirp(&root_nm).map_err(|e| Error::Xx(e.to_string()))?;
+        mkdirp(&aube_dir)?;
+        mkdirp(&root_nm)?;
 
         let mut stats = LinkStats::default();
 
@@ -1411,25 +1453,7 @@ impl Linker {
                             let global_entry =
                                 self.virtual_store.join(self.virtual_store_subdir(dep_path));
 
-                            enum EntryState {
-                                Fresh,
-                                Missing,
-                                Stale,
-                            }
-                            let state = match std::fs::read_link(&local_aube_entry) {
-                                Ok(existing) if existing == global_entry => {
-                                    if local_aube_entry.exists() {
-                                        EntryState::Fresh
-                                    } else {
-                                        EntryState::Stale
-                                    }
-                                }
-                                Ok(_) => EntryState::Stale,
-                                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                                    EntryState::Missing
-                                }
-                                Err(_) => EntryState::Stale,
-                            };
+                            let state = classify_entry_state(&local_aube_entry, &global_entry);
 
                             if matches!(state, EntryState::Fresh) {
                                 local_stats.packages_cached += 1;
@@ -1456,7 +1480,7 @@ impl Linker {
                                     .or_else(|_| std::fs::remove_file(&local_aube_entry));
                             }
                             if let Some(parent) = local_aube_entry.parent() {
-                                xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                                mkdirp(parent)?;
                             }
                             sys::create_dir_link(&global_entry, &local_aube_entry)
                                 .map_err(|e| Error::Io(local_aube_entry.clone(), e))?;
@@ -1530,8 +1554,7 @@ impl Linker {
                     if aube_dir_leaf.as_deref() == Some(name.as_os_str()) {
                         continue;
                     }
-                    let _ = std::fs::remove_dir_all(entry.path());
-                    let _ = std::fs::remove_file(entry.path());
+                    try_remove_entry(&entry.path());
                 }
             }
             self.link_hidden_hoist(&aube_dir, graph)?;
@@ -1586,7 +1609,7 @@ impl Linker {
                 root_dir.join(importer_path).join(&self.modules_dir_name)
             };
             if importer_path != "." {
-                xx::file::mkdirp(&nm).map_err(|e| Error::Xx(e.to_string()))?;
+                mkdirp(&nm)?;
             }
 
             let mut preserve: std::collections::HashSet<&str> =
@@ -1604,54 +1627,12 @@ impl Linker {
                     }
                 }
             }
-            let scope_prefixes: std::collections::HashSet<&str> = preserve
-                .iter()
-                .filter_map(|n| n.split_once('/').map(|(scope, _)| scope))
-                .collect();
-            let aube_leaf_here: Option<&std::ffi::OsString> = if importer_path == "." {
-                aube_dir_leaf_root.as_ref()
+            let aube_leaf_here = if importer_path == "." {
+                aube_dir_leaf_root.as_deref()
             } else {
                 None
             };
-            if let Ok(entries) = std::fs::read_dir(&nm) {
-                for entry in entries.flatten() {
-                    let name = entry.file_name();
-                    let name_str = name.to_string_lossy();
-                    if name_str.starts_with('.') {
-                        continue;
-                    }
-                    if aube_leaf_here.map(|l| l.as_os_str()) == Some(name.as_os_str()) {
-                        continue;
-                    }
-                    if preserve.contains(name_str.as_ref()) {
-                        continue;
-                    }
-                    if scope_prefixes.contains(name_str.as_ref()) {
-                        let scope_dir = entry.path();
-                        if let Ok(inner) = std::fs::read_dir(&scope_dir) {
-                            for inner_entry in inner.flatten() {
-                                let inner_name = inner_entry.file_name();
-                                let full = format!("{}/{}", name_str, inner_name.to_string_lossy());
-                                if !preserve.contains(full.as_str()) {
-                                    let _ = std::fs::remove_dir_all(inner_entry.path());
-                                    let _ = std::fs::remove_file(inner_entry.path());
-                                }
-                            }
-                        }
-                        // If the scope is now empty (no preserved members
-                        // left), drop the tombstone directory too.
-                        if std::fs::read_dir(&scope_dir)
-                            .map(|mut d| d.next().is_none())
-                            .unwrap_or(false)
-                        {
-                            let _ = std::fs::remove_dir(&scope_dir);
-                        }
-                        continue;
-                    }
-                    let _ = std::fs::remove_dir_all(entry.path());
-                    let _ = std::fs::remove_file(entry.path());
-                }
-            }
+            sweep_stale_top_level_entries(&nm, &preserve, aube_leaf_here);
         }
 
         // Step 2b: Create top-level symlinks in parallel.
@@ -1723,7 +1704,7 @@ impl Linker {
                             return Ok(false);
                         }
                         if let Some(parent) = link_path.parent() {
-                            xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                            mkdirp(parent)?;
                         }
                         sys::create_dir_link(&rel_target, &link_path)
                             .map_err(|e| Error::Io(link_path.clone(), e))?;
@@ -1742,7 +1723,7 @@ impl Linker {
                             return Ok(false);
                         }
                         if let Some(parent) = link_path.parent() {
-                            xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                            mkdirp(parent)?;
                         }
                         sys::create_dir_link(&rel_target, &link_path)
                             .map_err(|e| Error::Io(link_path.clone(), e))?;
@@ -1765,7 +1746,7 @@ impl Linker {
                         return Ok(false);
                     }
                     if let Some(parent) = link_path.parent() {
-                        xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                        mkdirp(parent)?;
                     }
                     sys::create_dir_link(&rel_target, &link_path)
                         .map_err(|e| Error::Io(link_path.clone(), e))?;
@@ -1873,7 +1854,7 @@ impl Linker {
             }
             let target_dir = hidden.join(&pkg.name);
             if let Some(parent) = target_dir.parent() {
-                xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                mkdirp(parent)?;
             }
             let link_parent = target_dir.parent().unwrap_or(&hidden);
             let rel_target = pathdiff::diff_paths(&source_dir, link_parent)
@@ -1980,7 +1961,7 @@ impl Linker {
                 continue;
             }
             if let Some(parent) = target_dir.parent() {
-                xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+                mkdirp(parent)?;
             }
             sys::create_dir_link(&rel_target, &target_dir)
                 .map_err(|e| Error::Io(target_dir.clone(), e))?;
@@ -2050,7 +2031,7 @@ impl Linker {
 
         // Ensure the parent of the final entry exists (e.g. for scoped packages).
         if let Some(parent) = final_entry.parent() {
-            xx::file::mkdirp(parent).map_err(|e| Error::Xx(e.to_string()))?;
+            mkdirp(parent)?;
         }
 
         match std::fs::rename(&tmp_entry, &final_entry) {
@@ -2190,7 +2171,7 @@ impl Linker {
         // patched bytes live alongside the unpatched ones at a
         // distinct subdir (the graph hash callback is responsible for
         // making sure that's true).
-        let patch_key = format!("{}@{}", pkg.name, pkg.version);
+        let patch_key = pkg.spec_key();
         if let Some(patch_text) = self.patches.get(&patch_key) {
             apply_multi_file_patch(&pkg_nm_dir, patch_text)
                 .map_err(|msg| Error::Patch(patch_key.clone(), msg))?;
@@ -2552,7 +2533,7 @@ fn wipe_changed_patched_entries(
         return;
     }
     for (dep_path, pkg) in &graph.packages {
-        let key = format!("{}@{}", pkg.name, pkg.version);
+        let key = pkg.spec_key();
         if affected.contains(&key) {
             let entry = aube_dir.join(dep_path_to_filename(dep_path, max_length));
             let _ = std::fs::remove_dir_all(entry);

--- a/crates/aube-linker/src/sys.rs
+++ b/crates/aube-linker/src/sys.rs
@@ -167,12 +167,7 @@ pub fn create_bin_shim(
         let link_path = bin_dir.join(name);
         let link_parent = link_path.parent().unwrap_or(bin_dir);
         // Remove any stale files (previous shims or legacy symlinks).
-        for ext in ["", ".cmd", ".ps1"] {
-            let p = if ext.is_empty() {
-                link_path.clone()
-            } else {
-                bin_dir.join(format!("{name}{ext}"))
-            };
+        for p in win_shim_paths(bin_dir, name) {
             let _ = std::fs::remove_file(&p);
         }
         std::fs::create_dir_all(link_parent)?;
@@ -342,15 +337,28 @@ pub fn remove_bin_shim(bin_dir: &Path, name: &str) {
     let link_path = bin_dir.join(name);
     let _ = std::fs::remove_file(&link_path);
     #[cfg(windows)]
-    {
-        let _ = std::fs::remove_file(bin_dir.join(format!("{name}.cmd")));
-        let _ = std::fs::remove_file(bin_dir.join(format!("{name}.ps1")));
+    for p in win_shim_paths(bin_dir, name).into_iter().skip(1) {
+        let _ = std::fs::remove_file(&p);
     }
     if let Some(parent) = link_path.parent()
         && parent != bin_dir
     {
         let _ = std::fs::remove_dir(parent);
     }
+}
+
+/// Paths of every Windows shim file `create_bin_shim` writes for
+/// `name`: the extensionless wrapper, the `.cmd` stub, and the
+/// `.ps1` stub. Index 0 is the extensionless wrapper — callers that
+/// already unlinked it (the unix-first branch of `remove_bin_shim`)
+/// can skip it with `.into_iter().skip(1)`.
+#[cfg(windows)]
+fn win_shim_paths(bin_dir: &Path, name: &str) -> [PathBuf; 3] {
+    [
+        bin_dir.join(name),
+        bin_dir.join(format!("{name}.cmd")),
+        bin_dir.join(format!("{name}.ps1")),
+    ]
 }
 
 /// Compute the relative path from `base_dir` to `target`, using

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -604,9 +604,7 @@ pub fn write(
         if matches!(pkg.local_source, Some(LocalSource::Link(_))) {
             continue;
         }
-        canonical
-            .entry(format!("{}@{}", pkg.name, pkg.version))
-            .or_insert(pkg);
+        canonical.entry(pkg.spec_key()).or_insert(pkg);
     }
 
     // Build the hoist tree from every importer's direct deps (not just
@@ -813,7 +811,7 @@ pub fn write(
             meta.insert("bin".to_string(), Value::Object(real_bins));
         }
 
-        let ident = format!("{}@{}", pkg.name, pkg.version);
+        let ident = pkg.spec_key();
         let integrity = pkg.integrity.clone().unwrap_or_default();
         let entry = Value::Array(vec![
             Value::String(ident),

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -578,6 +578,13 @@ impl LockedPackage {
     pub fn registry_name(&self) -> &str {
         self.alias_of.as_deref().unwrap_or(&self.name)
     }
+
+    /// Canonical `"name@version"` key used as a handle in patches,
+    /// approve-builds prompts, lockfile canonical maps, and display
+    /// paths. Not the dep-path — that includes peer-context suffixes.
+    pub fn spec_key(&self) -> String {
+        format!("{}@{}", self.name, self.version)
+    }
 }
 
 /// Metadata about a single declared peer dependency. Matches the shape of
@@ -831,14 +838,9 @@ impl LockfileGraph {
         // Build a canonical `name@version → prior pkg` lookup once so
         // repeated peer-context variants in `self.packages` all hit
         // the same prior entry.
-        let mut prior_index: BTreeMap<String, &LockedPackage> = BTreeMap::new();
-        for pkg in prior.packages.values() {
-            prior_index
-                .entry(format!("{}@{}", pkg.name, pkg.version))
-                .or_insert(pkg);
-        }
+        let prior_index = build_canonical_map(prior);
         for pkg in self.packages.values_mut() {
-            let key = format!("{}@{}", pkg.name, pkg.version);
+            let key = pkg.spec_key();
             let Some(prior_pkg) = prior_index.get(&key) else {
                 continue;
             };
@@ -1315,6 +1317,19 @@ pub fn write_lockfile(
 }
 
 /// Write a lockfile using the existing project lockfile kind, or
+/// Collapse peer-context variants from `graph` into a single map keyed
+/// by `"name@version"`, pointing at the first-seen package. Several
+/// writers (npm, yarn, …) share this shape: one canonical entry per
+/// `(name, version)` pair regardless of how many peer suffixes the
+/// full graph emits.
+pub fn build_canonical_map(graph: &LockfileGraph) -> BTreeMap<String, &LockedPackage> {
+    let mut canonical: BTreeMap<String, &LockedPackage> = BTreeMap::new();
+    for pkg in graph.packages.values() {
+        canonical.entry(pkg.spec_key()).or_insert(pkg);
+    }
+    canonical
+}
+
 /// `aube-lock.yaml` when the project does not have one yet.
 ///
 /// This is the default write path for commands that mutate the active

--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -710,12 +710,7 @@ pub fn write(
     // Key packages by `name@version` (ignore peer-context suffix) so
     // lookups from parent deps resolve to one canonical entry even if
     // the graph has several contextualized variants.
-    let mut canonical: BTreeMap<String, &LockedPackage> = BTreeMap::new();
-    for pkg in graph.packages.values() {
-        canonical
-            .entry(format!("{}@{}", pkg.name, pkg.version))
-            .or_insert(pkg);
-    }
+    let canonical = crate::build_canonical_map(graph);
 
     // Compute reachability for dev/optional flags. A package is
     // `dev: true` iff it's only reachable from dev roots; `optional:

--- a/crates/aube-lockfile/src/yarn.rs
+++ b/crates/aube-lockfile/src/yarn.rs
@@ -423,12 +423,7 @@ pub fn write_classic(
     manifest: &aube_manifest::PackageJson,
 ) -> Result<(), Error> {
     // Collapse peer-context variants: one entry per canonical (name, version).
-    let mut canonical: BTreeMap<String, &LockedPackage> = BTreeMap::new();
-    for pkg in graph.packages.values() {
-        canonical
-            .entry(format!("{}@{}", pkg.name, pkg.version))
-            .or_insert(pkg);
-    }
+    let canonical = crate::build_canonical_map(graph);
 
     // Collect every spec that points at a canonical `(name, version)` —
     // both root-manifest ranges *and* transitive declared ranges from
@@ -1079,12 +1074,7 @@ pub fn write_berry(
     // `(name, version)` — same as the classic writer. The canonical
     // key is `name@version`; we need it to look up a package's extra
     // specifiers in the same map.
-    let mut canonical: BTreeMap<String, &LockedPackage> = BTreeMap::new();
-    for pkg in graph.packages.values() {
-        canonical
-            .entry(format!("{}@{}", pkg.name, pkg.version))
-            .or_insert(pkg);
-    }
+    let canonical = crate::build_canonical_map(graph);
 
     // `extra_specs[canonical_key]` is the set of range-form
     // specifiers (e.g. `"foo@npm:^1.0.0"`) that should appear in the

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -80,6 +80,21 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
+/// Pull ETag + Last-Modified off a response as owned strings.
+fn extract_cache_headers(resp: &reqwest::Response) -> (Option<String>, Option<String>) {
+    let headers = resp.headers();
+    let grab = |name: reqwest::header::HeaderName| {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+    };
+    (
+        grab(reqwest::header::ETAG),
+        grab(reqwest::header::LAST_MODIFIED),
+    )
+}
+
 /// Client for interacting with the npm registry.
 pub struct RegistryClient {
     http: reqwest::Client,
@@ -567,16 +582,7 @@ impl RegistryClient {
                         return Ok(c.packument.clone());
                     }
 
-                    let etag = resp
-                        .headers()
-                        .get(reqwest::header::ETAG)
-                        .and_then(|v| v.to_str().ok())
-                        .map(|s| s.to_string());
-                    let last_modified = resp
-                        .headers()
-                        .get(reqwest::header::LAST_MODIFIED)
-                        .and_then(|v| v.to_str().ok())
-                        .map(|s| s.to_string());
+                    let (etag, last_modified) = extract_cache_headers(&resp);
                     let resp = resp.error_for_status()?;
                     check_body_cap(&resp, PACKUMENT_BODY_CAP, &label)?;
                     match resp.json::<serde_json::Value>().await {
@@ -860,16 +866,7 @@ impl RegistryClient {
                     return Ok(c.packument.clone());
                 }
                 Ok(resp) => {
-                    let etag = resp
-                        .headers()
-                        .get(reqwest::header::ETAG)
-                        .and_then(|v| v.to_str().ok())
-                        .map(|s| s.to_string());
-                    let last_modified = resp
-                        .headers()
-                        .get(reqwest::header::LAST_MODIFIED)
-                        .and_then(|v| v.to_str().ok())
-                        .map(|s| s.to_string());
+                    let (etag, last_modified) = extract_cache_headers(&resp);
 
                     let resp = resp.error_for_status()?;
                     check_body_cap(&resp, PACKUMENT_BODY_CAP, &label)?;

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -398,6 +398,50 @@ impl ResolveTask {
     fn registry_name(&self) -> &str {
         self.real_name.as_deref().unwrap_or(&self.name)
     }
+
+    /// Construct a root-importer task for `(name, range)` under
+    /// `importer`, with the appropriate `dep_type` and no parent/ancestry.
+    /// Every root-dep enqueue site uses this shape; the factory keeps
+    /// the literal in one place so a new field added to `ResolveTask`
+    /// lands consistently across prod/dev/optional loops.
+    fn root(name: String, range: String, dep_type: DepType, importer: String) -> Self {
+        let original = range.clone();
+        Self {
+            name,
+            range,
+            dep_type,
+            is_root: true,
+            parent: None,
+            importer,
+            original_specifier: Some(original),
+            real_name: None,
+            ancestors: Vec::new(),
+        }
+    }
+
+    /// Construct a transitive (non-root) task discovered by walking a
+    /// parent package's dependency map. Carries the parent dep_path
+    /// and inherited ancestor chain for overrides.
+    fn transitive(
+        name: String,
+        range: String,
+        dep_type: DepType,
+        parent: String,
+        importer: String,
+        ancestors: Vec<(String, String)>,
+    ) -> Self {
+        Self {
+            name,
+            range,
+            dep_type,
+            is_root: false,
+            parent: Some(parent),
+            importer,
+            original_specifier: None,
+            real_name: None,
+            ancestors,
+        }
+    }
 }
 
 impl Resolver {
@@ -836,33 +880,23 @@ impl Resolver {
             importers.insert(importer_path.clone(), Vec::new());
 
             for (name, range) in &manifest.dependencies {
-                queue.push_back(ResolveTask {
-                    name: name.clone(),
-                    range: range.clone(),
-                    dep_type: DepType::Production,
-                    is_root: true,
-                    parent: None,
-                    importer: importer_path.clone(),
-                    original_specifier: Some(range.clone()),
-                    real_name: None,
-                    ancestors: Vec::new(),
-                });
+                queue.push_back(ResolveTask::root(
+                    name.clone(),
+                    range.clone(),
+                    DepType::Production,
+                    importer_path.clone(),
+                ));
             }
             for (name, range) in &manifest.dev_dependencies {
                 if manifest.dependencies.contains_key(name) {
                     continue;
                 }
-                queue.push_back(ResolveTask {
-                    name: name.clone(),
-                    range: range.clone(),
-                    dep_type: DepType::Dev,
-                    is_root: true,
-                    parent: None,
-                    importer: importer_path.clone(),
-                    original_specifier: Some(range.clone()),
-                    real_name: None,
-                    ancestors: Vec::new(),
-                });
+                queue.push_back(ResolveTask::root(
+                    name.clone(),
+                    range.clone(),
+                    DepType::Dev,
+                    importer_path.clone(),
+                ));
             }
             for (name, range) in &manifest.optional_dependencies {
                 if self.ignored_optional_dependencies.contains(name) {
@@ -876,17 +910,12 @@ impl Resolver {
                 {
                     continue;
                 }
-                queue.push_back(ResolveTask {
-                    name: name.clone(),
-                    range: range.clone(),
-                    dep_type: DepType::Optional,
-                    is_root: true,
-                    parent: None,
-                    importer: importer_path.clone(),
-                    original_specifier: Some(range.clone()),
-                    real_name: None,
-                    ancestors: Vec::new(),
-                });
+                queue.push_back(ResolveTask::root(
+                    name.clone(),
+                    range.clone(),
+                    DepType::Optional,
+                    importer_path.clone(),
+                ));
             }
         }
 
@@ -1497,17 +1526,14 @@ impl Resolver {
                             let mut child_ancestors = task.ancestors.clone();
                             child_ancestors.push((linked_name.clone(), real_version.clone()));
                             for (child_name, child_range) in target_deps {
-                                queue.push_back(ResolveTask {
-                                    name: child_name,
-                                    range: child_range,
-                                    dep_type: DepType::Production,
-                                    is_root: false,
-                                    parent: Some(dep_path.clone()),
-                                    importer: task.importer.clone(),
-                                    original_specifier: None,
-                                    real_name: None,
-                                    ancestors: child_ancestors.clone(),
-                                });
+                                queue.push_back(ResolveTask::transitive(
+                                    child_name,
+                                    child_range,
+                                    DepType::Production,
+                                    dep_path.clone(),
+                                    task.importer.clone(),
+                                    child_ancestors.clone(),
+                                ));
                             }
                         }
                     }
@@ -1807,17 +1833,14 @@ impl Resolver {
                                     } else {
                                         DepType::Production
                                     };
-                                queue.push_back(ResolveTask {
-                                    name: dep_name.clone(),
-                                    range: canonical_version,
+                                queue.push_back(ResolveTask::transitive(
+                                    dep_name.clone(),
+                                    canonical_version,
                                     dep_type,
-                                    is_root: false,
-                                    parent: Some(dep_path.clone()),
-                                    importer: task.importer.clone(),
-                                    original_specifier: None,
-                                    real_name: None,
-                                    ancestors: child_ancestors.clone(),
-                                });
+                                    dep_path.clone(),
+                                    task.importer.clone(),
+                                    child_ancestors.clone(),
+                                ));
                             }
                         }
                         lockfile_reuse_count += 1;
@@ -2339,17 +2362,14 @@ impl Resolver {
                     {
                         ensure_fetch!(dep_name);
                     }
-                    queue.push_back(ResolveTask {
-                        name: dep_name.clone(),
-                        range: dep_range.clone(),
-                        dep_type: DepType::Production,
-                        is_root: false,
-                        parent: Some(dep_path.clone()),
-                        importer: task.importer.clone(),
-                        original_specifier: None,
-                        real_name: None,
-                        ancestors: child_ancestors.clone(),
-                    });
+                    queue.push_back(ResolveTask::transitive(
+                        dep_name.clone(),
+                        dep_range.clone(),
+                        DepType::Production,
+                        dep_path.clone(),
+                        task.importer.clone(),
+                        child_ancestors.clone(),
+                    ));
                 }
 
                 for (dep_name, dep_range) in &version_meta.optional_dependencies {
@@ -2374,17 +2394,14 @@ impl Resolver {
                     {
                         ensure_fetch!(dep_name);
                     }
-                    queue.push_back(ResolveTask {
-                        name: dep_name.clone(),
-                        range: dep_range.clone(),
-                        dep_type: DepType::Optional,
-                        is_root: false,
-                        parent: Some(dep_path.clone()),
-                        importer: task.importer.clone(),
-                        original_specifier: None,
-                        real_name: None,
-                        ancestors: child_ancestors.clone(),
-                    });
+                    queue.push_back(ResolveTask::transitive(
+                        dep_name.clone(),
+                        dep_range.clone(),
+                        DepType::Optional,
+                        dep_path.clone(),
+                        task.importer.clone(),
+                        child_ancestors.clone(),
+                    ));
                 }
 
                 // Peer dependencies: enqueue only required peers that
@@ -2462,17 +2479,14 @@ impl Resolver {
                         {
                             ensure_fetch!(dep_name);
                         }
-                        queue.push_back(ResolveTask {
-                            name: dep_name.clone(),
-                            range: dep_range.clone(),
-                            dep_type: DepType::Production,
-                            is_root: false,
-                            parent: Some(dep_path.clone()),
-                            importer: task.importer.clone(),
-                            original_specifier: None,
-                            real_name: None,
-                            ancestors: child_ancestors.clone(),
-                        });
+                        queue.push_back(ResolveTask::transitive(
+                            dep_name.clone(),
+                            dep_range.clone(),
+                            DepType::Production,
+                            dep_path.clone(),
+                            task.importer.clone(),
+                            child_ancestors.clone(),
+                        ));
                     }
                 }
 

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -68,7 +68,7 @@ pub fn detect_unmet_peers(graph: &LockfileGraph) -> Vec<UnmetPeer> {
             }
 
             let found_tail = pkg.dependencies.get(peer_name);
-            let found_version = found_tail.map(|t| t.split('(').next().unwrap_or(t).to_string());
+            let found_version = found_tail.map(|t| canonical_tail(t).to_string());
 
             let satisfied = match &found_version {
                 Some(v) => version_satisfies(v, declared_range),
@@ -194,7 +194,7 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
                 let Some(version) = resolved_version else {
                     continue;
                 };
-                let canonical_version = version.split('(').next().unwrap_or(&version).to_string();
+                let canonical_version = canonical_tail(&version).to_string();
                 let synth_dep_path = format!("{peer_name}@{canonical_version}");
                 if !graph.packages.contains_key(&synth_dep_path) {
                     // The peer version the package wired didn't match an
@@ -415,12 +415,12 @@ pub fn apply_peer_contexts(
 /// Packages whose `peer_dependencies` map is empty — i.e. the canonical
 /// base already has only one variant — are skipped.
 pub(crate) fn dedupe_peer_variants(graph: LockfileGraph) -> LockfileGraph {
-    let canonical_base = |key: &str| -> String { key.split('(').next().unwrap_or(key).to_string() };
+    let canonical_base = |key: &str| -> String { canonical_tail(key).to_string() };
     // Only the peer-bearing part of the resolved peer tail is
     // comparable across subtrees — the nested suffix could differ even
     // for peer-equivalent variants on mid-iterations of the outer
     // fixed-point loop.
-    let peer_base = |tail: &str| -> String { tail.split('(').next().unwrap_or(tail).to_string() };
+    let peer_base = |tail: &str| -> String { canonical_tail(tail).to_string() };
 
     // Group dep_paths by their peer-free base name.
     let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
@@ -623,18 +623,7 @@ fn apply_peer_contexts_once(
     let root_scope: FxHashMap<String, String> = canonical
         .importers
         .get(".")
-        .map(|deps| {
-            deps.iter()
-                .map(|d| {
-                    let tail = d
-                        .dep_path
-                        .strip_prefix(&format!("{}@", d.name))
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| d.dep_path.clone());
-                    (d.name.clone(), tail)
-                })
-                .collect()
-        })
+        .map(|deps| scope_map_from_deps(deps))
         .unwrap_or_default();
 
     for (importer_path, direct_deps) in &canonical.importers {
@@ -648,17 +637,7 @@ fn apply_peer_contexts_once(
         // it's already contextualized, and passing the plain version
         // would make descendants look up keys that don't exist in the
         // (now-nested) graph.
-        let importer_scope: FxHashMap<String, String> = direct_deps
-            .iter()
-            .map(|d| {
-                let tail = d
-                    .dep_path
-                    .strip_prefix(&format!("{}@", d.name))
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| d.dep_path.clone());
-                (d.name.clone(), tail)
-            })
-            .collect();
+        let importer_scope = scope_map_from_deps(direct_deps);
 
         let mut new_deps = Vec::with_capacity(direct_deps.len());
         for dep in direct_deps {
@@ -732,6 +711,32 @@ fn apply_peer_contexts_once(
 /// `name@version` base, and semver forbids `_` inside a version, so
 /// an underscore 10 chars from the end of `name@version` can only be
 /// our marker.
+/// Everything before the first `(` — i.e. the canonical `name@version`
+/// part of a dep-path with the peer-context suffix stripped. Returns
+/// the original string when no `(` is present. Borrowed; callers that
+/// need owned bump with `.to_string()`.
+fn canonical_tail(s: &str) -> &str {
+    s.split('(').next().unwrap_or(s)
+}
+
+/// Build a `name → contextualized tail` map from a direct-dep slice.
+/// The tail is the dep_path with the `{name}@` prefix stripped, which
+/// on pass 1 is equal to `pkg.version` and on pass 2+ carries the
+/// nested peer-context suffix. Used both for the root scope and for
+/// each importer's own scope inside `apply_peer_contexts_once`.
+fn scope_map_from_deps(deps: &[DirectDep]) -> FxHashMap<String, String> {
+    deps.iter()
+        .map(|d| {
+            let tail = d
+                .dep_path
+                .strip_prefix(&format!("{}@", d.name))
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| d.dep_path.clone());
+            (d.name.clone(), tail)
+        })
+        .collect()
+}
+
 fn strip_hashed_peer_suffix(s: &str) -> &str {
     const MARKER_LEN: usize = 11; // `_` + 10 hex chars
     if s.len() < MARKER_LEN {
@@ -1014,7 +1019,7 @@ fn visit_peer_context<'g>(
     //      stripped; otherwise each pass re-hashes the already-hashed
     //      key and appends another marker (exposed by the
     //      `peer_suffix_is_hashed_when_exceeding_cap` unit test).
-    let canonical_base = input_dep_path.split('(').next().unwrap_or(input_dep_path);
+    let canonical_base = canonical_tail(input_dep_path);
     let canonical_base = strip_hashed_peer_suffix(canonical_base).to_string();
 
     // Compute peer context: walk declared peers, resolve from ancestors
@@ -1051,7 +1056,7 @@ fn visit_peer_context<'g>(
         let satisfies_declared = |v: &str| -> bool {
             // The tail may carry a nested peer suffix on fixed-point
             // iterations 2+; strip it before checking the semver.
-            let canonical = v.split('(').next().unwrap_or(v);
+            let canonical = canonical_tail(v);
             version_satisfies(canonical, declared_range)
         };
 
@@ -1156,7 +1161,7 @@ fn visit_peer_context<'g>(
         .map(|(n, v)| {
             let cycles_back = contains_canonical_back_ref(v, &canonical_base);
             let display_v = if cycles_back {
-                v.split('(').next().unwrap_or(v).to_string()
+                canonical_tail(v).to_string()
             } else {
                 v.clone()
             };

--- a/crates/aube-scripts/src/policy.rs
+++ b/crates/aube-scripts/src/policy.rs
@@ -159,11 +159,7 @@ impl BuildPolicy {
         if self.denied.contains(name) || self.denied.contains(&with_version) {
             return AllowDecision::Deny;
         }
-        if self
-            .denied_wildcards
-            .iter()
-            .any(|p| matches_wildcard(name, p))
-        {
+        if matches_any_wildcard(name, &self.denied_wildcards) {
             return AllowDecision::Deny;
         }
         if self.allow_all {
@@ -172,11 +168,7 @@ impl BuildPolicy {
         if self.allowed.contains(name) || self.allowed.contains(&with_version) {
             return AllowDecision::Allow;
         }
-        if self
-            .allowed_wildcards
-            .iter()
-            .any(|p| matches_wildcard(name, p))
-        {
+        if matches_any_wildcard(name, &self.allowed_wildcards) {
             return AllowDecision::Allow;
         }
         AllowDecision::Unspecified
@@ -220,6 +212,10 @@ fn sort_entries(entries: Vec<String>, exact: &mut HashSet<String>, wildcards: &m
 /// right anchor is what makes this safe — `ends_with(last)` is
 /// independent of greedy choices, and everything between the last
 /// greedy hit and the suffix anchor is a free `*`.
+fn matches_any_wildcard(name: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|p| matches_wildcard(name, p))
+}
+
 fn matches_wildcard(name: &str, pattern: &str) -> bool {
     let parts: Vec<&str> = pattern.split('*').collect();
     // `split` on a pattern with N wildcards yields N+1 parts, so the

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -201,6 +201,59 @@ impl Store {
         Ok(())
     }
 
+    /// Atomically create `path` via `create_new` (O_CREAT|O_EXCL) and
+    /// optionally write + fsync `content`. `AlreadyExists` is a no-op —
+    /// in a CAS, same path = same bytes by construction. `NotFound`
+    /// means a concurrent prune or a missed `ensure_shards_exist`
+    /// removed the parent shard; recreate it and retry exactly once
+    /// before surfacing. Truncating fallbacks (`xx::file::write`) are
+    /// intentionally avoided so a crash can't leave a torn CAS file.
+    fn create_cas_file(path: &Path, content: Option<&[u8]>) -> Result<(), Error> {
+        fn do_create_and_write(path: &Path, content: Option<&[u8]>) -> Result<(), Error> {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+            {
+                Ok(mut file) => {
+                    if let Some(bytes) = content {
+                        use std::io::Write;
+                        file.write_all(bytes)
+                            .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+                        // fsync before closing. write_all returning
+                        // success only gets the bytes into the kernel
+                        // page cache, not stable storage; a power-loss
+                        // between here and the next checkpoint can
+                        // leave a hardlink pointing at zero-byte
+                        // content that downstream installs happily
+                        // reuse via the AlreadyExists fast path.
+                        file.sync_all()
+                            .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+                    }
+                    Ok(())
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+                Err(e) => Err(Error::Io(path.to_path_buf(), e)),
+            }
+        }
+
+        match do_create_and_write(path, content) {
+            Ok(()) => Ok(()),
+            Err(Error::Io(_, ref ioe)) if ioe.kind() == std::io::ErrorKind::NotFound => {
+                // Shard dir missing. `ensure_shards_exist` normally
+                // pre-creates all 256 shards; this only fires when the
+                // caller didn't call it or a concurrent prune wiped
+                // the tree mid-install.
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| Error::Io(parent.to_path_buf(), e))?;
+                }
+                do_create_and_write(path, content)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
     /// Import a single file's content into the store. Returns the stored file info.
     ///
     /// Hot path on cold installs: callers should invoke
@@ -220,70 +273,7 @@ impl Store {
         // install). On a warm CAS, concurrent writers are safe: EEXIST
         // means another writer already materialized this content (same
         // hash = same bytes), so we skip and share the entry.
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&store_path)
-        {
-            Ok(mut file) => {
-                use std::io::Write;
-                file.write_all(content)
-                    .map_err(|e| Error::Io(store_path.clone(), e))?;
-                // fsync before closing. write_all returning success
-                // only gets the bytes into the kernel page cache, not
-                // onto stable storage. If the host crashes or power
-                // fails between write_all and the next checkpoint,
-                // a hardlink pointing at this inode can survive with
-                // zero-byte content. Next install reuses it via the
-                // AlreadyExists fast path and ships empty files into
-                // node_modules. Real failure mode reported by users
-                // of other tools, fsync kills the class at modest
-                // cost (one syscall per new CAS file, cold install
-                // only since warm runs hit AlreadyExists and skip
-                // the write). Ignore fsync errors on platforms where
-                // sync_all is unsupported but do not swallow IO
-                // errors from real failures.
-                file.sync_all()
-                    .map_err(|e| Error::Io(store_path.clone(), e))?;
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                // Another writer already populated this content — skip.
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // Shard dir missing. ensure_shards_exist pre-creates
-                // all 256 shards so this only fires when the caller
-                // did not call it, or a concurrent prune wiped the
-                // shard tree mid-install. Recreate the shard dir
-                // then retry the atomic create_new path rather than
-                // falling back to xx::file::write which truncates
-                // in place and has no fsync. Non-atomic fallback
-                // left room for a torn CAS file after a second
-                // crash.
-                if let Some(parent) = store_path.parent() {
-                    std::fs::create_dir_all(parent)
-                        .map_err(|e| Error::Io(parent.to_path_buf(), e))?;
-                }
-                match std::fs::OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .open(&store_path)
-                {
-                    Ok(mut file) => {
-                        use std::io::Write;
-                        file.write_all(content)
-                            .map_err(|e| Error::Io(store_path.clone(), e))?;
-                        file.sync_all()
-                            .map_err(|e| Error::Io(store_path.clone(), e))?;
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                        // Another writer raced us. Same-content CAS
-                        // guarantees the existing file is correct.
-                    }
-                    Err(e) => return Err(Error::Io(store_path.clone(), e)),
-                }
-            }
-            Err(e) => return Err(Error::Io(store_path.clone(), e)),
-        }
+        Self::create_cas_file(&store_path, Some(content))?;
 
         if executable {
             // Behavior note: this branch now runs unconditionally when
@@ -306,33 +296,7 @@ impl Store {
             // through the `PackageIndex` and the linker. So flipping
             // a marker-absent-to-present for a shared hash is safe.
             let exec_marker = PathBuf::from(format!("{}-exec", store_path.display()));
-            match std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&exec_marker)
-            {
-                Ok(_) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    // Same as above, recreate the shard, retry
-                    // atomic create_new. Marker is a zero-byte
-                    // sidecar, no content to sync.
-                    if let Some(parent) = exec_marker.parent() {
-                        std::fs::create_dir_all(parent)
-                            .map_err(|e| Error::Io(parent.to_path_buf(), e))?;
-                    }
-                    match std::fs::OpenOptions::new()
-                        .write(true)
-                        .create_new(true)
-                        .open(&exec_marker)
-                    {
-                        Ok(_) => {}
-                        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
-                        Err(e) => return Err(Error::Io(exec_marker.clone(), e)),
-                    }
-                }
-                Err(e) => return Err(Error::Io(exec_marker, e)),
-            }
+            Self::create_cas_file(&exec_marker, None)?;
         }
 
         Ok(StoredFile {

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -1,5 +1,5 @@
 use super::catalogs::{CatalogRewrite, decide_add_rewrite};
-use super::{install, make_client, packument_cache_dir};
+use super::install;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::BTreeMap;
@@ -360,9 +360,7 @@ pub async fn run(
     // written lockfile) on disk, breaking the `--no-save` promise.
     let pipeline_result: miette::Result<()> = async {
         let existing = aube_lockfile::parse_lockfile(&cwd, &manifest).ok();
-        let mut resolver = aube_resolver::Resolver::new(std::sync::Arc::new(make_client(&cwd)))
-            .with_packument_cache(packument_cache_dir())
-            .with_catalogs(workspace_catalogs);
+        let mut resolver = super::build_resolver(&cwd, workspace_catalogs);
         let graph = resolver
             .resolve(&manifest, existing.as_ref())
             .await
@@ -370,17 +368,7 @@ pub async fn run(
             .wrap_err("failed to resolve dependencies")?;
         eprintln!("Resolved {} packages", graph.packages.len());
 
-        let written_path =
-            aube_lockfile::write_lockfile_preserving_existing(&cwd, &graph, &manifest)
-                .into_diagnostic()
-                .wrap_err("failed to write lockfile")?;
-        eprintln!(
-            "Wrote {}",
-            written_path
-                .file_name()
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_else(|| written_path.display().to_string())
-        );
+        super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
 
         install::run(install::InstallOptions::with_mode(
             super::chained_frozen_mode(install::FrozenMode::Prefer),
@@ -514,12 +502,10 @@ async fn update_manifest_for_add(
     let workspace_catalogs = super::load_workspace_catalogs(cwd)?;
     let default_catalog = workspace_catalogs.get("default");
     let manifest_path = cwd.join("package.json");
-    let mut manifest = aube_manifest::PackageJson::from_path(&manifest_path)
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let mut manifest = super::load_manifest(&manifest_path)?;
 
     // Parse all specs and fetch packuments concurrently.
-    let client = std::sync::Arc::new(make_client(cwd));
+    let client = std::sync::Arc::new(super::make_client(cwd));
     let parsed: Vec<_> = packages
         .iter()
         .map(|s| {
@@ -736,15 +722,7 @@ async fn update_manifest_for_add(
     // write the mutated manifest to disk for the duration of the
     // resolver + install pipeline (both re-read from disk), then
     // restore the original bytes from their snapshot before returning.
-    let json = serde_json::to_string_pretty(&manifest)
-        .into_diagnostic()
-        .wrap_err("failed to serialize package.json")?;
-    // Atomic write. Old fs::write truncates in place so a crash
-    // mid-write corrupts the user's manifest. Losing package.json
-    // is the worst failure mode of aube add, user has to `git
-    // restore` to recover. Tempfile + persist makes the swap
-    // atomic, crash leaves either old or new bytes, never torn.
-    write_atomic(&manifest_path, format!("{json}\n").as_bytes())?;
+    super::write_manifest_json(&manifest_path, &manifest)?;
     if print_updated {
         eprintln!("Updated package.json");
     }
@@ -1148,29 +1126,6 @@ async fn run_global_inner(
 /// remove / workspace writes so a crash mid-write cannot corrupt
 /// the user's manifest. Rename is atomic on POSIX, on Windows
 /// MoveFileEx gives the same guarantee post Win10.
-fn write_atomic(path: &std::path::Path, body: &[u8]) -> miette::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let tmp = tempfile::Builder::new()
-        .prefix(".aube-add-")
-        .suffix(".tmp")
-        .tempfile_in(parent)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("failed to open tempfile for {}", path.display()))?;
-    {
-        use std::io::Write as _;
-        let mut f = tmp.as_file();
-        f.write_all(body)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to write tempfile for {}", path.display()))?;
-        f.sync_all()
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to sync tempfile for {}", path.display()))?;
-    }
-    tmp.persist(path)
-        .map_err(|e| miette!("failed to persist {}: {e}", path.display()))?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -8,7 +8,6 @@
 //! Pure read: no lockfile writes, no `node_modules/` touches, no project lock.
 
 use super::DepFilter;
-use aube_lockfile::{DepType, DirectDep, LockedPackage, LockfileGraph};
 use aube_registry::Packument;
 use aube_registry::client::RegistryClient;
 use aube_registry::config::normalize_registry_url_pub;
@@ -121,22 +120,16 @@ pub enum Severity {
 pub async fn run(args: AuditArgs, registry_override: Option<&str>) -> miette::Result<()> {
     let cwd = crate::dirs::project_root()?;
 
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
-    let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
-        Ok(g) => g,
-        Err(aube_lockfile::Error::NotFound(_)) => {
-            return Err(miette!(
-                "no lockfile found — run `aube install` before `aube audit`"
-            ));
-        }
-        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
-    };
+    let graph = super::load_graph(
+        &cwd,
+        &manifest,
+        "no lockfile found — run `aube install` before `aube audit`",
+    )?;
 
     let filter = DepFilter::from_flags(args.prod, args.dev);
-    let closure = collect_closure(&graph, filter, args.no_optional);
+    let closure = super::collect_dep_closure(&graph, filter, args.no_optional);
 
     // Build the bulk request body: { name: [version, ...] } with versions
     // deduped so the registry doesn't do extra work on a diamond dep.
@@ -432,9 +425,7 @@ async fn write_fix_overrides(
         overrides.insert(name.clone(), serde_json::Value::String(version.clone()));
     }
 
-    let json = serde_json::to_string_pretty(&root).into_diagnostic()?;
-    write_manifest_atomic(&manifest_path, format!("{json}\n").as_bytes())
-        .wrap_err("failed to write package.json")?;
+    super::write_manifest_json(&manifest_path, &root)?;
     eprintln!(
         "Updated package.json overrides for {} package(s).",
         fixes.len()
@@ -443,32 +434,6 @@ async fn write_fix_overrides(
 }
 
 /// Atomic package.json write via tempfile + rename. Crash or Ctrl+C
-/// mid-write used to leave the user with a truncated manifest,
-/// worst-case aube failure mode. Matches the pattern used in
-/// add/remove/state.
-fn write_manifest_atomic(path: &std::path::Path, body: &[u8]) -> miette::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let tmp = tempfile::Builder::new()
-        .prefix(".aube-audit-")
-        .suffix(".tmp")
-        .tempfile_in(parent)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("failed to open tempfile for {}", path.display()))?;
-    {
-        use std::io::Write as _;
-        let mut f = tmp.as_file();
-        f.write_all(body)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to write tempfile for {}", path.display()))?;
-        f.sync_all()
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to sync tempfile for {}", path.display()))?;
-    }
-    tmp.persist(path)
-        .map_err(|e| miette!("failed to persist {}: {e}", path.display()))?;
-    Ok(())
-}
-
 fn best_non_vulnerable(packument: &Packument, vulnerable_versions: &[String]) -> Option<String> {
     let vulnerable: Vec<node_semver::Range> = vulnerable_versions
         .iter()
@@ -493,34 +458,6 @@ fn best_non_vulnerable(packument: &Packument, vulnerable_versions: &[String]) ->
 }
 
 /// Reachable packages from the filtered roots, keyed by `dep_path`.
-fn collect_closure(
-    graph: &LockfileGraph,
-    filter: DepFilter,
-    no_optional: bool,
-) -> BTreeMap<String, &LockedPackage> {
-    let mut out: BTreeMap<String, &LockedPackage> = BTreeMap::new();
-    let roots: Vec<&DirectDep> = graph
-        .root_deps()
-        .iter()
-        .filter(|d| filter.keeps(d.dep_type))
-        .filter(|d| !(no_optional && matches!(d.dep_type, DepType::Optional)))
-        .collect();
-
-    let mut stack: Vec<String> = roots.iter().map(|d| d.dep_path.clone()).collect();
-    while let Some(dep_path) = stack.pop() {
-        if out.contains_key(&dep_path) {
-            continue;
-        }
-        let Some(pkg) = graph.get_package(&dep_path) else {
-            continue;
-        };
-        out.insert(dep_path.clone(), pkg);
-        for (name, version) in &pkg.dependencies {
-            stack.push(format!("{name}@{version}"));
-        }
-    }
-    out
-}
 
 #[derive(Debug)]
 struct Row {

--- a/crates/aube/src/commands/clean.rs
+++ b/crates/aube/src/commands/clean.rs
@@ -17,7 +17,6 @@
 //! tree" command.
 
 use clap::Args;
-use miette::Context;
 
 #[derive(Debug, Args)]
 pub struct CleanArgs {
@@ -56,9 +55,7 @@ async fn run_as(invoked_as: &str, args: CleanArgs) -> miette::Result<()> {
     // stop — the user's script is authoritative.
     let root_pkg = cwd.join("package.json");
     if root_pkg.is_file() {
-        let manifest = aube_manifest::PackageJson::from_path(&root_pkg)
-            .map_err(miette::Report::new)
-            .wrap_err("failed to read package.json")?;
+        let manifest = super::load_manifest(&root_pkg)?;
         if manifest.scripts.contains_key(invoked_as) {
             // `--lockfile` is an aube-specific flag that the user's
             // script almost certainly doesn't know about, so warn

--- a/crates/aube/src/commands/dedupe.rs
+++ b/crates/aube/src/commands/dedupe.rs
@@ -5,7 +5,7 @@
 //! that always picks the highest version satisfying each range, which
 //! naturally collapses duplicates left over from past adds/removes/updates.
 
-use super::{install, make_client, packument_cache_dir};
+use super::install;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -23,9 +23,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root()?;
     let _lock = super::take_project_lock(&cwd)?;
 
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
     // Read the existing lockfile purely for the diff. We do NOT pass it to
     // the resolver — passing `None` is what makes this "dedupe" instead of
@@ -67,10 +65,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
     }
 
     let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
-    let client = std::sync::Arc::new(make_client(&cwd));
-    let mut resolver = aube_resolver::Resolver::new(client)
-        .with_packument_cache(packument_cache_dir())
-        .with_catalogs(workspace_catalogs);
+    let mut resolver = super::build_resolver(&cwd, workspace_catalogs);
     let graph = resolver
         .resolve_workspace(&manifests, None, &ws_package_versions)
         .await
@@ -106,16 +101,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
         return Err(miette!("dedupe --check: lockfile is not deduped"));
     }
 
-    let written_path = aube_lockfile::write_lockfile_preserving_existing(&cwd, &graph, &manifest)
-        .into_diagnostic()
-        .wrap_err("failed to write lockfile")?;
-    eprintln!(
-        "Wrote {}",
-        written_path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| written_path.display().to_string())
-    );
+    super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
 
     // Resync node_modules against the new lockfile.
     install::run(install::InstallOptions::with_mode(

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -389,11 +389,8 @@ fn seed_target_lockfile(
     // timestamps for any package resolved with a peer context.
     // Build the canonical key set from `LockedPackage.name` /
     // `.version` and filter against that.
-    let canonical_keys: std::collections::HashSet<String> = subset
-        .packages
-        .values()
-        .map(|pkg| format!("{}@{}", pkg.name, pkg.version))
-        .collect();
+    let canonical_keys: std::collections::HashSet<String> =
+        subset.packages.values().map(|pkg| pkg.spec_key()).collect();
     subset.times.retain(|key, _| canonical_keys.contains(key));
 
     // Re-read the rewritten target manifest. The writer uses `name`
@@ -433,9 +430,7 @@ fn stage_one(
         // `.git/`, and the target itself when nested). Read the
         // manifest directly to reuse `name`/`version` for the final
         // println without building a throwaway tarball.
-        let manifest = PackageJson::from_path(&source_pkg_dir.join("package.json"))
-            .map_err(miette::Report::new)
-            .wrap_err("failed to read package.json")?;
+        let manifest = super::load_manifest(&source_pkg_dir.join("package.json"))?;
         let name = manifest
             .name
             .ok_or_else(|| miette!("deploy: package.json has no `name` field"))?;

--- a/crates/aube/src/commands/deprecations.rs
+++ b/crates/aube/src/commands/deprecations.rs
@@ -47,9 +47,7 @@ struct JsonEntry {
 pub async fn run(args: DeprecationsArgs) -> miette::Result<Option<i32>> {
     let cwd = crate::dirs::project_root()?;
 
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
         Ok(g) => g,

--- a/crates/aube/src/commands/fetch.rs
+++ b/crates/aube/src/commands/fetch.rs
@@ -35,9 +35,7 @@ pub async fn run(args: FetchArgs) -> miette::Result<()> {
     // the manifest is effectively unused by the parser.
     let manifest_path = cwd.join("package.json");
     let manifest = if manifest_path.exists() {
-        aube_manifest::PackageJson::from_path(&manifest_path)
-            .map_err(miette::Report::new)
-            .wrap_err("failed to read package.json")?
+        super::load_manifest(&manifest_path)?
     } else {
         // Minimal empty manifest so parse_lockfile_with_kind's signature is happy.
         serde_json::from_str::<aube_manifest::PackageJson>("{}").into_diagnostic()?

--- a/crates/aube/src/commands/ignored_builds.rs
+++ b/crates/aube/src/commands/ignored_builds.rs
@@ -88,9 +88,7 @@ impl std::cmp::PartialOrd for IgnoredEntry {
 /// Returns an empty list (not an error) if there is no lockfile yet —
 /// callers print their own "nothing to do" message.
 pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<Vec<IgnoredEntry>> {
-    let manifest = aube_manifest::PackageJson::from_path(&project_dir.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&project_dir.join("package.json"))?;
 
     let graph = match aube_lockfile::parse_lockfile(project_dir, &manifest) {
         Ok(g) => g,

--- a/crates/aube/src/commands/import.rs
+++ b/crates/aube/src/commands/import.rs
@@ -38,9 +38,7 @@ pub async fn run(args: ImportArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root()?;
     let _lock = crate::commands::take_project_lock(&cwd)?;
 
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
     // Honor `gitBranchLockfile`: the destination is whichever aube
     // lockfile this branch would actually write through, so the

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -783,6 +783,64 @@ pub(crate) async fn run_dep_lifecycle_scripts(
     Ok(ran)
 }
 
+/// Verify + import + validate + save-index for a freshly fetched
+/// tarball. Shared between the lockfile-driven fetch path and the
+/// no-lockfile streaming fetch path so both honor the same integrity
+/// and content-check settings. Runs inside `spawn_blocking` — no
+/// async in this function.
+#[allow(clippy::too_many_arguments)]
+fn import_verified_tarball(
+    store: &aube_store::Store,
+    bytes: &[u8],
+    display_name: &str,
+    registry_name: &str,
+    version: &str,
+    integrity: Option<&str>,
+    verify_integrity: bool,
+    strict_integrity: bool,
+    strict_pkg_content_check: bool,
+) -> miette::Result<aube_store::PackageIndex> {
+    if verify_integrity {
+        if let Some(expected) = integrity {
+            aube_store::verify_integrity(bytes, expected)
+                .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
+        } else if strict_integrity {
+            // strict-store-integrity=true opts the user into
+            // fail-closed. Default is off so ecosystem parity with
+            // pnpm stays intact. A registry proxy that strips
+            // dist.integrity will no longer slip past silently when
+            // strict is on.
+            return Err(miette!(
+                "{display_name}@{version}: registry response has no `dist.integrity` and `strict-store-integrity` is on. Refusing to import unverified bytes."
+            ));
+        } else {
+            tracing::warn!(
+                "{display_name}@{version}: registry response has no `dist.integrity`, importing without content verification. Set `strict-store-integrity=true` to refuse instead."
+            );
+        }
+    }
+    let index = store
+        .import_tarball(bytes)
+        .map_err(|e| miette!("failed to import {display_name}@{version}: {e}"))?;
+    // strictStorePkgContentCheck: cross-check the freshly stored
+    // package.json against the resolver-asserted (name, version)
+    // before the index is cached or returned to the linker. Validate
+    // against `registry_name` — the real package name that appears
+    // in the tarball's own `package.json` — not the alias, or this
+    // would fail every npm-aliased entry.
+    if strict_pkg_content_check {
+        aube_store::validate_pkg_content(&index, registry_name, version)
+            .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
+    }
+    // Cache under `registry_name` so two aliases of the same real
+    // package hit the same on-disk index file and avoid redundant
+    // fetches.
+    if let Err(e) = store.save_index(registry_name, version, &index) {
+        tracing::warn!("Failed to cache index for {display_name}@{version}: {e}");
+    }
+    Ok(index)
+}
+
 fn validate_required_scripts(
     project_dir: &std::path::Path,
     manifest: &aube_manifest::PackageJson,
@@ -882,7 +940,7 @@ fn unreviewed_dep_builds(
             .map_err(miette::Report::new)
             .wrap_err_with(|| format!("failed to parse package.json for {}", pkg.name))?;
         if aube_scripts::has_dep_lifecycle_work(&package_dir, &dep_manifest) {
-            unreviewed.push(format!("{}@{}", pkg.name, pkg.version));
+            unreviewed.push(pkg.spec_key());
         }
     }
     unreviewed.sort();
@@ -1547,59 +1605,19 @@ where
                     let registry_name = registry_name.clone();
                     let version = version.clone();
                     move || -> miette::Result<_> {
-                        if verify_integrity {
-                            if let Some(ref expected) = integrity {
-                                aube_store::verify_integrity(&bytes, expected)
-                                    .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
-                            } else if strict_integrity {
-                                // strict-store-integrity=true opts the
-                                // user into fail-closed. Default is off
-                                // so ecosystem parity with pnpm stays
-                                // intact. A registry proxy that strips
-                                // dist.integrity will no longer slip
-                                // past silently when strict is on.
-                                return Err(miette!(
-                                    "{display_name}@{version}: registry response has no `dist.integrity` and `strict-store-integrity` is on. Refusing to import unverified bytes."
-                                ));
-                            } else {
-                                tracing::warn!(
-                                    "{display_name}@{version}: registry response has no `dist.integrity`, importing without content verification. Set `strict-store-integrity=true` to refuse instead."
-                                );
-                            }
-                        }
                         let import_start = std::time::Instant::now();
-                        let index = store.import_tarball(&bytes).map_err(|e| {
-                            miette!("failed to import {display_name}@{version}: {e}")
-                        })?;
-                        let import_time = import_start.elapsed();
-                        // strictStorePkgContentCheck: cross-check the
-                        // freshly stored package.json against the
-                        // resolver-asserted (name, version) before the
-                        // index is cached or returned to the linker.
-                        // Skip the check entirely when disabled — the
-                        // call would still be cheap (a single store
-                        // read + JSON parse) but pnpm parity is to
-                        // produce no error path at all when the user
-                        // opted out.
-                        //
-                        // Validate against `registry_name` — the real
-                        // package name that appears in the tarball's
-                        // own `package.json` — not the alias, or this
-                        // would fail every npm-aliased entry.
-                        if strict_pkg_content_check {
-                            aube_store::validate_pkg_content(&index, &registry_name, &version)
-                                .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
-                        }
-                        // Cache under `registry_name` so two aliases
-                        // of the same real package hit the same
-                        // on-disk index file and avoid redundant
-                        // fetches.
-                        if let Err(e) = store.save_index(&registry_name, &version, &index) {
-                            tracing::warn!(
-                                "Failed to cache index for {display_name}@{version}: {e}"
-                            );
-                        }
-                        Ok((index, import_time))
+                        let index = import_verified_tarball(
+                            &store,
+                            &bytes,
+                            &display_name,
+                            &registry_name,
+                            &version,
+                            integrity.as_deref(),
+                            verify_integrity,
+                            strict_integrity,
+                            strict_pkg_content_check,
+                        )?;
+                        Ok((index, import_start.elapsed()))
                     }
                 })
                 .await
@@ -1648,7 +1666,7 @@ fn remap_indices_to_contextualized(
 ) -> BTreeMap<String, aube_store::PackageIndex> {
     let mut out = BTreeMap::new();
     for (dep_path, pkg) in &graph.packages {
-        let canonical_key = format!("{}@{}", pkg.name, pkg.version);
+        let canonical_key = pkg.spec_key();
         if let Some(idx) = canonical_indices
             .get(dep_path)
             .or_else(|| canonical_indices.get(&canonical_key))
@@ -2889,10 +2907,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     handles.spawn(async move {
                         let _row = row;
                         let permit = sem.acquire().await.unwrap();
-                        let url = pkg
-                            .tarball_url
-                            .clone()
-                            .unwrap_or_else(|| client.tarball_url(&pkg_registry_name, &pkg.version));
+                        let url = pkg.tarball_url.clone().unwrap_or_else(|| {
+                            client.tarball_url(&pkg_registry_name, &pkg.version)
+                        });
                         tracing::trace!("Fetching {}@{}", pkg.name, pkg.version);
 
                         let bytes = client.fetch_tarball_bytes(&url).await.map_err(|e| {
@@ -2922,52 +2939,18 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         let pkg_version = pkg.version.clone();
                         let dep_path = pkg.dep_path.clone();
                         let integrity = pkg.integrity.clone();
-                        let index = tokio::task::spawn_blocking(move || -> miette::Result<_> {
-                            if fetch_verify_integrity {
-                                if let Some(ref expected) = integrity {
-                                    aube_store::verify_integrity(&bytes, expected).map_err(
-                                        |e| miette!("{pkg_display_name}@{pkg_version}: {e}"),
-                                    )?;
-                                } else if fetch_strict_integrity {
-                                    return Err(miette!(
-                                        "{pkg_display_name}@{pkg_version}: registry response has no `dist.integrity` and `strict-store-integrity` is on. Refusing to import unverified bytes."
-                                    ));
-                                } else {
-                                    tracing::warn!(
-                                        "{pkg_display_name}@{pkg_version}: registry response has no `dist.integrity`, importing without content verification. Set `strict-store-integrity=true` to refuse instead."
-                                    );
-                                }
-                            }
-                            let index = store.import_tarball(&bytes).map_err(|e| {
-                                miette!("failed to import {pkg_display_name}@{pkg_version}: {e}")
-                            })?;
-                            // strictStorePkgContentCheck: see the
-                            // matching block in `fetch_packages_with_root`
-                            // for the rationale. Both fetch paths must
-                            // honor the same setting or the no-lockfile
-                            // path would silently let through manifest
-                            // mismatches that the lockfile path catches.
-                            // Validates against the *registry* name —
-                            // the tarball's package.json records the
-                            // real name, not the alias, so comparing
-                            // against `pkg_display_name` would fail
-                            // every aliased install.
-                            if fetch_strict_pkg_content_check {
-                                aube_store::validate_pkg_content(
-                                    &index,
-                                    &pkg_registry_name,
-                                    &pkg_version,
-                                )
-                                .map_err(|e| miette!("{pkg_display_name}@{pkg_version}: {e}"))?;
-                            }
-                            if let Err(e) =
-                                store.save_index(&pkg_registry_name, &pkg_version, &index)
-                            {
-                                tracing::warn!(
-                                    "Failed to cache index for {pkg_display_name}@{pkg_version}: {e}"
-                                );
-                            }
-                            Ok(index)
+                        let index = tokio::task::spawn_blocking(move || {
+                            import_verified_tarball(
+                                &store,
+                                &bytes,
+                                &pkg_display_name,
+                                &pkg_registry_name,
+                                &pkg_version,
+                                integrity.as_deref(),
+                                fetch_verify_integrity,
+                                fetch_strict_integrity,
+                                fetch_strict_pkg_content_check,
+                            )
                         })
                         .await
                         .into_diagnostic()??;
@@ -3154,7 +3137,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     if pkg.local_source.is_some() {
                         continue;
                     }
-                    let canonical = format!("{}@{}", pkg.name, pkg.version);
+                    let canonical = pkg.spec_key();
                     canonical_to_contextualized
                         .entry(canonical)
                         .or_default()

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -85,9 +85,7 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
 
     let cwd = crate::dirs::project_root()?;
 
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
         Ok(g) => g,

--- a/crates/aube/src/commands/link.rs
+++ b/crates/aube/src/commands/link.rs
@@ -38,9 +38,7 @@ pub async fn run(args: LinkArgs) -> miette::Result<()> {
     match package {
         None => {
             // `aube link` — register current package globally
-            let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-                .map_err(miette::Report::new)
-                .wrap_err("failed to read package.json")?;
+            let manifest = super::load_manifest(&cwd.join("package.json"))?;
             let name = manifest
                 .name
                 .as_deref()

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -143,9 +143,7 @@ pub async fn run(
 
     // Read manifest (needed even for `list` — we print the project name/version
     // at the top, and the lockfile parser needs it for non-pnpm formats).
-    let manifest = aube_manifest::PackageJson::from_path(&read_from.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&read_from.join("package.json"))?;
 
     // Lockfile may be absent in a brand-new project — treat that as "nothing
     // installed yet" rather than a hard error, and print an empty tree.

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -423,6 +423,21 @@ pub(crate) fn make_client(cwd: &std::path::Path) -> aube_registry::client::Regis
     aube_registry::client::RegistryClient::from_config_with_policy(config, policy)
 }
 
+/// Build the standard resolver used by add/remove/update/dedupe: a
+/// shared `RegistryClient` wrapped in `Arc`, the shared packument
+/// cache directory, and the given catalog map. Every call site does
+/// these same three bindings in the same order; keep them in one
+/// place so a future addition (e.g. a fetch-policy tweak) lands
+/// everywhere at once.
+pub(crate) fn build_resolver(
+    cwd: &std::path::Path,
+    catalogs: CatalogMap,
+) -> aube_resolver::Resolver {
+    aube_resolver::Resolver::new(std::sync::Arc::new(make_client(cwd)))
+        .with_packument_cache(packument_cache_dir())
+        .with_catalogs(catalogs)
+}
+
 /// Resolve [`aube_registry::config::FetchPolicy`] from the same
 /// sources the rest of the CLI consumes settings from. Kept separate
 /// from [`make_client`] so tests and ad-hoc callers (publish,
@@ -707,6 +722,141 @@ pub(crate) fn discover_catalogs(project_root: &std::path::Path) -> miette::Resul
 /// [`discover_catalogs`] so every command sees the same merged view.
 pub(crate) fn load_workspace_catalogs(cwd: &std::path::Path) -> miette::Result<CatalogMap> {
     discover_catalogs(cwd)
+}
+
+/// Read and parse `package.json` at `manifest_path` with the standard
+/// miette-wrapped error message used across commands.
+pub(crate) fn load_manifest(manifest_path: &Path) -> miette::Result<aube_manifest::PackageJson> {
+    aube_manifest::PackageJson::from_path(manifest_path)
+        .map_err(miette::Report::new)
+        .wrap_err("failed to read package.json")
+}
+
+/// Serialize `value` as pretty JSON with a trailing newline and
+/// atomically write it to `path`. Wraps the serialize + atomic-write
+/// pair used by add/remove/update/audit when mutating `package.json`.
+pub(crate) fn write_manifest_json<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+) -> miette::Result<()> {
+    let json = serde_json::to_string_pretty(value)
+        .into_diagnostic()
+        .wrap_err("failed to serialize package.json")?;
+    write_manifest_atomic(path, format!("{json}\n").as_bytes())
+        .wrap_err("failed to write package.json")
+}
+
+/// Atomic write for `package.json` (and any sibling JSON we care
+/// about): write to a tempfile in the same directory then rename.
+/// The old `fs::write` truncates in place and a crash mid-write left
+/// users with an empty manifest — the worst aube failure mode.
+pub(crate) fn write_manifest_atomic(path: &Path, body: &[u8]) -> miette::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let tmp = tempfile::Builder::new()
+        .prefix(".aube-mf-")
+        .suffix(".tmp")
+        .tempfile_in(parent)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to open tempfile for {}", path.display()))?;
+    {
+        use std::io::Write as _;
+        let mut f = tmp.as_file();
+        f.write_all(body)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to write tempfile for {}", path.display()))?;
+        f.sync_all()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to sync tempfile for {}", path.display()))?;
+    }
+    tmp.persist(path)
+        .map_err(|e| miette!("failed to persist {}: {e}", path.display()))?;
+    Ok(())
+}
+
+/// Parse the project lockfile, mapping `NotFound` to a user-facing hint
+/// that includes `context` (e.g. `"aube audit"`).
+pub(crate) fn load_graph(
+    project_dir: &Path,
+    manifest: &aube_manifest::PackageJson,
+    missing_hint: &str,
+) -> miette::Result<aube_lockfile::LockfileGraph> {
+    match aube_lockfile::parse_lockfile(project_dir, manifest) {
+        Ok(g) => Ok(g),
+        Err(aube_lockfile::Error::NotFound(_)) => Err(miette!("{missing_hint}")),
+        Err(e) => Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
+    }
+}
+
+/// Collect the transitive dep-path closure reachable from the filtered
+/// root deps, keyed by dep_path for stable iteration. Used by audit,
+/// sbom, and anything else that needs "which packages would apply if
+/// the user ran install in this mode".
+pub(crate) fn collect_dep_closure(
+    graph: &aube_lockfile::LockfileGraph,
+    filter: DepFilter,
+    no_optional: bool,
+) -> std::collections::BTreeMap<String, &aube_lockfile::LockedPackage> {
+    let mut out: std::collections::BTreeMap<String, &aube_lockfile::LockedPackage> =
+        std::collections::BTreeMap::new();
+    let mut stack: Vec<String> = graph
+        .root_deps()
+        .iter()
+        .filter(|d| filter.keeps(d.dep_type))
+        .filter(|d| !(no_optional && matches!(d.dep_type, aube_lockfile::DepType::Optional)))
+        .map(|d| d.dep_path.clone())
+        .collect();
+    while let Some(dep_path) = stack.pop() {
+        if out.contains_key(&dep_path) {
+            continue;
+        }
+        let Some(pkg) = graph.get_package(&dep_path) else {
+            continue;
+        };
+        out.insert(dep_path.clone(), pkg);
+        for (name, version) in &pkg.dependencies {
+            stack.push(format!("{name}@{version}"));
+        }
+    }
+    out
+}
+
+/// Restore `cwd` after a filtered-workspace loop and fold any restore
+/// error into the original `result`. Filter loops mutate the process
+/// cwd so they can run per-package commands as if the user were in
+/// that directory; this puts things back exactly once, even when the
+/// loop itself failed.
+pub(crate) fn finish_filtered_workspace(
+    cwd: &Path,
+    result: miette::Result<()>,
+) -> miette::Result<()> {
+    let restore =
+        retarget_cwd(cwd).wrap_err_with(|| format!("failed to restore cwd to {}", cwd.display()));
+    match result {
+        Ok(()) => restore,
+        Err(err) => {
+            let _ = restore;
+            Err(err)
+        }
+    }
+}
+
+/// Write lockfile preserving existing format and log the file name.
+pub(crate) fn write_and_log_lockfile(
+    cwd: &Path,
+    graph: &aube_lockfile::LockfileGraph,
+    manifest: &aube_manifest::PackageJson,
+) -> miette::Result<std::path::PathBuf> {
+    let written_path = aube_lockfile::write_lockfile_preserving_existing(cwd, graph, manifest)
+        .into_diagnostic()
+        .wrap_err("failed to write lockfile")?;
+    eprintln!(
+        "Wrote {}",
+        written_path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| written_path.display().to_string())
+    );
+    Ok(written_path)
 }
 
 /// Walk up from `start` looking for a directory that marks a workspace

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -131,9 +131,7 @@ async fn run_filtered(
     filter: &aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<()> {
     let (root, matched) = super::select_workspace_packages(cwd, filter, "outdated")?;
-    let manifest = aube_manifest::PackageJson::from_path(&root.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&root.join("package.json"))?;
     let graph = match aube_lockfile::parse_lockfile(&root, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
@@ -173,9 +171,7 @@ async fn run_filtered(
 }
 
 async fn run_one(cwd: &Path, args: OutdatedArgs, importer: Option<String>) -> miette::Result<bool> {
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
     let graph = match aube_lockfile::parse_lockfile(cwd, &manifest) {
         Ok(g) => g,

--- a/crates/aube/src/commands/peers.rs
+++ b/crates/aube/src/commands/peers.rs
@@ -11,7 +11,6 @@
 
 use aube_lockfile::LockfileGraph;
 use clap::{Args, Subcommand};
-use miette::{Context, miette};
 use std::collections::BTreeMap;
 
 pub const CHECK_AFTER_LONG_HELP: &str = "\
@@ -65,17 +64,13 @@ pub async fn run(args: PeersArgs) -> miette::Result<()> {
 async fn check(args: PeersCheckArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root()?;
 
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
-    let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
-        Ok(g) => g,
-        Err(aube_lockfile::Error::NotFound(_)) => {
-            return Err(miette!("no lockfile found\nhelp: run `aube install` first"));
-        }
-        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
-    };
+    let graph = super::load_graph(
+        &cwd,
+        &manifest,
+        "no lockfile found\nhelp: run `aube install` first",
+    )?;
 
     let issues = collect_issues(&graph);
 

--- a/crates/aube/src/commands/prune.rs
+++ b/crates/aube/src/commands/prune.rs
@@ -37,9 +37,7 @@ pub async fn run(args: PruneArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root()?;
     let _lock = super::take_project_lock(&cwd)?;
 
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
     let graph = aube_lockfile::parse_lockfile(&cwd, &manifest)
         .map_err(miette::Report::new)

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -163,13 +163,5 @@ async fn run_filtered(filter: &aube_workspace::selector::EffectiveFilter) -> mie
         Ok(())
     }
     .await;
-    let restore_result = super::retarget_cwd(&cwd)
-        .wrap_err_with(|| format!("failed to restore cwd to {}", cwd.display()));
-    match result {
-        Ok(()) => restore_result,
-        Err(err) => {
-            let _ = restore_result;
-            Err(err)
-        }
-    }
+    super::finish_filtered_workspace(&cwd, result)
 }

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -1,4 +1,4 @@
-use super::{install, make_client, packument_cache_dir};
+use super::install;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 
@@ -63,9 +63,7 @@ pub async fn run(
     let _lock = super::take_project_lock(&cwd)?;
     let manifest_path = cwd.join("package.json");
 
-    let mut manifest = aube_manifest::PackageJson::from_path(&manifest_path)
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let mut manifest = super::load_manifest(&manifest_path)?;
 
     for name in packages {
         let removed = if args.save_dev {
@@ -106,19 +104,13 @@ pub async fn run(
     // Write updated package.json atomically. Crash mid-write would
     // otherwise truncate the user manifest, worst-case aube failure
     // mode. Tempfile + persist keeps the swap atomic.
-    let json = serde_json::to_string_pretty(&manifest)
-        .into_diagnostic()
-        .wrap_err("failed to serialize package.json")?;
-    write_manifest_atomic(&manifest_path, format!("{json}\n").as_bytes())?;
+    super::write_manifest_json(&manifest_path, &manifest)?;
     eprintln!("Updated package.json");
 
     // Re-resolve dependency tree without the removed packages
-    let client = std::sync::Arc::new(make_client(&cwd));
     let existing = aube_lockfile::parse_lockfile(&cwd, &manifest).ok();
     let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
-    let mut resolver = aube_resolver::Resolver::new(client)
-        .with_packument_cache(packument_cache_dir())
-        .with_catalogs(workspace_catalogs);
+    let mut resolver = super::build_resolver(&cwd, workspace_catalogs);
     let graph = resolver
         .resolve(&manifest, existing.as_ref())
         .await
@@ -126,16 +118,7 @@ pub async fn run(
         .wrap_err("failed to resolve dependencies")?;
     eprintln!("Resolved {} packages", graph.packages.len());
 
-    let written_path = aube_lockfile::write_lockfile_preserving_existing(&cwd, &graph, &manifest)
-        .into_diagnostic()
-        .wrap_err("failed to write lockfile")?;
-    eprintln!(
-        "Wrote {}",
-        written_path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| written_path.display().to_string())
-    );
+    super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
 
     // Reinstall to clean up node_modules
     let mut opts =
@@ -164,15 +147,7 @@ async fn run_filtered(
         Ok(())
     }
     .await;
-    let restore_result = super::retarget_cwd(&cwd)
-        .wrap_err_with(|| format!("failed to restore cwd to {}", cwd.display()));
-    match result {
-        Ok(()) => restore_result,
-        Err(err) => {
-            let _ = restore_result;
-            Err(err)
-        }
-    }
+    super::finish_filtered_workspace(&cwd, result)
 }
 
 /// `aube remove -g <pkg>...` — delete globally-installed packages and
@@ -276,27 +251,4 @@ fn prune_sidecar_entries(manifest: &mut aube_manifest::PackageJson, name: &str) 
             manifest.extra.remove("resolutions");
         }
     }
-}
-
-fn write_manifest_atomic(path: &std::path::Path, body: &[u8]) -> miette::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let tmp = tempfile::Builder::new()
-        .prefix(".aube-remove-")
-        .suffix(".tmp")
-        .tempfile_in(parent)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("failed to open tempfile for {}", path.display()))?;
-    {
-        use std::io::Write as _;
-        let mut f = tmp.as_file();
-        f.write_all(body)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to write tempfile for {}", path.display()))?;
-        f.sync_all()
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to sync tempfile for {}", path.display()))?;
-    }
-    tmp.persist(path)
-        .map_err(|e| miette!("failed to persist {}: {e}", path.display()))?;
-    Ok(())
 }

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -5,9 +5,9 @@
 //! 1.5 JSON or SPDX 2.3 JSON. Pure read; does not touch `node_modules/` or
 //! take the project lock.
 
-use aube_lockfile::{DirectDep, LockedPackage, LockfileGraph};
+use aube_lockfile::{LockedPackage, LockfileGraph};
 use clap::Args;
-use miette::{Context, IntoDiagnostic, miette};
+use miette::{Context, IntoDiagnostic};
 use std::collections::BTreeMap;
 
 use super::DepFilter;
@@ -41,22 +41,16 @@ pub enum SbomFormat {
 pub async fn run(args: SbomArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root()?;
 
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
-    let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
-        Ok(g) => g,
-        Err(aube_lockfile::Error::NotFound(_)) => {
-            return Err(miette!(
-                "no lockfile found — run `aube install` before generating an SBOM"
-            ));
-        }
-        Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
-    };
+    let graph = super::load_graph(
+        &cwd,
+        &manifest,
+        "no lockfile found — run `aube install` before generating an SBOM",
+    )?;
 
     let filter = DepFilter::from_flags(args.prod, args.dev);
-    let closure = collect_closure(&graph, filter);
+    let closure = super::collect_dep_closure(&graph, filter, false);
 
     let json = match args.format {
         SbomFormat::Cyclonedx => render_cyclonedx(&manifest, &closure)?,
@@ -65,32 +59,6 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
 
     println!("{json}");
     Ok(())
-}
-
-/// Reachable packages from the filtered root deps, keyed by dep_path. Sorted
-/// so output is byte-stable across runs.
-fn collect_closure(graph: &LockfileGraph, filter: DepFilter) -> BTreeMap<String, &LockedPackage> {
-    let mut out: BTreeMap<String, &LockedPackage> = BTreeMap::new();
-    let roots: Vec<&DirectDep> = graph
-        .root_deps()
-        .iter()
-        .filter(|d| filter.keeps(d.dep_type))
-        .collect();
-
-    let mut stack: Vec<String> = roots.iter().map(|d| d.dep_path.clone()).collect();
-    while let Some(dep_path) = stack.pop() {
-        if out.contains_key(&dep_path) {
-            continue;
-        }
-        let Some(pkg) = graph.get_package(&dep_path) else {
-            continue;
-        };
-        out.insert(dep_path.clone(), pkg);
-        for (name, version) in &pkg.dependencies {
-            stack.push(format!("{name}@{version}"));
-        }
-    }
-    out
 }
 
 /// CycloneDX 1.5 JSON. See https://cyclonedx.org/docs/1.5/json/.

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1,4 +1,4 @@
-use super::{install, make_client, packument_cache_dir};
+use super::install;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::{BTreeMap, BTreeSet};
@@ -215,11 +215,8 @@ pub async fn run(
     });
 
     // Re-resolve the full dependency tree
-    let client = std::sync::Arc::new(make_client(&cwd));
     let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
-    let mut resolver = aube_resolver::Resolver::new(client)
-        .with_packument_cache(packument_cache_dir())
-        .with_catalogs(workspace_catalogs);
+    let mut resolver = super::build_resolver(&cwd, workspace_catalogs);
     let graph = resolver
         .resolve(&resolver_manifest, filtered_existing.as_ref())
         .await
@@ -306,27 +303,13 @@ pub async fn run(
                 wrote_any = true;
             }
             if wrote_any {
-                let json = serde_json::to_string_pretty(&manifest)
-                    .into_diagnostic()
-                    .wrap_err("failed to serialize package.json")?;
-                std::fs::write(&manifest_path, format!("{json}\n"))
-                    .into_diagnostic()
-                    .wrap_err("failed to write package.json")?;
+                super::write_manifest_json(&manifest_path, &manifest)?;
                 eprintln!("Updated package.json");
             }
         }
     }
 
-    let written_path = aube_lockfile::write_lockfile_preserving_existing(&cwd, &graph, &manifest)
-        .into_diagnostic()
-        .wrap_err("failed to write lockfile")?;
-    eprintln!(
-        "Wrote {}",
-        written_path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| written_path.display().to_string())
-    );
+    super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
 
     install::run(install::InstallOptions::with_mode(
         super::chained_frozen_mode(install::FrozenMode::Prefer),
@@ -377,15 +360,7 @@ async fn run_filtered(
         Ok(())
     }
     .await;
-    let restore_result = super::retarget_cwd(&cwd)
-        .wrap_err_with(|| format!("failed to restore cwd to {}", cwd.display()));
-    match result {
-        Ok(()) => restore_result,
-        Err(err) => {
-            let _ = restore_result;
-            Err(err)
-        }
-    }
+    super::finish_filtered_workspace(&cwd, result)
 }
 
 /// Rewrite a direct-dep specifier to pin `resolved_version`, preserving:

--- a/crates/aube/src/commands/why.rs
+++ b/crates/aube/src/commands/why.rs
@@ -78,9 +78,7 @@ pub async fn run(
         return run_filtered(&cwd, &args, &filter);
     }
 
-    let manifest = aube_manifest::PackageJson::from_path(&cwd.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
         Ok(g) => g,
@@ -125,9 +123,7 @@ fn run_filtered(
         )
     })?;
 
-    let manifest = aube_manifest::PackageJson::from_path(&workspace_root.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
+    let manifest = super::load_manifest(&workspace_root.join("package.json"))?;
 
     let graph = match aube_lockfile::parse_lockfile(&workspace_root, &manifest) {
         Ok(g) => g,

--- a/crates/aube/src/engines.rs
+++ b/crates/aube/src/engines.rs
@@ -207,7 +207,7 @@ pub fn collect_dep_mismatches(
                 Ok(None)
             } else {
                 Ok(Some(Mismatch {
-                    package: format!("{}@{}", pkg.name, pkg.version),
+                    package: pkg.spec_key(),
                     declared: node_range.to_string(),
                     current: node_version.to_string(),
                 }))


### PR DESCRIPTION
consolidate repeated patterns into shared helpers across the workspace. no behavior change.

linker
- try_remove_entry, mkdirp, classify_entry_state, sweep_stale_top_level_entries, win_shim_paths

lockfile
- build_canonical_map, LockedPackage::spec_key

resolver
- ResolveTask::root + ::transitive factories, canonical_tail, scope_map_from_deps

registry
- extract_cache_headers

store
- create_cas_file (merged content + marker atomic-create fallbacks)

scripts
- matches_any_wildcard

cli
- load_manifest, load_graph, write_manifest_atomic, write_manifest_json,
- write_and_log_lockfile, finish_filtered_workspace, collect_dep_closure,
- build_resolver, import_verified_tarball