### PR TITLE
chore: release v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aube-util",
  "miette",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "blake3",
  "rustc-hash",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -506,9 +506,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -111,14 +111,14 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.1.0" }
-aube-settings = { path = "crates/aube-settings", version = "1.1.0" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.1.0" }
-aube-registry = { path = "crates/aube-registry", version = "1.1.0" }
-aube-store = { path = "crates/aube-store", version = "1.1.0" }
-aube-linker = { path = "crates/aube-linker", version = "1.1.0" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.1.0" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.1.0" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.1.0" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.1.0" }
-aube-util = { path = "crates/aube-util", version = "1.1.0" }
+aube = { path = "crates/aube", version = "1.2.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.2.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.2.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.2.0" }
+aube-store = { path = "crates/aube-store", version = "1.2.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.2.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.2.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.2.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.2.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.2.0" }
+aube-util = { path = "crates/aube-util", version = "1.2.0" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.1.0"
+version "1.2.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/endevco/aube/compare/aube-linker-v1.1.0...aube-linker-v1.2.0) - 2026-04-25
+
+### Fixed
+
+- cross-platform install correctness pass ([#293](https://github.com/endevco/aube/pull/293))
+
+### Security
+
+- cve-class hardening across linker, registry, resolver, install ([#296](https://github.com/endevco/aube/pull/296))
+
 ## [1.1.0](https://github.com/endevco/aube/compare/aube-linker-v1.0.0...aube-linker-v1.1.0) - 2026-04-24
 
 ### Fixed

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.1.0...aube-lockfile-v1.2.0) - 2026-04-25
+
+### Fixed
+
+- support git url specs in dlx and parser ([#295](https://github.com/endevco/aube/pull/295))
+- *(install)* link bins with mixed metadata ([#300](https://github.com/endevco/aube/pull/300))
+- lockfile and resolver correctness pass ([#291](https://github.com/endevco/aube/pull/291))
+
 ## [1.1.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.0.0...aube-lockfile-v1.1.0) - 2026-04-24
 
 ### Added

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/endevco/aube/compare/aube-manifest-v1.1.0...aube-manifest-v1.2.0) - 2026-04-25
+
+### Fixed
+
+- *(scripts)* don't fabricate pnpm-workspace.yaml on approve-builds ([#303](https://github.com/endevco/aube/pull/303))
+
 ## [1.1.0](https://github.com/endevco/aube/compare/aube-manifest-v1.0.0...aube-manifest-v1.1.0) - 2026-04-24
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/endevco/aube/compare/aube-registry-v1.1.0...aube-registry-v1.2.0) - 2026-04-25
+
+### Added
+
+- *(registry)* make packument + tarball body caps configurable, raise packument default to 200 MiB ([#282](https://github.com/endevco/aube/pull/282))
+
+### Fixed
+
+- cross-platform install correctness pass ([#293](https://github.com/endevco/aube/pull/293))
+
+### Security
+
+- cve-class hardening across linker, registry, resolver, install ([#296](https://github.com/endevco/aube/pull/296))
+
 ## [1.1.0](https://github.com/endevco/aube/compare/aube-registry-v1.0.0...aube-registry-v1.1.0) - 2026-04-24
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/endevco/aube/compare/aube-resolver-v1.1.0...aube-resolver-v1.2.0) - 2026-04-25
+
+### Fixed
+
+- lockfile and resolver correctness pass ([#291](https://github.com/endevco/aube/pull/291))
+
+### Security
+
+- cve-class hardening across linker, registry, resolver, install ([#296](https://github.com/endevco/aube/pull/296))
+
 ## [1.1.0](https://github.com/endevco/aube/compare/aube-resolver-v1.0.0...aube-resolver-v1.1.0) - 2026-04-24
 
 ### Added

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/endevco/aube/compare/aube-scripts-v1.1.0...aube-scripts-v1.2.0) - 2026-04-25
+
+### Fixed
+
+- cross-platform install correctness pass ([#293](https://github.com/endevco/aube/pull/293))
+
 ## [1.1.0](https://github.com/endevco/aube/compare/aube-scripts-v1.0.0...aube-scripts-v1.1.0) - 2026-04-24
 
 ### Added

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/endevco/aube/compare/aube-settings-v1.1.0...aube-settings-v1.2.0) - 2026-04-25
+
+### Added
+
+- *(settings)* declare env aliases in registry ([#294](https://github.com/endevco/aube/pull/294))
+- *(registry)* make packument + tarball body caps configurable, raise packument default to 200 MiB ([#282](https://github.com/endevco/aube/pull/282))
+
 ## [1.1.0](https://github.com/endevco/aube/compare/aube-settings-v1.0.0...aube-settings-v1.1.0) - 2026-04-24
 
 ### Other

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/endevco/aube/compare/aube-store-v1.1.0...aube-store-v1.2.0) - 2026-04-25
+
+### Security
+
+- cve-class hardening across linker, registry, resolver, install ([#296](https://github.com/endevco/aube/pull/296))
+
 ## [1.1.0](https://github.com/endevco/aube/compare/aube-store-v1.0.0...aube-store-v1.1.0) - 2026-04-24
 
 ### Fixed

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/endevco/aube/compare/aube-util-v1.1.0...aube-util-v1.2.0) - 2026-04-25
+
+### Security
+
+- cve-class hardening across linker, registry, resolver, install ([#296](https://github.com/endevco/aube/pull/296))
+
 ## [1.1.0](https://github.com/endevco/aube/compare/aube-util-v1.0.0...aube-util-v1.1.0) - 2026-04-24
 
 ### Fixed

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/endevco/aube/compare/v1.1.0...v1.2.0) - 2026-04-25
+
+### Added
+
+- *(cli)* mise-style --version + scope update notifier to version commands ([#301](https://github.com/endevco/aube/pull/301))
+- *(cli)* add short command aliases ([#299](https://github.com/endevco/aube/pull/299))
+
+### Fixed
+
+- support git url specs in dlx and parser ([#295](https://github.com/endevco/aube/pull/295))
+- *(install)* link bins with mixed metadata ([#300](https://github.com/endevco/aube/pull/300))
+- cross-platform install correctness pass ([#293](https://github.com/endevco/aube/pull/293))
+- *(install)* restore missing lockfile from install state ([#289](https://github.com/endevco/aube/pull/289))
+
+### Security
+
+- cve-class hardening across linker, registry, resolver, install ([#296](https://github.com/endevco/aube/pull/296))
+
 ## [1.1.0](https://github.com/endevco/aube/compare/v1.0.0...v1.1.0) - 2026-04-24
 
 ### Added

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5789,7 +5789,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.1.0",
+  "version": "1.2.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.1.0
+**Version**: 1.2.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.1.0",
-  "releasedAt": "2026-04-24T17:16:44Z"
+  "version": "1.2.0",
+  "releasedAt": "2026-04-25T18:16:41Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.2.0`

This PR bumps the workspace to `v1.2.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a release bookkeeping PR that mainly bumps crate versions and regenerates changelogs/docs, with no functional code changes shown in the diff.
> 
> **Overview**
> Bumps the workspace and all internal crates from `1.1.0` to `1.2.0`, updating `Cargo.toml`, `Cargo.lock` (including a `blake3` patch bump), and release metadata (`release.json`).
> 
> Regenerates release artifacts to match the new version: per-crate `CHANGELOG.md` entries, `aube.usage.kdl`, and generated CLI docs (`docs/cli/index.md`, `docs/cli/commands.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7fd793ae5496f8a815465632ea5ca4313600a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->