### PR TITLE
docs: add cross-site announcement banner

### DIFF
--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -1,5 +1,8 @@
 .jdx-banner {
-  position: relative;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
   z-index: 60;
   display: flex;
   gap: 0.75rem;

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -1,0 +1,37 @@
+.jdx-banner {
+  position: relative;
+  z-index: 60;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: var(--vp-c-brand-1, #3451b2);
+  color: #fff;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+.jdx-banner a {
+  color: #fff;
+  text-decoration: underline;
+  font-weight: 500;
+}
+.jdx-banner button {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  color: #fff;
+  font-size: 1.25rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 0.25rem;
+  opacity: 0.85;
+}
+.jdx-banner button:hover {
+  opacity: 1;
+}
+@media (max-width: 640px) {
+  .jdx-banner {
+    font-size: 0.85rem;
+    padding: 0.4rem 0.75rem;
+  }
+}

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -1,64 +1,73 @@
-import './banner.css'
+import "./banner.css";
 
 interface BannerData {
-  id: string
-  enabled: boolean
-  message: string
-  link?: string
-  linkText?: string
+  id: string;
+  enabled: boolean;
+  message: string;
+  link?: string;
+  linkText?: string;
 }
 
-const ENDPOINT = 'https://jdx.dev/banner.json'
-const STORAGE_KEY = 'jdx-banner-dismissed'
+const ENDPOINT = "https://jdx.dev/banner.json";
+const STORAGE_KEY = "jdx-banner-dismissed";
 
 export function initBanner(): void {
-  if (typeof window === 'undefined') return
-  fetch(ENDPOINT, { cache: 'no-cache' })
+  if (typeof window === "undefined") return;
+  fetch(ENDPOINT, { cache: "no-cache" })
     .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
     .then((b) => {
-      if (!b || !b.enabled) return
-      if (localStorage.getItem(STORAGE_KEY) === b.id) return
-      render(b)
+      if (!b || !b.enabled) return;
+      if (localStorage.getItem(STORAGE_KEY) === b.id) return;
+      render(b);
     })
-    .catch(() => {})
+    .catch(() => {});
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const u = new URL(value, window.location.href);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 function render(b: BannerData): void {
-  const el = document.createElement('div')
-  el.className = 'jdx-banner'
-  el.setAttribute('role', 'region')
-  el.setAttribute('aria-label', 'Site announcement')
+  const el = document.createElement("div");
+  el.className = "jdx-banner";
+  el.setAttribute("role", "region");
+  el.setAttribute("aria-label", "Site announcement");
 
-  const msg = document.createElement('span')
-  msg.textContent = b.message
-  el.appendChild(msg)
+  const msg = document.createElement("span");
+  msg.textContent = b.message;
+  el.appendChild(msg);
 
-  if (b.link) {
-    const a = document.createElement('a')
-    a.href = b.link
-    a.target = '_blank'
-    a.rel = 'noopener'
-    a.textContent = b.linkText || 'Learn more'
-    el.appendChild(a)
+  if (b.link && isHttpUrl(b.link)) {
+    const a = document.createElement("a");
+    a.href = b.link;
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    a.textContent = b.linkText || "Learn more";
+    el.appendChild(a);
   }
 
-  const btn = document.createElement('button')
-  btn.type = 'button'
-  btn.setAttribute('aria-label', 'Dismiss')
-  btn.textContent = '\u00d7'
-  btn.addEventListener('click', () => {
-    localStorage.setItem(STORAGE_KEY, b.id)
-    el.remove()
-    document.documentElement.style.removeProperty('--vp-layout-top-height')
-  })
-  el.appendChild(btn)
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.setAttribute("aria-label", "Dismiss");
+  btn.textContent = "\u00d7";
+  btn.addEventListener("click", () => {
+    localStorage.setItem(STORAGE_KEY, b.id);
+    el.remove();
+    document.documentElement.style.removeProperty("--vp-layout-top-height");
+  });
+  el.appendChild(btn);
 
-  document.body.prepend(el)
+  document.body.prepend(el);
 
   requestAnimationFrame(() => {
     document.documentElement.style.setProperty(
-      '--vp-layout-top-height',
+      "--vp-layout-top-height",
       `${el.offsetHeight}px`,
-    )
-  })
+    );
+  });
 }

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -1,0 +1,64 @@
+import './banner.css'
+
+interface BannerData {
+  id: string
+  enabled: boolean
+  message: string
+  link?: string
+  linkText?: string
+}
+
+const ENDPOINT = 'https://jdx.dev/banner.json'
+const STORAGE_KEY = 'jdx-banner-dismissed'
+
+export function initBanner(): void {
+  if (typeof window === 'undefined') return
+  fetch(ENDPOINT, { cache: 'no-cache' })
+    .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
+    .then((b) => {
+      if (!b || !b.enabled) return
+      if (localStorage.getItem(STORAGE_KEY) === b.id) return
+      render(b)
+    })
+    .catch(() => {})
+}
+
+function render(b: BannerData): void {
+  const el = document.createElement('div')
+  el.className = 'jdx-banner'
+  el.setAttribute('role', 'region')
+  el.setAttribute('aria-label', 'Site announcement')
+
+  const msg = document.createElement('span')
+  msg.textContent = b.message
+  el.appendChild(msg)
+
+  if (b.link) {
+    const a = document.createElement('a')
+    a.href = b.link
+    a.target = '_blank'
+    a.rel = 'noopener'
+    a.textContent = b.linkText || 'Learn more'
+    el.appendChild(a)
+  }
+
+  const btn = document.createElement('button')
+  btn.type = 'button'
+  btn.setAttribute('aria-label', 'Dismiss')
+  btn.textContent = '\u00d7'
+  btn.addEventListener('click', () => {
+    localStorage.setItem(STORAGE_KEY, b.id)
+    el.remove()
+    document.documentElement.style.removeProperty('--vp-layout-top-height')
+  })
+  el.appendChild(btn)
+
+  document.body.prepend(el)
+
+  requestAnimationFrame(() => {
+    document.documentElement.style.setProperty(
+      '--vp-layout-top-height',
+      `${el.offsetHeight}px`,
+    )
+  })
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -5,6 +5,7 @@ import AubeSocialLinks from "./AubeSocialLinks.vue";
 import BenchChart from "./BenchChart.vue";
 import EndevFooter from "./EndevFooter.vue";
 import HomeLanding from "./HomeLanding.vue";
+import { initBanner } from "./banner";
 import "./custom.css";
 
 export default {
@@ -19,5 +20,6 @@ export default {
   enhanceApp({ app }) {
     app.component("BenchChart", BenchChart);
     app.component("HomeLanding", HomeLanding);
+    initBanner();
   },
 } satisfies Theme;


### PR DESCRIPTION
## Summary
- Adds `docs/.vitepress/theme/banner.ts` + `banner.css` — a small module that fetches banner config from `https://jdx.dev/banner.json` and renders a dismissible announcement bar at the top of the docs
- Wires it into `.vitepress/theme/index.ts` via `enhanceApp`
- Dismissals persist per banner id in `localStorage`; bumping the id in the source JSON re-shows it to everyone

Used to announce en.dev, and any future cross-site announcements. Editing the source JSON + deploying the blog updates every consuming site within ~5 min.

## Test plan
- [ ] Run `npm run docs:dev` (or equivalent), confirm banner appears at top of page
- [ ] Click the × — banner disappears and stays dismissed across reloads
- [ ] Clear localStorage `jdx-banner-dismissed` key, reload — banner returns
- [ ] Temporarily flip `enabled: false` on the source JSON, reload — no banner

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces a runtime fetch to an external endpoint plus DOM/layout adjustments via `--vp-layout-top-height`, which could affect docs rendering if the endpoint misbehaves or the banner height calculation is off.
> 
> **Overview**
> Adds a dismissible, fixed top announcement banner to the docs theme that **fetches its content from `https://jdx.dev/banner.json`** and renders it when enabled.
> 
> Dismissal is persisted in `localStorage` keyed by banner `id`, and the theme updates `--vp-layout-top-height` to account for the banner’s height; `initBanner()` is wired into VitePress `enhanceApp` so it runs on app startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7ca90153d532d7af21cb9cc24030aed4d4e7410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->