### PR TITLE
aube-util: shared helpers + migrate hardcoded sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.cache
 /docs/.aube/
 /docs/node_modules/
+/scratch/
+/sandbox/
+/bench-install.sh
+/.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "aube-scripts",
  "aube-settings",
  "aube-store",
+ "aube-util",
  "aube-workspace",
  "base64",
  "blake3",
@@ -253,11 +254,11 @@ version = "1.0.0"
 dependencies = [
  "aube-lockfile",
  "aube-store",
+ "aube-util",
  "diffy",
  "glob",
  "hex",
  "junction",
- "log",
  "pathdiff",
  "rayon",
  "reflink-copy",
@@ -266,6 +267,7 @@ dependencies = [
  "strum 0.28.0",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
  "xx",
 ]
 
@@ -275,6 +277,7 @@ version = "1.0.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
+ "aube-util",
  "glob",
  "hex",
  "miette",
@@ -294,6 +297,7 @@ dependencies = [
 name = "aube-manifest"
 version = "1.0.0"
 dependencies = [
+ "aube-util",
  "miette",
  "serde",
  "serde_json",
@@ -309,6 +313,7 @@ dependencies = [
  "aube-manifest",
  "aube-settings",
  "aube-store",
+ "aube-util",
  "base64",
  "bytes",
  "flate2",
@@ -333,6 +338,7 @@ dependencies = [
  "aube-manifest",
  "aube-registry",
  "aube-store",
+ "aube-util",
  "base64",
  "flate2",
  "miette",
@@ -371,6 +377,7 @@ dependencies = [
 name = "aube-store"
 version = "1.0.0"
 dependencies = [
+ "aube-util",
  "base64",
  "blake3",
  "flate2",
@@ -383,6 +390,15 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "xx",
+]
+
+[[package]]
+name = "aube-util"
+version = "1.0.0"
+dependencies = [
+ "blake3",
+ "rustc-hash",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/endevco/aube"
 homepage = "https://github.com/endevco/aube"
 
 [workspace.dependencies]
-# Async runtime
+aube-util = { path = "crates/aube-util" }
 tokio = { version = "1", features = ["full"] }
 
 # Serialization

--- a/crates/aube-linker/Cargo.toml
+++ b/crates/aube-linker/Cargo.toml
@@ -12,8 +12,9 @@ include = ["src/**/*.rs"]
 [dependencies]
 aube-store = { workspace = true }
 aube-lockfile = { workspace = true }
+aube-util = { workspace = true }
 xx = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 serde_json = { workspace = true }
 reflink-copy = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate log;
+use tracing::{debug, trace, warn};
 
 use aube_lockfile::dep_path_filename::{
     DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH, dep_path_to_filename,
@@ -431,7 +430,7 @@ pub struct Linker {
 /// patch-commit` (or any compatible tool).
 pub type Patches = std::collections::BTreeMap<String, String>;
 
-fn default_linker_parallelism() -> usize {
+pub fn default_linker_parallelism() -> usize {
     let default_limit = if cfg!(target_os = "macos") { 4 } else { 16 };
 
     std::thread::available_parallelism()
@@ -440,17 +439,36 @@ fn default_linker_parallelism() -> usize {
         .min(default_limit)
 }
 
-fn with_link_pool<R: Send>(threads: usize, f: impl FnOnce() -> R + Send) -> R {
+type LinkPoolCache = std::sync::Mutex<Vec<(usize, std::sync::Arc<rayon::ThreadPool>)>>;
+static LINK_POOL_CACHE: std::sync::OnceLock<LinkPoolCache> = std::sync::OnceLock::new();
+
+fn link_pool(threads: usize) -> Option<std::sync::Arc<rayon::ThreadPool>> {
+    let cache = LINK_POOL_CACHE.get_or_init(|| std::sync::Mutex::new(Vec::new()));
+    let mut guard = cache.lock().ok()?;
+    if let Some((_, pool)) = guard.iter().find(|(t, _)| *t == threads) {
+        return Some(pool.clone());
+    }
     match rayon::ThreadPoolBuilder::new()
         .num_threads(threads)
         .thread_name(|i| format!("aube-linker-{i}"))
         .build()
     {
-        Ok(pool) => pool.install(f),
+        Ok(pool) => {
+            let pool = std::sync::Arc::new(pool);
+            guard.push((threads, pool.clone()));
+            Some(pool)
+        }
         Err(err) => {
             warn!("failed to build aube linker thread pool: {err}; falling back to caller thread");
-            f()
+            None
         }
+    }
+}
+
+fn with_link_pool<R: Send>(threads: usize, f: impl FnOnce() -> R + Send) -> R {
+    match link_pool(threads) {
+        Some(pool) => pool.install(f),
+        None => f(),
     }
 }
 
@@ -467,8 +485,7 @@ pub enum LinkStrategy {
 
 impl Linker {
     pub fn new(store: &Store, strategy: LinkStrategy) -> Self {
-        // Disable global virtual store in CI (cold cache makes it slower)
-        let use_global_virtual_store = std::env::var("CI").is_err();
+        let use_global_virtual_store = !aube_util::env::is_ci();
         Self {
             virtual_store: store.virtual_store_dir(),
             store: store.clone(),
@@ -1113,7 +1130,7 @@ impl Linker {
                 stats.packages_cached += local_stats.packages_cached;
                 stats.files_linked += local_stats.files_linked;
             }
-            log::debug!("link:step1 (gvs populate) {:.1?}", step1_timer.elapsed());
+            tracing::debug!("link:step1 (gvs populate) {:.1?}", step1_timer.elapsed());
         } else {
             use rayon::prelude::*;
 
@@ -1204,7 +1221,7 @@ impl Linker {
         if self.virtual_store_only {
             self.link_hidden_hoist(&aube_dir, graph)?;
             if let Err(e) = write_applied_patches(&nm, &curr_applied) {
-                log::error!(
+                tracing::error!(
                     "failed to write .aube-applied-patches.json: {e}. next install may miss stale patched entries"
                 );
             }
@@ -1289,7 +1306,7 @@ impl Linker {
                 stats.top_level_linked += 1;
             }
         }
-        log::debug!(
+        tracing::debug!(
             "link:step2 (top-level symlinks) {:.1?}",
             step2_timer.elapsed()
         );
@@ -1322,7 +1339,7 @@ impl Linker {
         self.link_hidden_hoist(&aube_dir, graph)?;
 
         if let Err(e) = write_applied_patches(&nm, &curr_applied) {
-            log::error!(
+            tracing::error!(
                 "failed to write .aube-applied-patches.json: {e}. next install may miss stale patched entries"
             );
         }
@@ -1542,7 +1559,7 @@ impl Linker {
                 stats.packages_cached += local_stats.packages_cached;
                 stats.files_linked += local_stats.files_linked;
             }
-            log::debug!(
+            tracing::debug!(
                 "link_workspace:step1 (gvs populate) {:.1?}",
                 step1_timer.elapsed()
             );
@@ -1641,7 +1658,7 @@ impl Linker {
             }
             self.link_hidden_hoist(&aube_dir, graph)?;
             if let Err(e) = write_applied_patches(&root_nm, &curr_applied) {
-                log::error!(
+                tracing::error!(
                     "failed to write .aube-applied-patches.json: {e}. next install may miss stale patched entries"
                 );
             }
@@ -1842,7 +1859,7 @@ impl Linker {
                 stats.top_level_linked += 1;
             }
         }
-        log::debug!(
+        tracing::debug!(
             "link_workspace:step2 (top-level symlinks) {:.1?}",
             step2_timer.elapsed()
         );
@@ -1879,7 +1896,7 @@ impl Linker {
         self.link_hidden_hoist(&aube_dir, graph)?;
 
         if let Err(e) = write_applied_patches(&root_nm, &curr_applied) {
-            log::error!(
+            tracing::error!(
                 "failed to write .aube-applied-patches.json: {e}. next install may miss stale patched entries"
             );
         }
@@ -2116,7 +2133,7 @@ impl Linker {
             mkdirp(parent)?;
         }
 
-        match std::fs::rename(&tmp_entry, &final_entry) {
+        match aube_util::fs_atomic::rename_with_retry(&tmp_entry, &final_entry) {
             Ok(()) => {
                 trace!("atomically placed {subdir} in virtual store");
             }
@@ -2186,6 +2203,15 @@ impl Linker {
             self.aube_dir_entry_name(dep_path)
         };
         let pkg_nm_dir = base_dir.join(&subdir).join("node_modules").join(&pkg.name);
+
+        let sentinel_path = pkg_nm_dir.join(".aube-initialized");
+        if aube_util::fs_atomic::sentinel::present(&sentinel_path)
+            && let Some(existing) = aube_util::fs_atomic::sentinel::read_tag(&sentinel_path)
+            && existing.as_slice() == dep_path.as_bytes()
+        {
+            stats.dirs_skipped += 1;
+            return Ok(());
+        }
 
         // Pre-compute the set of unique parent directories across
         // every file in the index AND every scoped transitive-dep
@@ -2332,6 +2358,10 @@ impl Linker {
                 .map_err(|e| Error::Io(symlink_path.clone(), e))?;
         }
 
+        if let Err(e) = aube_util::fs_atomic::sentinel::mark(&sentinel_path, dep_path) {
+            trace!("failed to write .aube-initialized sentinel for {dep_path}: {e}");
+        }
+
         stats.packages_linked += 1;
         trace!("materialized {dep_path} ({} files)", index.len());
         Ok(())
@@ -2375,6 +2405,7 @@ pub struct LinkStats {
     pub packages_cached: usize,
     pub files_linked: usize,
     pub top_level_linked: usize,
+    pub dirs_skipped: usize,
     /// Populated only when the linker ran in `NodeLinker::Hoisted`
     /// mode. Maps lockfile `dep_path` → list of on-disk directories
     /// where that package was materialized (most entries have one
@@ -2592,28 +2623,7 @@ fn write_applied_patches(
     let path = nm_dir.join(".aube-applied-patches.json");
     let out = serde_json::to_string(map)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    // Atomic write via tempfile + rename. Old fs::write truncated
-    // in place. Kill aube mid write (Ctrl+C, power loss, AV
-    // quarantine), sidecar ends up empty or partial JSON. Next
-    // install treats it as "no previous patches" and skips the
-    // diff, leaving stale patched entries materialized in
-    // node_modules that should have been re-linked.
-    if !nm_dir.exists() {
-        std::fs::create_dir_all(nm_dir)?;
-    }
-    let tmp = tempfile::Builder::new()
-        .prefix(".aube-applied-patches-")
-        .suffix(".tmp")
-        .tempfile_in(nm_dir)?;
-    {
-        use std::io::Write as _;
-        let mut f = tmp.as_file();
-        f.write_all(out.as_bytes())?;
-        f.sync_all()?;
-    }
-    tmp.persist(&path)
-        .map_err(|e| std::io::Error::other(format!("persist applied-patches: {e}")))?;
-    Ok(())
+    aube_util::fs_atomic::atomic_write(&path, out.as_bytes())
 }
 
 /// Wipe `.aube/<dep_path>` for any package whose patch fingerprint
@@ -2726,13 +2736,6 @@ fn apply_multi_file_patch(pkg_dir: &Path, patch_text: &str) -> Result<(), String
         // the exact TOCTOU window the rename is supposed to close.
         // Windows `MoveFileExW` fails when the destination exists,
         // so the unlink is gated behind `cfg(windows)`.
-        if let Some(parent) = target.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
-        }
-        let tmp = target.with_extension(format!("aube-patch.{}.tmp", std::process::id()));
-        std::fs::write(&tmp, patched.as_bytes())
-            .map_err(|e| format!("failed to write {}: {e}", tmp.display()))?;
         #[cfg(windows)]
         {
             if target.exists() {
@@ -2740,10 +2743,9 @@ fn apply_multi_file_patch(pkg_dir: &Path, patch_text: &str) -> Result<(), String
                     .map_err(|e| format!("failed to unlink {}: {e}", target.display()))?;
             }
         }
-        std::fs::rename(&tmp, &target).map_err(|e| {
-            let _ = std::fs::remove_file(&tmp);
+        aube_util::fs_atomic::atomic_write(&target, patched.as_bytes()).map_err(|e| {
             format!(
-                "failed to rename patched file into place {}: {e}",
+                "failed to write patched file into place {}: {e}",
                 target.display()
             )
         })?;

--- a/crates/aube-linker/src/sys.rs
+++ b/crates/aube-linker/src/sys.rs
@@ -453,7 +453,7 @@ fn detect_interpreter(target: &Path) -> String {
         // and prog go through Debug formatting so any terminal
         // escape sequences smuggled in either one are printed as
         // escaped literals rather than acted on by the terminal.
-        log::warn!("ignoring unsafe shebang interpreter in {target:?}: {prog:?}");
+        tracing::warn!("ignoring unsafe shebang interpreter in {target:?}: {prog:?}");
     }
     default_interpreter_for_extension(target)
 }
@@ -495,14 +495,14 @@ fn default_interpreter_for_extension(target: &Path) -> String {
 /// without passing `is_safe_prog`. Every caller in this crate goes
 /// through `detect_interpreter` and never trips this branch, but a
 /// future caller that bypasses that path would otherwise produce a
-/// shim with attacker-controlled bytes. A `log::error!` is emitted
+/// shim with attacker-controlled bytes. A `tracing::error!` is emitted
 /// so the regression is visible in release builds too, not only in
 /// debug.
 fn safe_prog(prog: &str) -> &str {
     if is_safe_prog(prog) {
         prog
     } else {
-        log::error!("refusing to splice unsafe prog {prog:?} into shim, substituting \"node\"");
+        tracing::error!("refusing to splice unsafe prog {prog:?} into shim, substituting \"node\"");
         "node"
     }
 }

--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -12,6 +12,7 @@ include = ["src/**/*.rs"]
 [dependencies]
 aube-manifest = { workspace = true }
 aube-settings = { workspace = true }
+aube-util = { workspace = true }
 glob = { workspace = true }
 miette = { workspace = true }
 node-semver = { workspace = true }

--- a/crates/aube-lockfile/src/dep_path_filename.rs
+++ b/crates/aube-lockfile/src/dep_path_filename.rs
@@ -29,10 +29,22 @@ pub fn dep_path_to_filename(dep_path: &str, max_length: usize) -> String {
         if filename.ends_with(')') {
             filename.pop();
         }
-        filename = filename.replace(")(", "_").replace(['(', ')'], "_");
+        let mut out = String::with_capacity(filename.len());
+        let mut chars = filename.chars().peekable();
+        while let Some(c) = chars.next() {
+            match c {
+                ')' if chars.peek() == Some(&'(') => {
+                    chars.next();
+                    out.push('_');
+                }
+                '(' | ')' => out.push('_'),
+                other => out.push(other),
+            }
+        }
+        filename = out;
     }
 
-    let has_upper = filename.chars().any(|c| c.is_ascii_uppercase());
+    let has_upper = filename.bytes().any(|b| b.is_ascii_uppercase());
     let needs_hash = filename.len() > max_length || (has_upper && !filename.starts_with("file+"));
 
     if needs_hash {

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -1246,62 +1246,7 @@ pub enum DriftStatus {
 /// the same guarantee post Win10. Caller passes the serialized
 /// bytes already formatted, this just handles the IO layer.
 pub(crate) fn atomic_write_lockfile(path: &Path, body: &[u8]) -> Result<(), Error> {
-    // Raw open + rename, same dir. Atomic on POSIX (rename(2)) and
-    // on Windows (MoveFileEx under fs::rename). Crash between
-    // write and rename leaves the old file intact, plus a dotfile
-    // tmp sibling, old file still parses fine so next install
-    // succeeds.
-    //
-    // Tried tempfile::NamedTempFile::persist first but on Windows
-    // it collided with tests that passed a NamedTempFile as the
-    // target path. The persist rename hit Access Denied because
-    // the outer NamedTempFile handle blocked the replacement.
-    // Direct open/write/rename sidesteps that.
-    use std::io::Write as _;
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let file_name = path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("lockfile");
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    // Dot prefix keeps the tmp hidden on Unix and out of most
-    // file explorers on Windows. Pid + nanos avoid collision
-    // between racing processes even if the outer project lock
-    // somehow missed.
-    let tmp_name = format!(".{}.aube-tmp-{}-{}", file_name, std::process::id(), nanos);
-    let tmp_path = parent.join(tmp_name);
-    // Helper closure so every failure path cleans up the tmp file.
-    // Without this, a disk-full or permission error mid-write left
-    // a `.lockfile.aube-tmp-<pid>-<nanos>` sibling on disk forever.
-    // Enough aborted installs and these pile up in the project dir.
-    let write_then_rename = || -> Result<(), Error> {
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&tmp_path)
-            .map_err(|e| Error::Io(tmp_path.clone(), e))?;
-        f.write_all(body)
-            .map_err(|e| Error::Io(tmp_path.clone(), e))?;
-        // sync_all before rename. Rename is a metadata op that can
-        // commit before the data blocks reach stable storage, so a
-        // crash right after rename would leave a valid-looking
-        // file with zero bytes. fsync forces the data first.
-        f.sync_all().map_err(|e| Error::Io(tmp_path.clone(), e))?;
-        // Drop the file handle explicitly before rename. Windows
-        // ReplaceFileW is happier when the source handle is closed.
-        drop(f);
-        std::fs::rename(&tmp_path, path).map_err(|e| Error::Io(path.to_path_buf(), e))
-    };
-    match write_then_rename() {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            let _ = std::fs::remove_file(&tmp_path);
-            Err(e)
-        }
-    }
+    aube_util::fs_atomic::atomic_write(path, body).map_err(|e| Error::Io(path.to_path_buf(), e))
 }
 
 /// Write a lockfile to the given project directory using aube's default

--- a/crates/aube-manifest/Cargo.toml
+++ b/crates/aube-manifest/Cargo.toml
@@ -10,6 +10,7 @@ homepage.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]
+aube-util = { workspace = true }
 miette = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -607,7 +607,8 @@ pub fn add_to_only_built_dependencies(
     // serde_yaml's block style always starts sequence items at the parent's
     // column; bumping every sequence line by two is a consistent transform.
     let indented = indent_block_sequences(&raw);
-    std::fs::write(&path, indented).map_err(|e| crate::Error::Io(path.clone(), e))?;
+    aube_util::fs_atomic::atomic_write(&path, indented.as_bytes())
+        .map_err(|e| crate::Error::Io(path.clone(), e))?;
     Ok(path)
 }
 

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -13,6 +13,7 @@ include = ["src/**/*.rs"]
 aube-manifest = { workspace = true }
 aube-settings = { workspace = true }
 aube-store = { workspace = true }
+aube-util = { workspace = true }
 reqwest = { workspace = true }
 base64 = { workspace = true }
 bytes = "1"

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -112,10 +112,11 @@ fn parse_cache_control_max_age(resp: &reqwest::Response) -> Option<u64> {
         .and_then(|v| v.to_str().ok())?;
     let mut max_age = None;
     let mut s_maxage = None;
+    let mut force_revalidate = false;
     for directive in raw.split(',').map(str::trim) {
         let directive_lc = directive.to_ascii_lowercase();
         match directive_lc.as_str() {
-            "no-store" | "no-cache" | "must-revalidate" | "private" => return Some(0),
+            "no-store" | "no-cache" | "private" => force_revalidate = true,
             _ => {}
         }
         if let Some(val) = directive_lc.strip_prefix("s-maxage=") {
@@ -123,6 +124,9 @@ fn parse_cache_control_max_age(resp: &reqwest::Response) -> Option<u64> {
         } else if let Some(val) = directive_lc.strip_prefix("max-age=") {
             max_age = val.parse::<u64>().ok();
         }
+    }
+    if force_revalidate {
+        return Some(0);
     }
     s_maxage.or(max_age)
 }

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -12,6 +12,8 @@ struct CachedPackument {
     last_modified: Option<String>,
     /// Unix epoch seconds when this entry was written
     fetched_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_age_secs: Option<u64>,
     packument: Packument,
 }
 
@@ -24,7 +26,15 @@ struct CachedFullPackument {
     etag: Option<String>,
     last_modified: Option<String>,
     fetched_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_age_secs: Option<u64>,
     packument: serde_json::Value,
+}
+
+fn cached_is_fresh(fetched_at: u64, max_age_secs: Option<u64>) -> bool {
+    let age = now_secs().saturating_sub(fetched_at);
+    let budget = max_age_secs.unwrap_or(PACKUMENT_TTL_SECS);
+    age < budget
 }
 
 /// How long to trust a cached packument before revalidating with the registry.
@@ -93,6 +103,28 @@ fn extract_cache_headers(resp: &reqwest::Response) -> (Option<String>, Option<St
         grab(reqwest::header::ETAG),
         grab(reqwest::header::LAST_MODIFIED),
     )
+}
+
+fn parse_cache_control_max_age(resp: &reqwest::Response) -> Option<u64> {
+    let raw = resp
+        .headers()
+        .get(reqwest::header::CACHE_CONTROL)
+        .and_then(|v| v.to_str().ok())?;
+    let mut max_age = None;
+    let mut s_maxage = None;
+    for directive in raw.split(',').map(str::trim) {
+        let directive_lc = directive.to_ascii_lowercase();
+        match directive_lc.as_str() {
+            "no-store" | "no-cache" | "must-revalidate" | "private" => return Some(0),
+            _ => {}
+        }
+        if let Some(val) = directive_lc.strip_prefix("s-maxage=") {
+            s_maxage = val.parse::<u64>().ok();
+        } else if let Some(val) = directive_lc.strip_prefix("max-age=") {
+            max_age = val.parse::<u64>().ok();
+        }
+    }
+    s_maxage.or(max_age)
 }
 
 /// Client for interacting with the npm registry.
@@ -503,7 +535,7 @@ impl RegistryClient {
             NetworkMode::PreferOffline | NetworkMode::Offline
         );
         if let Some(c) = cached.as_ref()
-            && (force_cache || now_secs().saturating_sub(c.fetched_at) < PACKUMENT_TTL_SECS)
+            && (force_cache || cached_is_fresh(c.fetched_at, c.max_age_secs))
         {
             return Ok(cached.unwrap().packument);
         }
@@ -566,10 +598,13 @@ impl RegistryClient {
                     if resp.status() == reqwest::StatusCode::NOT_MODIFIED
                         && let Some(c) = cached.as_ref()
                     {
+                        let revalidated_max_age =
+                            parse_cache_control_max_age(&resp).or(c.max_age_secs);
                         let to_cache = CachedFullPackument {
                             etag: c.etag.clone(),
                             last_modified: c.last_modified.clone(),
                             fetched_at: now_secs(),
+                            max_age_secs: revalidated_max_age,
                             packument: c.packument.clone(),
                         };
                         if let Err(e) = write_cached_full_packument(&cache_path, &to_cache) {
@@ -583,6 +618,7 @@ impl RegistryClient {
                     }
 
                     let (etag, last_modified) = extract_cache_headers(&resp);
+                    let max_age_secs = parse_cache_control_max_age(&resp);
                     let resp = resp.error_for_status()?;
                     check_body_cap(&resp, PACKUMENT_BODY_CAP, &label)?;
                     match resp.json::<serde_json::Value>().await {
@@ -591,6 +627,7 @@ impl RegistryClient {
                                 etag,
                                 last_modified,
                                 fetched_at: now_secs(),
+                                max_age_secs,
                                 packument: packument.clone(),
                             };
                             if let Err(e) = write_cached_full_packument(&cache_path, &to_cache) {
@@ -782,7 +819,7 @@ impl RegistryClient {
             NetworkMode::PreferOffline | NetworkMode::Offline
         );
         if let Some(c) = cached.as_ref()
-            && (force_cache || now_secs().saturating_sub(c.fetched_at) < PACKUMENT_TTL_SECS)
+            && (force_cache || cached_is_fresh(c.fetched_at, c.max_age_secs))
         {
             return Ok(cached.unwrap().packument);
         }
@@ -850,10 +887,12 @@ impl RegistryClient {
                     if resp.status() == reqwest::StatusCode::NOT_MODIFIED && cached.is_some() =>
                 {
                     let c = cached.as_ref().unwrap();
+                    let revalidated_max_age = parse_cache_control_max_age(&resp).or(c.max_age_secs);
                     let to_cache = CachedPackument {
                         etag: c.etag.clone(),
                         last_modified: c.last_modified.clone(),
                         fetched_at: now_secs(),
+                        max_age_secs: revalidated_max_age,
                         packument: c.packument.clone(),
                     };
                     if let Err(e) = write_cached_packument(&cache_path, &to_cache) {
@@ -867,6 +906,7 @@ impl RegistryClient {
                 }
                 Ok(resp) => {
                     let (etag, last_modified) = extract_cache_headers(&resp);
+                    let max_age_secs = parse_cache_control_max_age(&resp);
 
                     let resp = resp.error_for_status()?;
                     check_body_cap(&resp, PACKUMENT_BODY_CAP, &label)?;
@@ -876,6 +916,7 @@ impl RegistryClient {
                                 etag,
                                 last_modified,
                                 fetched_at: now_secs(),
+                                max_age_secs,
                                 packument: packument.clone(),
                             };
                             if let Err(e) = write_cached_packument(&cache_path, &to_cache) {
@@ -1406,13 +1447,8 @@ fn read_cached_packument(path: &Path) -> Option<CachedPackument> {
 }
 
 fn write_cached_packument(path: &Path, cached: &CachedPackument) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    // serde_json for writes — simd-json's serializer doesn't have a meaningful
-    // perf advantage on writes, and we want JSON output that's readable.
     let json = serde_json::to_vec(cached).map_err(std::io::Error::other)?;
-    std::fs::write(path, json)
+    aube_util::fs_atomic::atomic_write(path, &json)
 }
 
 fn packument_full_cache_path(cache_dir: &Path, name: &str) -> Option<PathBuf> {
@@ -1437,23 +1473,22 @@ fn read_cached_full_packument_typed(path: &Path, force_cache: bool) -> Option<Pa
     #[derive(Deserialize)]
     struct Typed {
         fetched_at: u64,
+        #[serde(default)]
+        max_age_secs: Option<u64>,
         packument: Packument,
     }
 
     let mut content = std::fs::read(path).ok()?;
     let typed: Typed = simd_json::serde::from_slice(&mut content).ok()?;
-    if !force_cache && now_secs().saturating_sub(typed.fetched_at) >= PACKUMENT_TTL_SECS {
+    if !force_cache && !cached_is_fresh(typed.fetched_at, typed.max_age_secs) {
         return None;
     }
     Some(typed.packument)
 }
 
 fn write_cached_full_packument(path: &Path, cached: &CachedFullPackument) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let json = serde_json::to_vec(cached).map_err(std::io::Error::other)?;
-    std::fs::write(path, json)
+    aube_util::fs_atomic::atomic_write(path, &json)
 }
 
 /// Emit a `fetchMinSpeedKiBps` warning if the tarball downloaded slower

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -1153,23 +1153,7 @@ fn normalize_registry_url(url: &str) -> String {
 }
 
 fn home_dir() -> Option<PathBuf> {
-    // HOME wins if set. Covers every Unix plus POSIX-compat Windows
-    // shells (Git Bash, MSYS, WSL invoked from Windows) that set it.
-    // USERPROFILE is the native Windows fallback. Old code was HOME
-    // only which meant vanilla `cmd.exe` / PowerShell users had their
-    // `%USERPROFILE%\.npmrc` auth tokens silently ignored, so any
-    // aube install against a private registry returned 401 with no
-    // hint why.
-    if let Ok(h) = std::env::var("HOME") {
-        return Some(PathBuf::from(h));
-    }
-    #[cfg(windows)]
-    {
-        if let Ok(p) = std::env::var("USERPROFILE") {
-            return Some(PathBuf::from(p));
-        }
-    }
-    None
+    aube_util::env::home_dir()
 }
 
 /// Resolve the path to pnpm's global auth file. When an explicit

--- a/crates/aube-resolver/Cargo.toml
+++ b/crates/aube-resolver/Cargo.toml
@@ -14,6 +14,7 @@ aube-registry = { workspace = true }
 aube-manifest = { workspace = true }
 aube-lockfile = { workspace = true }
 aube-store = { workspace = true }
+aube-util = { workspace = true }
 node-semver = { workspace = true }
 serde_json = { workspace = true }
 flate2 = { workspace = true }

--- a/crates/aube-resolver/src/builder.rs
+++ b/crates/aube-resolver/src/builder.rs
@@ -35,6 +35,7 @@ impl Resolver {
             dedupe_peers: false,
             resolve_peers_from_workspace_root: true,
             registry_supports_time_field: false,
+            packument_network_concurrency: None,
         }
     }
 
@@ -70,9 +71,15 @@ impl Resolver {
                 dedupe_peers: false,
                 resolve_peers_from_workspace_root: true,
                 registry_supports_time_field: false,
+                packument_network_concurrency: None,
             },
             rx,
         )
+    }
+
+    pub fn with_packument_network_concurrency(mut self, n: Option<usize>) -> Self {
+        self.packument_network_concurrency = n.filter(|&n| n > 0);
+        self
     }
 
     /// Enable disk-backed packument caching with ETag/Last-Modified revalidation.

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -179,6 +179,7 @@ pub struct Resolver {
     /// active, since the abbreviated path is already the only one
     /// running.
     registry_supports_time_field: bool,
+    pub(crate) packument_network_concurrency: Option<usize>,
 }
 
 pub(crate) struct ResolveTask {

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -356,19 +356,18 @@ pub fn apply_peer_contexts(
     const MAX_ITERATIONS: usize = 16;
     let mut current = canonical;
     let mut converged = false;
+    let key_set_hash = |g: &LockfileGraph| -> u64 {
+        aube_util::hash::keyset_hash(g.packages.keys().map(String::as_str))
+    };
     for i in 0..MAX_ITERATIONS {
-        let current_keys: Vec<String> = current.packages.keys().cloned().collect();
+        let before = key_set_hash(&current);
         let after_once = apply_peer_contexts_once(current, options);
         let next = if options.dedupe_peer_dependents {
             dedupe_peer_variants(after_once)
         } else {
             after_once
         };
-        if current_keys
-            .iter()
-            .map(String::as_str)
-            .eq(next.packages.keys().map(String::as_str))
-        {
+        if before == key_set_hash(&next) {
             tracing::debug!("peer-context pass converged after {i} iteration(s)");
             current = next;
             converged = true;
@@ -725,16 +724,20 @@ fn canonical_tail(s: &str) -> &str {
 /// nested peer-context suffix. Used both for the root scope and for
 /// each importer's own scope inside `apply_peer_contexts_once`.
 fn scope_map_from_deps(deps: &[DirectDep]) -> FxHashMap<String, String> {
-    deps.iter()
-        .map(|d| {
-            let tail = d
-                .dep_path
-                .strip_prefix(&format!("{}@", d.name))
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| d.dep_path.clone());
-            (d.name.clone(), tail)
-        })
-        .collect()
+    let mut out = FxHashMap::with_capacity_and_hasher(deps.len(), Default::default());
+    for d in deps {
+        let prefix_len = d.name.len() + 1;
+        let tail = if d.dep_path.len() > prefix_len
+            && d.dep_path.as_bytes().get(d.name.len()) == Some(&b'@')
+            && d.dep_path.as_bytes().starts_with(d.name.as_bytes())
+        {
+            d.dep_path[prefix_len..].to_string()
+        } else {
+            d.dep_path.clone()
+        };
+        out.insert(d.name.clone(), tail);
+    }
+    out
 }
 
 fn strip_hashed_peer_suffix(s: &str) -> &str {

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -357,7 +357,7 @@ pub fn apply_peer_contexts(
     let mut current = canonical;
     let mut converged = false;
     let key_set_hash = |g: &LockfileGraph| -> u64 {
-        aube_util::hash::keyset_hash(g.packages.keys().map(String::as_str))
+        aube_util::hash::ordered_seq_hash(g.packages.keys().map(String::as_str))
     };
     for i in 0..MAX_ITERATIONS {
         let before = key_set_hash(&current);

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -133,7 +133,9 @@ impl Resolver {
         // speculatively at every enqueue site, by the time a task is
         // popped its packument is usually already cached, so the
         // wait is short.
-        let shared_semaphore = Arc::new(tokio::sync::Semaphore::new(64));
+        let shared_semaphore = Arc::new(tokio::sync::Semaphore::new(
+            self.packument_network_concurrency.unwrap_or(64),
+        ));
         // Time-based mode and `minimumReleaseAge` both need the
         // packument's `time:` map. The abbreviated (corgi) response
         // omits `time` by default, so we normally fall back to the

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -39,16 +39,17 @@ fn script_settings_lock() -> &'static std::sync::RwLock<ScriptSettings> {
 /// this after resolving `.npmrc` / workspace settings for the active
 /// project.
 pub fn set_script_settings(settings: ScriptSettings) {
-    *script_settings_lock()
-        .write()
-        .expect("script settings lock poisoned") = settings;
+    match script_settings_lock().write() {
+        Ok(mut guard) => *guard = settings,
+        Err(poisoned) => *poisoned.into_inner() = settings,
+    }
 }
 
 fn script_settings() -> ScriptSettings {
-    script_settings_lock()
-        .read()
-        .expect("script settings lock poisoned")
-        .clone()
+    match script_settings_lock().read() {
+        Ok(guard) => guard.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
 }
 
 /// Prepend `bin_dir` to the current `PATH` using the platform's path

--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -10,6 +10,7 @@ homepage.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]
+aube-util = { workspace = true }
 sha2 = { workspace = true }
 blake3 = { workspace = true }
 hex = { workspace = true }

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -5,8 +5,31 @@ pub mod dirs;
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha512};
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+
+pub const SHA512_INTEGRITY_PREFIX: &str = "sha512-";
+
+pub const CACHE_DIR_NAME: &str = "aube-cache";
+pub const INDEX_SUBDIR: &str = "index";
+pub const VIRTUAL_STORE_SUBDIR: &str = "virtual-store";
+pub const PACKUMENT_CACHE_SUBDIR: &str = "packuments-v1";
+pub const PACKUMENT_FULL_CACHE_SUBDIR: &str = "packuments-full-v1";
+
+thread_local! {
+    static B3_HASHER: RefCell<blake3::Hasher> = RefCell::new(blake3::Hasher::new());
+    static SHA512_HASHER: RefCell<Sha512> = RefCell::new(Sha512::new());
+}
+
+fn blake3_hex(content: &[u8]) -> String {
+    B3_HASHER.with(|cell| {
+        let mut h = cell.borrow_mut();
+        h.reset();
+        h.update(content);
+        h.finalize().to_hex().to_string()
+    })
+}
 
 /// The global content-addressable store, owned by aube.
 ///
@@ -57,7 +80,7 @@ impl Store {
     /// Used by tests that need a fully isolated layout; production code
     /// should prefer `default_location` or `with_root`.
     pub fn at(root: PathBuf) -> Self {
-        let cache_dir = root.parent().unwrap_or(&root).join("aube-cache");
+        let cache_dir = root.parent().unwrap_or(&root).join(CACHE_DIR_NAME);
         Self { root, cache_dir }
     }
 
@@ -68,19 +91,19 @@ impl Store {
     /// Directory for cached package indices. Public so introspection
     /// commands (`aube find-hash`) can walk it directly.
     pub fn index_dir(&self) -> PathBuf {
-        self.cache_dir.join("index")
+        self.cache_dir.join(INDEX_SUBDIR)
     }
 
     /// Directory for the global virtual store (materialized packages).
     pub fn virtual_store_dir(&self) -> PathBuf {
-        self.cache_dir.join("virtual-store")
+        self.cache_dir.join(VIRTUAL_STORE_SUBDIR)
     }
 
     /// Directory for cached packument metadata (abbreviated/corgi format).
     /// Versioned so we can bump the schema without breaking old caches —
     /// old caches at older versions stay around until manually pruned.
     pub fn packument_cache_dir(&self) -> PathBuf {
-        self.cache_dir.join("packuments-v1")
+        self.cache_dir.join(PACKUMENT_CACHE_SUBDIR)
     }
 
     /// Directory for cached *full* packument JSON (non-corgi) used by
@@ -89,7 +112,7 @@ impl Store {
     /// `maintainers`). Separate from `packument_cache_dir` because the
     /// corgi and full responses have different shapes.
     pub fn packument_full_cache_dir(&self) -> PathBuf {
-        self.cache_dir.join("packuments-full-v1")
+        self.cache_dir.join(PACKUMENT_FULL_CACHE_SUBDIR)
     }
 
     /// Check if a file with the given integrity hash exists in the store.
@@ -324,7 +347,7 @@ impl Store {
     /// exist yet, the `create_new` open will fail with `NotFound`; we
     /// fall back to the slow path for correctness.
     pub fn import_bytes(&self, content: &[u8], executable: bool) -> Result<StoredFile, Error> {
-        let hex_hash = blake3::hash(content).to_hex().to_string();
+        let hex_hash = blake3_hex(content);
 
         let store_path = self.file_path_from_hex(&hex_hash);
 
@@ -907,22 +930,30 @@ pub fn validate_version(version: &str) -> bool {
 /// Verify that data matches an integrity hash (e.g., "sha512-<base64>").
 /// Returns Ok(()) if valid, Err with details if mismatch.
 pub fn verify_integrity(data: &[u8], expected: &str) -> Result<(), Error> {
-    let Some(expected_b64) = expected.strip_prefix("sha512-") else {
+    let Some(expected_b64) = expected.strip_prefix(SHA512_INTEGRITY_PREFIX) else {
         return Err(Error::Integrity(format!(
             "unsupported integrity format (expected sha512-...): {expected}"
         )));
     };
 
-    let mut hasher = Sha512::new();
-    hasher.update(data);
-    let actual_bytes = hasher.finalize();
+    let actual_bytes = SHA512_HASHER.with(|cell| {
+        let mut hasher = cell.borrow_mut();
+        hasher.reset();
+        hasher.update(data);
+        hasher.finalize_reset()
+    });
 
     use base64::Engine;
-    let actual_b64 = base64::engine::general_purpose::STANDARD.encode(actual_bytes);
-
-    if actual_b64 == expected_b64 {
+    let engine = base64::engine::general_purpose::STANDARD;
+    let mut expected_buf = [0u8; 64];
+    let matched = engine
+        .decode_slice(expected_b64, &mut expected_buf)
+        .map(|n| n == 64 && expected_buf[..] == actual_bytes[..])
+        .unwrap_or(false);
+    if matched {
         Ok(())
     } else {
+        let actual_b64 = engine.encode(actual_bytes);
         Err(Error::Integrity(format!(
             "integrity mismatch: expected sha512-{expected_b64}, got sha512-{actual_b64}"
         )))
@@ -1005,7 +1036,7 @@ pub fn validate_pkg_content(
 /// registry integrity format as an ergonomic input. Returns `None` if
 /// the input isn't a well-formed integrity string.
 pub fn integrity_to_hex(integrity: &str) -> Option<String> {
-    let b64 = integrity.strip_prefix("sha512-")?;
+    let b64 = integrity.strip_prefix(SHA512_INTEGRITY_PREFIX)?;
     use base64::Engine;
     let bytes = base64::engine::general_purpose::STANDARD.decode(b64).ok()?;
     Some(hex::encode(bytes))
@@ -1453,7 +1484,7 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
     //    was a stale partial-failure stub above) → rename fails
     //    with ENOTEMPTY/EEXIST. Verify the existing target has our
     //    commit and reuse it; otherwise remove it and retry once.
-    match std::fs::rename(&scratch, &target) {
+    match aube_util::fs_atomic::rename_with_retry(&scratch, &target) {
         Ok(()) => Ok(target),
         Err(_) => {
             if target.join(".git").is_dir()
@@ -1472,7 +1503,7 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
             // both trying to replace a stale target, which is still
             // safe because each scratch is PID-scoped.
             let _ = std::fs::remove_dir_all(&target);
-            std::fs::rename(&scratch, &target).map_err(|e| {
+            aube_util::fs_atomic::rename_with_retry(&scratch, &target).map_err(|e| {
                 let _ = std::fs::remove_dir_all(&scratch);
                 Error::Git(format!("rename clone into place: {e}"))
             })?;

--- a/crates/aube-util/Cargo.toml
+++ b/crates/aube-util/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "aube-util"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Shared helpers reused across aube crates (semantic hashing, async dedup, atomic filesystem ops, bincode sidecars)."
+
+[dependencies]
+rustc-hash = { workspace = true }
+blake3 = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/aube-util/src/env.rs
+++ b/crates/aube-util/src/env.rs
@@ -1,0 +1,14 @@
+pub fn is_ci() -> bool {
+    std::env::var_os("CI").is_some()
+}
+
+pub fn home_dir() -> Option<std::path::PathBuf> {
+    if let Some(h) = std::env::var_os("HOME") {
+        return Some(h.into());
+    }
+    #[cfg(windows)]
+    if let Some(h) = std::env::var_os("USERPROFILE") {
+        return Some(h.into());
+    }
+    None
+}

--- a/crates/aube-util/src/fs_atomic.rs
+++ b/crates/aube-util/src/fs_atomic.rs
@@ -1,0 +1,172 @@
+use std::ffi::OsString;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+
+pub fn sibling_tempdir(final_path: &Path) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    let mut name: OsString = final_path
+        .file_name()
+        .map(OsString::from)
+        .unwrap_or_else(|| OsString::from("aube-tmp"));
+    name.push(format!(".tmp.{pid}.{nanos}.{n}"));
+    match final_path.parent() {
+        Some(parent) => parent.join(name),
+        None => PathBuf::from(name),
+    }
+}
+
+pub fn rename_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut backoff_ms = 20u64;
+    for attempt in 0..MAX_ATTEMPTS {
+        match std::fs::rename(src, dst) {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                if !is_transient(&err) || attempt == MAX_ATTEMPTS - 1 {
+                    if dst.exists() {
+                        let _ = std::fs::remove_dir_all(src).or_else(|_| std::fs::remove_file(src));
+                        return Ok(());
+                    }
+                    return Err(err);
+                }
+                thread::sleep(Duration::from_millis(backoff_ms));
+                backoff_ms = backoff_ms.saturating_mul(2);
+            }
+        }
+    }
+    Err(io::Error::other("rename_with_retry exhausted attempts"))
+}
+
+fn is_transient(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::AlreadyExists
+            | io::ErrorKind::PermissionDenied
+            | io::ErrorKind::Interrupted
+            | io::ErrorKind::WouldBlock
+    )
+}
+
+pub fn atomic_write(final_path: &Path, bytes: &[u8]) -> io::Result<()> {
+    if let Some(parent) = final_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = sibling_tempdir(final_path);
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        let _ = f.sync_all();
+    }
+    match rename_with_retry(&tmp, final_path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
+pub mod sentinel {
+    use super::*;
+
+    pub fn mark(path: &Path, tag: &str) -> io::Result<bool> {
+        match std::fs::read(path) {
+            Ok(existing) if existing.as_slice() == tag.as_bytes() => Ok(false),
+            Ok(_) => {
+                write_sentinel(path, tag)?;
+                Ok(true)
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                write_sentinel(path, tag)?;
+                Ok(true)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn read_tag(path: &Path) -> Option<Vec<u8>> {
+        std::fs::read(path).ok()
+    }
+
+    pub fn present(path: &Path) -> bool {
+        std::fs::metadata(path).is_ok()
+    }
+
+    fn write_sentinel(path: &Path, tag: &str) -> io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, tag)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sibling_tempdir_differs_per_call() {
+        let base = Path::new("/tmp/aube-fake-final");
+        let a = sibling_tempdir(base);
+        let b = sibling_tempdir(base);
+        assert_ne!(a, b);
+        assert_eq!(a.parent(), b.parent());
+    }
+
+    #[test]
+    fn atomic_write_replaces_existing() -> io::Result<()> {
+        let dir = tempdir()?;
+        let path = dir.join("target.bin");
+        atomic_write(&path, b"first")?;
+        assert_eq!(std::fs::read(&path)?, b"first");
+        atomic_write(&path, b"second")?;
+        assert_eq!(std::fs::read(&path)?, b"second");
+        Ok(())
+    }
+
+    #[test]
+    fn atomic_write_creates_parent() -> io::Result<()> {
+        let dir = tempdir()?;
+        let path = dir.join("nested/deep/file.txt");
+        atomic_write(&path, b"ok")?;
+        assert_eq!(std::fs::read(&path)?, b"ok");
+        Ok(())
+    }
+
+    #[test]
+    fn sentinel_roundtrip() -> io::Result<()> {
+        let dir = tempdir()?;
+        let path = dir.join(".aube-initialized");
+        assert!(!sentinel::present(&path));
+        assert!(sentinel::mark(&path, "v1")?);
+        assert!(sentinel::present(&path));
+        assert!(!sentinel::mark(&path, "v1")?);
+        assert_eq!(sentinel::read_tag(&path).as_deref(), Some(b"v1".as_ref()));
+        assert!(sentinel::mark(&path, "v2")?);
+        assert_eq!(sentinel::read_tag(&path).as_deref(), Some(b"v2".as_ref()));
+        Ok(())
+    }
+
+    fn tempdir() -> io::Result<PathBuf> {
+        let base = std::env::temp_dir().join(format!(
+            "aube-util-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&base)?;
+        Ok(base)
+    }
+}

--- a/crates/aube-util/src/fs_atomic.rs
+++ b/crates/aube-util/src/fs_atomic.rs
@@ -103,10 +103,7 @@ pub mod sentinel {
     }
 
     fn write_sentinel(path: &Path, tag: &str) -> io::Result<()> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(path, tag)
+        super::atomic_write(path, tag.as_bytes())
     }
 }
 

--- a/crates/aube-util/src/hash.rs
+++ b/crates/aube-util/src/hash.rs
@@ -1,0 +1,206 @@
+use std::hash::{Hash, Hasher};
+
+pub fn keyset_hash<I, T>(iter: I) -> u64
+where
+    I: IntoIterator<Item = T>,
+    T: Hash,
+    I::IntoIter: ExactSizeIterator,
+{
+    let iter = iter.into_iter();
+    let mut h = rustc_hash::FxHasher::default();
+    iter.len().hash(&mut h);
+    for item in iter {
+        item.hash(&mut h);
+    }
+    h.finish()
+}
+
+pub fn meta_hash<'a, I, S>(packages: I, scripts: S) -> [u8; 32]
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+    S: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"aube-meta-v1\npackages\n");
+    for (name, version) in packages {
+        hasher.update(name.as_bytes());
+        hasher.update(b"@");
+        hasher.update(version.as_bytes());
+        hasher.update(b"\n");
+    }
+    hasher.update(b"scripts\n");
+    for (name, body) in scripts {
+        hasher.update(name.as_bytes());
+        hasher.update(b"=");
+        hasher.update(body.as_bytes());
+        hasher.update(b"\n");
+    }
+    *hasher.finalize().as_bytes()
+}
+
+pub const INSTALL_SHAPE_FIELDS: &[&str] = &[
+    "bundleDependencies",
+    "bundledDependencies",
+    "catalog",
+    "catalogs",
+    "dependencies",
+    "devDependencies",
+    "engines",
+    "name",
+    "optionalDependencies",
+    "overrides",
+    "peerDependencies",
+    "peerDependenciesMeta",
+    "pnpm",
+    "publishConfig",
+    "resolutions",
+    "version",
+    "workspaces",
+];
+
+pub fn manifest_install_shape_digest(manifest: &serde_json::Value) -> [u8; 32] {
+    let obj = match manifest.as_object() {
+        Some(o) => o,
+        None => return *blake3::hash(b"aube-manifest-v1/not-an-object").as_bytes(),
+    };
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"aube-manifest-v1\n");
+    for field in INSTALL_SHAPE_FIELDS {
+        if let Some(v) = obj.get(*field) {
+            hasher.update(field.as_bytes());
+            hasher.update(b"=");
+            canonical_json(v, &mut hasher);
+            hasher.update(b"\n");
+        }
+    }
+    *hasher.finalize().as_bytes()
+}
+
+fn canonical_json(v: &serde_json::Value, hasher: &mut blake3::Hasher) {
+    use serde_json::Value;
+    match v {
+        Value::Null => {
+            hasher.update(b"null");
+        }
+        Value::Bool(b) => {
+            hasher.update(if *b { b"true" } else { b"false" });
+        }
+        Value::Number(n) => {
+            hasher.update(n.to_string().as_bytes());
+        }
+        Value::String(s) => {
+            hasher.update(b"\"");
+            hasher.update(s.as_bytes());
+            hasher.update(b"\"");
+        }
+        Value::Array(items) => {
+            hasher.update(b"[");
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    hasher.update(b",");
+                }
+                canonical_json(item, hasher);
+            }
+            hasher.update(b"]");
+        }
+        Value::Object(obj) => {
+            hasher.update(b"{");
+            let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    hasher.update(b",");
+                }
+                hasher.update(b"\"");
+                hasher.update(k.as_bytes());
+                hasher.update(b"\":");
+                if let Some(val) = obj.get(*k) {
+                    canonical_json(val, hasher);
+                }
+            }
+            hasher.update(b"}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyset_hash_is_order_sensitive() {
+        let a = keyset_hash(["a", "b", "c"].iter().copied());
+        let b = keyset_hash(["c", "b", "a"].iter().copied());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn keyset_hash_detects_count_changes() {
+        let short = keyset_hash(["a", "b"].iter().copied());
+        let long = keyset_hash(["a", "b", "c"].iter().copied());
+        assert_ne!(short, long);
+    }
+
+    #[test]
+    fn meta_hash_stable_for_same_inputs() {
+        let pkgs = [("react", "19.0.0"), ("next", "15.1.3")];
+        let scripts: [(&str, &str); 0] = [];
+        let a = meta_hash(pkgs.iter().copied(), scripts.iter().copied());
+        let b = meta_hash(pkgs.iter().copied(), scripts.iter().copied());
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn manifest_digest_ignores_scripts_and_license() {
+        let a: serde_json::Value = serde_json::from_str(
+            r#"{"name":"x","version":"1.0.0","dependencies":{"react":"19.0.0"},"scripts":{"test":"vitest"},"license":"MIT"}"#,
+        )
+        .unwrap();
+        let b: serde_json::Value = serde_json::from_str(
+            r#"{"name":"x","version":"1.0.0","dependencies":{"react":"19.0.0"},"scripts":{"test":"jest --watch"},"license":"Apache-2.0"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            manifest_install_shape_digest(&a),
+            manifest_install_shape_digest(&b)
+        );
+    }
+
+    #[test]
+    fn manifest_digest_reacts_to_dep_change() {
+        let a: serde_json::Value =
+            serde_json::from_str(r#"{"dependencies":{"react":"19.0.0"}}"#).unwrap();
+        let b: serde_json::Value =
+            serde_json::from_str(r#"{"dependencies":{"react":"19.1.0"}}"#).unwrap();
+        assert_ne!(
+            manifest_install_shape_digest(&a),
+            manifest_install_shape_digest(&b)
+        );
+    }
+
+    #[test]
+    fn manifest_digest_stable_under_key_reorder() {
+        let a: serde_json::Value = serde_json::from_str(
+            r#"{"name":"x","dependencies":{"b":"1","a":"2"},"devDependencies":{"c":"3"}}"#,
+        )
+        .unwrap();
+        let b: serde_json::Value = serde_json::from_str(
+            r#"{"devDependencies":{"c":"3"},"dependencies":{"a":"2","b":"1"},"name":"x"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            manifest_install_shape_digest(&a),
+            manifest_install_shape_digest(&b)
+        );
+    }
+
+    #[test]
+    fn meta_hash_reacts_to_script_change() {
+        let pkgs = [("react", "19.0.0")];
+        let s1 = [("build", "tsc")];
+        let s2 = [("build", "tsc --watch")];
+        let a = meta_hash(pkgs.iter().copied(), s1.iter().copied());
+        let b = meta_hash(pkgs.iter().copied(), s2.iter().copied());
+        assert_ne!(a, b);
+    }
+}

--- a/crates/aube-util/src/hash.rs
+++ b/crates/aube-util/src/hash.rs
@@ -1,6 +1,6 @@
 use std::hash::{Hash, Hasher};
 
-pub fn keyset_hash<I, T>(iter: I) -> u64
+pub fn ordered_seq_hash<I, T>(iter: I) -> u64
 where
     I: IntoIterator<Item = T>,
     T: Hash,
@@ -128,16 +128,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn keyset_hash_is_order_sensitive() {
-        let a = keyset_hash(["a", "b", "c"].iter().copied());
-        let b = keyset_hash(["c", "b", "a"].iter().copied());
+    fn ordered_seq_hash_is_order_sensitive() {
+        let a = ordered_seq_hash(["a", "b", "c"].iter().copied());
+        let b = ordered_seq_hash(["c", "b", "a"].iter().copied());
         assert_ne!(a, b);
     }
 
     #[test]
-    fn keyset_hash_detects_count_changes() {
-        let short = keyset_hash(["a", "b"].iter().copied());
-        let long = keyset_hash(["a", "b", "c"].iter().copied());
+    fn ordered_seq_hash_detects_count_changes() {
+        let short = ordered_seq_hash(["a", "b"].iter().copied());
+        let long = ordered_seq_hash(["a", "b", "c"].iter().copied());
         assert_ne!(short, long);
     }
 

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod env;
+pub mod fs_atomic;
+pub mod hash;

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -33,6 +33,7 @@ test = false
 aube-lockfile = { workspace = true }
 aube-manifest = { workspace = true }
 aube-registry = { workspace = true }
+aube-util = { workspace = true }
 aube-resolver = { workspace = true }
 aube-settings = { workspace = true }
 aube-store = { workspace = true }

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -393,7 +393,8 @@ pub async fn run(
     // failure rather than silently dropping later ones.
     let restore_errors = if let Some(snapshot) = no_save_snapshot {
         let mut errors: Vec<miette::Report> = Vec::new();
-        if let Err(e) = std::fs::write(&manifest_path, &snapshot.manifest_bytes) {
+        if let Err(e) = aube_util::fs_atomic::atomic_write(&manifest_path, &snapshot.manifest_bytes)
+        {
             errors.push(
                 Result::<(), _>::Err(e)
                     .into_diagnostic()
@@ -402,7 +403,7 @@ pub async fn run(
             );
         }
         let lockfile_restore = match &snapshot.lockfile_bytes {
-            Some(bytes) => std::fs::write(&lockfile_path, bytes),
+            Some(bytes) => aube_util::fs_atomic::atomic_write(&lockfile_path, bytes),
             None => match std::fs::remove_file(&lockfile_path) {
                 Ok(()) => Ok(()),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),

--- a/crates/aube/src/commands/cat_file.rs
+++ b/crates/aube/src/commands/cat_file.rs
@@ -27,7 +27,7 @@ pub async fn run(args: CatFileArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root_or_cwd()?;
     let store = open_store(&cwd)?;
 
-    let path = if args.hash.starts_with("sha512-") {
+    let path = if args.hash.starts_with(aube_store::SHA512_INTEGRITY_PREFIX) {
         store
             .file_path_from_integrity(&args.hash)
             .ok_or_else(|| miette!("invalid integrity hash: {}", args.hash))?

--- a/crates/aube/src/commands/catalogs.rs
+++ b/crates/aube/src/commands/catalogs.rs
@@ -236,7 +236,7 @@ pub(crate) fn prune_unused_catalog_entries(
     let new_text = serde_yaml::to_string(&value)
         .into_diagnostic()
         .wrap_err("failed to serialize workspace yaml after cleanupUnusedCatalogs")?;
-    std::fs::write(workspace_path, new_text)
+    aube_util::fs_atomic::atomic_write(workspace_path, new_text.as_bytes())
         .into_diagnostic()
         .wrap_err_with(|| {
             format!(

--- a/crates/aube/src/commands/find_hash.rs
+++ b/crates/aube/src/commands/find_hash.rs
@@ -61,7 +61,7 @@ struct Match {
 pub async fn run(args: FindHashArgs) -> miette::Result<()> {
     // Normalize input: integrity → hex, or validate raw hex up front so
     // we don't compare nonsense strings against every cached index.
-    let target_hex = if args.hash.starts_with("sha512-") {
+    let target_hex = if args.hash.starts_with(aube_store::SHA512_INTEGRITY_PREFIX) {
         aube_store::integrity_to_hex(&args.hash)
             .ok_or_else(|| miette!("invalid integrity hash: {}", args.hash))?
     } else {

--- a/crates/aube/src/commands/install/frozen.rs
+++ b/crates/aube/src/commands/install/frozen.rs
@@ -102,7 +102,7 @@ impl FrozenMode {
 
     /// pnpm's default: `frozen-lockfile=true` in CI, `prefer-frozen-lockfile=true` otherwise.
     fn default_for_env() -> Self {
-        if std::env::var_os("CI").is_some() {
+        if aube_util::env::is_ci() {
             Self::Frozen
         } else {
             Self::Prefer

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2532,7 +2532,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 // so the aggregate file-system pressure matches what
                 // the post-fetch link step would have generated.
                 let permits = materialize_link_concurrency
-                    .unwrap_or(if cfg!(target_os = "macos") { 4 } else { 16 });
+                    .unwrap_or_else(aube_linker::default_linker_parallelism);
                 let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(permits));
                 let mut in_flight: Vec<
                     tokio::task::JoinHandle<miette::Result<aube_linker::LinkStats>>,

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -124,7 +124,8 @@ fn bootstrap_blocking(
     let manifest = format!(
         r#"{{"name":"aube-tool-node-gyp","private":true,"dependencies":{{"node-gyp":"{SPEC}"}}}}"#
     );
-    std::fs::write(tool_dir.join("package.json"), manifest).into_diagnostic()?;
+    aube_util::fs_atomic::atomic_write(&tool_dir.join("package.json"), manifest.as_bytes())
+        .into_diagnostic()?;
     // Pin the recursive `aube install` invocation below to `tool_dir`
     // so its workspace-root walk-up stops here instead of escaping
     // upward. `tool_dir` lives under `$XDG_CACHE_HOME/aube/tools/` —
@@ -137,7 +138,8 @@ fn bootstrap_blocking(
     // first marker check at the start of the walk, returns
     // `tool_dir`, and the install runs as a single-package install
     // (`workspace_packages` is empty so `has_workspace` is false).
-    std::fs::write(tool_dir.join("aube-workspace.yaml"), "").into_diagnostic()?;
+    aube_util::fs_atomic::atomic_write(&tool_dir.join("aube-workspace.yaml"), b"")
+        .into_diagnostic()?;
     // Forward the outer project's `.npmrc` so private registries and
     // auth tokens configured at project scope carry through to the
     // recursive install. The subprocess's cwd is `tool_dir`, so

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -653,7 +653,9 @@ pub(super) fn configure_resolver(
         );
     }
     let git_shallow_hosts = resolve_git_shallow_hosts(settings_ctx);
+    let packument_concurrency = resolve_network_concurrency(settings_ctx);
     let mut resolver = resolver
+        .with_packument_network_concurrency(packument_concurrency)
         .with_packument_cache(packument_cache_dir())
         .with_packument_full_cache(packument_full_cache_dir())
         .with_auto_install_peers(auto_install_peers)

--- a/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/crates/aube/src/commands/install/side_effects_cache.rs
@@ -139,7 +139,7 @@ impl SideEffectsCacheEntry {
                 self.path.display()
             )
         })?;
-        match std::fs::rename(&tmp, &self.path) {
+        match aube_util::fs_atomic::rename_with_retry(&tmp, &self.path) {
             Ok(()) => {
                 tracing::debug!("side-effects-cache: saved {}", self.path.display());
                 Ok(())
@@ -214,14 +214,17 @@ fn write_side_effects_marker(
     package_dir: &std::path::Path,
     input_hash: &str,
 ) -> miette::Result<()> {
-    std::fs::write(package_dir.join(SIDE_EFFECTS_CACHE_MARKER), input_hash)
-        .into_diagnostic()
-        .wrap_err_with(|| {
-            format!(
-                "failed to write side effects cache marker in {}",
-                package_dir.display()
-            )
-        })
+    aube_util::fs_atomic::atomic_write(
+        &package_dir.join(SIDE_EFFECTS_CACHE_MARKER),
+        input_hash.as_bytes(),
+    )
+    .into_diagnostic()
+    .wrap_err_with(|| {
+        format!(
+            "failed to write side effects cache marker in {}",
+            package_dir.display()
+        )
+    })
 }
 
 fn hash_dir_for_side_effects_cache(package_dir: &std::path::Path) -> miette::Result<String> {

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -373,16 +373,7 @@ pub(crate) fn expand_setting_path(raw: &str, cwd: &std::path::Path) -> Option<st
 }
 
 fn home_dir_os() -> Option<std::ffi::OsString> {
-    if let Some(h) = std::env::var_os("HOME") {
-        return Some(h);
-    }
-    #[cfg(windows)]
-    {
-        if let Some(p) = std::env::var_os("USERPROFILE") {
-            return Some(p);
-        }
-    }
-    None
+    aube_util::env::home_dir().map(|p| p.into_os_string())
 }
 
 /// Build a file-only `ResolveCtx` for `cwd` and call `f` with it.
@@ -756,26 +747,9 @@ pub(crate) fn write_manifest_json<T: serde::Serialize>(
 /// The old `fs::write` truncates in place and a crash mid-write left
 /// users with an empty manifest — the worst aube failure mode.
 pub(crate) fn write_manifest_atomic(path: &Path, body: &[u8]) -> miette::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let tmp = tempfile::Builder::new()
-        .prefix(".aube-mf-")
-        .suffix(".tmp")
-        .tempfile_in(parent)
+    aube_util::fs_atomic::atomic_write(path, body)
         .into_diagnostic()
-        .wrap_err_with(|| format!("failed to open tempfile for {}", path.display()))?;
-    {
-        use std::io::Write as _;
-        let mut f = tmp.as_file();
-        f.write_all(body)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to write tempfile for {}", path.display()))?;
-        f.sync_all()
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to sync tempfile for {}", path.display()))?;
-    }
-    tmp.persist(path)
-        .map_err(|e| miette!("failed to persist {}: {e}", path.display()))?;
-    Ok(())
+        .wrap_err_with(|| format!("failed to write {}", path.display()))
 }
 
 /// Parse the project lockfile, mapping `NotFound` to a user-facing hint

--- a/crates/aube/src/commands/npmrc.rs
+++ b/crates/aube/src/commands/npmrc.rs
@@ -13,7 +13,6 @@
 
 use aube_registry::config::{NpmConfig, normalize_registry_url_pub, registry_uri_key_pub};
 use miette::{Context, IntoDiagnostic, miette};
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Re-export of [`registry_uri_key_pub`] under the name used elsewhere
@@ -111,11 +110,6 @@ impl NpmrcEdit {
     /// original `~/.npmrc` intact rather than truncated (which would
     /// silently wipe every stored auth token).
     pub fn save(&self, path: &Path) -> miette::Result<()> {
-        let parent = path.parent().unwrap_or_else(|| Path::new("."));
-        std::fs::create_dir_all(parent)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
-
         let mut out = String::new();
         for line in &self.lines {
             match line {
@@ -129,14 +123,9 @@ impl NpmrcEdit {
             out.push('\n');
         }
 
-        let mut tmp = tempfile::NamedTempFile::new_in(parent)
+        aube_util::fs_atomic::atomic_write(path, out.as_bytes())
             .into_diagnostic()
-            .wrap_err_with(|| format!("failed to create temp file in {}", parent.display()))?;
-        tmp.write_all(out.as_bytes())
-            .into_diagnostic()
-            .wrap_err("failed to write temp npmrc")?;
-        tmp.persist(path)
-            .map_err(|e| miette!("failed to persist {}: {}", path.display(), e.error))?;
+            .wrap_err_with(|| format!("failed to write {}", path.display()))?;
         // .npmrc commonly holds _authToken values. Default umask
         // leaves the file at 0644 after the rename, readable by every
         // other user on a shared host. Force 0600 so only the owner

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -60,14 +60,7 @@ pub fn find_project_root(start: &Path) -> Option<PathBuf> {
 /// walk falls back to old unbounded behavior. Not ideal, but better
 /// than panicking, and CI runners always set one of them.
 fn home_stop_boundary() -> Option<PathBuf> {
-    if let Some(h) = std::env::var_os("HOME") {
-        return Some(PathBuf::from(h));
-    }
-    #[cfg(windows)]
-    if let Some(p) = std::env::var_os("USERPROFILE") {
-        return Some(PathBuf::from(p));
-    }
-    None
+    aube_util::env::home_dir()
 }
 
 /// Walk upward from `start` looking for the nearest workspace root.

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -73,6 +73,8 @@ pub struct InstallState {
     /// leaf-only diff.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub package_subtree_hashes: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub package_json_shape_digests: BTreeMap<String, String>,
     #[serde(default)]
     pub layout: Option<InstallLayoutState>,
 }
@@ -149,12 +151,29 @@ pub fn check_needs_install(project_dir: &Path) -> Option<String> {
         if !path.exists() {
             return Some(format!("{rel} is missing"));
         }
-        if hash_file(&path) != *stored_hash {
-            return Some(if rel == "." {
+        if hash_file(&path) == *stored_hash {
+            continue;
+        }
+        let stale_reason = || {
+            if rel == "." {
                 "package.json has changed".into()
             } else {
                 format!("{rel} has changed")
-            });
+            }
+        };
+        let Some(stored_shape) = state.package_json_shape_digests.get(rel) else {
+            return Some(stale_reason());
+        };
+        let Ok(content) = std::fs::read(&path) else {
+            return Some(stale_reason());
+        };
+        let parsed: Result<serde_json::Value, _> = serde_json::from_slice(&content);
+        let Ok(parsed) = parsed else {
+            return Some(stale_reason());
+        };
+        let current_shape = hex::encode(aube_util::hash::manifest_install_shape_digest(&parsed));
+        if current_shape != *stored_shape {
+            return Some(stale_reason());
         }
     }
 
@@ -252,6 +271,8 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         layout.placements,
     );
 
+    let package_json_shape_digests: BTreeMap<String, String> = BTreeMap::new();
+
     let state = InstallState {
         lockfile_hash,
         package_json_hashes,
@@ -261,38 +282,13 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         package_content_hashes,
         graph_lthash,
         package_subtree_hashes,
+        package_json_shape_digests,
         layout: Some(install_layout),
     };
 
     let state_path = state_file(project_dir);
-    if let Some(parent) = state_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let json = serde_json::to_string_pretty(&state)?;
-    // Atomic write via tempfile + rename. Old `fs::write` truncated
-    // the file in place, so Ctrl+C, AV quarantine, or a crash mid
-    // `write_all` left the state file zero bytes or partial JSON.
-    // Next install saw corrupt state, fell back to "install state
-    // not found" and ran a full cold install. User wondered why
-    // frozen fast path never kicked in. Rename on POSIX is atomic,
-    // on Windows ReplaceFileW behaves similarly post Win10.
-    let parent = state_path
-        .parent()
-        .unwrap_or_else(|| std::path::Path::new("."));
-    let tmp = tempfile::Builder::new()
-        .prefix(".aube-state-")
-        .suffix(".tmp")
-        .tempfile_in(parent)?;
-    use std::io::Write as _;
-    {
-        let mut f = tmp.as_file();
-        f.write_all(json.as_bytes())?;
-        f.sync_all()?;
-    }
-    // persist() does the atomic rename. On Windows it still succeeds
-    // when the target exists via MoveFileEx semantics.
-    tmp.persist(&state_path)
-        .map_err(|e| std::io::Error::other(format!("persist state: {e}")))?;
+    aube_util::fs_atomic::atomic_write(&state_path, json.as_bytes())?;
 
     Ok(())
 }
@@ -783,6 +779,7 @@ mod tests {
             package_content_hashes: BTreeMap::new(),
             graph_lthash: String::new(),
             package_subtree_hashes: BTreeMap::new(),
+            package_json_shape_digests: BTreeMap::new(),
             layout: Some(InstallLayoutState {
                 linker: InstallLayoutMode::Isolated,
                 direct_entries: BTreeMap::new(),
@@ -842,5 +839,54 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("temp dir should be creatable");
         dir
+    }
+
+    #[test]
+    fn shape_digest_keeps_fast_path_on_cosmetic_edit() {
+        use std::collections::BTreeMap;
+        let dir = temp_project_dir("shape-cosmetic");
+        let original = r#"{
+  "name": "x",
+  "dependencies": { "react": "19.0.0" },
+  "scripts": { "test": "vitest" }
+}"#;
+        let pkg_path = dir.join("package.json");
+        std::fs::write(&pkg_path, original).unwrap();
+
+        let orig_bytes = std::fs::read(&pkg_path).unwrap();
+        let orig_parsed: serde_json::Value = serde_json::from_slice(&orig_bytes).unwrap();
+        let orig_shape = hex::encode(aube_util::hash::manifest_install_shape_digest(&orig_parsed));
+
+        let mut pjh = BTreeMap::new();
+        pjh.insert(".".to_string(), hash_file(&pkg_path));
+        let mut shapes = BTreeMap::new();
+        shapes.insert(".".to_string(), orig_shape);
+        let state = InstallState {
+            lockfile_hash: String::new(),
+            package_json_hashes: pjh,
+            aube_version: env!("CARGO_PKG_VERSION").to_string(),
+            section_filtered: false,
+            settings_hash: String::new(),
+            package_content_hashes: BTreeMap::new(),
+            graph_lthash: String::new(),
+            package_subtree_hashes: BTreeMap::new(),
+            package_json_shape_digests: shapes,
+            layout: None,
+        };
+        let reformatted = r#"{
+  "name": "x",
+  "dependencies": { "react": "19.0.0" },
+  "scripts": { "test": "jest" }
+}
+"#;
+        std::fs::write(&pkg_path, reformatted).unwrap();
+
+        let new_bytes = std::fs::read(&pkg_path).unwrap();
+        let new_parsed: serde_json::Value = serde_json::from_slice(&new_bytes).unwrap();
+        let new_shape = hex::encode(aube_util::hash::manifest_install_shape_digest(&new_parsed));
+        assert_eq!(
+            new_shape, state.package_json_shape_digests["."],
+            "shape digest should ignore scripts + whitespace"
+        );
     }
 }

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -271,7 +271,22 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         layout.placements,
     );
 
-    let package_json_shape_digests: BTreeMap<String, String> = BTreeMap::new();
+    let package_json_shape_digests: BTreeMap<String, String> = package_json_hashes
+        .keys()
+        .filter_map(|rel| {
+            let path = if rel == "." {
+                project_dir.join("package.json")
+            } else {
+                project_dir.join(rel)
+            };
+            let bytes = std::fs::read(&path).ok()?;
+            let parsed: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+            Some((
+                rel.clone(),
+                hex::encode(aube_util::hash::manifest_install_shape_digest(&parsed)),
+            ))
+        })
+        .collect();
 
     let state = InstallState {
         lockfile_hash,

--- a/crates/aube/src/update_check.rs
+++ b/crates/aube/src/update_check.rs
@@ -63,7 +63,7 @@ fn should_check(offline: bool) -> bool {
     if offline {
         return false;
     }
-    if std::env::var_os("CI").is_some() {
+    if aube_util::env::is_ci() {
         return false;
     }
     if std::env::var_os("AUBE_NO_UPDATE_CHECK").is_some() {


### PR DESCRIPTION
## Summary

- new crate `aube-util` hosts `env`, `fs_atomic`, `hash` modules
- 20+ sites across 8 crates migrated to shared helpers so future fixes + perf tweaks land everywhere at once

## shipped

**helpers**
- `fs_atomic::{atomic_write, rename_with_retry, sibling_tempdir, sentinel::{mark, present, read_tag}}`
- `env::{is_ci, home_dir}`
- `hash::{keyset_hash, meta_hash, manifest_install_shape_digest, INSTALL_SHAPE_FIELDS, canonical_json}`

**migrations**
- atomic-replace: `.aube-state`, lockfile, side-effects cache, manifest workspace yaml, catalogs cleanup, `add --no-save` restore, packument cache, manifest-atomic, `.npmrc` save, `node-gyp-bootstrap` writes
- rename-with-retry: linker virtual-store rename, store git-clone rename
- sentinel: `.aube-initialized` per-package marker at linker materialize entry/exit
- CI / HOME lookup unified across resolver, update-check, linker, registry config, commands, project-root walk

## perf

- resolver packument semaphore now honors `network-concurrency` (was hardcoded `64`)
- linker rayon pool cached by thread count across 7 materialize phases
- aube-store thread_local BLAKE3 + SHA-512 hashers reset between uses (no per-file `::new`)
- peer_context convergence probe: `keyset_hash` replaces per-iteration full `Vec<String>` clone
- `scope_map_from_deps`: byte-level prefix check, no `format!`
- `dep_path_to_filename`: single-pass paren flatten, no throwaway Strings
- `verify_integrity`: stack `[u8; 64]` buffer, skip base64 encode alloc
- `Cache-Control: max-age` / `s-maxage` / `no-cache` honored in packument freshness (was blanket 30-min TTL)

## consistency

- aube-linker `log::` → `tracing::`, Cargo dep swap
- aube-scripts `set_script_settings` / `script_settings` recover from poisoned lock via `into_inner` (no panic at public API)
- `SHA512_INTEGRITY_PREFIX`, `CACHE_DIR_NAME`, `INDEX_SUBDIR`, `VIRTUAL_STORE_SUBDIR`, `PACKUMENT_CACHE_SUBDIR`, `PACKUMENT_FULL_CACHE_SUBDIR` exported from aube-store
- `default_linker_parallelism` exported from aube-linker and reused at install materialize site

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --release` — 1012 passed / 0 failed