### PR TITLE
docs: darken banner for better contrast

### DIFF
--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -9,14 +9,14 @@
   align-items: center;
   justify-content: center;
   padding: 0.5rem 2.75rem;
-  background: var(--vp-c-brand-1, #f0a584);
-  color: #000;
+  background: var(--aube-coral-dark, #9e4a2a);
+  color: #fff;
   font-size: 0.9rem;
   line-height: 1.4;
   text-align: center;
 }
 .jdx-banner a {
-  color: #000;
+  color: #fff;
   text-decoration: underline;
   font-weight: 600;
 }


### PR DESCRIPTION
Swap banner background from \`--vp-c-brand-1\` (aube coral, lightness 0.75) to \`--aube-coral-dark\` (lightness 0.52) and switch text from black to white.

The original light-coral-on-black was low contrast; the darker coral with white text reads clearly while staying on-brand.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CSS styling change to the docs banner colors; low risk aside from potential visual/theming regressions.
> 
> **Overview**
> Updates the docs `jdx-banner` styling to use a darker brand background (`--aube-coral-dark`) and switches banner/link text from black to white to improve contrast and readability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac8125fddd17c558cee6f1802eec484b11427bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->