### PR TITLE
fix(bench): force gvs modes in refresh job

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -119,7 +119,7 @@ jobs:
           cat > /tmp/bench_body.md <<EOF
           ## 🤖 Refreshed benchmarks
 
-          \`benchmarks/results.json\` was pinned to aube \`${BENCH:-<unset>}\` but the workspace is now \`${WORKSPACE}\`. Re-ran \`mise run bench:bump\` on the hermetic Verdaccio registry (throttled per the mise task) and regenerated \`benchmarks/results.json\` plus the README \`BENCH_RATIOS\` block.
+          \`benchmarks/results.json\` was pinned to aube \`${BENCH:-<unset>}\` but the workspace is now \`${WORKSPACE}\`. Re-ran \`mise run bench:bump\` on the hermetic Verdaccio registry (throttled per the mise task) and regenerated \`benchmarks/results.json\` plus the README \`BENCH_RATIOS\` block. The benchmark matrix forces aube's GVS scenarios with \`--enable-gvs\` and CI scenarios with \`--disable-gvs\`, so GitHub Actions' inherited \`CI=true\` environment does not change the measured mode.
 
           **Review the numbers** before merging — if anything looks wildly off vs. the previous release, investigate before landing. Hermetic proxy jitter or an npmjs uplink hiccup can occasionally skew results.
 

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -119,7 +119,7 @@ jobs:
           cat > /tmp/bench_body.md <<EOF
           ## 🤖 Refreshed benchmarks
 
-          \`benchmarks/results.json\` was pinned to aube \`${BENCH:-<unset>}\` but the workspace is now \`${WORKSPACE}\`. Re-ran \`mise run bench:bump\` on the hermetic Verdaccio registry (throttled per the mise task) and regenerated \`benchmarks/results.json\` plus the README \`BENCH_RATIOS\` block. The benchmark matrix forces aube's GVS scenarios with \`--enable-gvs\` and CI scenarios with \`--disable-gvs\`, so GitHub Actions' inherited \`CI=true\` environment does not change the measured mode.
+          \`benchmarks/results.json\` was pinned to aube \`${BENCH:-<unset>}\` but the workspace is now \`${WORKSPACE}\`. Re-ran \`mise run bench:bump\` on the hermetic Verdaccio registry (throttled per the mise task) and regenerated \`benchmarks/results.json\` plus the README \`BENCH_RATIOS\` block. The benchmark matrix pins each scenario's GVS mode via \`npm_config_enable_global_virtual_store=true|false\` (the auto-synthesized env alias for the \`enableGlobalVirtualStore\` setting), so GitHub Actions' inherited \`CI=true\` environment does not change the measured mode.
 
           **Review the numbers** before merging — if anything looks wildly off vs. the previous release, investigate before landing. Hermetic proxy jitter or an npmjs uplink hiccup can occasionally skew results.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ## Why Try It
 
 <!-- BENCH_RATIOS:START -->
-**[Fast installs](https://aube.en.dev/benchmarks).** Warm installs with the global virtual store are about 6x faster than pnpm and 3x faster than Bun in the current benchmarks. Repeat test commands run up to ~49x faster than pnpm and up to 3x faster than Bun.
+**[Fast installs](https://aube.en.dev/benchmarks).** Warm installs with the global virtual store are about 6x faster than pnpm and about 3x faster than Bun in the current benchmarks. Repeat test commands run up to 49x faster than pnpm and up to 3x faster than Bun.
 <!-- BENCH_RATIOS:END -->
 
 **[Existing lockfiles](https://aube.en.dev/package-manager/lockfiles).** Reads and writes `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock` in place.

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -291,6 +291,17 @@ BUN_BASE="HOME={home} BUN_INSTALL={home}/.bun {bin} install --cache-dir {cache} 
 # and `COLD_WIPE` wouldn't find it to clean up between iterations.
 AUBE_ENV="HOME={home} XDG_CACHE_HOME={cache} XDG_DATA_HOME={home}/.local/share"
 
+# Per-scenario AUBE_ENV variants that pin the global virtual store mode
+# via the `enableGlobalVirtualStore` setting's auto-synthesized env-var
+# alias (`npm_config_<snake_case>` — see `aube-settings/build.rs`).
+# Using an env var rather than `--enable-gvs` / `--disable-gvs` means
+# scenarios that go through `aube test` and `aube add` (which trigger
+# auto-install internally) get the same forcing as direct `aube install`
+# calls. The setting wins over `Linker::new`'s `CI` heuristic, so
+# GitHub Actions' inherited `CI=true` cannot silently flip the mode.
+AUBE_ENV_GVS_ON="$AUBE_ENV npm_config_enable_global_virtual_store=true"
+AUBE_ENV_GVS_OFF="$AUBE_ENV npm_config_enable_global_virtual_store=false"
+
 # Scenario keys describe what's on disk before the run. Every install
 # scenario assumes a committed lockfile is present; the axes are
 # cache/store warmth and whether aube's global virtual store is enabled.
@@ -298,28 +309,28 @@ AUBE_ENV="HOME={home} XDG_CACHE_HOME={cache} XDG_DATA_HOME={home}/.local/share"
 # "install-test" scenario that measures install + script dispatch end-to-end.
 
 # Scenario 1: Fresh install, warm cache (aube GVS enabled) ------------------
-CMDS["gvs-warm:aube"]="cd {project} && $AUBE_ENV {bin} install --frozen-lockfile --enable-gvs >/dev/null 2>&1"
+CMDS["gvs-warm:aube"]="cd {project} && $AUBE_ENV_GVS_ON {bin} install --frozen-lockfile >/dev/null 2>&1"
 CMDS["gvs-warm:bun"]="cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1"
 CMDS["gvs-warm:npm"]="cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps --prefer-offline >/dev/null 2>&1"
 CMDS["gvs-warm:pnpm"]="cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
 CMDS["gvs-warm:yarn"]="cd {project} && HOME={home} YARN_CACHE_FOLDER={cache} {bin} install --frozen-lockfile --ignore-scripts --ignore-engines --no-progress --prefer-offline >/dev/null 2>&1"
 
 # Scenario 2: Fresh install, cold cache (aube GVS enabled) ------------------
-CMDS["gvs-cold:aube"]="cd {project} && $AUBE_ENV {bin} install --frozen-lockfile --enable-gvs >/dev/null 2>&1"
+CMDS["gvs-cold:aube"]="cd {project} && $AUBE_ENV_GVS_ON {bin} install --frozen-lockfile >/dev/null 2>&1"
 CMDS["gvs-cold:bun"]="cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1"
 CMDS["gvs-cold:npm"]="cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps >/dev/null 2>&1"
 CMDS["gvs-cold:pnpm"]="cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
 CMDS["gvs-cold:yarn"]="cd {project} && HOME={home} YARN_CACHE_FOLDER={cache} {bin} install --frozen-lockfile --ignore-scripts --ignore-engines --no-progress >/dev/null 2>&1"
 
 # Scenario 3: CI install, warm cache (aube GVS disabled) --------------------
-CMDS["ci-warm:aube"]="cd {project} && $AUBE_ENV {bin} install --frozen-lockfile --disable-gvs >/dev/null 2>&1"
+CMDS["ci-warm:aube"]="cd {project} && $AUBE_ENV_GVS_OFF {bin} install --frozen-lockfile >/dev/null 2>&1"
 CMDS["ci-warm:bun"]="cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1"
 CMDS["ci-warm:npm"]="cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps --prefer-offline >/dev/null 2>&1"
 CMDS["ci-warm:pnpm"]="cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
 CMDS["ci-warm:yarn"]="cd {project} && HOME={home} YARN_CACHE_FOLDER={cache} {bin} install --frozen-lockfile --ignore-scripts --ignore-engines --no-progress --prefer-offline >/dev/null 2>&1"
 
 # Scenario 4: CI install, cold cache (aube GVS disabled) --------------------
-CMDS["ci-cold:aube"]="cd {project} && $AUBE_ENV {bin} install --frozen-lockfile --disable-gvs >/dev/null 2>&1"
+CMDS["ci-cold:aube"]="cd {project} && $AUBE_ENV_GVS_OFF {bin} install --frozen-lockfile >/dev/null 2>&1"
 CMDS["ci-cold:bun"]="cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1"
 CMDS["ci-cold:npm"]="cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps >/dev/null 2>&1"
 CMDS["ci-cold:pnpm"]="cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
@@ -331,7 +342,7 @@ CMDS["ci-cold:yarn"]="cd {project} && HOME={home} YARN_CACHE_FOLDER={cache} {bin
 # before running the script; pnpm and npm ship `install-test`; bun and yarn
 # need an explicit chain. The fixture's `test` script is the POSIX shell
 # no-op `:`, so this measures install + script dispatch, not test-runtime work.
-CMDS["install-test:aube"]="cd {project} && $AUBE_ENV {bin} test >/dev/null 2>&1"
+CMDS["install-test:aube"]="cd {project} && $AUBE_ENV_GVS_ON {bin} test >/dev/null 2>&1"
 CMDS["install-test:bun"]="cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1 && HOME={home} BUN_INSTALL={home}/.bun {bin} run test >/dev/null 2>&1"
 # `npm install-test` (the `install` variant, not `ci`) is the right
 # command for the "already installed" semantics this scenario uses —
@@ -342,7 +353,7 @@ CMDS["install-test:pnpm"]="cd {project} && HOME={home} {bin} install-test --froz
 CMDS["install-test:yarn"]="cd {project} && HOME={home} YARN_CACHE_FOLDER={cache} {bin} install --frozen-lockfile --ignore-scripts --ignore-engines --no-progress --prefer-offline >/dev/null 2>&1 && HOME={home} YARN_CACHE_FOLDER={cache} {bin} test >/dev/null 2>&1"
 
 # Scenario 6: add a dependency (warm store+cache, existing lockfile) --------
-CMDS["add:aube"]="cd {project} && $AUBE_ENV {bin} add is-odd >/dev/null 2>&1"
+CMDS["add:aube"]="cd {project} && $AUBE_ENV_GVS_ON {bin} add is-odd >/dev/null 2>&1"
 CMDS["add:bun"]="cd {project} && HOME={home} BUN_INSTALL={home}/.bun {bin} add is-odd --cache-dir {cache} --ignore-scripts --no-summary >/dev/null 2>&1"
 CMDS["add:npm"]="cd {project} && HOME={home} npm_config_cache={cache} {bin} install --ignore-scripts --no-audit --no-fund --legacy-peer-deps is-odd >/dev/null 2>&1"
 CMDS["add:pnpm"]="cd {project} && HOME={home} {bin} add is-odd --ignore-scripts >/dev/null 2>&1"

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -298,28 +298,28 @@ AUBE_ENV="HOME={home} XDG_CACHE_HOME={cache} XDG_DATA_HOME={home}/.local/share"
 # "install-test" scenario that measures install + script dispatch end-to-end.
 
 # Scenario 1: Fresh install, warm cache (aube GVS enabled) ------------------
-CMDS["gvs-warm:aube"]="cd {project} && $AUBE_ENV {bin} install --frozen-lockfile >/dev/null 2>&1"
+CMDS["gvs-warm:aube"]="cd {project} && $AUBE_ENV {bin} install --frozen-lockfile --enable-gvs >/dev/null 2>&1"
 CMDS["gvs-warm:bun"]="cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1"
 CMDS["gvs-warm:npm"]="cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps --prefer-offline >/dev/null 2>&1"
 CMDS["gvs-warm:pnpm"]="cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
 CMDS["gvs-warm:yarn"]="cd {project} && HOME={home} YARN_CACHE_FOLDER={cache} {bin} install --frozen-lockfile --ignore-scripts --ignore-engines --no-progress --prefer-offline >/dev/null 2>&1"
 
 # Scenario 2: Fresh install, cold cache (aube GVS enabled) ------------------
-CMDS["gvs-cold:aube"]="cd {project} && $AUBE_ENV {bin} install --frozen-lockfile >/dev/null 2>&1"
+CMDS["gvs-cold:aube"]="cd {project} && $AUBE_ENV {bin} install --frozen-lockfile --enable-gvs >/dev/null 2>&1"
 CMDS["gvs-cold:bun"]="cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1"
 CMDS["gvs-cold:npm"]="cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps >/dev/null 2>&1"
 CMDS["gvs-cold:pnpm"]="cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
 CMDS["gvs-cold:yarn"]="cd {project} && HOME={home} YARN_CACHE_FOLDER={cache} {bin} install --frozen-lockfile --ignore-scripts --ignore-engines --no-progress >/dev/null 2>&1"
 
-# Scenario 3: CI install, warm cache (aube GVS disabled by CI=1) ------------
-CMDS["ci-warm:aube"]="cd {project} && CI=1 $AUBE_ENV {bin} install --frozen-lockfile >/dev/null 2>&1"
+# Scenario 3: CI install, warm cache (aube GVS disabled) --------------------
+CMDS["ci-warm:aube"]="cd {project} && $AUBE_ENV {bin} install --frozen-lockfile --disable-gvs >/dev/null 2>&1"
 CMDS["ci-warm:bun"]="cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1"
 CMDS["ci-warm:npm"]="cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps --prefer-offline >/dev/null 2>&1"
 CMDS["ci-warm:pnpm"]="cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
 CMDS["ci-warm:yarn"]="cd {project} && HOME={home} YARN_CACHE_FOLDER={cache} {bin} install --frozen-lockfile --ignore-scripts --ignore-engines --no-progress --prefer-offline >/dev/null 2>&1"
 
-# Scenario 4: CI install, cold cache (aube GVS disabled by CI=1) ------------
-CMDS["ci-cold:aube"]="cd {project} && CI=1 $AUBE_ENV {bin} install --frozen-lockfile >/dev/null 2>&1"
+# Scenario 4: CI install, cold cache (aube GVS disabled) --------------------
+CMDS["ci-cold:aube"]="cd {project} && $AUBE_ENV {bin} install --frozen-lockfile --disable-gvs >/dev/null 2>&1"
 CMDS["ci-cold:bun"]="cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1"
 CMDS["ci-cold:npm"]="cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps >/dev/null 2>&1"
 CMDS["ci-cold:pnpm"]="cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
@@ -457,8 +457,8 @@ WARM_PREP="rm -rf {project}/node_modules {project}/pnpm-lock.yaml {project}/aube
 
 # ── Benchmark 1: Fresh install, warm cache, GVS enabled ────────────────────
 # Lockfile present, node_modules deleted, store and cache warm.
-# Measures aube's default local-install path with the global virtual
-# store enabled.
+# Forces aube's global virtual store on so GitHub Actions' inherited
+# CI=true environment cannot silently turn this into per-project mode.
 
 echo ""
 echo "━━━ Benchmark 1: Fresh install (warm cache, GVS) ━━━"
@@ -475,7 +475,8 @@ run_bench "gvs-cold" \
 
 # ── Benchmark 3: CI install, warm cache ────────────────────────────────────
 # Lockfile present, node_modules deleted, store and cache warm.
-# CI=1 disables aube's global virtual store to match real CI defaults.
+# Forces aube's global virtual store off to model real CI defaults without
+# relying on runner-provided environment variables.
 
 echo ""
 echo "━━━ Benchmark 3: CI install (warm cache, GVS disabled) ━━━"
@@ -483,7 +484,8 @@ run_bench "ci-warm" "$WARM_PREP"
 
 # ── Benchmark 4: CI install, cold cache ────────────────────────────────────
 # Lockfile present, but store and cache are empty.
-# CI=1 disables aube's global virtual store to match real CI defaults.
+# Forces aube's global virtual store off to model real CI defaults without
+# relying on runner-provided environment variables.
 
 echo ""
 echo "━━━ Benchmark 4: CI install (cold cache, GVS disabled) ━━━"

--- a/benchmarks/update-readme.mjs
+++ b/benchmarks/update-readme.mjs
@@ -18,14 +18,22 @@ function row(key) {
   return v
 }
 
-const ratio = (key, tool) => Math.round(row(key)[tool] / row(key).aube)
+function ratio(key, tool, { approximate = false } = {}) {
+  const speedup = row(key)[tool] / row(key).aube
+  const label = speedup < 2 ? `${speedup.toFixed(1)}x` : `${Math.round(speedup)}x`
+  return approximate && speedup < 2 ? `~${label}` : label
+}
 
-const gvsPnpm = ratio('gvs-warm', 'pnpm')
-const gvsBun = ratio('gvs-warm', 'bun')
+function about(label) {
+  return label.startsWith('~') ? label : `about ${label}`
+}
+
+const gvsPnpm = ratio('gvs-warm', 'pnpm', { approximate: true })
+const gvsBun = ratio('gvs-warm', 'bun', { approximate: true })
 const testPnpm = ratio('install-test', 'pnpm')
 const testBun = ratio('install-test', 'bun')
 
-const paragraph = `**[Fast installs](https://aube.en.dev/benchmarks).** Warm installs with the global virtual store are about ${gvsPnpm}x faster than pnpm and ${gvsBun}x faster than Bun in the current benchmarks. Repeat test commands run up to ~${testPnpm}x faster than pnpm and up to ${testBun}x faster than Bun.`
+const paragraph = `**[Fast installs](https://aube.en.dev/benchmarks).** Warm installs with the global virtual store are ${about(gvsPnpm)} faster than pnpm and ${about(gvsBun)} faster than Bun in the current benchmarks. Repeat test commands run up to ${testPnpm} faster than pnpm and up to ${testBun} faster than Bun.`
 
 const START = '<!-- BENCH_RATIOS:START -->'
 const END = '<!-- BENCH_RATIOS:END -->'
@@ -39,4 +47,4 @@ if (startIdx === -1 || endIdx === -1) {
 }
 
 writeFileSync(readmePath, readme.slice(0, startIdx) + `${START}\n${paragraph}\n${END}` + readme.slice(endIdx + END.length))
-console.log(`bench ratios: gvs-warm pnpm=${gvsPnpm}x bun=${gvsBun}x / install-test pnpm=${testPnpm}x bun=${testBun}x`)
+console.log(`bench ratios: gvs-warm pnpm=${gvsPnpm} bun=${gvsBun} / install-test pnpm=${testPnpm} bun=${testBun}`)


### PR DESCRIPTION
## Summary

- Force benchmark GVS scenarios to pass `--enable-gvs` so GitHub Actions' inherited `CI=true` does not silently disable the mode being measured.
- Force CI benchmark scenarios with `--disable-gvs` instead of relying on `CI=1` as an ambient side effect.
- Format small generated README benchmark ratios with one decimal, so values like `1.18x` render as `~1.2x` instead of `1x`.

## Validation

- `bash -n benchmarks/bench.sh`
- `node --check benchmarks/update-readme.mjs`
- `actionlint .github/workflows/bench-refresh.yml`
- commit hooks: `actionlint`, `shfmt`, `shellcheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to benchmarking/CI automation and README generation, with the main impact being benchmark comparability rather than runtime behavior of the product.
> 
> **Overview**
> **Benchmark refreshes now pin the measured GVS mode explicitly** so GitHub Actions’ inherited `CI=true` can’t silently flip scenarios. `benchmarks/bench.sh` introduces `AUBE_ENV_GVS_ON/OFF` and uses them across install/test/add scenarios instead of relying on `CI=1` side effects.
> 
> **README benchmark ratios are formatted more accurately for small deltas.** `benchmarks/update-readme.mjs` now emits one-decimal, optional approximate (`~`) speedups and updates the generated `BENCH_RATIOS` paragraph; the `bench-refresh` workflow PR body was updated to document the new env-based pinning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6deb96b445a6d057a3e021b7bce32d9f669b67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->