### PR TITLE
linker: copy small files instead of reflinking

### DIFF
--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -401,7 +401,7 @@ pub(crate) fn link_hoisted_importer(
             // Key already validated in the parent-collection loop
             // above. The index is immutable between the two loops.
             let target = pkg_dir.join(rel_path);
-            linker.link_file_fresh(&stored.store_path, &target)?;
+            linker.link_file_fresh(stored, &target)?;
             stats.files_linked += 1;
             if stored.executable {
                 #[cfg(unix)]

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2345,6 +2345,7 @@ impl Linker {
     /// Eliminates one syscall per linked file (~45k on the medium
     /// benchmark fixture).
     pub(crate) fn link_file_fresh(&self, stored: &StoredFile, dst: &Path) -> Result<(), Error> {
+        #[cfg(target_os = "macos")]
         const SMALL_FILE_COPY_MAX: u64 = 16 * 1024;
         match self.strategy {
             LinkStrategy::Reflink => {

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -6,7 +6,7 @@ use aube_lockfile::dep_path_filename::{
 };
 use aube_lockfile::graph_hash::GraphHashes;
 use aube_lockfile::{LocalSource, LockedPackage, LockfileGraph};
-use aube_store::{PackageIndex, Store};
+use aube_store::{PackageIndex, Store, StoredFile};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -2238,7 +2238,7 @@ impl Linker {
             // above. The index is immutable between the two loops.
             let target = pkg_nm_dir.join(rel_path);
 
-            self.link_file_fresh(&stored.store_path, &target)?;
+            self.link_file_fresh(stored, &target)?;
             stats.files_linked += 1;
 
             if stored.executable {
@@ -2344,24 +2344,34 @@ impl Linker {
     /// `remove_file(dst)` an idempotent variant would need is skipped.
     /// Eliminates one syscall per linked file (~45k on the medium
     /// benchmark fixture).
-    pub(crate) fn link_file_fresh(&self, src: &Path, dst: &Path) -> Result<(), Error> {
+    pub(crate) fn link_file_fresh(&self, stored: &StoredFile, dst: &Path) -> Result<(), Error> {
+        const SMALL_FILE_COPY_MAX: u64 = 16 * 1024;
         match self.strategy {
             LinkStrategy::Reflink => {
-                if let Err(e) = reflink_copy::reflink(src, dst) {
+                #[cfg(target_os = "macos")]
+                if matches!(stored.size, Some(size) if size <= SMALL_FILE_COPY_MAX) {
+                    std::fs::copy(&stored.store_path, dst)
+                        .map_err(|e| Error::Io(dst.to_path_buf(), e))?;
+                    return Ok(());
+                }
+                if let Err(e) = reflink_copy::reflink(&stored.store_path, dst) {
                     // Fall back to copy on cross-filesystem errors
                     trace!("reflink failed, falling back to copy: {e}");
-                    std::fs::copy(src, dst).map_err(|e| Error::Io(dst.to_path_buf(), e))?;
+                    std::fs::copy(&stored.store_path, dst)
+                        .map_err(|e| Error::Io(dst.to_path_buf(), e))?;
                 }
             }
             LinkStrategy::Hardlink => {
-                if let Err(e) = std::fs::hard_link(src, dst) {
+                if let Err(e) = std::fs::hard_link(&stored.store_path, dst) {
                     // Fall back to copy on cross-filesystem errors (EXDEV)
                     trace!("hardlink failed, falling back to copy: {e}");
-                    std::fs::copy(src, dst).map_err(|e| Error::Io(dst.to_path_buf(), e))?;
+                    std::fs::copy(&stored.store_path, dst)
+                        .map_err(|e| Error::Io(dst.to_path_buf(), e))?;
                 }
             }
             LinkStrategy::Copy => {
-                std::fs::copy(src, dst).map_err(|e| Error::Io(dst.to_path_buf(), e))?;
+                std::fs::copy(&stored.store_path, dst)
+                    .map_err(|e| Error::Io(dst.to_path_buf(), e))?;
             }
         }
 

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -30,6 +30,9 @@ pub struct StoredFile {
     pub store_path: PathBuf,
     /// Whether the file is executable.
     pub executable: bool,
+    /// File size in bytes when the entry was imported.
+    #[serde(default)]
+    pub size: Option<u64>,
 }
 
 /// Index of all files in a package, keyed by relative path within the package.
@@ -365,6 +368,7 @@ impl Store {
             hex_hash,
             store_path,
             executable,
+            size: Some(content.len() as u64),
         })
     }
 


### PR DESCRIPTION
## Summary
- copy known-small package files on macOS instead of using APFS reflink for every file
- thread file-size metadata through `StoredFile` so the linker can make that decision without extra stats
- keep existing behavior for larger files and for cached indexes that do not yet have size metadata

## Why
The next hotspot after the Babylon workspace-glob fix is the strict rebuild path where we remove `node_modules/.aube` and rebuild the local virtual store from warm cache.

I profiled that shape locally and the hot stack was consistently in linker materialization:
- `aube_linker::Linker::materialize_into`
- `aube_linker::Linker::link_file_fresh`
- `reflink_copy::sys::unix::macos::reflink`

A quick scan of cached package files showed that the file-size distribution is extremely skewed toward tiny files:
- 50th percentile: `932 B`
- 75th percentile: `2497 B`
- 95th percentile: `14962 B`
- about `95.45%` of sampled files were `<= 16 KiB`

On macOS, reflink still has setup/syscall overhead even when the file is tiny. For those files, a plain copy is cheaper.

## Benchmark
Fixture: `/tmp/vltpkg-benchmarks/fixtures/babylon`

Strict rebuild repro:
```bash
rm -rf node_modules/.aube
bash ../../scripts/clean-helpers.sh clean_lockfiles clean_package_manager_files >/dev/null || true
CI=1 aube install --silent --no-frozen-lockfile
```

Before this patch, representative strict runs were in the `8.5s` to `10.8s` range, with especially high syscall time:
- example runs from local profiling/repro:
  - `real 8.51`, `user 1.44`, `sys 18.91`
  - `real 9.14`, `user 1.45`, `sys 18.89`
  - `real 10.84`, `user 8.14`, `sys 20.13`

After this patch:
- single run:
  - `real 8.67`, `user 1.32`, `sys 12.59`
- `hyperfine --warmup 1 --runs 3`:
  - `7.279 s ± 2.843 s`
  - range `3.997 s … 8.983 s`

This is still noisy, but the signal is encouraging: the wall-clock result is at least competitive with the prior strict runs, and syscall time dropped meaningfully.

## Validation
- `cargo fmt --check`
- `cargo test -p aube-linker -p aube-store`
- `cargo clippy --manifest-path crates/aube/Cargo.toml --all-targets -- -D warnings`
- `cargo build --release -p aube`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the linker’s file materialization behavior (reflink/hardlink/copy selection) and adds new serialized `StoredFile` metadata that must remain backward-compatible with existing caches.
> 
> **Overview**
> On macOS, the linker now **copies small package files (<= 16KiB)** instead of attempting APFS reflinks for every file when `LinkStrategy::Reflink` is selected, reducing syscall overhead on rebuild-heavy installs.
> 
> This threads optional file-size metadata through `aube_store::StoredFile` (persisted in `PackageIndex` with a backward-compatible `Option<u64>`), and updates both isolated and hoisted materialization paths to pass `StoredFile` into `link_file_fresh` so the size-based decision can be made without extra `stat` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a440f54136834b2ce021f3fb7bac19929e7cbf6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->