### PR TITLE
feat(resolver): support pnpm `&path:/<sub>` git dep selector

### DIFF
--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -627,6 +627,7 @@ fn classify_bun_ident(
                 url: format!("https://github.com/{url}.git"),
                 committish: committish.clone(),
                 resolved: committish.unwrap_or_default(),
+                subpath: None,
             })),
             alias_of,
         ));
@@ -634,7 +635,7 @@ fn classify_bun_ident(
     if (raw_version.starts_with("git+")
         || raw_version.starts_with("git://")
         || raw_version.starts_with("git@"))
-        && let Some((url, committish)) = crate::parse_git_spec(raw_version)
+        && let Some((url, committish, subpath)) = crate::parse_git_spec(raw_version)
     {
         return Ok((
             name,
@@ -643,6 +644,7 @@ fn classify_bun_ident(
                 url,
                 committish: committish.clone(),
                 resolved: committish.unwrap_or_default(),
+                subpath,
             })),
             alias_of,
         ));

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -222,6 +222,12 @@ pub struct GitSource {
     pub url: String,
     pub committish: Option<String>,
     pub resolved: String,
+    /// pnpm `&path:/sub/dir` selector — when set, only this
+    /// subdirectory of the cloned repo is treated as the package
+    /// root. Stored without leading slash so dep_path hashes are
+    /// stable regardless of whether the user wrote `path:/x` or
+    /// `path:x`.
+    pub subpath: Option<String>,
 }
 
 impl LocalSource {
@@ -267,7 +273,10 @@ impl LocalSource {
     /// separators so the resulting lockfile is portable.
     pub fn specifier(&self) -> String {
         match self {
-            LocalSource::Git(g) => format!("{}#{}", g.url, g.resolved),
+            LocalSource::Git(g) => match &g.subpath {
+                Some(sub) => format!("{}#{}&path:/{}", g.url, g.resolved, sub),
+                None => format!("{}#{}", g.url, g.resolved),
+            },
             LocalSource::RemoteTarball(t) => t.url.clone(),
             _ => format!("{}:{}", self.kind_str(), self.path_posix()),
         }
@@ -296,6 +305,10 @@ impl LocalSource {
                 hasher.update(g.url.as_bytes());
                 hasher.update(b"#");
                 hasher.update(g.resolved.as_bytes());
+                if let Some(sub) = &g.subpath {
+                    hasher.update(b"&path:/");
+                    hasher.update(sub.as_bytes());
+                }
             }
             LocalSource::RemoteTarball(t) => {
                 hasher.update(t.url.as_bytes());
@@ -316,7 +329,7 @@ impl LocalSource {
         // Check git first so URLs like `https://host/user/repo.git`
         // aren't swallowed by the broader bare-http tarball check
         // below.
-        if let Some((url, committish)) = parse_git_spec(spec) {
+        if let Some((url, committish, subpath)) = parse_git_spec(spec) {
             // `resolved` is filled in by the resolver after running
             // `git ls-remote`. A lockfile round-trip that never
             // re-resolves will leave this empty, which is the sentinel
@@ -325,6 +338,7 @@ impl LocalSource {
                 url,
                 committish,
                 resolved: String::new(),
+                subpath,
             }));
         }
         // Any remaining bare `http(s)://` URL is a remote tarball.
@@ -391,10 +405,13 @@ impl LocalSource {
 ///
 /// Returns `None` for any specifier that doesn't look like a git URL,
 /// so the caller can fall through to other protocol parsers.
-pub fn parse_git_spec(spec: &str) -> Option<(String, Option<String>)> {
-    let (body, committish) = match spec.find('#') {
-        Some(idx) => (&spec[..idx], normalize_git_fragment(&spec[idx + 1..])),
-        None => (spec, None),
+pub fn parse_git_spec(spec: &str) -> Option<(String, Option<String>, Option<String>)> {
+    let (body, committish, subpath) = match spec.find('#') {
+        Some(idx) => {
+            let (c, s) = parse_git_fragment(&spec[idx + 1..]);
+            (&spec[..idx], c, s)
+        }
+        None => (spec, None, None),
     };
     let is_bare_transport = body.starts_with("https://")
         || body.starts_with("http://")
@@ -427,7 +444,7 @@ pub fn parse_git_spec(spec: &str) -> Option<(String, Option<String>)> {
     } else {
         return None;
     };
-    Some((url, committish))
+    Some((url, committish, subpath))
 }
 
 /// Normalize git URL fragments used by npm-compatible lockfiles.
@@ -438,33 +455,60 @@ pub fn parse_git_spec(spec: &str) -> Option<(String, Option<String>)> {
 /// `git checkout`, so strip the selector key here and keep only the
 /// actual ref name or SHA.
 pub(crate) fn normalize_git_fragment(fragment: &str) -> Option<String> {
+    parse_git_fragment(fragment).0
+}
+
+/// Parse a git URL fragment into `(committish, subpath)`. Handles the
+/// pnpm/hosted-git-info form `<ref>&path:/sub/dir` (the `path:` key
+/// uses a colon, not `=`, by historical convention) as well as the
+/// `key=value` form npm/Yarn Berry write. Unknown selectors are
+/// ignored. Subpath is returned without leading slash so the caller
+/// can join it with a clone dir without tripping the absolute-path
+/// branch of `Path::join`.
+pub(crate) fn parse_git_fragment(fragment: &str) -> (Option<String>, Option<String>) {
     if fragment.is_empty() {
-        return None;
+        return (None, None);
     }
 
     let mut fallback: Option<&str> = None;
     let mut preferred: Option<&str> = None;
+    let mut subpath: Option<String> = None;
     for part in fragment.split('&') {
         if part.is_empty() {
             continue;
         }
-        let (key, value) = part.split_once('=').unwrap_or(("", part));
+        // Try `key=value` first; fall back to `key:value` only for
+        // the small set of well-known selectors so a tag name that
+        // happens to contain a colon (e.g. `release:2026-01`) is not
+        // misparsed as a key.
+        let split = part.split_once('=').or_else(|| {
+            part.split_once(':').filter(|(k, _)| {
+                matches!(*k, "commit" | "tag" | "head" | "branch" | "path" | "semver")
+            })
+        });
+        let (key, value) = split.unwrap_or(("", part));
         if value.is_empty() {
             continue;
         }
         match key {
-            "commit" => {
-                preferred = Some(value);
-                break;
+            "commit" => preferred = Some(value),
+            "tag" | "head" | "branch" => {
+                fallback.get_or_insert(value);
             }
-            "tag" | "head" | "branch" | "" => {
+            "path" => {
+                let trimmed = value.trim_start_matches('/');
+                if !trimmed.is_empty() {
+                    subpath = Some(trimmed.to_string());
+                }
+            }
+            "" => {
                 fallback.get_or_insert(value);
             }
             _ => {}
         }
     }
 
-    preferred.or(fallback).map(ToString::to_string)
+    (preferred.or(fallback).map(ToString::to_string), subpath)
 }
 
 /// A single resolved package in the lockfile.
@@ -2023,9 +2067,10 @@ mod git_spec_tests {
     #[test]
     fn git_plus_https_without_dot_git_roundtrips_via_lockfile_form() {
         // Initial parse: `git+https://…/repo` (no `.git`).
-        let (url, committish) = parse_git_spec("git+https://host/user/repo").unwrap();
+        let (url, committish, subpath) = parse_git_spec("git+https://host/user/repo").unwrap();
         assert_eq!(url, "https://host/user/repo");
         assert_eq!(committish, None);
+        assert_eq!(subpath, None);
 
         // After resolving, the serializer writes `<url>#<sha>` into
         // the lockfile's importer `version:` field.
@@ -2034,15 +2079,18 @@ mod git_spec_tests {
             url: url.clone(),
             committish: None,
             resolved: sha.to_string(),
+            subpath: None,
         });
         let lockfile_version = source.specifier();
         assert_eq!(lockfile_version, format!("https://host/user/repo#{sha}"));
 
         // Re-parse must recognize the bare URL because the 40-hex
         // committish suffix unambiguously tags it as git.
-        let (round_url, round_committish) = parse_git_spec(&lockfile_version).unwrap();
+        let (round_url, round_committish, round_subpath) =
+            parse_git_spec(&lockfile_version).unwrap();
         assert_eq!(round_url, "https://host/user/repo");
         assert_eq!(round_committish.as_deref(), Some(sha));
+        assert_eq!(round_subpath, None);
     }
 
     #[test]
@@ -2054,14 +2102,14 @@ mod git_spec_tests {
 
     #[test]
     fn github_shorthand_expands_and_roundtrips() {
-        let (url, _) = parse_git_spec("github:user/repo").unwrap();
+        let (url, _, _) = parse_git_spec("github:user/repo").unwrap();
         assert_eq!(url, "https://github.com/user/repo.git");
     }
 
     #[test]
     fn commit_selector_fragment_normalizes_to_sha() {
         let sha = "abcdef0123456789abcdef0123456789abcdef01";
-        let (url, committish) =
+        let (url, committish, _) =
             parse_git_spec(&format!("https://host/user/repo.git#commit={sha}")).unwrap();
         assert_eq!(url, "https://host/user/repo.git");
         assert_eq!(committish.as_deref(), Some(sha));
@@ -2069,9 +2117,61 @@ mod git_spec_tests {
 
     #[test]
     fn named_selector_fragment_normalizes_to_ref() {
-        let (url, committish) = parse_git_spec("git+https://host/user/repo#tag=v1.2.3").unwrap();
+        let (url, committish, _) = parse_git_spec("git+https://host/user/repo#tag=v1.2.3").unwrap();
         assert_eq!(url, "https://host/user/repo");
         assert_eq!(committish.as_deref(), Some("v1.2.3"));
+    }
+
+    #[test]
+    fn pnpm_path_subpath_extracted_from_fragment() {
+        // pnpm syntax: `<url>#<ref>&path:/<subdir>` selects a
+        // subdirectory of the cloned repo as the package root.
+        let (url, committish, subpath) =
+            parse_git_spec("github:org/dep#v0.1.4&path:/packages/special").unwrap();
+        assert_eq!(url, "https://github.com/org/dep.git");
+        assert_eq!(committish.as_deref(), Some("v0.1.4"));
+        assert_eq!(subpath.as_deref(), Some("packages/special"));
+    }
+
+    #[test]
+    fn path_subpath_roundtrips_via_specifier() {
+        let sha = "abcdef0123456789abcdef0123456789abcdef01";
+        let source = LocalSource::Git(GitSource {
+            url: "https://github.com/org/dep.git".to_string(),
+            committish: None,
+            resolved: sha.to_string(),
+            subpath: Some("packages/special".to_string()),
+        });
+        let spec = source.specifier();
+        assert_eq!(
+            spec,
+            format!("https://github.com/org/dep.git#{sha}&path:/packages/special")
+        );
+        let (url, committish, subpath) = parse_git_spec(&spec).unwrap();
+        assert_eq!(url, "https://github.com/org/dep.git");
+        assert_eq!(committish.as_deref(), Some(sha));
+        assert_eq!(subpath.as_deref(), Some("packages/special"));
+    }
+
+    #[test]
+    fn dep_path_distinguishes_subpaths_under_same_commit() {
+        // Two packages from the same repo+commit but different
+        // subdirs must hash to distinct dep_paths so the linker
+        // doesn't collapse them.
+        let sha = "abcdef0123456789abcdef0123456789abcdef01";
+        let a = LocalSource::Git(GitSource {
+            url: "https://example.com/r.git".to_string(),
+            committish: None,
+            resolved: sha.to_string(),
+            subpath: Some("packages/a".to_string()),
+        });
+        let b = LocalSource::Git(GitSource {
+            url: "https://example.com/r.git".to_string(),
+            committish: None,
+            resolved: sha.to_string(),
+            subpath: Some("packages/b".to_string()),
+        });
+        assert_ne!(a.dep_path("dep"), b.dep_path("dep"));
     }
 }
 

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -503,6 +503,10 @@ pub(crate) fn parse_git_fragment(fragment: &str) -> (Option<String>, Option<Stri
                 // crafted spec like `&path:/../../etc` would let the
                 // resolver and installer escape the clone dir and
                 // import an arbitrary host directory into the store.
+                if subpath.is_some() {
+                    // First-wins, matching the other selectors above.
+                    continue;
+                }
                 let trimmed = value.trim_start_matches('/');
                 if trimmed.is_empty() {
                     continue;

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -478,28 +478,42 @@ pub(crate) fn parse_git_fragment(fragment: &str) -> (Option<String>, Option<Stri
             continue;
         }
         // Try `key=value` first; fall back to `key:value` only for
-        // the small set of well-known selectors so a tag name that
-        // happens to contain a colon (e.g. `release:2026-01`) is not
-        // misparsed as a key.
+        // the small set of selectors we actually handle below. A tag
+        // name with a colon (e.g. `release:2026-01`) is left alone —
+        // and `semver:^1.0.0` stays as a literal ref so `ls-remote`
+        // surfaces an explicit error rather than silently HEAD-ing.
         let split = part.split_once('=').or_else(|| {
-            part.split_once(':').filter(|(k, _)| {
-                matches!(*k, "commit" | "tag" | "head" | "branch" | "path" | "semver")
-            })
+            part.split_once(':')
+                .filter(|(k, _)| matches!(*k, "commit" | "tag" | "head" | "branch" | "path"))
         });
         let (key, value) = split.unwrap_or(("", part));
         if value.is_empty() {
             continue;
         }
         match key {
-            "commit" => preferred = Some(value),
+            "commit" => {
+                preferred.get_or_insert(value);
+            }
             "tag" | "head" | "branch" => {
                 fallback.get_or_insert(value);
             }
             "path" => {
+                // Strip leading slashes (pnpm writes `path:/sub`) and
+                // reject any `..` / `.` component. Without this, a
+                // crafted spec like `&path:/../../etc` would let the
+                // resolver and installer escape the clone dir and
+                // import an arbitrary host directory into the store.
                 let trimmed = value.trim_start_matches('/');
-                if !trimmed.is_empty() {
-                    subpath = Some(trimmed.to_string());
+                if trimmed.is_empty() {
+                    continue;
                 }
+                if trimmed
+                    .split('/')
+                    .any(|c| c.is_empty() || c == "." || c == "..")
+                {
+                    continue;
+                }
+                subpath = Some(trimmed.to_string());
             }
             "" => {
                 fallback.get_or_insert(value);
@@ -2151,6 +2165,23 @@ mod git_spec_tests {
         assert_eq!(url, "https://github.com/org/dep.git");
         assert_eq!(committish.as_deref(), Some(sha));
         assert_eq!(subpath.as_deref(), Some("packages/special"));
+    }
+
+    #[test]
+    fn path_traversal_components_in_subpath_are_rejected() {
+        // `..` and `.` components would let a crafted spec escape the
+        // clone dir at install time. The parser drops them so the
+        // resolver/installer never see a traversal-laden subpath.
+        let cases = [
+            "github:org/dep#main&path:/../../etc",
+            "github:org/dep#main&path:/packages/../../../etc",
+            "github:org/dep#main&path:/./packages/foo",
+            "github:org/dep#main&path:/packages//foo",
+        ];
+        for spec in cases {
+            let (_, _, subpath) = parse_git_spec(spec).unwrap();
+            assert_eq!(subpath, None, "spec should drop subpath: {spec}");
+        }
     }
 
     #[test]

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -214,10 +214,20 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                         Some(LocalSource::Directory(std::path::PathBuf::from(dir)));
                 } else if let (Some(repo), Some(commit)) = (res.repo.as_ref(), res.commit.as_ref())
                 {
+                    // Preserve any `path:` selector that was already
+                    // captured from the importer's `version:` URL —
+                    // the resolution block doesn't always echo it
+                    // (pnpm v9 also encodes the subpath in the
+                    // snapshot key).
+                    let prior_subpath = match &local_pkg.local_source {
+                        Some(LocalSource::Git(g)) => g.subpath.clone(),
+                        _ => None,
+                    };
                     local_pkg.local_source = Some(LocalSource::Git(GitSource {
                         url: repo.clone(),
                         committish: None,
                         resolved: commit.clone(),
+                        subpath: res.path.clone().or(prior_subpath),
                     }));
                 }
             }
@@ -686,6 +696,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 commit: None,
                 repo: None,
                 type_: Some("directory".to_string()),
+                path: None,
             }),
             Some(local @ LocalSource::Tarball(_)) => Some(WritableResolution {
                 integrity: None,
@@ -694,6 +705,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 commit: None,
                 repo: None,
                 type_: None,
+                path: None,
             }),
             Some(LocalSource::Link(_)) => None,
             Some(LocalSource::Git(g)) => Some(WritableResolution {
@@ -703,6 +715,11 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 commit: Some(g.resolved.clone()),
                 repo: Some(g.url.clone()),
                 type_: Some("git".to_string()),
+                // pnpm v9 emits `path: /<sub>` (with leading `/`) on
+                // the resolution block when a git dep was installed
+                // with a `&path:/<sub>` selector. Keep the same shape
+                // so byte-identical round-trips survive.
+                path: g.subpath.as_ref().map(|s| format!("/{s}")),
             }),
             Some(LocalSource::RemoteTarball(t)) => Some(WritableResolution {
                 integrity: if t.integrity.is_empty() {
@@ -715,6 +732,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 commit: None,
                 repo: None,
                 type_: None,
+                path: None,
             }),
             None if url_keyed => {
                 // URL-keyed transitive entries (github overrides, etc.)
@@ -729,6 +747,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                     commit: None,
                     repo: None,
                     type_: None,
+                    path: None,
                 })
             }
             None => pkg.integrity.as_ref().map(|i| WritableResolution {
@@ -748,6 +767,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 commit: None,
                 repo: None,
                 type_: None,
+                path: None,
             }),
         };
         // Mirror pnpm: emit `version:` alongside the resolution block
@@ -1127,6 +1147,10 @@ struct WritableResolution {
     repo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     type_: Option<String>,
+    /// pnpm `&path:/<sub>` selector — emitted with leading `/` to
+    /// match pnpm's own writer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1431,6 +1455,28 @@ struct Resolution {
     #[serde(default, rename = "type")]
     #[allow(dead_code)]
     type_: Option<String>,
+    /// pnpm `&path:/<sub>` selector for git deps. Newer pnpm
+    /// (>= v9.x) emits this on the resolution block in addition to
+    /// encoding it in the snapshot key.
+    #[serde(default, deserialize_with = "deserialize_subpath")]
+    path: Option<String>,
+}
+
+/// Strip the leading `/` from pnpm's `path:` field so the value lines
+/// up with how `parse_git_fragment` stores it.
+fn deserialize_subpath<'de, D>(de: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: Option<String> = serde::Deserialize::deserialize(de)?;
+    Ok(raw.and_then(|s| {
+        let trimmed = s.trim_start_matches('/');
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -1463,7 +1463,10 @@ struct Resolution {
 }
 
 /// Strip the leading `/` from pnpm's `path:` field so the value lines
-/// up with how `parse_git_fragment` stores it.
+/// up with how `parse_git_fragment` stores it. Mirror the same
+/// `..`/`.`/empty-component guard as the in-URL parser so a crafted
+/// lockfile cannot direct the resolver to read a `package.json`
+/// outside the clone dir.
 fn deserialize_subpath<'de, D>(de: D) -> Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -1471,7 +1474,11 @@ where
     let raw: Option<String> = serde::Deserialize::deserialize(de)?;
     Ok(raw.and_then(|s| {
         let trimmed = s.trim_start_matches('/');
-        if trimmed.is_empty() {
+        if trimmed.is_empty()
+            || trimmed
+                .split('/')
+                .any(|c| c.is_empty() || c == "." || c == "..")
+        {
             None
         } else {
             Some(trimmed.to_string())

--- a/crates/aube-lockfile/src/yarn.rs
+++ b/crates/aube-lockfile/src/yarn.rs
@@ -698,6 +698,7 @@ fn parse_berry_str(
                     url: strip_commit_hash(&url),
                     committish: None,
                     resolved: extract_commit_hash(&url).unwrap_or_default(),
+                    subpath: None,
                 }))
             }
             _ => {
@@ -1017,6 +1018,7 @@ fn classify_remote(url: &str, _block: &serde_yaml::Mapping) -> Option<LocalSourc
             url: strip_commit_hash(url),
             committish: None,
             resolved: extract_commit_hash(url).unwrap_or_default(),
+            subpath: None,
         }))
     } else {
         Some(LocalSource::RemoteTarball(RemoteTarballSource {

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -221,16 +221,29 @@ pub(crate) async fn resolve_git_source(
     // thread via `spawn_blocking`.
     let url = git.url.clone();
     let committish = git.committish.clone();
+    let subpath = git.subpath.clone();
     let name_owned = name.to_string();
     let (local, version, deps) = tokio::task::spawn_blocking(move || -> Result<_, Error> {
         let resolved = aube_store::git_resolve_ref(&url, committish.as_deref())
             .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
         let clone_dir = aube_store::git_shallow_clone(&url, &resolved, shallow)
             .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
-        let manifest_bytes = std::fs::read(clone_dir.join("package.json")).map_err(|e| {
+        // `&path:/<sub>` narrows the package root to a subdirectory
+        // of the cloned repo (pnpm-compatible). The manifest, version,
+        // and transitive deps all come from the subdir's
+        // `package.json`, not the repo root's.
+        let pkg_root = match &subpath {
+            Some(sub) => clone_dir.join(sub),
+            None => clone_dir.clone(),
+        };
+        let manifest_bytes = std::fs::read(pkg_root.join("package.json")).map_err(|e| {
+            let where_ = subpath
+                .as_deref()
+                .map(|s| format!(" at /{s}"))
+                .unwrap_or_default();
             Error::Registry(
                 name_owned.clone(),
-                format!("read package.json in clone: {e}"),
+                format!("read package.json in clone{where_}: {e}"),
             )
         })?;
         let pj: aube_manifest::PackageJson = serde_json::from_slice(&manifest_bytes)
@@ -242,6 +255,7 @@ pub(crate) async fn resolve_git_source(
                 url,
                 committish,
                 resolved,
+                subpath,
             }),
             version,
             deps,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -479,6 +479,12 @@ pub(super) async fn import_local_source(
             // Everything below this line — manifest read, prepare
             // scratch copy, archive build, plain directory import —
             // operates on the subdir rather than the whole clone.
+            //
+            // Defense in depth against a `..`-laden subpath: the
+            // parser already rejects them, but we also canonicalize
+            // and assert the result stays under `clone_dir` so a
+            // future code path that fills `subpath` from a different
+            // source can't bypass the check.
             let pkg_root = match &g.subpath {
                 Some(sub) => clone_dir.join(sub),
                 None => clone_dir.clone(),
@@ -488,6 +494,23 @@ pub(super) async fn import_local_source(
                     "git dep {spec}: subpath {} not found in clone",
                     pkg_root.display()
                 ));
+            }
+            if g.subpath.is_some() {
+                let canonical_clone = clone_dir
+                    .canonicalize()
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("canonicalize clone dir for {spec}"))?;
+                let canonical_pkg = pkg_root
+                    .canonicalize()
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("canonicalize subpath for {spec}"))?;
+                if !canonical_pkg.starts_with(&canonical_clone) {
+                    return Err(miette!(
+                        "git dep {spec}: subpath {} escapes clone root {}",
+                        canonical_pkg.display(),
+                        canonical_clone.display()
+                    ));
+                }
             }
 
             // If the cloned repo defines a `prepare` script, treat

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -474,6 +474,22 @@ pub(super) async fn import_local_source(
             .map_err(|e| miette!("git clone task panicked: {e}"))?
             .map_err(|e| miette!("failed to clone {spec}: {e}"))?;
 
+            // `&path:/<sub>` narrows the package root to a
+            // subdirectory of the cloned repo (pnpm-compatible).
+            // Everything below this line — manifest read, prepare
+            // scratch copy, archive build, plain directory import —
+            // operates on the subdir rather than the whole clone.
+            let pkg_root = match &g.subpath {
+                Some(sub) => clone_dir.join(sub),
+                None => clone_dir.clone(),
+            };
+            if !pkg_root.is_dir() {
+                return Err(miette!(
+                    "git dep {spec}: subpath {} not found in clone",
+                    pkg_root.display()
+                ));
+            }
+
             // If the cloned repo defines a `prepare` script, treat
             // it as a source checkout that needs to be built before
             // we snapshot it. Matches npm/pnpm: a TypeScript repo
@@ -492,7 +508,7 @@ pub(super) async fn import_local_source(
             // through to the plain directory import. Matches pnpm,
             // which skips `prepare` for git deps under
             // `--ignore-scripts` as well.
-            let manifest_path = clone_dir.join("package.json");
+            let manifest_path = pkg_root.join("package.json");
             let needs_prepare = !ignore_scripts
                 && aube_manifest::PackageJson::from_path(&manifest_path)
                     .ok()
@@ -515,7 +531,7 @@ pub(super) async fn import_local_source(
                 //
                 // `ScratchDir` removes the copy on drop, including
                 // on the error path.
-                let scratch = prepare_scratch_copy(&clone_dir, &spec)?;
+                let scratch = prepare_scratch_copy(&pkg_root, &spec)?;
                 run_git_dep_prepare(scratch.path(), &spec, ignore_scripts, git_prepare_depth)
                     .await?;
                 let archive = crate::commands::pack::build_archive(scratch.path())
@@ -527,7 +543,7 @@ pub(super) async fn import_local_source(
             }
 
             let index = store
-                .import_directory(&clone_dir)
+                .import_directory(&pkg_root)
                 .map_err(|e| miette!("failed to import {}: {e}", local.specifier()))?;
             Ok(Some(index))
         }

--- a/test/git_deps.bats
+++ b/test/git_deps.bats
@@ -168,6 +168,79 @@ EOF
 	[ "$first_lockfile" = "$second_lockfile" ]
 }
 
+# Build a bare git repo whose tree has a `packages/<sub>/package.json`
+# instead of one at the root. Used to exercise the pnpm `&path:/<sub>`
+# selector that narrows a git dep to a subdirectory of the clone.
+_make_git_repo_with_subpath() {
+	local bare="$1" subdir="$2" name="$3" version="$4"
+	local work
+	work="$(temp_make)"
+	(
+		cd "$work" || exit 1
+		git init -q
+		git config commit.gpgsign false
+		# Root-level package.json with a name that does NOT match
+		# what the consumer asks for — so a wrong implementation
+		# (importing the repo root) is detectable as the wrong
+		# `index.js` being missing in the consumer's node_modules.
+		cat >package.json <<EOF
+{"name":"monorepo-root","version":"0.0.0","private":true}
+EOF
+		mkdir -p "$subdir"
+		cat >"$subdir/package.json" <<EOF
+{"name":"$name","version":"$version","main":"index.js"}
+EOF
+		cat >"$subdir/index.js" <<EOF
+module.exports = "from $name subdir";
+EOF
+		git add -A
+		git commit -q -m "init"
+	)
+	git init -q --bare "$bare"
+	(cd "$work" && git push -q "$bare" HEAD:refs/heads/main)
+	(cd "$work" && git rev-parse HEAD)
+}
+
+@test "aube install handles git dep with &path: subpath selector" {
+	sha="$(_make_git_repo_with_subpath "$TEST_TEMP_DIR/git-sub.git" packages/foo gitsubpkg 1.2.3)"
+
+	mkdir -p app
+	cd app
+	cat >package.json <<EOF
+{"name":"app","version":"0.0.0","dependencies":{"gitsubpkg":"git+file://$TEST_TEMP_DIR/git-sub.git#main&path:/packages/foo"}}
+EOF
+
+	run aube install
+	assert_success
+
+	# The dep we get must come from the subdir, not the repo root.
+	# Root's package.json has name "monorepo-root" — if aube ignored
+	# the &path: selector, the consumer's node_modules entry would
+	# be missing index.js (root tree has no index.js).
+	assert_file_exists node_modules/gitsubpkg/package.json
+	assert_file_exists node_modules/gitsubpkg/index.js
+	run cat node_modules/gitsubpkg/package.json
+	assert_output --partial '"name":"gitsubpkg"'
+	assert_output --partial '"version":"1.2.3"'
+	run cat node_modules/gitsubpkg/index.js
+	assert_output --partial 'from gitsubpkg subdir'
+
+	# Lockfile pins the commit AND records the subpath so a
+	# second install (from lockfile alone) reaches the same dir.
+	run cat aube-lock.yaml
+	assert_output --partial "commit: $sha"
+	assert_output --partial "path: /packages/foo"
+
+	# Round-trip: wipe node_modules and install from the existing
+	# lockfile. The subpath must survive parse + re-resolve.
+	rm -rf node_modules
+	run aube install
+	assert_success
+	assert_file_exists node_modules/gitsubpkg/index.js
+	run cat node_modules/gitsubpkg/package.json
+	assert_output --partial '"name":"gitsubpkg"'
+}
+
 @test "git dep with prepare script builds before linking" {
 	sha="$(_make_git_repo_with_prepare "$TEST_TEMP_DIR/git-prep.git" gitprep 1.2.3)"
 


### PR DESCRIPTION
## Summary
- Resolves [Discussion #252](https://github.com/endevco/aube/discussions/252) — `&path:/sub/dir` on a git dep now narrows the package root to the named subdirectory of the cloned repo, matching pnpm/hosted-git-info semantics.
- `GitSource` gains a `subpath: Option<String>` field. The git-fragment parser now extracts both `path:/x` (pnpm form) and `path=x` (npm/Yarn Berry form). Subpath is included in `dep_path` hashes so two deps from the same repo+commit but different subdirs don't collide.
- Resolver reads the subdir's `package.json` for name/version/deps, install imports only the subdir into the store, and `prepare` runs against the subdir scratch copy.
- Lockfile round-trip preserves the subpath in three spots: importer `version:`, snapshot key, and the resolution block's `path: /<sub>` field. Works for `aube-lock.yaml` and `pnpm-lock.yaml`.

## Test plan
- [x] `cargo test --release` (180 lockfile tests, including 3 new ones for subpath parse/specifier/dep_path)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `mise run test:bats test/git_deps.bats` — new test `aube install handles git dep with &path: subpath selector` covers both initial install and lockfile round-trip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git dependency parsing, lockfile serialization, and install-time import paths; mistakes could cause incorrect packages to be installed or path-handling bugs despite added traversal/canonicalization guards.
> 
> **Overview**
> Adds first-class support for pnpm-style git subdirectory selectors (`&path:/<sub>`) by extending `GitSource` with `subpath` and teaching git spec parsing to extract/validate `path` fragments.
> 
> Updates lockfile behavior to **preserve and round-trip** the subpath (in `LocalSource::specifier()`, `dep_path` hashing, bun/pnpm/yarn parsing/writing, and pnpm `resolution.path`), and updates resolver + installer flows to read `package.json`, run `prepare`, and import files from the selected subdirectory instead of the repo root (with path-traversal defenses).
> 
> Adds tests covering fragment parsing/round-trips, dep_path disambiguation, and an end-to-end bats install test for `&path:` git deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9021bdd112bd2d4b43c81807b6c094936ca1153d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->