### PR TITLE
cli: anchor auto-install freshness check at workspace root

### DIFF
--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -1065,9 +1065,18 @@ pub(crate) async fn ensure_installed(no_install: bool) -> miette::Result<()> {
     }
 
     let initial_cwd = crate::dirs::cwd()?;
-    // Walk up to the nearest `package.json` so auto-install from a
-    // subdirectory checks (and installs into) the project root.
-    let cwd = crate::dirs::find_project_root(&initial_cwd).unwrap_or(initial_cwd);
+    // Prefer the workspace root as the freshness anchor. A monorepo
+    // install writes exactly one `.aube-state` file, at the workspace
+    // root — subpackages get symlinked `node_modules/` with no state
+    // file of their own. Walking up only to the nearest `package.json`
+    // (the subpackage itself) would miss that state file and report
+    // "install state not found" on every `aube run`/`exec`/`start`
+    // from a subpackage even when the root install is fresh. Fall
+    // back to the nearest `package.json` for non-workspace projects,
+    // and finally to the cwd itself so we never panic resolving it.
+    let cwd = crate::dirs::find_workspace_root(&initial_cwd)
+        .or_else(|| crate::dirs::find_project_root(&initial_cwd))
+        .unwrap_or(initial_cwd);
     // Resolve both pieces of auto-install policy in a single
     // `with_settings_ctx` call so the `.npmrc` + workspace-yaml read
     // pays off once. `aubeNoAutoInstall` lets a project/workspace opt

--- a/test/run.bats
+++ b/test/run.bats
@@ -80,6 +80,20 @@ teardown() {
 	assert_output --partial "hello from aube!"
 }
 
+@test "aube run from workspace subpackage reuses root install state" {
+	# Regression: ensure_installed used to anchor its freshness check
+	# at the nearest package.json (the subpackage) and miss the state
+	# file that install writes only at the workspace root. Result: every
+	# `aube run` / `aube start` from a subpackage spuriously reported
+	# "install state not found" and re-ran install.
+	cp -r "$PROJECT_ROOT/fixtures/workspace/"* .
+	aube install
+	cd packages/app
+	run aube start
+	assert_success
+	refute_output --partial "Auto-installing"
+}
+
 @test "aube run auto-installs when package.json changes" {
 	_setup_basic_fixture
 	aube install


### PR DESCRIPTION
## Summary

- `ensure_installed` walked up to the nearest `package.json`, which in a monorepo subpackage stops at the subpackage. The install state file only exists at the workspace root, so every `aube run` / `exec` / `start` from a subpackage reported `install state not found` and spuriously re-ran install even when the root tree was fresh.
- Prefer `find_workspace_root` as the freshness anchor, fall back to `find_project_root` for non-workspace projects, and finally to the cwd.
- Added a regression test: `aube install` at the workspace root, then `aube start` from `packages/app` must not print `Auto-installing`.

## Why

User report (bug #3): `aube start` in a workspace package re-ran install on every invocation after a root `aube install`. The freshness check was reading the wrong `node_modules/.aube-state` path.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release -p aube` — 278 unit + 4 e2e pass
- [x] `mise run test:bats test/run.bats` — 17 tests pass, including the new regression

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the directory used to determine dependency freshness for auto-install, which can affect when installs run in monorepos vs single-package projects. Risk is limited by simple fallback logic and added end-to-end regression coverage.
> 
> **Overview**
> Fixes auto-install staleness checks in workspaces by anchoring `ensure_installed` at the *workspace root* (falling back to the nearest `package.json`, then the current directory) so subpackages reuse the root `.aube-state` instead of repeatedly reporting missing state and re-installing.
> 
> Adds a Bats regression test that runs `aube install` at the workspace root and then `aube start` from `packages/app`, asserting it does **not** print `Auto-installing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf9b04303e5628ad31e93648b2a7b7ecb25551c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->