### PR TITLE
install: speed up babylon warm reinstalls

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -1115,41 +1115,80 @@ impl Linker {
             }
             log::debug!("link:step1 (gvs populate) {:.1?}", step1_timer.elapsed());
         } else {
+            use rayon::prelude::*;
+
             // `wipe_changed_patched_entries` above already removed any
             // `.aube/<dep_path>` whose patch fingerprint changed since
             // the last install, so the existence check below will fall
             // through to `materialize_into` for those packages and
-            // pick up the current patch state.
-            for (dep_path, pkg) in &graph.packages {
-                if pkg.local_source.is_some() {
-                    continue;
-                }
-                let aube_entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
-                if aube_entry.exists() {
-                    // Already in place from a previous run — count as
-                    // cached. `install.rs` deliberately omits this
-                    // dep_path from `package_indices` on the fast
-                    // path, so do the existence check first.
-                    stats.packages_cached += 1;
-                    continue;
-                }
-                // Entry missing — load the index. Fast path in
-                // `install.rs` skips `load_index` when `aube_entry`
-                // already exists; lazy-load here for the case where a
-                // patch / allowBuilds change invalidated the entry
-                // since.
-                let owned_index;
-                let index = match package_indices.get(dep_path) {
-                    Some(idx) => idx,
-                    None => {
-                        owned_index = self
-                            .store
-                            .load_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref())
-                            .ok_or_else(|| Error::MissingPackageIndex(dep_path.to_string()))?;
-                        &owned_index
-                    }
-                };
-                self.materialize_into(&aube_dir, dep_path, pkg, index, &mut stats, false)?;
+            // pick up the current patch state. In per-project mode the
+            // dep paths are already isolated, so we can materialize
+            // them independently on the same rayon pool the gvs path
+            // uses instead of rebuilding the whole tree serially.
+            let link_parallelism = self.link_parallelism();
+            let step1_results: Vec<Result<LinkStats, Error>> =
+                with_link_pool(link_parallelism, || {
+                    graph
+                        .packages
+                        .par_iter()
+                        .filter_map(|(dep_path, pkg)| {
+                            if pkg.local_source.is_some() {
+                                return None;
+                            }
+                            Some((dep_path, pkg))
+                        })
+                        .map(|(dep_path, pkg)| {
+                            let mut local_stats = LinkStats::default();
+                            let aube_entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
+                            if aube_entry.exists() {
+                                // Already in place from a previous run —
+                                // count as cached. `install.rs`
+                                // deliberately omits this dep_path from
+                                // `package_indices` on the fast path, so
+                                // do the existence check first.
+                                local_stats.packages_cached += 1;
+                                return Ok(local_stats);
+                            }
+                            // Entry missing — load the index. Fast path in
+                            // `install.rs` skips `load_index` when
+                            // `aube_entry` already exists; lazy-load here
+                            // for the case where a patch / allowBuilds
+                            // change invalidated the entry since.
+                            let owned_index;
+                            let index = match package_indices.get(dep_path) {
+                                Some(idx) => idx,
+                                None => {
+                                    owned_index = self
+                                        .store
+                                        .load_index(
+                                            pkg.registry_name(),
+                                            &pkg.version,
+                                            pkg.integrity.as_deref(),
+                                        )
+                                        .ok_or_else(|| {
+                                            Error::MissingPackageIndex(dep_path.to_string())
+                                        })?;
+                                    &owned_index
+                                }
+                            };
+                            self.materialize_into(
+                                &aube_dir,
+                                dep_path,
+                                pkg,
+                                index,
+                                &mut local_stats,
+                                false,
+                            )?;
+                            Ok(local_stats)
+                        })
+                        .collect()
+                });
+
+            for result in step1_results {
+                let local_stats = result?;
+                stats.packages_linked += local_stats.packages_linked;
+                stats.packages_cached += local_stats.packages_cached;
+                stats.files_linked += local_stats.files_linked;
             }
         }
 
@@ -1508,27 +1547,62 @@ impl Linker {
                 step1_timer.elapsed()
             );
         } else {
-            for (dep_path, pkg) in &graph.packages {
-                if pkg.local_source.is_some() {
-                    continue;
-                }
-                let aube_entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
-                if aube_entry.exists() {
-                    stats.packages_cached += 1;
-                    continue;
-                }
-                let owned_index;
-                let index = match package_indices.get(dep_path) {
-                    Some(idx) => idx,
-                    None => {
-                        owned_index = self
-                            .store
-                            .load_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref())
-                            .ok_or_else(|| Error::MissingPackageIndex(dep_path.to_string()))?;
-                        &owned_index
-                    }
-                };
-                self.materialize_into(&aube_dir, dep_path, pkg, index, &mut stats, false)?;
+            use rayon::prelude::*;
+
+            let link_parallelism = self.link_parallelism();
+            let step1_results: Vec<Result<LinkStats, Error>> =
+                with_link_pool(link_parallelism, || {
+                    graph
+                        .packages
+                        .par_iter()
+                        .filter_map(|(dep_path, pkg)| {
+                            if pkg.local_source.is_some() {
+                                return None;
+                            }
+                            Some((dep_path, pkg))
+                        })
+                        .map(|(dep_path, pkg)| {
+                            let mut local_stats = LinkStats::default();
+                            let aube_entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
+                            if aube_entry.exists() {
+                                local_stats.packages_cached += 1;
+                                return Ok(local_stats);
+                            }
+                            let owned_index;
+                            let index = match package_indices.get(dep_path) {
+                                Some(idx) => idx,
+                                None => {
+                                    owned_index = self
+                                        .store
+                                        .load_index(
+                                            pkg.registry_name(),
+                                            &pkg.version,
+                                            pkg.integrity.as_deref(),
+                                        )
+                                        .ok_or_else(|| {
+                                            Error::MissingPackageIndex(dep_path.to_string())
+                                        })?;
+                                    &owned_index
+                                }
+                            };
+                            self.materialize_into(
+                                &aube_dir,
+                                dep_path,
+                                pkg,
+                                index,
+                                &mut local_stats,
+                                false,
+                            )?;
+                            Ok(local_stats)
+                        })
+                        .collect()
+                });
+
+            for result in step1_results {
+                let local_stats = result?;
+                stats.packages_linked += local_stats.packages_linked;
+                stats.packages_cached += local_stats.packages_cached;
+                stats.files_linked += local_stats.files_linked;
             }
         }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -4013,19 +4013,21 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         }
         state::write_state(
             &cwd,
-            opts.dep_selection.prod_or_dev_axis(),
-            package_json_hashes,
-            &opts.cli_flags,
-            package_content_hashes,
-            graph_lthash,
-            package_subtree_hashes,
-            state::WriteStateLayout {
-                graph: &graph_for_link,
-                node_linker,
-                modules_dir_name: &modules_dir_name,
-                aube_dir: &aube_dir,
-                virtual_store_dir_max_length,
-                placements: placements_ref,
+            state::WriteStateInput {
+                section_filtered: opts.dep_selection.prod_or_dev_axis(),
+                package_json_hashes,
+                cli_flags: &opts.cli_flags,
+                package_content_hashes,
+                graph_lthash,
+                package_subtree_hashes,
+                layout: state::WriteStateLayout {
+                    graph: &graph_for_link,
+                    node_linker,
+                    modules_dir_name: &modules_dir_name,
+                    aube_dir: &aube_dir,
+                    virtual_store_dir_max_length,
+                    placements: placements_ref,
+                },
             },
         )
         .into_diagnostic()

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3919,6 +3919,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         let package_content_hashes = delta::compute_package_hashes(&graph);
         let package_subtree_hashes = delta::compute_subtree_hashes(&graph);
         let graph_lthash = hex::encode(delta::lthash_of(&package_content_hashes).digest());
+        let package_json_hashes =
+            state::collect_package_json_hashes_from_manifests(&cwd, &manifests);
         // Diff against the previous install. Logs delta counts at
         // debug so `-v` installs surface what actually moved. A
         // later pass feeds the plan into fetch and link as a
@@ -4012,6 +4014,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         state::write_state(
             &cwd,
             opts.dep_selection.prod_or_dev_axis(),
+            package_json_hashes,
             &opts.cli_flags,
             package_content_hashes,
             graph_lthash,

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -1,3 +1,4 @@
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -218,6 +219,7 @@ pub struct WriteStateLayout<'a> {
 pub fn write_state(
     project_dir: &Path,
     section_filtered: bool,
+    package_json_hashes: BTreeMap<String, String>,
     cli_flags: &[(String, String)],
     package_content_hashes: BTreeMap<String, String>,
     graph_lthash: String,
@@ -228,25 +230,27 @@ pub fn write_state(
         Some(path) => hash_file(&path),
         None => String::new(),
     };
+    let settings_hash = hash_settings(project_dir, cli_flags);
+    let install_layout = InstallLayoutState::from_graph(
+        project_dir,
+        layout.graph,
+        layout.node_linker,
+        layout.modules_dir_name,
+        layout.aube_dir,
+        layout.virtual_store_dir_max_length,
+        layout.placements,
+    );
 
     let state = InstallState {
         lockfile_hash,
-        package_json_hashes: collect_package_json_hashes(project_dir),
+        package_json_hashes,
         aube_version: env!("CARGO_PKG_VERSION").to_string(),
         section_filtered,
-        settings_hash: hash_settings(project_dir, cli_flags),
+        settings_hash,
         package_content_hashes,
         graph_lthash,
         package_subtree_hashes,
-        layout: Some(InstallLayoutState::from_graph(
-            project_dir,
-            layout.graph,
-            layout.node_linker,
-            layout.modules_dir_name,
-            layout.aube_dir,
-            layout.virtual_store_dir_max_length,
-            layout.placements,
-        )),
+        layout: Some(install_layout),
     };
 
     let state_path = state_file(project_dir);
@@ -531,25 +535,24 @@ fn read_installed_package_manifest(
     Ok(Some(parsed))
 }
 
-fn collect_package_json_hashes(project_dir: &Path) -> BTreeMap<String, String> {
-    let mut hashes = BTreeMap::new();
-    let pkg_path = project_dir.join("package.json");
-    if pkg_path.exists() {
-        hashes.insert(".".to_string(), hash_file(&pkg_path));
-    }
-    if let Ok(workspaces) = aube_workspace::find_workspace_packages(project_dir) {
-        for pkg_dir in workspaces {
-            let pkg_json = pkg_dir.join("package.json");
+pub fn collect_package_json_hashes_from_manifests(
+    project_dir: &Path,
+    manifests: &[(String, aube_manifest::PackageJson)],
+) -> BTreeMap<String, String> {
+    manifests
+        .par_iter()
+        .filter_map(|(rel, _)| {
+            let pkg_json = if rel == "." {
+                project_dir.join("package.json")
+            } else {
+                project_dir.join(rel).join("package.json")
+            };
             if !pkg_json.is_file() {
-                continue;
+                return None;
             }
-            hashes.insert(
-                relative_path_or_original(&pkg_json, project_dir),
-                hash_file(&pkg_json),
-            );
-        }
-    }
-    hashes
+            Some((rel.clone(), hash_file(&pkg_json)))
+        })
+        .collect()
 }
 
 fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -216,16 +216,27 @@ pub struct WriteStateLayout<'a> {
     pub placements: Option<&'a aube_linker::HoistedPlacements>,
 }
 
-pub fn write_state(
-    project_dir: &Path,
-    section_filtered: bool,
-    package_json_hashes: BTreeMap<String, String>,
-    cli_flags: &[(String, String)],
-    package_content_hashes: BTreeMap<String, String>,
-    graph_lthash: String,
-    package_subtree_hashes: BTreeMap<String, String>,
-    layout: WriteStateLayout<'_>,
-) -> Result<(), std::io::Error> {
+pub struct WriteStateInput<'a> {
+    pub section_filtered: bool,
+    pub package_json_hashes: BTreeMap<String, String>,
+    pub cli_flags: &'a [(String, String)],
+    pub package_content_hashes: BTreeMap<String, String>,
+    pub graph_lthash: String,
+    pub package_subtree_hashes: BTreeMap<String, String>,
+    pub layout: WriteStateLayout<'a>,
+}
+
+pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(), std::io::Error> {
+    let WriteStateInput {
+        section_filtered,
+        package_json_hashes,
+        cli_flags,
+        package_content_hashes,
+        graph_lthash,
+        package_subtree_hashes,
+        layout,
+    } = input;
+
     let lockfile_hash = match active_lockfile(project_dir).1 {
         Some(path) => hash_file(&path),
         None => String::new(),

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -550,7 +550,12 @@ pub fn collect_package_json_hashes_from_manifests(
             if !pkg_json.is_file() {
                 return None;
             }
-            Some((rel.clone(), hash_file(&pkg_json)))
+            let key = if rel == "." {
+                ".".to_string()
+            } else {
+                relative_path_or_original(&pkg_json, project_dir)
+            };
+            Some((key, hash_file(&pkg_json)))
         })
         .collect()
 }
@@ -738,7 +743,8 @@ fn empty_blake3_hash() -> &'static str {
 mod tests {
     use super::{
         InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
-        empty_blake3_hash, relative_path_or_original, verify_install_layout,
+        collect_package_json_hashes_from_manifests, empty_blake3_hash, hash_file,
+        relative_path_or_original, verify_install_layout,
     };
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -789,6 +795,33 @@ mod tests {
                 "installed package metadata missing: node_modules/.aube/missing/node_modules/is-odd/package.json"
                     .to_string()
             )
+        );
+    }
+
+    #[test]
+    fn collect_package_json_hashes_from_manifests_uses_file_paths_for_workspaces() {
+        let project_dir = temp_project_dir("manifest-hash-keys");
+        let root_pkg = project_dir.join("package.json");
+        let ws_pkg = project_dir.join("packages/foo/package.json");
+        std::fs::create_dir_all(ws_pkg.parent().expect("workspace dir"))
+            .expect("workspace dir should be creatable");
+        std::fs::write(&root_pkg, "{\"name\":\"root\"}").expect("root package.json should write");
+        std::fs::write(&ws_pkg, "{\"name\":\"foo\"}").expect("workspace package.json should write");
+
+        let manifests = vec![
+            (".".to_string(), aube_manifest::PackageJson::default()),
+            (
+                "packages/foo".to_string(),
+                aube_manifest::PackageJson::default(),
+            ),
+        ];
+
+        let hashes = collect_package_json_hashes_from_manifests(&project_dir, &manifests);
+
+        assert_eq!(hashes.get("."), Some(&hash_file(&root_pkg)));
+        assert_eq!(
+            hashes.get("packages/foo/package.json"),
+            Some(&hash_file(&ws_pkg))
         );
     }
 


### PR DESCRIPTION
## Summary

This speeds up Babylon warm-cache reinstalls by removing an expensive post-link state write bottleneck and parallelizing per-project `.aube` materialization.

## What changed

- reuse the install's already-loaded workspace manifests when hashing `package.json` files for `.aube-state` instead of rediscovering the workspace during `write_state`
- collect those manifest hashes in parallel from the known manifest list
- parallelize the non-GVS isolated-linker step that materializes per-project `.aube/<dep_path>` entries

## Root cause

On the Babylon `cache+node_modules` fixture, the install/link phases were relatively small, but the post-link state write was spending tens of seconds rediscovering the workspace and rehashing workspace manifests from scratch. That work happened after `phase:link_bins`, so it dominated warm-cache reinstalls even when no packages were fetched or relinked.

## Benchmark

Fixture: `/tmp/vltpkg-benchmarks/fixtures/babylon`

Warm-cache local repro shape:
1. `aube install --silent --no-frozen-lockfile`
2. `bash ../../scripts/clean-helpers.sh clean_lockfiles clean_package_manager_files`
3. rerun `aube install --silent --no-frozen-lockfile`

Matched local numbers on my machine:

- baseline `HEAD`: `real 86.94`
- patched branch: `real 45.57`

That is about a 48% improvement for the warm-cache reinstall path.

## Validation

- `cargo build -p aube`
- `cargo test -p aube-linker`
- local Babylon benchmark repro above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install/link hot paths by adding Rayon-parallel materialization and changing `.aube-state` write inputs; concurrency and state-fingerprint changes could surface as missed cache hits or relink churn if edge cases exist.
> 
> **Overview**
> Speeds up warm-cache reinstalls by removing a post-link state-write bottleneck and by parallelizing isolated-linker `.aube/<dep_path>` materialization when not using the global virtual store.
> 
> `install` now reuses the already-loaded workspace `manifests` to hash `package.json` files (in parallel) and passes those hashes into `state::write_state` via a new `WriteStateInput` struct, instead of rediscovering workspaces during state writing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c7ca5dd536c073ebe2283eb962c62b21aec9fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->