### PR TITLE
cli(install): show transfer rate + elapsed timer in progress bars

### DIFF
--- a/crates/aube/src/progress/ci.rs
+++ b/crates/aube/src/progress/ci.rs
@@ -81,7 +81,7 @@ pub(super) struct CiState {
 /// GitHub Actions), then falls back to `console::Term::stderr().size()`
 /// (works when stderr is a TTY), then a sensible 80-column default.
 /// Clamped into `[MIN_BAR_WIDTH, MAX_BAR_WIDTH]`.
-fn term_width() -> usize {
+pub(super) fn term_width() -> usize {
     let raw = std::env::var("COLUMNS")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
@@ -114,26 +114,39 @@ impl CiState {
         }
     }
 
-    fn snapshot(&self) -> (usize, usize, usize, usize, u64) {
+    fn snapshot(&self) -> (usize, usize, usize, usize, u64, u64) {
         (
             self.phase.load(Ordering::Relaxed),
             self.resolved.load(Ordering::Relaxed),
             self.reused.load(Ordering::Relaxed),
             self.downloaded.load(Ordering::Relaxed),
             self.downloaded_bytes.load(Ordering::Relaxed),
+            self.start.elapsed().as_millis() as u64,
         )
     }
 
-    fn render(snap: (usize, usize, usize, usize, u64)) -> String {
-        let (phase, resolved, reused, downloaded, bytes) = snap;
+    fn render(snap: (usize, usize, usize, usize, u64, u64)) -> String {
+        let (phase, resolved, reused, downloaded, bytes, elapsed_ms) = snap;
         let completed = reused + downloaded;
         let phase_str = if phase > 0 {
             format!(" [{phase}/3]")
         } else {
             String::new()
         };
+        // Only show transfer rate during the fetching phase, and only when
+        // at least one byte has landed. Before fetch starts it's always 0;
+        // after fetch finishes it becomes stale (decaying toward 0 as
+        // elapsed grows with no new bytes). Gating to phase == 2 keeps it
+        // meaningful.
+        let rate_str = if phase == 2 && bytes > 0 && elapsed_ms > 0 {
+            let rate = bytes.saturating_mul(1000) / elapsed_ms;
+            format!(" · {}/s", format_bytes(rate))
+        } else {
+            String::new()
+        };
+        let elapsed_str = format!(" · {}", format_duration(Duration::from_millis(elapsed_ms)));
         let label = format!(
-            "{completed}/{resolved} pkgs{phase_str} · {}",
+            "{completed}/{resolved} pkgs{phase_str} · {}{rate_str}{elapsed_str}",
             format_bytes(bytes)
         );
         render_bar_with_label(completed, resolved, term_width(), &label)
@@ -261,7 +274,7 @@ impl CiState {
         // coherent unit. Each segment is labeled so the numbers are
         // self-describing in a CI log weeks later without needing
         // context about aube's vocabulary.
-        let (_phase, resolved, reused, downloaded, bytes) = snap;
+        let (_phase, resolved, reused, downloaded, bytes, _elapsed_ms) = snap;
         let elapsed = self.start.elapsed();
         let summary = format!(
             "{} {} · resolved {} · reused {} · downloaded {} ({})",
@@ -303,7 +316,7 @@ pub(super) fn format_duration(d: Duration) -> String {
 /// bold styling); width is measured with `console::measure_text_width`
 /// so escapes are excluded from the layout math. Text longer than the
 /// inner width is returned as-is inside the brackets with no padding.
-fn render_centered_line(text: &str, outer_width: usize) -> String {
+pub(super) fn render_centered_line(text: &str, outer_width: usize) -> String {
     let outer_width = outer_width.max(MIN_BAR_WIDTH);
     let inner_width = outer_width.saturating_sub(2);
     let text_width = console::measure_text_width(text);
@@ -360,7 +373,7 @@ fn render_bar_with_label(current: usize, total: usize, outer_width: usize, label
 /// `MB`, `GB`. Decimal (1000-based) because that's what every package
 /// manager uses for on-the-wire sizes — closer to what the registry
 /// `Content-Length` reports.
-fn format_bytes(bytes: u64) -> String {
+pub(super) fn format_bytes(bytes: u64) -> String {
     const KB: u64 = 1_000;
     const MB: u64 = 1_000_000;
     const GB: u64 = 1_000_000_000;

--- a/crates/aube/src/progress/ci.rs
+++ b/crates/aube/src/progress/ci.rs
@@ -12,7 +12,7 @@
 use clx::style;
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -49,6 +49,12 @@ pub(super) struct CiState {
     pub(super) downloaded: AtomicUsize,
     pub(super) downloaded_bytes: AtomicU64,
     start: Instant,
+    /// Captured the first time `set_phase("fetching")` is called. Used
+    /// as the denominator for the transfer rate so it measures network
+    /// throughput during the fetch window, not `bytes / (resolve_time +
+    /// fetch_time)`. `OnceLock` makes the first-writer-wins semantics
+    /// explicit without a mutex.
+    fetch_start: OnceLock<Instant>,
     /// The last rendered line we actually wrote. Dedup on the rendered
     /// string (not the raw counter tuple) so changes that round to the
     /// same display — e.g. a byte delta that stays in the same MB
@@ -59,7 +65,7 @@ pub(super) struct CiState {
     /// line. Stays `false` for fast installs that finish before the
     /// first 2s tick — those stay completely silent, including in the
     /// final summary.
-    shown: AtomicBool,
+    pub(super) shown: AtomicBool,
     done: AtomicBool,
     /// Live `InstallProgress` clone count. Incremented in `Clone`,
     /// decremented in `Drop`. When it hits zero the last clone is gone
@@ -104,6 +110,7 @@ impl CiState {
             downloaded: AtomicUsize::new(0),
             downloaded_bytes: AtomicU64::new(0),
             start: Instant::now(),
+            fetch_start: OnceLock::new(),
             last_printed: Mutex::new(String::new()),
             shown: AtomicBool::new(false),
             done: AtomicBool::new(false),
@@ -114,7 +121,16 @@ impl CiState {
         }
     }
 
-    fn snapshot(&self) -> (usize, usize, usize, usize, u64, u64) {
+    fn snapshot(&self) -> (usize, usize, usize, usize, u64, u64, u64) {
+        // `fetch_elapsed_ms` is 0 until fetching has started, and
+        // frozen at the elapsed-so-far value once it does — so after
+        // fetching ends the rate no longer decays, and before it
+        // begins we never divide.
+        let fetch_elapsed_ms = self
+            .fetch_start
+            .get()
+            .map(|t| t.elapsed().as_millis() as u64)
+            .unwrap_or(0);
         (
             self.phase.load(Ordering::Relaxed),
             self.resolved.load(Ordering::Relaxed),
@@ -122,11 +138,12 @@ impl CiState {
             self.downloaded.load(Ordering::Relaxed),
             self.downloaded_bytes.load(Ordering::Relaxed),
             self.start.elapsed().as_millis() as u64,
+            fetch_elapsed_ms,
         )
     }
 
-    fn render(snap: (usize, usize, usize, usize, u64, u64)) -> String {
-        let (phase, resolved, reused, downloaded, bytes, elapsed_ms) = snap;
+    fn render(snap: (usize, usize, usize, usize, u64, u64, u64)) -> String {
+        let (phase, resolved, reused, downloaded, bytes, elapsed_ms, fetch_elapsed_ms) = snap;
         let completed = reused + downloaded;
         let phase_str = if phase > 0 {
             format!(" [{phase}/3]")
@@ -137,9 +154,11 @@ impl CiState {
         // at least one byte has landed. Before fetch starts it's always 0;
         // after fetch finishes it becomes stale (decaying toward 0 as
         // elapsed grows with no new bytes). Gating to phase == 2 keeps it
-        // meaningful.
-        let rate_str = if phase == 2 && bytes > 0 && elapsed_ms > 0 {
-            let rate = bytes.saturating_mul(1000) / elapsed_ms;
+        // meaningful. Denominator is `fetch_elapsed_ms` (time since the
+        // fetching transition), not total install time — otherwise
+        // multi-second resolves would deflate the displayed rate.
+        let rate_str = if phase == 2 && bytes > 0 && fetch_elapsed_ms > 0 {
+            let rate = bytes.saturating_mul(1000) / fetch_elapsed_ms;
             format!(" · {}/s", format_bytes(rate))
         } else {
             String::new()
@@ -225,6 +244,11 @@ impl CiState {
             "linking" => 3,
             _ => return,
         };
+        if n == 2 {
+            // First-writer-wins; a second "fetching" transition (shouldn't
+            // happen but defend against it) doesn't reset the rate window.
+            let _ = self.fetch_start.set(Instant::now());
+        }
         if self.phase.swap(n, Ordering::Relaxed) != n {
             self.wake.notify_all();
         }
@@ -274,7 +298,7 @@ impl CiState {
         // coherent unit. Each segment is labeled so the numbers are
         // self-describing in a CI log weeks later without needing
         // context about aube's vocabulary.
-        let (_phase, resolved, reused, downloaded, bytes, _elapsed_ms) = snap;
+        let (_phase, resolved, reused, downloaded, bytes, _elapsed_ms, _fetch_elapsed_ms) = snap;
         let elapsed = self.start.elapsed();
         let summary = format!(
             "{} {} · resolved {} · reused {} · downloaded {} ({})",

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -32,9 +32,9 @@ use clx::progress::{
 };
 use clx::style;
 use std::io::{IsTerminal, Write};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, Weak};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Cap on the number of simultaneously-visible per-package fetch rows
 /// in TTY mode. Bursts above this are collapsed into a single overflow
@@ -61,6 +61,16 @@ enum Mode {
         /// fetch-add without racing a concurrent reader/writer through clx's
         /// separate `overall_progress()` / `progress_total()` calls.
         total: Arc<AtomicUsize>,
+        /// Phase number: 0=init, 1=resolving, 2=fetching, 3=linking. Used
+        /// by `inc_downloaded_bytes` to gate the transfer-rate prop to the
+        /// fetching window — before/after that the rate is either zero or
+        /// stale.
+        phase_num: Arc<AtomicUsize>,
+        /// Cumulative downloaded bytes. Fed into the transfer-rate
+        /// calculation displayed in the TTY bar's `rate` prop.
+        downloaded_bytes: Arc<AtomicU64>,
+        /// Start of the install, for rate = bytes / elapsed.
+        start: Instant,
         /// Bounded visible-fetch-row bookkeeping. `visible` is the count
         /// of live per-package child rows (capped at
         /// `TTY_MAX_VISIBLE_FETCH_ROWS`); `overflow` is the count of
@@ -128,10 +138,15 @@ impl InstallProgress {
             style::edim("by en.dev"),
         );
         let root = ProgressJobBuilder::new()
-            .body("{{aube}}{{phase}}  {{progress_bar(flex=true)}} {{cur}}/{{total}}")
-            .body_text(Some("{{aube}}{{phase}} {{cur}}/{{total}}"))
+            .body(
+                "{{aube}}{{phase}}  {{progress_bar(flex=true)}} {{cur}}/{{total}}{{rate}} · {{ elapsed() }}",
+            )
+            .body_text(Some(
+                "{{aube}}{{phase}} {{cur}}/{{total}}{{rate}} · {{ elapsed() }}",
+            ))
             .prop("aube", &header)
             .prop("phase", "")
+            .prop("rate", "")
             .progress_current(0)
             .progress_total(0)
             .on_done(ProgressJobDoneBehavior::Hide)
@@ -140,6 +155,9 @@ impl InstallProgress {
             mode: Mode::Tty {
                 root,
                 total: Arc::new(AtomicUsize::new(0)),
+                phase_num: Arc::new(AtomicUsize::new(0)),
+                downloaded_bytes: Arc::new(AtomicU64::new(0)),
+                start: Instant::now(),
                 fetch_state: Arc::new(Mutex::new(FetchState {
                     visible: 0,
                     overflow: 0,
@@ -193,11 +211,26 @@ impl InstallProgress {
     /// bumps the `[N/3]` phase counter shown on the status line.
     pub fn set_phase(&self, phase: &str) {
         match &self.mode {
-            Mode::Tty { root, .. } => {
+            Mode::Tty {
+                root, phase_num, ..
+            } => {
                 if phase.is_empty() {
                     root.prop("phase", "");
                 } else {
                     root.prop("phase", &format!("{}", style::edim(format!(" — {phase}"))));
+                }
+                let n = match phase {
+                    "resolving" => 1,
+                    "fetching" => 2,
+                    "linking" => 3,
+                    _ => 0,
+                };
+                phase_num.store(n, Ordering::Relaxed);
+                // Transfer rate is only meaningful *during* fetching — clear
+                // the prop when we leave the phase so the label doesn't
+                // carry a stale number into `linking`.
+                if n != 2 {
+                    root.prop("rate", "");
                 }
             }
             Mode::Ci(s) => s.set_phase(phase),
@@ -216,13 +249,44 @@ impl InstallProgress {
         }
     }
 
-    /// Credit `bytes` to the CI-mode downloaded-bytes total. Called once per
+    /// Credit `bytes` to the downloaded-bytes total. Called once per
     /// tarball after the registry fetch completes, on top of the per-package
     /// increment that `FetchRow::drop` contributes to the downloaded count.
-    /// No-op in TTY mode (the animated bar has no room for a byte counter).
+    ///
+    /// In TTY mode this updates the transfer-rate prop rendered to the right
+    /// of `cur/total` — gated to `phase == fetching && bytes > 0` so the
+    /// label stays clean before/after the fetch window. In CI mode the
+    /// heartbeat re-renders the rate from the cumulative byte counter on
+    /// each tick; here we just bump that counter.
     pub fn inc_downloaded_bytes(&self, bytes: u64) {
-        if let Mode::Ci(s) = &self.mode {
-            s.downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+        match &self.mode {
+            Mode::Tty {
+                root,
+                phase_num,
+                downloaded_bytes,
+                start,
+                ..
+            } => {
+                let total = downloaded_bytes.fetch_add(bytes, Ordering::Relaxed) + bytes;
+                if phase_num.load(Ordering::Relaxed) != 2 || total == 0 {
+                    return;
+                }
+                let elapsed_ms = start.elapsed().as_millis() as u64;
+                if elapsed_ms == 0 {
+                    return;
+                }
+                let rate = total.saturating_mul(1000) / elapsed_ms;
+                root.prop(
+                    "rate",
+                    &format!(
+                        " · {}",
+                        style::edim(format!("{}/s", ci::format_bytes(rate)))
+                    ),
+                );
+            }
+            Mode::Ci(s) => {
+                s.downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+            }
         }
     }
 
@@ -354,18 +418,27 @@ impl InstallProgress {
                     pluralizer::pluralize("package", total_packages as isize, true)
                 )
             };
-            // Same `aube VERSION by en.dev · …` shape in both TTY and
-            // CI modes so the no-op line reads as part of the install
-            // UI family. `style::e*` respects `NO_COLOR` / `--no-color`,
-            // so CI environments that strip styling get plain text.
-            let line = format!(
-                "{} {} {} {} {}",
-                style::emagenta("aube").bold(),
-                style::edim(crate::version::VERSION.as_str()),
-                style::edim("by en.dev"),
-                style::edim("·"),
-                style::egreen(msg).bold(),
-            );
+            // In CI mode the framed `aube VERSION by en.dev` header already
+            // prints above the bar, so repeating the prefix in the summary
+            // is noise. Use the same bracketed frame as the bar and the
+            // normal-path `[ ✓ resolved … ]` summary so the no-op line
+            // slots into the existing CI block. TTY mode has no persistent
+            // header (the bar was cleared by `finish()`), so keep the
+            // full `aube VERSION · …` form there.
+            let line = match &self.mode {
+                Mode::Tty { .. } => format!(
+                    "{} {} {} {} {}",
+                    style::emagenta("aube").bold(),
+                    style::edim(crate::version::VERSION.as_str()),
+                    style::edim("by en.dev"),
+                    style::edim("·"),
+                    style::egreen(&msg).bold(),
+                ),
+                Mode::Ci(_) => {
+                    let inner = format!("{} {}", style::egreen("✓"), style::egreen(&msg).bold());
+                    ci::render_centered_line(&inner, ci::term_width())
+                }
+            };
             let _ = writeln!(std::io::stderr(), "{line}");
             return;
         }

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -33,7 +33,7 @@ use clx::progress::{
 use clx::style;
 use std::io::{IsTerminal, Write};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 /// Cap on the number of simultaneously-visible per-package fetch rows
@@ -69,8 +69,11 @@ enum Mode {
         /// Cumulative downloaded bytes. Fed into the transfer-rate
         /// calculation displayed in the TTY bar's `rate` prop.
         downloaded_bytes: Arc<AtomicU64>,
-        /// Start of the install, for rate = bytes / elapsed.
-        start: Instant,
+        /// Captured the first time `set_phase("fetching")` is called.
+        /// Used as the rate denominator so the displayed throughput
+        /// measures the fetch window only, not `bytes / (resolve_time +
+        /// fetch_time)`.
+        fetch_start: Arc<OnceLock<Instant>>,
         /// Bounded visible-fetch-row bookkeeping. `visible` is the count
         /// of live per-package child rows (capped at
         /// `TTY_MAX_VISIBLE_FETCH_ROWS`); `overflow` is the count of
@@ -157,7 +160,7 @@ impl InstallProgress {
                 total: Arc::new(AtomicUsize::new(0)),
                 phase_num: Arc::new(AtomicUsize::new(0)),
                 downloaded_bytes: Arc::new(AtomicU64::new(0)),
-                start: Instant::now(),
+                fetch_start: Arc::new(OnceLock::new()),
                 fetch_state: Arc::new(Mutex::new(FetchState {
                     visible: 0,
                     overflow: 0,
@@ -212,7 +215,10 @@ impl InstallProgress {
     pub fn set_phase(&self, phase: &str) {
         match &self.mode {
             Mode::Tty {
-                root, phase_num, ..
+                root,
+                phase_num,
+                fetch_start,
+                ..
             } => {
                 if phase.is_empty() {
                     root.prop("phase", "");
@@ -226,10 +232,14 @@ impl InstallProgress {
                     _ => 0,
                 };
                 phase_num.store(n, Ordering::Relaxed);
-                // Transfer rate is only meaningful *during* fetching — clear
-                // the prop when we leave the phase so the label doesn't
-                // carry a stale number into `linking`.
-                if n != 2 {
+                if n == 2 {
+                    // Seed the rate denominator on the fetching transition.
+                    // First-writer-wins; repeated calls are no-ops.
+                    let _ = fetch_start.set(Instant::now());
+                } else {
+                    // Transfer rate is only meaningful *during* fetching — clear
+                    // the prop when we leave the phase so the label doesn't
+                    // carry a stale number into `linking`.
                     root.prop("rate", "");
                 }
             }
@@ -264,14 +274,21 @@ impl InstallProgress {
                 root,
                 phase_num,
                 downloaded_bytes,
-                start,
+                fetch_start,
                 ..
             } => {
                 let total = downloaded_bytes.fetch_add(bytes, Ordering::Relaxed) + bytes;
                 if phase_num.load(Ordering::Relaxed) != 2 || total == 0 {
                     return;
                 }
-                let elapsed_ms = start.elapsed().as_millis() as u64;
+                // `fetch_start` is seeded by `set_phase("fetching")`; if
+                // bytes land before that (shouldn't happen but defend
+                // against it), skip the update instead of computing against
+                // install start time.
+                let Some(fetch_start) = fetch_start.get() else {
+                    return;
+                };
+                let elapsed_ms = fetch_start.elapsed().as_millis() as u64;
                 if elapsed_ms == 0 {
                     return;
                 }
@@ -418,26 +435,29 @@ impl InstallProgress {
                     pluralizer::pluralize("package", total_packages as isize, true)
                 )
             };
-            // In CI mode the framed `aube VERSION by en.dev` header already
-            // prints above the bar, so repeating the prefix in the summary
-            // is noise. Use the same bracketed frame as the bar and the
-            // normal-path `[ ✓ resolved … ]` summary so the no-op line
-            // slots into the existing CI block. TTY mode has no persistent
-            // header (the bar was cleared by `finish()`), so keep the
-            // full `aube VERSION · …` form there.
-            let line = match &self.mode {
-                Mode::Tty { .. } => format!(
+            // In CI mode the framed `aube VERSION by en.dev` header prints
+            // above the bar on the first heartbeat tick, so repeating the
+            // prefix in the summary is noise — use the bracketed frame
+            // instead, matching the `[ ✓ resolved … ]` summary from the
+            // non-empty path. *But* if the install finished before the
+            // first heartbeat tick (`shown == false`), the framed header
+            // was never printed; a framed summary would then appear as an
+            // orphaned bracketed block with no context. Fall back to the
+            // unframed `aube VERSION · …` shape in that case so the
+            // no-op line still identifies itself.
+            let framed_ci = matches!(&self.mode, Mode::Ci(s) if s.shown.load(Ordering::Relaxed));
+            let line = if framed_ci {
+                let inner = format!("{} {}", style::egreen("✓"), style::egreen(&msg).bold());
+                ci::render_centered_line(&inner, ci::term_width())
+            } else {
+                format!(
                     "{} {} {} {} {}",
                     style::emagenta("aube").bold(),
                     style::edim(crate::version::VERSION.as_str()),
                     style::edim("by en.dev"),
                     style::edim("·"),
                     style::egreen(&msg).bold(),
-                ),
-                Mode::Ci(_) => {
-                    let inner = format!("{} {}", style::egreen("✓"), style::egreen(&msg).bold());
-                    ci::render_centered_line(&inner, ci::term_width())
-                }
+                )
             };
             let _ = writeln!(std::io::stderr(), "{line}");
             return;


### PR DESCRIPTION
## Summary

- Add a live transfer rate to both progress bar styles (TTY + CI), gated to the fetching phase and suppressed until the first byte lands so the label doesn't carry a stale number into resolving/linking.
- Add an elapsed-time readout that ticks throughout the install in both styles. TTY mode uses clx's built-in `{{ elapsed() }}`; CI mode renders it from `CiState::start` on each 2s heartbeat tick.
- Frame the CI "Already up to date" line to match the existing `[ header ]` / `[ bar ]` / `[ ✓ summary ]` block, and drop the redundant `aube VERSION by en.dev ·` prefix that's already shown in the framed header above it. TTY mode keeps the full prefix (its bar is cleared on finish, so there's no lingering header).

## What it looks like

**CI mode, fresh install:**
```
[                      aube 1.0.0-beta.12-DEBUG by en.dev                      ]
[################# 6/8 pkgs [2/3] · 18 kB · 102 kB/s · 179ms ------------------]
[####################### 8/8 pkgs [3/3] · 21 kB · 236ms #######################]
[            ✓ 251ms · resolved 8 · reused 1 · downloaded 7 (21 kB)            ]
```

**CI mode, no-op re-run:**
```
[                      aube 1.0.0-beta.12-DEBUG by en.dev                      ]
[------------------------- 0/8 pkgs [2/3] · 0 B · 1ms -------------------------]
[######################## 8/8 pkgs [3/3] · 0 B · 22ms #########################]
[                      ✓ Already up to date (8 packages)                       ]
```

**TTY mode:**
```
aube 1.0.0-beta.12 by en.dev — fetching  [██████░░░] 47/142 · 4.2 MB/s · 2.1s
```

## Notes for reviewers

- The `rate` prop in TTY mode only refreshes when a tarball completes (no extra ticker thread) — during a slow single-file fetch the displayed rate will look static between completions.
- `set_phase` on TTY now clears the `rate` prop whenever the phase isn't fetching, so the stale number from the last fetch completion doesn't carry into linking.
- `ci::format_bytes`, `ci::render_centered_line`, and `ci::term_width` moved from `fn` to `pub(super) fn` so `mod.rs` can reuse them for the TTY rate string and the framed no-op line.

## Test plan

- [x] `cargo check -p aube`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `mise run test:bats test/install.bats` (57/57 passing, including the "Already up to date" partial-match assertions which still hit the framed line)
- [x] Manual smoke test: fresh install + no-op re-run under `CI=1 COLUMNS=80` showing the shapes above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes progress rendering and CI heartbeat/threaded output logic, which could affect log formatting or introduce timing/phase edge cases, but it does not touch install semantics.
> 
> **Overview**
> **Progress output now includes transfer rate and elapsed timer in both modes.** CI heartbeat rendering is extended to track a `fetch_start` window and append `· <bytes>/s` (fetching-only) plus `· <elapsed>` to the bar label.
> 
> **TTY mode progress bar text is updated** to show `{{ elapsed() }}` and a dynamic `rate` prop, with new atomics/`OnceLock` state to compute rate during the fetching phase and clear it when leaving the phase.
> 
> **CI no-op summary formatting is adjusted** so `Already up to date` is rendered in the same bracketed frame when the CI header was shown, falling back to the previous unframed `aube VERSION …` line if the heartbeat never printed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e58d2376b3d9469293fc1989ec01676e99dde2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->