### PR TITLE
chore: release v1.0.0

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,7 +1,7 @@
 name: publish-homebrew
 
-# Homebrew/core does not accept beta releases, so releases are published
-# to the Endev tap until aube is stable enough for the main formula index.
+# Releases are published to the Endev tap until aube is submitted to and
+# accepted by homebrew-core.
 
 on:
   release:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0-beta.12"
+version = "1.0.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0-beta.12"
+version = "1.0.0"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0-beta.12"
+version = "1.0.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0-beta.12"
+version = "1.0.0"
 dependencies = [
  "miette",
  "serde",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0-beta.12"
+version = "1.0.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0-beta.12"
+version = "1.0.0"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0-beta.12"
+version = "1.0.0"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0-beta.12"
+version = "1.0.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0-beta.12"
+version = "1.0.0"
 dependencies = [
  "base64",
  "blake3",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0-beta.12"
+version = "1.0.0"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ strip = "debuginfo"
 panic = "abort"
 
 [workspace.package]
-version = "1.0.0-beta.12"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -103,13 +103,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0-beta.12" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0-beta.12" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0-beta.12" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0-beta.12" }
-aube-store = { path = "crates/aube-store", version = "1.0.0-beta.12" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0-beta.12" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0-beta.12" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0-beta.12" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0-beta.12" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0-beta.12" }
+aube = { path = "crates/aube", version = "1.0.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.0.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.0.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.0.0" }
+aube-store = { path = "crates/aube-store", version = "1.0.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.0.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.0.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.0.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.0.0" }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ aube is also published on npm:
 npm install -g @endevco/aube
 ```
 
-While aube is beta, Homebrew installs come from the Endev tap:
+Homebrew installs come from the Endev tap:
 
 ```sh
 brew install endevco/tap/aube

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0-beta.12"
+version "1.0.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.12...aube-linker-v1.0.0) - 2026-04-23
+
+### Other
+
+- windows install correctness + workspace filter fixes ([#229](https://github.com/endevco/aube/pull/229))
+- speed up babylon warm reinstalls ([#224](https://github.com/endevco/aube/pull/224))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.11...aube-linker-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.12...aube-lockfile-v1.0.0) - 2026-04-23
+
+### Other
+
+- *(yarn)* drop per-lookup String allocs in berry parser ([#234](https://github.com/endevco/aube/pull/234))
+- extract read_lockfile helper to dedupe parser I/O ([#232](https://github.com/endevco/aube/pull/232))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.11...aube-lockfile-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.12...aube-resolver-v1.0.0) - 2026-04-23
+
+### Other
+
+- split lib.rs into focused modules ([#235](https://github.com/endevco/aube/pull/235))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.11...aube-resolver-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.12...aube-workspace-v1.0.0) - 2026-04-23
+
+### Other
+
+- skip node_modules in recursive glob discovery ([#236](https://github.com/endevco/aube/pull/236))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.11...aube-workspace-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/endevco/aube/compare/v1.0.0-beta.12...v1.0.0) - 2026-04-23
+
+### Other
+
+- split lib.rs into focused modules ([#235](https://github.com/endevco/aube/pull/235))
+- split mod.rs into bin_linking/git_prepare/lifecycle submodules ([#237](https://github.com/endevco/aube/pull/237))
+- *(delta)* invalidate changed no-gvs subtrees ([#233](https://github.com/endevco/aube/pull/233))
+- link importer's own bin into node_modules/.bin ([#230](https://github.com/endevco/aube/pull/230))
+- windows install correctness + workspace filter fixes ([#229](https://github.com/endevco/aube/pull/229))
+- *(pack)* drop CHANGELOG from always-included files ([#227](https://github.com/endevco/aube/pull/227))
+- *(install)* show transfer rate + elapsed timer in progress bars ([#225](https://github.com/endevco/aube/pull/225))
+- speed up babylon warm reinstalls ([#224](https://github.com/endevco/aube/pull/224))
+- *(install)* fix node-gyp bootstrap walkup causing bats parallel hang ([#220](https://github.com/endevco/aube/pull/220))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/v1.0.0-beta.11...v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5745,7 +5745,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0-beta.12
+**Version**: 1.0.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,8 +27,7 @@ same dependency versions CI built against. The compiled binary lands in
 
 ## From Homebrew
 
-Homebrew/core does not accept beta releases, so aube is published from
-the Endev tap for now:
+aube is published from the Endev tap until it lands in homebrew-core:
 
 ```sh
 brew install endevco/tap/aube

--- a/docs/pnpm-users.md
+++ b/docs/pnpm-users.md
@@ -48,7 +48,7 @@ Everything else — `add`, `remove`, `update`, `dlx`, `list`, `why`, `pack`,
 
 aube reads pnpm v11 YAML files for compatibility. `aube-lock.yaml` and
 `aube-workspace.yaml` use pnpm-compatible shapes today but are the long-term
-contract and may diverge after the beta compatibility push.
+contract and may diverge over time.
 
 aube never touches pnpm's `node_modules/.pnpm/` or `~/.pnpm-store/`. The two
 virtual stores can coexist under `node_modules`. For the lockfile and

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -152,7 +152,7 @@ aube -F 'api...' run build
 
 Keep the existing lockfile while evaluating aube. Since aube writes supported
 lockfiles in place, the original package manager can keep using the same file
-during rollout. If aube hits a beta bug in a project, fall back for that job,
+during rollout. If aube hits a bug in a project, fall back for that job,
 keep the failing command and lockfile handy, and open a thread in
 [GitHub Discussions](https://github.com/endevco/aube/discussions) with the
 exact command and package manager versions.

--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -69,10 +69,6 @@ function versionFromTag(tag) {
 }
 
 function defaultNpmTag(version) {
-    // During the 1.0.0 beta series, npm is still one of the documented
-    // install paths, so `npm install -g @endevco/aube` should track the
-    // current beta. Future prerelease trains can use `next` again.
-    if (version.startsWith('1.0.0-')) return 'latest';
     return version.includes('-') ? 'next' : 'latest';
 }
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0-beta.12",
-  "releasedAt": "2026-04-22T22:31:24Z"
+  "version": "1.0.0",
+  "releasedAt": "2026-04-23T18:45:45Z"
 }


### PR DESCRIPTION
## 🚀 Cutting v1.0.0

Promoting from `1.0.0-beta.12` to stable `1.0.0`. Replaces the auto-generated [#221](https://github.com/endevco/aube/pull/221) (which bumped to `1.0.0-beta.13`).

### Commit 1 — release-plz output, retargeted to `1.0.0`
Mirrors what release-plz produced for beta.13 with `1.0.0` in place of `1.0.0-beta.13`:

- `Cargo.toml` / `Cargo.lock` workspace version
- `aube.usage.kdl`, `docs/cli/index.md`, `docs/cli/commands.json` (regenerated CLI docs)
- `release.json` (docs homepage "Released at")
- CHANGELOG entries for `aube`, `aube-linker`, `aube-lockfile`, `aube-resolver`, `aube-workspace`

### Commit 2 — drop beta-era prose
- `README.md`: Homebrew install section no longer gates on beta
- `docs/installation.md`: phrase tap as pre-homebrew-core install path
- `docs/troubleshooting.md`: drop "beta bug" qualifier
- `docs/pnpm-users.md`: lockfile/workspace shapes "may diverge over time"
- `.github/workflows/publish-homebrew.yml`: rewrite header comment for 1.0
- `npm/scripts/publish.mjs`: simplify `defaultNpmTag` — the `1.0.0-beta.*` branch is dead post-1.0 (`version.includes('-')` already handles prereleases)

### What happens on merge
`release-plz-release` tags `v1.0.0`, publishes every workspace crate to crates.io in dependency order, and opens a draft GitHub release. Then `upload-assets` attaches binaries, `publish-release` un-drafts, `enhance-release` rewrites notes via communique.

## Test plan
- [ ] CI green (clippy, fmt, tests, bats)
- [ ] Windows CI green
- [ ] `cargo publish --dry-run` clean for every workspace crate (run by release-plz in dry mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is primarily a coordinated version promotion and documentation/changelog regeneration, with only a small change to npm dist-tag selection logic.
> 
> **Overview**
> Promotes the entire Rust workspace from `1.0.0-beta.12` to stable `1.0.0`, updating `Cargo.toml`/`Cargo.lock`, the CLI usage spec, and regenerated CLI docs to reflect the new version.
> 
> Adds `1.0.0` release entries across crate changelogs and updates release metadata timestamps, plus minor wording cleanups removing “beta” language and simplifying npm publish tagging (prereleases -> `next`, stable -> `latest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 229cb65cbfb81c8140216bbc4c22f9944a618dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->