### PR TITLE
install: always shim self-bin so CI artifact round-trips work

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3115,14 +3115,24 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         )?;
         // Root importer's own `bin` (discussion #228). Runs after
         // `link_bins` so a self-bin overrides a same-named dep bin.
+        // Self-bin targets are files in the importer's own tree — often
+        // build outputs that don't exist at install time, or are
+        // later restored from an `actions/upload-artifact` round-trip
+        // that strips the POSIX exec bit. A POSIX shim (shell script
+        // that invokes `node`) is itself `+x` and does not rely on
+        // the target's exec bit, so `aube run` works in both flows.
         if let Some(bin) = manifest.extra.get("bin") {
             let root_bin_dir = cwd.join(&modules_dir_name).join(".bin");
+            let self_shim_opts = aube_linker::BinShimOptions {
+                prefer_symlinked_executables: Some(false),
+                ..shim_opts
+            };
             link_bin_entries(
                 &root_bin_dir,
                 &cwd,
                 manifest.name.as_deref(),
                 bin,
-                shim_opts,
+                self_shim_opts,
             )?;
         }
         if has_workspace {
@@ -3158,16 +3168,22 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 }
                 // Workspace member's own `bin` (discussion #228). `manifests`
                 // was parsed once upstream and keys by importer relpath.
+                // See the root self-bin call site for why this forces a
+                // POSIX shim instead of a symlink.
                 if let Some((_, member_manifest)) =
                     manifests.iter().find(|(p, _)| p == importer_path)
                     && let Some(bin) = member_manifest.extra.get("bin")
                 {
+                    let self_shim_opts = aube_linker::BinShimOptions {
+                        prefer_symlinked_executables: Some(false),
+                        ..shim_opts
+                    };
                     link_bin_entries(
                         &bin_dir,
                         &pkg_dir,
                         member_manifest.name.as_deref(),
                         bin,
-                        shim_opts,
+                        self_shim_opts,
                     )?;
                 }
             }

--- a/test/run.bats
+++ b/test/run.bats
@@ -264,6 +264,56 @@ JSON
 	assert_output --partial "bar!"
 }
 
+# discussion #228 follow-up: the bin target is often a build output
+# restored from `actions/upload-artifact` / `download-artifact`, which
+# strips the POSIX exec bit. A symlink-based self-bin would then hit
+# `Permission denied` at exec time. Writing a POSIX shim makes the
+# target's exec bit irrelevant.
+@test "aube run self-bin works when target lacks exec bit" {
+	mkdir -p dist
+	cat >dist/bin.js <<'EOF'
+#!/usr/bin/env node
+console.log("built-bin")
+EOF
+	chmod -x dist/bin.js
+	cat >package.json <<'JSON'
+{
+  "name": "built-cli",
+  "version": "1.0.0",
+  "bin": "./dist/bin.js",
+  "scripts": { "self": "built-cli" }
+}
+JSON
+	aube install
+	run aube run self
+	assert_success
+	assert_output --partial "built-bin"
+}
+
+# Matches the tstyche CI flow: `aube ci` runs before `dist/` is
+# materialized (later downloaded from an artifact), so the self-bin
+# target does not exist at install time.
+@test "aube run self-bin works when target is absent at install time" {
+	cat >package.json <<'JSON'
+{
+  "name": "artifact-cli",
+  "version": "1.0.0",
+  "bin": "./dist/bin.js",
+  "scripts": { "self": "artifact-cli" }
+}
+JSON
+	aube install
+	mkdir -p dist
+	cat >dist/bin.js <<'EOF'
+#!/usr/bin/env node
+console.log("late-bin")
+EOF
+	chmod -x dist/bin.js
+	run aube run self
+	assert_success
+	assert_output --partial "late-bin"
+}
+
 @test "aube run resolves workspace member's own bin" {
 	cat >package.json <<'JSON'
 { "name": "root", "version": "1.0.0" }


### PR DESCRIPTION
## Summary

- Root / workspace-member **self-bin** entries now always write a POSIX shim instead of a symlink on Unix. Windows already wrote shims and is unaffected.
- Fixes the tstyche report in [endevco/aube#228](https://github.com/endevco/aube/discussions/228#discussioncomment-16698384): `sh: 1: tstyche: Permission denied`.

## Why

tstyche's CI splits `build` (produces `dist/`, uploads as artifact) from `Test Types` (downloads `dist/` artifact, runs `aube run test:types`). `actions/upload-artifact` + `download-artifact` strips the POSIX exec bit on round-trip, so the self-bin symlink `node_modules/.bin/tstyche` → `./dist/bin.js` resolved to a file without `+x` and the shell refused to execute it.

The install-time `chmod 0o755` in `create_bin_shim` is gated on `target.exists()`, which is also false when `aube ci` runs before the artifact download step — so that chmod wouldn't have fired anyway.

A shim sidesteps both:
- the shim file itself gets `+x` at install time
- the shim invokes `node "$basedir/dist/bin.js"`, so the target's mode and existence at install time are irrelevant

## Implementation

- Two call sites in `crates/aube/src/commands/install/mod.rs` (root importer + each workspace member) override `shim_opts` with `prefer_symlinked_executables: Some(false)` before calling `link_bin_entries`. The rest of `shim_opts` (e.g. `extend_node_path`) is preserved.
- Dep-bin and bundled-bin passes are unchanged — those targets live inside the CAS / virtual store and always exist with correct modes at link time.

## Tests

Two new bats cases in `test/run.bats`:
- target file exists at install time but lacks `+x` (simulates post-artifact state)
- target file is completely absent at install time, created later (simulates `aube ci` running before `download-artifact`)

Both fail on `main` with the original symlink approach; both pass with this change. Full `test/run.bats` suite still green (22/22).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `mise run test:bats test/run.bats`
- [ ] tstyche PR re-run picks up the new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes executable linking behavior for root/workspace `bin` entries on POSIX, which could affect projects that relied on symlinked self-bins or their filesystem semantics. Scope is limited to self-bins; dependency/bin linking paths are unchanged.
> 
> **Overview**
> Ensures a project’s own `bin` entries (root importer and workspace members) are **always linked as POSIX shims on Unix** by forcing `prefer_symlinked_executables: Some(false)` for self-bin linking.
> 
> Adds bats coverage for `aube run` when the self-bin target **lacks the exec bit** or **doesn’t exist at install time** (e.g., CI artifact restore flows), preventing `Permission denied` failures that symlink-based self-bins could trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94c4c5503cd38d35ce428ccc5aba0fa37878eef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->