### PR TITLE
fix(packaging): add cmake/gcc-c++/perl buildrequires for copr

### DIFF
--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -200,6 +200,9 @@ Source1:        %{name}-vendor-%{tarball_version}.tar.gz
 BuildRequires:  rust >= 1.93
 BuildRequires:  cargo
 BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  cmake
+BuildRequires:  perl-interpreter
 BuildRequires:  git
 BuildRequires:  openssl-devel
 BuildRequires:  pkgconf-pkg-config


### PR DESCRIPTION
## Summary

- EPEL 10 aarch64 COPR build (`10364349`) failed at `libz-ng-sys` with `failed to find tool "g++"` and `is cmake not installed?`. The spec only declared `gcc`, but `flate2`'s `zlib-ng` feature vendors `libz-ng` (needs `cmake` + a C++ compiler), and the default rustls backend `aws-lc-sys` additionally needs `cmake` + `perl`.
- Add `gcc-c++`, `cmake`, and `perl-interpreter` to the spec's `BuildRequires` so all chroots can build the vendored C/C++ deps from source.

## Test plan

- [ ] Re-run the COPR build (e.g. `packaging/copr/build-copr.sh -v <version> -d` to produce an SRPM, then submit) and confirm EPEL 10 aarch64 + the other chroots now reach `%install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: packaging-only change that expands RPM `BuildRequires` to satisfy toolchain needs; no runtime behavior or application code is modified.
> 
> **Overview**
> Fixes COPR SRPM/RPM builds that fail when compiling vendored C/C++ dependencies by adding `gcc-c++`, `cmake`, and `perl-interpreter` to the generated spec in `packaging/copr/build-copr.sh`.
> 
> This ensures the COPR chroots have the required C++ compiler, CMake, and Perl tooling during `%build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd32562f88f68bec63ef7883fc8f61c186362ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->