### PR TITLE
docs: polish announcement banner

### DIFF
--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -3,31 +3,36 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 60;
+  z-index: 1001;
   display: flex;
   gap: 0.75rem;
   align-items: center;
-  padding: 0.5rem 1rem;
+  justify-content: center;
+  padding: 0.5rem 2.75rem 0.5rem 1rem;
   background: var(--vp-c-brand-1, #3451b2);
-  color: #fff;
+  color: #000;
   font-size: 0.9rem;
   line-height: 1.4;
+  text-align: center;
 }
 .jdx-banner a {
-  color: #fff;
+  color: #000;
   text-decoration: underline;
-  font-weight: 500;
+  font-weight: 600;
 }
 .jdx-banner button {
-  margin-left: auto;
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
   background: transparent;
   border: 0;
-  color: #fff;
+  color: inherit;
   font-size: 1.25rem;
   cursor: pointer;
   line-height: 1;
-  padding: 0 0.25rem;
-  opacity: 0.85;
+  padding: 0 0.5rem;
+  opacity: 0.7;
 }
 .jdx-banner button:hover {
   opacity: 1;
@@ -35,6 +40,6 @@
 @media (max-width: 640px) {
   .jdx-banner {
     font-size: 0.85rem;
-    padding: 0.4rem 0.75rem;
+    padding: 0.4rem 2.5rem 0.4rem 0.75rem;
   }
 }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -9,7 +9,7 @@
   align-items: center;
   justify-content: center;
   padding: 0.5rem 2.75rem;
-  background: var(--vp-c-brand-1, #3451b2);
+  background: var(--vp-c-brand-1, #f0a584);
   color: #000;
   font-size: 0.9rem;
   line-height: 1.4;

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -8,7 +8,7 @@
   gap: 0.75rem;
   align-items: center;
   justify-content: center;
-  padding: 0.5rem 2.75rem 0.5rem 1rem;
+  padding: 0.5rem 2.75rem;
   background: var(--vp-c-brand-1, #3451b2);
   color: #000;
   font-size: 0.9rem;
@@ -40,6 +40,6 @@
 @media (max-width: 640px) {
   .jdx-banner {
     font-size: 0.85rem;
-    padding: 0.4rem 2.5rem 0.4rem 0.75rem;
+    padding: 0.4rem 2.5rem;
   }
 }

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -46,7 +46,7 @@ function render(b: BannerData): void {
     const a = document.createElement("a");
     a.href = b.link;
     a.target = "_blank";
-    a.rel = "noopener noreferrer";
+    a.rel = "noopener";
     a.textContent = b.linkText || "Learn more";
     el.appendChild(a);
   }

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -13,7 +13,7 @@ const STORAGE_KEY = "jdx-banner-dismissed";
 
 export function initBanner(): void {
   if (typeof window === "undefined") return;
-  fetch(ENDPOINT, { cache: "no-cache" })
+  fetch(ENDPOINT)
     .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
     .then((b) => {
       if (!b || !b.enabled) return;


### PR DESCRIPTION
Follow-ups to #238 that landed after the merge:

## Summary
- **Contrast**: the coral brand bg was rendering white-on-light, which failed contrast. Switch to dark text (black) on the banner and bold links.
- **z-index**: bump to 1001 so the banner stays above the site's nav and custom overrides.
- **Centering**: message + link are now centered in the viewport; dismiss button is pinned to the right via absolute positioning so it doesn't skew the centering.
- **Analytics**: drop `rel=noreferrer` so en.dev gets referrer attribution. Keep `rel=noopener` for security.

## Test plan
- [ ] Run docs dev server, confirm banner renders with dark text on coral bg
- [ ] Resize to mobile width \u2014 banner still readable, dismiss still clickable
- [ ] Click the \u00d7 \u2014 dismisses; reload confirms it stays hidden

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/UX tweaks to docs-only banner styling plus a small change to link `rel`/fetch options; main risk is minor layout or attribution behavior changes.
> 
> **Overview**
> Polishes the docs announcement banner styling for **better contrast and layout**: raises `z-index`, switches to dark text on a coral background, centers content, and pins the dismiss button via absolute positioning (with updated desktop/mobile padding).
> 
> Adjusts banner networking/security details by removing `fetch`'s `no-cache` option and changing external link `rel` from `noopener noreferrer` to `noopener` to allow referrer attribution while keeping tabnabbing protection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e2f7411cfeec1a7027f8703c375e13048b1f047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->