### PR TITLE
chore: bump communique to v1.0.2

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -72,38 +72,39 @@ checksum = "sha256:89706aa5215c164d8d091597a470fee72308ac87e8553af395ea77db844a8
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-pc-windows-msvc.zip"
 
 [[tools.communique]]
-version = "1.0.1"
+version = "1.0.2"
 backend = "github:jdx/communique"
 
 [tools.communique."platforms.linux-arm64"]
-checksum = "sha256:7be8c2a327212b41e7d39c9866f49c09c26beddfcdfbde1289804c836c45797b"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318499"
+checksum = "sha256:5eb07c9d6b71c2e43b009c51150616937f21bca098ead69c54cbe04f105784e6"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268923"
 
 [tools.communique."platforms.linux-arm64-musl"]
-checksum = "sha256:7be8c2a327212b41e7d39c9866f49c09c26beddfcdfbde1289804c836c45797b"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318499"
+checksum = "sha256:5eb07c9d6b71c2e43b009c51150616937f21bca098ead69c54cbe04f105784e6"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268923"
 
 [tools.communique."platforms.linux-x64"]
-checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+checksum = "sha256:0b1fc485a8a388b8fa6f3bf198e5053ce7c7f47418e9a31893a369a95d411dbc"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268760"
 
 [tools.communique."platforms.linux-x64-musl"]
-checksum = "sha256:33a48d38d83cba48c0e2dca967633baf1a22ea1f2aeb89b59106379c17b18bc2"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318330"
+checksum = "sha256:0b1fc485a8a388b8fa6f3bf198e5053ce7c7f47418e9a31893a369a95d411dbc"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268760"
 
 [tools.communique."platforms.macos-arm64"]
-checksum = "sha256:9adcd413f3377b98aa12df003ffa4c24f084e7bea549104e29088a3b79892dd8"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400318491"
+checksum = "sha256:3696f3d4ed046bf023aa3dac48892ee8705e83916378c8d5a7e911fbb2c61093"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401268880"
+provenance = "github-attestations"
 
 [tools.communique."platforms.windows-x64"]
-checksum = "sha256:2474f4ed704c9a94bb9dd357452275b8efe92df132ab81b642055c858441a905"
-url = "https://github.com/jdx/communique/releases/download/v1.0.1/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/400319696"
+checksum = "sha256:5108ddc80650f28be27d231b5fa9bfb43075d3ac2f6bd7526c32aa08ab7ca534"
+url = "https://github.com/jdx/communique/releases/download/v1.0.2/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/401269462"
 
 [[tools."github:bnjbvr/cargo-machete"]]
 version = "0.9.2"


### PR DESCRIPTION
## Summary
- Bump pinned communique tool from v1.0.1 to v1.0.2 in mise.lock (resilient release note submissions).

## Test plan
- [ ] CI green (release-plz workflow still installs communique correctly)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change that updates the pinned `communique` binary and its download metadata; main risk is CI/dev tooling install failures if the new checksums/URLs are incorrect.
> 
> **Overview**
> Bumps the `communique` dev tool pin in `mise.lock` from `v1.0.1` to `v1.0.2`, updating per-platform download URLs, asset IDs, and checksums.
> 
> Adds GitHub attestation provenance metadata for the macOS ARM64 `communique` artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3498fa53370b64890dc7d0c1efb04e545e7d9098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->