### PR TITLE
fix(linker): strip windows verbatim prefix before diffing bin-shim paths

### DIFF
--- a/crates/aube-linker/src/sys.rs
+++ b/crates/aube-linker/src/sys.rs
@@ -392,11 +392,40 @@ fn win_shim_paths(bin_dir: &Path, name: &str) -> [PathBuf; 3] {
 
 /// Compute the relative path from `base_dir` to `target`, using
 /// forward slashes.
+///
+/// On Windows, strip any `\\?\` verbatim drive prefix from both inputs
+/// before diffing. Mixing a plain `C:\…` base with a verbatim
+/// `\\?\C:\…` target makes `pathdiff` treat the two `Component::Prefix`
+/// values as distinct (`Disk` != `VerbatimDisk`) and fall back to
+/// returning the raw absolute target. The raw target then gets
+/// interpolated into the `.cmd` shim as `"%~dp0\\\\?\\<target>"`, which
+/// `cmd.exe` + Node surface as the classic `Cannot find module
+/// '<bin>\\?\\<target>'` error. Stripping on both sides keeps the
+/// prefix components equal so `pathdiff` produces the expected
+/// `..\\…` form. No-op on Unix.
 fn relative_bin_target(base_dir: &Path, target: &Path) -> String {
-    pathdiff::diff_paths(target, base_dir)
-        .unwrap_or_else(|| PathBuf::from(target))
+    let base = strip_verbatim(base_dir);
+    let target = strip_verbatim(target);
+    pathdiff::diff_paths(&target, &base)
+        .unwrap_or(target)
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+#[cfg(windows)]
+fn strip_verbatim(p: &Path) -> PathBuf {
+    let s = p.to_string_lossy();
+    if let Some(rest) = s.strip_prefix(r"\\?\")
+        && !rest.starts_with("UNC\\")
+    {
+        return PathBuf::from(rest);
+    }
+    p.to_path_buf()
+}
+
+#[cfg(not(windows))]
+fn strip_verbatim(p: &Path) -> PathBuf {
+    p.to_path_buf()
 }
 
 fn node_modules_dir_for_bin(bin_dir: &Path) -> &Path {
@@ -819,6 +848,44 @@ mod tests {
             Path::new("/project/node_modules/.aube/is-odd@3.0.1/node_modules/is-odd/cli.js");
         let rel = relative_bin_target(bin_dir, target);
         assert_eq!(rel, "../.aube/is-odd@3.0.1/node_modules/is-odd/cli.js");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn relative_bin_target_strips_verbatim_prefix_from_target() {
+        // `std::fs::canonicalize` on Windows returns `\\?\C:\…`. If a
+        // canonicalized `target` flows in next to a plain-drive
+        // `base_dir`, `pathdiff` sees `Disk` vs `VerbatimDisk` prefix
+        // components and falls back to the absolute target — which
+        // then gets spliced into the `.cmd` shim as
+        // `%~dp0\\?\<target>` and surfaces as Node's
+        // `Cannot find module '<bin>\?\<target>'`.
+        let base = Path::new(r"C:\pkg\bin");
+        let target = Path::new(r"\\?\C:\pkg\global-aube\abc\node_modules\p\bin\p.cjs");
+        let rel = relative_bin_target(base, target);
+        assert_eq!(rel, "../global-aube/abc/node_modules/p/bin/p.cjs");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn relative_bin_target_strips_verbatim_prefix_from_base() {
+        let base = Path::new(r"\\?\C:\pkg\bin");
+        let target = Path::new(r"C:\pkg\global-aube\abc\node_modules\p\bin\p.cjs");
+        let rel = relative_bin_target(base, target);
+        assert_eq!(rel, "../global-aube/abc/node_modules/p/bin/p.cjs");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn relative_bin_target_preserves_unc_share_prefix() {
+        // `\\?\UNC\…` identifies a real network share and has no
+        // non-verbatim equivalent — strip_verbatim must leave it
+        // alone so the shim points at the share, not at a bogus
+        // drive-rooted path.
+        let base = Path::new(r"\\?\UNC\server\share\pkg\bin");
+        let target = Path::new(r"\\?\UNC\server\share\pkg\lib\cli.js");
+        let rel = relative_bin_target(base, target);
+        assert_eq!(rel, "../lib/cli.js");
     }
 
     #[cfg(windows)]

--- a/crates/aube-linker/src/sys.rs
+++ b/crates/aube-linker/src/sys.rs
@@ -402,30 +402,14 @@ fn win_shim_paths(bin_dir: &Path, name: &str) -> [PathBuf; 3] {
 /// `cmd.exe` + Node surface as the classic `Cannot find module
 /// '<bin>\\?\\<target>'` error. Stripping on both sides keeps the
 /// prefix components equal so `pathdiff` produces the expected
-/// `..\\…` form. No-op on Unix.
+/// `..\\…` form.
 fn relative_bin_target(base_dir: &Path, target: &Path) -> String {
-    let base = strip_verbatim(base_dir);
-    let target = strip_verbatim(target);
+    let base = aube_util::path::strip_verbatim_prefix(base_dir);
+    let target = aube_util::path::strip_verbatim_prefix(target);
     pathdiff::diff_paths(&target, &base)
         .unwrap_or(target)
         .to_string_lossy()
         .replace('\\', "/")
-}
-
-#[cfg(windows)]
-fn strip_verbatim(p: &Path) -> PathBuf {
-    let s = p.to_string_lossy();
-    if let Some(rest) = s.strip_prefix(r"\\?\")
-        && !rest.starts_with("UNC\\")
-    {
-        return PathBuf::from(rest);
-    }
-    p.to_path_buf()
-}
-
-#[cfg(not(windows))]
-fn strip_verbatim(p: &Path) -> PathBuf {
-    p.to_path_buf()
 }
 
 fn node_modules_dir_for_bin(bin_dir: &Path) -> &Path {

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod env;
 pub mod fs_atomic;
 pub mod hash;
+pub mod path;
 pub mod pkg;

--- a/crates/aube-util/src/path.rs
+++ b/crates/aube-util/src/path.rs
@@ -1,0 +1,64 @@
+//! Cross-crate path normalization helpers.
+
+use std::path::{Path, PathBuf};
+
+/// Strip a Windows `\\?\` verbatim drive prefix from `path` so callers
+/// that interpolate it into a path-concatenating template (`%~dp0\{rel}`
+/// in the bin-shim generator, `starts_with` ownership checks in
+/// `scan_packages` / `remove_package`, `CreateDirectoryW` calls in the
+/// linker) all see the plain `C:\…` form.
+///
+/// `\\?\UNC\server\share\…` identifies a real network share and has no
+/// non-verbatim equivalent — callers that strip it would produce an
+/// unresolvable drive-rooted path, so leave UNC verbatim prefixes
+/// intact.
+///
+/// No-op on non-Windows.
+pub fn strip_verbatim_prefix(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let s = path.to_string_lossy();
+        if let Some(rest) = s.strip_prefix(r"\\?\")
+            && !rest.starts_with("UNC\\")
+        {
+            return PathBuf::from(rest);
+        }
+    }
+    path.to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn strips_verbatim_drive_prefix() {
+        let p = Path::new(r"\\?\C:\Users\foo");
+        assert_eq!(strip_verbatim_prefix(p), PathBuf::from(r"C:\Users\foo"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn preserves_verbatim_unc_share() {
+        let p = Path::new(r"\\?\UNC\server\share\foo");
+        assert_eq!(
+            strip_verbatim_prefix(p),
+            PathBuf::from(r"\\?\UNC\server\share\foo")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn leaves_plain_drive_path_unchanged() {
+        let p = Path::new(r"C:\Users\foo");
+        assert_eq!(strip_verbatim_prefix(p), PathBuf::from(r"C:\Users\foo"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn is_noop_on_unix() {
+        let p = Path::new("/home/foo");
+        assert_eq!(strip_verbatim_prefix(p), PathBuf::from("/home/foo"));
+    }
+}

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -173,19 +173,7 @@ pub fn set_cwd(path: &Path) -> miette::Result<()> {
 /// No-op on non-Windows.
 pub fn canonicalize(path: &Path) -> std::io::Result<PathBuf> {
     let canon = std::fs::canonicalize(path)?;
-    #[cfg(windows)]
-    {
-        let s = canon.to_string_lossy();
-        // Only strip the plain verbatim-drive prefix (`\\?\C:\…`). Leave
-        // `\\?\UNC\…` alone — that's a real network share and callers
-        // can't use a non-verbatim form for it.
-        if let Some(rest) = s.strip_prefix(r"\\?\")
-            && !rest.starts_with("UNC\\")
-        {
-            return Ok(PathBuf::from(rest));
-        }
-    }
-    Ok(canon)
+    Ok(aube_util::path::strip_verbatim_prefix(&canon))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes the Windows `aube add -g` failure:

```
Error: Cannot find module 'C:\Users\…\bin\?\C:\Users\…\global-aube\<pid>-<ts>\node_modules\<pkg>\bin\<pkg>.cjs'
```

When `relative_bin_target` runs with a plain-drive `base_dir` and a verbatim-drive `target` (e.g. one that came back from `std::fs::canonicalize` as `\\?\C:\…`), `pathdiff` sees the two `Component::Prefix` values as distinct (`Disk` vs `VerbatimDisk`) and falls back to returning the raw absolute target. That raw target then flows into the `.cmd` shim template as `"%~dp0\\\\?\\<target>"`, and cmd.exe + Node surface it as the `Cannot find module '<bin>\\?\\<target>'` failure above.

`run_global` already strips `\\?\` from `install_dir` via `dirs::canonicalize` — the bug reappears when *either* side of the bin-shim path diff is in the opposite form. The `bin_dir` `aube` gets from a user's `.npmrc` `globalBinDir` setting is plain, so any canonicalized `target` on that same install was enough to trip it.

## Fix

Strip any `\\?\` drive prefix from both inputs of `relative_bin_target` before calling `pathdiff`. Leave `\\?\UNC\…` alone — real network shares have no non-verbatim equivalent, so rewriting those would produce an unresolvable path.

## Repro / observed in the wild

This was reliably reproducible via the [mise](https://mise.jdx.dev) npm backend on GitHub's `windows-latest` runner:

```
mise x node@24.4.1 npm:prettier@3.6.2 -- prettier --version
```

With `MISE_NPM_PACKAGE_MANAGER=auto` + aube present, mise routes the install through `aube add -g`, hits this path, and the test prettier binary comes out of the shim pointing at `…\bin\?\C:\…\prettier.cjs`.

## Test plan

- [x] `cargo test -p aube-linker` — 61 passed, 0 failed on macOS
- [x] `cargo clippy -p aube-linker --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Added 3 new `#[cfg(windows)]` regression tests:
  - `relative_bin_target_strips_verbatim_prefix_from_target`
  - `relative_bin_target_strips_verbatim_prefix_from_base`
  - `relative_bin_target_preserves_unc_share_prefix`

Windows CI will exercise the new `#[cfg(windows)]` tests + the existing `create_bin_shim_writes_three_files` e2e.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Windows-specific path normalization used to generate executable shims; mistakes could break global installs or UNC path handling, but changes are small and covered by new regression tests.
> 
> **Overview**
> Fixes Windows global bin shims that could embed an absolute `\\?\C:\…` target when `pathdiff` sees mixed verbatim vs non-verbatim drive prefixes.
> 
> Adds `aube_util::path::strip_verbatim_prefix` (preserving `\\?\UNC\…`) and reuses it in both `aube-linker`’s `relative_bin_target` (strip on *both* base/target before diffing) and `aube::dirs::canonicalize`.
> 
> Adds focused Windows-only tests to verify verbatim prefix stripping for base/target inputs and that UNC share prefixes remain intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c02ee34858ebc4b78a713a4da48ad7a6b827be1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->