### PR TITLE
lockfile: extract read_lockfile helper to dedupe parser I/O

### DIFF
--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -164,8 +164,7 @@ struct RawBunMeta {
 
 /// Parse a bun.lock file into a LockfileGraph.
 pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
-    let raw_content =
-        std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+    let raw_content = crate::read_lockfile(path)?;
     let cleaned = strip_jsonc(&raw_content);
     // `strip_jsonc` preserves byte offsets, so a serde_json error on
     // `cleaned` points at the same byte in `raw_content`. Feed the

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -1652,6 +1652,11 @@ pub enum Error {
     ParseDiag(Box<aube_manifest::ParseError>),
 }
 
+/// Read a lockfile from disk, mapping I/O errors to `Error::Io`.
+pub fn read_lockfile(path: &std::path::Path) -> Result<String, Error> {
+    std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))
+}
+
 /// Parse a JSON lockfile document, attaching a miette source span on
 /// failure so the fancy handler can point at the offending byte.
 pub fn parse_json<T: serde::de::DeserializeOwned>(

--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -197,7 +197,7 @@ struct RawNpmPeerDepMeta {
 
 /// Parse a package-lock.json or npm-shrinkwrap.json file into a LockfileGraph.
 pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
-    let content = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+    let content = crate::read_lockfile(path)?;
     let raw: RawNpmLockfile = crate::parse_json(path, content)?;
 
     if raw.lockfile_version < 2 {

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 /// Parse a pnpm-lock.yaml file into a LockfileGraph.
 pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
-    let content = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+    let content = crate::read_lockfile(path)?;
     let raw = parse_raw_lockfile(&content)
         .map_err(|e| Error::parse_yaml_err(path, content.clone(), &e))?;
 

--- a/crates/aube-lockfile/src/yarn.rs
+++ b/crates/aube-lockfile/src/yarn.rs
@@ -61,7 +61,7 @@ use std::path::{Path, PathBuf};
 /// The manifest is needed to identify direct dependencies (yarn.lock has
 /// no notion of direct vs transitive).
 pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<LockfileGraph, Error> {
-    let content = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+    let content = crate::read_lockfile(path)?;
     if is_berry(&content) {
         parse_berry_str(path, &content, manifest)
     } else {


### PR DESCRIPTION
## Summary

- Four lockfile parsers (`pnpm`, `npm`, `bun`, `yarn`) all repeated the same incantation:
  ```rust
  std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?
  ```
- Extract it into a single `aube_lockfile::read_lockfile(path)` helper in `lib.rs`, and call it from each parser.
- No behavior change — pure deduplication. Future cross-cutting changes (tracing spans, permission-denied hints, retries) now live in one place.

Net: +9 / -5.

## Test plan

- [x] `cargo build -p aube-lockfile`
- [x] `cargo clippy -p aube-lockfile --all-targets -- -D warnings`
- [ ] CI: unit + bats

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only deduplicates how lockfiles are read from disk; parsing logic and error mapping remain effectively the same, but any future behavior changes to reading now affect all parsers at once.
> 
> **Overview**
> Refactors the bun/npm/pnpm/yarn lockfile parsers to use a new shared `read_lockfile()` helper instead of repeating `std::fs::read_to_string` + `Error::Io` mapping.
> 
> Adds `read_lockfile()` to `aube-lockfile`’s `lib.rs` to centralize lockfile I/O and keep the parsers’ behavior consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c618382417e0d2762fab51a913ff290e468af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->