### PR TITLE
fix: cross-platform install correctness pass

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2769,12 +2769,12 @@ struct PatchSection {
 /// out of the `b/...` half (post-edit name), and capture everything
 /// from the next `--- ` line until the following `diff --git ` (or
 /// EOF) as the diffy-compatible body.
-fn parse_diff_git_b_path(rest: &str) -> Option<&str> {
+fn parse_diff_git_b_path(rest: &str) -> Option<String> {
     if let Some(after) = rest.strip_prefix("\"a/") {
         let end_a = after.find("\" \"b/")?;
         let after_b = &after[end_a + 5..];
         let close = after_b.rfind('"')?;
-        return Some(&after_b[..close]);
+        return unescape_git_quoted(&after_b[..close]);
     }
     let body = rest.strip_prefix("a/")?;
     let mut search_from = 0;
@@ -2783,11 +2783,76 @@ fn parse_diff_git_b_path(rest: &str) -> Option<&str> {
         let path_a = &body[..abs];
         let path_b = &body[abs + 3..];
         if path_a == path_b {
-            return Some(path_b);
+            return Some(path_b.to_string());
         }
         search_from = abs + 1;
     }
-    body.find(" b/").map(|i| &body[i + 3..])
+    body.find(" b/").map(|i| body[i + 3..].to_string())
+}
+
+fn unescape_git_quoted(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'\\' {
+            out.push(bytes[i]);
+            i += 1;
+            continue;
+        }
+        if i + 1 >= bytes.len() {
+            return None;
+        }
+        match bytes[i + 1] {
+            b'\\' => {
+                out.push(b'\\');
+                i += 2;
+            }
+            b'"' => {
+                out.push(b'"');
+                i += 2;
+            }
+            b'n' => {
+                out.push(b'\n');
+                i += 2;
+            }
+            b't' => {
+                out.push(b'\t');
+                i += 2;
+            }
+            b'r' => {
+                out.push(b'\r');
+                i += 2;
+            }
+            b'a' => {
+                out.push(0x07);
+                i += 2;
+            }
+            b'b' => {
+                out.push(0x08);
+                i += 2;
+            }
+            b'f' => {
+                out.push(0x0C);
+                i += 2;
+            }
+            b'v' => {
+                out.push(0x0B);
+                i += 2;
+            }
+            d0 @ b'0'..=b'3'
+                if i + 3 < bytes.len()
+                    && (b'0'..=b'7').contains(&bytes[i + 2])
+                    && (b'0'..=b'7').contains(&bytes[i + 3]) =>
+            {
+                let n = ((d0 - b'0') << 6) | ((bytes[i + 2] - b'0') << 3) | (bytes[i + 3] - b'0');
+                out.push(n);
+                i += 4;
+            }
+            _ => return None,
+        }
+    }
+    String::from_utf8(out).ok()
 }
 
 fn split_patch_sections(text: &str) -> Vec<PatchSection> {
@@ -2820,7 +2885,7 @@ fn split_patch_sections(text: &str) -> Vec<PatchSection> {
             in_body = false;
             // Parse `a/<path> b/<path>` and prefer the post-edit
             // (`b/`) path so renames land on the new name.
-            current_path = parse_diff_git_b_path(rest).map(String::from);
+            current_path = parse_diff_git_b_path(rest);
             continue;
         }
         if !in_body {
@@ -3030,6 +3095,18 @@ mod patch_tests {
         let sections = split_patch_sections(patch);
         assert_eq!(sections.len(), 1);
         assert_eq!(sections[0].rel_path.as_deref(), Some("path with spaces.js"));
+    }
+
+    #[test]
+    fn diff_git_quoted_path_unescapes_git_escapes() {
+        let path = parse_diff_git_b_path(r#""a/foo\".js" "b/foo\".js""#).expect("quoted parse");
+        assert_eq!(path, "foo\".js");
+        let path = parse_diff_git_b_path(r#""a/back\\slash.js" "b/back\\slash.js""#)
+            .expect("backslash parse");
+        assert_eq!(path, "back\\slash.js");
+        let path = parse_diff_git_b_path("\"a/caf\\303\\251.js\" \"b/caf\\303\\251.js\"")
+            .expect("octal parse");
+        assert_eq!(path, "café.js");
     }
 }
 

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2769,6 +2769,27 @@ struct PatchSection {
 /// out of the `b/...` half (post-edit name), and capture everything
 /// from the next `--- ` line until the following `diff --git ` (or
 /// EOF) as the diffy-compatible body.
+fn parse_diff_git_b_path(rest: &str) -> Option<&str> {
+    if let Some(after) = rest.strip_prefix("\"a/") {
+        let end_a = after.find("\" \"b/")?;
+        let after_b = &after[end_a + 5..];
+        let close = after_b.rfind('"')?;
+        return Some(&after_b[..close]);
+    }
+    let body = rest.strip_prefix("a/")?;
+    let mut search_from = 0;
+    while let Some(rel) = body[search_from..].find(" b/") {
+        let abs = search_from + rel;
+        let path_a = &body[..abs];
+        let path_b = &body[abs + 3..];
+        if path_a == path_b {
+            return Some(path_b);
+        }
+        search_from = abs + 1;
+    }
+    body.find(" b/").map(|i| &body[i + 3..])
+}
+
 fn split_patch_sections(text: &str) -> Vec<PatchSection> {
     let mut out: Vec<PatchSection> = Vec::new();
     let mut current_path: Option<String> = None;
@@ -2792,17 +2813,14 @@ fn split_patch_sections(text: &str) -> Vec<PatchSection> {
     };
 
     for line in text.split_inclusive('\n') {
-        let stripped = line.trim_end_matches('\n');
+        let stripped = line.trim_end_matches(['\n', '\r']);
         if let Some(rest) = stripped.strip_prefix("diff --git ") {
             // New file boundary — flush whatever we were collecting.
             flush(&mut out, &mut current_path, &mut body, &mut is_deletion);
             in_body = false;
             // Parse `a/<path> b/<path>` and prefer the post-edit
             // (`b/`) path so renames land on the new name.
-            if let Some(b_idx) = rest.find(" b/") {
-                let after_b = &rest[b_idx + 3..];
-                current_path = Some(after_b.to_string());
-            }
+            current_path = parse_diff_git_b_path(rest).map(String::from);
             continue;
         }
         if !in_body {
@@ -2817,7 +2835,8 @@ fn split_patch_sections(text: &str) -> Vec<PatchSection> {
                 {
                     body.push_str(&format!("--- a/{rel}\n"));
                 } else {
-                    body.push_str(line);
+                    body.push_str(stripped);
+                    body.push('\n');
                 }
             }
             // Skip git's `index ...` / `new file mode ...` /
@@ -2834,7 +2853,8 @@ fn split_patch_sections(text: &str) -> Vec<PatchSection> {
             is_deletion = true;
             continue;
         }
-        body.push_str(line);
+        body.push_str(stripped);
+        body.push('\n');
     }
     flush(&mut out, &mut current_path, &mut body, &mut is_deletion);
     out
@@ -2958,6 +2978,58 @@ mod patch_tests {
             std::fs::read_to_string(pkg.join("index.js")).unwrap(),
             "module.exports = 'new';\n"
         );
+    }
+
+    #[test]
+    fn crlf_patch_path_does_not_carry_carriage_return() {
+        let patch = "diff --git a/index.js b/index.js\r\n\
+                     --- a/index.js\r\n\
+                     +++ b/index.js\r\n\
+                     @@ -1 +1 @@\r\n\
+                     -module.exports = 'old';\r\n\
+                     +module.exports = 'new';\r\n";
+        let sections = split_patch_sections(patch);
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].rel_path.as_deref(), Some("index.js"));
+    }
+
+    #[test]
+    fn crlf_deletion_patch_recognized() {
+        let patch = "diff --git a/removed.js b/removed.js\r\n\
+                     deleted file mode 100644\r\n\
+                     --- a/removed.js\r\n\
+                     +++ /dev/null\r\n\
+                     @@ -1 +0,0 @@\r\n\
+                     -gone\r\n";
+        let sections = split_patch_sections(patch);
+        assert_eq!(sections.len(), 1);
+        assert!(sections[0].is_deletion);
+    }
+
+    #[test]
+    fn diff_git_path_with_space_b_substring() {
+        let patch = "diff --git a/a b/c.js b/a b/c.js\n\
+                     --- a/a b/c.js\n\
+                     +++ b/a b/c.js\n\
+                     @@ -1 +1 @@\n\
+                     -x\n\
+                     +y\n";
+        let sections = split_patch_sections(patch);
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].rel_path.as_deref(), Some("a b/c.js"));
+    }
+
+    #[test]
+    fn diff_git_quoted_path_form() {
+        let patch = "diff --git \"a/path with spaces.js\" \"b/path with spaces.js\"\n\
+                     --- a/path with spaces.js\n\
+                     +++ b/path with spaces.js\n\
+                     @@ -1 +1 @@\n\
+                     -x\n\
+                     +y\n";
+        let sections = split_patch_sections(patch);
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].rel_path.as_deref(), Some("path with spaces.js"));
     }
 }
 

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -271,7 +271,7 @@ impl NpmConfig {
     /// Get the registry URL for a given package name.
     pub fn registry_for(&self, package_name: &str) -> &str {
         if let Some(scope) = package_scope(package_name)
-            && let Some(url) = self.scoped_registries.get(scope)
+            && let Some(url) = self.scoped_registries.get(&scope.to_lowercase())
         {
             return url;
         }
@@ -408,7 +408,7 @@ impl NpmConfig {
             } else if let Some(scope) = key.strip_suffix(":registry") {
                 if scope.starts_with('@') {
                     self.scoped_registries
-                        .insert(scope.to_string(), normalize_registry_url(&value));
+                        .insert(scope.to_lowercase(), normalize_registry_url(&value));
                 }
             } else if key.starts_with("//") {
                 // URI-specific config: //registry.url/:_authToken=TOKEN
@@ -955,7 +955,8 @@ fn userconfig_override_from_env(env: &[(String, String)], home: Option<&Path>) -
 /// truncate the value at the first line break and reparse the
 /// continuation as a bogus key.
 fn parse_npmrc(path: &Path) -> Result<Vec<(String, String)>, std::io::Error> {
-    let content = std::fs::read_to_string(path)?;
+    let raw_content = std::fs::read_to_string(path)?;
+    let content = raw_content.strip_prefix('\u{feff}').unwrap_or(&raw_content);
     let mut entries = Vec::new();
 
     // Fold backslash-continuation before line iteration. Trailing
@@ -1242,6 +1243,30 @@ pub(crate) fn run_token_helper(command: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_npmrc_strips_utf8_bom() {
+        let dir = tempfile::tempdir().unwrap();
+        let rc = dir.path().join(".npmrc");
+        std::fs::write(&rc, "\u{feff}registry=https://r.example.com\n").unwrap();
+        let entries = parse_npmrc(&rc).unwrap();
+        assert_eq!(
+            entries,
+            vec![("registry".to_string(), "https://r.example.com".to_string())]
+        );
+    }
+
+    #[test]
+    fn scoped_registry_lookup_is_case_insensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".npmrc"),
+            "@MyOrg:registry=https://myorg.example.com/\n",
+        )
+        .unwrap();
+        let cfg = NpmConfig::load_isolated(dir.path());
+        assert_eq!(cfg.registry_for("@myorg/pkg"), "https://myorg.example.com/");
+    }
 
     #[test]
     fn test_parse_npmrc_basic() {

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -156,10 +156,17 @@ pub fn shell_quote_arg(arg: &str) -> String {
     {
         let mut out = String::with_capacity(arg.len() + 2);
         out.push('"');
+        let mut backslashes: usize = 0;
         for ch in arg.chars() {
             match ch {
-                '"' => out.push_str("\\\""),
-                '\\' => out.push_str("\\\\"),
+                '\\' => backslashes += 1,
+                '"' => {
+                    for _ in 0..backslashes * 2 + 1 {
+                        out.push('\\');
+                    }
+                    out.push('"');
+                    backslashes = 0;
+                }
                 // cmd.exe expands %VAR% even inside double quotes.
                 // Outer `/s /c "..."` only strips the outermost
                 // quote pair, the shell still runs env expansion
@@ -170,9 +177,24 @@ pub fn shell_quote_arg(arg: &str) -> String {
                 // caret-escaping of `^ & | < > ( )` is a deeper
                 // rabbit hole, this handles the common injection
                 // vector.
-                '%' => out.push_str("%%"),
-                _ => out.push(ch),
+                '%' => {
+                    for _ in 0..backslashes {
+                        out.push('\\');
+                    }
+                    backslashes = 0;
+                    out.push_str("%%");
+                }
+                _ => {
+                    for _ in 0..backslashes {
+                        out.push('\\');
+                    }
+                    backslashes = 0;
+                    out.push(ch);
+                }
             }
+        }
+        for _ in 0..backslashes * 2 {
+            out.push('\\');
         }
         out.push('"');
         out
@@ -556,4 +578,28 @@ pub enum Error {
     Spawn(String, String),
     #[error("script `{script}` exited with code {code:?}")]
     NonZeroExit { script: String, code: Option<i32> },
+}
+
+#[cfg(all(test, windows))]
+mod windows_quote_tests {
+    use super::shell_quote_arg;
+
+    #[test]
+    fn windows_path_backslash_not_doubled() {
+        let q = shell_quote_arg(r"C:\Users\me\file.txt");
+        assert_eq!(q, "\"C:\\Users\\me\\file.txt\"");
+    }
+
+    #[test]
+    fn windows_trailing_backslash_doubled_before_close_quote() {
+        let q = shell_quote_arg(r"C:\path\");
+        assert_eq!(q, "\"C:\\path\\\\\"");
+    }
+
+    #[test]
+    fn windows_quote_in_arg_escapes_with_backslash() {
+        assert_eq!(shell_quote_arg(r#"a"b"#), "\"a\\\"b\"");
+        assert_eq!(shell_quote_arg(r#"a\"b"#), "\"a\\\\\\\"b\"");
+        assert_eq!(shell_quote_arg(r#"a\\"b"#), "\"a\\\\\\\\\\\"b\"");
+    }
 }

--- a/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/crates/aube/src/commands/install/side_effects_cache.rs
@@ -432,12 +432,11 @@ mod tests {
         std::fs::create_dir_all(&pkg).unwrap();
         std::fs::write(pkg.join("package.json"), "{\"name\":\"p\"}\n").unwrap();
         let entry = SideEffectsCacheEntry::new(dir.path(), "p", "1.0.0", &pkg).unwrap();
-        let s = entry.path.to_string_lossy().to_lowercase();
-        let arch = std::env::consts::ARCH;
-        let os = std::env::consts::OS;
+        let s = entry.path.to_string_lossy().into_owned();
+        let segment = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
         assert!(
-            s.contains(arch) || s.contains(os),
-            "cache path lacks platform marker: {s}"
+            s.contains(&segment),
+            "cache path lacks platform segment {segment}: {s}"
         );
     }
 

--- a/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/crates/aube/src/commands/install/side_effects_cache.rs
@@ -61,9 +61,11 @@ impl SideEffectsCacheEntry {
             None => hash_dir_for_side_effects_cache(package_dir)?,
         };
         let safe_name = name.replace('/', "__");
+        let platform = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
         Ok(Self {
             path: root
                 .join(format!("{safe_name}@{version}"))
+                .join(platform)
                 .join(&input_hash),
             input_hash,
         })
@@ -422,6 +424,22 @@ fn create_symlink_like(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cache_path_segregates_by_platform() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("package.json"), "{\"name\":\"p\"}\n").unwrap();
+        let entry = SideEffectsCacheEntry::new(dir.path(), "p", "1.0.0", &pkg).unwrap();
+        let s = entry.path.to_string_lossy().to_lowercase();
+        let arch = std::env::consts::ARCH;
+        let os = std::env::consts::OS;
+        assert!(
+            s.contains(arch) || s.contains(os),
+            "cache path lacks platform marker: {s}"
+        );
+    }
 
     #[test]
     fn side_effects_marker_accepts_only_sha512_hex() {


### PR DESCRIPTION
## correctness
- patch parser strips trailing `\r` so crlf-saved `.patch` files parse instead of failing on `b/<path>\r`, and `+++ /dev/null` deletion markers are detected on crlf input
- new `parse_diff_git_b_path` handles git's quoted-path form (`"a/x" "b/y"`) and disambiguates `diff --git a/X b/X` when paths embed ` b/`
- side-effects cache path now includes `<os>-<arch>`, blocking cross-platform restores that would hard-link a foreign-abi `.node` into node_modules
- npmrc parser strips a leading utf-8 bom so windows notepad / vs code saves do not silently turn the first line key into `﻿registry`
- scoped registry keys are stored and looked up lowercased, matching npm's scope normalization (`@MyOrg:registry=` now resolves for `@myorg/foo`)
- windows `shell_quote_arg` follows the canonical commandlinetoargvw backslash rule (only doubled before `"`, otherwise verbatim, doubled at end-of-arg before the close quote), unblocking every windows path passed via `aube run script -- <path>`

## testing
- regression test per fix plus quoted-path patch case and `\"` / `\\\"` / trailing-backslash arg cases
- `cargo test --workspace --lib` clean on windows
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## scope
- linker, registry, scripts, install — no shared boundary with the previous lockfile + resolver pass
- pure parser / quoter / path logic, behaves identically on windows, macos, linux