### PR TITLE
fix(release): add version to aube-util workspace dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ repository = "https://github.com/endevco/aube"
 homepage = "https://github.com/endevco/aube"
 
 [workspace.dependencies]
-aube-util = { path = "crates/aube-util" }
 tokio = { version = "1", features = ["full"] }
 
 # Serialization
@@ -122,3 +121,4 @@ aube-lockfile = { path = "crates/aube-lockfile", version = "1.1.0" }
 aube-manifest = { path = "crates/aube-manifest", version = "1.1.0" }
 aube-scripts = { path = "crates/aube-scripts", version = "1.1.0" }
 aube-workspace = { path = "crates/aube-workspace", version = "1.1.0" }
+aube-util = { path = "crates/aube-util", version = "1.1.0" }


### PR DESCRIPTION
## Summary

Fix release job failure in [actions/runs/24902685963](https://github.com/endevco/aube/actions/runs/24902685963/job/72924131210).

`cargo publish` requires every path dependency to declare a version when publishing to crates.io. `aube-util` was the only workspace dep declared as pure `{ path = ... }`, so release-plz aborted publishing `aube-manifest` with:

```
dependency `aube-util` does not specify a version
```

Moved it next to the other internal crates that already pair `path + version` — release-plz keeps these in sync on each release PR.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo publish -p aube-manifest --dry-run --allow-dirty` succeeds (previously failed at verify-manifest step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a metadata-only `Cargo.toml` change that affects publishing/packaging but not runtime behavior.
> 
> **Overview**
> Ensures `aube-util` is declared like the other internal workspace crates by adding `version = "1.1.0"` alongside its `path` in `Cargo.toml`.
> 
> This unblocks `cargo publish`/release automation that requires versions for path dependencies when publishing crates to crates.io.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 973604a3d0abde822b0be5a9b013e15b7b52ecd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->