### PR TITLE
ci(release-plz): set MISE_LOCKED=1 to prevent mise.lock drift

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -188,13 +188,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.AUBE_GH_TOKEN }}
           submodules: recursive
+      # MISE_LOCKED=1 makes `mise install` fail if the committed
+      # mise.lock doesn't already pin the current platform's URL, instead
+      # of silently re-resolving `"latest"` pins and rewriting mise.lock.
+      # release-plz refuses to run against a dirty tree, and intentional
+      # lockfile bumps should land via their own PR.
       - uses: jdx/mise-action@v2
-      # mise-action resolves `"latest"` pins in mise.toml and can rewrite
-      # mise.lock when upstream ships a new version between commits.
-      # release-plz refuses to run against a dirty tree, so restore the
-      # committed lockfile before any release-plz step.
-      - name: Restore mise.lock
-        run: git checkout -- mise.lock
+        env:
+          MISE_LOCKED: "1"
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -189,6 +189,12 @@ jobs:
           token: ${{ secrets.AUBE_GH_TOKEN }}
           submodules: recursive
       - uses: jdx/mise-action@v2
+      # mise-action resolves `"latest"` pins in mise.toml and can rewrite
+      # mise.lock when upstream ships a new version between commits.
+      # release-plz refuses to run against a dirty tree, so restore the
+      # committed lockfile before any release-plz step.
+      - name: Restore mise.lock
+        run: git checkout -- mise.lock
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
## Summary

- `jdx/mise-action@v2` runs `mise install`, which re-resolves the `"latest"` pins in `mise.toml` (communique, actionlint, cargo-binstall, hk, etc.) and rewrites `mise.lock` whenever upstream has shipped a new version.
- That leaves the working tree dirty, and `release-plz update` aborts on dirty trees — which is what broke [run 24808608494](https://github.com/endevco/aube/actions/runs/24808608494/job/72608385073).
- Fix: set `MISE_LOCKED=1` on the mise-action step. With `locked` enabled, `mise install` fails if the committed `mise.lock` doesn't already pin the current platform's URL, instead of silently rewriting it. Intentional lockfile bumps still land via their own PR (see [commit 7d8a92b](https://github.com/endevco/aube/commit/7d8a92b)), but CI can't drift underneath release-plz.

## Test plan

- [ ] Merge and confirm the next `release-plz PR` run on `main` completes the `Apply version bumps` step successfully.
- [ ] Confirm CI fails loudly (not silently rewrites) if an upstream tool ships a new version and `mise lock` hasn't been re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)