### PR TITLE
fix: support git url specs in dlx and parser

### DIFF
--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -399,7 +399,9 @@ impl LocalSource {
 /// - `git+ssh://git@host/user/repo.git[#ref]`
 /// - `git://host/user/repo.git[#ref]`
 /// - `https://host/user/repo.git[#ref]` (only when ending in `.git`)
-/// - `user@host:path[.git][#ref]` (scp-form) → `ssh://user@host/path[.git]`
+/// - `user@host:path[.git][#ref]` (scp-form, only for github.com / gitlab.com /
+///   bitbucket.org — matches pnpm 11 behavior, where unknown SCP hosts are
+///   treated as local paths) → `ssh://user@host/path[.git]`
 /// - `github:user/repo[#ref]` → `https://github.com/user/repo.git`
 /// - `gitlab:user/repo[#ref]` → `https://gitlab.com/user/repo.git`
 /// - `bitbucket:user/repo[#ref]` → `https://bitbucket.org/user/repo.git`
@@ -467,6 +469,12 @@ fn parse_scp_url(body: &str) -> Option<String> {
     let user = &before[..at];
     let host = &before[at + 1..];
     if user.is_empty() || host.is_empty() || host.contains('/') || host.contains('@') {
+        return None;
+    }
+    // pnpm 11 only resolves SCP-form as hosted Git for the three known
+    // providers; other hosts (e.g. `git@example.com:foo/bar.git`) are
+    // treated as local paths, and `host:path` without a user errors.
+    if !matches!(host, "github.com" | "gitlab.com" | "bitbucket.org") {
         return None;
     }
     Some(format!("ssh://{user}@{host}/{path}"))
@@ -2163,6 +2171,25 @@ mod git_spec_tests {
             parse_git_spec("git@github.com:EthanHenrickson/math-mcp.git#0.1.5").unwrap();
         assert_eq!(url, "ssh://git@github.com/EthanHenrickson/math-mcp.git");
         assert_eq!(committish.as_deref(), Some("0.1.5"));
+    }
+
+    #[test]
+    fn scp_form_bitbucket_recognized() {
+        let (url, _, _) = parse_git_spec("git@bitbucket.org:pnpmjs/git-resolver.git").unwrap();
+        assert_eq!(url, "ssh://git@bitbucket.org/pnpmjs/git-resolver.git");
+    }
+
+    #[test]
+    fn scp_form_unknown_host_rejected() {
+        // pnpm 11 treats `user@unknown-host:path` as a local path, not Git.
+        assert!(parse_git_spec("git@example.com:org/repo.git").is_none());
+        assert!(parse_git_spec("alice@host.example.com:org/repo.git").is_none());
+    }
+
+    #[test]
+    fn scp_form_without_user_rejected() {
+        // pnpm 11 errors on bare `host:path` as unsupported.
+        assert!(parse_git_spec("github.com:user/repo.git").is_none());
     }
 
     #[test]

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -399,6 +399,7 @@ impl LocalSource {
 /// - `git+ssh://git@host/user/repo.git[#ref]`
 /// - `git://host/user/repo.git[#ref]`
 /// - `https://host/user/repo.git[#ref]` (only when ending in `.git`)
+/// - `[user@]host:path[.git][#ref]` (scp-form) → `ssh://[user@]host/path[.git]`
 /// - `github:user/repo[#ref]` → `https://github.com/user/repo.git`
 /// - `gitlab:user/repo[#ref]` → `https://gitlab.com/user/repo.git`
 /// - `bitbucket:user/repo[#ref]` → `https://bitbucket.org/user/repo.git`
@@ -423,6 +424,8 @@ pub fn parse_git_spec(spec: &str) -> Option<(String, Option<String>, Option<Stri
         rest.to_string()
     } else if body.starts_with("git://") {
         body.to_string()
+    } else if let Some(scp) = parse_scp_url(body) {
+        scp
     } else if let Some(path) = body.strip_prefix("github:") {
         format!("https://github.com/{path}.git")
     } else if let Some(path) = body.strip_prefix("gitlab:") {
@@ -445,6 +448,28 @@ pub fn parse_git_spec(spec: &str) -> Option<(String, Option<String>, Option<Stri
         return None;
     };
     Some((url, committish, subpath))
+}
+
+fn parse_scp_url(body: &str) -> Option<String> {
+    if body.contains("://") {
+        return None;
+    }
+    let colon = body.find(':')?;
+    let before = &body[..colon];
+    let path = &body[colon + 1..];
+    if before.is_empty() || path.is_empty() {
+        return None;
+    }
+    if path.starts_with('/') {
+        return None;
+    }
+    let at = before.find('@')?;
+    let user = &before[..at];
+    let host = &before[at + 1..];
+    if user.is_empty() || host.is_empty() || host.contains('/') || host.contains('@') {
+        return None;
+    }
+    Some(format!("ssh://{user}@{host}/{path}"))
 }
 
 /// Normalize git URL fragments used by npm-compatible lockfiles.
@@ -2122,6 +2147,22 @@ mod git_spec_tests {
     fn github_shorthand_expands_and_roundtrips() {
         let (url, _, _) = parse_git_spec("github:user/repo").unwrap();
         assert_eq!(url, "https://github.com/user/repo.git");
+    }
+
+    #[test]
+    fn scp_form_recognized() {
+        let (url, committish, _) =
+            parse_git_spec("git@github.com:EthanHenrickson/math-mcp.git").unwrap();
+        assert_eq!(url, "ssh://git@github.com/EthanHenrickson/math-mcp.git");
+        assert!(committish.is_none());
+    }
+
+    #[test]
+    fn scp_form_with_ref_recognized() {
+        let (url, committish, _) =
+            parse_git_spec("git@github.com:EthanHenrickson/math-mcp.git#0.1.5").unwrap();
+        assert_eq!(url, "ssh://git@github.com/EthanHenrickson/math-mcp.git");
+        assert_eq!(committish.as_deref(), Some("0.1.5"));
     }
 
     #[test]

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -399,7 +399,7 @@ impl LocalSource {
 /// - `git+ssh://git@host/user/repo.git[#ref]`
 /// - `git://host/user/repo.git[#ref]`
 /// - `https://host/user/repo.git[#ref]` (only when ending in `.git`)
-/// - `[user@]host:path[.git][#ref]` (scp-form) → `ssh://[user@]host/path[.git]`
+/// - `user@host:path[.git][#ref]` (scp-form) → `ssh://user@host/path[.git]`
 /// - `github:user/repo[#ref]` → `https://github.com/user/repo.git`
 /// - `gitlab:user/repo[#ref]` → `https://gitlab.com/user/repo.git`
 /// - `bitbucket:user/repo[#ref]` → `https://bitbucket.org/user/repo.git`

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -310,9 +310,12 @@ fn is_non_registry_spec(s: &str) -> bool {
     {
         return true;
     }
-    is_scp_form(s)
+    is_scp_form(s) || is_owner_repo_shorthand(s)
 }
 
+/// SCP-form `user@host:path` is only treated as Git for the three known
+/// providers, matching pnpm 11. Unknown hosts fall through (pnpm treats
+/// them as local paths).
 fn is_scp_form(s: &str) -> bool {
     if s.contains("://") {
         return false;
@@ -324,7 +327,31 @@ fn is_scp_form(s: &str) -> bool {
     let Some(at) = before.find('@') else {
         return false;
     };
-    !before[..at].is_empty() && !before[at + 1..].is_empty()
+    let user = &before[..at];
+    let host = &before[at + 1..];
+    if user.is_empty() || host.is_empty() {
+        return false;
+    }
+    matches!(host, "github.com" | "gitlab.com" | "bitbucket.org")
+}
+
+/// Pnpm 11: a bare `owner/repo[#ref]` with no provider prefix defaults
+/// to GitHub. Distinguished from registry specs (`name`, `@scope/name`,
+/// `name@version`) by: no leading `@`, no `@` anywhere (registry version
+/// separator), no `:` (URL/SCP), exactly one `/`, both halves non-empty.
+fn is_owner_repo_shorthand(s: &str) -> bool {
+    let body = s.split('#').next().unwrap_or(s);
+    if body.starts_with('@') || body.contains('@') || body.contains(':') {
+        return false;
+    }
+    let mut parts = body.splitn(2, '/');
+    let Some(owner) = parts.next() else {
+        return false;
+    };
+    let Some(repo) = parts.next() else {
+        return false;
+    };
+    !owner.is_empty() && !repo.is_empty() && !repo.contains('/')
 }
 
 fn derive_dlx_pkg_name(spec: &str) -> Option<String> {
@@ -339,6 +366,12 @@ fn derive_dlx_pkg_name(spec: &str) -> Option<String> {
 }
 
 fn synthesize_dlx_dep(spec: &str) -> (String, String) {
+    if is_owner_repo_shorthand(spec) {
+        // Rewrite to the explicit `github:` form so the resolver picks
+        // it up via the same code path as `aube dlx github:owner/repo`.
+        let name = derive_dlx_pkg_name(spec).unwrap_or_else(|| "aube-dlx-pkg".to_string());
+        return (name, format!("github:{spec}"));
+    }
     if is_non_registry_spec(spec) {
         let name = derive_dlx_pkg_name(spec).unwrap_or_else(|| "aube-dlx-pkg".to_string());
         return (name, spec.to_string());
@@ -550,10 +583,33 @@ mod tests {
     }
 
     #[test]
-    fn synthesize_dlx_dep_handles_scp_url_with_non_git_user() {
-        let (name, value) = synthesize_dlx_dep("alice@host.example.com:org/repo.git");
-        assert_eq!(name, "repo");
-        assert_eq!(value, "alice@host.example.com:org/repo.git");
+    fn synthesize_dlx_dep_handles_scp_url_bitbucket() {
+        let (name, value) = synthesize_dlx_dep("git@bitbucket.org:pnpmjs/git-resolver.git");
+        assert_eq!(name, "git-resolver");
+        assert_eq!(value, "git@bitbucket.org:pnpmjs/git-resolver.git");
+    }
+
+    #[test]
+    fn synthesize_dlx_dep_rejects_unknown_host_scp() {
+        // pnpm 11 treats `user@unknown-host:path` as a local path, not Git.
+        // Aube falls through to registry handling — the install will fail
+        // later with a clearer error than silently cloning an arbitrary host.
+        let (name, _) = synthesize_dlx_dep("alice@host.example.com:org/repo.git");
+        assert_ne!(name, "repo");
+    }
+
+    #[test]
+    fn synthesize_dlx_dep_handles_owner_repo_shorthand() {
+        let (name, value) = synthesize_dlx_dep("zkochan/is-negative");
+        assert_eq!(name, "is-negative");
+        assert_eq!(value, "github:zkochan/is-negative");
+    }
+
+    #[test]
+    fn synthesize_dlx_dep_handles_owner_repo_shorthand_with_ref() {
+        let (name, value) = synthesize_dlx_dep("zkochan/is-negative#2.0.1");
+        assert_eq!(name, "is-negative");
+        assert_eq!(value, "github:zkochan/is-negative#2.0.1");
     }
 
     #[test]

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -124,11 +124,8 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
     let deps: serde_json::Map<String, serde_json::Value> = install_specs
         .iter()
         .map(|spec| {
-            let (name, version) = split_spec(spec);
-            (
-                name.to_string(),
-                serde_json::Value::String(version.to_string()),
-            )
+            let (name, value) = synthesize_dlx_dep(spec);
+            (name, serde_json::Value::String(value))
         })
         .collect();
     let manifest = serde_json::json!({
@@ -293,10 +290,48 @@ fn split_spec(spec: &str) -> (&str, &str) {
     (name, version.unwrap_or("latest"))
 }
 
+fn is_non_registry_spec(s: &str) -> bool {
+    s.starts_with("github:")
+        || s.starts_with("gitlab:")
+        || s.starts_with("bitbucket:")
+        || s.starts_with("gist:")
+        || s.starts_with("git+")
+        || s.starts_with("git://")
+        || s.starts_with("git@")
+        || s.starts_with("https://")
+        || s.starts_with("http://")
+        || s.starts_with("ssh://")
+        || s.starts_with("file:")
+        || s.starts_with("link:")
+}
+
+fn derive_dlx_pkg_name(spec: &str) -> Option<String> {
+    let body = spec.split('#').next().unwrap_or(spec);
+    let after_colon = body.rsplit(':').next().unwrap_or(body);
+    let last = after_colon.rsplit('/').next().unwrap_or(after_colon);
+    let trimmed = last.strip_suffix(".git").unwrap_or(last);
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn synthesize_dlx_dep(spec: &str) -> (String, String) {
+    if is_non_registry_spec(spec) {
+        let name = derive_dlx_pkg_name(spec).unwrap_or_else(|| "aube-dlx-pkg".to_string());
+        return (name, spec.to_string());
+    }
+    let (name, version) = split_spec(spec);
+    (name.to_string(), version.to_string())
+}
+
 /// The binary name `aube dlx <cmd>` should resolve to — strip any version
 /// suffix and any `@scope/` prefix, since `node_modules/.bin/` is flat and
 /// scoped packages still land under their unscoped bin name.
 fn bin_name_for(command: &str) -> String {
+    if is_non_registry_spec(command) {
+        return derive_dlx_pkg_name(command).unwrap_or_else(|| "aube-dlx-pkg".to_string());
+    }
     let (name, _) = split_spec(command);
     name.rsplit('/').next().unwrap_or(name).to_string()
 }
@@ -469,5 +504,53 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write_pkg_json(tmp.path(), "foo", serde_json::json!({"name": "foo"}));
         assert_eq!(resolve_bin_from_package(tmp.path(), "foo"), None);
+    }
+
+    #[test]
+    fn synthesize_dlx_dep_handles_github_shorthand() {
+        let (name, value) = synthesize_dlx_dep("github:user/repo");
+        assert_eq!(name, "repo");
+        assert_eq!(value, "github:user/repo");
+    }
+
+    #[test]
+    fn synthesize_dlx_dep_handles_github_shorthand_with_ref() {
+        let (name, value) = synthesize_dlx_dep("github:user/repo#v1.2.3");
+        assert_eq!(name, "repo");
+        assert_eq!(value, "github:user/repo#v1.2.3");
+    }
+
+    #[test]
+    fn synthesize_dlx_dep_handles_scp_url() {
+        let (name, value) = synthesize_dlx_dep("git@github.com:user/repo.git");
+        assert_eq!(name, "repo");
+        assert_eq!(value, "git@github.com:user/repo.git");
+    }
+
+    #[test]
+    fn synthesize_dlx_dep_handles_git_plus_url() {
+        let (name, value) = synthesize_dlx_dep("git+https://host/u/r.git#v1");
+        assert_eq!(name, "r");
+        assert_eq!(value, "git+https://host/u/r.git#v1");
+    }
+
+    #[test]
+    fn synthesize_dlx_dep_registry_spec_unchanged() {
+        let (name, value) = synthesize_dlx_dep("lodash@4.17.0");
+        assert_eq!(name, "lodash");
+        assert_eq!(value, "4.17.0");
+    }
+
+    #[test]
+    fn synthesize_dlx_dep_scoped_registry_spec_unchanged() {
+        let (name, value) = synthesize_dlx_dep("@babel/core@7.0.0");
+        assert_eq!(name, "@babel/core");
+        assert_eq!(value, "7.0.0");
+    }
+
+    #[test]
+    fn bin_name_for_non_registry_spec_uses_repo_name() {
+        assert_eq!(bin_name_for("github:user/repo"), "repo");
+        assert_eq!(bin_name_for("git@github.com:user/repo.git"), "repo");
     }
 }

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -121,13 +121,18 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
 
     // Minimal package.json. Version specs and dist-tags pass through as-is
     // — the resolver handles them exactly as it would from a real manifest.
-    let deps: serde_json::Map<String, serde_json::Value> = install_specs
-        .iter()
-        .map(|spec| {
-            let (name, value) = synthesize_dlx_dep(spec);
-            (name, serde_json::Value::String(value))
-        })
-        .collect();
+    let mut deps: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+    for spec in &install_specs {
+        let (mut name, value) = synthesize_dlx_dep(spec);
+        if deps.contains_key(&name) {
+            let mut suffix = 2usize;
+            while deps.contains_key(&format!("{name}-{suffix}")) {
+                suffix += 1;
+            }
+            name = format!("{name}-{suffix}");
+        }
+        deps.insert(name, serde_json::Value::String(value));
+    }
     let manifest = serde_json::json!({
         "name": "aube-dlx",
         "version": "0.0.0",
@@ -291,18 +296,35 @@ fn split_spec(spec: &str) -> (&str, &str) {
 }
 
 fn is_non_registry_spec(s: &str) -> bool {
-    s.starts_with("github:")
+    if s.starts_with("github:")
         || s.starts_with("gitlab:")
         || s.starts_with("bitbucket:")
         || s.starts_with("gist:")
         || s.starts_with("git+")
         || s.starts_with("git://")
-        || s.starts_with("git@")
         || s.starts_with("https://")
         || s.starts_with("http://")
         || s.starts_with("ssh://")
         || s.starts_with("file:")
         || s.starts_with("link:")
+    {
+        return true;
+    }
+    is_scp_form(s)
+}
+
+fn is_scp_form(s: &str) -> bool {
+    if s.contains("://") {
+        return false;
+    }
+    let Some(colon) = s.find(':') else {
+        return false;
+    };
+    let before = &s[..colon];
+    let Some(at) = before.find('@') else {
+        return false;
+    };
+    !before[..at].is_empty() && !before[at + 1..].is_empty()
 }
 
 fn derive_dlx_pkg_name(spec: &str) -> Option<String> {
@@ -525,6 +547,13 @@ mod tests {
         let (name, value) = synthesize_dlx_dep("git@github.com:user/repo.git");
         assert_eq!(name, "repo");
         assert_eq!(value, "git@github.com:user/repo.git");
+    }
+
+    #[test]
+    fn synthesize_dlx_dep_handles_scp_url_with_non_git_user() {
+        let (name, value) = synthesize_dlx_dep("alice@host.example.com:org/repo.git");
+        assert_eq!(name, "repo");
+        assert_eq!(value, "alice@host.example.com:org/repo.git");
     }
 
     #[test]

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -205,8 +205,8 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
         // installed package's `bin` field and prefer the actual bin name
         // it ships — e.g. `@tanstack/cli` ships `tanstack`, not `cli`.
         let resolved_bin_name = if !explicit_package && !bin_dir.join(&bin_name).exists() {
-            resolve_bin_from_package(&modules_dir, &install_specs[0])
-                .unwrap_or_else(|| bin_name.clone())
+            let (pkg_name, _) = synthesize_dlx_dep(&install_specs[0]);
+            resolve_bin_from_package(&modules_dir, &pkg_name).unwrap_or_else(|| bin_name.clone())
         } else {
             bin_name.clone()
         };
@@ -402,8 +402,7 @@ fn bin_name_for(command: &str) -> String {
 /// `modulesDir` still sees the fallback work. Returns `None` when we can't
 /// make a confident pick; caller keeps the original inference and lets the
 /// bin-missing error fire.
-fn resolve_bin_from_package(modules_dir: &std::path::Path, install_spec: &str) -> Option<String> {
-    let (pkg_name, _) = split_spec(install_spec);
+fn resolve_bin_from_package(modules_dir: &std::path::Path, pkg_name: &str) -> Option<String> {
     let pkg_json_path = modules_dir.join(pkg_name).join("package.json");
     let content = std::fs::read_to_string(&pkg_json_path).ok()?;
     let pkg_json: serde_json::Value = serde_json::from_str(&content).ok()?;
@@ -501,7 +500,7 @@ mod tests {
             }),
         );
         assert_eq!(
-            resolve_bin_from_package(tmp.path(), "@tanstack/cli@latest"),
+            resolve_bin_from_package(tmp.path(), "@tanstack/cli"),
             Some("tanstack".to_string())
         );
     }


### PR DESCRIPTION
## correctness
- `parse_git_spec` recognizes the scp-form `[user@]host:path[.git][#ref]` and rewrites it to `ssh://[user@]host/path[.git]`, so `aube dlx git@github.com:user/repo.git[#0.1.5]` parses as a git dep instead of falling through and being treated as a registry version range
- `aube dlx <github:|gitlab:|bitbucket:|gist:|git+|git://|git@|ssh://|file:|link:|http(s)://>` now derives the package name from the spec's last path segment (stripping `.git`) and uses the spec verbatim as the dependency value, so the synthetic dlx manifest is `{ "<repo>": "<spec>" }` instead of `{ "<spec>": "latest" }` (which was rejected as an invalid package name)
- `bin_name_for` shares the same derivation, so the launched binary lookup matches the resolved package name

## reported by
- discord report from TheAifam5: `aubx github:EthanHenrickson/math-mcp` → `invalid package name`, and `aubx git@github.com:EthanHenrickson/math-mcp.git[#0.1.5]` → `no version of git matches range`

## testing
- `parse_git_spec`: `scp_form_recognized`, `scp_form_with_ref_recognized`
- dlx helpers: 7 cases covering github shorthand, github+ref, scp, git+https, registry passthrough, scoped registry passthrough, bin name derivation
- `cargo test --workspace --lib` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## scope
- pure string parsing, no fs / network / process surface, identical on windows / macos / linux
- no overlap with open prs (#285 release, #287 bench-refresh, #292 bench fix, #294 settings env aliases)