### PR TITLE
bench: default to hermetic registry

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -19,19 +19,16 @@ set -euo pipefail
 #   RESULTS_JSON — override the structured JSON output path
 #
 #   BENCH_HERMETIC=1 — route all registry traffic through a local
-#                      Verdaccio instance pre-populated from npmjs. Makes
-#                      cold-cache numbers deterministic (no npmjs CDN
-#                      jitter). First hermetic run warms the cache at
+#                      Verdaccio instance pre-populated from npmjs. This
+#                      is the default for mise tasks; leave it on so
+#                      cold-cache numbers are not npmjs/CDN latency tests.
+#                      First hermetic run warms the cache at
 #                      ~/.cache/aube-bench/registry/; subsequent runs
 #                      are fully offline. See benchmarks/hermetic.bash.
 #   BENCH_BANDWIDTH  — optional throttle (e.g. `50mbit`, `6mbit`, bare
-#                      integer bytes/s). Only meaningful with
-#                      BENCH_HERMETIC=1; routes traffic through a tiny
-#                      Node.js token-bucket proxy in front of Verdaccio.
-#
-# Do NOT combine BENCH_HERMETIC or BENCH_BANDWIDTH with `bench:bump` —
-# results.json is the published "real internet" baseline and must not
-# be overwritten from a hermetic run.
+#                      integer bytes/s). Defaults to `500mbit` in mise
+#                      tasks; routes traffic through a tiny token-bucket
+#                      proxy in front of Verdaccio.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -66,12 +66,10 @@ updated JSON to refresh the chart above — the VitePress data loader at
 reads it at build time, so you don't need to edit `benchmarks.md` or
 hand-write any chart data.
 
-For cross-machine reproducibility, ad-hoc runs use a hermetic local
-registry with the link throttled to a fixed 500mbit baseline — a
-"fast home broadband" speed — so two runs on different ISPs or CI
-runners produce comparable numbers:
+Benchmark runs use a hermetic local registry with the link throttled to
+a fixed 500mbit baseline — a "fast home broadband" speed — so two runs
+on different ISPs or CI runners produce comparable numbers:
 
 ```sh
-flock /tmp/aube-bench.lock \
-  env BENCH_HERMETIC=1 BENCH_BANDWIDTH=500mbit mise run bench
+flock /tmp/aube-bench.lock mise run bench
 ```

--- a/mise.toml
+++ b/mise.toml
@@ -39,6 +39,7 @@ run = "../target/debug/aube install && exec ../target/debug/aube run docs:build"
 
 [tasks.bench]
 dir = "{{config_root}}"
+env = { BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit" }
 run = [
   "cargo build --release",
   "mise x aqua:sharkdp/hyperfine@latest aqua:pnpm/pnpm@latest npm:yarn@1 bun@latest node@24 -- bash benchmarks/bench.sh",
@@ -52,7 +53,7 @@ run = [
 # data loader at `docs/benchmarks.data.ts` reads it at build time.
 [tasks."bench:bump"]
 dir = "{{config_root}}"
-env = { RUNS = "10", WARMUP = "3", RESULTS_JSON = "{{config_root}}/benchmarks/results.json" }
+env = { RUNS = "10", WARMUP = "3", RESULTS_JSON = "{{config_root}}/benchmarks/results.json", BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit" }
 run = [
   "cargo build --release",
   "mise x aqua:sharkdp/hyperfine@latest aqua:pnpm/pnpm@latest npm:yarn@1 bun@latest node@24 -- bash benchmarks/bench.sh",


### PR DESCRIPTION
## Summary

- Default `mise run bench` to `BENCH_HERMETIC=1` and `BENCH_BANDWIDTH=500mbit`.
- Apply the same defaults to `bench:bump` so published benchmark refreshes also use Verdaccio and the fixed throttle.
- Update benchmark docs and script comments to make Verdaccio the expected path instead of an ad-hoc opt-in.

## Validation

- `git diff --check`
- pre-commit hooks: `shfmt`, `shellcheck`

No benchmark result files were changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to benchmark tooling and documentation, though it may change how benchmark numbers are produced and interpreted.
> 
> **Overview**
> Benchmark tasks now **default to a hermetic Verdaccio-backed registry** with a fixed `500mbit` throttle by setting `BENCH_HERMETIC=1` and `BENCH_BANDWIDTH=500mbit` in `mise.toml` for both `bench` and `bench:bump`.
> 
> Documentation and `benchmarks/bench.sh` comments are updated to treat hermetic mode as the expected path, simplifying the reproduction instructions (no extra env vars needed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b48bd8f7cd64b7dfb0aa45bf7187598a8fa569f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->