### PR TITLE
workspace: skip node_modules in recursive glob discovery

### DIFF
--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -46,31 +46,73 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
     let mut seen = std::collections::HashSet::new();
     let mut packages = Vec::new();
     for pattern in &patterns {
-        let full_pattern = project_dir.join(pattern).join("package.json");
-        if let Ok(entries) = glob::glob(full_pattern.to_str().unwrap_or_default()) {
-            for entry in entries.flatten() {
-                // Skip paths under any node_modules/ segment. Raw
-                // `packages/**` glob otherwise picks up installed
-                // deps' package.json files and registers them as
-                // workspace members. Pollutes importer iteration,
-                // state hash, validate_required_scripts, everything
-                // downstream. npm and pnpm implicitly exclude the
-                // same. Check every path component, not just leading
-                // segment, since workspace could be `apps/*/packages`
-                // with node_modules nested arbitrarily deep.
-                if entry.components().any(|c| c.as_os_str() == "node_modules") {
-                    continue;
-                }
-                if let Some(parent) = entry.parent()
-                    && seen.insert(parent.to_path_buf())
-                {
-                    packages.push(parent.to_path_buf());
-                }
+        for pkg_dir in expand_workspace_pattern(project_dir, pattern)? {
+            if seen.insert(pkg_dir.clone()) {
+                packages.push(pkg_dir);
             }
         }
     }
 
+    packages.sort_unstable();
     Ok(packages)
+}
+
+fn expand_workspace_pattern(project_dir: &Path, pattern: &str) -> Result<Vec<PathBuf>, Error> {
+    let matcher = glob::Pattern::new(pattern)
+        .map_err(|e| Error::Parse(project_dir.join("pnpm-workspace.yaml"), e.to_string()))?;
+    if !pattern.contains("**") {
+        return Ok(glob_workspace_pattern(project_dir, pattern));
+    }
+
+    let mut packages = Vec::new();
+    let mut stack = vec![workspace_pattern_root(project_dir, pattern)];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            if entry.file_name() == "node_modules" {
+                continue;
+            }
+            stack.push(path.clone());
+            let Ok(rel_path) = path.strip_prefix(project_dir) else {
+                continue;
+            };
+            if matcher.matches_path(rel_path) && path.join("package.json").is_file() {
+                packages.push(path);
+            }
+        }
+    }
+    Ok(packages)
+}
+
+fn glob_workspace_pattern(project_dir: &Path, pattern: &str) -> Vec<PathBuf> {
+    let full_pattern = project_dir.join(pattern).join("package.json");
+    let mut packages = Vec::new();
+    if let Ok(entries) = glob::glob(full_pattern.to_str().unwrap_or_default()) {
+        for entry in entries.flatten() {
+            if entry.components().any(|c| c.as_os_str() == "node_modules") {
+                continue;
+            }
+            if let Some(parent) = entry.parent() {
+                packages.push(parent.to_path_buf());
+            }
+        }
+    }
+    packages
+}
+
+fn workspace_pattern_root(project_dir: &Path, pattern: &str) -> PathBuf {
+    let wildcard_idx = pattern.find(['*', '?', '[', '{']).unwrap_or(pattern.len());
+    let literal_prefix = &pattern[..wildcard_idx];
+    project_dir.join(literal_prefix.trim_end_matches('/'))
 }
 
 /// Read the `workspaces` field from `<project_dir>/package.json`. Returns
@@ -248,6 +290,28 @@ mod tests {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
+        );
+    }
+
+    #[test]
+    fn recursive_glob_skips_node_modules_subtrees() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/**/*'\n",
+        );
+        write(&dir.path().join("packages/a/package.json"), "{}");
+        write(&dir.path().join("packages/nested/b/package.json"), "{}");
+        write(
+            &dir.path()
+                .join("packages/a/node_modules/not-a-workspace/package.json"),
+            "{}",
+        );
+
+        let found = find_workspace_packages(dir.path()).unwrap();
+        assert_eq!(
+            names(found),
+            ["a", "b"].iter().map(|s| s.to_string()).collect()
         );
     }
 }

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -112,7 +112,11 @@ fn glob_workspace_pattern(project_dir: &Path, pattern: &str) -> Vec<PathBuf> {
 fn workspace_pattern_root(project_dir: &Path, pattern: &str) -> PathBuf {
     let wildcard_idx = pattern.find(['*', '?', '[', '{']).unwrap_or(pattern.len());
     let literal_prefix = &pattern[..wildcard_idx];
-    project_dir.join(literal_prefix.trim_end_matches('/'))
+    let root = literal_prefix
+        .trim_end_matches('/')
+        .rsplit_once('/')
+        .map_or("", |(parent, _)| parent);
+    project_dir.join(root)
 }
 
 /// Read the `workspaces` field from `<project_dir>/package.json`. Returns
@@ -312,6 +316,27 @@ mod tests {
         assert_eq!(
             names(found),
             ["a", "b"].iter().map(|s| s.to_string()).collect()
+        );
+    }
+
+    #[test]
+    fn recursive_glob_with_mid_component_wildcard_uses_parent_root() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/prefix-*/**/*'\n",
+        );
+        write(&dir.path().join("packages/prefix-a/pkg/package.json"), "{}");
+        write(
+            &dir.path().join("packages/prefix-b/nested/app/package.json"),
+            "{}",
+        );
+        write(&dir.path().join("packages/other/nope/package.json"), "{}");
+
+        let found = find_workspace_packages(dir.path()).unwrap();
+        assert_eq!(
+            names(found),
+            ["app", "pkg"].iter().map(|s| s.to_string()).collect()
         );
     }
 }


### PR DESCRIPTION
## Summary
- skip `node_modules` subtrees while expanding recursive workspace globs
- preserve the existing glob behavior for non-recursive patterns
- add a regression test for recursive workspace discovery under nested `node_modules`

## Why
The Babylon fixture uses `packages/**/*` in `pnpm-workspace.yaml`. Our recursive workspace discovery was letting `glob` traverse the entire tree and then filtering out `node_modules` matches afterward. In Babylon that meant walking roughly 1690 nested `node_modules` directories before install work even started.

## Benchmark
Fixture: `/tmp/vltpkg-benchmarks/fixtures/babylon`

Repro shape:
```bash
bash ../../scripts/clean-helpers.sh clean_lockfiles clean_package_manager_files
CI=1 aube install --no-frozen-lockfile
```

Before on `origin/main`:
- `/usr/bin/time -p`: `real 38.38`

After this patch:
- `/usr/bin/time -p`: `real 1.41`
- `hyperfine --warmup 1 --runs 3 --time-unit second`:
  - `0.741 s ± 0.018 s`
  - range `0.730 s … 0.762 s`

Phase logs on the patched build show the remaining install work is already sub-second:
- `phase:resolve`: ~242ms
- `phase:fetch`: ~72ms
- `phase:link`: ~179ms

## Validation
- `cargo test -p aube-workspace`
- `cargo clippy --manifest-path crates/aube-workspace/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo build --release -p aube`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace package discovery for `**` patterns to do manual directory traversal with early `node_modules` pruning; incorrect matching/root selection could cause missing or extra workspace packages in some repos.
> 
> **Overview**
> Improves workspace package discovery for recursive `**` patterns by replacing `glob`-based expansion with a manual directory walk that *skips `node_modules` subtrees before traversing*, avoiding expensive scans.
> 
> Preserves existing `glob` behavior for non-recursive patterns, sorts the final package list deterministically, and adds tests covering `node_modules` pruning and recursive patterns with mid-component wildcards (rooted at the literal parent directory).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca6ac60c490623af197598c88312d8730470231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->