### PR TITLE
install(delta): invalidate changed no-gvs subtrees

### DIFF
--- a/crates/aube/src/commands/install/delta.rs
+++ b/crates/aube/src/commands/install/delta.rs
@@ -244,6 +244,22 @@ pub fn compute_subtree_hashes(graph: &LockfileGraph) -> BTreeMap<String, String>
         .collect()
 }
 
+/// Return the current dep_paths whose subtree hash changed since the
+/// previous install. This is the minimal invalidation set for
+/// per-project `.aube/<dep_path>` directories: if a child changed,
+/// every ancestor's internal sibling links must be rebuilt even when
+/// the ancestor's own leaf fingerprint is identical.
+pub fn changed_subtree_roots(
+    stored: &BTreeMap<String, String>,
+    current: &BTreeMap<String, String>,
+) -> Vec<String> {
+    current
+        .iter()
+        .filter(|(dep_path, hash)| stored.get(*dep_path) != Some(*hash))
+        .map(|(dep_path, _)| dep_path.clone())
+        .collect()
+}
+
 /// Iterative Tarjan SCC over `graph.packages`. Returns each SCC as
 /// a `Vec` of `dep_path` keys. Acyclic nodes show up as one-member
 /// SCCs. Iterative because deep peer-suffix chains blew the stack
@@ -461,6 +477,15 @@ mod tests {
         }
     }
 
+    fn pkg_with_deps(name: &str, version: &str, deps: &[(&str, &str)]) -> LockedPackage {
+        let mut pkg = pkg(name, version);
+        for (dep_name, dep_version) in deps {
+            pkg.dependencies
+                .insert((*dep_name).to_string(), format!("{dep_name}@{dep_version}"));
+        }
+        pkg
+    }
+
     fn graph_of(pkgs: &[LockedPackage]) -> LockfileGraph {
         let mut graph = LockfileGraph::default();
         for p in pkgs {
@@ -588,6 +613,24 @@ mod tests {
         g2.packages.insert("a@1".into(), pkg("a", "1"));
         let plan = diff(&compute_package_hashes(&g1), &compute_package_hashes(&g2));
         assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn changed_subtree_roots_includes_changed_ancestors() {
+        let before = compute_subtree_hashes(&graph_of(&[
+            pkg_with_deps("app", "1", &[("dep", "1")]),
+            pkg("dep", "1"),
+            pkg("peer", "1"),
+        ]));
+        let after = compute_subtree_hashes(&graph_of(&[
+            pkg_with_deps("app", "1", &[("dep", "2")]),
+            pkg("dep", "2"),
+            pkg("peer", "1"),
+        ]));
+
+        let changed = changed_subtree_roots(&before, &after);
+
+        assert_eq!(changed, vec!["app@1".to_string(), "dep@2".to_string()]);
     }
 
     #[test]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3635,6 +3635,23 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         linker = linker.with_use_global_virtual_store(enabled);
     }
 
+    let current_subtree_hashes = (!virtual_store_only
+        && matches!(node_linker, aube_linker::NodeLinker::Isolated)
+        && !opts.dep_selection.is_filtered()
+        && opts.workspace_filter.is_empty())
+    .then(|| delta::compute_subtree_hashes(&graph_for_link));
+    if !linker.uses_global_virtual_store()
+        && let Some(current_subtree_hashes) = current_subtree_hashes.as_ref()
+        && let Some(prior_subtrees) = state::read_state_subtree_hashes(&cwd)
+    {
+        let touched = delta::changed_subtree_roots(&prior_subtrees, current_subtree_hashes);
+        let invalidated =
+            invalidate_changed_aube_entries(&aube_dir, &touched, virtual_store_dir_max_length);
+        if invalidated > 0 {
+            tracing::debug!("delta: invalidated {invalidated} changed .aube entry/entries");
+        }
+    }
+
     // 6a. Pre-compute content-addressed virtual-store hashes.
     //     Only necessary when linking into the shared global virtual
     //     store — in per-project mode (`CI=1`) the `.aube/<dep_path>`
@@ -4187,6 +4204,24 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+fn invalidate_changed_aube_entries(
+    aube_dir: &std::path::Path,
+    dep_paths: &[String],
+    virtual_store_dir_max_length: usize,
+) -> usize {
+    let mut removed = 0usize;
+    for dep_path in dep_paths {
+        let path = aube_dir.join(dep_path_to_filename(dep_path, virtual_store_dir_max_length));
+        let result = std::fs::remove_dir_all(&path).or_else(|_| std::fs::remove_file(&path));
+        match result {
+            Ok(()) => removed += 1,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::debug!("delta: failed to invalidate {}: {e}", path.display()),
+        }
+    }
+    removed
 }
 
 /// Remove `node_modules/.aube/<encoded_dep_path>` entries that aren't

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3973,7 +3973,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         // stale fingerprints fall back to a full install on the
         // read side. Safe for older readers that ignore the field.
         let package_content_hashes = delta::compute_package_hashes(&graph);
-        let package_subtree_hashes = delta::compute_subtree_hashes(&graph);
+        let package_subtree_hashes =
+            current_subtree_hashes.unwrap_or_else(|| delta::compute_subtree_hashes(&graph));
         let graph_lthash = hex::encode(delta::lthash_of(&package_content_hashes).digest());
         let package_json_hashes =
             state::collect_package_json_hashes_from_manifests(&cwd, &manifests);
@@ -4218,7 +4219,7 @@ fn invalidate_changed_aube_entries(
         match result {
             Ok(()) => removed += 1,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => tracing::debug!("delta: failed to invalidate {}: {e}", path.display()),
+            Err(e) => tracing::warn!("delta: failed to invalidate {}: {e}", path.display()),
         }
     }
     removed

--- a/crates/aube/tests/e2e.rs
+++ b/crates/aube/tests/e2e.rs
@@ -8,6 +8,7 @@
 
 use assert_cmd::Command;
 use std::fs;
+use std::sync::{Mutex, MutexGuard, OnceLock};
 use tempfile::TempDir;
 
 /// Build an isolated project root plus private `HOME` / aube store /
@@ -60,8 +61,17 @@ impl Sandbox {
     }
 }
 
+fn e2e_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    match LOCK.get_or_init(|| Mutex::new(())).lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
 #[test]
 fn version_flag_reports_binary_version() {
+    let _guard = e2e_lock();
     let sbx = Sandbox::new();
     sbx.cmd()
         .arg("--version")
@@ -72,6 +82,7 @@ fn version_flag_reports_binary_version() {
 
 #[test]
 fn help_flag_lists_install_command() {
+    let _guard = e2e_lock();
     let sbx = Sandbox::new();
     sbx.cmd()
         .arg("--help")
@@ -82,6 +93,7 @@ fn help_flag_lists_install_command() {
 
 #[test]
 fn install_on_manifest_without_deps_creates_state_file() {
+    let _guard = e2e_lock();
     let sbx = Sandbox::new();
     sbx.write_manifest(r#"{"name":"e2e-empty","version":"0.0.0"}"#);
 
@@ -95,6 +107,7 @@ fn install_on_manifest_without_deps_creates_state_file() {
 
 #[test]
 fn run_executes_a_simple_script() {
+    let _guard = e2e_lock();
     let sbx = Sandbox::new();
     sbx.write_manifest(
         r#"{


### PR DESCRIPTION
## Summary
- compare prior vs current subtree hashes during isolated no-GVS installs
- invalidate only changed `node_modules/.aube/<dep_path>` entries before linking
- add a delta test proving ancestor packages are invalidated when a child subtree changes

## Why
This is the first step toward real delta relinking in no-GVS mode. Instead of treating every warm reinstall like a full rematerialization, we now preserve unchanged per-project `.aube` entries and only force relinking for packages whose subtree changed.

## Validation
- `cargo fmt --check`
- `cargo clippy --manifest-path crates/aube/Cargo.toml --all-targets -- -D warnings`
- `cargo test -p aube changed_subtree_roots_includes_changed_ancestors`
- `./test/bats/bin/bats test/overrides.bats --filter 'top-level overrides pin a transitive dep'`

## Caveat
This improves warm reinstalls where `.aube` survives. It does not by itself move the `cache+node_modules` Babylon benchmark, because that benchmark deletes `.aube` before each run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds pre-link filesystem invalidation of `.aube` entries based on subtree-hash diffs; incorrect hashing or selection logic could cause unnecessary relinks or stale links in isolated/no-GVS installs.
> 
> **Overview**
> Adds subtree-hash based invalidation for isolated installs that do *not* use the global virtual store: on startup, the install now compares stored vs current subtree hashes and removes only the changed `node_modules/.aube/<dep_path>` entries before linking.
> 
> Introduces `delta::changed_subtree_roots` plus a new unit test asserting ancestor packages are marked changed when a descendant subtree changes, and reuses precomputed subtree hashes when persisting install state. E2E tests are serialized via a global mutex to avoid cross-test interference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3faee3c4dac22067efe8fcb0b513c0abee80bfed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->