### PR TITLE
feat(scripts): run pack/publish/version lifecycle hooks

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -554,6 +554,7 @@ cmd owner hide=#true help="Manage package owners (not implemented — use `npm o
 }
 cmd pack help="Create a publishable `.tgz` tarball from the current project" {
     flag --dry-run help="Don't write the tarball; print what would be packed"
+    flag --ignore-scripts help="Skip `prepack` / `prepare` / `postpack` lifecycle scripts"
     flag --json help="Print the result as a JSON object"
     flag --pack-destination help="Directory to write the tarball into (default: current directory)" {
         arg <DIR>
@@ -602,9 +603,7 @@ cmd publish help="Publish the current package to the registry" {
     flag --force help="Republish `name@version` even when that version is already on the target registry" {
         long_help "Republish `name@version` even when that version is already on the target registry.\n\nBy default `aube publish` issues a GET before the PUT and refuses to proceed when the version exists, surfacing a clear error instead of relying on the registry to return 409. In `--recursive` / `--filter` mode, `--force` overrides the silent \"already-published\" skip so every selected workspace package is re-PUT. The registry must still accept the republish — npm's public registry rejects re-publishes outright; Verdaccio and most private mirrors allow them."
     }
-    flag --ignore-scripts help="Skip `prepublishOnly` / `prepack` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish" {
-        long_help "Skip `prepublishOnly` / `prepack` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish.\n\nAccepted for pnpm parity; aube's publish path does not run those scripts today, so this is a no-op kept for wrapper compatibility."
-    }
+    flag --ignore-scripts help="Skip `prepublishOnly` / `prepublish` / `prepack` / `prepare` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish"
     flag --json help="Emit the publish result as JSON: an array with one `{name, version, filename, files: [{path}]}` entry, matching `pnpm publish --json` / `aube pack --json`"
     flag --no-git-checks help="Skip the \"working tree must be clean\" check" {
         long_help "Skip the \"working tree must be clean\" check.\n\nWhen unset, aube refuses to publish from a dirty git checkout (uncommitted tracked changes) or from a detached / non-release branch."
@@ -795,6 +794,7 @@ cmd update help="Update dependencies" {
 cmd usage hide=#true help="Print a usage.jdx.dev KDL spec for the CLI (internal)"
 cmd version help="Bump the version in package.json (and optionally create a git commit + tag)" {
     flag --allow-same-version help="Allow setting the version to its current value without erroring"
+    flag --ignore-scripts help="Skip `preversion` / `version` / `postversion` lifecycle scripts"
     flag --json help="Emit the result as JSON instead of `v<version>` text"
     flag "-m --message" help="Commit message template" {
         long_help "Commit message template.\n\n`%s` is replaced with the new version. Defaults to `v%s`."

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -401,7 +401,21 @@ pub async fn run_root_hook(
     manifest: &PackageJson,
     hook: LifecycleHook,
 ) -> Result<bool, Error> {
-    let name = hook.script_name();
+    run_root_script_by_name(project_dir, modules_dir_name, manifest, hook.script_name()).await
+}
+
+/// Run a named root-package script if it's defined. Used by commands
+/// (pack, publish, version) that need to run lifecycle hooks outside
+/// the install-focused [`LifecycleHook`] enum. Returns `Ok(false)` if
+/// the script isn't defined.
+///
+/// The caller is responsible for gating on `--ignore-scripts`.
+pub async fn run_root_script_by_name(
+    project_dir: &Path,
+    modules_dir_name: &str,
+    manifest: &PackageJson,
+    name: &str,
+) -> Result<bool, Error> {
     let Some(script_cmd) = manifest.scripts.get(name) else {
         return Ok(false);
     };

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -188,6 +188,26 @@ pub(crate) fn configure_script_settings(ctx: &aube_settings::ResolveCtx<'_>) {
     });
 }
 
+/// Load `.npmrc` + workspace settings for `cwd` and push them into the
+/// process-wide script settings snapshot. Used by commands that run
+/// lifecycle hooks (pack/publish/version) outside the install path,
+/// which already does this via `configure_script_settings` directly.
+pub(crate) fn configure_script_settings_for_cwd(cwd: &Path) -> miette::Result<()> {
+    let npmrc_entries = aube_registry::config::load_npmrc_entries(cwd);
+    let (_, raw_workspace) = aube_manifest::workspace::load_both(cwd)
+        .into_diagnostic()
+        .wrap_err("failed to load workspace config")?;
+    let env_snapshot = aube_settings::values::capture_env();
+    let ctx = aube_settings::ResolveCtx {
+        npmrc: &npmrc_entries,
+        workspace_yaml: &raw_workspace,
+        env: &env_snapshot,
+        cli: &[],
+    };
+    configure_script_settings(&ctx);
+    Ok(())
+}
+
 fn non_empty_string(value: String) -> Option<String> {
     let trimmed = value.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -35,6 +35,9 @@ pub struct PackArgs {
     /// Don't write the tarball; print what would be packed
     #[arg(long)]
     pub dry_run: bool,
+    /// Skip `prepack` / `prepare` / `postpack` lifecycle scripts.
+    #[arg(long)]
+    pub ignore_scripts: bool,
     /// Print the result as a JSON object
     #[arg(long)]
     pub json: bool,
@@ -59,7 +62,10 @@ struct FileEntry {
 pub async fn run(args: PackArgs) -> miette::Result<()> {
     let invocation_cwd = crate::dirs::cwd()?;
     let project_root = crate::dirs::project_root()?;
+
+    run_pack_lifecycle_pre(&project_root, args.ignore_scripts).await?;
     let archive = build_archive(&project_root)?;
+    run_pack_lifecycle_post(&project_root, args.ignore_scripts).await?;
 
     let dest_dir = args
         .pack_destination
@@ -115,6 +121,59 @@ pub async fn run(args: PackArgs) -> miette::Result<()> {
         println!("  {}", result.filename);
     }
 
+    Ok(())
+}
+
+/// Run `prepack` then `prepare` against the root manifest, in npm's
+/// documented order. No-op under `--ignore-scripts`, and silently
+/// skips scripts that aren't defined. Shared with `aube publish` so
+/// the two commands can't drift on the pack-time lifecycle.
+pub(crate) async fn run_pack_lifecycle_pre(
+    project_root: &Path,
+    ignore_scripts: bool,
+) -> miette::Result<()> {
+    if ignore_scripts {
+        return Ok(());
+    }
+    run_root_lifecycle_script(project_root, "prepack").await?;
+    run_root_lifecycle_script(project_root, "prepare").await?;
+    Ok(())
+}
+
+/// Run `postpack` against the root manifest. No-op under
+/// `--ignore-scripts`. Symmetric with [`run_pack_lifecycle_pre`].
+pub(crate) async fn run_pack_lifecycle_post(
+    project_root: &Path,
+    ignore_scripts: bool,
+) -> miette::Result<()> {
+    if ignore_scripts {
+        return Ok(());
+    }
+    run_root_lifecycle_script(project_root, "postpack").await?;
+    Ok(())
+}
+
+/// Run a single named root-package lifecycle script. Wraps
+/// `aube_scripts::run_root_script_by_name` with our standard
+/// `modulesDir` + error mapping, and ensures the process-wide
+/// `ScriptSettings` are populated from the project's npmrc/workspace
+/// config before we spawn.
+pub(crate) async fn run_root_lifecycle_script(
+    project_root: &Path,
+    script_name: &str,
+) -> miette::Result<()> {
+    let manifest = PackageJson::from_path(&project_root.join("package.json"))
+        .map_err(miette::Report::new)
+        .wrap_err("failed to read package.json")?;
+    if !manifest.scripts.contains_key(script_name) {
+        return Ok(());
+    }
+    super::configure_script_settings_for_cwd(project_root)?;
+    let modules_dir_name = super::resolve_modules_dir_name_for_cwd(project_root);
+    tracing::debug!("lifecycle: {script_name}");
+    aube_scripts::run_root_script_by_name(project_root, &modules_dir_name, &manifest, script_name)
+        .await
+        .map_err(|e| miette!("root `{script_name}` script failed: {e}"))?;
     Ok(())
 }
 

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -127,7 +127,9 @@ pub async fn run(args: PackArgs) -> miette::Result<()> {
 /// Run `prepack` then `prepare` against the root manifest, in npm's
 /// documented order. No-op under `--ignore-scripts`, and silently
 /// skips scripts that aren't defined. Shared with `aube publish` so
-/// the two commands can't drift on the pack-time lifecycle.
+/// the two commands can't drift on the pack-time lifecycle. The
+/// manifest is read once here so callers that chain multiple hooks
+/// don't re-parse `package.json` on every call.
 pub(crate) async fn run_pack_lifecycle_pre(
     project_root: &Path,
     ignore_scripts: bool,
@@ -135,8 +137,9 @@ pub(crate) async fn run_pack_lifecycle_pre(
     if ignore_scripts {
         return Ok(());
     }
-    run_root_lifecycle_script(project_root, "prepack").await?;
-    run_root_lifecycle_script(project_root, "prepare").await?;
+    let manifest = read_root_manifest(project_root)?;
+    run_root_lifecycle_script(project_root, &manifest, "prepack").await?;
+    run_root_lifecycle_script(project_root, &manifest, "prepare").await?;
     Ok(())
 }
 
@@ -149,29 +152,38 @@ pub(crate) async fn run_pack_lifecycle_post(
     if ignore_scripts {
         return Ok(());
     }
-    run_root_lifecycle_script(project_root, "postpack").await?;
+    let manifest = read_root_manifest(project_root)?;
+    run_root_lifecycle_script(project_root, &manifest, "postpack").await?;
     Ok(())
+}
+
+/// Read and parse the root `package.json`. Shared helper so the
+/// lifecycle paths (pack/publish/version) all surface the same error
+/// context when the manifest is missing or malformed.
+pub(crate) fn read_root_manifest(project_root: &Path) -> miette::Result<PackageJson> {
+    PackageJson::from_path(&project_root.join("package.json"))
+        .map_err(miette::Report::new)
+        .wrap_err("failed to read package.json")
 }
 
 /// Run a single named root-package lifecycle script. Wraps
 /// `aube_scripts::run_root_script_by_name` with our standard
 /// `modulesDir` + error mapping, and ensures the process-wide
 /// `ScriptSettings` are populated from the project's npmrc/workspace
-/// config before we spawn.
+/// config before we spawn. The manifest is passed in so callers that
+/// chain multiple hooks can share a single parse.
 pub(crate) async fn run_root_lifecycle_script(
     project_root: &Path,
+    manifest: &PackageJson,
     script_name: &str,
 ) -> miette::Result<()> {
-    let manifest = PackageJson::from_path(&project_root.join("package.json"))
-        .map_err(miette::Report::new)
-        .wrap_err("failed to read package.json")?;
     if !manifest.scripts.contains_key(script_name) {
         return Ok(());
     }
     super::configure_script_settings_for_cwd(project_root)?;
     let modules_dir_name = super::resolve_modules_dir_name_for_cwd(project_root);
     tracing::debug!("lifecycle: {script_name}");
-    aube_scripts::run_root_script_by_name(project_root, &modules_dir_name, &manifest, script_name)
+    aube_scripts::run_root_script_by_name(project_root, &modules_dir_name, manifest, script_name)
         .await
         .map_err(|e| miette!("root `{script_name}` script failed: {e}"))?;
     Ok(())

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -413,9 +413,9 @@ async fn publish_one(
         // their `prepublishOnly` / `prepack` / `prepare` scripts without
         // hitting the registry, matching pnpm. `publish` / `postpublish`
         // are skipped — nothing was actually uploaded.
-        run_publish_lifecycle_pre(pkg_dir, args.ignore_scripts).await?;
+        run_publish_lifecycle_pre(pkg_dir, &manifest, args.ignore_scripts).await?;
         let archive = build_archive(pkg_dir)?;
-        run_publish_lifecycle_postpack(pkg_dir, args.ignore_scripts).await?;
+        super::pack::run_pack_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
         // `--dry-run --provenance` is a common "does my CI actually have
         // OIDC wired up?" smoke test. Silently skipping the OIDC probe
         // here would give a false green light — so we run the ambient
@@ -465,9 +465,9 @@ async fn publish_one(
     // we're actually going to PUT. For a re-run of `-r publish` where
     // every package is already on the registry, the loop never reaches
     // this point and the whole fanout is script-free and gzip-free.
-    run_publish_lifecycle_pre(pkg_dir, args.ignore_scripts).await?;
+    run_publish_lifecycle_pre(pkg_dir, &manifest, args.ignore_scripts).await?;
     let archive = build_archive(pkg_dir)?;
-    run_publish_lifecycle_postpack(pkg_dir, args.ignore_scripts).await?;
+    super::pack::run_pack_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
 
     // Sigstore signing is the one step here that can take seconds
     // (Fulcio + Rekor + optional TSA round-trips), so we do it *before*
@@ -527,7 +527,7 @@ async fn publish_one(
         return Err(miette!("publish failed: {status}: {}", body.trim()));
     }
 
-    run_publish_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
+    run_publish_lifecycle_post(pkg_dir, &manifest, args.ignore_scripts).await?;
 
     Ok(PublishOutcome {
         name,
@@ -543,35 +543,37 @@ async fn publish_one(
 /// being uploaded — the "already on registry" skip path avoids all of
 /// this so `aube -r publish` remains idempotent. `prepublish` is
 /// deprecated by npm but pnpm still runs it on publish, so we match
-/// pnpm for the common case the discussion in #253 flagged.
-async fn run_publish_lifecycle_pre(pkg_dir: &Path, ignore_scripts: bool) -> miette::Result<()> {
+/// pnpm for the common case the discussion in #253 flagged. The
+/// manifest is threaded through so the whole chain shares a single
+/// parse of `package.json`.
+async fn run_publish_lifecycle_pre(
+    pkg_dir: &Path,
+    manifest: &PackageJson,
+    ignore_scripts: bool,
+) -> miette::Result<()> {
     if ignore_scripts {
         return Ok(());
     }
-    super::pack::run_root_lifecycle_script(pkg_dir, "prepublishOnly").await?;
-    super::pack::run_root_lifecycle_script(pkg_dir, "prepublish").await?;
-    super::pack::run_pack_lifecycle_pre(pkg_dir, false).await
-}
-
-/// `postpack` hook — fires after the tarball is built but before the
-/// upload, matching npm docs ("after the tarball has been generated
-/// but before it is moved to its final destination").
-async fn run_publish_lifecycle_postpack(
-    pkg_dir: &Path,
-    ignore_scripts: bool,
-) -> miette::Result<()> {
-    super::pack::run_pack_lifecycle_post(pkg_dir, ignore_scripts).await
+    super::pack::run_root_lifecycle_script(pkg_dir, manifest, "prepublishOnly").await?;
+    super::pack::run_root_lifecycle_script(pkg_dir, manifest, "prepublish").await?;
+    super::pack::run_root_lifecycle_script(pkg_dir, manifest, "prepack").await?;
+    super::pack::run_root_lifecycle_script(pkg_dir, manifest, "prepare").await?;
+    Ok(())
 }
 
 /// Post-upload chain for publish: `publish` → `postpublish`. These
 /// run only after a successful PUT — a non-2xx response short-circuits
 /// out before we get here, matching pnpm.
-async fn run_publish_lifecycle_post(pkg_dir: &Path, ignore_scripts: bool) -> miette::Result<()> {
+async fn run_publish_lifecycle_post(
+    pkg_dir: &Path,
+    manifest: &PackageJson,
+    ignore_scripts: bool,
+) -> miette::Result<()> {
     if ignore_scripts {
         return Ok(());
     }
-    super::pack::run_root_lifecycle_script(pkg_dir, "publish").await?;
-    super::pack::run_root_lifecycle_script(pkg_dir, "postpublish").await?;
+    super::pack::run_root_lifecycle_script(pkg_dir, manifest, "publish").await?;
+    super::pack::run_root_lifecycle_script(pkg_dir, manifest, "postpublish").await?;
     Ok(())
 }
 

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -469,6 +469,17 @@ async fn publish_one(
     let archive = build_archive(pkg_dir)?;
     super::pack::run_pack_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
 
+    // Re-read the manifest *after* the pre-pack chain. Publish-time
+    // hooks often rewrite `package.json` on the fly — `clean-package`
+    // strips `devDependencies`, build tools inject `exports`, a
+    // `prepublishOnly` might stamp a git SHA into the version. The
+    // tarball always reflects the on-disk state (`build_archive`
+    // reads it fresh), so the registry-visible metadata at
+    // `versions.<v>.*` and the env seen by `publish` / `postpublish`
+    // must agree with it or consumers get a mismatch between
+    // `npm info` output and the tarball they actually download.
+    let manifest = super::pack::read_root_manifest(pkg_dir)?;
+
     // Sigstore signing is the one step here that can take seconds
     // (Fulcio + Rekor + optional TSA round-trips), so we do it *before*
     // serializing the publish body rather than after — a signing
@@ -492,8 +503,12 @@ async fn publish_one(
     // Without this, a first-time `@scope/pkg` publish with
     // `publishConfig.access=public` in package.json would fail with
     // 402 unless the user also passed `--access public` on every
-    // publish invocation.
-    let pc_access = publish_config
+    // publish invocation. Re-derive from the post-hook manifest so
+    // `prepublishOnly`-injected publishConfig entries are honored.
+    let pc_access = manifest
+        .extra
+        .get("publishConfig")
+        .and_then(|v| v.as_object())
         .and_then(|p| p.get("access"))
         .and_then(|v| v.as_str());
     let effective_access = args.access.as_deref().or(pc_access);

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -66,12 +66,9 @@ pub struct PublishArgs {
     /// outright; Verdaccio and most private mirrors allow them.
     #[arg(long)]
     pub force: bool,
-    /// Skip `prepublishOnly` / `prepack` / `postpack` / `publish` /
-    /// `postpublish` lifecycle scripts for this publish.
-    ///
-    /// Accepted for pnpm parity; aube's publish path does not run
-    /// those scripts today, so this is a no-op kept for wrapper
-    /// compatibility.
+    /// Skip `prepublishOnly` / `prepublish` / `prepack` / `prepare` /
+    /// `postpack` / `publish` / `postpublish` lifecycle scripts for
+    /// this publish.
     #[arg(long)]
     pub ignore_scripts: bool,
     /// Emit the publish result as JSON: an array with one
@@ -112,7 +109,6 @@ pub async fn run(
     filter: aube_workspace::selector::EffectiveFilter,
     registry_override: Option<&str>,
 ) -> miette::Result<()> {
-    let _ = args.ignore_scripts; // parity no-op: aube's publish path doesn't run lifecycle scripts yet
     let cwd = crate::dirs::project_root()?;
 
     if !args.no_git_checks {
@@ -413,9 +409,13 @@ async fn publish_one(
         .to_string();
 
     if args.dry_run {
-        // Dry-run still builds the archive: the whole point is to show
-        // the user what *would* be uploaded, including the file list.
+        // Dry-run still runs the pre-publish chain so users can smoke-test
+        // their `prepublishOnly` / `prepack` / `prepare` scripts without
+        // hitting the registry, matching pnpm. `publish` / `postpublish`
+        // are skipped — nothing was actually uploaded.
+        run_publish_lifecycle_pre(pkg_dir, args.ignore_scripts).await?;
         let archive = build_archive(pkg_dir)?;
+        run_publish_lifecycle_postpack(pkg_dir, args.ignore_scripts).await?;
         // `--dry-run --provenance` is a common "does my CI actually have
         // OIDC wired up?" smoke test. Silently skipping the OIDC probe
         // here would give a false green light — so we run the ambient
@@ -461,11 +461,13 @@ async fn publish_one(
         ));
     }
 
-    // Build the tarball + publish body only now that we know we're
-    // actually going to PUT. For a re-run of `-r publish` where every
-    // package is already on the registry, the loop never reaches this
-    // point and the whole fanout is gzip-free.
+    // Lifecycle hooks + tarball build only happen now that we know
+    // we're actually going to PUT. For a re-run of `-r publish` where
+    // every package is already on the registry, the loop never reaches
+    // this point and the whole fanout is script-free and gzip-free.
+    run_publish_lifecycle_pre(pkg_dir, args.ignore_scripts).await?;
     let archive = build_archive(pkg_dir)?;
+    run_publish_lifecycle_postpack(pkg_dir, args.ignore_scripts).await?;
 
     // Sigstore signing is the one step here that can take seconds
     // (Fulcio + Rekor + optional TSA round-trips), so we do it *before*
@@ -525,6 +527,8 @@ async fn publish_one(
         return Err(miette!("publish failed: {status}: {}", body.trim()));
     }
 
+    run_publish_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
+
     Ok(PublishOutcome {
         name,
         version,
@@ -532,6 +536,43 @@ async fn publish_one(
         archive: Some(archive),
         status: PublishStatus::Published,
     })
+}
+
+/// Pre-pack chain for publish: `prepublishOnly` → `prepublish` →
+/// `prepack` → `prepare`. Runs only for packages that are actually
+/// being uploaded — the "already on registry" skip path avoids all of
+/// this so `aube -r publish` remains idempotent. `prepublish` is
+/// deprecated by npm but pnpm still runs it on publish, so we match
+/// pnpm for the common case the discussion in #253 flagged.
+async fn run_publish_lifecycle_pre(pkg_dir: &Path, ignore_scripts: bool) -> miette::Result<()> {
+    if ignore_scripts {
+        return Ok(());
+    }
+    super::pack::run_root_lifecycle_script(pkg_dir, "prepublishOnly").await?;
+    super::pack::run_root_lifecycle_script(pkg_dir, "prepublish").await?;
+    super::pack::run_pack_lifecycle_pre(pkg_dir, false).await
+}
+
+/// `postpack` hook — fires after the tarball is built but before the
+/// upload, matching npm docs ("after the tarball has been generated
+/// but before it is moved to its final destination").
+async fn run_publish_lifecycle_postpack(
+    pkg_dir: &Path,
+    ignore_scripts: bool,
+) -> miette::Result<()> {
+    super::pack::run_pack_lifecycle_post(pkg_dir, ignore_scripts).await
+}
+
+/// Post-upload chain for publish: `publish` → `postpublish`. These
+/// run only after a successful PUT — a non-2xx response short-circuits
+/// out before we get here, matching pnpm.
+async fn run_publish_lifecycle_post(pkg_dir: &Path, ignore_scripts: bool) -> miette::Result<()> {
+    if ignore_scripts {
+        return Ok(());
+    }
+    super::pack::run_root_lifecycle_script(pkg_dir, "publish").await?;
+    super::pack::run_root_lifecycle_script(pkg_dir, "postpublish").await?;
+    Ok(())
 }
 
 /// GET `{registry}/{name}` and check whether `versions[version]` is

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -87,9 +87,13 @@ pub async fn run(args: VersionArgs) -> miette::Result<()> {
 
     // npm/pnpm order: `preversion` fires BEFORE the manifest is
     // rewritten so the script sees the outgoing version and can
-    // abort the bump (e.g. "refuse to bump while tests are red").
+    // abort the bump (e.g. "refuse to bump while tests are red"). We
+    // re-read the manifest between each hook so `npm_package_version`
+    // reflects the right state of the world — preversion sees the
+    // old version, version/postversion see the new one.
     if !args.ignore_scripts {
-        super::pack::run_root_lifecycle_script(&cwd, "preversion").await?;
+        let manifest = super::pack::read_root_manifest(&cwd)?;
+        super::pack::run_root_lifecycle_script(&cwd, &manifest, "preversion").await?;
     }
 
     let updated = replace_version(&raw, &new_version)
@@ -103,7 +107,8 @@ pub async fn run(args: VersionArgs) -> miette::Result<()> {
     // `version: 'git add CHANGELOG.md'`) so they're included in the
     // version tag's tree. Matches npm docs.
     if !args.ignore_scripts {
-        super::pack::run_root_lifecycle_script(&cwd, "version").await?;
+        let manifest = super::pack::read_root_manifest(&cwd)?;
+        super::pack::run_root_lifecycle_script(&cwd, &manifest, "version").await?;
     }
 
     // Skip git ops when the version hasn't actually changed (e.g.
@@ -126,10 +131,14 @@ pub async fn run(args: VersionArgs) -> miette::Result<()> {
         )?;
     }
 
-    // `postversion` fires last — after the tag is pushed into the git
-    // history. Common idiom is `postversion: 'git push && git push --tags'`.
+    // `postversion` fires last — after the git commit + tag (if any;
+    // `--no-git-tag-version` or a clean-same-version run skips that
+    // step, in which case postversion just fires after the manifest
+    // write). Common idiom when tagging is enabled is
+    // `postversion: 'git push && git push --tags'`.
     if !args.ignore_scripts {
-        super::pack::run_root_lifecycle_script(&cwd, "postversion").await?;
+        let manifest = super::pack::read_root_manifest(&cwd)?;
+        super::pack::run_root_lifecycle_script(&cwd, &manifest, "postversion").await?;
     }
 
     if args.json {

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -24,6 +24,10 @@ pub struct VersionArgs {
     #[arg(long)]
     pub allow_same_version: bool,
 
+    /// Skip `preversion` / `version` / `postversion` lifecycle scripts.
+    #[arg(long)]
+    pub ignore_scripts: bool,
+
     /// Emit the result as JSON instead of `v<version>` text.
     #[arg(long)]
     pub json: bool,
@@ -81,11 +85,26 @@ pub async fn run(args: VersionArgs) -> miette::Result<()> {
         ));
     }
 
+    // npm/pnpm order: `preversion` fires BEFORE the manifest is
+    // rewritten so the script sees the outgoing version and can
+    // abort the bump (e.g. "refuse to bump while tests are red").
+    if !args.ignore_scripts {
+        super::pack::run_root_lifecycle_script(&cwd, "preversion").await?;
+    }
+
     let updated = replace_version(&raw, &new_version)
         .ok_or_else(|| miette!("failed to locate version string in package.json"))?;
     aube_util::fs_atomic::atomic_write(&manifest_path, updated.as_bytes())
         .into_diagnostic()
         .wrap_err("failed to write package.json")?;
+
+    // `version` fires AFTER the manifest edit but BEFORE the git
+    // commit. Scripts usually regenerate derived files here (e.g.
+    // `version: 'git add CHANGELOG.md'`) so they're included in the
+    // version tag's tree. Matches npm docs.
+    if !args.ignore_scripts {
+        super::pack::run_root_lifecycle_script(&cwd, "version").await?;
+    }
 
     // Skip git ops when the version hasn't actually changed (e.g.
     // `--allow-same-version` bumping to the current version) — otherwise
@@ -105,6 +124,12 @@ pub async fn run(args: VersionArgs) -> miette::Result<()> {
             args.no_commit_hooks,
             args.sign_git_tag,
         )?;
+    }
+
+    // `postversion` fires last — after the tag is pushed into the git
+    // history. Common idiom is `postversion: 'git push && git push --tags'`.
+    if !args.ignore_scripts {
+        super::pack::run_root_lifecycle_script(&cwd, "postversion").await?;
     }
 
     if args.json {

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -96,6 +96,16 @@ pub async fn run(args: VersionArgs) -> miette::Result<()> {
         super::pack::run_root_lifecycle_script(&cwd, &manifest, "preversion").await?;
     }
 
+    // Re-read the raw file *after* preversion: a common idiom is
+    // `preversion: 'npm test && git add CHANGELOG.md'`, but hooks
+    // can also mutate the manifest directly (formatting, touching
+    // related fields, …). Using the pre-hook `raw` for
+    // `replace_version` would silently discard those edits on the
+    // atomic write.
+    let raw = std::fs::read_to_string(&manifest_path)
+        .into_diagnostic()
+        .wrap_err("failed to read package.json")?;
+
     let updated = replace_version(&raw, &new_version)
         .ok_or_else(|| miette!("failed to locate version string in package.json"))?;
     aube_util::fs_atomic::atomic_write(&manifest_path, updated.as_bytes())

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3305,6 +3305,18 @@
             "global": false
           },
           {
+            "name": "ignore-scripts",
+            "usage": "--ignore-scripts",
+            "help": "Skip `prepack` / `prepare` / `postpack` lifecycle scripts",
+            "help_first_line": "Skip `prepack` / `prepare` / `postpack` lifecycle scripts",
+            "short": [],
+            "long": [
+              "ignore-scripts"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "json",
             "usage": "--json",
             "help": "Print the result as a JSON object",
@@ -3661,9 +3673,8 @@
           {
             "name": "ignore-scripts",
             "usage": "--ignore-scripts",
-            "help": "Skip `prepublishOnly` / `prepack` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish",
-            "help_long": "Skip `prepublishOnly` / `prepack` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish.\n\nAccepted for pnpm parity; aube's publish path does not run those scripts today, so this is a no-op kept for wrapper compatibility.",
-            "help_first_line": "Skip `prepublishOnly` / `prepack` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish",
+            "help": "Skip `prepublishOnly` / `prepublish` / `prepack` / `prepare` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish",
+            "help_first_line": "Skip `prepublishOnly` / `prepublish` / `prepack` / `prepare` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish",
             "short": [],
             "long": [
               "ignore-scripts"
@@ -5056,6 +5067,18 @@
             "short": [],
             "long": [
               "allow-same-version"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "ignore-scripts",
+            "usage": "--ignore-scripts",
+            "help": "Skip `preversion` / `version` / `postversion` lifecycle scripts",
+            "help_first_line": "Skip `preversion` / `version` / `postversion` lifecycle scripts",
+            "short": [],
+            "long": [
+              "ignore-scripts"
             ],
             "hide": false,
             "global": false

--- a/docs/cli/pack.md
+++ b/docs/cli/pack.md
@@ -11,6 +11,10 @@ Create a publishable `.tgz` tarball from the current project
 
 Don't write the tarball; print what would be packed
 
+### `--ignore-scripts`
+
+Skip `prepack` / `prepare` / `postpack` lifecycle scripts
+
 ### `--json`
 
 Print the result as a JSON object

--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -25,9 +25,7 @@ By default `aube publish` issues a GET before the PUT and refuses to proceed whe
 
 ### `--ignore-scripts`
 
-Skip `prepublishOnly` / `prepack` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish.
-
-Accepted for pnpm parity; aube's publish path does not run those scripts today, so this is a no-op kept for wrapper compatibility.
+Skip `prepublishOnly` / `prepublish` / `prepack` / `prepare` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish
 
 ### `--json`
 

--- a/docs/cli/version.md
+++ b/docs/cli/version.md
@@ -19,6 +19,10 @@ When omitted, prints the current version.
 
 Allow setting the version to its current value without erroring
 
+### `--ignore-scripts`
+
+Skip `preversion` / `version` / `postversion` lifecycle scripts
+
 ### `--json`
 
 Emit the result as JSON instead of `v<version>` text

--- a/test/pack.bats
+++ b/test/pack.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
 
 setup() {
 	load 'test_helper/common_setup'
@@ -123,4 +124,86 @@ _write_pkg_with_files() {
 	assert_success
 	assert_line "package/package.json"
 	assert_line "package/index.js"
+}
+
+@test "aube pack runs prepack, prepare, postpack in order" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "pack-hooks",
+		  "version": "1.0.0",
+		  "main": "index.js",
+		  "files": ["index.js"],
+		  "scripts": {
+		    "prepack": "echo prepack >>$HOOK_LOG",
+		    "prepare": "echo prepare >>$HOOK_LOG",
+		    "postpack": "echo postpack >>$HOOK_LOG"
+		  }
+		}
+	EOF
+	cat >index.js <<-'EOF'
+		module.exports = 1
+	EOF
+
+	export HOOK_LOG="$PWD/hooks.log"
+	: >"$HOOK_LOG"
+
+	run aube pack
+	assert_success
+
+	run cat "$HOOK_LOG"
+	assert_success
+	assert_line --index 0 "prepack"
+	assert_line --index 1 "prepare"
+	assert_line --index 2 "postpack"
+}
+
+@test "aube pack --ignore-scripts skips lifecycle hooks" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "pack-hooks",
+		  "version": "1.0.0",
+		  "main": "index.js",
+		  "files": ["index.js"],
+		  "scripts": {
+		    "prepack": "echo prepack >>$HOOK_LOG",
+		    "prepare": "echo prepare >>$HOOK_LOG",
+		    "postpack": "echo postpack >>$HOOK_LOG"
+		  }
+		}
+	EOF
+	cat >index.js <<-'EOF'
+		module.exports = 1
+	EOF
+
+	export HOOK_LOG="$PWD/hooks.log"
+	: >"$HOOK_LOG"
+
+	run aube pack --ignore-scripts
+	assert_success
+
+	# Log should still exist but be empty — no hook fired.
+	run cat "$HOOK_LOG"
+	assert_success
+	assert_output ""
+}
+
+@test "aube pack propagates a failing prepack" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "pack-hooks",
+		  "version": "1.0.0",
+		  "main": "index.js",
+		  "files": ["index.js"],
+		  "scripts": {
+		    "prepack": "exit 3"
+		  }
+		}
+	EOF
+	cat >index.js <<-'EOF'
+		module.exports = 1
+	EOF
+
+	run aube pack
+	assert_failure
+	[ ! -f pack-hooks-1.0.0.tgz ]
 }

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
 
 setup() {
 	load 'test_helper/common_setup'
@@ -260,6 +261,90 @@ _stop_publish_server() {
 	run grep -c "^/publish-smoke " publish-server-put.log
 	assert_success
 	[ "$output" = "1" ]
+}
+
+@test "aube publish --dry-run runs prepublishOnly, prepublish, prepack, prepare, postpack" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "publish-hooks",
+		  "version": "0.1.0",
+		  "main": "index.js",
+		  "files": ["index.js"],
+		  "scripts": {
+		    "prepublishOnly": "echo prepublishOnly >>$HOOK_LOG",
+		    "prepublish": "echo prepublish >>$HOOK_LOG",
+		    "prepack": "echo prepack >>$HOOK_LOG",
+		    "prepare": "echo prepare >>$HOOK_LOG",
+		    "postpack": "echo postpack >>$HOOK_LOG",
+		    "publish": "echo publish >>$HOOK_LOG",
+		    "postpublish": "echo postpublish >>$HOOK_LOG"
+		  }
+		}
+	EOF
+	echo "module.exports = 1" >index.js
+
+	export HOOK_LOG="$PWD/hooks.log"
+	: >"$HOOK_LOG"
+
+	run aube publish --dry-run --registry=https://r.example.com/
+	assert_success
+
+	# Dry-run: pre-pack chain fires, post-upload hooks don't.
+	run cat "$HOOK_LOG"
+	assert_success
+	assert_line --index 0 "prepublishOnly"
+	assert_line --index 1 "prepublish"
+	assert_line --index 2 "prepack"
+	assert_line --index 3 "prepare"
+	assert_line --index 4 "postpack"
+	refute_line "publish"
+	refute_line "postpublish"
+}
+
+@test "aube publish --dry-run --ignore-scripts skips lifecycle hooks" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "publish-hooks",
+		  "version": "0.1.0",
+		  "main": "index.js",
+		  "files": ["index.js"],
+		  "scripts": {
+		    "prepublishOnly": "echo prepublishOnly >>$HOOK_LOG",
+		    "prepack": "echo prepack >>$HOOK_LOG",
+		    "prepare": "echo prepare >>$HOOK_LOG",
+		    "postpack": "echo postpack >>$HOOK_LOG"
+		  }
+		}
+	EOF
+	echo "module.exports = 1" >index.js
+
+	export HOOK_LOG="$PWD/hooks.log"
+	: >"$HOOK_LOG"
+
+	run aube publish --dry-run --ignore-scripts --registry=https://r.example.com/
+	assert_success
+
+	run cat "$HOOK_LOG"
+	assert_success
+	assert_output ""
+}
+
+@test "aube publish --dry-run aborts when prepublishOnly fails" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "publish-hooks",
+		  "version": "0.1.0",
+		  "main": "index.js",
+		  "files": ["index.js"],
+		  "scripts": {
+		    "prepublishOnly": "exit 5"
+		  }
+		}
+	EOF
+	echo "module.exports = 1" >index.js
+
+	run aube publish --dry-run --registry=https://r.example.com/
+	assert_failure
 }
 
 @test "aube publish --dry-run --json emits a pnpm-compatible array" {

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -347,6 +347,89 @@ _stop_publish_server() {
 	assert_failure
 }
 
+@test "aube publish re-reads package.json after pre-pack hooks so registry metadata matches tarball" {
+	# Regression test for Cursor Bugbot issue: if a `prepublishOnly`
+	# script mutates package.json (e.g. stamping a git SHA into the
+	# version, stripping devDependencies), `build_publish_body` must
+	# see the post-hook manifest so `versions.<v>` metadata agrees
+	# with what's in the tarball. Previously we serialized the
+	# pre-hook snapshot and consumers saw a mismatch.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "publish-mutated",
+		  "version": "0.1.0",
+		  "main": "index.js",
+		  "files": ["index.js"],
+		  "devDependencies": {
+		    "should-be-stripped": "1.0.0"
+		  },
+		  "scripts": {
+		    "prepublishOnly": "node ./rewrite.mjs"
+		  }
+		}
+	EOF
+	echo "module.exports = 1" >index.js
+	cat >rewrite.mjs <<'NODE'
+import fs from 'node:fs';
+const m = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+delete m.devDependencies;
+m.publishedBy = 'prepublishOnly';
+fs.writeFileSync('package.json', JSON.stringify(m, null, 2));
+NODE
+
+	cat >record-server.mjs <<'NODE'
+import http from 'node:http';
+import fs from 'node:fs';
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/publish-mutated') {
+    res.statusCode = 404;
+    res.end('{}');
+    return;
+  }
+  if (req.method === 'PUT' && req.url === '/publish-mutated') {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      fs.writeFileSync('put-body.json', Buffer.concat(chunks));
+      res.statusCode = 201;
+      res.end('{"ok":true}');
+    });
+    return;
+  }
+  res.statusCode = 404;
+  res.end('{}');
+});
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync('record-server-port', String(server.address().port));
+});
+NODE
+	node record-server.mjs &
+	local pid=$!
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		[ -f record-server-port ] && break
+		sleep 0.1
+	done
+	port="$(cat record-server-port)"
+	echo "//127.0.0.1:${port}/:_authToken=fake" >.npmrc
+
+	run aube publish --no-git-checks --registry "http://127.0.0.1:${port}/"
+	rc=$status
+	kill "$pid" 2>/dev/null || true
+	wait "$pid" 2>/dev/null || true
+	[ "$rc" -eq 0 ]
+
+	# The PUT body's `versions["0.1.0"]` must reflect the post-hook
+	# manifest — `devDependencies` stripped, `publishedBy` added.
+	run jq -r '.versions."0.1.0".publishedBy' put-body.json
+	assert_success
+	assert_output "prepublishOnly"
+
+	run jq '.versions."0.1.0".devDependencies' put-body.json
+	assert_success
+	assert_output "null"
+}
+
 @test "aube publish --dry-run --json emits a pnpm-compatible array" {
 	_write_publishable_pkg
 

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -7,6 +7,13 @@ setup() {
 }
 
 teardown() {
+	# Safety net: every test in this file that spawns a background
+	# mock registry is expected to call `_stop_publish_server`
+	# inline, but a failing assertion between _start and _stop would
+	# leak the node process and keep the CI shard alive forever (the
+	# http.createServer event loop never exits on its own). Always
+	# kill here as a backstop.
+	_stop_publish_server
 	_common_teardown
 }
 
@@ -404,8 +411,10 @@ server.listen(0, '127.0.0.1', () => {
   fs.writeFileSync('record-server-port', String(server.address().port));
 });
 NODE
+	# Use PUBLISH_SERVER_PID so teardown's `_stop_publish_server`
+	# safety net catches it if the test aborts early.
 	node record-server.mjs &
-	local pid=$!
+	PUBLISH_SERVER_PID=$!
 	for _ in 1 2 3 4 5 6 7 8 9 10; do
 		[ -f record-server-port ] && break
 		sleep 0.1
@@ -415,8 +424,7 @@ NODE
 
 	run aube publish --no-git-checks --registry "http://127.0.0.1:${port}/"
 	rc=$status
-	kill "$pid" 2>/dev/null || true
-	wait "$pid" 2>/dev/null || true
+	_stop_publish_server
 	[ "$rc" -eq 0 ]
 
 	# The PUT body's `versions["0.1.0"]` must reflect the post-hook

--- a/test/version.bats
+++ b/test/version.bats
@@ -194,6 +194,38 @@ _write_pkg() {
 	assert_output ""
 }
 
+@test "aube version preserves manifest edits made by preversion" {
+	# Regression: `replace_version` used to operate on the pre-hook
+	# snapshot of `package.json`, so any edits `preversion` made to
+	# other fields (here: stripping a `draft` flag) were silently
+	# overwritten by the atomic write of the new version.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "version-mutates",
+		  "version": "1.0.0",
+		  "draft": true,
+		  "scripts": {
+		    "preversion": "node ./strip-draft.mjs"
+		  }
+		}
+	EOF
+	cat >strip-draft.mjs <<'NODE'
+import fs from 'node:fs';
+const m = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+delete m.draft;
+fs.writeFileSync('package.json', JSON.stringify(m, null, 2));
+NODE
+
+	run aube version patch --no-git-tag-version
+	assert_success
+	assert_output "v1.0.1"
+
+	# Both the preversion edit AND the version bump must survive.
+	run cat package.json
+	assert_output --partial '"version": "1.0.1"'
+	refute_output --partial '"draft"'
+}
+
 @test "aube version aborts bump when preversion fails" {
 	cat >package.json <<-'EOF'
 		{

--- a/test/version.bats
+++ b/test/version.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
 
 setup() {
 	load 'test_helper/common_setup'
@@ -140,4 +141,74 @@ _write_pkg() {
 	assert_output "init"
 	run git tag --list
 	assert_output ""
+}
+
+@test "aube version runs preversion, version, postversion in order" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "version-hooks",
+		  "version": "1.0.0",
+		  "scripts": {
+		    "preversion": "echo preversion >>$HOOK_LOG",
+		    "version": "echo version >>$HOOK_LOG",
+		    "postversion": "echo postversion >>$HOOK_LOG"
+		  }
+		}
+	EOF
+
+	export HOOK_LOG="$PWD/hooks.log"
+	: >"$HOOK_LOG"
+
+	run aube version patch --no-git-tag-version
+	assert_success
+	assert_output "v1.0.1"
+
+	run cat "$HOOK_LOG"
+	assert_success
+	assert_line --index 0 "preversion"
+	assert_line --index 1 "version"
+	assert_line --index 2 "postversion"
+}
+
+@test "aube version --ignore-scripts skips lifecycle hooks" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "version-hooks",
+		  "version": "1.0.0",
+		  "scripts": {
+		    "preversion": "echo preversion >>$HOOK_LOG",
+		    "version": "echo version >>$HOOK_LOG",
+		    "postversion": "echo postversion >>$HOOK_LOG"
+		  }
+		}
+	EOF
+
+	export HOOK_LOG="$PWD/hooks.log"
+	: >"$HOOK_LOG"
+
+	run aube version patch --no-git-tag-version --ignore-scripts
+	assert_success
+
+	run cat "$HOOK_LOG"
+	assert_success
+	assert_output ""
+}
+
+@test "aube version aborts bump when preversion fails" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "version-hooks",
+		  "version": "1.0.0",
+		  "scripts": {
+		    "preversion": "exit 7"
+		  }
+		}
+	EOF
+
+	run aube version patch --no-git-tag-version
+	assert_failure
+
+	# Manifest should be untouched since preversion fires BEFORE the edit.
+	run cat package.json
+	assert_output --partial '"version": "1.0.0"'
 }


### PR DESCRIPTION
## Summary

- `aube pack` now runs `prepack` → `prepare` → (archive) → `postpack`
- `aube publish` runs `prepublishOnly` → `prepublish` → pack chain → (PUT) → `publish` → `postpublish`; `--ignore-scripts` is no longer a no-op
- `aube version` runs `preversion` (before manifest edit) → `version` (before git commit) → `postversion` (after tag), with a new `--ignore-scripts` flag
- Shared `run_root_script_by_name` helper in `aube-scripts` keeps the three commands on one code path

Closes [#253](https://github.com/endevco/aube/discussions/253) and fills the parallel gaps in `pack` + `version` I found while investigating.

Ordering mirrors pnpm so projects migrating from pnpm don't see their build/test gates silently skipped at publish time. Dry-run `publish` still runs the pre-pack chain (so users can smoke-test their `prepublishOnly`) but skips `publish` / `postpublish` since nothing was uploaded.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release -p aube -p aube-scripts`
- [x] `mise run test:bats test/pack.bats` — 9/9 pass (3 new)
- [x] `mise run test:bats test/publish.bats` — 17/17 pass (3 new)
- [x] `mise run test:bats test/version.bats` — 16/16 pass (3 new)
- [ ] End-to-end against a real registry with a `prepublishOnly` that builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds execution of root lifecycle scripts during `pack`, `publish`, and `version`, which can change build/publish side effects and cause new failures in existing workflows. Publish metadata is now derived after hook mutations, reducing mismatch risk but altering what gets sent to registries.
> 
> **Overview**
> `aube pack` now runs root lifecycle scripts (`prepack` → `prepare` → `postpack`) and adds `--ignore-scripts` to skip them.
> 
> `aube publish`’s `--ignore-scripts` is no longer a no-op: it runs `prepublishOnly`/`prepublish` plus the pack-time chain before building the tarball (even in `--dry-run`), runs `publish`/`postpublish` only after a successful PUT, and re-reads `package.json` after pre-hooks so registry metadata matches hook-mutated manifests.
> 
> `aube version` adds `--ignore-scripts` and runs `preversion` (before writing `package.json`), `version` (after the edit), and `postversion` (after git ops when applicable), preserving any manifest edits made by `preversion`. Documentation/CLI specs and Bats tests are updated accordingly, and `aube-scripts` gains `run_root_script_by_name` plus a shared script-settings loader for these non-install hook paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dbbfe7ef80b0cab3abf8d68c2e42f81e2b94101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->