### PR TITLE
fix(docs): stack banner message and link on mobile

### DIFF
--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -47,6 +47,8 @@
     text-wrap: balance;
   }
   .jdx-banner button {
+    top: 0.25rem;
     right: 0.25rem;
+    transform: none;
   }
 }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -39,7 +39,14 @@
 }
 @media (max-width: 640px) {
   .jdx-banner {
-    font-size: 0.85rem;
-    padding: 0.4rem 2.5rem;
+    flex-direction: column;
+    gap: 0.125rem;
+    font-size: 0.8rem;
+    padding: 0.5rem 2.25rem;
+    line-height: 1.3;
+    text-wrap: balance;
+  }
+  .jdx-banner button {
+    right: 0.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- On narrow viewports the site banner rendered cramped: `flex-wrap: nowrap` forced the message onto two squeezed lines while the "Read more" link sat jammed against the text.
- At `<=640px`, switch the banner to `flex-direction: column` so the message and link stack cleanly. Also shrink the font slightly, tighten line-height, add `text-wrap: balance` for even two-line breaks, and nudge the close button flush to the corner.

Matches the identical fix going out to the mise and hk docs.

## Test plan
- [ ] Visit aube.jdx.dev on a mobile device (or DevTools <=640px) after deploy and confirm the banner stacks cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only tweaks scoped to the docs banner’s `<=640px` responsive styles; main risk is minor visual regressions on small viewports.
> 
> **Overview**
> Updates `docs/.vitepress/theme/banner.css` mobile (`@media (max-width: 640px)`) styles so the banner switches to `flex-direction: column` with tighter spacing, smaller text, adjusted padding/line-height, and `text-wrap: balance` for cleaner wrapping.
> 
> Also repositions the close button in the mobile layout (top/right corner and removes centering transform) to avoid overlap and reduce cramped rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e418d006ebc0db7f6fa14c81fe03de79eaa1b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->