### PR TITLE
chore: release v1.0.0-beta.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "miette",
  "serde",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "base64",
  "blake3",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ strip = "debuginfo"
 panic = "abort"
 
 [workspace.package]
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -103,13 +103,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.12" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.12" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.12" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.12" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.12" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.12" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.12" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.12" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.12" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.12" }
+aube = { path = "crates/aube", version = "1.0.0-beta.13" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.13" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.13" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.13" }
+aube-store = { path = "crates/aube-store", version = "1.0.0-beta.13" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.13" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.13" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.13" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.13" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.13" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.12"
+version "1.0.0-beta.13"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.13](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.12...aube-linker-v1.0.0-beta.13) - 2026-04-23
+
+### Other
+
+- windows install correctness + workspace filter fixes ([#229](https://github.com/endevco/aube/pull/229))
+- speed up babylon warm reinstalls ([#224](https://github.com/endevco/aube/pull/224))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.11...aube-linker-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.13](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.12...aube-lockfile-v1.0.0-beta.13) - 2026-04-23
+
+### Other
+
+- *(yarn)* drop per-lookup String allocs in berry parser ([#234](https://github.com/endevco/aube/pull/234))
+- extract read_lockfile helper to dedupe parser I/O ([#232](https://github.com/endevco/aube/pull/232))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.11...aube-lockfile-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.13](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.12...aube-resolver-v1.0.0-beta.13) - 2026-04-23
+
+### Other
+
+- split lib.rs into focused modules ([#235](https://github.com/endevco/aube/pull/235))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.11...aube-resolver-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.13](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.12...aube-workspace-v1.0.0-beta.13) - 2026-04-23
+
+### Other
+
+- skip node_modules in recursive glob discovery ([#236](https://github.com/endevco/aube/pull/236))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.11...aube-workspace-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.13](https://github.com/endevco/aube/compare/v1.0.0-beta.12...v1.0.0-beta.13) - 2026-04-23
+
+### Other
+
+- split lib.rs into focused modules ([#235](https://github.com/endevco/aube/pull/235))
+- split mod.rs into bin_linking/git_prepare/lifecycle submodules ([#237](https://github.com/endevco/aube/pull/237))
+- *(delta)* invalidate changed no-gvs subtrees ([#233](https://github.com/endevco/aube/pull/233))
+- link importer's own bin into node_modules/.bin ([#230](https://github.com/endevco/aube/pull/230))
+- windows install correctness + workspace filter fixes ([#229](https://github.com/endevco/aube/pull/229))
+- *(pack)* drop CHANGELOG from always-included files ([#227](https://github.com/endevco/aube/pull/227))
+- *(install)* show transfer rate + elapsed timer in progress bars ([#225](https://github.com/endevco/aube/pull/225))
+- speed up babylon warm reinstalls ([#224](https://github.com/endevco/aube/pull/224))
+- *(install)* fix node-gyp bootstrap walkup causing bats parallel hang ([#220](https://github.com/endevco/aube/pull/220))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/v1.0.0-beta.11...v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5745,7 +5745,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.12
+**Version**: 1.0.0-beta.13
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.12",
-  "releasedAt": "2026-04-22T22:31:24Z"
+  "version": "1.0.0-beta.13",
+  "releasedAt": "2026-04-23T18:45:45Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.0.0-beta.13`

This PR bumps the workspace to `v1.0.0-beta.13` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR is a release bookkeeping update (version bumps, regenerated changelogs/docs) with no functional code changes in the diff.
> 
> **Overview**
> Bumps the workspace and all internal crates from `1.0.0-beta.12` to `1.0.0-beta.13` (including `Cargo.toml`, `Cargo.lock`, and `release.json`).
> 
> Regenerates release artifacts: per-crate `CHANGELOG.md` entries for `beta.13`, updates the CLI usage spec `aube.usage.kdl`, and refreshes generated CLI docs (`docs/cli/index.md` and `docs/cli/commands.json`) to reflect the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f2486693c0f29c8e25430ff011ce7fb9b2f16a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->