### PR TITLE
cli(install): fix node-gyp bootstrap walkup causing bats parallel hang

### DIFF
--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -125,6 +125,19 @@ fn bootstrap_blocking(
         r#"{{"name":"aube-tool-node-gyp","private":true,"dependencies":{{"node-gyp":"{SPEC}"}}}}"#
     );
     std::fs::write(tool_dir.join("package.json"), manifest).into_diagnostic()?;
+    // Pin the recursive `aube install` invocation below to `tool_dir`
+    // so its workspace-root walk-up stops here instead of escaping
+    // upward. `tool_dir` lives under `$XDG_CACHE_HOME/aube/tools/` —
+    // i.e. inside the user's HOME and inside any test temp dir set
+    // via `HOME=$TEST_TEMP_DIR`. Without this stub yaml,
+    // `find_workspace_root` would walk past `$XDG_CACHE_HOME`,
+    // discover the outer project's `pnpm-workspace.yaml`, and run
+    // the recursive install against the *outer* tree — deadlocking
+    // on the outer process's project lock. The empty yaml hits the
+    // first marker check at the start of the walk, returns
+    // `tool_dir`, and the install runs as a single-package install
+    // (`workspace_packages` is empty so `has_workspace` is false).
+    std::fs::write(tool_dir.join("aube-workspace.yaml"), "").into_diagnostic()?;
     // Forward the outer project's `.npmrc` so private registries and
     // auth tokens configured at project scope carry through to the
     // recursive install. The subprocess's cwd is `tool_dir`, so


### PR DESCRIPTION
## Summary

Found the actual root cause of the post-#217 bats parallel deadlock: **#217's workspace-root walk-up in `install::run` interacted catastrophically with the recursive `aube install` that `node-gyp` bootstrap spawns.**

### The deadlock

1. [`node_gyp_bootstrap::bootstrap_blocking`](crates/aube/src/commands/install/node_gyp_bootstrap.rs:152) puts its scratch project at `$XDG_CACHE_HOME/aube/tools/node-gyp/v12/` and spawns a recursive `aube install` there.
2. Under bats, `HOME=$TEST_TEMP_DIR` and `XDG_CACHE_HOME=$TEST_TEMP_DIR/.cache`. If the test has a `pnpm-workspace.yaml` at `$TEST_TEMP_DIR/` (very common — workspace tests, `allowBuilds`, lifecycle tests, etc.), then:
3. The recursive `aube install` starts at `tool_dir`, walks up via `find_workspace_root` (added in #217), and finds the outer test's `pnpm-workspace.yaml`.
4. The recursive process tries to install the outer workspace and blocks on the outer project lock at `$TEST_TEMP_DIR/node_modules/` — the lock the parent `aube install` is already holding.
5. **Two-process deadlock. Both wedge forever.**

### Why it only reproduced in GHA

- GHA runners hit the lifecycle-script path more densely under `--jobs >= 2` because multiple parallel tests concurrently trigger postinstall hooks.
- Dev machines usually have `node-gyp` already on PATH, so [`ensure()`](crates/aube/src/commands/install/node_gyp_bootstrap.rs:88) short-circuits and the recursive install never runs.

### Fix

Write an empty `aube-workspace.yaml` in `tool_dir` alongside the synthetic `package.json`. `find_workspace_root`'s first-ancestor check finds the marker at `tool_dir` and returns immediately — the walk no longer escapes. `workspace_packages` stays empty so `has_workspace` is false and the install runs as a single-package install.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Manual reasoning: the marker kills the walk at its first ancestor, so the recursive install can no longer target the outer workspace, breaking the lock-cycle
- [ ] CI green on shards that previously hung (this PR restores `--jobs` parallelism in #219)

## Follow-up

Close #219 (was a CI-only workaround); the parallel-hang it papered over is fixed here at the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the node-gyp bootstrap scratch directory setup by adding a local workspace marker to avoid workspace root walk-up and related lock deadlocks during recursive installs.
> 
> **Overview**
> Prevents the recursive `aube install` used for `node-gyp` bootstrapping from walking up into an outer workspace (e.g., test fixtures with `pnpm-workspace.yaml`) and deadlocking on the parent install’s project lock.
> 
> This does so by writing an empty `aube-workspace.yaml` into the node-gyp tool cache directory before spawning the recursive install, ensuring workspace-root discovery stops at `tool_dir` and runs as a single-package install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b9e1f5b2b9b1d6726577f67b3fc980ee56d8f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->