### PR TITLE
settings: default publicHoistPattern to match pnpm

### DIFF
--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -375,7 +375,7 @@ examples = []
 [publicHoistPattern]
 description = "Packages to hoist directly to the root node_modules."
 type = "list<string>"
-default = "[]"
+default = "[\"*types*\", \"*eslint*\", \"@prettier/plugin-*\", \"*prettier-plugin-*\"]"
 docs = """
 Glob list matched against package names. Any non-local package in the
 resolved graph whose name matches at least one positive pattern (and
@@ -384,9 +384,14 @@ symlink in addition to the usual direct-dep entries, so frameworks
 like Next.js, Storybook, and Jest can resolve transitive deps from the
 project root without adding them to `package.json`.
 
+The default patterns match pnpm: `*types*` hoists `@types/*` and similar
+type-definition packages so TypeScript can resolve them from the project
+root; `*eslint*` hoists ESLint configs and plugins; `@prettier/plugin-*`
+and `*prettier-plugin-*` hoist Prettier plugins. Setting this option in
+`.npmrc` or `pnpm-workspace.yaml` replaces the defaults entirely.
+
 Matching is case-insensitive; direct deps always win on name clashes,
-and the pattern pass runs before `shamefullyHoist`. Use sparingly —
-anything hoisted becomes a phantom dep at the root.
+and the pattern pass runs before `shamefullyHoist`.
 """
 sources.cli = ["public-hoist-pattern"]
 sources.env = []

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -391,7 +391,8 @@ and `*prettier-plugin-*` hoist Prettier plugins. Setting this option in
 `.npmrc` or `pnpm-workspace.yaml` replaces the defaults entirely.
 
 Matching is case-insensitive; direct deps always win on name clashes,
-and the pattern pass runs before `shamefullyHoist`.
+and the pattern pass runs before `shamefullyHoist`. Use sparingly --
+anything hoisted becomes a phantom dep at the root.
 """
 sources.cli = ["public-hoist-pattern"]
 sources.env = []

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -447,7 +447,7 @@ leaving `hoist=true` (equivalent to setting `hoist=false`).
 Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
-- Default: `[]`
+- Default: `["*types*", "*eslint*", "@prettier/plugin-*", "*prettier-plugin-*"]`
 - CLI flags: `public-hoist-pattern`
 - Environment: `npm_config_public_hoist_pattern`, `NPM_CONFIG_PUBLIC_HOIST_PATTERN`
 - .npmrc keys: `public-hoist-pattern`, `publicHoistPattern`
@@ -460,9 +460,14 @@ symlink in addition to the usual direct-dep entries, so frameworks
 like Next.js, Storybook, and Jest can resolve transitive deps from the
 project root without adding them to `package.json`.
 
+The default patterns match pnpm: `*types*` hoists `@types/*` and similar
+type-definition packages so TypeScript can resolve them from the project
+root; `*eslint*` hoists ESLint configs and plugins; `@prettier/plugin-*`
+and `*prettier-plugin-*` hoist Prettier plugins. Setting this option in
+`.npmrc` or `pnpm-workspace.yaml` replaces the defaults entirely.
+
 Matching is case-insensitive; direct deps always win on name clashes,
-and the pattern pass runs before `shamefullyHoist`. Use sparingly —
-anything hoisted becomes a phantom dep at the root.
+and the pattern pass runs before `shamefullyHoist`.
 
 ### `shamefullyHoist` {#setting-shamefullyhoist}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -467,7 +467,8 @@ and `*prettier-plugin-*` hoist Prettier plugins. Setting this option in
 `.npmrc` or `pnpm-workspace.yaml` replaces the defaults entirely.
 
 Matching is case-insensitive; direct deps always win on name clashes,
-and the pattern pass runs before `shamefullyHoist`.
+and the pattern pass runs before `shamefullyHoist`. Use sparingly --
+anything hoisted becomes a phantom dep at the root.
 
 ### `shamefullyHoist` {#setting-shamefullyhoist}
 

--- a/test/public_hoist_pattern.bats
+++ b/test/public_hoist_pattern.bats
@@ -107,3 +107,42 @@ JSON
 	assert_link_exists node_modules/is-odd
 	assert_not_exists node_modules/is-number
 }
+
+@test "default public-hoist-pattern hoists *types* transitives" {
+	cat >package.json <<'JSON'
+{
+  "name": "default-hoist-types",
+  "version": "1.0.0",
+  "dependencies": {
+    "@types/react": "18.3.28"
+  }
+}
+JSON
+	# No .npmrc override — the built-in default ["*types*", ...] applies.
+	# @types/react depends on @types/prop-types (matches *types*) and
+	# csstype (does NOT match *types*). Only the former should be hoisted.
+	run aube install
+	assert_success
+	assert_link_exists node_modules/@types/react
+	assert_link_exists node_modules/@types/prop-types
+	assert_not_exists node_modules/csstype
+}
+
+@test "explicit empty public-hoist-pattern overrides default" {
+	cat >package.json <<'JSON'
+{
+  "name": "empty-override",
+  "version": "1.0.0",
+  "dependencies": {
+    "@types/react": "18.3.28"
+  }
+}
+JSON
+	# Setting an explicit empty pattern in .npmrc replaces the default
+	# entirely — no transitive gets hoisted.
+	echo 'public-hoist-pattern=' >.npmrc
+	run aube install
+	assert_success
+	assert_link_exists node_modules/@types/react
+	assert_not_exists node_modules/@types/prop-types
+}


### PR DESCRIPTION
## Problem

`publicHoistPattern` defaults to `[]` (empty). pnpm defaults to
`["*types*", "*eslint*", "@prettier/plugin-*", "*prettier-plugin-*"]`.
Transitive `@types/*` packages are never symlinked to the project root
`node_modules/`, so `tsc` fails with `TS2307: Cannot find module` when
user code imports types from those packages (see #256).

## Fix

Change the default to match pnpm. The `publicHoistPattern` infrastructure
is already fully implemented; only the default value was wrong.

### Changes

- `crates/aube-settings/settings.toml`: set default to
  `["*types*", "*eslint*", "@prettier/plugin-*", "*prettier-plugin-*"]`,
  update docs
- `test/public_hoist_pattern.bats`: add two tests verifying default
  auto-hoisting of `*types*` transitives and explicit empty override

### Behavior

- Setting `public-hoist-pattern` in `.npmrc` or `pnpm-workspace.yaml`
  replaces the default entirely (pnpm-compatible)
- Non-`@types` transitive deps (e.g. `hast-util-sanitize`) still need
  explicit config or a direct dependency, same as pnpm

Related: #257