### PR TITLE
ci(release): attest uploaded release archives

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -110,6 +110,8 @@ jobs:
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ name: release
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 on:
   workflow_call:
@@ -76,6 +78,7 @@ jobs:
       # already expect. On macOS we ask it to codesign with the Developer
       # ID cert we just imported; the prefix applies to all three bins.
       - name: Upload binary (macOS signed)
+        id: upload-macos
         if: startsWith(matrix.os, 'macos')
         uses: taiki-e/upload-rust-binary-action@v1
         with:
@@ -88,6 +91,7 @@ jobs:
           codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           codesign_prefix: dev.jdx.
       - name: Upload binary (non-macOS)
+        id: upload-non-macos
         if: ${{ !startsWith(matrix.os, 'macos') }}
         uses: taiki-e/upload-rust-binary-action@v1
         with:
@@ -97,3 +101,20 @@ jobs:
           build-tool: ${{ matrix.build-tool }}
           ref: refs/tags/${{ inputs.tag }}
           token: ${{ secrets.AUBE_GH_TOKEN }}
+      - name: Resolve uploaded archive
+        id: archive
+        env:
+          MACOS_TAR: ${{ steps.upload-macos.outputs.tar }}
+          UNIX_TAR: ${{ steps.upload-non-macos.outputs.tar }}
+          WINDOWS_ZIP: ${{ steps.upload-non-macos.outputs.zip }}
+        run: |
+          archive="${MACOS_TAR}${UNIX_TAR}${WINDOWS_ZIP}"
+          if [ -z "$archive" ]; then
+            echo "::error::upload-rust-binary-action did not report an archive"
+            exit 1
+          fi
+          echo "path=$archive" >> "$GITHUB_OUTPUT"
+      - name: Attest release archive
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: ${{ steps.archive.outputs.path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
           token: ${{ secrets.AUBE_GH_TOKEN }}
       - name: Resolve uploaded archive
         id: archive
+        shell: bash
         env:
           MACOS_TAR: ${{ steps.upload-macos.outputs.tar }}
           UNIX_TAR: ${{ steps.upload-non-macos.outputs.tar }}


### PR DESCRIPTION
## Summary

- add artifact attestation permissions to the release upload workflow and release-plz caller
- attest the archive emitted by `taiki-e/upload-rust-binary-action` for each release target
- fail early if the upload action does not report a tar/zip archive

## Validation

- `mise x actionlint -- actionlint .github/workflows/release.yml .github/workflows/release-plz.yml`
- `git diff --check`

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies GitHub Actions release permissions and adds provenance attestation steps; main risk is CI/release pipeline breakage if archive resolution or OIDC/attestation permissions are misconfigured.
> 
> **Overview**
> **Release CI now generates provenance attestations for published binaries.** The reusable `release.yml` workflow requests `id-token`/`attestations` permissions, captures the archive path output by `taiki-e/upload-rust-binary-action`, fails if no archive is reported, and then runs `actions/attest-build-provenance@v3` against the uploaded tar/zip.
> 
> The `release-plz.yml` caller job (`upload-assets`) is updated to grant the additional permissions needed for the attestation step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 780b832b9e3e14d961c71870a20032a9ebdfc606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->