### PR TITLE
ci: enforce conventional commit PR titles

### DIFF
--- a/.github/workflows/semantic-pr-lint.yml
+++ b/.github/workflows/semantic-pr-lint.yml
@@ -1,0 +1,33 @@
+name: semantic-pr-lint
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            refactor
+            chore
+            docs
+            style
+            test
+            perf
+            build
+            ci
+            revert
+            security

--- a/.rules
+++ b/.rules
@@ -85,26 +85,30 @@ when_to_use_release:
     - shipping release-only asserts that don't exist in debug — keep invariants consistent across profiles
 
 commits:
-  format: <area>(<subscope>): <description>
-  style: lowercase after colon, imperative mood, concise, subject typically <=80 chars (p95 in history is 73), usually no body
-  areas_crates[10]: cli, resolver, registry, lockfile, store, linker, manifest, scripts, workspace, settings
-  areas_features[12]: install, add, publish, dlx, audit, login, logout, deprecate, unpublish, fetch, import, catalog
-  areas_infra[8]: ci, docs, bench, test, packaging, release, chore, refactor
-  subscopes_examples[5]: lockfile(yarn), bench(hermetic), ci(release-plz), docs(home), fix(dlx)
-  fallback: feat, fix (accepted history uses feat(cli) and fix(dlx) freely, subsystem prefix still preferred when it fits)
+  format: <type>(<scope>): <description>
+  style: conventional commits — lowercase after colon, imperative mood, concise, subject typically <=80 chars (p95 in history is 73), usually no body
+  why: PR titles drive release-plz version bumps (feat→minor, fix→patch, BREAKING CHANGE/`!` →major, others→no bump). enforced by .github/workflows/semantic-pr-lint.yml on PR title via amannn/action-semantic-pull-request
+  types[12]: fix, feat, refactor, chore, docs, style, test, perf, build, ci, revert, security
+  scope_optional: true (omit for repo-wide changes like `chore: release v1.2.0`)
+  scopes_crates[10]: cli, resolver, registry, lockfile, store, linker, manifest, scripts, workspace, settings
+  scopes_features[12]: install, add, publish, dlx, audit, login, logout, deprecate, unpublish, fetch, import, catalog
+  scopes_infra[5]: bench, packaging, release, deps, release-plz
+  breaking: append `!` after type/scope (e.g. `feat(resolver)!: drop yarn classic`) or include `BREAKING CHANGE:` footer in body. release-plz will cut a major bump
   body_rules: reserve body for breaking changes, security fixes, benchmark tables, non-obvious WHY. wrap 72, use - not *
   pr_numbers: never type (#NN) yourself, GitHub squash-merge appends them automatically
+  pr_titles: must match the same `<type>(<scope>): <desc>` format — the lint workflow blocks merges that don't
   forbidden[2]:
     - "[codex]" or tool-branding prefix in subject
     - emoji in commit subject
   trailers_accepted: Co-authored-by (agents + bots are normal aube history, 50+ commits use them)
-  examples[6]:
-    - cli: add aubr/aubx multicall shims for run and dlx
-    - resolver: preserve npm-alias as folder name on fresh resolve
-    - store: swap CAS hash from SHA-512 to BLAKE3
-    - lockfile(yarn): add yarn berry (v2+) parse + write support
-    - bench(hermetic): warm registry with every PM, pin via .npmrc
+  examples[7]:
+    - feat(cli): add aubr/aubx multicall shims for run and dlx
+    - fix(resolver): preserve npm-alias as folder name on fresh resolve
+    - refactor(store): swap CAS hash from SHA-512 to BLAKE3
+    - feat(lockfile): add yarn berry (v2+) parse + write support
+    - perf(bench): warm registry with every PM, pin via .npmrc
     - chore: release v1.0.0-beta.4
+    - feat(resolver)!: drop yarn classic lockfile support
 
 progress_ui:
   lib: clx::progress

--- a/.rules
+++ b/.rules
@@ -90,6 +90,7 @@ commits:
   why: PR titles drive release-plz version bumps (feat→minor, fix→patch, BREAKING CHANGE/`!` →major, others→no bump). enforced by .github/workflows/semantic-pr-lint.yml on PR title via amannn/action-semantic-pull-request
   types[12]: fix, feat, refactor, chore, docs, style, test, perf, build, ci, revert, security
   scope_optional: true (omit for repo-wide changes like `chore: release v1.2.0`)
+  scope_enforcement: advisory — the lint workflow only validates `type`, not `scope`. lists below are the conventional set, but new crates/features can introduce new scopes without a workflow change. release-plz keys off `type` only
   scopes_crates[10]: cli, resolver, registry, lockfile, store, linker, manifest, scripts, workspace, settings
   scopes_features[12]: install, add, publish, dlx, audit, login, logout, deprecate, unpublish, fetch, import, catalog
   scopes_infra[5]: bench, packaging, release, deps, release-plz


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/semantic-pr-lint.yml` (mirrors mise's setup) that runs `amannn/action-semantic-pull-request@v6` on PR open/edit/reopen so squash-merge titles are conventional-commits clean.
- Rewrites `.rules` (and CLAUDE.md via symlink) `commits:` from the ad-hoc `<area>(<subscope>):` shape to standard conventional commits with 12 accepted types and scopes regrouped from the previous `areas_*` lists.
- Documents the `!` breaking-change suffix and the WHY: release-plz derives version bumps from these titles (`feat→minor`, `fix→patch`, `!`/`BREAKING CHANGE→major`).

## Why
Today release-plz can't reliably pick a bump because squash titles mix `area:` and `feat(area):` styles freely. Enforcing conventional commits at PR-title time makes the bump deterministic and matches what we already do in `mise`.

## Notes for reviewers
- Token: uses the workflow's default `GITHUB_TOKEN` (with `pull-requests: read`) rather than the bespoke `MISE_PR_COMMENT_TOKEN` from mise — no new secret to provision.
- The `registry` type from mise's list is dropped (mise-specific); `security` is kept.
- Existing history is unchanged; only future PRs are gated.

## Test plan
- [ ] Workflow runs on this PR and passes against the title above.
- [ ] Open a throwaway draft PR with a non-conforming title (e.g. `update stuff`) and confirm the check fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces a new `pull_request_target` workflow that can affect merge gating and CI behavior. No application/runtime code changes, but misconfiguration could block valid PRs or create CI security footguns if expanded later.
> 
> **Overview**
> Adds a new `.github/workflows/semantic-pr-lint.yml` check that runs on PR open/edit/reopen to validate PR titles via `amannn/action-semantic-pull-request` and restricts allowed conventional-commit `type`s.
> 
> Updates `.rules` to standardize on conventional commits (`<type>(<scope>): ...`), document breaking-change notation (`!`/`BREAKING CHANGE`), and explicitly state that PR titles must follow the same format to drive `release-plz` version bumping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8010a040700e045dd2589aeeea5259e84da4831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->