### PR TITLE
fix(global): strip Windows \\?\\ verbatim prefix from canonicalized install dir

### DIFF
--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -895,7 +895,13 @@ async fn run_global(packages: &[String]) -> miette::Result<()> {
     // the hash-symlink targets — so without normalizing our side the
     // `!=` / `starts_with` checks all come out wrong and we either leak
     // orphan install dirs or leave duplicate hash pointers behind.
-    let install_dir = std::fs::canonicalize(&install_dir_raw)
+    // Use `dirs::canonicalize` (not `std::fs::canonicalize`) so the
+    // result on Windows is a plain drive path, not the `\\?\C:\…`
+    // verbatim form. `link_bin_entries` later concatenates this dir
+    // into the relative bin-shim target via `%~dp0\{rel}`; a verbatim
+    // prefix in `{rel}` produces a path neither `cmd.exe` nor Node can
+    // resolve and surfaces as `Cannot find module '<bin>\?\<target>'`.
+    let install_dir = crate::dirs::canonicalize(&install_dir_raw)
         .into_diagnostic()
         .wrap_err_with(|| {
             format!(
@@ -903,7 +909,7 @@ async fn run_global(packages: &[String]) -> miette::Result<()> {
                 install_dir_raw.display()
             )
         })?;
-    if let Ok(canon) = std::fs::canonicalize(&layout.pkg_dir) {
+    if let Ok(canon) = crate::dirs::canonicalize(&layout.pkg_dir) {
         layout.pkg_dir = canon;
     }
 
@@ -935,7 +941,10 @@ async fn run_global(packages: &[String]) -> miette::Result<()> {
                 }
                 // Only unlink pointers that resolved to our install dir —
                 // don't touch pointers for other live global installs.
-                if let Ok(target) = std::fs::canonicalize(&path)
+                // Use `dirs::canonicalize` so the equality check against
+                // `install_dir` (also stripped of any Windows `\\?\`
+                // verbatim prefix) actually matches.
+                if let Ok(target) = crate::dirs::canonicalize(&path)
                     && target == install_dir
                 {
                     let _ = std::fs::remove_file(&path);
@@ -1047,7 +1056,9 @@ async fn run_global_inner(
     let hash = global::cache_key(&aliases, &registries);
     let hash_ptr = global::hash_link(&layout.pkg_dir, &hash);
     let mut priors: Vec<global::GlobalPackageInfo> = Vec::new();
-    if let Ok(existing_target) = std::fs::canonicalize(&hash_ptr)
+    // `dirs::canonicalize` for the same Windows-prefix reason as above —
+    // we compare against `install_dir`, which is itself stripped.
+    if let Ok(existing_target) = crate::dirs::canonicalize(&hash_ptr)
         && existing_target != install_dir
     {
         priors.extend(

--- a/crates/aube/src/commands/global.rs
+++ b/crates/aube/src/commands/global.rs
@@ -168,7 +168,13 @@ pub fn scan_packages(pkg_dir: &Path) -> Vec<GlobalPackageInfo> {
             continue;
         }
         let link_path = entry.path();
-        let Ok(install_dir) = std::fs::canonicalize(&link_path) else {
+        // `crate::dirs::canonicalize` strips the Windows `\\?\` verbatim
+        // prefix so the `install_dir` we hand back can be compared with
+        // `==` / `starts_with` against paths produced by `run_global` (also
+        // routed through the same helper). Without this, the prior-cleanup
+        // branch in `run_global_inner` never matches on Windows and stale
+        // hash pointers / install dirs accumulate.
+        let Ok(install_dir) = crate::dirs::canonicalize(&link_path) else {
             continue;
         };
         let manifest_path = install_dir.join("package.json");
@@ -466,8 +472,12 @@ pub fn remove_package(info: &GlobalPackageInfo, layout: &GlobalLayout) -> miette
         }
     }
 
+    // `crate::dirs::canonicalize` so `pkg_canon` is comparable with the
+    // `info.install_dir` `scan_packages` produced — both must be in the
+    // same Windows form (no `\\?\` prefix) or the `starts_with` check
+    // fails and the install dir leaks.
     let pkg_canon =
-        std::fs::canonicalize(&layout.pkg_dir).unwrap_or_else(|_| layout.pkg_dir.clone());
+        crate::dirs::canonicalize(&layout.pkg_dir).unwrap_or_else(|_| layout.pkg_dir.clone());
     if info.install_dir.starts_with(&pkg_canon) {
         match std::fs::remove_dir_all(&info.install_dir) {
             Ok(_) => {}

--- a/crates/aube/src/commands/install/bin_linking.rs
+++ b/crates/aube/src/commands/install/bin_linking.rs
@@ -398,16 +398,16 @@ fn create_bin_link(
     // when the leaf sits behind a junction in the path, even when the
     // leaf is absent. The isolated layout's `.aube/<dep_path>` is a
     // junction into the global virtual store, so every `.bin/` under it
-    // hits the quirk. Fix: canonicalize the parent, strip the `\\?\`
-    // UNC prefix (which trips its own CreateDirectoryW quirk, os 123),
-    // create the leaf on the plain drive path. No-op on Unix.
+    // hits the quirk. Fix: canonicalize the parent (`crate::dirs::canonicalize`
+    // already strips the `\\?\` verbatim prefix, which would otherwise
+    // trip CreateDirectoryW's own os-123 quirk, while keeping real
+    // `\\?\UNC\…` share paths intact), then create the leaf on the
+    // resulting plain drive path. No-op on Unix.
     #[cfg(windows)]
     let target_for_mkdir_owned = bin_dir.parent().and_then(|parent| {
         let leaf = bin_dir.file_name()?;
-        let canon = std::fs::canonicalize(parent).ok()?;
-        let s = canon.to_string_lossy();
-        let cleaned = s.strip_prefix(r"\\?\").unwrap_or(&s);
-        Some(std::path::PathBuf::from(cleaned).join(leaf))
+        let canon = crate::dirs::canonicalize(parent).ok()?;
+        Some(canon.join(leaf))
     });
     #[cfg(windows)]
     let target_for_mkdir: &std::path::Path = target_for_mkdir_owned.as_deref().unwrap_or(bin_dir);

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -159,6 +159,42 @@ pub fn set_cwd(path: &Path) -> miette::Result<()> {
     Ok(())
 }
 
+/// Canonicalize a path to its on-disk form using a "native" (non-verbatim)
+/// Windows path.
+///
+/// On Windows, `std::fs::canonicalize` returns the UNC / extended-length
+/// form (`\\?\C:\foo\bar`). That prefix breaks every downstream step that
+/// concatenates the result with another path, which is exactly what the
+/// global-install bin-shim path builder does — `%~dp0\{rel}` where `{rel}`
+/// starts with `\\?\C:\...` produces a path that neither `cmd.exe` nor
+/// Node.js can dereference, and the installed bin silently fails with
+/// `Cannot find module '<bin_dir>\?\<target>'`.
+///
+/// This helper gives the same behavior as `dunce::canonicalize` without
+/// adding the dep: canonicalize, then strip the `\\?\` prefix when it
+/// didn't turn into a genuine UNC share path. `CreateDirectoryW` also
+/// returns `ERROR_INVALID_NAME` (os 123) on verbatim-prefixed paths that
+/// contain a `.`-relative leaf, so downstream `create_dir_all` calls on
+/// the result likewise stay clean.
+///
+/// No-op on non-Windows.
+pub fn canonicalize(path: &Path) -> std::io::Result<PathBuf> {
+    let canon = std::fs::canonicalize(path)?;
+    #[cfg(windows)]
+    {
+        let s = canon.to_string_lossy();
+        // Only strip the plain verbatim-drive prefix (`\\?\C:\…`). Leave
+        // `\\?\UNC\…` alone — that's a real network share and callers
+        // can't use a non-verbatim form for it.
+        if let Some(rest) = s.strip_prefix(r"\\?\")
+            && !rest.starts_with("UNC\\")
+        {
+            return Ok(PathBuf::from(rest));
+        }
+    }
+    Ok(canon)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -257,5 +293,39 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         write(&dir.path().join("package.json"), r#"{"name":"solo"}"#);
         assert!(find_workspace_root(dir.path()).is_none());
+    }
+
+    #[test]
+    fn canonicalize_round_trips_an_existing_path() {
+        // Smoke test on every platform: the helper should resolve an
+        // existing path the same way `std::fs::canonicalize` does on
+        // POSIX, and additionally strip the `\\?\` verbatim prefix on
+        // Windows. The latter is exercised in `canonicalize_strips_…`
+        // below.
+        let dir = tempfile::tempdir().unwrap();
+        let canon = canonicalize(dir.path()).unwrap();
+        assert!(canon.is_absolute());
+        assert!(canon.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn canonicalize_strips_verbatim_drive_prefix() {
+        // `std::fs::canonicalize` on Windows always returns
+        // `\\?\C:\…`. The helper must hand callers the plain drive
+        // form, otherwise downstream `%~dp0\{rel}` shim concatenation
+        // produces the `<bin>\?\C:\…` path that `cmd.exe` and Node
+        // both fail to dereference.
+        let dir = tempfile::tempdir().unwrap();
+        let canon = canonicalize(dir.path()).unwrap();
+        let s = canon.to_string_lossy();
+        assert!(
+            !s.starts_with(r"\\?\"),
+            "expected non-verbatim path, got {s}"
+        );
+        assert!(
+            s.chars().nth(1) == Some(':'),
+            "expected drive form, got {s}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`run_global` calls `std::fs::canonicalize` on the freshly-created install directory and on `layout.pkg_dir`. On Windows those calls return the extended-length form `\\?\C:\…`. Every downstream step that concatenates this dir into another path then carries the verbatim prefix forward, and the bin-shim writer in particular ends up baking it into the relative target string it interpolates into `%~dp0\{rel}`.

The resulting `.cmd` points at `<bin_dir>\\\\?\\C:\…\prettier.cjs`, which `cmd.exe` collapses to `<bin_dir>\?\C:\…\prettier.cjs`, which Node then refuses with:

```
Cannot find module 'C:\…\bin\?\C:\…\node_modules\prettier\bin\prettier.cjs'
```

There is already an inline fix for the same class of bug for the per-dep bin dir at [`aube::commands::install::link_bin_via_dep`](crates/aube/src/commands/install/mod.rs#L4814). This PR generalizes it into a reusable `dirs::canonicalize` helper (matches `dunce::canonicalize` without adding the dep) and routes the three `run_global` call sites through it so the install dir, the layout pkg dir, and the symmetric post-install equality checks all see the same plain drive-letter form.

## Approach

- New `aube::dirs::canonicalize` (in `crates/aube/src/dirs.rs`) — runs `std::fs::canonicalize`, then strips the `\\?\` prefix on Windows when the result wasn't a real `\\?\UNC\…` share path. No-op on Unix.
- Three call sites in `crates/aube/src/commands/add.rs::run_global` switch from `std::fs::canonicalize` → `crate::dirs::canonicalize`. Two of them are equality checks against `install_dir`; if `install_dir` is now stripped, the other side has to be stripped the same way or the comparisons silently regress.

## Reproduced via

mise's `windows-e2e` tranche, after switching mise's npm-publish to aube and triggering `mise install npm:prettier@3.6.2`. The CI run that surfaced it: <https://github.com/jdx/mise/actions/runs/24852804095>.

## Test plan

- [x] `cargo test --bin aube` — **281 pass** (1 new: `canonicalize_round_trips_an_existing_path`; plus a `#[cfg(windows)]` guard test `canonicalize_strips_verbatim_drive_prefix`)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets`
- [ ] Manual repro on Windows is gated on landing this and re-running mise's windows-e2e — confident the fix is correct from the existing precedent at install/mod.rs:4814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global install/bin-linking path canonicalization and cleanup logic; mainly Windows-specific but could affect how paths compare and which directories get cleaned up.
> 
> **Overview**
> Fixes Windows global installs by routing canonicalization through a new `crate::dirs::canonicalize` helper that strips the `\\?\` verbatim-drive prefix (while preserving real `\\?\UNC\…` shares).
> 
> `add -g` and global package scanning/removal now use this helper so path comparisons (`==`/`starts_with`) and bin-shim target construction don’t break on Windows, preventing broken `.cmd` shims and leaked/stale global install dirs/hash pointers. Bin-linking’s Windows mkdir workaround is simplified to rely on the same helper, and new unit tests cover the canonicalize behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6018f5ebe9d4a3a6d1bad8958536f8f9996019b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->