### PR TITLE
chore: release v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aube-util",
  "miette",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "rustc-hash",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -587,9 +587,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1963,9 +1963,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2980,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -112,13 +112,13 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.0.0" }
-aube-settings = { path = "crates/aube-settings", version = "1.0.0" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.0.0" }
-aube-registry = { path = "crates/aube-registry", version = "1.0.0" }
-aube-store = { path = "crates/aube-store", version = "1.0.0" }
-aube-linker = { path = "crates/aube-linker", version = "1.0.0" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.0.0" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.0.0" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.0.0" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.0.0" }
+aube = { path = "crates/aube", version = "1.1.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.1.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.1.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.1.0" }
+aube-store = { path = "crates/aube-store", version = "1.1.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.1.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.1.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.1.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.1.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.1.0" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.0.0"
+version "1.1.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/endevco/aube/compare/aube-linker-v1.0.0...aube-linker-v1.1.0) - 2026-04-24
+
+### Fixed
+
+- *(store)* speed up cold installs ([#267](https://github.com/endevco/aube/pull/267))
+- *(linker)* strip windows verbatim prefix before diffing bin-shim paths ([#275](https://github.com/endevco/aube/pull/275))
+
+### Other
+
+- dedup pass + registry/store perf wave ([#254](https://github.com/endevco/aube/pull/254))
+- copy small files instead of reflinking ([#251](https://github.com/endevco/aube/pull/251))
+- shared helpers + migrate hardcoded sites ([#245](https://github.com/endevco/aube/pull/245))
+
 ## [1.0.0](https://github.com/endevco/aube/compare/aube-linker-v1.0.0-beta.12...aube-linker-v1.0.0) - 2026-04-23
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0...aube-lockfile-v1.1.0) - 2026-04-24
+
+### Added
+
+- *(resolver)* support pnpm `&path:/<sub>` git dep selector ([#273](https://github.com/endevco/aube/pull/273))
+
+### Fixed
+
+- *(resolver)* wire transitive url/git subdeps into parent snapshot ([#276](https://github.com/endevco/aube/pull/276))
+
+### Other
+
+- *(bun)* preserve top-level + per-entry metadata on roundtrip ([#250](https://github.com/endevco/aube/pull/250))
+- *(pnpm)* preserve workspace importer specifiers ([#260](https://github.com/endevco/aube/pull/260))
+- dedup pass + registry/store perf wave ([#254](https://github.com/endevco/aube/pull/254))
+- resolve catalog: in overrides + honor override-rewritten importer specs ([#249](https://github.com/endevco/aube/pull/249))
+- shared helpers + migrate hardcoded sites ([#245](https://github.com/endevco/aube/pull/245))
+
 ## [1.0.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0-beta.12...aube-lockfile-v1.0.0) - 2026-04-23
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0...aube-manifest-v1.1.0) - 2026-04-24
+
+### Other
+
+- dedup pass + registry/store perf wave ([#254](https://github.com/endevco/aube/pull/254))
+- shared helpers + migrate hardcoded sites ([#245](https://github.com/endevco/aube/pull/245))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0-beta.11...aube-manifest-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/endevco/aube/compare/aube-registry-v1.0.0...aube-registry-v1.1.0) - 2026-04-24
+
+### Other
+
+- dedup pass + registry/store perf wave ([#254](https://github.com/endevco/aube/pull/254))
+- shared helpers + migrate hardcoded sites ([#245](https://github.com/endevco/aube/pull/245))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-registry-v1.0.0-beta.11...aube-registry-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0...aube-resolver-v1.1.0) - 2026-04-24
+
+### Added
+
+- *(resolver)* support pnpm `&path:/<sub>` git dep selector ([#273](https://github.com/endevco/aube/pull/273))
+
+### Fixed
+
+- *(resolver)* wire transitive url/git subdeps into parent snapshot ([#276](https://github.com/endevco/aube/pull/276))
+
+### Other
+
+- *(bun)* preserve top-level + per-entry metadata on roundtrip ([#250](https://github.com/endevco/aube/pull/250))
+- dedup pass + registry/store perf wave ([#254](https://github.com/endevco/aube/pull/254))
+- shared helpers + migrate hardcoded sites ([#245](https://github.com/endevco/aube/pull/245))
+
 ## [1.0.0](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0-beta.12...aube-resolver-v1.0.0) - 2026-04-23
 
 ### Other

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0...aube-scripts-v1.1.0) - 2026-04-24
+
+### Added
+
+- *(scripts)* run pack/publish/version lifecycle hooks ([#262](https://github.com/endevco/aube/pull/262))
+
+### Other
+
+- shared helpers + migrate hardcoded sites ([#245](https://github.com/endevco/aube/pull/245))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0-beta.11...aube-scripts-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/endevco/aube/compare/aube-settings-v1.0.0...aube-settings-v1.1.0) - 2026-04-24
+
+### Other
+
+- accept legacy sha1/sha256/sha384 integrity in verify_integrity ([#263](https://github.com/endevco/aube/pull/263))
+- default publicHoistPattern to match pnpm ([#258](https://github.com/endevco/aube/pull/258))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-settings-v1.0.0-beta.11...aube-settings-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/endevco/aube/compare/aube-store-v1.0.0...aube-store-v1.1.0) - 2026-04-24
+
+### Fixed
+
+- *(store)* speed up cold installs ([#267](https://github.com/endevco/aube/pull/267))
+
+### Other
+
+- accept legacy sha1/sha256/sha384 integrity in verify_integrity ([#263](https://github.com/endevco/aube/pull/263))
+- dedup pass + registry/store perf wave ([#254](https://github.com/endevco/aube/pull/254))
+- copy small files instead of reflinking ([#251](https://github.com/endevco/aube/pull/251))
+- shared helpers + migrate hardcoded sites ([#245](https://github.com/endevco/aube/pull/245))
+
 ## [1.0.0-beta.12](https://github.com/endevco/aube/compare/aube-store-v1.0.0-beta.11...aube-store-v1.0.0-beta.12) - 2026-04-22
 
 ### Other

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0](https://github.com/endevco/aube/compare/aube-util-v1.0.0...aube-util-v1.1.0) - 2026-04-24
+
+### Fixed
+
+- *(linker)* strip windows verbatim prefix before diffing bin-shim paths ([#275](https://github.com/endevco/aube/pull/275))
+
+### Other
+
+- dedup pass + registry/store perf wave ([#254](https://github.com/endevco/aube/pull/254))

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/endevco/aube/compare/v1.0.0...v1.1.0) - 2026-04-24
+
+### Added
+
+- *(resolver)* support pnpm `&path:/<sub>` git dep selector ([#273](https://github.com/endevco/aube/pull/273))
+- *(install)* support global approve-builds ([#274](https://github.com/endevco/aube/pull/274))
+- *(scripts)* run pack/publish/version lifecycle hooks ([#262](https://github.com/endevco/aube/pull/262))
+
+### Fixed
+
+- *(store)* speed up cold installs ([#267](https://github.com/endevco/aube/pull/267))
+- *(linker)* strip windows verbatim prefix before diffing bin-shim paths ([#275](https://github.com/endevco/aube/pull/275))
+- *(publish)* report post-hook name/version in PublishOutcome ([#272](https://github.com/endevco/aube/pull/272))
+- *(global)* strip Windows \\?\\ verbatim prefix from canonicalized install dir ([#243](https://github.com/endevco/aube/pull/243))
+
+### Other
+
+- *(install)* split warm freshness state ([#271](https://github.com/endevco/aube/pull/271))
+- avoid duplicate warm state reads ([#266](https://github.com/endevco/aube/pull/266))
+- use warm path in frozen mode ([#264](https://github.com/endevco/aube/pull/264))
+- always shim self-bin so CI artifact round-trips work ([#259](https://github.com/endevco/aube/pull/259))
+- dedup pass + registry/store perf wave ([#254](https://github.com/endevco/aube/pull/254))
+- resolve catalog: in overrides + honor override-rewritten importer specs ([#249](https://github.com/endevco/aube/pull/249))
+- shared helpers + migrate hardcoded sites ([#245](https://github.com/endevco/aube/pull/245))
+
 ## [1.0.0](https://github.com/endevco/aube/compare/v1.0.0-beta.12...v1.0.0) - 2026-04-23
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5768,7 +5768,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0
+**Version**: 1.1.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0",
-  "releasedAt": "2026-04-23T18:45:45Z"
+  "version": "1.1.0",
+  "releasedAt": "2026-04-24T17:16:44Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.1.0`

This PR bumps the workspace to `v1.1.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, and the CLI docs.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR is primarily versioning and regenerated documentation/metadata, with only routine dependency lockfile updates.
> 
> **Overview**
> Updates the workspace and all `aube-*` crates from `1.0.0` to `1.1.0`, including synchronized internal dependency versions in `Cargo.toml` and corresponding `Cargo.lock` updates.
> 
> Regenerates release artifacts: per-crate `CHANGELOG.md` entries for `1.1.0` (and adds a new `crates/aube-util/CHANGELOG.md`), bumps the CLI usage spec/version in `aube.usage.kdl` and generated CLI docs, and updates `release.json` with the new version/timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c58768e515892b1feb2ca73f6da8ecc899a092c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->