### PR TITLE
cli: apply dependency policy in add/remove/update/dedupe resolver

### DIFF
--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -360,7 +360,7 @@ pub async fn run(
     // written lockfile) on disk, breaking the `--no-save` promise.
     let pipeline_result: miette::Result<()> = async {
         let existing = aube_lockfile::parse_lockfile(&cwd, &manifest).ok();
-        let mut resolver = super::build_resolver(&cwd, workspace_catalogs);
+        let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
         let graph = resolver
             .resolve(&manifest, existing.as_ref())
             .await

--- a/crates/aube/src/commands/dedupe.rs
+++ b/crates/aube/src/commands/dedupe.rs
@@ -65,7 +65,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
     }
 
     let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
-    let mut resolver = super::build_resolver(&cwd, workspace_catalogs);
+    let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
     let graph = resolver
         .resolve_workspace(&manifests, None, &ws_package_versions)
         .await

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -17,6 +17,7 @@ mod side_effects_cache;
 pub use dep_selection::DepSelection;
 pub use frozen::{FrozenMode, FrozenOverride, GlobalVirtualStoreFlags};
 pub(crate) use settings::PeerDependencyRules;
+pub(crate) use settings::resolve_dependency_policy;
 pub(crate) use side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root};
 
 use settings::{

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -368,7 +368,7 @@ fn resolve_registry_supports_time_field(ctx: &aube_settings::ResolveCtx<'_>) -> 
     aube_settings::resolved::registry_supports_time_field(ctx)
 }
 
-fn resolve_dependency_policy(
+pub(crate) fn resolve_dependency_policy(
     manifest: &aube_manifest::PackageJson,
     ctx: &aube_settings::ResolveCtx<'_>,
 ) -> aube_resolver::DependencyPolicy {

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -425,17 +425,22 @@ pub(crate) fn make_client(cwd: &std::path::Path) -> aube_registry::client::Regis
 
 /// Build the standard resolver used by add/remove/update/dedupe: a
 /// shared `RegistryClient` wrapped in `Arc`, the shared packument
-/// cache directory, and the given catalog map. Every call site does
-/// these same three bindings in the same order; keep them in one
-/// place so a future addition (e.g. a fetch-policy tweak) lands
-/// everywhere at once.
+/// cache directory, the given catalog map, and the dependency policy
+/// resolved from `.npmrc` / workspace yaml. Without applying the
+/// policy here `blockExoticSubdeps=false` (and other policy bits)
+/// gets honored by `aube install` but ignored by `aube add` — the
+/// install pipeline runs `configure_resolver` while these commands
+/// re-resolve manifests through this stripped-down builder.
 pub(crate) fn build_resolver(
     cwd: &std::path::Path,
+    manifest: &aube_manifest::PackageJson,
     catalogs: CatalogMap,
 ) -> aube_resolver::Resolver {
+    let policy = with_settings_ctx(cwd, |ctx| install::resolve_dependency_policy(manifest, ctx));
     aube_resolver::Resolver::new(std::sync::Arc::new(make_client(cwd)))
         .with_packument_cache(packument_cache_dir())
         .with_catalogs(catalogs)
+        .with_dependency_policy(policy)
 }
 
 /// Resolve [`aube_registry::config::FetchPolicy`] from the same

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -110,7 +110,7 @@ pub async fn run(
     // Re-resolve dependency tree without the removed packages
     let existing = aube_lockfile::parse_lockfile(&cwd, &manifest).ok();
     let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
-    let mut resolver = super::build_resolver(&cwd, workspace_catalogs);
+    let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
     let graph = resolver
         .resolve(&manifest, existing.as_ref())
         .await

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -216,7 +216,7 @@ pub async fn run(
 
     // Re-resolve the full dependency tree
     let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
-    let mut resolver = super::build_resolver(&cwd, workspace_catalogs);
+    let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
     let graph = resolver
         .resolve(&resolver_manifest, filtered_existing.as_ref())
         .await


### PR DESCRIPTION
## Summary

- \`build_resolver\` constructed the shared resolver used by \`aube add\` / \`remove\` / \`update\` / \`dedupe\` with \`DependencyPolicy::default()\`, so user-configured dep-policy bits (notably \`blockExoticSubdeps=false\`) were silently ignored — only \`aube install\` ran through \`configure_resolver\` and honored them.
- Plumbed the resolved policy through \`build_resolver\` by reusing \`install::resolve_dependency_policy\` (now \`pub(crate)\` and re-exported from \`commands::install\`).
- All four call sites now pass \`&manifest\` so the policy lookup sees the same manifest the resolver does.

## Repro

\`\`\`
# .npmrc: blockExoticSubdeps=false
aube install      # works — install applies the policy
aube add test     # fails: "uses exotic specifier ... blocked by blockExoticSubdeps"
\`\`\`

## Test plan

- [x] \`cargo build\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --release --workspace\` (~955 unit tests, all green)
- [ ] manual repro: \`.npmrc: blockExoticSubdeps=false\` + \`aube add\` of a package with an exotic transitive subdep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency resolution behavior for multiple CLI commands by applying `.npmrc`/workspace policy (e.g. `blockExoticSubdeps`), which can affect what gets installed and written to lockfiles. Risk is moderate due to behavior changes in core resolve paths, though the change is narrowly scoped to resolver configuration.
> 
> **Overview**
> Makes `aube add`, `remove`, `update`, and `dedupe` apply the resolved `DependencyPolicy` (from `.npmrc` / workspace YAML) when constructing their resolver, aligning them with `aube install` behavior (notably honoring settings like `blockExoticSubdeps`).
> 
> This updates `build_resolver` to accept the current `package.json` manifest, reuse `install::resolve_dependency_policy` (now `pub(crate)` and re-exported), and updates all call sites to pass `&manifest` so policy resolution matches the manifest being resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb621053b5c9df357ad77dc751d8885e2e26b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->