### PR TITLE
ci(bats): restore parallel jobs after #220 fixed the bootstrap deadlock

### DIFF
--- a/mise-tasks/ci/bats/nonserial
+++ b/mise-tasks/ci/bats/nonserial
@@ -25,23 +25,13 @@ printf "Running non-serial BATS shard %s/%s with %s files\n" "$((shard_index + 1
 printf "  %s\n" "${test_files[@]}"
 mkdir -p "$report_dir"
 status=0
-# DEBUG (TEMP): run files one at a time with a 90s per-file timeout so
-# any hanging test surfaces as a SIGTERM with the file name visible in
-# the log. Revert this change once the hang is identified.
-for tf in "${test_files[@]}"; do
-	echo "::group::bats $tf"
-	if ! timeout --signal=KILL --verbose 90 ./test/bats/bin/bats \
-		--filter-tags "!serial" \
-		--timing \
-		"$tf"; then
-		rc=$?
-		echo "::endgroup::"
-		echo "BATS file failed or timed out: $tf (exit $rc)"
-		status=$rc
-		break
-	fi
-	echo "::endgroup::"
-done
+BATS_REPORT_FILENAME="$report_name" ./test/bats/bin/bats \
+	--report-formatter junit \
+	--output "$report_dir" \
+	--jobs "$jobs" \
+	--parallel-binary-name parallel \
+	--filter-tags "!serial" \
+	"${test_files[@]}" || status=$?
 
 upload_status=0
 mise run ci:test-engine:upload -- "$report_path" || upload_status=$?


### PR DESCRIPTION
## Summary

#217 was squash-merged with a debug version of `mise-tasks/ci/bats/nonserial` — a per-file `for` loop with a 90s timeout, breaks-on-first-failure, no junit reporting. Main has been running on that debug loop ever since.

#220 fixed the actual root cause of the bats parallel deadlock (node-gyp bootstrap recursing back into the outer test workspace via #217's walk-up). With that fix on main, the debug script is no longer needed.

This PR restores the original `bats --jobs N` parallel invocation with junit reporting.

## Test plan

- [x] CI green proves it: shards 1+2 ubuntu and both macOS shards previously hung indefinitely with `--jobs >= 2`. With #220 merged, the deadlock is gone, so this PR's parallel invocation should land bats wall-time back at ~2 min/shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI test execution from a per-file, timed loop back to a single parallel `bats` run, which may reintroduce hangs or alter failure/reporting behavior in CI.
> 
> **Overview**
> Replaces the temporary debug per-file/timeout loop in `mise-tasks/ci/bats/nonserial` with a single `bats` invocation over the shard’s file list.
> 
> The new run restores JUnit output (`--report-formatter junit`, `--output`, `BATS_REPORT_FILENAME`) and uses `--jobs`/`--parallel-binary-name` for parallel execution while still filtering out `serial` tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf4f39097c0d785d53c04d425a03a6dc4cf45d04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->