### PR TITLE
cli(pack): drop CHANGELOG from always-included files

### DIFF
--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -15,6 +15,10 @@
 //!
 //! In both cases `package.json`, `README*`, `LICENSE*`/`LICENCE*`, and the
 //! `main` entry are always included — matching npm's "always-on" list.
+//! `CHANGELOG*` is intentionally excluded (npm dropped it in
+//! npm/npm-packlist#61): changelogs grow forever and few consumers read
+//! them out of `node_modules`. Users who want it shipped can list it in
+//! the `files` field.
 
 use aube_manifest::PackageJson;
 use clap::Args;
@@ -401,7 +405,8 @@ fn is_npm_ignored(name: &str) -> bool {
 fn always_included_files(project_dir: &Path, manifest: &PackageJson) -> Vec<String> {
     let mut out = vec!["package.json".to_string()];
 
-    // README, LICENSE, LICENCE, CHANGELOG — any extension.
+    // README, LICENSE, LICENCE — any extension. CHANGELOG is intentionally
+    // omitted to match npm's behavior (npm/npm-packlist#61).
     let Ok(entries) = std::fs::read_dir(project_dir) else {
         return out;
     };
@@ -412,10 +417,7 @@ fn always_included_files(project_dir: &Path, manifest: &PackageJson) -> Vec<Stri
             .rsplit_once('.')
             .map(|(s, _)| s.to_string())
             .unwrap_or(upper);
-        if matches!(
-            stem.as_str(),
-            "README" | "LICENSE" | "LICENCE" | "CHANGELOG"
-        ) {
+        if matches!(stem.as_str(), "README" | "LICENSE" | "LICENCE") {
             out.push(name);
         }
     }


### PR DESCRIPTION
## Summary
- Remove `CHANGELOG*` from `pack`'s always-on file list, matching npm's behavior in [npm/npm-packlist#61](https://github.com/npm/npm-packlist/pull/61). README and LICENSE/LICENCE still force-include.
- Users who actually want a changelog shipped can list it in the `files` field.

Closes [#226](https://github.com/endevco/aube/discussions/226).

## Test plan
- [x] \`cargo build -p aube\` passes
- [x] no existing bats/Rust tests reference \`CHANGELOG\` in pack/publish paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrows `aube pack`'s default always-included set by removing `CHANGELOG*`, which only affects tarball contents and not execution paths beyond packaging.
> 
> **Overview**
> Updates `aube pack` to **stop force-including `CHANGELOG*`** in generated tarballs, matching npm behavior; `README*` and `LICENSE*`/`LICENCE*` remain always included.
> 
> Adds inline documentation explaining the exclusion and that users can still ship changelogs by listing them in `package.json` `files`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06b73e64a488d14bac4338b8d45640a2c334446d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->