### PR TITLE
chore(release): append en.dev sponsor blurb to release notes

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -159,6 +159,23 @@ jobs:
           TAG: ${{ needs.release-plz-release.outputs.tag }}
         run: |
           communique generate "$TAG" --github-release
+      - name: Append en.dev sponsor blurb
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+          TAG: ${{ needs.release-plz-release.outputs.tag }}
+        run: |
+          {
+            gh release view "$TAG" --json body --jq .body
+            cat <<'EOF'
+
+          ## 💚 Sponsor aube
+
+          aube is part of [**en.dev**](https://en.dev) — an independent developer-tooling studio run by [@jdx](https://github.com/jdx), also behind [mise](https://mise.jdx.dev/). Work on aube is funded entirely by sponsors.
+
+          If aube is saving your team install time or CI minutes, please consider [sponsoring at en.dev](https://en.dev). Individual and company sponsorships are what keep the project fast, free, and independent.
+          EOF
+          } > /tmp/release-notes.md
+          gh release edit "$TAG" --notes-file /tmp/release-notes.md
 
   # On every push to main: keep a running "chore: release" PR open with
   # the next version bump + regenerated CHANGELOG. Merging the PR is


### PR DESCRIPTION
## Summary

- Appends a **Sponsor aube** section to every GitHub Release body, run after `communique generate` in the `enhance-release` job in [`.github/workflows/release-plz.yml`](.github/workflows/release-plz.yml).
- The blurb explains that aube is funded by sponsors at [en.dev](https://en.dev) and links to other en.dev projects — consistent with [mise#9272](https://github.com/jdx/mise/pull/9272).

## What it looks like

Rendered at the bottom of each release body:

> ## 💚 Sponsor aube
>
> aube is part of [**en.dev**](https://en.dev) — an independent developer-tooling studio run by [@jdx](https://github.com/jdx), also behind [mise](https://mise.jdx.dev/). Work on aube is funded entirely by sponsors.
>
> If aube is saving your team install time or CI minutes, please consider [sponsoring at en.dev](https://en.dev). Individual and company sponsorships are what keep the project fast, free, and independent.

## Test plan

- [x] \`actionlint\` + \`yamllint\` pass on the modified workflow
- [x] Simulated the heredoc locally to confirm YAML indentation strips cleanly and bash terminates the heredoc correctly
- [ ] Next tagged release produces a GitHub Release whose body ends with the sponsor section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the GitHub Actions `enhance-release` job to post-process release notes via `gh release edit`, with no changes to build, publishing, or runtime behavior.
> 
> **Overview**
> After `communique generate` runs in the `enhance-release` workflow, the release job now **appends an en.dev “Sponsor aube” section** to the existing GitHub Release body.
> 
> This is implemented by fetching the current release notes (`gh release view`), concatenating a fixed markdown blurb, and updating the release via `gh release edit --notes-file`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0d909fb3f1b8dfba2965b9982051810549eac30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->