### PR TITLE
feat(registry): make packument + tarball body caps configurable, raise packument default to 200 MiB

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -62,13 +62,14 @@ const PACKUMENT_ACCEPT: &str =
 /// `PACKUMENT_ACCEPT` — some proxies won't serve JSON unless it's in the list.
 const PACKUMENT_FULL_ACCEPT: &str = "application/json; q=1.0, */*";
 
-/// Hard cap on a packument response body, compressed or not. A hostile
-/// registry (or MITM with a valid cert on a compromised mirror) could
-/// otherwise stream gigabytes of JSON into the resolver and OOM the
-/// whole install. 64 MiB is ~10x the largest packument on npmjs today
-/// (`@types/node`, `lodash`, `chalk` all land well under 6 MiB) so the
-/// cap is a loud failure if reality ever tries to exceed it.
-const PACKUMENT_BODY_CAP: u64 = 64 << 20;
+// Packument body cap — now configurable via the `packumentMaxBytes`
+// setting. Default lives in `FetchPolicy::default()`. See the
+// corresponding settings.toml entry for the full rationale; in short,
+// this prevents a hostile registry (or MITM on a compromised mirror)
+// from streaming gigabytes of JSON into the resolver and OOMing the
+// install, while letting projects that depend on packages with long
+// release histories (e.g. drizzle-orm, which already exceeds 64 MiB)
+// raise the cap rather than hardcode it out of the way.
 
 /// Hard cap on a tarball response body (still compressed on the wire).
 /// The decompressed cap in `aube-store` (1 GiB) only fires after the
@@ -618,7 +619,7 @@ impl RegistryClient {
                     let (etag, last_modified) = extract_cache_headers(&resp);
                     let max_age_secs = parse_cache_control_max_age(&resp);
                     let resp = resp.error_for_status()?;
-                    check_body_cap(&resp, PACKUMENT_BODY_CAP, &label)?;
+                    check_body_cap(&resp, self.fetch_policy.packument_max_bytes, &label)?;
                     match parse_full_response::<serde_json::Value>(resp).await {
                         Ok(packument) => {
                             let to_cache = CachedFullPackument {
@@ -901,7 +902,7 @@ impl RegistryClient {
                     let max_age_secs = parse_cache_control_max_age(&resp);
 
                     let resp = resp.error_for_status()?;
-                    check_body_cap(&resp, PACKUMENT_BODY_CAP, &label)?;
+                    check_body_cap(&resp, self.fetch_policy.packument_max_bytes, &label)?;
                     match parse_full_response::<Packument>(resp).await {
                         Ok(packument) => {
                             let to_cache = CachedPackument {
@@ -1046,7 +1047,7 @@ impl RegistryClient {
             return Err(Error::NotFound(name.to_string()));
         }
         let resp = resp.error_for_status()?;
-        check_body_cap(&resp, PACKUMENT_BODY_CAP, "packument")?;
+        check_body_cap(&resp, self.fetch_policy.packument_max_bytes, "packument")?;
         let value: serde_json::Value = resp.json().await?;
         Ok(value)
     }
@@ -1376,7 +1377,15 @@ fn force_full_packument() -> bool {
 /// cap-while-reading variant is left for a follow-up, since it needs
 /// a `futures` / `tokio-stream` dep that the crate does not yet pull
 /// in.
+///
+/// A `cap` of `0` disables the check entirely — an escape hatch for
+/// users who need to pull packuments that exceed the default (e.g.
+/// packages with very long release histories) and accept the DoS
+/// exposure on the trusted-registry side.
 fn check_body_cap(resp: &reqwest::Response, cap: u64, label: &str) -> Result<(), Error> {
+    if cap == 0 {
+        return Ok(());
+    }
     if let Some(len) = resp.content_length()
         && len > cap
     {
@@ -1833,6 +1842,7 @@ mod retry_tests {
             retry_max_timeout_ms: 1,
             warn_timeout_ms: 1,
             min_speed_kibps: 0,
+            ..FetchPolicy::default()
         };
         let client = client_with(&server, policy);
         let packument = client

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -62,14 +62,12 @@ const PACKUMENT_ACCEPT: &str =
 /// `PACKUMENT_ACCEPT` — some proxies won't serve JSON unless it's in the list.
 const PACKUMENT_FULL_ACCEPT: &str = "application/json; q=1.0, */*";
 
-// Packument body cap — now configurable via the `packumentMaxBytes`
-// setting. Default lives in `FetchPolicy::default()`. See the
-// corresponding settings.toml entry for the full rationale; in short,
-// this prevents a hostile registry (or MITM on a compromised mirror)
-// from streaming gigabytes of JSON into the resolver and OOMing the
-// install, while letting projects that depend on packages with long
-// release histories (e.g. drizzle-orm, which already exceeds 64 MiB)
-// raise the cap rather than hardcode it out of the way.
+// Packument body cap — configurable via the `packumentMaxBytes`
+// setting. Default (200 MiB) lives in `FetchPolicy::default()` and is
+// sized to sit comfortably above the largest real-world packument
+// known today (`drizzle-orm` at ~97 MiB) while still bounding a
+// runaway registry response. `packumentMaxBytes=0` disables the cap
+// entirely for users who accept that exposure.
 
 /// Hard cap on a tarball response body (still compressed on the wire).
 /// The decompressed cap in `aube-store` (1 GiB) only fires after the

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -62,22 +62,11 @@ const PACKUMENT_ACCEPT: &str =
 /// `PACKUMENT_ACCEPT` — some proxies won't serve JSON unless it's in the list.
 const PACKUMENT_FULL_ACCEPT: &str = "application/json; q=1.0, */*";
 
-// Packument body cap — configurable via the `packumentMaxBytes`
-// setting. Default (200 MiB) lives in `FetchPolicy::default()` and is
-// sized to sit comfortably above the largest real-world packument
-// known today (`drizzle-orm` at ~97 MiB) while still bounding a
-// runaway registry response. `packumentMaxBytes=0` disables the cap
-// entirely for users who accept that exposure.
-
-/// Hard cap on a tarball response body (still compressed on the wire).
-/// The decompressed cap in `aube-store` (1 GiB) only fires after the
-/// gzip reader runs, so without a wire-level cap a hostile mirror can
-/// still stream a multi-GiB compressed payload into memory before the
-/// decompressor ever sees a byte. 1 GiB compressed is comfortably
-/// above the biggest real npm tarball (a handful of packages like
-/// `playwright` cross 100 MiB compressed) while still stopping runaway
-/// streams.
-const TARBALL_BODY_CAP: u64 = 1 << 30;
+// Packument and tarball body caps are configurable via the
+// `packumentMaxBytes` / `tarballMaxBytes` settings. Defaults live in
+// `FetchPolicy::default()`; setting either to `0` disables the cap.
+// These are hardening knobs against hostile or misconfigured
+// registries streaming runaway bodies into the resolver.
 
 /// Hard cap for the `/-/npm/v1/security/advisories/bulk` response. The
 /// body scales with the number of distinct `<name>@<version>` pairs in
@@ -1017,7 +1006,9 @@ impl RegistryClient {
         // (e.g. `//host/artifactory/npm/`). Retries cover transient
         // 5xx / 429 / connection errors; see [`Self::send_with_retry`].
         let (bytes, body_elapsed) = self
-            .retry_bytes_body_read(url, TARBALL_BODY_CAP, || self.authed_get(url, url))
+            .retry_bytes_body_read(url, self.fetch_policy.tarball_max_bytes, || {
+                self.authed_get(url, url)
+            })
             .await?;
         warn_slow_tarball(
             self.fetch_policy.min_speed_kibps,

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -506,12 +506,13 @@ pub struct FetchPolicy {
     pub min_speed_kibps: u64,
     /// `packumentMaxBytes` — hard cap on a packument response body.
     /// Primarily a hardening knob against hostile or misconfigured
-    /// registries. The default (64 MiB) is well above real-world
-    /// packument sizes on npmjs.org, but a few packages with long
-    /// release histories exceed it; raise this setting on projects that
-    /// depend on them. `0` disables the cap entirely (not recommended
-    /// for untrusted registries).
+    /// registries. `0` disables the cap entirely (not recommended for
+    /// untrusted registries).
     pub packument_max_bytes: u64,
+    /// `tarballMaxBytes` — hard cap on a tarball response body
+    /// (on-wire, still compressed). Same hardening role as
+    /// `packument_max_bytes`; `0` disables.
+    pub tarball_max_bytes: u64,
 }
 
 impl Default for FetchPolicy {
@@ -527,11 +528,9 @@ impl Default for FetchPolicy {
             retry_max_timeout_ms: 60_000,
             warn_timeout_ms: 10_000,
             min_speed_kibps: 50,
-            // 200 MiB — also the default declared in settings.toml.
-            // Chosen to sit comfortably above real-world packument sizes
-            // (the largest known today, `drizzle-orm`, is ~97 MiB) while
-            // still bounding a runaway registry response.
+            // Defaults match `settings.toml`.
             packument_max_bytes: 200 << 20,
+            tarball_max_bytes: 1 << 30,
         }
     }
 }
@@ -551,6 +550,7 @@ impl FetchPolicy {
             warn_timeout_ms: aube_settings::resolved::fetch_warn_timeout_ms(ctx),
             min_speed_kibps: aube_settings::resolved::fetch_min_speed_ki_bps(ctx),
             packument_max_bytes: aube_settings::resolved::packument_max_bytes(ctx),
+            tarball_max_bytes: aube_settings::resolved::tarball_max_bytes(ctx),
         }
     }
 

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -527,8 +527,11 @@ impl Default for FetchPolicy {
             retry_max_timeout_ms: 60_000,
             warn_timeout_ms: 10_000,
             min_speed_kibps: 50,
-            // 64 MiB — also the default declared in settings.toml.
-            packument_max_bytes: 64 << 20,
+            // 200 MiB — also the default declared in settings.toml.
+            // Chosen to sit comfortably above real-world packument sizes
+            // (the largest known today, `drizzle-orm`, is ~97 MiB) while
+            // still bounding a runaway registry response.
+            packument_max_bytes: 200 << 20,
         }
     }
 }

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -504,6 +504,14 @@ pub struct FetchPolicy {
     /// this value (KiB/s). `0` disables the warning. As with
     /// `warn_timeout_ms`, we only warn — we never abort the transfer.
     pub min_speed_kibps: u64,
+    /// `packumentMaxBytes` — hard cap on a packument response body.
+    /// Primarily a hardening knob against hostile or misconfigured
+    /// registries. The default (64 MiB) is well above real-world
+    /// packument sizes on npmjs.org, but a few packages with long
+    /// release histories exceed it; raise this setting on projects that
+    /// depend on them. `0` disables the cap entirely (not recommended
+    /// for untrusted registries).
+    pub packument_max_bytes: u64,
 }
 
 impl Default for FetchPolicy {
@@ -519,6 +527,8 @@ impl Default for FetchPolicy {
             retry_max_timeout_ms: 60_000,
             warn_timeout_ms: 10_000,
             min_speed_kibps: 50,
+            // 64 MiB — also the default declared in settings.toml.
+            packument_max_bytes: 64 << 20,
         }
     }
 }
@@ -537,6 +547,7 @@ impl FetchPolicy {
             retry_max_timeout_ms: aube_settings::resolved::fetch_retry_maxtimeout(ctx),
             warn_timeout_ms: aube_settings::resolved::fetch_warn_timeout_ms(ctx),
             min_speed_kibps: aube_settings::resolved::fetch_min_speed_ki_bps(ctx),
+            packument_max_bytes: aube_settings::resolved::packument_max_bytes(ctx),
         }
     }
 

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1263,20 +1263,22 @@ examples = []
 [packumentMaxBytes]
 description = "Hard cap on a packument response body size in bytes."
 type = "int"
-default = "67108864"
+default = "209715200"
 docs = """
 Refuses any packument response whose `Content-Length` exceeds this
 many bytes. Primarily a hardening knob: a hostile or misconfigured
 registry (including a MITM on a compromised mirror) could otherwise
 stream gigabytes of JSON into the resolver and OOM the install.
 
-The default (64 MiB) is ~10x larger than the biggest packument on
-`registry.npmjs.org` at the time of writing (`@types/node`, `lodash`,
-`chalk` all land well under 6 MiB), but a few packages with long
-release histories (e.g. `drizzle-orm` at ~97 MiB) already exceed it
-and fail to resolve under the hardcoded cap. Raise this setting on
-projects that depend on such packages; set to `0` to disable the cap
-entirely (not recommended for untrusted registries).
+The default (200 MiB) sits above the largest packuments on
+`registry.npmjs.org` known at the time of writing — `drizzle-orm`
+sits around 97 MiB with room for continued release growth, while
+the common-case metadata files (`@types/node`, `lodash`, `chalk`)
+all land under 6 MiB — so normal installs never see the cap but a
+runaway registry response still fails loudly. Raise this setting if
+a package with an even longer release history hits the new ceiling;
+set to `0` to disable the cap entirely (not recommended for
+untrusted registries).
 
 Applies to every packument fetch: corgi and non-corgi variants, the
 cached-resolve path, and the fresh-read path used by `deprecate` /

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1260,6 +1260,34 @@ sources.env = []
 sources.npmrc = ["fetchMinSpeedKiBps"]
 examples = []
 
+[packumentMaxBytes]
+description = "Hard cap on a packument response body size in bytes."
+type = "int"
+default = "67108864"
+docs = """
+Refuses any packument response whose `Content-Length` exceeds this
+many bytes. Primarily a hardening knob: a hostile or misconfigured
+registry (including a MITM on a compromised mirror) could otherwise
+stream gigabytes of JSON into the resolver and OOM the install.
+
+The default (64 MiB) is ~10x larger than the biggest packument on
+`registry.npmjs.org` at the time of writing (`@types/node`, `lodash`,
+`chalk` all land well under 6 MiB), but a few packages with long
+release histories (e.g. `drizzle-orm` at ~97 MiB) already exceed it
+and fail to resolve under the hardcoded cap. Raise this setting on
+projects that depend on such packages; set to `0` to disable the cap
+entirely (not recommended for untrusted registries).
+
+Applies to every packument fetch: corgi and non-corgi variants, the
+cached-resolve path, and the fresh-read path used by `deprecate` /
+`undeprecate`. Tarball downloads are capped separately by a
+hardcoded 1 GiB ceiling in `aube-registry`.
+"""
+sources.cli = []
+sources.env = []
+sources.npmrc = ["packumentMaxBytes"]
+examples = []
+
 # ========================================= Peer Dependencies =========================================
 
 [autoInstallPeers]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1266,28 +1266,41 @@ type = "int"
 default = "209715200"
 docs = """
 Refuses any packument response whose `Content-Length` exceeds this
-many bytes. Primarily a hardening knob: a hostile or misconfigured
-registry (including a MITM on a compromised mirror) could otherwise
-stream gigabytes of JSON into the resolver and OOM the install.
+many bytes. A hostile or misconfigured registry (including a MITM on
+a compromised mirror) could otherwise stream gigabytes of JSON into
+the resolver and OOM the install; the cap makes that fail loudly.
 
-The default (200 MiB) sits above the largest packuments on
-`registry.npmjs.org` known at the time of writing — `drizzle-orm`
-sits around 97 MiB with room for continued release growth, while
-the common-case metadata files (`@types/node`, `lodash`, `chalk`)
-all land under 6 MiB — so normal installs never see the cap but a
-runaway registry response still fails loudly. Raise this setting if
-a package with an even longer release history hits the new ceiling;
-set to `0` to disable the cap entirely (not recommended for
-untrusted registries).
+Default: 200 MiB. Raise if you hit the cap, or set to `0` to disable
+it entirely (only reasonable against a registry you fully trust).
 
 Applies to every packument fetch: corgi and non-corgi variants, the
 cached-resolve path, and the fresh-read path used by `deprecate` /
-`undeprecate`. Tarball downloads are capped separately by a
-hardcoded 1 GiB ceiling in `aube-registry`.
+`undeprecate`. Tarball downloads are capped separately via
+`tarballMaxBytes`.
 """
 sources.cli = []
 sources.env = []
 sources.npmrc = ["packumentMaxBytes"]
+examples = []
+
+[tarballMaxBytes]
+description = "Hard cap on a tarball response body size in bytes (on-wire, still compressed)."
+type = "int"
+default = "1073741824"
+docs = """
+Refuses any tarball response whose `Content-Length` exceeds this many
+bytes before any decompression runs. Without a wire-level cap a
+hostile mirror could stream a multi-GiB compressed payload into
+memory before the gzip reader ever sees a byte; the separate
+decompressed ceiling in `aube-store` would only fire after that.
+
+Default: 1 GiB. Raise if a legitimate tarball exceeds it, or set to
+`0` to disable the cap entirely (only reasonable against a registry
+you fully trust).
+"""
+sources.cli = []
+sources.env = []
+sources.npmrc = ["tarballMaxBytes"]
 examples = []
 
 # ========================================= Peer Dependencies =========================================

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -70,6 +70,8 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`fetchTimeout`](#setting-fetchtimeout) | `int` | Max time (ms) to wait for an HTTP request. |
 | [`fetchWarnTimeoutMs`](#setting-fetchwarntimeoutms) | `int` | Warn if a metadata request exceeds this threshold (ms). |
 | [`fetchMinSpeedKiBps`](#setting-fetchminspeedkibps) | `int` | Warn if download speed falls below this threshold (KiB/s). |
+| [`packumentMaxBytes`](#setting-packumentmaxbytes) | `int` | Hard cap on a packument response body size in bytes. |
+| [`tarballMaxBytes`](#setting-tarballmaxbytes) | `int` | Hard cap on a tarball response body size in bytes (on-wire, still compressed). |
 | [`autoInstallPeers`](#setting-autoinstallpeers) | `bool` | Automatically install missing peer dependencies. |
 | [`dedupePeerDependents`](#setting-dedupepeerdependents) | `bool` | Deduplicate packages that have peer dependencies. |
 | [`dedupePeers`](#setting-dedupepeers) | `bool` | Use version-only identifiers for peer suffixes in the lockfile. |
@@ -1306,6 +1308,47 @@ Warn if download speed falls below this threshold (KiB/s).
 
 Warn when a tarball's end-to-end average throughput falls below this
 many KiB/s. Set to `0` to disable.
+
+### `packumentMaxBytes` {#setting-packumentmaxbytes}
+
+Hard cap on a packument response body size in bytes.
+
+- Type: `int`
+- Default: `209715200`
+- Environment: `npm_config_packument_max_bytes`, `NPM_CONFIG_PACKUMENT_MAX_BYTES`
+- .npmrc keys: `packumentMaxBytes`, `packument-max-bytes`
+
+Refuses any packument response whose `Content-Length` exceeds this
+many bytes. A hostile or misconfigured registry (including a MITM on
+a compromised mirror) could otherwise stream gigabytes of JSON into
+the resolver and OOM the install; the cap makes that fail loudly.
+
+Default: 200 MiB. Raise if you hit the cap, or set to `0` to disable
+it entirely (only reasonable against a registry you fully trust).
+
+Applies to every packument fetch: corgi and non-corgi variants, the
+cached-resolve path, and the fresh-read path used by `deprecate` /
+`undeprecate`. Tarball downloads are capped separately via
+`tarballMaxBytes`.
+
+### `tarballMaxBytes` {#setting-tarballmaxbytes}
+
+Hard cap on a tarball response body size in bytes (on-wire, still compressed).
+
+- Type: `int`
+- Default: `1073741824`
+- Environment: `npm_config_tarball_max_bytes`, `NPM_CONFIG_TARBALL_MAX_BYTES`
+- .npmrc keys: `tarballMaxBytes`, `tarball-max-bytes`
+
+Refuses any tarball response whose `Content-Length` exceeds this many
+bytes before any decompression runs. Without a wire-level cap a
+hostile mirror could stream a multi-GiB compressed payload into
+memory before the gzip reader ever sees a byte; the separate
+decompressed ceiling in `aube-store` would only fire after that.
+
+Default: 1 GiB. Raise if a legitimate tarball exceeds it, or set to
+`0` to disable the cap entirely (only reasonable against a registry
+you fully trust).
 
 ## Peer Dependencies
 


### PR DESCRIPTION
## Summary
- Expose the previously-hardcoded `PACKUMENT_BODY_CAP` and `TARBALL_BODY_CAP` constants as two new settings, `packumentMaxBytes` and `tarballMaxBytes`.
- Raise the packument default from 64 MiB → **200 MiB**. The tarball default (1 GiB) is unchanged.
- `0` disables either cap entirely.

## Why change the packument default
The 64 MiB cap was set when the largest packument on `registry.npmjs.org` was a few MiB. That's no longer true — `drizzle-orm`'s packument is ~97 MiB at the time of writing, which trips the cap and breaks resolution:

```
registry error for drizzle-orm: I/O error: packument drizzle-orm:
response Content-Length 97963046 exceeds cap 67108864
```

Raising the const in lockstep with each outlier is whack-a-mole. 200 MiB gives ~2× headroom over the current worst case and still bounds the DoS scenario the cap was added for — a runaway registry response fails loudly well before it can stream gigabytes into the resolver.

**Users who want the stricter 64 MiB floor back can set `packumentMaxBytes=67108864` in `.npmrc`.**

## Why expose both as settings
- The original 64 MiB const was chosen against a snapshot of the npm ecosystem that has since shifted. A setting avoids future const-bump PRs each time a package accretes release history.
- Corporate registries and CI environments can tune both caps to match their threat model (lower for defense-in-depth, higher where a trusted registry serves legitimate giants).

## Wiring
- **`settings.toml`**: new `[packumentMaxBytes]` (default `209715200`) and `[tarballMaxBytes]` (default `1073741824`) entries, both `npmrc`-sourced. Docs cover purpose, default, how to raise/disable, what they apply to — no empirical bookkeeping that would go stale.
- **`FetchPolicy`**: two new `u64` fields, resolved via the generated `aube_settings::resolved::*` accessors in `from_ctx`; `Default` sets them to match `settings.toml`.
- **`client.rs`**: replaces `PACKUMENT_BODY_CAP` / `TARBALL_BODY_CAP` constants with `self.fetch_policy.packument_max_bytes` / `tarball_max_bytes` at all 4 call sites (3 packument paths + 1 tarball path).
- **`check_body_cap`**: `cap == 0` short-circuits the check.

## Test plan
- [x] `cargo check --all-features` clean
- [x] `cargo clippy --all-features --no-deps` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p aube-registry` — 105 tests pass (existing `FetchPolicy` test constructions updated to use `..FetchPolicy::default()` spread)
- [x] `cargo test -p aube-settings` — including `every_setting_has_a_typed_accessor_caller`, which confirms both new accessors are consumed by `FetchPolicy::from_ctx`
- [x] `cargo test -p aube-manifest` — 70 tests pass

## Motivating use case
Migrating https://github.com/jdx/mise-versions from npm+bun to aube failed at `aube install` because of the drizzle-orm packument. With this PR, it resolves under the new default — no `.npmrc` tweak needed.