### PR TITLE
fix(resolver): wire transitive url/git subdeps into parent snapshot

### DIFF
--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -395,6 +395,40 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         // emitted value for aliased packages.
         let alias_of = pkg_info.and_then(|p| p.alias_of.clone());
 
+        // Mirror the local_packages reclassification (lines ~195-223)
+        // so transitive URL-keyed entries — github forks, pkg.pr.new,
+        // `file:` targets — round-trip with the right `local_source`.
+        // Without this, the install path sees `local_source: None` +
+        // a URL-form version and tries to fetch the dep from the npm
+        // registry (404).
+        let local_source = pkg_info
+            .and_then(|p| p.resolution.as_ref())
+            .and_then(|res| {
+                if let Some(ref tb) = res.tarball {
+                    if let Some(rel) = tb.strip_prefix("file:") {
+                        Some(LocalSource::Tarball(std::path::PathBuf::from(rel)))
+                    } else if tb.starts_with("http://") || tb.starts_with("https://") {
+                        Some(LocalSource::RemoteTarball(crate::RemoteTarballSource {
+                            url: tb.clone(),
+                            integrity: res.integrity.clone().unwrap_or_default(),
+                        }))
+                    } else {
+                        None
+                    }
+                } else if let Some(ref dir) = res.directory {
+                    Some(LocalSource::Directory(std::path::PathBuf::from(dir)))
+                } else if let (Some(repo), Some(commit)) = (res.repo.as_ref(), res.commit.as_ref())
+                {
+                    Some(LocalSource::Git(GitSource {
+                        url: repo.clone(),
+                        committish: None,
+                        resolved: commit.clone(),
+                    }))
+                } else {
+                    None
+                }
+            });
+
         packages.insert(
             dep_path.clone(),
             LockedPackage {
@@ -406,7 +440,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 peer_dependencies,
                 peer_dependencies_meta,
                 dep_path,
-                local_source: None,
+                local_source,
                 os: os.into(),
                 cpu: cpu.into(),
                 libc: libc.into(),
@@ -802,6 +836,27 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         );
     }
 
+    // Translate internal dep_path tails (`git+<hash>`, `url+<hash>`,
+    // `file+<hash>`) to the specifier form pnpm expects in snapshot
+    // dependency maps (`<url>#<sha>` for git, raw URL for tarball,
+    // `file:<path>` for local). Registry deps keep their plain semver
+    // values. The target package's `local_source` is authoritative:
+    // the tail alone doesn't encode the URL.
+    let rewrite_local_deps = |deps: BTreeMap<String, String>| -> BTreeMap<String, String> {
+        deps.into_iter()
+            .map(|(name, value)| {
+                let dp = format!("{name}@{value}");
+                if let Some(target) = graph.packages.get(&dp)
+                    && let Some(ref local) = target.local_source
+                    && !matches!(local, LocalSource::Link(_))
+                {
+                    (name, local.specifier())
+                } else {
+                    (name, value)
+                }
+            })
+            .collect()
+    };
     let mut snapshots = BTreeMap::new();
     for (dep_path, pkg) in &graph.packages {
         // `link:` deps are omitted from snapshots (pnpm parity); other
@@ -812,20 +867,22 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
             Some(local) => format!("{}@{}", pkg.name, local.specifier()),
             None => dep_path.clone(),
         };
+        let pkg_deps = rewrite_local_deps(pkg.dependencies.clone());
+        let pkg_opt_deps = rewrite_local_deps(pkg.optional_dependencies.clone());
         snapshots.insert(
             key,
             WritableSnapshot {
                 dependencies: {
-                    let mut deps = pkg.dependencies.clone();
-                    for name in pkg.optional_dependencies.keys() {
+                    let mut deps = pkg_deps;
+                    for name in pkg_opt_deps.keys() {
                         deps.remove(name);
                     }
                     if deps.is_empty() { None } else { Some(deps) }
                 },
-                optional_dependencies: if pkg.optional_dependencies.is_empty() {
+                optional_dependencies: if pkg_opt_deps.is_empty() {
                     None
                 } else {
-                    Some(pkg.optional_dependencies.clone())
+                    Some(pkg_opt_deps)
                 },
                 bundled_dependencies: if pkg.bundled_dependencies.is_empty() {
                     None

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -192,44 +192,24 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 local_pkg.dependencies.extend(opt_deps.clone());
                 local_pkg.optional_dependencies = opt_deps;
             }
+            // Prefer the authoritative LocalSource classification
+            // from the `resolution:` block over the guess the
+            // importers loop made from the bare specifier. For git
+            // deps, preserve any `path:` selector already captured
+            // from the importer's `version:` URL — pnpm v9 encodes
+            // the subpath in the snapshot key and doesn't always
+            // echo it on the resolution block.
             if let Some(pkg_info) = raw.packages.get(&canonical)
                 && let Some(ref res) = pkg_info.resolution
+                && let Some(mut ls) = local_source_from_resolution(res)
             {
-                // Prefer the authoritative LocalSource classification
-                // from the `resolution:` block over the guess the
-                // importers loop made from the bare specifier.
-                if let Some(ref tb) = res.tarball {
-                    if let Some(rel) = tb.strip_prefix("file:") {
-                        local_pkg.local_source =
-                            Some(LocalSource::Tarball(std::path::PathBuf::from(rel)));
-                    } else if tb.starts_with("http://") || tb.starts_with("https://") {
-                        local_pkg.local_source =
-                            Some(LocalSource::RemoteTarball(crate::RemoteTarballSource {
-                                url: tb.clone(),
-                                integrity: res.integrity.clone().unwrap_or_default(),
-                            }));
-                    }
-                } else if let Some(ref dir) = res.directory {
-                    local_pkg.local_source =
-                        Some(LocalSource::Directory(std::path::PathBuf::from(dir)));
-                } else if let (Some(repo), Some(commit)) = (res.repo.as_ref(), res.commit.as_ref())
+                if let LocalSource::Git(ref mut g) = ls
+                    && g.subpath.is_none()
+                    && let Some(LocalSource::Git(prior)) = &local_pkg.local_source
                 {
-                    // Preserve any `path:` selector that was already
-                    // captured from the importer's `version:` URL —
-                    // the resolution block doesn't always echo it
-                    // (pnpm v9 also encodes the subpath in the
-                    // snapshot key).
-                    let prior_subpath = match &local_pkg.local_source {
-                        Some(LocalSource::Git(g)) => g.subpath.clone(),
-                        _ => None,
-                    };
-                    local_pkg.local_source = Some(LocalSource::Git(GitSource {
-                        url: repo.clone(),
-                        committish: None,
-                        resolved: commit.clone(),
-                        subpath: res.path.clone().or(prior_subpath),
-                    }));
+                    g.subpath = prior.subpath.clone();
                 }
+                local_pkg.local_source = Some(ls);
             }
         }
     }
@@ -395,39 +375,14 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         // emitted value for aliased packages.
         let alias_of = pkg_info.and_then(|p| p.alias_of.clone());
 
-        // Mirror the local_packages reclassification (lines ~195-223)
-        // so transitive URL-keyed entries — github forks, pkg.pr.new,
-        // `file:` targets — round-trip with the right `local_source`.
-        // Without this, the install path sees `local_source: None` +
-        // a URL-form version and tries to fetch the dep from the npm
-        // registry (404).
+        // Reclassify transitive URL-keyed entries — github forks,
+        // pkg.pr.new, `file:` targets — so they round-trip with the
+        // right `local_source`. Without this, the install path sees
+        // `local_source: None` + a URL-form version and tries to
+        // fetch the dep from the npm registry (404).
         let local_source = pkg_info
             .and_then(|p| p.resolution.as_ref())
-            .and_then(|res| {
-                if let Some(ref tb) = res.tarball {
-                    if let Some(rel) = tb.strip_prefix("file:") {
-                        Some(LocalSource::Tarball(std::path::PathBuf::from(rel)))
-                    } else if tb.starts_with("http://") || tb.starts_with("https://") {
-                        Some(LocalSource::RemoteTarball(crate::RemoteTarballSource {
-                            url: tb.clone(),
-                            integrity: res.integrity.clone().unwrap_or_default(),
-                        }))
-                    } else {
-                        None
-                    }
-                } else if let Some(ref dir) = res.directory {
-                    Some(LocalSource::Directory(std::path::PathBuf::from(dir)))
-                } else if let (Some(repo), Some(commit)) = (res.repo.as_ref(), res.commit.as_ref())
-                {
-                    Some(LocalSource::Git(GitSource {
-                        url: repo.clone(),
-                        committish: None,
-                        resolved: commit.clone(),
-                    }))
-                } else {
-                    None
-                }
-            });
+            .and_then(local_source_from_resolution);
 
         packages.insert(
             dep_path.clone(),
@@ -1541,6 +1496,38 @@ where
             Some(trimmed.to_string())
         }
     }))
+}
+
+/// Convert a pnpm `resolution:` block into a `LocalSource` classification.
+/// Returns `None` for registry-sourced packages (plain integrity with no
+/// tarball/directory/repo fields). Shared by the direct-dep and
+/// transitive-dep reader paths so both stay in lockstep when new
+/// resolution shapes are added.
+fn local_source_from_resolution(res: &Resolution) -> Option<LocalSource> {
+    if let Some(ref tb) = res.tarball {
+        if let Some(rel) = tb.strip_prefix("file:") {
+            return Some(LocalSource::Tarball(std::path::PathBuf::from(rel)));
+        }
+        if tb.starts_with("http://") || tb.starts_with("https://") {
+            return Some(LocalSource::RemoteTarball(crate::RemoteTarballSource {
+                url: tb.clone(),
+                integrity: res.integrity.clone().unwrap_or_default(),
+            }));
+        }
+        return None;
+    }
+    if let Some(ref dir) = res.directory {
+        return Some(LocalSource::Directory(std::path::PathBuf::from(dir)));
+    }
+    if let (Some(repo), Some(commit)) = (res.repo.as_ref(), res.commit.as_ref()) {
+        return Some(LocalSource::Git(GitSource {
+            url: repo.clone(),
+            committish: None,
+            resolved: commit.clone(),
+            subpath: res.path.clone(),
+        }));
+    }
+    None
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -687,6 +687,33 @@ impl Resolver {
                         });
                     }
 
+                    // Wire parent -> this exotic transitive. Without
+                    // this, the parent snapshot's `dependencies` map
+                    // omits the git/url/file subdep entirely, so the
+                    // linker never creates the sibling symlink inside
+                    // the parent's node_modules and the package fails
+                    // to resolve at runtime. The value is the dep_path
+                    // tail (e.g. `git+<hash>`) so the linker can
+                    // reconstruct the full dep_path by concatenating
+                    // `{name}@{value}` — matching the key format used
+                    // when inserting the resolved package below.
+                    if let Some(ref parent_dp) = task.parent
+                        && let Some(parent_pkg) = resolved.get_mut(parent_dp)
+                    {
+                        let dep_tail = dep_path
+                            .strip_prefix(&format!("{}@", task.name))
+                            .unwrap_or(&dep_path)
+                            .to_string();
+                        parent_pkg
+                            .dependencies
+                            .insert(task.name.clone(), dep_tail.clone());
+                        if task.dep_type == DepType::Optional {
+                            parent_pkg
+                                .optional_dependencies
+                                .insert(task.name.clone(), dep_tail);
+                        }
+                    }
+
                     if visited.insert(std::sync::Arc::from(dep_path.as_str())) {
                         resolved.insert(
                             dep_path.clone(),

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -700,8 +700,17 @@ impl Resolver {
                     if let Some(ref parent_dp) = task.parent
                         && let Some(parent_pkg) = resolved.get_mut(parent_dp)
                     {
+                        // `local.dep_path(name)` always returns
+                        // `{name}@{tail}`; if that invariant ever
+                        // breaks we'd silently store a malformed dep
+                        // value that the pnpm writer would emit as-is.
+                        let name_prefix = format!("{}@", task.name);
+                        debug_assert!(
+                            dep_path.starts_with(&name_prefix),
+                            "local.dep_path returned {dep_path:?} without expected prefix {name_prefix:?}"
+                        );
                         let dep_tail = dep_path
-                            .strip_prefix(&format!("{}@", task.name))
+                            .strip_prefix(&name_prefix)
                             .unwrap_or(&dep_path)
                             .to_string();
                         parent_pkg


### PR DESCRIPTION
## Summary

When a package installed via a `github:` / git / URL spec declared a transitive dep that was itself a git/URL spec, aube silently dropped it: the subdep was fetched and stored, but never added to the parent's `dependencies` map. The linker therefore never created the sibling symlink and Node failed at runtime with `Cannot find package <dep>`.

Concrete repro (via [rubnogueira/aube-exotic-bug](https://github.com/rubnogueira/aube-exotic-bug)): `imagemin-gifsicle` installed from a PruvoNet fork via `github:PruvoNet/imagemin-gifsicle#<sha>` declares `gifsicle: https://github.com/PruvoNet/gifsicle-bin#<sha>` in its `package.json`. pnpm follows the edge; aube did not.

## Changes

Three-part fix so the resolver + pnpm lockfile round-trip cleanly:

- **Resolver** ([crates/aube-resolver/src/resolve.rs](crates/aube-resolver/src/resolve.rs)) — exotic-dep branch now writes into `parent_pkg.dependencies` / `optional_dependencies` using the dep_path tail, matching what the registry branch already does.
- **pnpm writer** ([crates/aube-lockfile/src/pnpm.rs](crates/aube-lockfile/src/pnpm.rs)) — translates internal `git+<hash>` / `url+<hash>` / `file+<hash>` tails in snapshot dep maps to the pnpm-compatible `<url>#<sha>` / `<url>` / `file:<path>` specifier on write.
- **pnpm reader** ([crates/aube-lockfile/src/pnpm.rs](crates/aube-lockfile/src/pnpm.rs)) — reclassifies transitive URL-keyed packages into `LocalSource::Git` / `RemoteTarball` / `Directory` from the `resolution:` block. Previously only direct deps got this treatment; transitive URL deps came back with `local_source: None`, so the install path tried to fetch them from the npm registry and 404'd.

## Test plan

- [x] `cargo test --release` — 282 + 183 + 61 + 119 + 4 tests pass across aube, aube-lockfile, aube-linker, aube-resolver, e2e
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual repro: fresh install from scratch → `node index.js` against a real gif runs gifsicle successfully
- [x] Lockfile round-trip: install → `rm -rf node_modules` → reinstall from aube-lock.yaml → still works
- [x] pnpm-lock import path: install from user-committed `pnpm-lock.yaml` → still works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dependency resolution and pnpm lockfile parse/write logic for git/URL/file dependencies; mistakes could drop edges or misclassify sources, leading to missing installs or incorrect fetches.
> 
> **Overview**
> Fixes resolution of *exotic* (git/URL/file) **transitive dependencies** by wiring them into the parent package’s `dependencies`/`optional_dependencies` maps so the linker can create the required `node_modules` edges.
> 
> Improves pnpm lockfile round-tripping for non-registry packages: parsing now derives `local_source` for transitive URL-keyed entries from the `resolution` block (with a shared `local_source_from_resolution` helper and git subpath preservation), and writing rewrites snapshot dependency-map values to pnpm-compatible specifiers (`<url>#<sha>`, raw URL, `file:<path>`) based on the target package’s `local_source`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbcfc0104ab770a83561e6f4eb4f7725d2bef43b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->