### PR TITLE
install: use warm path in frozen mode

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1085,7 +1085,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // is effectively a no-op on a state-matched warm install (no
     // orphans accumulate when deps are unchanged), so we keep the
     // fast path only when the setting is at its default.
-    let warm_path_eligible = matches!(opts.mode, FrozenMode::Prefer)
+    let warm_path_eligible = matches!(opts.mode, FrozenMode::Frozen | FrozenMode::Prefer)
         && !opts.force
         && !opts.lockfile_only
         && !opts.dep_selection.is_filtered()

--- a/test/install.bats
+++ b/test/install.bats
@@ -30,6 +30,18 @@ teardown() {
 	assert_output --partial "Already up to date"
 }
 
+@test "aube install warm path works in CI frozen mode" {
+	_setup_basic_fixture
+	export CI=1
+
+	run aube install
+	assert_success
+
+	run aube install
+	assert_success
+	assert_output --partial "Already up to date"
+}
+
 @test "aube install does not print 'Already up to date' when it does real work" {
 	# Guard against regression: a fresh install (or one that had to
 	# recreate node_modules) must not claim the tree was already up


### PR DESCRIPTION
## Summary

- allow the install warm-path shortcut to run in `FrozenMode::Frozen` as well as `FrozenMode::Prefer`
- add a BATS regression test that simulates CI mode and verifies a second frozen install reports `Already up to date`

## Why

CI defaults to frozen lockfile mode, but a state-verified install tree can safely skip the resolve/fetch/link pipeline the same way local prefer-frozen installs already do. This targets already-installed benchmark shapes such as `cache+lockfile+node_modules` where the lockfile and `.aube-state` both prove the tree is fresh.

## Validation

- `cargo fmt --check`
- `cargo build`
- `mise run test:bats test/install.bats`
- `cargo clippy --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes install short-circuit conditions in `install::run`, which can affect CI behavior and could skip needed work if eligibility gating is wrong.
> 
> **Overview**
> Allows `aube install` to take the warm-path no-op shortcut when running in `FrozenMode::Frozen` (in addition to `Prefer`), so state-verified CI installs can skip the resolve/fetch/link pipeline and still report `Already up to date`.
> 
> Adds a BATS regression test that sets `CI=1` and asserts a second install run hits the warm path and prints `Already up to date`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f340549ece5e3648f7382d20ccd4a2426fb1e332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->