### PR TITLE
install: link importer's own bin into node_modules/.bin

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3770,7 +3770,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         // `link_bins` so a self-bin overrides a same-named dep bin.
         if let Some(bin) = manifest.extra.get("bin") {
             let root_bin_dir = cwd.join(&modules_dir_name).join(".bin");
-            link_self_bins(
+            link_bin_entries(
                 &root_bin_dir,
                 &cwd,
                 manifest.name.as_deref(),
@@ -3815,7 +3815,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     manifests.iter().find(|(p, _)| p == importer_path)
                     && let Some(bin) = member_manifest.extra.get("bin")
                 {
-                    link_self_bins(
+                    link_bin_entries(
                         &bin_dir,
                         &pkg_dir,
                         member_manifest.name.as_deref(),
@@ -4524,27 +4524,7 @@ fn link_bins_for_dep(
         placements,
     )? && let Some(bin) = pkg_json.get("bin")
     {
-        match bin {
-            serde_json::Value::String(bin_path) => {
-                let bin_name = name.split('/').next_back().unwrap_or(name);
-                if aube_linker::validate_bin_name(bin_name).is_ok()
-                    && aube_linker::validate_bin_target(bin_path).is_ok()
-                {
-                    create_bin_link(bin_dir, bin_name, &pkg_dir.join(bin_path), shim_opts)?;
-                }
-            }
-            serde_json::Value::Object(bins) => {
-                for (bin_name, path) in bins {
-                    if let Some(path_str) = path.as_str()
-                        && aube_linker::validate_bin_name(bin_name).is_ok()
-                        && aube_linker::validate_bin_target(path_str).is_ok()
-                    {
-                        create_bin_link(bin_dir, bin_name, &pkg_dir.join(path_str), shim_opts)?;
-                    }
-                }
-            }
-            _ => {}
-        }
+        link_bin_entries(bin_dir, &pkg_dir, Some(name), bin, shim_opts)?;
     }
     link_bundled_bins(bin_dir, &pkg_dir, graph, dep_path, shim_opts)?;
     Ok(())
@@ -4716,40 +4696,25 @@ fn link_bundled_bins(
         let Some(bin) = bundled_pkg_json.get("bin") else {
             continue;
         };
-        match bin {
-            serde_json::Value::String(bin_path) => {
-                let bin_name = bundled.split('/').next_back().unwrap_or(bundled);
-                if aube_linker::validate_bin_name(bin_name).is_ok()
-                    && aube_linker::validate_bin_target(bin_path).is_ok()
-                {
-                    create_bin_link(bin_dir, bin_name, &bundled_dir.join(bin_path), shim_opts)?;
-                }
-            }
-            serde_json::Value::Object(bins) => {
-                for (name, path) in bins {
-                    if let Some(path_str) = path.as_str()
-                        && aube_linker::validate_bin_name(name).is_ok()
-                        && aube_linker::validate_bin_target(path_str).is_ok()
-                    {
-                        create_bin_link(bin_dir, name, &bundled_dir.join(path_str), shim_opts)?;
-                    }
-                }
-            }
-            _ => {}
-        }
+        link_bin_entries(bin_dir, &bundled_dir, Some(bundled), bin, shim_opts)?;
     }
     Ok(())
 }
 
-/// Link an importer's *own* `bin` entries into its own
-/// `node_modules/.bin/`. Without this, scripts that invoke the package
-/// by its own name (`"scripts": {"test": "my-cli-app"}`) can't find it
-/// on PATH — npm requires `npx my-cli-app`, yarn and pnpm shim the
-/// self-bin so the bare name works. Runs after dep-bin linking at each
-/// call site so a self-bin wins a name collision with a same-named
-/// dep bin (the user explicitly named this package; its own bin owns
-/// the identifier).
-fn link_self_bins(
+/// Shim each entry of a package.json `bin` field into `bin_dir`,
+/// resolving relative targets against `pkg_dir`. Shared by the
+/// dep-bin pass (`link_bins_for_dep`), bundled-deps pass
+/// (`link_bundled_bins`), and importer self-bin pass (root + each
+/// workspace member, discussion #228).
+///
+/// String-form `bin: "./x.js"` uses the basename of `pkg_name` as the
+/// shim name (scope `@a/b` → `b`); the entry is silently skipped when
+/// `pkg_name` is `None`. Object-form `bin: { foo: "./f" }` uses each
+/// key as-is. Entries whose name or target fail
+/// [`aube_linker::validate_bin_name`] / [`aube_linker::validate_bin_target`]
+/// are dropped without error, matching the pnpm/npm "silently ignore
+/// invalid bin" behavior.
+fn link_bin_entries(
     bin_dir: &std::path::Path,
     pkg_dir: &std::path::Path,
     pkg_name: Option<&str>,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3766,6 +3766,18 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             shim_opts,
             has_bin_metadata,
         )?;
+        // Root importer's own `bin` (discussion #228). Runs after
+        // `link_bins` so a self-bin overrides a same-named dep bin.
+        if let Some(bin) = manifest.extra.get("bin") {
+            let root_bin_dir = cwd.join(&modules_dir_name).join(".bin");
+            link_self_bins(
+                &root_bin_dir,
+                &cwd,
+                manifest.name.as_deref(),
+                bin,
+                shim_opts,
+            )?;
+        }
         if has_workspace {
             for (importer_path, deps) in &graph_for_link.importers {
                 if importer_path == "." {
@@ -3795,6 +3807,20 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         placements_ref,
                         shim_opts,
                         has_bin_metadata,
+                    )?;
+                }
+                // Workspace member's own `bin` (discussion #228). `manifests`
+                // was parsed once upstream and keys by importer relpath.
+                if let Some((_, member_manifest)) =
+                    manifests.iter().find(|(p, _)| p == importer_path)
+                    && let Some(bin) = member_manifest.extra.get("bin")
+                {
+                    link_self_bins(
+                        &bin_dir,
+                        &pkg_dir,
+                        member_manifest.name.as_deref(),
+                        bin,
+                        shim_opts,
                     )?;
                 }
             }
@@ -4711,6 +4737,48 @@ fn link_bundled_bins(
             }
             _ => {}
         }
+    }
+    Ok(())
+}
+
+/// Link an importer's *own* `bin` entries into its own
+/// `node_modules/.bin/`. Without this, scripts that invoke the package
+/// by its own name (`"scripts": {"test": "my-cli-app"}`) can't find it
+/// on PATH — npm requires `npx my-cli-app`, yarn and pnpm shim the
+/// self-bin so the bare name works. Runs after dep-bin linking at each
+/// call site so a self-bin wins a name collision with a same-named
+/// dep bin (the user explicitly named this package; its own bin owns
+/// the identifier).
+fn link_self_bins(
+    bin_dir: &std::path::Path,
+    pkg_dir: &std::path::Path,
+    pkg_name: Option<&str>,
+    bin: &serde_json::Value,
+    shim_opts: aube_linker::BinShimOptions,
+) -> miette::Result<()> {
+    match bin {
+        serde_json::Value::String(bin_path) => {
+            let Some(name) = pkg_name else {
+                return Ok(());
+            };
+            let bin_name = name.split('/').next_back().unwrap_or(name);
+            if aube_linker::validate_bin_name(bin_name).is_ok()
+                && aube_linker::validate_bin_target(bin_path).is_ok()
+            {
+                create_bin_link(bin_dir, bin_name, &pkg_dir.join(bin_path), shim_opts)?;
+            }
+        }
+        serde_json::Value::Object(bins) => {
+            for (bin_name, path) in bins {
+                if let Some(path_str) = path.as_str()
+                    && aube_linker::validate_bin_name(bin_name).is_ok()
+                    && aube_linker::validate_bin_target(path_str).is_ok()
+                {
+                    create_bin_link(bin_dir, bin_name, &pkg_dir.join(path_str), shim_opts)?;
+                }
+            }
+        }
+        _ => {}
     }
     Ok(())
 }

--- a/test/run.bats
+++ b/test/run.bats
@@ -213,3 +213,82 @@ JSON
 	assert_output --partial "true"
 	assert_file_exists shell.log
 }
+
+# discussion #228: a package's own `bin` should resolve from its own
+# scripts without `npx`, matching yarn/pnpm behavior.
+@test "aube run resolves package's own bin (string form)" {
+	cat >bin.js <<'EOF'
+#!/usr/bin/env node
+console.log("self-bin:", process.argv.slice(2).join(" "))
+EOF
+	chmod +x bin.js
+	cat >package.json <<'JSON'
+{
+  "name": "my-cli-app",
+  "version": "1.0.0",
+  "bin": "./bin.js",
+  "scripts": { "self": "my-cli-app hello" }
+}
+JSON
+	aube install
+	assert_file_exists node_modules/.bin/my-cli-app
+	run aube run self
+	assert_success
+	assert_output --partial "self-bin: hello"
+}
+
+@test "aube run resolves package's own bin (object form)" {
+	cat >foo.js <<'EOF'
+#!/usr/bin/env node
+console.log("foo!")
+EOF
+	cat >bar.js <<'EOF'
+#!/usr/bin/env node
+console.log("bar!")
+EOF
+	chmod +x foo.js bar.js
+	cat >package.json <<'JSON'
+{
+  "name": "multi-bin",
+  "version": "1.0.0",
+  "bin": { "foo": "./foo.js", "bar": "./bar.js" },
+  "scripts": { "run-both": "foo && bar" }
+}
+JSON
+	aube install
+	assert_file_exists node_modules/.bin/foo
+	assert_file_exists node_modules/.bin/bar
+	run aube run run-both
+	assert_success
+	assert_output --partial "foo!"
+	assert_output --partial "bar!"
+}
+
+@test "aube run resolves workspace member's own bin" {
+	cat >package.json <<'JSON'
+{ "name": "root", "version": "1.0.0" }
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - "packages/*"
+YAML
+	mkdir -p packages/cli
+	cat >packages/cli/bin.js <<'EOF'
+#!/usr/bin/env node
+console.log("cli-bin")
+EOF
+	chmod +x packages/cli/bin.js
+	cat >packages/cli/package.json <<'JSON'
+{
+  "name": "my-cli",
+  "version": "1.0.0",
+  "bin": "./bin.js",
+  "scripts": { "self": "my-cli" }
+}
+JSON
+	aube install
+	assert_file_exists packages/cli/node_modules/.bin/my-cli
+	run aube -C packages/cli run self
+	assert_success
+	assert_output --partial "cli-bin"
+}


### PR DESCRIPTION
## Summary

- Each importer's own `bin` entries now get shimmed into its own `node_modules/.bin/` at install time — matches yarn/pnpm behavior, unblocks scripts that invoke the package by its own name (`"test:app": "my-cli-app"`) without `npx`.
- Covers the root importer and every workspace member. Runs after dep-bin linking so a self-bin wins a name collision with a same-named dep bin.
- Fixes endevco/aube#228.

## Implementation

- New `link_self_bins` helper in [crates/aube/src/commands/install/mod.rs](../blob/claude/recursing-ishizaka-19db42/crates/aube/src/commands/install/mod.rs) handles both string-form (`"bin": "./x.js"`, shim name = basename of pkg name) and object-form (`"bin": {...}`). Reuses the existing `create_bin_link` + `aube_linker::validate_bin_{name,target}` validation surface.
- Two call sites: right after the root `link_bins(...)` call, and inside the workspace-importer loop after each member's dep-bin pass. The workspace loop re-uses the already-parsed `manifests` vec (keyed by importer relpath) so no extra disk reads.
- `bin` lives in `PackageJson::extra` (serde flatten) — no new field needed in aube-manifest.
- Frozen fast path already hashes `package.json`, so adding/removing a `bin` invalidates and re-links without any state-file changes.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (zero warnings)
- [x] `cargo test --release -p aube` (279 unit + 4 e2e, all pass)
- [x] `mise run test:bats` (916 tests, 0 failures)
- [x] 3 new bats cases in [test/run.bats](../blob/claude/recursing-ishizaka-19db42/test/run.bats): string-form bin, object-form bin, workspace-member bin
- [x] Manual repro from discussion #228's exact `package.json` → `aube test:app` now executes `./bin.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time executable linking by adding importer self-bin shims (root and workspace members) and adjusting precedence/validation handling, which could affect command resolution and bin collisions across projects.
> 
> **Overview**
> Adds install-time support for linking an importer’s own `package.json` `bin` entries into its local `node_modules/.bin` (root and each workspace member), ensuring scripts can invoke the package by name without `npx` and that self-bins override same-named dependency bins.
> 
> Refactors bin shimming into a shared `link_bin_entries` helper and reuses it for dependency and bundled-dependency bin linking, plus adds Bats coverage for string/object `bin` forms and workspace member self-bins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6922ed9703f91f464e0dd3071e05b5c59451ad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->