### PR TITLE
lockfile(yarn): drop per-lookup String allocs in berry parser

### DIFF
--- a/crates/aube-lockfile/src/yarn.rs
+++ b/crates/aube-lockfile/src/yarn.rs
@@ -578,9 +578,9 @@ fn parse_berry_str(
     // headers, `resolution:` / `checksum:`) hasn't changed across
     // those versions.
     let meta_version = map
-        .get(serde_yaml::Value::String("__metadata".to_string()))
+        .get("__metadata")
         .and_then(|m| m.as_mapping())
-        .and_then(|m| m.get(serde_yaml::Value::String("version".to_string())))
+        .and_then(|m| m.get("version"))
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
     if meta_version < 3 {
@@ -628,7 +628,7 @@ fn parse_berry_str(
         // reporting "has no version" against a spec that obviously
         // does.
         let version = block
-            .get(serde_yaml::Value::String("version".to_string()))
+            .get("version")
             .and_then(yaml_scalar_as_string)
             .ok_or_else(|| {
                 Error::Parse(
@@ -638,7 +638,7 @@ fn parse_berry_str(
             })?;
 
         let resolution = block
-            .get(serde_yaml::Value::String("resolution".to_string()))
+            .get("resolution")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
                 Error::Parse(
@@ -756,7 +756,7 @@ fn parse_berry_str(
             .collect();
 
         let checksum = block
-            .get(serde_yaml::Value::String("checksum".to_string()))
+            .get("checksum")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
@@ -947,7 +947,7 @@ fn yaml_scalar_as_string(v: &serde_yaml::Value) -> Option<String> {
 /// recording `"5"` as the range.
 fn collect_dep_map(block: &serde_yaml::Mapping, key: &str) -> BTreeMap<String, String> {
     block
-        .get(serde_yaml::Value::String(key.to_string()))
+        .get(key)
         .and_then(|v| v.as_mapping())
         .map(|m| {
             m.iter()
@@ -962,9 +962,7 @@ fn collect_dep_map(block: &serde_yaml::Mapping, key: &str) -> BTreeMap<String, S
 /// the meta block (if any) are ignored.
 fn collect_peer_meta(block: &serde_yaml::Mapping) -> BTreeMap<String, crate::PeerDepMeta> {
     block
-        .get(serde_yaml::Value::String(
-            "peerDependenciesMeta".to_string(),
-        ))
+        .get("peerDependenciesMeta")
         .and_then(|v| v.as_mapping())
         .map(|m| {
             m.iter()
@@ -972,7 +970,7 @@ fn collect_peer_meta(block: &serde_yaml::Mapping) -> BTreeMap<String, crate::Pee
                     let name = k.as_str()?.to_string();
                     let meta = v.as_mapping()?;
                     let optional = meta
-                        .get(serde_yaml::Value::String("optional".to_string()))
+                        .get("optional")
                         .and_then(|o| o.as_bool())
                         .unwrap_or(false);
                     Some((name, crate::PeerDepMeta { optional }))


### PR DESCRIPTION
## Summary

- In the yarn berry lockfile parser, `serde_yaml::Mapping::get` was being called with `serde_yaml::Value::String(\"key\".to_string())` — allocating a fresh `String` just to hash-compare against literal keys, inside a per-package loop.
- `Mapping::get` takes `impl Index`, and `Index` is implemented for `&str` zero-cost, so replacing the 7 call sites with string literals eliminates the allocations with no other change.
- On a 1k-package berry lockfile, ~7–10k fewer `String` heap allocations per parse (9 field lookups × per-package loop + the two `__metadata` one-shots).

## Sites touched

All in `crates/aube-lockfile/src/yarn.rs`:

- `__metadata` + nested `version` lookup (one-shot)
- `version` (per-package)
- `resolution` (per-package)
- `checksum` (per-package)
- `collect_dep_map` — called 3× per package (deps, optional, peer)
- `peerDependenciesMeta` + nested `optional` (per-package)

## Test plan

- [x] `cargo clippy -p aube-lockfile --all-targets -- -D warnings` clean
- [x] `cargo test --release -p aube-lockfile` — 172/172 pass (covers the berry roundtrip, byte-identity, and protocol fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, behavior-preserving micro-optimization in the Yarn Berry lockfile parser that only changes how YAML mapping keys are looked up. Main risk is subtle key-mismatch if `serde_yaml::Mapping::get(&str)` behaved differently, but it targets the same literal keys.
> 
> **Overview**
> Reduces overhead in the Yarn Berry (`yarn.lock` v2+) parser by switching YAML mapping lookups from allocating `serde_yaml::Value::String("…".to_string())` keys to zero-allocation `&str` keys (e.g., `"version"`, `"resolution"`, `"checksum"`, `"__metadata"`).
> 
> This is a targeted performance change in the hot per-package parse loop (and related helpers like `collect_dep_map`/`collect_peer_meta`) with no intended change to parsing semantics or output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdfe20e5165526b1f40842d61968bd6b0b6d4e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->