### PR TITLE
ci(release): add x86_64 and aarch64 linux-musl targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             build-tool: cross
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            build-tool: cross
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            build-tool: cross
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             build-tool: cargo

--- a/npm/installArchSpecificPackage.js
+++ b/npm/installArchSpecificPackage.js
@@ -22,7 +22,16 @@ function main() {
 
     var platform = process.platform; // darwin | linux | win32
     var arch = process.arch;         // arm64 | x64
-    var subpkgName = '@endevco/aube-' + platform + '-' + arch;
+    // On Linux, `process.report` exposes `glibcVersionRuntime` when the
+    // runtime linked against glibc; its absence means musl (Alpine,
+    // distroless-static). Same heuristic the `detect-libc` package uses.
+    var suffix = '';
+    if (platform === 'linux') {
+        var glibc = '';
+        try { glibc = process.report.getReport().header.glibcVersionRuntime || ''; } catch (_) {}
+        if (!glibc) suffix = '-musl';
+    }
+    var subpkgName = '@endevco/aube-' + platform + '-' + arch + suffix;
 
     var npmCmd = platform === 'win32' ? 'npm.cmd' : 'npm';
     var args = ['install', '--no-save', '--no-package-lock', subpkgName + '@' + version];

--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -34,12 +34,18 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const npmDir = resolve(__dirname, '..');
 const stageRoot = resolve(npmDir, '.stage');
 
+// `libc` is only set on Linux targets; it feeds both the published
+// package name suffix (`-musl`) and the `libc` field in the generated
+// package.json so npm picks the right variant if ever listed as an
+// optional dep. Absence of `libc` = not applicable (darwin/win32).
 const TARGETS = [
-    { triple: 'aarch64-apple-darwin',       os: 'darwin', cpu: 'arm64', ext: '.tar.gz', exe: '' },
-    { triple: 'x86_64-unknown-linux-gnu',   os: 'linux',  cpu: 'x64',   ext: '.tar.gz', exe: '' },
-    { triple: 'aarch64-unknown-linux-gnu',  os: 'linux',  cpu: 'arm64', ext: '.tar.gz', exe: '' },
-    { triple: 'x86_64-pc-windows-msvc',     os: 'win32',  cpu: 'x64',   ext: '.zip',    exe: '.exe' },
-    { triple: 'aarch64-pc-windows-msvc',    os: 'win32',  cpu: 'arm64', ext: '.zip',    exe: '.exe' },
+    { triple: 'aarch64-apple-darwin',       os: 'darwin', cpu: 'arm64',                 ext: '.tar.gz', exe: '' },
+    { triple: 'x86_64-unknown-linux-gnu',   os: 'linux',  cpu: 'x64',   libc: 'glibc',  ext: '.tar.gz', exe: '' },
+    { triple: 'aarch64-unknown-linux-gnu',  os: 'linux',  cpu: 'arm64', libc: 'glibc',  ext: '.tar.gz', exe: '' },
+    { triple: 'x86_64-unknown-linux-musl',  os: 'linux',  cpu: 'x64',   libc: 'musl',   ext: '.tar.gz', exe: '' },
+    { triple: 'aarch64-unknown-linux-musl', os: 'linux',  cpu: 'arm64', libc: 'musl',   ext: '.tar.gz', exe: '' },
+    { triple: 'x86_64-pc-windows-msvc',     os: 'win32',  cpu: 'x64',                   ext: '.zip',    exe: '.exe' },
+    { triple: 'aarch64-pc-windows-msvc',    os: 'win32',  cpu: 'arm64',                 ext: '.zip',    exe: '.exe' },
 ];
 
 const BINS = ['aube', 'aubr', 'aubx'];
@@ -104,15 +110,18 @@ function extractArchive(archivePath, target, destDir) {
 }
 
 async function buildPlatformPackage(repo, tag, version, target) {
-    const pkgName = `@endevco/aube-${target.os}-${target.cpu}`;
-    const stageDir = resolve(stageRoot, `${target.os}-${target.cpu}`);
+    // musl gets a `-musl` name suffix; glibc keeps the historical name
+    // so existing installers upgrade in place without a rename.
+    const suffix = target.libc === 'musl' ? '-musl' : '';
+    const pkgName = `@endevco/aube-${target.os}-${target.cpu}${suffix}`;
+    const stageDir = resolve(stageRoot, `${target.os}-${target.cpu}${suffix}`);
     rmSync(stageDir, { recursive: true, force: true });
     const binDir = resolve(stageDir, 'bin');
     mkdirSync(binDir, { recursive: true });
 
     const dlDir = resolve(stageRoot, '_downloads');
     const archivePath = await downloadArchive(repo, tag, target, dlDir);
-    const extractDir = resolve(stageRoot, `_extract-${target.os}-${target.cpu}`);
+    const extractDir = resolve(stageRoot, `_extract-${target.os}-${target.cpu}${suffix}`);
     rmSync(extractDir, { recursive: true, force: true });
     extractArchive(archivePath, target, extractDir);
 
@@ -137,6 +146,7 @@ async function buildPlatformPackage(repo, tag, version, target) {
         files: ['bin', 'README.md'],
         os: [target.os],
         cpu: [target.cpu],
+        ...(target.libc ? { libc: [target.libc] } : {}),
     };
     writeFileSync(resolve(stageDir, 'package.json'), JSON.stringify(pkgJson, null, 2) + '\n');
 


### PR DESCRIPTION
## Summary
- Add `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to the release workflow matrix so tagged releases ship static musl archives alongside the existing glibc ones. `cross` handles both out of the box.
- Extend `npm/scripts/publish.mjs` to build `@endevco/aube-linux-{x64,arm64}-musl` sub-packages with `libc: ["musl"]`; existing glibc packages keep their historical names and gain `libc: ["glibc"]`.
- `npm/installArchSpecificPackage.js` now detects libc on Linux via `process.report.getReport().header.glibcVersionRuntime` (same heuristic as the `detect-libc` package) and appends `-musl` to the sub-package it fetches.

## Why
Alpine and distroless-static users currently have nothing to grab — glibc binaries won't run there. Shipping musl archives and wiring them through the npm install path makes `npm install -g @endevco/aube` work on those environments.

## Test plan
- [ ] Next tagged release produces `aube-<tag>-x86_64-unknown-linux-musl.tar.gz` and `aube-<tag>-aarch64-unknown-linux-musl.tar.gz`
- [ ] `npm install -g @endevco/aube` on an Alpine container resolves `@endevco/aube-linux-x64-musl` and runs
- [ ] Same install on a glibc distro continues to resolve `@endevco/aube-linux-x64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the release/build matrix and changes npm install-time platform selection on Linux, which could break binary resolution if libc detection or package naming is wrong. No runtime business logic changes beyond packaging/distribution.
> 
> **Overview**
> Tagged releases now build and upload additional static Linux musl archives (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`) alongside existing targets.
> 
> The npm distribution pipeline is updated to publish separate musl platform subpackages (name suffix `-musl`) and to include the npm `libc` metadata for Linux variants; the `preinstall` script now detects glibc vs musl via `process.report` and installs the appropriate subpackage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db6e834600e720caf975e49fa91d115a259e0ddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->