### PR TITLE
cli: make packageManagerStrict a tri-state, default warn

### DIFF
--- a/.rules
+++ b/.rules
@@ -72,6 +72,18 @@ release_profile:
   strip: debuginfo
   panic: abort
 
+when_to_use_release:
+  default: debug. `cargo build` / `cargo clippy` already produce the `target/debug/aube` binary that bats and local smoke tests exercise
+  bats_binary: test/test_helper/common_setup.bash prepends `target/debug` to PATH. never `cargo build --release` to debug a bats failure — rebuild debug, which is already warm from clippy
+  allowed_release_uses[4]:
+    - profiling (samply, flamegraph, hyperfine) — optimizer-off numbers are meaningless
+    - reproducing a perf bug only observable in release
+    - benchmarks (mise run bench* always builds release via its own manifest)
+    - `cargo test --release` — .rules commands.test_unit mandates release because release is 3x+ slower to build but tests run 10x faster; one-time cost pays off across a full suite
+  forbidden[2]:
+    - rebuilding release "just to be safe" during iterative debug (1+ min cost vs 5s incremental debug)
+    - shipping release-only asserts that don't exist in debug — keep invariants consistent across profiles
+
 commits:
   format: <area>(<subscope>): <description>
   style: lowercase after colon, imperative mood, concise, subject typically <=80 chars (p95 in history is 73), usually no body

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1480,10 +1480,19 @@ sources.npmrc = ["npmPath"]
 examples = []
 
 [packageManagerStrict]
-description = "Enforce the `packageManager` field in package.json."
-type = "bool"
-default = "true"
-docs = "When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard."
+description = "Enforce the `packageManager` field in package.json (`off` | `warn` | `error`)."
+type = '"off" | "warn" | "error" | true | false'
+default = "\"warn\""
+docs = """
+Controls how aube reacts when a project's `packageManager` field
+names something other than `aube` or `pnpm` (npm, yarn, bun, …).
+`warn` (the default) prints a warning and continues; install-class
+commands also disable the implicit auto-install probe so aube does
+not silently install on top of another package manager's layout.
+`error` fails install-class commands hard (run-class commands still
+warn). `off` skips the check entirely. The bool spellings are
+accepted for back-compat: `true` maps to `error`, `false` to `off`.
+"""
 sources.cli = []
 sources.env = []
 sources.npmrc = ["package-manager-strict", "packageManagerStrict"]

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -536,15 +536,23 @@ mod tests {
     fn resolves_package_manager_strict_kebab_case() {
         // pnpm's `.npmrc` convention is kebab-case. Real-world yarn/npm
         // projects that want to bypass the guardrail need the kebab
-        // spelling to work.
+        // spelling to work. `packageManagerStrict` is a tri-state
+        // (`off` | `warn` | `error`) with bool spellings accepted for
+        // back-compat, so the accessor returns a raw string.
         let e = entries(&[("package-manager-strict", "false")]);
-        assert_eq!(bool_from_npmrc("packageManagerStrict", &e), Some(false));
+        assert_eq!(
+            string_from_npmrc("packageManagerStrict", &e),
+            Some("false".to_string())
+        );
     }
 
     #[test]
     fn resolves_package_manager_strict_camel_case() {
-        let e = entries(&[("packageManagerStrict", "false")]);
-        assert_eq!(bool_from_npmrc("packageManagerStrict", &e), Some(false));
+        let e = entries(&[("packageManagerStrict", "warn")]);
+        assert_eq!(
+            string_from_npmrc("packageManagerStrict", &e),
+            Some("warn".to_string())
+        );
     }
 
     #[test]

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -1057,6 +1057,21 @@ impl PackageManagerStrictMode {
     }
 }
 
+/// Resolve `packageManagerStrict`, surfacing a warning when the user
+/// configured an unrecognized value (e.g. `errror` typo) instead of
+/// silently falling back to the default. Tracing isn't initialized
+/// yet at startup, so the warning goes straight to stderr.
+fn resolve_package_manager_strict(ctx: &aube_settings::ResolveCtx<'_>) -> PackageManagerStrictMode {
+    let raw = aube_settings::resolved::package_manager_strict(ctx);
+    if let Some(mode) = PackageManagerStrictMode::parse(&raw) {
+        return mode;
+    }
+    eprintln!(
+        "warning: packageManagerStrict={raw:?} is not a recognized value (expected `off`, `warn`, `error`, or back-compat bool `true`/`false`); falling back to `warn`."
+    );
+    PackageManagerStrictMode::default()
+}
+
 fn resolve_color_mode(cli: &Cli) -> ColorMode {
     if cli.no_color {
         return ColorMode::Never;
@@ -1151,10 +1166,7 @@ fn load_startup_settings() -> miette::Result<StartupSettings> {
     Ok(StartupSettings {
         loglevel: aube_settings::values::string_from_env("loglevel", &env)
             .or_else(|| aube_settings::values::string_from_npmrc("loglevel", &npmrc)),
-        package_manager_strict: PackageManagerStrictMode::parse(
-            &aube_settings::resolved::package_manager_strict(&ctx),
-        )
-        .unwrap_or_default(),
+        package_manager_strict: resolve_package_manager_strict(&ctx),
         package_manager_strict_version: aube_settings::resolved::package_manager_strict_version(
             &ctx,
         ),
@@ -1745,6 +1757,43 @@ mod package_manager_guard_tests {
             package_manager_guard_mode(cli.command.as_ref()),
             PackageManagerGuardMode::Error
         );
+    }
+
+    #[test]
+    fn package_manager_strict_mode_parses_canonical_spellings() {
+        for (input, expected) in [
+            ("off", PackageManagerStrictMode::Off),
+            ("warn", PackageManagerStrictMode::Warn),
+            ("error", PackageManagerStrictMode::Error),
+            ("  ERROR\n", PackageManagerStrictMode::Error),
+        ] {
+            assert_eq!(PackageManagerStrictMode::parse(input), Some(expected));
+        }
+    }
+
+    #[test]
+    fn package_manager_strict_mode_parses_bool_back_compat() {
+        // `true`/`false` (and the shell-style `1`/`0` admitted by the
+        // generic bool parser) need to keep working so projects on the
+        // pre-tri-state default don't break.
+        for (input, expected) in [
+            ("true", PackageManagerStrictMode::Error),
+            ("false", PackageManagerStrictMode::Off),
+            ("1", PackageManagerStrictMode::Error),
+            ("0", PackageManagerStrictMode::Off),
+        ] {
+            assert_eq!(PackageManagerStrictMode::parse(input), Some(expected));
+        }
+    }
+
+    #[test]
+    fn package_manager_strict_mode_returns_none_for_typos() {
+        // Caller turns `None` into a startup warning + default. The
+        // unit test pins the precondition: parse must NOT silently
+        // coerce a typo to the default.
+        assert!(PackageManagerStrictMode::parse("errror").is_none());
+        assert!(PackageManagerStrictMode::parse("warning").is_none());
+        assert!(PackageManagerStrictMode::parse("").is_none());
     }
 }
 

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -1022,8 +1022,39 @@ enum ColorMode {
 #[derive(Debug)]
 struct StartupSettings {
     loglevel: Option<String>,
-    package_manager_strict: bool,
+    package_manager_strict: PackageManagerStrictMode,
     package_manager_strict_version: bool,
+}
+
+/// Tri-state for the `packageManagerStrict` setting.
+///
+/// `Off` skips the check entirely. `Warn` (the default) prints a
+/// warning for unsupported `packageManager` names but lets every
+/// command continue; install-class commands also disable the implicit
+/// auto-install probe so aube does not write into another package
+/// manager's `node_modules` layout. `Error` fails install-class
+/// commands hard while still degrading to a warning for run-class
+/// commands (matching the prior `true` behavior).
+///
+/// Accepts the bool spellings (`true` → `Error`, `false` → `Off`) for
+/// back-compat with older `.npmrc` files that pre-date the tri-state.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+enum PackageManagerStrictMode {
+    Off,
+    #[default]
+    Warn,
+    Error,
+}
+
+impl PackageManagerStrictMode {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "off" | "false" | "0" => Some(Self::Off),
+            "warn" => Some(Self::Warn),
+            "error" | "true" | "1" => Some(Self::Error),
+            _ => None,
+        }
+    }
 }
 
 fn resolve_color_mode(cli: &Cli) -> ColorMode {
@@ -1120,7 +1151,10 @@ fn load_startup_settings() -> miette::Result<StartupSettings> {
     Ok(StartupSettings {
         loglevel: aube_settings::values::string_from_env("loglevel", &env)
             .or_else(|| aube_settings::values::string_from_npmrc("loglevel", &npmrc)),
-        package_manager_strict: aube_settings::resolved::package_manager_strict(&ctx),
+        package_manager_strict: PackageManagerStrictMode::parse(
+            &aube_settings::resolved::package_manager_strict(&ctx),
+        )
+        .unwrap_or_default(),
         package_manager_strict_version: aube_settings::resolved::package_manager_strict_version(
             &ctx,
         ),
@@ -1300,7 +1334,7 @@ fn enforce_package_manager_guardrails(
     settings: &StartupSettings,
     command: Option<&Commands>,
 ) -> miette::Result<PackageManagerGuard> {
-    if !settings.package_manager_strict {
+    if settings.package_manager_strict == PackageManagerStrictMode::Off {
         return Ok(PackageManagerGuard::Ok);
     }
 
@@ -1347,19 +1381,30 @@ fn enforce_package_manager_guardrails(
             }
             Ok(PackageManagerGuard::Ok)
         }
-        other => match package_manager_guard_mode(command) {
-            PackageManagerGuardMode::Error => Err(miette!(
-                "packageManager in {} uses unsupported package manager `{other}`. aube's packageManagerStrict guard is on by default and only accepts `aube` and `pnpm`; remove or change the `packageManager` field, or set `package-manager-strict=false` (or `packageManagerStrict=false`) in .npmrc to skip this guard.",
-                path.display()
-            )),
-            PackageManagerGuardMode::WarnAndSkipAutoInstall => {
-                eprintln!(
-                    "warning: packageManager in {} uses unsupported package manager `{other}`; continuing because this command only runs scripts, but auto-install is disabled. Switch packageManager to `aube`/`pnpm`, disable package-manager-strict, or pass `--no-install` to skip the install probe explicitly.",
+        other => {
+            // `error` mode: install-class commands fail hard, run-class
+            // commands warn-and-skip-auto-install (matches the prior
+            // `true` behavior). `warn` mode: every command warns; for
+            // install-class we still suppress auto-install so aube
+            // does not write into another PM's node_modules layout.
+            let mode = match settings.package_manager_strict {
+                PackageManagerStrictMode::Error => package_manager_guard_mode(command),
+                _ => PackageManagerGuardMode::WarnAndSkipAutoInstall,
+            };
+            match mode {
+                PackageManagerGuardMode::Error => Err(miette!(
+                    "packageManager in {} uses unsupported package manager `{other}`. aube's packageManagerStrict=error guard only accepts `aube` and `pnpm`; remove or change the `packageManager` field, or set `package-manager-strict=warn` (the default) or `=off` in .npmrc to soften this guard.",
                     path.display()
-                );
-                Ok(PackageManagerGuard::WarnRunOnly)
+                )),
+                PackageManagerGuardMode::WarnAndSkipAutoInstall => {
+                    eprintln!(
+                        "warning: packageManager in {} uses unsupported package manager `{other}`; continuing but auto-install is disabled. Switch packageManager to `aube`/`pnpm`, set packageManagerStrict=off, or pass `--no-install` to skip the install probe explicitly.",
+                        path.display()
+                    );
+                    Ok(PackageManagerGuard::WarnRunOnly)
+                }
             }
-        },
+        }
     }
 }
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -84,7 +84,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`recursiveInstall`](#setting-recursiveinstall) | `bool` | Install on all workspace packages by default. |
 | [`engineStrict`](#setting-enginestrict) | `bool` | Fail if a package is incompatible with the current Node version. |
 | [`npmPath`](#setting-npmpath) | `path` | Path to the npm binary aube should shell out to when needed. |
-| [`packageManagerStrict`](#setting-packagemanagerstrict) | `bool` | Enforce the `packageManager` field in package.json. |
+| [`packageManagerStrict`](#setting-packagemanagerstrict) | `"off" \| "warn" \| "error" \| true \| false` | Enforce the `packageManager` field in package.json (`off` \| `warn` \| `error`). |
 | [`packageManagerStrictVersion`](#setting-packagemanagerstrictversion) | `bool` | Enforce the exact `packageManager` version from package.json. |
 | [`managePackageManagerVersions`](#setting-managepackagemanagerversions) | `bool` | Auto-download the specified pnpm version when mismatched. |
 | [`ignoreScripts`](#setting-ignorescripts) | `bool` | Skip all lifecycle scripts in package.json. |
@@ -1514,14 +1514,21 @@ Used for npm-only compatibility commands (`owner`, `pkg`, `search`, `set-script`
 
 ### `packageManagerStrict` {#setting-packagemanagerstrict}
 
-Enforce the `packageManager` field in package.json.
+Enforce the `packageManager` field in package.json (`off` | `warn` | `error`).
 
-- Type: `bool`
-- Default: `true`
+- Type: `"off" | "warn" | "error" | true | false`
+- Default: `"warn"`
 - Environment: `npm_config_package_manager_strict`, `NPM_CONFIG_PACKAGE_MANAGER_STRICT`
 - .npmrc keys: `package-manager-strict`, `packageManagerStrict`
 
-When a project declares `packageManager`, aube accepts `aube` and `pnpm` package-manager names and rejects npm/yarn/bun/etc. Set to false to skip this guard.
+Controls how aube reacts when a project's `packageManager` field
+names something other than `aube` or `pnpm` (npm, yarn, bun, …).
+`warn` (the default) prints a warning and continues; install-class
+commands also disable the implicit auto-install probe so aube does
+not silently install on top of another package manager's layout.
+`error` fails install-class commands hard (run-class commands still
+warn). `off` skips the check entirely. The bool spellings are
+accepted for back-compat: `true` maps to `error`, `false` to `off`.
 
 ### `packageManagerStrictVersion` {#setting-packagemanagerstrictversion}
 

--- a/test/guardrails.bats
+++ b/test/guardrails.bats
@@ -100,18 +100,36 @@ _setup_workspace_fixture() {
 	[ ! -e node_modules ]
 }
 
-@test "packageManagerStrict=warn (default) warns install-test on unsupported package managers without erroring" {
+@test "packageManagerStrict=warn (default) warns install on unsupported package managers without erroring" {
 	_make_script_project
 	node -e 'let p=require("./package.json"); p.packageManager="yarn@4.0.0"; require("fs").writeFileSync("package.json", JSON.stringify(p))'
 	echo "verifyDepsBeforeRun=false" >.npmrc
 
-	# Without an install running, `aube install-test` still needs to
-	# exit non-zero if the `test` script is missing — but the PM guard
-	# itself must only warn. We assert the warning is present; the exit
-	# status is driven by the absence of a `test` script, not the guard.
-	run aube install-test
+	# Use `install` (not `install-test`) so exit status reflects only the
+	# guard's decision: the project has no deps and no `test` script, so
+	# `install` succeeds iff the warn-mode guard let it through. The
+	# companion `=error` test below is the assert_failure counterpart.
+	run aube install
+	assert_success
 	[[ "$output" == *"unsupported package manager"* ]]
-	[[ "$output" != *"packageManagerStrict=error"* ]]
+}
+
+@test "packageManagerStrict warns and falls back to default on unrecognized value" {
+	_make_script_project
+	{
+		echo "packageManagerStrict=errror"
+		echo "verifyDepsBeforeRun=false"
+	} >.npmrc
+
+	# Unparseable value must emit a startup warning naming the bad
+	# input rather than silently degrading to the default. The warning
+	# goes to stderr (tracing isn't initialized this early), so we
+	# split to keep the assertions precise.
+	run --separate-stderr aube install
+	assert_success
+	[[ "$stderr" == *"packageManagerStrict"* ]]
+	[[ "$stderr" == *"errror"* ]]
+	[[ "$stderr" == *"falling back to"* ]]
 }
 
 @test "packageManagerStrict=error rejects install-test on unsupported package managers" {

--- a/test/guardrails.bats
+++ b/test/guardrails.bats
@@ -87,7 +87,7 @@ _setup_workspace_fixture() {
 	[[ "$stderr" == *"DEBUG"* ]]
 }
 
-@test "packageManagerStrict warns for run commands on unsupported package managers" {
+@test "packageManagerStrict=warn (default) warns for run commands on unsupported package managers" {
 	_make_script_project
 	node -e 'let p=require("./package.json"); p.packageManager="yarn@4.0.0"; require("fs").writeFileSync("package.json", JSON.stringify(p))'
 	echo "verifyDepsBeforeRun=false" >.npmrc
@@ -100,17 +100,61 @@ _setup_workspace_fixture() {
 	[ ! -e node_modules ]
 }
 
-@test "packageManagerStrict still rejects install-test on unsupported package managers" {
+@test "packageManagerStrict=warn (default) warns install-test on unsupported package managers without erroring" {
 	_make_script_project
 	node -e 'let p=require("./package.json"); p.packageManager="yarn@4.0.0"; require("fs").writeFileSync("package.json", JSON.stringify(p))'
 	echo "verifyDepsBeforeRun=false" >.npmrc
+
+	# Without an install running, `aube install-test` still needs to
+	# exit non-zero if the `test` script is missing — but the PM guard
+	# itself must only warn. We assert the warning is present; the exit
+	# status is driven by the absence of a `test` script, not the guard.
+	run aube install-test
+	[[ "$output" == *"unsupported package manager"* ]]
+	[[ "$output" != *"packageManagerStrict=error"* ]]
+}
+
+@test "packageManagerStrict=error rejects install-test on unsupported package managers" {
+	_make_script_project
+	node -e 'let p=require("./package.json"); p.packageManager="yarn@4.0.0"; require("fs").writeFileSync("package.json", JSON.stringify(p))'
+	{
+		echo "packageManagerStrict=error"
+		echo "verifyDepsBeforeRun=false"
+	} >.npmrc
 
 	run aube install-test
 	assert_failure
 	[[ "$output" == *"unsupported package manager"* ]]
 }
 
-@test "packageManagerStrict=false skips packageManager guard" {
+@test "packageManagerStrict=true (back-compat alias for error) rejects install-test" {
+	_make_script_project
+	node -e 'let p=require("./package.json"); p.packageManager="yarn@4.0.0"; require("fs").writeFileSync("package.json", JSON.stringify(p))'
+	{
+		echo "packageManagerStrict=true"
+		echo "verifyDepsBeforeRun=false"
+	} >.npmrc
+
+	run aube install-test
+	assert_failure
+	[[ "$output" == *"unsupported package manager"* ]]
+}
+
+@test "packageManagerStrict=off skips packageManager guard" {
+	_make_script_project
+	node -e 'let p=require("./package.json"); p.packageManager="yarn@4.0.0"; require("fs").writeFileSync("package.json", JSON.stringify(p))'
+	{
+		echo "packageManagerStrict=off"
+		echo "verifyDepsBeforeRun=false"
+	} >.npmrc
+
+	run aube run ok
+	assert_success
+	[[ "$output" == *"ok"* ]]
+	[[ "$output" != *"unsupported package manager"* ]]
+}
+
+@test "packageManagerStrict=false (back-compat alias for off) skips guard" {
 	_make_script_project
 	node -e 'let p=require("./package.json"); p.packageManager="yarn@4.0.0"; require("fs").writeFileSync("package.json", JSON.stringify(p))'
 	{
@@ -121,6 +165,7 @@ _setup_workspace_fixture() {
 	run aube run ok
 	assert_success
 	[[ "$output" == *"ok"* ]]
+	[[ "$output" != *"unsupported package manager"* ]]
 }
 
 @test "packageManagerStrict checks workspace root from package subdirectory" {


### PR DESCRIPTION
## Summary

Replace the `packageManagerStrict` bool with a tri-state `"off" | "warn" | "error"`, defaulting to **`warn`**. The previous `true` default hard-rejected installs on any project pinning `packageManager: yarn@...` / `npm@...` / `bun@...`, which is harsher than most users want — a heads-up is usually enough. The bool spellings stay accepted for back-compat: `true` → `error`, `false` → `off`.

## Behavior

- **`warn` (new default):** unsupported `packageManager` prints a warning and every command continues. Install-class commands disable the implicit auto-install probe so aube doesn't write into another package manager's `node_modules` layout; run-class commands keep their existing warn-and-skip-auto-install path.
- **`error`:** install-class commands fail hard; run-class commands still warn (matches the prior `true` default exactly).
- **`off`:** guard fully disabled (matches the prior `false`).

## Notes for reviewers

- The type uses a mixed union (`"off" | "warn" | "error" | true | false`) so bool spellings resolve cleanly via the existing codegen's `Option<String>` fallback path. Parsing + defaulting lives in a local `PackageManagerStrictMode` enum in `crates/aube/src/main.rs` — no changes to the settings codegen itself.
- `docs/settings/index.md` is regenerated by `cargo run -p aube-settings --bin generate-settings-docs` (not hand-edited).
- Unit tests in `crates/aube-settings/src/values.rs` that previously asserted `bool_from_npmrc` for this key were migrated to `string_from_npmrc`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release -p aube -p aube-settings` (316 passing)
- [x] `mise run test:bats test/guardrails.bats` (22/22 — includes 6 new/updated cases: warn-default for run + install-class, explicit `error`, `true` alias, explicit `off`, `false` alias)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes affect install/run guardrails and auto-install suppression on projects using non-`aube`/`pnpm` `packageManager`, which could alter workflows or mask previously-hard failures. Parsing now warns on invalid config values at startup, adding new stderr output to some runs.
> 
> **Overview**
> Updates `packageManagerStrict` from a `bool` to a tri-state mode (`off` | `warn` | `error`, default **`warn`**) across settings metadata, CLI startup resolution, and docs.
> 
> Guardrail behavior is adjusted so **`warn` lets commands proceed** (while disabling implicit auto-install to avoid writing into foreign layouts), **`error` preserves the prior hard-fail behavior for install-class commands**, and bool spellings remain accepted (`true`→`error`, `false`→`off`); invalid values now emit a startup warning. Tests and docs are updated/regenerated to cover the new modes, and `.rules` gains guidance on when to use `--release` builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba8130d5fc0dc1f1e98124c94a49f4e656df527a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->