### PR TITLE
cli: compare packageManagerStrictVersion against user-facing version

### DIFF
--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -1380,10 +1380,10 @@ fn enforce_package_manager_guardrails(
 
     match name {
         "aube" => {
-            if settings.package_manager_strict_version && version != env!("CARGO_PKG_VERSION") {
+            if settings.package_manager_strict_version && version != version::VERSION.as_str() {
                 return Err(miette!(
                     "packageManager requires aube@{version}, but this is aube@{}",
-                    env!("CARGO_PKG_VERSION")
+                    version::VERSION.as_str()
                 ));
             }
             Ok(PackageManagerGuard::Ok)
@@ -1392,7 +1392,7 @@ fn enforce_package_manager_guardrails(
             if settings.package_manager_strict_version {
                 return Err(miette!(
                     "packageManager requires exact pnpm@{version}, but aube cannot download or re-exec a specific pnpm version. Use pnpm directly, set packageManagerStrictVersion=false, or pin packageManager to aube@{}.",
-                    env!("CARGO_PKG_VERSION")
+                    version::VERSION.as_str()
                 ));
             }
             Ok(PackageManagerGuard::Ok)

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -1378,12 +1378,18 @@ fn enforce_package_manager_guardrails(
         ));
     };
 
+    // Accept either the clean CARGO_PKG_VERSION or the `-DEBUG`-suffixed
+    // runtime string: users may copy `aube --version` (which appends `-DEBUG`
+    // on non-release builds) into `packageManager`, and `aube init` writes
+    // the clean version. Both should pass the strict check on the same
+    // binary.
+    let normalized = version.strip_suffix("-DEBUG").unwrap_or(version);
     match name {
         "aube" => {
-            if settings.package_manager_strict_version && version != version::VERSION.as_str() {
+            if settings.package_manager_strict_version && normalized != env!("CARGO_PKG_VERSION") {
                 return Err(miette!(
                     "packageManager requires aube@{version}, but this is aube@{}",
-                    version::VERSION.as_str()
+                    env!("CARGO_PKG_VERSION")
                 ));
             }
             Ok(PackageManagerGuard::Ok)
@@ -1392,7 +1398,7 @@ fn enforce_package_manager_guardrails(
             if settings.package_manager_strict_version {
                 return Err(miette!(
                     "packageManager requires exact pnpm@{version}, but aube cannot download or re-exec a specific pnpm version. Use pnpm directly, set packageManagerStrictVersion=false, or pin packageManager to aube@{}.",
-                    version::VERSION.as_str()
+                    env!("CARGO_PKG_VERSION")
                 ));
             }
             Ok(PackageManagerGuard::Ok)

--- a/test/guardrails.bats
+++ b/test/guardrails.bats
@@ -225,6 +225,20 @@ _setup_workspace_fixture() {
 	[[ "$output" == *"ok"* ]]
 }
 
+@test "packageManagerStrictVersion accepts the clean version aube init writes on debug builds" {
+	_make_script_project
+	clean="$(aube --version | awk '{print $2}' | sed 's/-DEBUG$//')"
+	node -e 'let p=require("./package.json"); p.packageManager=`aube@'"$clean"'`; require("fs").writeFileSync("package.json", JSON.stringify(p))'
+	{
+		echo "packageManagerStrictVersion=true"
+		echo "verifyDepsBeforeRun=false"
+	} >.npmrc
+
+	run aube run ok
+	assert_success
+	[[ "$output" == *"ok"* ]]
+}
+
 @test "bare aube prints help without packageManager guardrail" {
 	_make_script_project
 	node -e 'let p=require("./package.json"); p.packageManager="yarn@4.0.0"; require("fs").writeFileSync("package.json", JSON.stringify(p))'


### PR DESCRIPTION
## Summary

- `aube --version` and the install progress header append `-DEBUG` on non-release builds (bea3f50), but the `packageManagerStrictVersion` guard in `crates/aube/src/main.rs` was still comparing the parsed `packageManager` field against `CARGO_PKG_VERSION` (no suffix).
- Consequence: a user (or a test) that copies `aube --version` into `packageManager` — e.g. `aube@1.0.0-beta.11-DEBUG+sha512.abc123` — hits a spurious mismatch: `× packageManager requires aube@1.0.0-beta.11-DEBUG, but this is aube@1.0.0-beta.11`.
- Fix: compare against `version::VERSION` so the guard, `--version`, and the install progress header all speak the same string.

## Repro (before fix)

```
$ aube --version
aube 1.0.0-beta.11-DEBUG
$ jq '.packageManager = "aube@1.0.0-beta.11-DEBUG+sha512.abc"' package.json | sponge package.json
$ echo packageManagerStrictVersion=true >.npmrc
$ aube run ok
Error:   × packageManager requires aube@1.0.0-beta.11-DEBUG, but this is aube@1.0.0-beta.11
```

After the fix the command succeeds.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `mise run test:bats test/guardrails.bats` — 23/23 passing, including `packageManagerStrictVersion accepts aube version with corepack hash` which was the CI red on [run 24802045576](https://github.com/endevco/aube/actions/runs/24802045576/job/72587372492)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to version string comparison in the `packageManagerStrictVersion` guardrail, plus a targeted regression test.
> 
> **Overview**
> Fixes `packageManagerStrictVersion` validation so debug builds accept both the user-visible `aube --version` string (which may include `-DEBUG`) and the clean version written by `aube init`, by stripping an optional `-DEBUG` suffix before comparing to `CARGO_PKG_VERSION`.
> 
> Adds a Bats regression test ensuring a debug build can run successfully when `package.json` pins `packageManager` to the clean (non-`-DEBUG`) aube version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c92194be4983793b922f9c183769e2de42bbe3a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->