### PR TITLE
fix(install): restore missing lockfile from install state

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1108,13 +1108,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         let _ = state::remove_state(&cwd);
     }
 
-    // Warm-path short-circuit: when the state file says the tree is
-    // fresh and no flag demands a full re-run, skip the resolve → fetch
-    // → link pipeline entirely and emit the same "Already up to date"
-    // line the full path would print. Mirrors the check already wired
-    // into `ensure_installed` (see `commands::mod.rs::ensure_installed`).
-    // Gated so any flag that implies real work falls through to the
-    // main pipeline.
     // `modulesCacheMaxAge` drives the orphan sweep that runs at the
     // end of every successful install. When users explicitly tune
     // this setting (e.g. `modulesCacheMaxAge=1` to force sweeping on
@@ -1122,8 +1115,35 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // pipeline would leave planted orphans in place until a dep
     // change forced a re-install. The default (10080 min = 7 days)
     // is effectively a no-op on a state-matched warm install (no
-    // orphans accumulate when deps are unchanged), so we keep the
-    // fast path only when the setting is at its default.
+    // orphans accumulate when deps are unchanged), so keep install
+    // fast paths only when the setting is at its default.
+    let modules_cache_sweep_default = super::with_settings_ctx(&cwd, |ctx| {
+        aube_settings::resolved::modules_cache_max_age(ctx) == 10080
+    });
+
+    let missing_lockfile_restore_eligible = matches!(opts.mode, FrozenMode::No)
+        && !opts.force
+        && !opts.lockfile_only
+        && !opts.dep_selection.is_filtered()
+        && !opts.merge_git_branch_lockfiles
+        && !opts.strict_no_lockfile
+        && !opts.dangerously_allow_all_builds
+        && opts.workspace_filter.is_empty()
+        && modules_cache_sweep_default
+        && state::restore_missing_lockfile_if_fresh(&cwd, &opts.cli_flags);
+
+    if missing_lockfile_restore_eligible {
+        print_already_up_to_date();
+        return Ok(());
+    }
+
+    // Warm-path short-circuit: when the state file says the tree is
+    // fresh and no flag demands a full re-run, skip the resolve → fetch
+    // → link pipeline entirely and emit the same "Already up to date"
+    // line the full path would print. Mirrors the check already wired
+    // into `ensure_installed` (see `commands::mod.rs::ensure_installed`).
+    // Gated so any flag that implies real work falls through to the
+    // main pipeline.
     let warm_path_eligible = matches!(opts.mode, FrozenMode::Frozen | FrozenMode::Prefer)
         && !opts.force
         && !opts.lockfile_only
@@ -1132,9 +1152,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         && !opts.strict_no_lockfile
         && !opts.dangerously_allow_all_builds
         && opts.workspace_filter.is_empty()
-        && super::with_settings_ctx(&cwd, |ctx| {
-            aube_settings::resolved::modules_cache_max_age(ctx) == 10080
-        })
+        && modules_cache_sweep_default
         && state::check_needs_install_with_flags(&cwd, &opts.cli_flags).is_none();
 
     if warm_path_eligible {
@@ -1145,19 +1163,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         // `print_install_summary` is never called. `--silent` additionally
         // has its `SilentStderrGuard` redirect fd 2 to /dev/null, so this
         // check is belt-and-suspenders for `-v` and the JSON reporters.
-        if clx::progress::output() != clx::progress::ProgressOutput::Text {
-            use clx::style;
-            use std::io::Write;
-            let line = format!(
-                "{} {} {} {} {}",
-                style::emagenta("aube").bold(),
-                style::edim(crate::version::VERSION.as_str()),
-                style::edim("by en.dev"),
-                style::edim("·"),
-                style::egreen("Already up to date").bold(),
-            );
-            let _ = writeln!(std::io::stderr(), "{line}");
-        }
+        print_already_up_to_date();
         let _ = start;
         return Ok(());
     }
@@ -3584,6 +3590,23 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+fn print_already_up_to_date() {
+    if clx::progress::output() == clx::progress::ProgressOutput::Text {
+        return;
+    }
+    use clx::style;
+    use std::io::Write;
+    let line = format!(
+        "{} {} {} {} {}",
+        style::emagenta("aube").bold(),
+        style::edim(crate::version::VERSION.as_str()),
+        style::edim("by en.dev"),
+        style::edim("·"),
+        style::egreen("Already up to date").bold(),
+    );
+    let _ = writeln!(std::io::stderr(), "{line}");
 }
 
 fn invalidate_changed_aube_entries(

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -7,6 +7,7 @@ const DEFAULT_STATE_DIR: &str = "node_modules";
 const STATE_DIR_NAME: &str = ".aube-state";
 const INSTALL_STATE_FILE_NAME: &str = "state.json";
 const FRESH_STATE_FILE_NAME: &str = "fresh.json";
+const LOCKFILE_SNAPSHOT_FILE_NAME: &str = "lockfile";
 
 /// Resolve the modules dir and state directory path for `project_dir` in a
 /// single settings-context load. `check_needs_install` and `write_state`
@@ -46,6 +47,8 @@ fn relative_path_or_original(path: &Path, base: &Path) -> String {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InstallState {
     pub lockfile_hash: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lockfile_snapshot_name: Option<String>,
     pub package_json_hashes: BTreeMap<String, String>,
     pub aube_version: String,
     #[serde(default, rename = "prod")]
@@ -84,6 +87,8 @@ pub struct InstallState {
 #[derive(Debug, Serialize, Deserialize)]
 struct FreshnessState {
     lockfile_hash: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    lockfile_snapshot_name: Option<String>,
     package_json_hashes: BTreeMap<String, String>,
     #[serde(default, rename = "prod")]
     section_filtered: bool,
@@ -99,6 +104,7 @@ impl From<&InstallState> for FreshnessState {
     fn from(state: &InstallState) -> Self {
         Self {
             lockfile_hash: state.lockfile_hash.clone(),
+            lockfile_snapshot_name: state.lockfile_snapshot_name.clone(),
             package_json_hashes: state.package_json_hashes.clone(),
             section_filtered: state.section_filtered,
             settings_hash: state.settings_hash.clone(),
@@ -180,16 +186,76 @@ fn check_needs_install_inner(
     // "no lockfile found" — see `active_lockfile` for the full resolution
     // order.
     let (lockfile_name, lockfile_path) = active_lockfile(project_dir);
+    let mut lockfile_missing = false;
     if let Some(path) = lockfile_path {
         let current_hash = hash_file(&path);
         if current_hash != state.lockfile_hash {
             return Some(format!("{lockfile_name} has changed"));
         }
     } else {
-        return Some("no lockfile found".into());
+        lockfile_missing = true;
     }
 
-    // Check root + workspace package.json hashes.
+    if let Some(reason) = package_jsons_stale(project_dir, &state) {
+        return Some(reason);
+    }
+
+    if state.section_filtered {
+        return Some(
+            "previous install omitted dependency sections; auto-installing full graph".into(),
+        );
+    }
+
+    if let Some(reason) = verify_install_layout(project_dir, state.layout.as_ref()) {
+        return Some(reason);
+    }
+
+    if let Some(cli_flags) = cli_flags {
+        let current_settings_hash = hash_settings(project_dir, cli_flags);
+        if current_settings_hash != state.settings_hash {
+            return Some(".npmrc or workspace config has changed".into());
+        }
+    }
+
+    // No settings_hash check when cli_flags is None. That path feeds
+    // ensure_installed (aube run / exec / test). Those commands do not
+    // care about install-shape settings changing because the tree is
+    // still the tree built by the last install. Skipping this check
+    // also avoids the asymmetry bug where `aube install
+    // --node-linker=hoisted` writes a hash with cli_flags set, then
+    // bare `aube run` reads without the flag, mismatches, and triggers
+    // a spurious auto-install.
+    if lockfile_missing
+        && restore_lockfile_snapshot(project_dir, &state_path, &state, &lockfile_name).is_none()
+    {
+        return Some("no lockfile found".into());
+    }
+    None
+}
+
+pub fn restore_missing_lockfile_if_fresh(
+    project_dir: &Path,
+    cli_flags: &[(String, String)],
+) -> bool {
+    let (modules_dir, state_path) = resolve_paths(project_dir);
+    let (lockfile_name, lockfile_path) = active_lockfile(project_dir);
+    if lockfile_path.is_some() || !modules_dir.exists() {
+        return false;
+    }
+    let Some(state) = read_or_migrate_fresh_state(&state_path) else {
+        return false;
+    };
+    if package_jsons_stale(project_dir, &state).is_some()
+        || state.section_filtered
+        || verify_install_layout(project_dir, state.layout.as_ref()).is_some()
+        || hash_settings(project_dir, cli_flags) != state.settings_hash
+    {
+        return false;
+    }
+    restore_lockfile_snapshot(project_dir, &state_path, &state, &lockfile_name).is_some()
+}
+
+fn package_jsons_stale(project_dir: &Path, state: &FreshnessState) -> Option<String> {
     for (rel, stored_hash) in &state.package_json_hashes {
         let path = if rel == "." {
             project_dir.join("package.json")
@@ -224,32 +290,6 @@ fn check_needs_install_inner(
             return Some(stale_reason());
         }
     }
-
-    if state.section_filtered {
-        return Some(
-            "previous install omitted dependency sections; auto-installing full graph".into(),
-        );
-    }
-
-    if let Some(reason) = verify_install_layout(project_dir, state.layout.as_ref()) {
-        return Some(reason);
-    }
-
-    if let Some(cli_flags) = cli_flags {
-        let current_settings_hash = hash_settings(project_dir, cli_flags);
-        if current_settings_hash != state.settings_hash {
-            return Some(".npmrc or workspace config has changed".into());
-        }
-    }
-
-    // No settings_hash check when cli_flags is None. That path feeds
-    // ensure_installed (aube run / exec / test). Those commands do not
-    // care about install-shape settings changing because the tree is
-    // still the tree built by the last install. Skipping this check
-    // also avoids the asymmetry bug where `aube install
-    // --node-linker=hoisted` writes a hash with cli_flags set, then
-    // bare `aube run` reads without the flag, mismatches, and triggers
-    // a spurious auto-install.
     None
 }
 
@@ -289,10 +329,10 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         layout,
     } = input;
 
-    let lockfile_hash = match active_lockfile(project_dir).1 {
-        Some(path) => hash_file(&path),
-        None => String::new(),
-    };
+    let state_path = state_dir(project_dir);
+    remove_legacy_state_file(&state_path)?;
+    let (lockfile_hash, lockfile_snapshot_name) =
+        snapshot_active_lockfile(project_dir, &state_path)?;
     let settings_hash = hash_settings(project_dir, cli_flags);
     let install_layout = InstallLayoutState::from_graph(
         project_dir,
@@ -323,6 +363,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
 
     let state = InstallState {
         lockfile_hash,
+        lockfile_snapshot_name,
         package_json_hashes,
         aube_version: env!("CARGO_PKG_VERSION").to_string(),
         section_filtered,
@@ -335,13 +376,28 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     };
 
     let fresh_state = FreshnessState::from(&state);
-    let state_path = state_dir(project_dir);
     let json = serde_json::to_string_pretty(&state)?;
-    remove_legacy_state_file(&state_path)?;
     aube_util::fs_atomic::atomic_write(&install_state_file(&state_path), json.as_bytes())?;
     write_fresh_state(&state_path, &fresh_state)?;
 
     Ok(())
+}
+
+fn snapshot_active_lockfile(
+    project_dir: &Path,
+    state_path: &Path,
+) -> Result<(String, Option<String>), std::io::Error> {
+    let (name, path) = active_lockfile(project_dir);
+    let Some(path) = path else {
+        let _ = std::fs::remove_file(lockfile_snapshot_file(state_path));
+        return Ok((String::new(), None));
+    };
+    let Ok(content) = std::fs::read(&path) else {
+        let _ = std::fs::remove_file(lockfile_snapshot_file(state_path));
+        return Ok((String::new(), None));
+    };
+    aube_util::fs_atomic::atomic_write(&lockfile_snapshot_file(state_path), &content)?;
+    Ok((hash_bytes(&content), Some(name)))
 }
 
 /// Read per-package fingerprints from a project's state directory.
@@ -470,6 +526,10 @@ fn fresh_state_file(state_path: &Path) -> PathBuf {
     state_path.join(FRESH_STATE_FILE_NAME)
 }
 
+fn lockfile_snapshot_file(state_path: &Path) -> PathBuf {
+    state_path.join(LOCKFILE_SNAPSHOT_FILE_NAME)
+}
+
 fn read_fresh_state(state_path: &Path) -> Option<FreshnessState> {
     if state_path.is_file() {
         let _ = std::fs::remove_file(state_path);
@@ -491,6 +551,47 @@ fn read_or_migrate_fresh_state(state_path: &Path) -> Option<FreshnessState> {
 fn write_fresh_state(state_path: &Path, state: &FreshnessState) -> Result<(), std::io::Error> {
     let json = serde_json::to_string_pretty(state)?;
     aube_util::fs_atomic::atomic_write(&fresh_state_file(state_path), json.as_bytes())
+}
+
+fn restore_lockfile_snapshot(
+    project_dir: &Path,
+    state_path: &Path,
+    state: &FreshnessState,
+    expected_name: &str,
+) -> Option<PathBuf> {
+    let name = state.lockfile_snapshot_name.as_ref()?;
+    if !is_restorable_lockfile_name(name) {
+        return None;
+    }
+    if is_branch_lockfile_name(name) && name != expected_name {
+        return None;
+    }
+    let content = std::fs::read(lockfile_snapshot_file(state_path)).ok()?;
+    if hash_bytes(&content) != state.lockfile_hash {
+        return None;
+    }
+    let path = project_dir.join(name);
+    aube_util::fs_atomic::atomic_write(&path, &content).ok()?;
+    Some(path)
+}
+
+fn is_restorable_lockfile_name(name: &str) -> bool {
+    matches!(
+        name,
+        "aube-lock.yaml"
+            | "pnpm-lock.yaml"
+            | "bun.lock"
+            | "yarn.lock"
+            | "npm-shrinkwrap.json"
+            | "package-lock.json"
+    ) || is_branch_lockfile_name(name)
+}
+
+fn is_branch_lockfile_name(name: &str) -> bool {
+    (name.starts_with("aube-lock.") || name.starts_with("pnpm-lock."))
+        && name.ends_with(".yaml")
+        && name != "aube-lock.yaml"
+        && name != "pnpm-lock.yaml"
 }
 
 fn remove_legacy_state_file(state_path: &Path) -> Result<(), std::io::Error> {
@@ -836,6 +937,11 @@ fn hash_file(path: &Path) -> String {
     format!("blake3:{}", hash.to_hex())
 }
 
+fn hash_bytes(content: &[u8]) -> String {
+    let hash = blake3::hash(content);
+    format!("blake3:{}", hash.to_hex())
+}
+
 fn hash_file_if_exists(path: &Path) -> Option<String> {
     std::fs::read(path).ok().map(|content| {
         let hash = blake3::hash(&content);
@@ -874,6 +980,7 @@ mod tests {
         let project_dir = temp_project_dir("legacy-empty-hash");
         let state = InstallState {
             lockfile_hash: String::new(),
+            lockfile_snapshot_name: None,
             package_json_hashes: BTreeMap::new(),
             aube_version: String::new(),
             section_filtered: false,
@@ -942,6 +1049,7 @@ mod tests {
         std::fs::create_dir_all(&state_path).expect("state dir should write");
         let state = InstallState {
             lockfile_hash: "blake3:lock".to_string(),
+            lockfile_snapshot_name: None,
             package_json_hashes: BTreeMap::from([(".".to_string(), "blake3:pkg".to_string())]),
             aube_version: env!("CARGO_PKG_VERSION").to_string(),
             section_filtered: false,
@@ -1032,6 +1140,7 @@ mod tests {
         shapes.insert(".".to_string(), orig_shape);
         let state = InstallState {
             lockfile_hash: String::new(),
+            lockfile_snapshot_name: None,
             package_json_hashes: pjh,
             aube_version: env!("CARGO_PKG_VERSION").to_string(),
             section_filtered: false,

--- a/test/git_branch_lockfile.bats
+++ b/test/git_branch_lockfile.bats
@@ -86,6 +86,36 @@ teardown() {
 	refute_output --partial "no lockfile found"
 }
 
+@test "gitBranchLockfile missing lockfile restore respects current branch name" {
+	git init -q
+	git config user.email "t@t"
+	git config user.name "t"
+	git checkout -q -b main
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-gbl-restore",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "3.0.1" }
+		}
+	EOF
+	cat >pnpm-workspace.yaml <<-'EOF'
+		gitBranchLockfile: true
+	EOF
+	git add package.json pnpm-workspace.yaml
+	git commit -q -m "init"
+
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_file_exists aube-lock.main.yaml
+	assert_file_exists node_modules/.aube-state/lockfile
+
+	git checkout -q -b dev
+	rm aube-lock.main.yaml
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_file_exists aube-lock.dev.yaml
+}
+
 # ===================================================================
 # mergeGitBranchLockfilesBranchPattern / --merge-git-branch-lockfiles
 # ===================================================================

--- a/test/install.bats
+++ b/test/install.bats
@@ -470,6 +470,21 @@ JSON
 	assert_output --partial "No lockfile found"
 }
 
+@test "aube install --no-frozen-lockfile restores missing lockfile from fresh state" {
+	_setup_basic_fixture
+	run aube install
+	assert_success
+	cp aube-lock.yaml aube-lock.yaml.expected
+	assert_file_exists node_modules/.aube-state/lockfile
+
+	rm aube-lock.yaml
+	run aube -v install --no-frozen-lockfile
+	assert_success
+	refute_output --partial "No lockfile found"
+	assert_file_exists aube-lock.yaml
+	assert_equal "$(cat aube-lock.yaml)" "$(cat aube-lock.yaml.expected)"
+}
+
 @test "aube install --fix-lockfile is a no-op on a fresh lockfile" {
 	# Surgical heal: when nothing has drifted, the lockfile should round-trip
 	# byte-for-byte. Proves we're seeding the resolver with the existing


### PR DESCRIPTION
## Summary

- Snapshot the active lockfile into `node_modules/.aube-state/lockfile` after a successful install.
- When `aube install --no-frozen-lockfile` sees a fresh install state but the lockfile has been deleted, restore that snapshot and take the no-op fast path instead of resolving from scratch.
- Keep branch-specific lockfiles safe by refusing to restore an `aube-lock.<branch>.yaml` / `pnpm-lock.<branch>.yaml` snapshot when the current expected branch lockfile name differs.

## Root Cause

The vlt `node_modules` benchmark keeps `node_modules` but deletes lockfiles and aube's metadata cache between runs. In 1.1.0 that forced aube off the install-state fast path, so it re-resolved from `package.json` despite the materialized tree still matching the last install.

## Manual Benchmark

Fixture: `vltpkg/benchmarks` `next` fixture, local reproduction of the `node_modules` variation with `CI=1`, lockfiles removed, aube metadata cache removed, and `node_modules` kept.

| Build | Mean | Range | Runs |
| --- | ---: | ---: | --- |
| `@endevco/aube@1.0.0` | 2.086s | 1.958s-2.251s | 3 |
| `@endevco/aube@1.1.0` | 5.695s | 2.218s-12.568s | 3 |
| this branch, release build | 0.013s | 0.013s-0.014s | 5 |

Control runs:

| Scenario | 1.0.0 | 1.1.0 |
| --- | ---: | ---: |
| `next`, lockfile kept | 0.038s | 0.048s |
| `next`, lockfile deleted but metadata cache kept | 0.403s | 0.418s |

## Validation

- `cargo fmt --check`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `mise run test:bats test/install.bats --filter 'restores missing lockfile'`
- `mise run test:bats test/git_branch_lockfile.bats --filter 'missing lockfile restore'`
- `cargo build --release`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-state semantics by snapshotting/restoring lockfiles and adding new no-op short-circuit paths; mistakes could cause stale lockfiles to be resurrected or installs to be incorrectly skipped, especially with branch-specific lockfiles.
> 
> **Overview**
> Makes `aube install --no-frozen-lockfile` able to **restore a deleted lockfile** from `node_modules/.aube-state/lockfile` when the install state is still fresh, then take the no-op fast path instead of re-resolving.
> 
> Extends install state (`state.json`/`fresh.json`) to record the snapshotted lockfile name+hash, snapshots the active lockfile after successful installs, and adds safety checks to only restore known lockfile filenames and to refuse restoring a branch lockfile snapshot when the current expected branch lockfile name differs.
> 
> Refactors the “Already up to date” output into `print_already_up_to_date()` and adds bats coverage for missing-lockfile restore (including `gitBranchLockfile` branch switching).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb33647448d4ebba27b0e969e042f13024014db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->