### PR TITLE
lockfile(bun): preserve top-level + per-entry metadata on roundtrip

### DIFF
--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -282,8 +282,13 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         // through the default registry and either 404-ing or
         // downloading the wrong tarball.
         let alias_name = bun_key_to_alias_name(key);
-        let (name, version, local_source, alias_of) =
-            classify_bun_ident(&alias_name, &raw_name, &raw_version, path)?;
+        let (name, version, local_source, alias_of) = classify_bun_ident(
+            &alias_name,
+            &raw_name,
+            &raw_version,
+            entry.integrity.as_deref(),
+            path,
+        )?;
         key_info.insert(key.clone(), (name.clone(), version.clone()));
 
         let dep_path = format!("{name}@{version}");
@@ -529,7 +534,19 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         bun_config_version: Some(raw.config_version),
         overrides: raw.overrides,
         patched_dependencies: raw.patched_dependencies,
-        trusted_dependencies: raw.trusted_dependencies.into_iter().collect(),
+        // Preserve bun's insertion order verbatim — dedupe to guard
+        // against a hand-authored lockfile with repeats but never
+        // reorder, so a re-emit is byte-identical to bun's own output.
+        trusted_dependencies: {
+            let mut seen = BTreeSet::new();
+            let mut out: Vec<String> = Vec::with_capacity(raw.trusted_dependencies.len());
+            for name in raw.trusted_dependencies {
+                if seen.insert(name.clone()) {
+                    out.push(name);
+                }
+            }
+            out
+        },
         catalogs: catalogs_map,
         extra_fields: raw.extra,
         workspace_extra_fields,
@@ -571,6 +588,7 @@ fn classify_bun_ident(
     alias_name: &str,
     raw_name: &str,
     raw_version: &str,
+    integrity: Option<&str>,
     _path: &Path,
 ) -> Result<(String, String, Option<LocalSource>, Option<String>), Error> {
     // npm-alias tail: bun writes the registry identity into the ident,
@@ -585,11 +603,17 @@ fn classify_bun_ident(
 
     // Non-registry tails.
     if raw_version.starts_with("workspace:") {
-        let rel = raw_version
-            .strip_prefix("workspace:")
-            .unwrap_or("")
-            .to_string();
-        let path_buf = std::path::PathBuf::from(if rel.is_empty() { "." } else { rel.as_str() });
+        let rel = raw_version.strip_prefix("workspace:").unwrap_or("");
+        // `workspace:*` / `workspace:^` / `workspace:~` are version-
+        // range selectors, not directory paths — a `PathBuf::from("*")`
+        // would silently become `{project_root}/*` under any caller
+        // that does `project_root.join(link.path())`. Only treat the
+        // tail as a path when it looks like one (leading `.` or `/`);
+        // otherwise fall back to `.` so the link points at the
+        // workspace root and the caller resolves the actual location
+        // from the graph's workspace map.
+        let is_path = rel.starts_with('.') || rel.starts_with('/');
+        let path_buf = std::path::PathBuf::from(if rel.is_empty() || !is_path { "." } else { rel });
         return Ok((
             name,
             raw_version.to_string(),
@@ -627,12 +651,17 @@ fn classify_bun_ident(
         ));
     }
     if raw_version.starts_with("http://") || raw_version.starts_with("https://") {
+        // Mirror the sibling `LockedPackage.integrity` hash onto the
+        // `RemoteTarballSource` so consumers of
+        // `local_source.specifier()` or integrity-verification paths
+        // see the same value — leaving it empty would make the two
+        // fields drift apart for the same entry.
         return Ok((
             name,
             raw_version.to_string(),
             Some(LocalSource::RemoteTarball(RemoteTarballSource {
                 url: raw_version.to_string(),
-                integrity: String::new(),
+                integrity: integrity.map(str::to_string).unwrap_or_default(),
             })),
             alias_of,
         ));
@@ -2329,8 +2358,11 @@ mod tests {
                 .map(String::as_str),
             Some("patches/lodash@4.17.21.patch")
         );
-        assert!(graph.trusted_dependencies.contains("sharp"));
-        assert!(graph.trusted_dependencies.contains("esbuild"));
+        assert_eq!(
+            graph.trusted_dependencies,
+            vec!["sharp".to_string(), "esbuild".to_string()],
+            "trustedDependencies must preserve bun's original order on parse"
+        );
         assert_eq!(graph.catalogs["default"]["react"].specifier, "^18.2.0");
         assert_eq!(graph.catalogs["evens"]["date-fns"].specifier, "^2.30.0");
 
@@ -2356,6 +2388,19 @@ mod tests {
         assert!(
             written.contains("\"trustedDependencies\""),
             "trustedDependencies dropped:\n{written}"
+        );
+        // trustedDependencies must round-trip in insertion order
+        // (bun writes [sharp, esbuild] — alphabetized emit would
+        // produce a gratuitous diff against bun's own output).
+        let sharp_at = written
+            .find("\"sharp\"")
+            .expect("sharp in trustedDependencies");
+        let esbuild_at = written
+            .find("\"esbuild\"")
+            .expect("esbuild in trustedDependencies");
+        assert!(
+            sharp_at < esbuild_at,
+            "trustedDependencies reordered on write — expected sharp before esbuild:\n{written}"
         );
         assert!(
             written.contains("\"catalog\""),

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -92,15 +92,12 @@ struct RawBunWorkspace {
     dev_dependencies: BTreeMap<String, String>,
     #[serde(default)]
     optional_dependencies: BTreeMap<String, String>,
-    /// bun's workspaces carry these verbatim; preserving them on
-    /// round-trip is load-bearing when the lockfile is the
-    /// authoritative source for peer metadata (bun treats it as such
-    /// for non-root workspaces).
-    #[serde(default)]
-    peer_dependencies: BTreeMap<String, String>,
     /// Unknown per-workspace fields (`name`, `version`, `bin`,
-    /// `optionalPeers`, and anything else bun adds in a future
-    /// release) preserved verbatim.
+    /// `peerDependencies`, `optionalPeers`, and anything else bun
+    /// adds in a future release) preserved verbatim. The writer's
+    /// ws-extras fallback re-emits them so bun-authored workspace
+    /// peer data round-trips even when the manifest isn't
+    /// authoritative for the importer.
     #[serde(flatten)]
     extra: BTreeMap<String, serde_json::Value>,
 }
@@ -720,7 +717,6 @@ impl Clone for RawBunWorkspace {
             dependencies: self.dependencies.clone(),
             dev_dependencies: self.dev_dependencies.clone(),
             optional_dependencies: self.optional_dependencies.clone(),
-            peer_dependencies: self.peer_dependencies.clone(),
             extra: self.extra.clone(),
         }
     }
@@ -2618,5 +2614,73 @@ mod tests {
         assert_eq!(foo2.os, foo.os);
         assert_eq!(foo2.cpu, foo.cpu);
         assert_eq!(foo2.libc, foo.libc);
+    }
+
+    /// Workspace-level `peerDependencies` must survive round-trip
+    /// through the serde-flatten `extra` map even though aube's
+    /// typed workspace model doesn't claim the field directly. The
+    /// prior revision had a typed slot that silently drained bun's
+    /// peer block without plumbing it anywhere — regression guard.
+    #[test]
+    fn test_roundtrip_workspace_peer_dependencies() {
+        use tempfile::TempDir;
+
+        let project = TempDir::new().unwrap();
+        let project_dir = project.path();
+        std::fs::write(
+            project_dir.join("package.json"),
+            r#"{"name":"root","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(project_dir.join("packages/app")).unwrap();
+        // Non-root workspace's package.json deliberately omits
+        // peerDependencies; the lockfile is the only place they live.
+        std::fs::write(
+            project_dir.join("packages/app/package.json"),
+            r#"{"name":"app","version":"2.0.0"}"#,
+        )
+        .unwrap();
+
+        let lock_path = project_dir.join("bun.lock");
+        std::fs::write(
+            &lock_path,
+            r#"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "root" },
+    "packages/app": {
+      "name": "app",
+      "version": "2.0.0",
+      "peerDependencies": { "react": "^18.0.0" }
+    }
+  },
+  "packages": {}
+}"#,
+        )
+        .unwrap();
+
+        let graph = parse(&lock_path).unwrap();
+        let app_extras = graph
+            .workspace_extra_fields
+            .get("packages/app")
+            .expect("packages/app workspace_extra_fields entry");
+        let peers = app_extras
+            .get("peerDependencies")
+            .and_then(serde_json::Value::as_object)
+            .expect("peerDependencies captured in extras");
+        assert_eq!(peers.get("react").and_then(|v| v.as_str()), Some("^18.0.0"));
+
+        let manifest =
+            aube_manifest::PackageJson::from_path(&project_dir.join("package.json")).unwrap();
+        write(&lock_path, &graph, &manifest).unwrap();
+        let written = std::fs::read_to_string(&lock_path).unwrap();
+        assert!(
+            written.contains("\"peerDependencies\""),
+            "workspace peerDependencies dropped on re-emit:\n{written}"
+        );
+        assert!(
+            written.contains("\"react\""),
+            "workspace peerDependencies.react dropped on re-emit:\n{written}"
+        );
     }
 }

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -31,7 +31,10 @@
 //! allowed. We pre-process the content to strip those before handing it
 //! to `serde_json`.
 
-use crate::{DepType, DirectDep, Error, LocalSource, LockedPackage, LockfileGraph};
+use crate::{
+    DepType, DirectDep, Error, GitSource, LocalSource, LockedPackage, LockfileGraph, PeerDepMeta,
+    RemoteTarballSource,
+};
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
@@ -50,6 +53,30 @@ struct RawBunLockfile {
     workspaces: BTreeMap<String, RawBunWorkspace>,
     #[serde(default)]
     packages: BTreeMap<String, Vec<serde_json::Value>>,
+    /// bun 1.1+ top-level `overrides:` block (mirrors the key under
+    /// the same name in package.json). Map of selector → version.
+    #[serde(default)]
+    overrides: BTreeMap<String, String>,
+    /// bun 1.1+ top-level `patchedDependencies:` block. Map of
+    /// `pkg@version` selector → relative patch file path.
+    #[serde(default, rename = "patchedDependencies")]
+    patched_dependencies: BTreeMap<String, String>,
+    /// bun 1.1+ top-level `trustedDependencies:` — a package-name
+    /// allowlist for lifecycle script execution.
+    #[serde(default, rename = "trustedDependencies")]
+    trusted_dependencies: Vec<String>,
+    /// bun 1.2+ unnamed catalog (`catalog: { foo: "^1.0.0" }`).
+    /// Pairs with pnpm's `catalog:` in `pnpm-workspace.yaml`.
+    #[serde(default)]
+    catalog: BTreeMap<String, String>,
+    /// bun 1.2+ named catalogs (`catalogs: { evens: { foo: "^2" } }`).
+    #[serde(default)]
+    catalogs: BTreeMap<String, BTreeMap<String, String>>,
+    /// Unknown top-level fields preserved verbatim so a future bun
+    /// bump (or anything hand-authored we don't model) round-trips
+    /// without getting silently stripped.
+    #[serde(flatten)]
+    extra: BTreeMap<String, serde_json::Value>,
 }
 
 fn default_config_version() -> u32 {
@@ -65,6 +92,17 @@ struct RawBunWorkspace {
     dev_dependencies: BTreeMap<String, String>,
     #[serde(default)]
     optional_dependencies: BTreeMap<String, String>,
+    /// bun's workspaces carry these verbatim; preserving them on
+    /// round-trip is load-bearing when the lockfile is the
+    /// authoritative source for peer metadata (bun treats it as such
+    /// for non-root workspaces).
+    #[serde(default)]
+    peer_dependencies: BTreeMap<String, String>,
+    /// Unknown per-workspace fields (`name`, `version`, `bin`,
+    /// `optionalPeers`, and anything else bun adds in a future
+    /// release) preserved verbatim.
+    #[serde(flatten)]
+    extra: BTreeMap<String, serde_json::Value>,
 }
 
 /// Decoded view of one bun.lock package entry.
@@ -153,13 +191,35 @@ struct RawBunMeta {
     dependencies: BTreeMap<String, String>,
     #[serde(default)]
     optional_dependencies: BTreeMap<String, String>,
+    /// bun records peer declarations on the meta block in the same
+    /// shape as `dependencies`. Keeping them typed lets the writer
+    /// emit them back in bun's native field order; anything we don't
+    /// have an explicit slot for drops through to `extra` below.
+    #[serde(default)]
+    peer_dependencies: BTreeMap<String, String>,
+    /// Compact list form of `peerDependenciesMeta[name].optional:
+    /// true` — bun's preferred representation on per-entry meta.
+    #[serde(default)]
+    optional_peers: Vec<String>,
     /// `bin:` map — bun records executables by name on each package's
     /// meta block (`{ "bin": { "semver": "bin/semver.js" } }`). Round-
     /// tripping it is what keeps `aube install --no-frozen-lockfile`
     /// from silently dropping the `bin:` line and drifting against
     /// bun's own output.
     #[serde(default)]
-    bin: BTreeMap<String, String>,
+    bin: serde_json::Value,
+    /// Platform filters — bun writes arrays of `os` / `cpu` / `libc`
+    /// entries on meta blocks for optional platform packages.
+    #[serde(default)]
+    os: Vec<String>,
+    #[serde(default)]
+    cpu: Vec<String>,
+    #[serde(default)]
+    libc: Vec<String>,
+    /// Unknown per-entry meta fields preserved for round-trip
+    /// (`deprecated`, `hasInstallScript`, anything new bun adds).
+    #[serde(flatten)]
+    extra: BTreeMap<String, serde_json::Value>,
 }
 
 /// Parse a bun.lock file into a LockfileGraph.
@@ -202,7 +262,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     let mut packages: BTreeMap<String, LockedPackage> = BTreeMap::new();
 
     for (key, entry) in &entries {
-        let Some((name, version)) = split_ident(&entry.ident) else {
+        let Some((raw_name, raw_version)) = split_ident(&entry.ident) else {
             return Err(Error::parse(
                 path,
                 format!(
@@ -211,6 +271,19 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 ),
             ));
         };
+
+        // Detect non-registry specifiers embedded in bun's ident form
+        // (`foo@github:user/repo#sha`, `foo@file:./vendor`,
+        // `foo@https://…/pkg.tgz`, `foo@workspace:*`, …). The bun key
+        // is always the alias-side name; the ident carries the
+        // registry identity when bun wrote an npm-alias entry
+        // (`foo@npm:real@1.2.3`). Reconstructing a `LocalSource`
+        // here keeps the installer from re-routing every such entry
+        // through the default registry and either 404-ing or
+        // downloading the wrong tarball.
+        let alias_name = bun_key_to_alias_name(key);
+        let (name, version, local_source, alias_of) =
+            classify_bun_ident(&alias_name, &raw_name, &raw_version, path)?;
         key_info.insert(key.clone(), (name.clone(), version.clone()));
 
         let dep_path = format!("{name}@{version}");
@@ -249,6 +322,39 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             declared.insert(k.clone(), v.clone());
         }
 
+        // Normalize bun's `bin` meta into the typed BTreeMap while
+        // preserving the raw shape (string vs object) on `extra_meta`
+        // so the writer can echo the original representation back.
+        let bin_map = bin_value_to_map(&name, &entry.meta.bin);
+        let mut extra_meta = entry.meta.extra.clone();
+        if !matches!(&entry.meta.bin, serde_json::Value::Null) {
+            extra_meta.insert("bin".to_string(), entry.meta.bin.clone());
+        }
+        if !entry.meta.optional_peers.is_empty() {
+            extra_meta.insert(
+                "optionalPeers".to_string(),
+                serde_json::Value::Array(
+                    entry
+                        .meta
+                        .optional_peers
+                        .iter()
+                        .map(|s| serde_json::Value::String(s.clone()))
+                        .collect(),
+                ),
+            );
+        }
+
+        // Peer declarations survive on their typed slot so drift
+        // detection sees them; the meta map round-trip survives
+        // through `extra_meta` for anything we don't model.
+        let peer_dependencies = entry.meta.peer_dependencies.clone();
+        let peer_dependencies_meta: BTreeMap<String, PeerDepMeta> = entry
+            .meta
+            .optional_peers
+            .iter()
+            .map(|n| (n.clone(), PeerDepMeta { optional: true }))
+            .collect();
+
         packages.insert(
             dep_path.clone(),
             LockedPackage {
@@ -257,9 +363,17 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 integrity: entry.integrity.clone().filter(|s| !s.is_empty()),
                 dependencies: deps,
                 optional_dependencies: optional_deps,
+                peer_dependencies,
+                peer_dependencies_meta,
                 dep_path,
+                local_source,
+                alias_of,
+                os: entry.meta.os.iter().cloned().collect(),
+                cpu: entry.meta.cpu.iter().cloned().collect(),
+                libc: entry.meta.libc.iter().cloned().collect(),
                 declared_dependencies: declared,
-                bin: entry.meta.bin.clone(),
+                bin: bin_map,
+                extra_meta,
                 ..Default::default()
             },
         );
@@ -328,6 +442,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     // partial walk could wrongly match a literal npm package named
     // `packages` that has its own nested `foo` entry.
     let mut importers: BTreeMap<String, Vec<DirectDep>> = BTreeMap::new();
+    let mut workspace_extra_fields: BTreeMap<String, BTreeMap<String, serde_json::Value>> =
+        BTreeMap::new();
     for (ws_path, ws_raw) in &raw.workspaces {
         let importer_path = if ws_path.is_empty() {
             ".".to_string()
@@ -335,40 +451,238 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             ws_path.clone()
         };
         let mut direct: Vec<DirectDep> = Vec::new();
-        let push_dep = |name: &str, dep_type: DepType, direct: &mut Vec<DirectDep>| {
-            if let Some(target_key) = resolve_workspace_dep(ws_path, name, &key_info)
-                && let Some((dname, dver)) = key_info.get(&target_key)
-            {
-                direct.push(DirectDep {
-                    name: dname.clone(),
-                    dep_path: format!("{dname}@{dver}"),
-                    dep_type,
-                    specifier: None,
-                });
-            }
-        };
-        for n in ws_raw.dependencies.keys() {
-            push_dep(n, DepType::Production, &mut direct);
+        let push_dep =
+            |name: &str, specifier: &str, dep_type: DepType, direct: &mut Vec<DirectDep>| {
+                if let Some(target_key) = resolve_workspace_dep(ws_path, name, &key_info)
+                    && let Some((dname, dver)) = key_info.get(&target_key)
+                {
+                    direct.push(DirectDep {
+                        name: dname.clone(),
+                        dep_path: format!("{dname}@{dver}"),
+                        dep_type,
+                        specifier: Some(specifier.to_string()),
+                    });
+                }
+            };
+        for (n, spec) in &ws_raw.dependencies {
+            push_dep(n, spec, DepType::Production, &mut direct);
         }
-        for n in ws_raw.dev_dependencies.keys() {
-            push_dep(n, DepType::Dev, &mut direct);
+        for (n, spec) in &ws_raw.dev_dependencies {
+            push_dep(n, spec, DepType::Dev, &mut direct);
         }
-        for n in ws_raw.optional_dependencies.keys() {
-            push_dep(n, DepType::Optional, &mut direct);
+        for (n, spec) in &ws_raw.optional_dependencies {
+            push_dep(n, spec, DepType::Optional, &mut direct);
         }
-        importers.insert(importer_path, direct);
+        importers.insert(importer_path.clone(), direct);
+        if !ws_raw.extra.is_empty() {
+            workspace_extra_fields.insert(importer_path, ws_raw.extra.clone());
+        }
     }
     // The `importers` map always needs a `.` entry even when the
     // lockfile omits the `""` workspace entirely (hand-authored
     // fixtures sometimes do).
     importers.entry(".".to_string()).or_default();
 
+    // Translate bun's unnamed `catalog:` / named `catalogs:` blocks
+    // into the shared `LockfileGraph.catalogs` shape — outer key is
+    // the catalog name (`default` for the unnamed one), inner key is
+    // the package name. We don't have a separate resolved version on
+    // bun's side, so the `specifier` and `version` track the same
+    // value (the declared range); refreshing the catalog at resolve
+    // time rewrites `version` to the picked pin.
+    let mut catalogs_map: BTreeMap<String, BTreeMap<String, crate::CatalogEntry>> = BTreeMap::new();
+    if !raw.catalog.is_empty() {
+        let inner = raw
+            .catalog
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    crate::CatalogEntry {
+                        specifier: v.clone(),
+                        version: v.clone(),
+                    },
+                )
+            })
+            .collect();
+        catalogs_map.insert("default".to_string(), inner);
+    }
+    for (catalog_name, entries) in &raw.catalogs {
+        let inner = entries
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    crate::CatalogEntry {
+                        specifier: v.clone(),
+                        version: v.clone(),
+                    },
+                )
+            })
+            .collect();
+        catalogs_map.insert(catalog_name.clone(), inner);
+    }
+
     Ok(LockfileGraph {
         importers,
         packages,
         bun_config_version: Some(raw.config_version),
+        overrides: raw.overrides,
+        patched_dependencies: raw.patched_dependencies,
+        trusted_dependencies: raw.trusted_dependencies.into_iter().collect(),
+        catalogs: catalogs_map,
+        extra_fields: raw.extra,
+        workspace_extra_fields,
         ..Default::default()
     })
+}
+
+/// Extract the alias name bun uses as the hoist key. bun's `packages`
+/// key is `<alias_name>` hoisted or `<parent>/<alias_name>` nested,
+/// where `alias_name` matches `package.json`'s dep key verbatim.
+fn bun_key_to_alias_name(key: &str) -> String {
+    if let Some(last_slash) = key.rfind('/') {
+        // Scoped names like `@scope/name` are a single unit — if the
+        // slice before the last slash is itself `@scope`, keep the
+        // whole suffix.
+        let tail_start = key[..last_slash].rfind('/').map(|i| i + 1).unwrap_or(0);
+        if key[tail_start..last_slash].starts_with('@') {
+            key[tail_start..].to_string()
+        } else {
+            key[last_slash + 1..].to_string()
+        }
+    } else {
+        key.to_string()
+    }
+}
+
+/// Classify a bun ident's version tail as a registry pin, an npm alias
+/// target, or a non-registry source (git, file, link, workspace, http
+/// tarball). Returns `(name, version, local_source, alias_of)`.
+///
+/// - `alias_name` is the hoist key (bun's left-hand side).
+/// - `raw_name` / `raw_version` come from `split_ident()` on the ident
+///   (the right-hand side of the tuple's position 0).
+///
+/// The alias name wins as `LockedPackage.name` whenever it differs
+/// from the ident's name (npm-alias case). `alias_of` records the
+/// registry-side name only then.
+fn classify_bun_ident(
+    alias_name: &str,
+    raw_name: &str,
+    raw_version: &str,
+    _path: &Path,
+) -> Result<(String, String, Option<LocalSource>, Option<String>), Error> {
+    // npm-alias tail: bun writes the registry identity into the ident,
+    // so the raw name is the real registry name and the alias key is
+    // the hoist name.
+    let alias_of = if alias_name != raw_name {
+        Some(raw_name.to_string())
+    } else {
+        None
+    };
+    let name = alias_name.to_string();
+
+    // Non-registry tails.
+    if raw_version.starts_with("workspace:") {
+        let rel = raw_version
+            .strip_prefix("workspace:")
+            .unwrap_or("")
+            .to_string();
+        let path_buf = std::path::PathBuf::from(if rel.is_empty() { "." } else { rel.as_str() });
+        return Ok((
+            name,
+            raw_version.to_string(),
+            Some(LocalSource::Link(path_buf)),
+            alias_of,
+        ));
+    }
+    if let Some(rest) = raw_version.strip_prefix("github:") {
+        let (url, committish) = split_committish(rest);
+        return Ok((
+            name,
+            raw_version.to_string(),
+            Some(LocalSource::Git(GitSource {
+                url: format!("https://github.com/{url}.git"),
+                committish: committish.clone(),
+                resolved: committish.unwrap_or_default(),
+            })),
+            alias_of,
+        ));
+    }
+    if (raw_version.starts_with("git+")
+        || raw_version.starts_with("git://")
+        || raw_version.starts_with("git@"))
+        && let Some((url, committish)) = crate::parse_git_spec(raw_version)
+    {
+        return Ok((
+            name,
+            raw_version.to_string(),
+            Some(LocalSource::Git(GitSource {
+                url,
+                committish: committish.clone(),
+                resolved: committish.unwrap_or_default(),
+            })),
+            alias_of,
+        ));
+    }
+    if raw_version.starts_with("http://") || raw_version.starts_with("https://") {
+        return Ok((
+            name,
+            raw_version.to_string(),
+            Some(LocalSource::RemoteTarball(RemoteTarballSource {
+                url: raw_version.to_string(),
+                integrity: String::new(),
+            })),
+            alias_of,
+        ));
+    }
+    if let Some(rest) = raw_version.strip_prefix("file:") {
+        let rel = std::path::PathBuf::from(rest);
+        let kind = if LocalSource::path_looks_like_tarball(&rel) {
+            LocalSource::Tarball(rel)
+        } else {
+            LocalSource::Directory(rel)
+        };
+        return Ok((name, raw_version.to_string(), Some(kind), alias_of));
+    }
+    if let Some(rest) = raw_version.strip_prefix("link:") {
+        return Ok((
+            name,
+            raw_version.to_string(),
+            Some(LocalSource::Link(std::path::PathBuf::from(rest))),
+            alias_of,
+        ));
+    }
+    // Plain registry pin.
+    Ok((name, raw_version.to_string(), None, alias_of))
+}
+
+fn split_committish(spec: &str) -> (String, Option<String>) {
+    match spec.rfind('#') {
+        Some(i) => (spec[..i].to_string(), Some(spec[i + 1..].to_string())),
+        None => (spec.to_string(), None),
+    }
+}
+
+/// Normalize bun's `bin` meta (either a single-string form or a
+/// `{name: path}` object) into the typed BTreeMap LockedPackage uses.
+/// String form defaults the bin name to `default_name` (the package
+/// name), matching npm's own fallback when `package.json` writes
+/// `"bin": "./foo.js"` shorthand.
+fn bin_value_to_map(default_name: &str, value: &serde_json::Value) -> BTreeMap<String, String> {
+    match value {
+        serde_json::Value::String(s) => {
+            let mut map = BTreeMap::new();
+            map.insert(default_name.to_string(), s.clone());
+            map
+        }
+        serde_json::Value::Object(obj) => obj
+            .iter()
+            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+            .collect(),
+        _ => BTreeMap::new(),
+    }
 }
 
 impl Clone for RawBunWorkspace {
@@ -377,6 +691,8 @@ impl Clone for RawBunWorkspace {
             dependencies: self.dependencies.clone(),
             dev_dependencies: self.dev_dependencies.clone(),
             optional_dependencies: self.optional_dependencies.clone(),
+            peer_dependencies: self.peer_dependencies.clone(),
+            extra: self.extra.clone(),
         }
     }
 }
@@ -675,30 +991,34 @@ pub fn write(
     fn build_workspace_pairs(
         pj: &aube_manifest::PackageJson,
         is_root: bool,
-    ) -> Vec<(&'static str, Value)> {
-        let mut pairs: Vec<(&'static str, Value)> = Vec::new();
+        ws_extras: Option<&BTreeMap<String, Value>>,
+    ) -> Vec<(String, Value)> {
+        let mut pairs: Vec<(String, Value)> = Vec::new();
         if let Some(name) = &pj.name {
-            pairs.push(("name", json!(name)));
+            pairs.push(("name".to_string(), json!(name)));
         }
         if !is_root {
             if let Some(version) = &pj.version {
-                pairs.push(("version", json!(version)));
+                pairs.push(("version".to_string(), json!(version)));
             }
             if let Some(bin) = pj.extra.get("bin") {
-                pairs.push(("bin", bin.clone()));
+                pairs.push(("bin".to_string(), bin.clone()));
             }
         }
         if !pj.dependencies.is_empty() {
-            pairs.push(("dependencies", json!(pj.dependencies)));
+            pairs.push(("dependencies".to_string(), json!(pj.dependencies)));
         }
         if !pj.dev_dependencies.is_empty() {
-            pairs.push(("devDependencies", json!(pj.dev_dependencies)));
+            pairs.push(("devDependencies".to_string(), json!(pj.dev_dependencies)));
         }
         if !pj.optional_dependencies.is_empty() {
-            pairs.push(("optionalDependencies", json!(pj.optional_dependencies)));
+            pairs.push((
+                "optionalDependencies".to_string(),
+                json!(pj.optional_dependencies),
+            ));
         }
         if !pj.peer_dependencies.is_empty() {
-            pairs.push(("peerDependencies", json!(pj.peer_dependencies)));
+            pairs.push(("peerDependencies".to_string(), json!(pj.peer_dependencies)));
         }
         if !is_root
             && let Some(meta) = pj
@@ -723,16 +1043,36 @@ pub fn write(
                     .into_iter()
                     .map(|k| Value::String(k.clone()))
                     .collect();
-                pairs.push(("optionalPeers", Value::Array(optional_peers)));
+                pairs.push(("optionalPeers".to_string(), Value::Array(optional_peers)));
+            }
+        }
+        // Re-emit unknown workspace fields (anything bun writes that
+        // we don't model above) so a bun-side roundtrip preserves
+        // them verbatim. Skip keys we've already rendered to avoid
+        // duplicating the serde-flatten collision with typed fields.
+        if let Some(extras) = ws_extras {
+            let already: BTreeSet<String> = pairs.iter().map(|(k, _)| k.clone()).collect();
+            for (k, v) in extras {
+                if already.contains(k) {
+                    continue;
+                }
+                pairs.push((k.clone(), v.clone()));
             }
         }
         pairs
     }
 
-    let mut workspace_pairs: Vec<(String, Vec<(&'static str, Value)>)> = Vec::new();
-    workspace_pairs.push(("".to_string(), build_workspace_pairs(manifest, true)));
+    let mut workspace_pairs: Vec<(String, Vec<(String, Value)>)> = Vec::new();
+    workspace_pairs.push((
+        "".to_string(),
+        build_workspace_pairs(manifest, true, graph.workspace_extra_fields.get(".")),
+    ));
     for (importer_path, pj) in &workspace_manifests {
-        workspace_pairs.push((importer_path.clone(), build_workspace_pairs(pj, false)));
+        let extras = graph.workspace_extra_fields.get(importer_path);
+        workspace_pairs.push((
+            importer_path.clone(),
+            build_workspace_pairs(pj, false, extras),
+        ));
     }
 
     let mut package_entries: Vec<(String, Value)> = Vec::new();
@@ -788,6 +1128,33 @@ pub fn write(
                 Value::Object(opt_deps_obj),
             );
         }
+        // Peer declarations survive on bun's per-entry meta.
+        // Collapsing them into `dependencies` on re-emit is one of
+        // the reported parity bugs, so round-trip through the typed
+        // slot.
+        if !pkg.peer_dependencies.is_empty() {
+            let map: serde_json::Map<String, Value> = pkg
+                .peer_dependencies
+                .iter()
+                .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+                .collect();
+            meta.insert("peerDependencies".to_string(), Value::Object(map));
+        }
+        // `optionalPeers` is bun's compact list form — derive from
+        // `peer_dependencies_meta` when present, fall back to any
+        // original extra_meta["optionalPeers"] array.
+        let optional_peer_names: Vec<String> = pkg
+            .peer_dependencies_meta
+            .iter()
+            .filter(|(_, v)| v.optional)
+            .map(|(k, _)| k.clone())
+            .collect();
+        if !optional_peer_names.is_empty() {
+            let mut sorted = optional_peer_names.clone();
+            sorted.sort();
+            let arr: Vec<Value> = sorted.into_iter().map(Value::String).collect();
+            meta.insert("optionalPeers".to_string(), Value::Array(arr));
+        }
         // Preserve the full `bin:` map — bun's meta block records
         // executables by name so `bun install --frozen-lockfile` can
         // recreate the `.bin` shims without re-reading each tarball's
@@ -795,21 +1162,72 @@ pub fn write(
         // both representations on `LockedPackage.bin` so either
         // writer can render byte-identical output.
         //
+        // Prefer the original shape captured in `extra_meta["bin"]`
+        // (string vs object) so a bun-authored lockfile that wrote
+        // `"bin": "./foo"` doesn't round-trip to `"bin": {"foo": "./foo"}`.
         // Skip empty-key entries — those are the placeholder bins
         // pnpm's lockfile synthesizes when it knows `hasBin: true`
-        // but has no paths. Emitting them would produce a
-        // `{"bin": {"": ""}}` block bun wouldn't accept.
-        let real_bins: serde_json::Map<String, Value> = pkg
-            .bin
-            .iter()
-            .filter(|(k, _)| !k.is_empty())
-            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
-            .collect();
-        if !real_bins.is_empty() {
-            meta.insert("bin".to_string(), Value::Object(real_bins));
+        // but has no paths.
+        if let Some(raw_bin) = pkg.extra_meta.get("bin")
+            && !matches!(raw_bin, Value::Null)
+        {
+            meta.insert("bin".to_string(), raw_bin.clone());
+        } else {
+            let real_bins: serde_json::Map<String, Value> = pkg
+                .bin
+                .iter()
+                .filter(|(k, _)| !k.is_empty())
+                .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+                .collect();
+            if !real_bins.is_empty() {
+                meta.insert("bin".to_string(), Value::Object(real_bins));
+            }
+        }
+        // Preserve optional-platform packages' filter metadata so
+        // bun's platform-aware resolution still has what it needs
+        // on the next install.
+        if !pkg.os.is_empty() {
+            let arr: Vec<Value> = pkg.os.iter().map(|s| Value::String(s.clone())).collect();
+            meta.insert("os".to_string(), Value::Array(arr));
+        }
+        if !pkg.cpu.is_empty() {
+            let arr: Vec<Value> = pkg.cpu.iter().map(|s| Value::String(s.clone())).collect();
+            meta.insert("cpu".to_string(), Value::Array(arr));
+        }
+        if !pkg.libc.is_empty() {
+            let arr: Vec<Value> = pkg.libc.iter().map(|s| Value::String(s.clone())).collect();
+            meta.insert("libc".to_string(), Value::Array(arr));
+        }
+        // Extras: anything bun wrote on the meta block that we don't
+        // model on `LockedPackage` (e.g. `deprecated`,
+        // `hasInstallScript`). Skip keys we've already rendered to
+        // avoid duplicate slots — the serde-flatten capture would
+        // include them only if the typed slot was missing.
+        const MODELED_META_KEYS: &[&str] = &[
+            "dependencies",
+            "optionalDependencies",
+            "peerDependencies",
+            "optionalPeers",
+            "bin",
+            "os",
+            "cpu",
+            "libc",
+        ];
+        for (k, v) in &pkg.extra_meta {
+            if MODELED_META_KEYS.contains(&k.as_str()) {
+                continue;
+            }
+            meta.insert(k.clone(), v.clone());
         }
 
-        let ident = pkg.spec_key();
+        // npm-alias identity: bun writes the *registry* name and
+        // resolved version as the ident when the hoist key is an
+        // alias (`foo-alias: [bar@1.2.3, ...]`), not the alias name.
+        // Aube's earlier writer emitted `{name}@{version}` which
+        // collapsed to the alias name and produced a gratuitous diff
+        // against bun's own output.
+        let ident_name = pkg.alias_of.as_deref().unwrap_or(&pkg.name);
+        let ident = format!("{}@{}", ident_name, pkg.version);
         let integrity = pkg.integrity.clone().unwrap_or_default();
         let entry = Value::Array(vec![
             Value::String(ident),
@@ -824,7 +1242,85 @@ pub fn write(
     // lockfiles that predate the field) so a bun-bumped value round-
     // trips instead of silently downgrading on re-emit.
     let config_version = graph.bun_config_version.unwrap_or(1);
-    let body = format_bun_lockfile(&workspace_pairs, &package_entries, config_version);
+
+    // Collect top-level blocks bun understands natively. Overrides /
+    // catalog / catalogs / patchedDependencies / trustedDependencies
+    // are all round-tripped from the parsed graph; anything else the
+    // lockfile carried drops through `graph.extra_fields`.
+    let mut top_level_extras: Vec<(String, Value)> = Vec::new();
+    if !graph.overrides.is_empty() {
+        let mut obj = serde_json::Map::new();
+        for (k, v) in &graph.overrides {
+            obj.insert(k.clone(), Value::String(v.clone()));
+        }
+        top_level_extras.push(("overrides".to_string(), Value::Object(obj)));
+    }
+    if !graph.patched_dependencies.is_empty() {
+        let mut obj = serde_json::Map::new();
+        for (k, v) in &graph.patched_dependencies {
+            obj.insert(k.clone(), Value::String(v.clone()));
+        }
+        top_level_extras.push(("patchedDependencies".to_string(), Value::Object(obj)));
+    }
+    if !graph.trusted_dependencies.is_empty() {
+        let arr: Vec<Value> = graph
+            .trusted_dependencies
+            .iter()
+            .map(|s| Value::String(s.clone()))
+            .collect();
+        top_level_extras.push(("trustedDependencies".to_string(), Value::Array(arr)));
+    }
+    if let Some(default_catalog) = graph.catalogs.get("default") {
+        let mut obj = serde_json::Map::new();
+        for (k, v) in default_catalog {
+            obj.insert(k.clone(), Value::String(v.specifier.clone()));
+        }
+        if !obj.is_empty() {
+            top_level_extras.push(("catalog".to_string(), Value::Object(obj)));
+        }
+    }
+    let named_catalogs: BTreeMap<&String, &BTreeMap<String, crate::CatalogEntry>> = graph
+        .catalogs
+        .iter()
+        .filter(|(k, _)| k.as_str() != "default")
+        .collect();
+    if !named_catalogs.is_empty() {
+        let mut outer = serde_json::Map::new();
+        for (name, entries) in named_catalogs {
+            let mut inner = serde_json::Map::new();
+            for (k, v) in entries {
+                inner.insert(k.clone(), Value::String(v.specifier.clone()));
+            }
+            outer.insert(name.clone(), Value::Object(inner));
+        }
+        top_level_extras.push(("catalogs".to_string(), Value::Object(outer)));
+    }
+    // Finally, anything else the parser stashed in `extra_fields`
+    // (future bun bumps or hand-authored blocks we don't model).
+    const MODELED_TOP_KEYS: &[&str] = &[
+        "lockfileVersion",
+        "configVersion",
+        "workspaces",
+        "packages",
+        "overrides",
+        "patchedDependencies",
+        "trustedDependencies",
+        "catalog",
+        "catalogs",
+    ];
+    for (k, v) in &graph.extra_fields {
+        if MODELED_TOP_KEYS.contains(&k.as_str()) {
+            continue;
+        }
+        top_level_extras.push((k.clone(), v.clone()));
+    }
+
+    let body = format_bun_lockfile(
+        &workspace_pairs,
+        &package_entries,
+        config_version,
+        &top_level_extras,
+    );
     crate::atomic_write_lockfile(path, body.as_bytes())?;
     Ok(())
 }
@@ -849,9 +1345,10 @@ pub fn write(
 /// `config_version` is echoed back into the output as bun itself does —
 /// hardcoding would silently downgrade the field when bun bumps it.
 fn format_bun_lockfile(
-    workspaces: &[(String, Vec<(&'static str, serde_json::Value)>)],
+    workspaces: &[(String, Vec<(String, serde_json::Value)>)],
     package_entries: &[(String, serde_json::Value)],
     config_version: u32,
+    top_level_extras: &[(String, serde_json::Value)],
 ) -> String {
     let mut out = String::with_capacity(8192);
     out.push_str("{\n");
@@ -880,7 +1377,9 @@ fn format_bun_lockfile(
             // bun emits a trailing comma after every workspace-level
             // field, including the last one — `},` closes the block.
             match v {
-                serde_json::Value::Object(map) if !map.is_empty() && MULTILINE_KEYS.contains(k) => {
+                serde_json::Value::Object(map)
+                    if !map.is_empty() && MULTILINE_KEYS.contains(&k.as_str()) =>
+                {
                     out.push_str(&format!("      {key_str}: {{\n"));
                     for (dk, dv) in map {
                         out.push_str(&format!(
@@ -902,6 +1401,31 @@ fn format_bun_lockfile(
         out.push_str("    },\n");
     }
     out.push_str("  },\n");
+
+    // Top-level extras (`overrides`, `catalog`, `catalogs`,
+    // `patchedDependencies`, `trustedDependencies`, plus anything
+    // the parser captured in `extra_fields`). Emit in the order the
+    // caller supplied so a bun-first write preserves bun's own
+    // field order on re-read.
+    for (k, v) in top_level_extras {
+        let key_str = serde_json::to_string(k).unwrap();
+        match v {
+            serde_json::Value::Object(map) if !map.is_empty() => {
+                out.push_str(&format!("  {key_str}: {{\n"));
+                for (dk, dv) in map {
+                    out.push_str(&format!(
+                        "    {}: {},\n",
+                        serde_json::to_string(dk).unwrap(),
+                        inline_json(dv, 0)
+                    ));
+                }
+                out.push_str("  },\n");
+            }
+            _ => {
+                out.push_str(&format!("  {key_str}: {},\n", inline_json(v, 0)));
+            }
+        }
+    }
 
     // Packages block. Each entry is its own line; bun separates
     // entries with a blank line (an empty line between every
@@ -1755,5 +2279,299 @@ mod tests {
             bar.dep_path, "bar@1.0.0",
             "workspace `bar` must resolve to hoisted 1.0.0, not packages/bar@9.9.9"
         );
+    }
+
+    /// Top-level `overrides` / `patchedDependencies` / `trustedDependencies`
+    /// and the unnamed `catalog` / named `catalogs` blocks must round-trip
+    /// verbatim — bun preserves all five on re-emit, so aube dropping any
+    /// of them is a real-repo churn source on every install. Keep this
+    /// test format-agnostic (no SRI hashes, no packages) so it only
+    /// exercises the metadata-preservation path.
+    #[test]
+    fn test_roundtrip_top_level_metadata() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "root" }
+  },
+  "overrides": {
+    "lodash": "^4.17.21",
+    "lodash>debug": "^4.0.0"
+  },
+  "patchedDependencies": {
+    "lodash@4.17.21": "patches/lodash@4.17.21.patch"
+  },
+  "trustedDependencies": ["sharp", "esbuild"],
+  "catalog": {
+    "react": "^18.2.0"
+  },
+  "catalogs": {
+    "evens": { "date-fns": "^2.30.0" }
+  },
+  "packages": {}
+}"#;
+        std::fs::write(tmp.path(), content).unwrap();
+        let graph = parse(tmp.path()).unwrap();
+
+        assert_eq!(
+            graph.overrides.get("lodash").map(String::as_str),
+            Some("^4.17.21")
+        );
+        assert_eq!(
+            graph.overrides.get("lodash>debug").map(String::as_str),
+            Some("^4.0.0")
+        );
+        assert_eq!(
+            graph
+                .patched_dependencies
+                .get("lodash@4.17.21")
+                .map(String::as_str),
+            Some("patches/lodash@4.17.21.patch")
+        );
+        assert!(graph.trusted_dependencies.contains("sharp"));
+        assert!(graph.trusted_dependencies.contains("esbuild"));
+        assert_eq!(graph.catalogs["default"]["react"].specifier, "^18.2.0");
+        assert_eq!(graph.catalogs["evens"]["date-fns"].specifier, "^2.30.0");
+
+        let manifest = aube_manifest::PackageJson {
+            name: Some("root".to_string()),
+            ..Default::default()
+        };
+        let out = tempfile::NamedTempFile::new().unwrap();
+        write(out.path(), &graph, &manifest).unwrap();
+        let written = std::fs::read_to_string(out.path()).unwrap();
+
+        // Every round-tripped block must appear in the re-emitted
+        // lockfile — the exact rendering is implementation-defined
+        // but a substring check is enough to catch regression.
+        assert!(
+            written.contains("\"overrides\""),
+            "overrides dropped:\n{written}"
+        );
+        assert!(
+            written.contains("\"patchedDependencies\""),
+            "patchedDependencies dropped:\n{written}"
+        );
+        assert!(
+            written.contains("\"trustedDependencies\""),
+            "trustedDependencies dropped:\n{written}"
+        );
+        assert!(
+            written.contains("\"catalog\""),
+            "catalog dropped:\n{written}"
+        );
+        assert!(
+            written.contains("\"catalogs\""),
+            "catalogs dropped:\n{written}"
+        );
+
+        let reparsed = parse(out.path()).unwrap();
+        assert_eq!(reparsed.overrides, graph.overrides);
+        assert_eq!(reparsed.patched_dependencies, graph.patched_dependencies);
+        assert_eq!(reparsed.trusted_dependencies, graph.trusted_dependencies);
+        assert_eq!(reparsed.catalogs["default"]["react"].specifier, "^18.2.0");
+    }
+
+    /// Non-registry specifier classes (github:, file:, link:, https:,
+    /// workspace:) must parse into `LocalSource` rather than fall
+    /// through as registry pins. The installer routes by
+    /// `LocalSource`, so mis-classification here sends the package
+    /// through the default registry and either 404s or downloads the
+    /// wrong tarball — bug class #1 in the parity report.
+    #[test]
+    fn test_parse_routes_non_registry_specs_to_localsource() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "vfs": "github:collinstevens/vfs#0b6ea53",
+        "localdir": "file:./vendor/localdir",
+        "localtgz": "file:./vendor/thing.tgz",
+        "sibling": "link:../sibling",
+        "remote": "https://example.com/thing.tgz"
+      }
+    }
+  },
+  "packages": {
+    "vfs": ["vfs@github:collinstevens/vfs#0b6ea53abcdef", {}, "collinstevens-vfs-0b6ea53abcdef"],
+    "localdir": ["localdir@file:./vendor/localdir", {}],
+    "localtgz": ["localtgz@file:./vendor/thing.tgz", {}],
+    "sibling": ["sibling@link:../sibling", {}],
+    "remote": ["remote@https://example.com/thing.tgz", {}]
+  }
+}"#;
+        std::fs::write(tmp.path(), content).unwrap();
+        let graph = parse(tmp.path()).unwrap();
+
+        let vfs = graph
+            .packages
+            .values()
+            .find(|p| p.name == "vfs")
+            .expect("vfs package");
+        assert!(
+            matches!(vfs.local_source, Some(LocalSource::Git(_))),
+            "github dep must be LocalSource::Git, got {:?}",
+            vfs.local_source
+        );
+
+        let localdir = graph
+            .packages
+            .values()
+            .find(|p| p.name == "localdir")
+            .expect("localdir package");
+        assert!(
+            matches!(localdir.local_source, Some(LocalSource::Directory(_))),
+            "file:./dir must be LocalSource::Directory, got {:?}",
+            localdir.local_source
+        );
+
+        let localtgz = graph
+            .packages
+            .values()
+            .find(|p| p.name == "localtgz")
+            .expect("localtgz package");
+        assert!(
+            matches!(localtgz.local_source, Some(LocalSource::Tarball(_))),
+            "file:./*.tgz must be LocalSource::Tarball, got {:?}",
+            localtgz.local_source
+        );
+
+        let sibling = graph
+            .packages
+            .values()
+            .find(|p| p.name == "sibling")
+            .expect("sibling package");
+        assert!(
+            matches!(sibling.local_source, Some(LocalSource::Link(_))),
+            "link: must be LocalSource::Link, got {:?}",
+            sibling.local_source
+        );
+
+        let remote = graph
+            .packages
+            .values()
+            .find(|p| p.name == "remote")
+            .expect("remote package");
+        assert!(
+            matches!(remote.local_source, Some(LocalSource::RemoteTarball(_))),
+            "https://*.tgz must be LocalSource::RemoteTarball, got {:?}",
+            remote.local_source
+        );
+    }
+
+    /// npm-alias ident: bun writes `<real>@<version>` as the ident
+    /// string while using the alias name as the `packages[]` hoist
+    /// key. Aube's earlier writer emitted `<alias>@<version>` and
+    /// produced a gratuitous diff against bun's own output. Cover
+    /// both parse (populates `alias_of`) and write (emits real name
+    /// in ident).
+    #[test]
+    fn test_parse_and_write_npm_alias() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sri = fake_sri('a');
+        let content = r#"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "dependencies": { "h3-v2": "npm:h3@2.0.1" } }
+  },
+  "packages": {
+    "h3-v2": ["h3@2.0.1", "", {}, "SRI"]
+  }
+}"#
+        .replace("SRI", &sri);
+        std::fs::write(tmp.path(), &content).unwrap();
+        let graph = parse(tmp.path()).unwrap();
+        let h3 = graph
+            .packages
+            .values()
+            .find(|p| p.name == "h3-v2")
+            .expect("h3-v2 package");
+        assert_eq!(h3.alias_of.as_deref(), Some("h3"));
+        assert_eq!(h3.version, "2.0.1");
+
+        let manifest = aube_manifest::PackageJson {
+            name: Some("root".to_string()),
+            dependencies: [("h3-v2".to_string(), "npm:h3@2.0.1".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let out = tempfile::NamedTempFile::new().unwrap();
+        write(out.path(), &graph, &manifest).unwrap();
+        let written = std::fs::read_to_string(out.path()).unwrap();
+
+        // Ident reads `h3@2.0.1` (registry identity), not `h3-v2@...`.
+        assert!(
+            written.contains("\"h3@2.0.1\""),
+            "expected ident `h3@2.0.1`, got:\n{written}"
+        );
+        assert!(
+            !written.contains("\"h3-v2@2.0.1\""),
+            "alias-name ident leaked into packages entry:\n{written}"
+        );
+    }
+
+    /// Per-entry meta blocks bun preserves that aube historically
+    /// dropped: `peerDependencies`, `optionalPeers`, `os`, `cpu`,
+    /// `libc`. Round-trip through a single package entry and confirm
+    /// every field survives re-parse.
+    #[test]
+    fn test_roundtrip_peer_and_platform_metadata() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sri = fake_sri('a');
+        let content = r#"{
+  "lockfileVersion": 1,
+  "workspaces": { "": { "dependencies": { "foo": "^1.0.0" } } },
+  "packages": {
+    "foo": ["foo@1.0.0", "", {
+      "peerDependencies": { "react": "^18.0.0" },
+      "optionalPeers": ["react"],
+      "os": ["darwin", "linux"],
+      "cpu": ["arm64", "x64"],
+      "libc": ["glibc"]
+    }, "SRI"]
+  }
+}"#
+        .replace("SRI", &sri);
+        std::fs::write(tmp.path(), &content).unwrap();
+        let graph = parse(tmp.path()).unwrap();
+        let foo = &graph.packages["foo@1.0.0"];
+        assert_eq!(
+            foo.peer_dependencies.get("react").map(String::as_str),
+            Some("^18.0.0")
+        );
+        assert!(
+            foo.peer_dependencies_meta
+                .get("react")
+                .is_some_and(|m| m.optional)
+        );
+        assert_eq!(
+            foo.os.as_slice(),
+            &["darwin".to_string(), "linux".to_string()]
+        );
+        assert_eq!(
+            foo.cpu.as_slice(),
+            &["arm64".to_string(), "x64".to_string()]
+        );
+        assert_eq!(foo.libc.as_slice(), &["glibc".to_string()]);
+
+        let manifest = aube_manifest::PackageJson {
+            name: Some("root".to_string()),
+            dependencies: [("foo".to_string(), "^1.0.0".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let out = tempfile::NamedTempFile::new().unwrap();
+        write(out.path(), &graph, &manifest).unwrap();
+        let reparsed = parse(out.path()).unwrap();
+        let foo2 = &reparsed.packages["foo@1.0.0"];
+        assert_eq!(foo2.peer_dependencies, foo.peer_dependencies);
+        assert_eq!(foo2.os, foo.os);
+        assert_eq!(foo2.cpu, foo.cpu);
+        assert_eq!(foo2.libc, foo.libc);
     }
 }

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -82,6 +82,31 @@ pub struct LockfileGraph {
     /// (e.g. from `2` back to `1`) when bun bumps it in a future
     /// release.
     pub bun_config_version: Option<u32>,
+    /// Top-level `patchedDependencies:` block mirrored by bun 1.1+ and
+    /// pnpm 9+. Key: selector (`lodash@4.17.21`), value: relative patch
+    /// file path (`patches/lodash@4.17.21.patch`). Round-tripped
+    /// verbatim so a parse/write cycle doesn't silently drop user
+    /// patches from the lockfile.
+    pub patched_dependencies: BTreeMap<String, String>,
+    /// Top-level `trustedDependencies:` block (bun) — a package-name
+    /// allowlist for lifecycle script execution. Preserved so
+    /// re-emitting a bun.lock doesn't strip the allowlist and cause
+    /// subsequent installs to skip scripts the user explicitly
+    /// approved.
+    pub trusted_dependencies: BTreeSet<String>,
+    /// Top-level lockfile fields that aren't explicitly modeled on
+    /// `LockfileGraph`. Populated by per-format parsers on best-effort
+    /// basis so the writer can re-emit blocks a future lockfile
+    /// version might add (or ones we haven't promoted to typed fields
+    /// yet) without silently stripping them on round-trip. Each
+    /// parser/writer is responsible for emitting values in its
+    /// format's native serialization.
+    pub extra_fields: BTreeMap<String, serde_json::Value>,
+    /// Per-workspace-importer extras keyed by importer path (`""` for
+    /// root in bun, `"."` for others). Stores anything in the
+    /// workspace entry the typed model doesn't capture so a parse/
+    /// write cycle doesn't drop fields the user (or bun) wrote there.
+    pub workspace_extra_fields: BTreeMap<String, BTreeMap<String, serde_json::Value>>,
 }
 
 /// One entry in a lockfile catalog: the workspace-declared range and the
@@ -567,6 +592,14 @@ pub struct LockedPackage {
     /// Round-tripped so npm's lockfile keeps its per-entry
     /// `"funding": {"url": "…"}` block.
     pub funding_url: Option<String>,
+    /// Per-package-meta extras preserved verbatim from the source
+    /// lockfile. Captures fields the typed model doesn't yet cover
+    /// (`deprecated`, `hasInstallScript`, bun's `optionalPeers`, and
+    /// anything a future lockfile bump adds) so a parse/write cycle
+    /// doesn't drop them. Each format's writer re-emits what makes
+    /// sense there — bun inlines the extras back on the package-entry
+    /// meta object, pnpm / yarn / npm currently ignore them.
+    pub extra_meta: BTreeMap<String, serde_json::Value>,
 }
 
 impl LockedPackage {
@@ -762,6 +795,10 @@ impl LockfileGraph {
             skipped_optional_dependencies: self.skipped_optional_dependencies.clone(),
             catalogs: self.catalogs.clone(),
             bun_config_version: self.bun_config_version,
+            patched_dependencies: self.patched_dependencies.clone(),
+            trusted_dependencies: self.trusted_dependencies.clone(),
+            extra_fields: self.extra_fields.clone(),
+            workspace_extra_fields: self.workspace_extra_fields.clone(),
         }
     }
 
@@ -818,6 +855,10 @@ impl LockfileGraph {
             skipped_optional_dependencies,
             catalogs: self.catalogs.clone(),
             bun_config_version: self.bun_config_version,
+            patched_dependencies: self.patched_dependencies.clone(),
+            trusted_dependencies: self.trusted_dependencies.clone(),
+            extra_fields: self.extra_fields.clone(),
+            workspace_extra_fields: self.workspace_extra_fields.clone(),
         })
     }
 
@@ -850,9 +891,29 @@ impl LockfileGraph {
             if pkg.funding_url.is_none() && prior_pkg.funding_url.is_some() {
                 pkg.funding_url = prior_pkg.funding_url.clone();
             }
+            // Per-entry extras (`deprecated`, `optionalPeers`,
+            // format-specific fields bun/npm/yarn wrote into the
+            // meta block) can't be recovered from a fresh resolve,
+            // so carry them forward when the newer graph doesn't
+            // already carry its own. `self`-side keys always win.
+            for (k, v) in &prior_pkg.extra_meta {
+                pkg.extra_meta.entry(k.clone()).or_insert_with(|| v.clone());
+            }
         }
         if self.bun_config_version.is_none() {
             self.bun_config_version = prior.bun_config_version;
+        }
+        if self.patched_dependencies.is_empty() {
+            self.patched_dependencies = prior.patched_dependencies.clone();
+        }
+        if self.trusted_dependencies.is_empty() {
+            self.trusted_dependencies = prior.trusted_dependencies.clone();
+        }
+        if self.extra_fields.is_empty() {
+            self.extra_fields = prior.extra_fields.clone();
+        }
+        if self.workspace_extra_fields.is_empty() {
+            self.workspace_extra_fields = prior.workspace_extra_fields.clone();
         }
     }
 

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -93,7 +93,12 @@ pub struct LockfileGraph {
     /// re-emitting a bun.lock doesn't strip the allowlist and cause
     /// subsequent installs to skip scripts the user explicitly
     /// approved.
-    pub trusted_dependencies: BTreeSet<String>,
+    ///
+    /// Kept as a `Vec` (not a set) so bun's original order round-trips
+    /// byte-identically; bun emits the list in insertion order. The
+    /// parser is responsible for deduping if the source lockfile
+    /// carried a duplicate.
+    pub trusted_dependencies: Vec<String>,
     /// Top-level lockfile fields that aren't explicitly modeled on
     /// `LockfileGraph`. Populated by per-format parsers on best-effort
     /// basis so the writer can re-emit blocks a future lockfile

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use aube_manifest::PackageJson;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 /// Parse a pnpm-lock.yaml file into a LockfileGraph.
@@ -419,6 +419,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 // `None`.
                 license: None,
                 funding_url: None,
+                extra_meta: BTreeMap::new(),
             },
         );
     }
@@ -459,6 +460,13 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         })
         .collect();
 
+    let patched_dependencies: BTreeMap<String, String> = raw
+        .patched_dependencies
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(k, v)| (k, v.into_path()))
+        .collect();
+
     Ok(LockfileGraph {
         importers,
         packages,
@@ -473,6 +481,10 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         skipped_optional_dependencies,
         catalogs,
         bun_config_version: None,
+        patched_dependencies,
+        trusted_dependencies: BTreeSet::new(),
+        extra_fields: BTreeMap::new(),
+        workspace_extra_fields: BTreeMap::new(),
     })
 }
 
@@ -859,6 +871,15 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                     .collect(),
             )
         },
+        // pnpm v9 emits patched deps as `{ path, hash }`. We don't
+        // track the patch hash on the graph (install-time concern),
+        // so write the path form which pnpm still accepts. Skipped
+        // when empty to keep parity with no-patch installs.
+        patched_dependencies: if graph.patched_dependencies.is_empty() {
+            None
+        } else {
+            Some(graph.patched_dependencies.clone())
+        },
         time,
         importers,
         packages,
@@ -1036,6 +1057,11 @@ struct WritablePnpmLockfile {
     /// identical to pnpm's output.
     #[serde(skip_serializing_if = "Option::is_none")]
     ignored_optional_dependencies: Option<Vec<String>>,
+    /// pnpm v9+ top-level `patchedDependencies:` — preserved so a
+    /// bun→aube-lock conversion keeps the user's patches and a
+    /// re-emit doesn't strip the block.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    patched_dependencies: Option<BTreeMap<String, String>>,
     snapshots: BTreeMap<String, WritableSnapshot>,
 }
 
@@ -1275,6 +1301,13 @@ struct RawPnpmLockfile {
     overrides: Option<BTreeMap<String, String>>,
     #[serde(default)]
     catalogs: Option<BTreeMap<String, BTreeMap<String, RawCatalogEntry>>>,
+    /// pnpm v9+ top-level `patchedDependencies:` block. Map of
+    /// `pkg@version` selector → patch entry (pnpm uses a nested
+    /// `{ path, hash }` object, but we only model the path string
+    /// on the shared graph). Round-tripped verbatim so a parse/
+    /// write cycle doesn't drop user patches.
+    #[serde(default)]
+    patched_dependencies: Option<BTreeMap<String, RawPatchedDependency>>,
     #[serde(default)]
     ignored_optional_dependencies: Option<Vec<String>>,
     #[serde(default)]
@@ -1285,6 +1318,31 @@ struct RawPnpmLockfile {
     snapshots: BTreeMap<String, RawSnapshot>,
     #[serde(default)]
     time: Option<BTreeMap<String, String>>,
+}
+
+/// pnpm writes `patchedDependencies` as either a bare path string
+/// (v8 style) or a nested `{ path, hash }` object (v9+). We accept
+/// both via an untagged enum and collapse to the path string on the
+/// shared graph.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawPatchedDependency {
+    Path(String),
+    Object {
+        path: String,
+        #[serde(default)]
+        #[allow(dead_code)]
+        hash: Option<String>,
+    },
+}
+
+impl RawPatchedDependency {
+    fn into_path(self) -> String {
+        match self {
+            RawPatchedDependency::Path(p) => p,
+            RawPatchedDependency::Object { path, .. } => path,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use aube_manifest::PackageJson;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::Path;
 
 /// Parse a pnpm-lock.yaml file into a LockfileGraph.
@@ -482,7 +482,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         catalogs,
         bun_config_version: None,
         patched_dependencies,
-        trusted_dependencies: BTreeSet::new(),
+        trusted_dependencies: Vec::new(),
         extra_fields: BTreeMap::new(),
         workspace_extra_fields: BTreeMap::new(),
     })
@@ -1034,6 +1034,13 @@ struct WritablePnpmLockfile {
     // for the no-overrides case (the field is skipped when empty).
     #[serde(skip_serializing_if = "Option::is_none")]
     overrides: Option<BTreeMap<String, String>>,
+    /// pnpm v9+ top-level `patchedDependencies:` — preserved so a
+    /// bun→aube-lock conversion keeps the user's patches and a
+    /// re-emit doesn't strip the block. pnpm emits this block right
+    /// after `overrides:` and before `catalogs:`, so the field order
+    /// here follows the same sequence for byte-identical output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    patched_dependencies: Option<BTreeMap<String, String>>,
     /// pnpm v9 emits a top-level `catalogs:` map after
     /// `overrides:` and before `importers:` when `pnpm-workspace.yaml`
     /// declares any referenced catalog entries.
@@ -1057,11 +1064,6 @@ struct WritablePnpmLockfile {
     /// identical to pnpm's output.
     #[serde(skip_serializing_if = "Option::is_none")]
     ignored_optional_dependencies: Option<Vec<String>>,
-    /// pnpm v9+ top-level `patchedDependencies:` — preserved so a
-    /// bun→aube-lock conversion keeps the user's patches and a
-    /// re-emit doesn't strip the block.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    patched_dependencies: Option<BTreeMap<String, String>>,
     snapshots: BTreeMap<String, WritableSnapshot>,
 }
 
@@ -2112,6 +2114,59 @@ snapshots:
         assert_eq!(reparsed.overrides.len(), 2);
         assert_eq!(reparsed.overrides.get("lodash").unwrap(), "4.17.21");
         assert_eq!(reparsed.overrides.get("foo").unwrap(), "npm:bar@^2");
+    }
+
+    /// `patchedDependencies:` must land between `overrides:` and
+    /// `catalogs:` in the emitted YAML — that's where pnpm itself
+    /// writes it, and any other position produces a gratuitous diff
+    /// against pnpm's output on every install.
+    #[test]
+    fn patched_dependencies_emitted_after_overrides_before_catalogs() {
+        let dir = tempfile::tempdir().unwrap();
+        let lockfile_path = dir.path().join("pnpm-lock.yaml");
+
+        let mut overrides = BTreeMap::new();
+        overrides.insert("lodash".to_string(), "4.17.21".to_string());
+        let mut patched_dependencies = BTreeMap::new();
+        patched_dependencies.insert(
+            "lodash@4.17.21".to_string(),
+            "patches/lodash@4.17.21.patch".to_string(),
+        );
+        let mut default_catalog = BTreeMap::new();
+        default_catalog.insert(
+            "react".to_string(),
+            CatalogEntry {
+                specifier: "^18.2.0".to_string(),
+                version: "18.2.0".to_string(),
+            },
+        );
+        let mut catalogs = BTreeMap::new();
+        catalogs.insert("default".to_string(), default_catalog);
+
+        let graph = LockfileGraph {
+            overrides,
+            patched_dependencies,
+            catalogs,
+            ..Default::default()
+        };
+
+        let manifest = PackageJson {
+            name: Some("test".to_string()),
+            ..Default::default()
+        };
+
+        write(&lockfile_path, &graph, &manifest).unwrap();
+        let yaml = std::fs::read_to_string(&lockfile_path).unwrap();
+
+        let overrides_at = yaml.find("overrides:").expect("overrides:");
+        let patched_at = yaml
+            .find("patchedDependencies:")
+            .expect("patchedDependencies:");
+        let catalogs_at = yaml.find("catalogs:").expect("catalogs:");
+        assert!(
+            overrides_at < patched_at && patched_at < catalogs_at,
+            "expected order: overrides < patchedDependencies < catalogs, got\n{yaml}"
+        );
     }
 
     #[test]

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -529,6 +529,10 @@ pub(crate) fn dedupe_peer_variants(graph: LockfileGraph) -> LockfileGraph {
         skipped_optional_dependencies,
         catalogs,
         bun_config_version,
+        patched_dependencies,
+        trusted_dependencies,
+        extra_fields,
+        workspace_extra_fields,
     } = graph;
 
     let mut new_packages: BTreeMap<String, LockedPackage> = BTreeMap::new();
@@ -571,6 +575,10 @@ pub(crate) fn dedupe_peer_variants(graph: LockfileGraph) -> LockfileGraph {
         skipped_optional_dependencies,
         catalogs,
         bun_config_version,
+        patched_dependencies,
+        trusted_dependencies,
+        extra_fields,
+        workspace_extra_fields,
     }
 }
 
@@ -691,6 +699,10 @@ fn apply_peer_contexts_once(
         skipped_optional_dependencies: canonical.skipped_optional_dependencies,
         catalogs: canonical.catalogs,
         bun_config_version: canonical.bun_config_version,
+        patched_dependencies: canonical.patched_dependencies,
+        trusted_dependencies: canonical.trusted_dependencies,
+        extra_fields: canonical.extra_fields,
+        workspace_extra_fields: canonical.workspace_extra_fields,
     }
 }
 
@@ -914,6 +926,7 @@ pub(crate) fn dedupe_peer_suffixes(graph: LockfileGraph) -> LockfileGraph {
                 declared_dependencies: pkg.declared_dependencies,
                 license: pkg.license,
                 funding_url: pkg.funding_url,
+                extra_meta: pkg.extra_meta,
             },
         );
     }
@@ -951,6 +964,10 @@ pub(crate) fn dedupe_peer_suffixes(graph: LockfileGraph) -> LockfileGraph {
         skipped_optional_dependencies: graph.skipped_optional_dependencies,
         catalogs: graph.catalogs,
         bun_config_version: graph.bun_config_version,
+        patched_dependencies: graph.patched_dependencies,
+        trusted_dependencies: graph.trusted_dependencies,
+        extra_fields: graph.extra_fields,
+        workspace_extra_fields: graph.workspace_extra_fields,
     }
 }
 
@@ -1321,6 +1338,7 @@ fn visit_peer_context<'g>(
             declared_dependencies: pkg.declared_dependencies.clone(),
             license: pkg.license.clone(),
             funding_url: pkg.funding_url.clone(),
+            extra_meta: pkg.extra_meta.clone(),
         },
     );
     Some(contextualized)

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -1010,6 +1010,7 @@ impl Resolver {
                                     declared_dependencies: locked_pkg.declared_dependencies.clone(),
                                     license: locked_pkg.license.clone(),
                                     funding_url: locked_pkg.funding_url.clone(),
+                                    extra_meta: locked_pkg.extra_meta.clone(),
                                 },
                             );
 
@@ -1529,6 +1530,7 @@ impl Resolver {
                         },
                         license: version_meta.license.clone(),
                         funding_url: version_meta.funding_url.clone(),
+                        extra_meta: BTreeMap::new(),
                     },
                 );
 
@@ -1750,6 +1752,13 @@ impl Resolver {
             // defaults `configVersion` to 1 when emitting a fresh
             // lockfile.
             bun_config_version: None,
+            // Fresh resolves don't carry over unknown blocks; the
+            // install-side merge (`overlay_metadata_from`) copies
+            // them back from the prior lockfile when round-tripping.
+            patched_dependencies: BTreeMap::new(),
+            trusted_dependencies: BTreeSet::new(),
+            extra_fields: BTreeMap::new(),
+            workspace_extra_fields: BTreeMap::new(),
         };
 
         // Second pass: hoist every auto-installed peer to its importer's

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -1756,7 +1756,7 @@ impl Resolver {
             // install-side merge (`overlay_metadata_from`) copies
             // them back from the prior lockfile when round-tripping.
             patched_dependencies: BTreeMap::new(),
-            trusted_dependencies: BTreeSet::new(),
+            trusted_dependencies: Vec::new(),
             extra_fields: BTreeMap::new(),
             workspace_extra_fields: BTreeMap::new(),
         };

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -2260,7 +2260,7 @@ async fn resolve_handles_lockfile_reused_name_with_incompatible_transitive_range
         catalogs: BTreeMap::new(),
         bun_config_version: None,
         patched_dependencies: BTreeMap::new(),
-        trusted_dependencies: BTreeSet::new(),
+        trusted_dependencies: Vec::new(),
         extra_fields: BTreeMap::new(),
         workspace_extra_fields: BTreeMap::new(),
     };
@@ -2333,7 +2333,7 @@ async fn lockfile_reuse_preserves_transitive_optional_edges() {
         catalogs: BTreeMap::new(),
         bun_config_version: None,
         patched_dependencies: BTreeMap::new(),
-        trusted_dependencies: BTreeSet::new(),
+        trusted_dependencies: Vec::new(),
         extra_fields: BTreeMap::new(),
         workspace_extra_fields: BTreeMap::new(),
     };

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -2259,6 +2259,10 @@ async fn resolve_handles_lockfile_reused_name_with_incompatible_transitive_range
         skipped_optional_dependencies: BTreeMap::new(),
         catalogs: BTreeMap::new(),
         bun_config_version: None,
+        patched_dependencies: BTreeMap::new(),
+        trusted_dependencies: BTreeSet::new(),
+        extra_fields: BTreeMap::new(),
+        workspace_extra_fields: BTreeMap::new(),
     };
 
     let mut manifest = PackageJson::default();
@@ -2328,6 +2332,10 @@ async fn lockfile_reuse_preserves_transitive_optional_edges() {
         skipped_optional_dependencies: BTreeMap::new(),
         catalogs: BTreeMap::new(),
         bun_config_version: None,
+        patched_dependencies: BTreeMap::new(),
+        trusted_dependencies: BTreeSet::new(),
+        extra_fields: BTreeMap::new(),
+        workspace_extra_fields: BTreeMap::new(),
     };
 
     let mut manifest = PackageJson::default();


### PR DESCRIPTION
## Summary

Addresses the parity report in [#248](https://github.com/endevco/aube/discussions/248) — `aube install` was rewriting `bun.lock` in ways that dropped top-level blocks (overrides, catalog, catalogs, patchedDependencies, trustedDependencies), mis-routed non-registry specifiers through the default registry, and churned per-entry metadata on every install.

### What changed

**Top-level preservation**
- `overrides`, `patchedDependencies`, `trustedDependencies`, `catalog`, and `catalogs` all round-trip verbatim through the bun parser + writer now.
- New `extra_fields` / `workspace_extra_fields` / `extra_meta` serde-flatten catchalls on the shared `LockfileGraph` / `LockedPackage` so future bun fields survive without an aube release.
- pnpm writer also emits `patchedDependencies`; the parser accepts both v8 (path string) and v9 (`{path, hash}`) shapes.

**Specifier routing**
- `file:`, `link:`, `github:`, `git+…`, `http(s)://`, and `workspace:` idents now parse into `LocalSource` variants, so the installer dispatches them correctly instead of re-routing through the default registry.

**Entry churn**
- npm-alias entries emit `{registry_name}@{version}` as the ident (previously emitted `{alias}@{version}`, producing a gratuitous diff against bun's own output).
- `peerDependencies`, `optionalPeers`, `os`, `cpu`, `libc`, and the `bin` string-vs-object shape all survive per-entry round-trip.
- `overlay_metadata_from` now also carries `patched_dependencies` / `trusted_dependencies` / extras / per-entry extras forward across resolve cycles.

### Scope deliberately left out

- Optional-platform pruning and transitive version drift (e.g. `electron-to-chromium@1.5.344 → 1.5.343`) are resolver-behavior issues, not lockfile serialization. Separate fix.
- Workspace-package `packages[]` entries — the existing `test_write_skips_workspace_link_packages` asserts the drop and reworking it cleanly needs its own design pass. Flagged for follow-up.

### Test plan

- [x] 22 bun unit tests pass (4 new: top-level metadata round-trip, non-registry spec routing, npm-alias ident, peer + platform metadata round-trip)
- [x] `cargo test --release` — 977 workspace tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `test_write_byte_identical_to_native_bun` still green (fixture round-trip against a real bun 1.3 lockfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lockfile parsing/writing and shared graph models (bun + pnpm), so mistakes could cause install drift or incorrect source resolution for dependencies; changes are mostly additive and guarded by new round-trip tests.
> 
> **Overview**
> Fixes bun lockfile parity by **round-tripping previously-dropped metadata**: top-level `overrides`, `patchedDependencies`, `trustedDependencies`, `catalog`/`catalogs`, plus unknown future fields via new `extra_fields` and `workspace_extra_fields` captures.
> 
> Improves bun package entry fidelity by preserving per-entry meta (`peerDependencies`, `optionalPeers`, `os`/`cpu`/`libc`, and `bin` string-vs-object shape via `extra_meta`) and emitting correct npm-alias idents; bun parsing now classifies non-registry idents (`workspace:`, `github:`, `git+…`, `file:`, `link:`, `http(s)://`) into `LocalSource` variants.
> 
> Extends the shared `LockfileGraph`/`LockedPackage` model and plumbing across resolver peer-context/canonicalization to carry these new fields, and updates pnpm support to parse and emit `patchedDependencies` (accepting both v8 string and v9 `{path, hash}` shapes) with order parity tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8af8f6acdd010291b75a050f7007f915cf574c67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->