### PR TITLE
fix(publish): report post-hook name/version in PublishOutcome

### DIFF
--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -428,8 +428,8 @@ async fn publish_one(
                 .wrap_err("--dry-run --provenance: OIDC probe failed")?;
         }
         return Ok(PublishOutcome {
-            name,
-            version,
+            name: archive.name.clone(),
+            version: archive.version.clone(),
             registry_url,
             archive: Some(archive),
             status: PublishStatus::DryRun,
@@ -545,8 +545,8 @@ async fn publish_one(
     run_publish_lifecycle_post(pkg_dir, &manifest, args.ignore_scripts).await?;
 
     Ok(PublishOutcome {
-        name,
-        version,
+        name: archive.name.clone(),
+        version: archive.version.clone(),
         registry_url,
         archive: Some(archive),
         status: PublishStatus::Published,

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -438,6 +438,37 @@ NODE
 	assert_output "null"
 }
 
+@test "aube publish --dry-run --json reports post-hook version when prepublishOnly bumps version" {
+	# Regression: PublishOutcome captured `name`/`version` from the
+	# pre-hook manifest, so if `prepublishOnly` stamped a git SHA into
+	# the version, the tarball (and registry) would carry the new
+	# version but the --json / user-facing line still reported the old
+	# one. Outcome now pulls from the built archive, which reads
+	# package.json fresh after hooks.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "publish-outcome-version",
+		  "version": "0.1.0",
+		  "main": "index.js",
+		  "files": ["index.js"],
+		  "scripts": {
+		    "prepublishOnly": "node ./bump.mjs"
+		  }
+		}
+	EOF
+	echo "module.exports = 1" >index.js
+	cat >bump.mjs <<'NODE'
+import fs from 'node:fs';
+const m = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+m.version = '0.1.0-sha.abc123';
+fs.writeFileSync('package.json', JSON.stringify(m, null, 2));
+NODE
+
+	run bash -c "aube publish --dry-run --json --registry=https://r.example.com/ | jq -r '.[0].version'"
+	assert_success
+	assert_output "0.1.0-sha.abc123"
+}
+
 @test "aube publish --dry-run --json emits a pnpm-compatible array" {
 	_write_publishable_pkg
 


### PR DESCRIPTION
## Summary

- `PublishOutcome.name` / `.version` were captured from the manifest **before** lifecycle hooks ran. If `prepublishOnly` (or any pre-pack hook) mutates `package.json` — e.g. stamps a git SHA into the version — the tarball and registry metadata correctly carry the new value, but `aube publish --json` and the success-line output still reported the stale pre-hook value.
- Pull `name` / `version` from the built `archive` (which reads `package.json` fresh after hooks) in the `DryRun` and `Published` outcome construction sites. The `AlreadyPublished` branch keeps the pre-hook values — it fires before any hook runs.
- Follow-up to #262 — addresses the unfixed piece of the Cursor Bugbot review on that PR (https://github.com/endevco/aube/pull/262#pullrequestreview).

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release -p aube` (286/286 passed)
- [x] `mise run test:bats test/publish.bats` (19/19 passed, including new regression test)
- [x] New bats case: `aube publish --dry-run --json reports post-hook version when prepublishOnly bumps version` — asserts `.version` in JSON output reflects the hook's mutation, not the pre-hook value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how `aube publish` reports `name`/`version` in its outcome, aligning output with the already-built tarball metadata; behavior of uploads and registry interactions is unchanged.
> 
> **Overview**
> Fixes `aube publish` to report the *post-lifecycle-hook* `name`/`version` in both dry-run and successful publish outcomes by sourcing these fields from the built `archive` rather than the pre-hook manifest.
> 
> Adds a regression Bats test ensuring `--dry-run --json` reflects a version mutated by `prepublishOnly` (e.g., stamping a git SHA), preventing mismatches between tarball/registry metadata and user-facing output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f3744ca0701b3ca0a2f2e74a35a14e1f63ddb7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->