### PR TITLE
fix: lockfile and resolver correctness pass

### DIFF
--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -832,10 +832,10 @@ fn strip_jsonc(input: &str) -> String {
 
         if in_string {
             out.push(c);
-            if c < 0x80 {
-                if escape {
-                    escape = false;
-                } else if c == b'\\' {
+            if escape {
+                escape = false;
+            } else if c < 0x80 {
+                if c == b'\\' {
                     escape = true;
                 } else if c == b'"' {
                     in_string = false;

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -821,8 +821,8 @@ fn split_ident(ident: &str) -> Option<(String, String)> {
 /// when rendered against the original source via `miette`'s fancy
 /// handler.
 fn strip_jsonc(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
     let mut i = 0;
     let mut in_string = false;
     let mut escape = false;
@@ -831,13 +831,15 @@ fn strip_jsonc(input: &str) -> String {
         let c = bytes[i];
 
         if in_string {
-            out.push(c as char);
-            if escape {
-                escape = false;
-            } else if c == b'\\' {
-                escape = true;
-            } else if c == b'"' {
-                in_string = false;
+            out.push(c);
+            if c < 0x80 {
+                if escape {
+                    escape = false;
+                } else if c == b'\\' {
+                    escape = true;
+                } else if c == b'"' {
+                    in_string = false;
+                }
             }
             i += 1;
             continue;
@@ -847,7 +849,7 @@ fn strip_jsonc(input: &str) -> String {
         // newline with a space. The `\n` itself is kept.
         if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
             while i < bytes.len() && bytes[i] != b'\n' {
-                out.push(' ');
+                out.push(b' ');
                 i += 1;
             }
             continue;
@@ -856,23 +858,23 @@ fn strip_jsonc(input: &str) -> String {
         // Block comment: replace every byte with a space, but keep
         // embedded newlines so line numbers don't shift.
         if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
-            out.push(' ');
-            out.push(' ');
+            out.push(b' ');
+            out.push(b' ');
             i += 2;
             while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                out.push(if bytes[i] == b'\n' { '\n' } else { ' ' });
+                out.push(if bytes[i] == b'\n' { b'\n' } else { b' ' });
                 i += 1;
             }
             if i + 1 < bytes.len() {
                 // consume the closing `*/`
-                out.push(' ');
-                out.push(' ');
+                out.push(b' ');
+                out.push(b' ');
                 i += 2;
             } else {
                 // unterminated block comment — mirror every remaining
                 // byte to preserve length, keeping newlines intact.
                 while i < bytes.len() {
-                    out.push(if bytes[i] == b'\n' { '\n' } else { ' ' });
+                    out.push(if bytes[i] == b'\n' { b'\n' } else { b' ' });
                     i += 1;
                 }
             }
@@ -883,11 +885,11 @@ fn strip_jsonc(input: &str) -> String {
         // non-whitespace char is `}` or `]`.
         if c == b',' {
             let mut j = i + 1;
-            while j < bytes.len() && (bytes[j] as char).is_whitespace() {
+            while j < bytes.len() && bytes[j] < 0x80 && (bytes[j] as char).is_whitespace() {
                 j += 1;
             }
             if j < bytes.len() && (bytes[j] == b'}' || bytes[j] == b']') {
-                out.push(' ');
+                out.push(b' ');
                 i += 1;
                 continue;
             }
@@ -897,11 +899,11 @@ fn strip_jsonc(input: &str) -> String {
             in_string = true;
         }
 
-        out.push(c as char);
+        out.push(c);
         i += 1;
     }
 
-    out
+    String::from_utf8(out).expect("strip_jsonc preserves UTF-8 validity")
 }
 
 // ---------------------------------------------------------------------------
@@ -1580,6 +1582,22 @@ mod tests {
         let out = strip_jsonc(input);
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["url"], "http://example.com/path");
+    }
+
+    #[test]
+    fn strip_jsonc_preserves_utf8_string_value() {
+        let input = "{ \"name\": \"café\" }";
+        let out = strip_jsonc(input);
+        assert_eq!(out.len(), input.len());
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["name"], "café");
+    }
+
+    #[test]
+    fn strip_jsonc_preserves_offsets_for_nonascii_in_comments() {
+        let input = "{ // café\n  \"a\": 1 }";
+        let out = strip_jsonc(input);
+        assert_eq!(out.len(), input.len());
     }
 
     /// `strip_jsonc` must preserve byte offsets so a `serde_json` error

--- a/crates/aube-lockfile/src/merge.rs
+++ b/crates/aube-lockfile/src/merge.rs
@@ -260,8 +260,10 @@ fn merge_into(dst: &mut LockfileGraph, src: LockfileGraph, report: &mut MergeRep
             }
         }
     }
+    let mut seen: rustc_hash::FxHashSet<String> =
+        dst.trusted_dependencies.iter().cloned().collect();
     for name in src.trusted_dependencies {
-        if !dst.trusted_dependencies.iter().any(|n| n == &name) {
+        if seen.insert(name.clone()) {
             dst.trusted_dependencies.push(name);
         }
     }

--- a/crates/aube-lockfile/src/merge.rs
+++ b/crates/aube-lockfile/src/merge.rs
@@ -242,6 +242,29 @@ fn merge_into(dst: &mut LockfileGraph, src: LockfileGraph, report: &mut MergeRep
     for name in src.ignored_optional_dependencies {
         dst.ignored_optional_dependencies.insert(name);
     }
+    for (key, incoming) in src.patched_dependencies {
+        use std::collections::btree_map::Entry;
+        match dst.patched_dependencies.entry(key) {
+            Entry::Vacant(slot) => {
+                slot.insert(incoming);
+            }
+            Entry::Occupied(slot) => {
+                if slot.get() != &incoming {
+                    report.conflicts.push(format!(
+                        "patched dependency `{}`: kept {} over {}",
+                        slot.key(),
+                        slot.get(),
+                        incoming
+                    ));
+                }
+            }
+        }
+    }
+    for name in src.trusted_dependencies {
+        if !dst.trusted_dependencies.iter().any(|n| n == &name) {
+            dst.trusted_dependencies.push(name);
+        }
+    }
     for (importer_key, entries) in src.skipped_optional_dependencies {
         let merged = dst
             .skipped_optional_dependencies
@@ -509,5 +532,36 @@ mod tests {
         assert!(!prefer_higher_version("1.0.0", "2.0.0"));
         // Fallback: string compare for non-semver tails.
         assert!(prefer_higher_version("workspace:z", "workspace:a"));
+    }
+
+    #[test]
+    fn merge_into_preserves_patched_dependencies() {
+        let mut dst = LockfileGraph::default();
+        let mut src = LockfileGraph::default();
+        src.patched_dependencies.insert(
+            "lodash@4.17.21".into(),
+            "patches/lodash@4.17.21.patch".into(),
+        );
+        let mut report = MergeReport::default();
+        merge_into(&mut dst, src, &mut report);
+        assert!(
+            dst.patched_dependencies.contains_key("lodash@4.17.21"),
+            "patched_dependencies entry was dropped on merge: {:?}",
+            dst.patched_dependencies
+        );
+    }
+
+    #[test]
+    fn merge_into_preserves_trusted_dependencies() {
+        let mut dst = LockfileGraph::default();
+        let mut src = LockfileGraph::default();
+        src.trusted_dependencies.push("esbuild".into());
+        let mut report = MergeReport::default();
+        merge_into(&mut dst, src, &mut report);
+        assert!(
+            dst.trusted_dependencies.iter().any(|n| n == "esbuild"),
+            "trusted_dependencies was dropped on merge: {:?}",
+            dst.trusted_dependencies
+        );
     }
 }

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -61,18 +61,18 @@ pub(crate) fn pick_version<'a>(
     // npm and pnpm fall back to the highest non-prerelease version.
     // Do the same so `aube install foo` does not silently fail on a
     // packument that just happens to lack the tag.
-    let parses_as_range = node_semver::Range::parse(normalize_range(range_str)).is_ok();
-    let effective_range =
-        if !parses_as_range && let Some(tagged_version) = packument.dist_tags.get(range_str) {
-            tagged_version.clone()
-        } else if !parses_as_range && range_str == "latest" {
-            match highest_stable_version(packument) {
-                Some(v) => v,
-                None => return PickResult::NoMatch,
-            }
-        } else {
-            range_str.to_string()
-        };
+    let effective_range = if node_semver::Range::parse(normalize_range(range_str)).is_ok() {
+        range_str.to_string()
+    } else if let Some(tagged_version) = packument.dist_tags.get(range_str) {
+        tagged_version.clone()
+    } else if range_str == "latest" {
+        match highest_stable_version(packument) {
+            Some(v) => v,
+            None => return PickResult::NoMatch,
+        }
+    } else {
+        range_str.to_string()
+    };
 
     let range = match node_semver::Range::parse(normalize_range(&effective_range)) {
         Ok(r) => r,

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -61,22 +61,24 @@ pub(crate) fn pick_version<'a>(
     // npm and pnpm fall back to the highest non-prerelease version.
     // Do the same so `aube install foo` does not silently fail on a
     // packument that just happens to lack the tag.
-    let effective_range = if node_semver::Range::parse(normalize_range(range_str)).is_ok() {
-        range_str.to_string()
-    } else if let Some(tagged_version) = packument.dist_tags.get(range_str) {
-        tagged_version.clone()
-    } else if range_str == "latest" {
-        match highest_stable_version(packument) {
-            Some(v) => v,
-            None => return PickResult::NoMatch,
-        }
-    } else {
-        range_str.to_string()
-    };
-
-    let range = match node_semver::Range::parse(normalize_range(&effective_range)) {
+    let range = match node_semver::Range::parse(normalize_range(range_str)) {
         Ok(r) => r,
-        Err(_) => return PickResult::NoMatch,
+        Err(_) => {
+            let effective_range = if let Some(tagged_version) = packument.dist_tags.get(range_str) {
+                tagged_version.clone()
+            } else if range_str == "latest" {
+                match highest_stable_version(packument) {
+                    Some(v) => v,
+                    None => return PickResult::NoMatch,
+                }
+            } else {
+                return PickResult::NoMatch;
+            };
+            match node_semver::Range::parse(normalize_range(&effective_range)) {
+                Ok(r) => r,
+                Err(_) => return PickResult::NoMatch,
+            }
+        }
     };
 
     let passes_cutoff = |ver: &str| -> bool {

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -61,16 +61,18 @@ pub(crate) fn pick_version<'a>(
     // npm and pnpm fall back to the highest non-prerelease version.
     // Do the same so `aube install foo` does not silently fail on a
     // packument that just happens to lack the tag.
-    let effective_range = if let Some(tagged_version) = packument.dist_tags.get(range_str) {
-        tagged_version.clone()
-    } else if range_str == "latest" {
-        match highest_stable_version(packument) {
-            Some(v) => v,
-            None => return PickResult::NoMatch,
-        }
-    } else {
-        range_str.to_string()
-    };
+    let parses_as_range = node_semver::Range::parse(normalize_range(range_str)).is_ok();
+    let effective_range =
+        if !parses_as_range && let Some(tagged_version) = packument.dist_tags.get(range_str) {
+            tagged_version.clone()
+        } else if !parses_as_range && range_str == "latest" {
+            match highest_stable_version(packument) {
+                Some(v) => v,
+                None => return PickResult::NoMatch,
+            }
+        } else {
+            range_str.to_string()
+        };
 
     let range = match node_semver::Range::parse(normalize_range(&effective_range)) {
         Ok(r) => r,

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -2751,3 +2751,13 @@ async fn same_dep_in_dev_and_optional_dependencies_dedupes() {
     assert_eq!(root[0].name, "p-map");
     assert_eq!(root[0].dep_type, DepType::Dev);
 }
+
+#[test]
+fn pick_version_exact_pin_not_hijacked_by_dist_tag() {
+    let mut packument = make_packument("foo", &["1.0.0", "1.5.0"], "1.5.0");
+    packument
+        .dist_tags
+        .insert("1.0.0".to_string(), "1.5.0".to_string());
+    let result = pick_version(&packument, "1.0.0", None, false, None, false).unwrap();
+    assert_eq!(result.version, "1.0.0");
+}


### PR DESCRIPTION
## correctness
- `bun::strip_jsonc` now rebuilds the cleaned buffer over `Vec<u8>` instead of `String::push(c as char)`, fixing utf-8 corruption inside `bun.lock` string literals and restoring the byte-offset invariant relied on by miette spans
- `lockfile::merge::merge_into` unions `patched_dependencies` (conflict-record, keep-base) and dedupe-appends `trusted_dependencies`, no more silent drop of patches or bun lifecycle allowlist when branch lockfiles collapse into `aube-lock.yaml`
- `resolver::semver_util::pick_version` probes `node_semver::Range::parse` before the dist-tag fallback, exact pins like `foo@1.0.0` can no longer be hijacked by a registry serving `dist_tags["1.0.0"] = "1.5.0"`

## testing
- regression test per fix in the existing `#[cfg(test)] mod tests` blocks
- 191 lockfile + 120 resolver lib tests pass on windows
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## scope
- pure byte/string and data-structure logic, no fs / path / process surface, behaves identically on windows / macos / linux