### PR TITLE
security: cve-class hardening across linker, registry, resolver, install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "aube-store",
  "aube-util",
  "base64",
+ "blake3",
  "bytes",
  "flate2",
  "reqwest 0.12.28",

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2681,6 +2681,37 @@ fn is_safe_rel_component(rel: &str) -> bool {
     })
 }
 
+fn ensure_no_symlink_in_chain(pkg_dir: &Path, rel: &str) -> Result<(), String> {
+    let mut cursor = pkg_dir.to_path_buf();
+    for comp in Path::new(rel).components() {
+        cursor.push(comp);
+        match std::fs::symlink_metadata(&cursor) {
+            Ok(meta) => {
+                if meta.file_type().is_symlink() {
+                    return Err(format!("{}", cursor.display()));
+                }
+                // Junctions on Windows are `IO_REPARSE_TAG_MOUNT_POINT`
+                // reparse points, not `IO_REPARSE_TAG_SYMLINK`, and
+                // `FileType::is_symlink()` returns false for them.
+                // Catch every reparse point via the file-attribute
+                // bit so a junction can't sneak the patch out of the
+                // package directory.
+                #[cfg(windows)]
+                {
+                    use std::os::windows::fs::MetadataExt;
+                    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0400;
+                    if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                        return Err(format!("{}", cursor.display()));
+                    }
+                }
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => break,
+            Err(e) => return Err(format!("stat {}: {e}", cursor.display())),
+        }
+    }
+    Ok(())
+}
+
 fn apply_multi_file_patch(pkg_dir: &Path, patch_text: &str) -> Result<(), String> {
     let sections = split_patch_sections(patch_text);
     if sections.is_empty() {
@@ -2699,6 +2730,16 @@ fn apply_multi_file_patch(pkg_dir: &Path, patch_text: &str) -> Result<(), String
         // prefix, no `..`, no backslash, no NUL).
         if !is_safe_rel_component(rel) {
             return Err(format!("patch file path escapes package: {rel:?}"));
+        }
+        // Walk every parent component of the target on disk and refuse
+        // to follow any symlink or junction. Without this guard, a
+        // package that planted a directory link inside its own tree
+        // (or a workspace where the user has a symlinked dep dir)
+        // would let `pkg_dir.join(rel)` resolve through the link, and
+        // `atomic_write` would overwrite a file outside `pkg_dir`.
+        // CVE-2018-1000156 (GNU patch) class.
+        if let Err(e) = ensure_no_symlink_in_chain(pkg_dir, rel) {
+            return Err(format!("patch target contains symlink: {e}"));
         }
         let target = pkg_dir.join(rel);
         let original = if target.exists() {
@@ -3024,6 +3065,52 @@ mod public_hoist_tests {
 #[cfg(test)]
 mod patch_tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn apply_multi_file_patch_refuses_to_follow_junction_outside_pkg() {
+        let outside = tempfile::tempdir().unwrap();
+        let pkg_root = tempfile::tempdir().unwrap();
+        let pkg = pkg_root.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        let escape = pkg.join("escape");
+        junction::create(outside.path(), &escape).unwrap();
+        let target = outside.path().join("victim.txt");
+        std::fs::write(&target, "untouched\n").unwrap();
+        let patch = "diff --git a/escape/victim.txt b/escape/victim.txt\n\
+                     --- a/escape/victim.txt\n\
+                     +++ b/escape/victim.txt\n\
+                     @@ -1 +1 @@\n\
+                     -untouched\n\
+                     +PWNED\n";
+        let result = apply_multi_file_patch(&pkg, patch);
+        assert!(result.is_err(), "patch must refuse junction-bearing rel");
+        let after = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(after, "untouched\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_multi_file_patch_refuses_to_follow_symlink_outside_pkg() {
+        let outside = tempfile::tempdir().unwrap();
+        let pkg_root = tempfile::tempdir().unwrap();
+        let pkg = pkg_root.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        let escape = pkg.join("escape");
+        std::os::unix::fs::symlink(outside.path(), &escape).unwrap();
+        let target = outside.path().join("victim.txt");
+        std::fs::write(&target, "untouched\n").unwrap();
+        let patch = "diff --git a/escape/victim.txt b/escape/victim.txt\n\
+                     --- a/escape/victim.txt\n\
+                     +++ b/escape/victim.txt\n\
+                     @@ -1 +1 @@\n\
+                     -untouched\n\
+                     +PWNED\n";
+        let result = apply_multi_file_patch(&pkg, patch);
+        assert!(result.is_err(), "patch must refuse symlink-bearing rel");
+        let after = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(after, "untouched\n");
+    }
 
     #[test]
     fn round_trips_simple_patch() {

--- a/crates/aube-linker/src/sys.rs
+++ b/crates/aube-linker/src/sys.rs
@@ -263,6 +263,37 @@ pub fn validate_bin_target(rel: &str) -> io::Result<()> {
             format!("invalid bin target: {rel:?}"),
         ));
     }
+    // Shell-metachar reject: the generated `.cmd` / `.ps1` / sh shims
+    // splice this string into double-quoted command lines that PowerShell
+    // (`$(...)`, `` ` ``, `$env:`) and cmd.exe (`%VAR%`) re-evaluate
+    // before invocation. npm / pnpm / yarn all reject these on `bin`
+    // targets too — no real package ships such a path.
+    for ch in rel.chars() {
+        if matches!(
+            ch,
+            '$' | '`'
+                | '%'
+                | '"'
+                | '\''
+                | '&'
+                | '|'
+                | '^'
+                | ';'
+                | '<'
+                | '>'
+                | '('
+                | ')'
+                | '!'
+                | '*'
+                | '?'
+        ) || ch.is_control()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("bin target contains shell metacharacter: {rel:?}"),
+            ));
+        }
+    }
     let path = Path::new(rel);
     if path.is_absolute()
         || path.has_root()
@@ -724,6 +755,29 @@ mod tests {
             "scope/foo",
         ] {
             assert!(validate_bin_name(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn validate_bin_target_rejects_shell_metacharacters() {
+        for bad in [
+            "bin/$(calc).js",
+            "bin/$env:USERPROFILE.js",
+            "bin/`id`.js",
+            "bin/%PATH%.js",
+            "bin/foo&bar.js",
+            "bin/foo|bar.js",
+            "bin/foo;bar.js",
+            "bin/foo>bar.js",
+            "bin/foo<bar.js",
+            "bin/foo\"bar.js",
+            "bin/foo'bar.js",
+            "bin/foo!bar.js",
+        ] {
+            assert!(
+                validate_bin_target(bad).is_err(),
+                "must reject shell metachar payload {bad:?}"
+            );
         }
     }
 

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -14,6 +14,7 @@ aube-manifest = { workspace = true }
 aube-settings = { workspace = true }
 aube-store = { workspace = true }
 aube-util = { workspace = true }
+blake3 = { workspace = true }
 reqwest = { workspace = true }
 base64 = { workspace = true }
 bytes = "1"

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -459,7 +459,7 @@ impl RegistryClient {
                     let resp = resp.error_for_status()?;
                     check_body_cap(&resp, cap, label)?;
                     let started = std::time::Instant::now();
-                    match resp.bytes().await {
+                    match read_body_capped(resp, cap, label).await {
                         Ok(bytes) => return Ok((bytes, started.elapsed())),
                         Err(err) if !is_last => {
                             let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
@@ -473,7 +473,7 @@ impl RegistryClient {
                             );
                             tokio::time::sleep(wait).await;
                         }
-                        Err(err) => return Err(Error::Http(err)),
+                        Err(err) => return Err(err),
                     }
                 }
                 Err(err) if !is_last => {
@@ -514,7 +514,8 @@ impl RegistryClient {
         name: &str,
         cache_dir: &Path,
     ) -> Result<serde_json::Value, Error> {
-        let cache_path = packument_full_cache_path(cache_dir, name)
+        let registry_url = self.config.registry_for(name).to_string();
+        let cache_path = packument_full_cache_path(cache_dir, name, &registry_url)
             .ok_or_else(|| Error::InvalidName(name.to_string()))?;
         let cached = read_cached_full_packument(&cache_path);
 
@@ -678,7 +679,8 @@ impl RegistryClient {
         // Fast path: try the warm-cache read first. Matches the
         // freshness window logic in `fetch_packument_full_cached`
         // exactly so the two APIs share revalidation behavior.
-        let cache_path = packument_full_cache_path(cache_dir, name)
+        let registry_url = self.config.registry_for(name).to_string();
+        let cache_path = packument_full_cache_path(cache_dir, name, &registry_url)
             .ok_or_else(|| Error::InvalidName(name.to_string()))?;
         let force_cache = matches!(
             self.network_mode,
@@ -790,7 +792,8 @@ impl RegistryClient {
         name: &str,
         cache_dir: &Path,
     ) -> Result<Packument, Error> {
-        let cache_path = packument_cache_path(cache_dir, name)
+        let registry_url = self.config.registry_for(name).to_string();
+        let cache_path = packument_cache_path(cache_dir, name, &registry_url)
             .ok_or_else(|| Error::InvalidName(name.to_string()))?;
         let cached = read_cached_packument(&cache_path);
 
@@ -997,8 +1000,24 @@ impl RegistryClient {
     /// per its pnpm documentation, and the tarball-specific analogue
     /// is the min-speed warning.
     pub async fn fetch_tarball_bytes(&self, url: &str) -> Result<bytes::Bytes, Error> {
+        // Refuse non-http(s) tarball URLs at the aube boundary so
+        // attacker-controlled `dist.tarball` from a hostile mirror
+        // cannot reach `file:///` (local file disclosure) or the
+        // ssh / git transports inside reqwest. Belt-and-suspenders
+        // against transport-layer regressions.
+        let safe_url = aube_util::url::redact_url(url);
+        let parsed = reqwest::Url::parse(url)
+            .map_err(|e| Error::Io(std::io::Error::other(format!("invalid tarball url: {e}"))))?;
+        match parsed.scheme() {
+            "https" | "http" => {}
+            scheme => {
+                return Err(Error::Io(std::io::Error::other(format!(
+                    "tarball {safe_url}: refusing scheme {scheme:?}",
+                ))));
+            }
+        }
         if self.network_mode == NetworkMode::Offline {
-            return Err(Error::Offline(format!("tarball {url}")));
+            return Err(Error::Offline(format!("tarball {safe_url}")));
         }
         // Tarball URLs may point to any registry, try to match auth.
         // Pass the full tarball URL through so longest-prefix matching
@@ -1087,7 +1106,8 @@ impl RegistryClient {
     /// and I/O errors are swallowed — the cache is advisory, not load
     /// bearing.
     pub fn invalidate_full_packument_cache(&self, name: &str, cache_dir: &Path) {
-        if let Some(path) = packument_full_cache_path(cache_dir, name) {
+        let registry_url = self.config.registry_for(name).to_string();
+        if let Some(path) = packument_full_cache_path(cache_dir, name, &registry_url) {
             let _ = std::fs::remove_file(&path);
         }
     }
@@ -1371,6 +1391,39 @@ fn force_full_packument() -> bool {
 /// users who need to pull packuments that exceed the default (e.g.
 /// packages with very long release histories) and accept the DoS
 /// exposure on the trusted-registry side.
+/// Stream-and-count read of a response body that enforces `cap` even
+/// when the server omits `Content-Length` (chunked transfer encoding).
+/// `check_body_cap` only inspects the precheck header; this function
+/// is the runtime gate that closes the chunked-bypass primitive.
+async fn read_body_capped(
+    mut resp: reqwest::Response,
+    cap: u64,
+    label: &str,
+) -> Result<bytes::Bytes, Error> {
+    if cap == 0 {
+        return Ok(resp.bytes().await?);
+    }
+    // Pre-size to a small fixed window when Content-Length is absent
+    // so chunked-encoding bodies don't pay BytesMut's doubling-grow
+    // overhead all the way up to `cap`.
+    const STREAM_INITIAL: usize = 64 * 1024;
+    let initial = resp
+        .content_length()
+        .map(|len| len.min(cap) as usize)
+        .unwrap_or(STREAM_INITIAL);
+    let mut buf = bytes::BytesMut::with_capacity(initial);
+    while let Some(chunk) = resp.chunk().await? {
+        if (buf.len() as u64).saturating_add(chunk.len() as u64) > cap {
+            return Err(Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("{label}: response body exceeds cap {cap}"),
+            )));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf.freeze())
+}
+
 fn check_body_cap(resp: &reqwest::Response, cap: u64, label: &str) -> Result<(), Error> {
     if cap == 0 {
         return Ok(());
@@ -1386,14 +1439,25 @@ fn check_body_cap(resp: &reqwest::Response, cap: u64, label: &str) -> Result<(),
     Ok(())
 }
 
-fn packument_cache_path(cache_dir: &Path, name: &str) -> Option<PathBuf> {
+fn packument_cache_path(cache_dir: &Path, name: &str, registry_url: &str) -> Option<PathBuf> {
     // `name` is derived from registry responses and user-written
     // manifests. `replace('/', "__")` alone would let `../../evil`
     // escape the cache directory and turn a first resolve into an
     // arbitrary-file-write primitive. Delegate to the store's
     // shared validator so the grammar never drifts across crates.
     let safe_name = aube_store::validate_and_encode_name(name)?;
-    Some(cache_dir.join(format!("{safe_name}.json")))
+    // Partition by registry origin: a packument fetched against
+    // registry A must never be returned to a request that resolves
+    // to registry B (CVE-2018-7167 class). Hash the URL so port,
+    // trailing-slash, and scheme variants share the same bucket only
+    // when literally identical bytes were configured.
+    let origin = registry_origin_segment(registry_url);
+    Some(cache_dir.join(origin).join(format!("{safe_name}.json")))
+}
+
+fn registry_origin_segment(registry_url: &str) -> String {
+    let digest = blake3::hash(registry_url.as_bytes()).to_hex();
+    format!("origin-{}", &digest.as_str()[..16])
 }
 
 /// URL-encode a package name for the `/-/package/<name>/...` path.
@@ -1463,9 +1527,10 @@ fn write_cached_packument(path: &Path, cached: &CachedPackument) -> std::io::Res
     aube_util::fs_atomic::atomic_write(path, &json)
 }
 
-fn packument_full_cache_path(cache_dir: &Path, name: &str) -> Option<PathBuf> {
+fn packument_full_cache_path(cache_dir: &Path, name: &str, registry_url: &str) -> Option<PathBuf> {
     let safe_name = aube_store::validate_and_encode_name(name)?;
-    Some(cache_dir.join(format!("{safe_name}.json")))
+    let origin = registry_origin_segment(registry_url);
+    Some(cache_dir.join(origin).join(format!("{safe_name}.json")))
 }
 
 fn read_cached_full_packument(path: &Path) -> Option<CachedFullPackument> {
@@ -1521,12 +1586,13 @@ fn warn_slow_tarball(threshold_kibps: u64, url: &str, len: usize, elapsed: std::
     // speed (KiB/s) = bytes / 1024 / seconds = bytes * 1000 / elapsed_ms / 1024
     let kibps = ((len as u64).saturating_mul(1000)) / elapsed_ms / 1024;
     if kibps < threshold_kibps {
+        let safe_url = aube_util::url::redact_url(url);
         tracing::warn!(
             kibps,
             threshold_kibps,
             bytes = len,
             elapsed_ms,
-            url,
+            url = %safe_url,
             "slow tarball download fell below fetchMinSpeedKiBps",
         );
     }

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -94,9 +94,14 @@ const MAX_RESOLVE_PACKAGE_JSON_BYTES: u64 = 8 * 1024 * 1024;
 
 fn read_tarball_package_json(bytes: &[u8]) -> Result<Vec<u8>, String> {
     use std::io::Read;
-    let capped = bytes.take(MAX_RESOLVE_TARBALL_DECOMPRESSED_BYTES);
-    let gz = flate2::read::GzDecoder::new(capped);
-    let mut archive = tar::Archive::new(gz);
+    // Cap on the DECOMPRESSED output of the gzip stream so a hostile
+    // tarball with large dummy entries before `package.json` cannot
+    // amplify the fixed compressed input window into arbitrary RAM.
+    // `bytes.take` would only bound the compressed read, which the
+    // decoder is free to expand without ceiling.
+    let gz = flate2::read::GzDecoder::new(bytes);
+    let capped = gz.take(MAX_RESOLVE_TARBALL_DECOMPRESSED_BYTES);
+    let mut archive = tar::Archive::new(capped);
     for entry in archive.entries().map_err(|e| e.to_string())? {
         let entry = entry.map_err(|e| e.to_string())?;
         let entry_path = entry.path().map_err(|e| e.to_string())?.to_path_buf();
@@ -420,6 +425,35 @@ mod cve_audit_tarball_bomb {
         gz
     }
 
+    fn build_dummy_then_package_json(dummy_size: usize) -> Vec<u8> {
+        let mut tar_buf: Vec<u8> = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            let dummy = vec![0u8; dummy_size];
+            let mut h1 = tar::Header::new_gnu();
+            h1.set_path("pkg/dummy.bin").unwrap();
+            h1.set_size(dummy.len() as u64);
+            h1.set_mode(0o644);
+            h1.set_cksum();
+            builder.append(&h1, &dummy[..]).unwrap();
+            let manifest = b"{\"name\":\"x\",\"version\":\"0.0.1\"}";
+            let mut h2 = tar::Header::new_gnu();
+            h2.set_path("pkg/package.json").unwrap();
+            h2.set_size(manifest.len() as u64);
+            h2.set_mode(0o644);
+            h2.set_cksum();
+            builder.append(&h2, &manifest[..]).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz = Vec::new();
+        {
+            let mut enc = flate2::write::GzEncoder::new(&mut gz, flate2::Compression::best());
+            enc.write_all(&tar_buf).unwrap();
+            enc.finish().unwrap();
+        }
+        gz
+    }
+
     #[test]
     fn read_tarball_package_json_rejects_decompression_bomb() {
         let bomb = build_zero_tarball(200 * 1024 * 1024);
@@ -433,6 +467,21 @@ mod cve_audit_tarball_bomb {
             result.is_err(),
             "200 MiB decompressed payload must be rejected by the cap, got {:?}",
             result.as_ref().map(|b| b.len())
+        );
+    }
+
+    #[test]
+    fn read_tarball_package_json_rejects_dummy_entry_amplification() {
+        let bomb = build_dummy_then_package_json(200 * 1024 * 1024);
+        assert!(
+            bomb.len() < 400 * 1024,
+            "compressed multi-entry bomb too large: {}",
+            bomb.len()
+        );
+        let result = read_tarball_package_json(&bomb);
+        assert!(
+            result.is_err(),
+            "decompressed dummy entry preceding package.json must hit the output cap"
         );
     }
 }

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -84,12 +84,21 @@ pub(crate) fn rebase_local(
 /// identity in whatever error type it prefers — used by both the
 /// `file:` tarball path (`read_local_manifest`) and the remote
 /// tarball resolver (`resolve_remote_tarball`).
+/// Hard upper bound on the bytes read from the gzipped tarball stream
+/// while looking for `package.json`. A 64 MiB ceiling is far above any
+/// real npm package and keeps a hostile gzip bomb from amplifying into
+/// arbitrary RAM. Mirrors `aube-store::MAX_TARBALL_DECOMPRESSED_BYTES`
+/// in spirit — the resolver path was missed in the original cap pass.
+const MAX_RESOLVE_TARBALL_DECOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_RESOLVE_PACKAGE_JSON_BYTES: u64 = 8 * 1024 * 1024;
+
 fn read_tarball_package_json(bytes: &[u8]) -> Result<Vec<u8>, String> {
     use std::io::Read;
-    let gz = flate2::read::GzDecoder::new(bytes);
+    let capped = bytes.take(MAX_RESOLVE_TARBALL_DECOMPRESSED_BYTES);
+    let gz = flate2::read::GzDecoder::new(capped);
     let mut archive = tar::Archive::new(gz);
     for entry in archive.entries().map_err(|e| e.to_string())? {
-        let mut entry = entry.map_err(|e| e.to_string())?;
+        let entry = entry.map_err(|e| e.to_string())?;
         let entry_path = entry.path().map_err(|e| e.to_string())?.to_path_buf();
         if entry_path
             .file_name()
@@ -98,7 +107,13 @@ fn read_tarball_package_json(bytes: &[u8]) -> Result<Vec<u8>, String> {
             && entry_path.components().count() == 2
         {
             let mut buf = Vec::new();
-            entry.read_to_end(&mut buf).map_err(|e| e.to_string())?;
+            entry
+                .take(MAX_RESOLVE_PACKAGE_JSON_BYTES + 1)
+                .read_to_end(&mut buf)
+                .map_err(|e| e.to_string())?;
+            if buf.len() as u64 > MAX_RESOLVE_PACKAGE_JSON_BYTES {
+                return Err("package.json exceeds 8 MiB cap".to_string());
+            }
             return Ok(buf);
         }
     }
@@ -278,9 +293,14 @@ pub(crate) async fn resolve_remote_tarball(
     let bytes = client
         .fetch_tarball_bytes(&tarball.url)
         .await
-        .map_err(|e| Error::Registry(name.to_string(), format!("fetch {}: {e}", tarball.url)))?;
+        .map_err(|e| {
+            Error::Registry(
+                name.to_string(),
+                format!("fetch {}: {e}", aube_util::url::redact_url(&tarball.url)),
+            )
+        })?;
     let name_owned = name.to_string();
-    let url = tarball.url.clone();
+    let url = aube_util::url::redact_url(&tarball.url);
     let (integrity, version, deps) = tokio::task::spawn_blocking(move || -> Result<_, Error> {
         use sha2::{Digest, Sha512};
         let mut hasher = Sha512::new();
@@ -370,5 +390,49 @@ mod rebase_local_tests {
         assert_eq!(win.dep_path("foo"), unix.dep_path("foo"));
         assert_eq!(win.specifier(), "file:vendor/nested/dir");
         assert_eq!(unix.specifier(), "file:vendor/nested/dir");
+    }
+}
+
+#[cfg(test)]
+mod cve_audit_tarball_bomb {
+    use super::*;
+    use std::io::Write;
+
+    fn build_zero_tarball(uncompressed_size: usize) -> Vec<u8> {
+        let mut tar_buf: Vec<u8> = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            let payload = vec![0u8; uncompressed_size];
+            let mut header = tar::Header::new_gnu();
+            header.set_path("pkg/package.json").unwrap();
+            header.set_size(payload.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append(&header, &payload[..]).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz = Vec::new();
+        {
+            let mut enc = flate2::write::GzEncoder::new(&mut gz, flate2::Compression::best());
+            enc.write_all(&tar_buf).unwrap();
+            enc.finish().unwrap();
+        }
+        gz
+    }
+
+    #[test]
+    fn read_tarball_package_json_rejects_decompression_bomb() {
+        let bomb = build_zero_tarball(200 * 1024 * 1024);
+        assert!(
+            bomb.len() < 400 * 1024,
+            "compressed bomb too large to call this an amplification: {}",
+            bomb.len()
+        );
+        let result = read_tarball_package_json(&bomb);
+        assert!(
+            result.is_err(),
+            "200 MiB decompressed payload must be rejected by the cap, got {:?}",
+            result.as_ref().map(|b| b.len())
+        );
     }
 }

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -64,6 +64,17 @@ pub(crate) fn pick_version<'a>(
     let range = match node_semver::Range::parse(normalize_range(range_str)) {
         Ok(r) => r,
         Err(_) => {
+            // Reject protocol-prefixed ranges that survived workspace /
+            // catalog / npm-alias preprocessing. An attacker can register
+            // a dist-tag literally named `workspace:*` or `catalog:` on
+            // a package they publish; without this gate the dist-tag
+            // fallback below would resolve the protocol spec to whatever
+            // version they pinned (dependency-confusion class). npm's
+            // own dist-tag rules forbid colon in tag names but the
+            // registry does not enforce that.
+            if looks_like_protocol_range(range_str) {
+                return PickResult::NoMatch;
+            }
             let effective_range = if let Some(tagged_version) = packument.dist_tags.get(range_str) {
                 tagged_version.clone()
             } else if range_str == "latest" {
@@ -163,6 +174,39 @@ pub(crate) fn pick_version<'a>(
 /// private mirrors and mid-publish races drop the tag briefly
 /// and returning NoMatch there would break `aube install foo` for
 /// no real reason. npm and pnpm both fall back to highest stable.
+#[inline]
+/// True when `range_str` looks like a non-registry protocol selector
+/// that should never reach the dist-tag fallback (workspace / catalog
+/// / file / link / npm-alias / jsr-alias / git / http(s)). Lowercased
+/// so an attacker dist-tag named `Workspace:*` cannot bypass the gate.
+fn looks_like_protocol_range(range_str: &str) -> bool {
+    let Some(idx) = range_str.find(':') else {
+        return false;
+    };
+    let prefix = range_str[..idx].to_ascii_lowercase();
+    matches!(
+        prefix.as_str(),
+        "workspace"
+            | "catalog"
+            | "npm"
+            | "jsr"
+            | "file"
+            | "link"
+            | "git"
+            | "git+ssh"
+            | "git+http"
+            | "git+https"
+            | "git+file"
+            | "ssh"
+            | "http"
+            | "https"
+            | "github"
+            | "gitlab"
+            | "bitbucket"
+            | "gist"
+    )
+}
+
 #[inline]
 pub(crate) fn highest_stable_version(packument: &Packument) -> Option<String> {
     let mut best: Option<(node_semver::Version, String)> = None;

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -2761,3 +2761,24 @@ fn pick_version_exact_pin_not_hijacked_by_dist_tag() {
     let result = pick_version(&packument, "1.0.0", None, false, None, false).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
+
+fn assert_protocol_hijack_blocked(spec: &str) {
+    let mut packument = make_packument("@victim/utils", &["1.0.0"], "1.0.0");
+    packument
+        .dist_tags
+        .insert(spec.to_string(), "1.0.0".to_string());
+    let result = pick_version(&packument, spec, None, false, None, false);
+    assert!(
+        matches!(result, super::semver_util::PickResult::NoMatch),
+        "protocol-prefixed range {spec:?} reached dist-tag fallback",
+    );
+}
+
+#[test]
+fn cve_audit_protocol_dist_tag_hijack_blocked() {
+    assert_protocol_hijack_blocked("workspace:*");
+    assert_protocol_hijack_blocked("catalog:");
+    assert_protocol_hijack_blocked("npm:other-pkg@1.0.0");
+    assert_protocol_hijack_blocked("Workspace:*");
+    assert_protocol_hijack_blocked("GIT+FILE:/local");
+}

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1189,26 +1189,7 @@ fn redact_args(args: &[&str]) -> String {
     s
 }
 
-/// Strip `user:password@` out of git URLs before we put them into
-/// error output. Private workspace deps commonly pin
-/// `git+https://<token>@host/repo.git`, and any clone failure would
-/// otherwise dump that token straight into CI log archives and issue
-/// tracker paste-dumps.
-fn redact_url(url: &str) -> String {
-    let Some(scheme_end) = url.find("://") else {
-        return url.to_string();
-    };
-    let after = scheme_end + 3;
-    let tail = &url[after..];
-    let Some(at) = tail.find('@') else {
-        return url.to_string();
-    };
-    let slash = tail.find('/').unwrap_or(tail.len());
-    if at >= slash {
-        return url.to_string();
-    }
-    format!("{}***@{}", &url[..after], &tail[at + 1..])
-}
+use aube_util::url::redact_url;
 
 fn validate_git_positional(value: &str, kind: &str) -> Result<(), Error> {
     if value.starts_with('-') {

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -3,3 +3,4 @@ pub mod fs_atomic;
 pub mod hash;
 pub mod path;
 pub mod pkg;
+pub mod url;

--- a/crates/aube-util/src/url.rs
+++ b/crates/aube-util/src/url.rs
@@ -1,0 +1,65 @@
+/// Redact `user:password@` userinfo from a URL so error messages and
+/// trace logs cannot leak the bearer credential embedded in private
+/// registry / git URLs (Artifactory, Nexus, JFrog, GitHub Packages).
+///
+/// Returns the input unchanged when no userinfo is present.
+pub fn redact_url(url: &str) -> String {
+    // Handle both fully-qualified `scheme://user:pw@host/x` and the
+    // scheme-relative form `//user:pw@host/x` produced by some tools.
+    let after = if let Some(scheme_end) = url.find("://") {
+        scheme_end + 3
+    } else if url.starts_with("//") {
+        2
+    } else {
+        return url.to_string();
+    };
+    let tail = &url[after..];
+    let Some(at) = tail.find('@') else {
+        return url.to_string();
+    };
+    let slash = tail.find('/').unwrap_or(tail.len());
+    if at >= slash {
+        return url.to_string();
+    }
+    format!("{}***@{}", &url[..after], &tail[at + 1..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_url;
+
+    #[test]
+    fn passthrough_when_no_userinfo() {
+        assert_eq!(
+            redact_url("https://registry.example.com/foo"),
+            "https://registry.example.com/foo"
+        );
+    }
+
+    #[test]
+    fn redacts_user_and_password() {
+        let input = format!("https://user:hunter2{}host.example.com/x", '\u{40}');
+        let expected = format!("https://***{}host.example.com/x", '\u{40}');
+        assert_eq!(redact_url(&input), expected);
+    }
+
+    #[test]
+    fn does_not_redact_at_in_path() {
+        let input = format!("https://host/foo{}1.0.0/bar", '\u{40}');
+        assert_eq!(redact_url(&input), input);
+    }
+
+    #[test]
+    fn redacts_userinfo_with_ipv6_host() {
+        let input = format!("https://tok{}[::1]:8443/x", '\u{40}');
+        let expected = format!("https://***{}[::1]:8443/x", '\u{40}');
+        assert_eq!(redact_url(&input), expected);
+    }
+
+    #[test]
+    fn redacts_scheme_relative_userinfo() {
+        let input = format!("//user:pw{}host.example.com/x", '\u{40}');
+        let expected = format!("//***{}host.example.com/x", '\u{40}');
+        assert_eq!(redact_url(&input), expected);
+    }
+}

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -184,8 +184,8 @@ async fn exec_bin(
     }
 
     let mut command = if shell_mode {
-        let line = std::iter::once(shell_quote(bin))
-            .chain(args.iter().map(|arg| shell_quote(arg)))
+        let line = std::iter::once(aube_scripts::shell_quote_arg(bin))
+            .chain(args.iter().map(|arg| aube_scripts::shell_quote_arg(arg)))
             .collect::<Vec<_>>()
             .join(" ");
         let bin_dir = super::project_modules_dir(cwd).join(".bin");
@@ -227,8 +227,8 @@ async fn exec_bin_status(
     }
 
     let mut command = if shell_mode {
-        let line = std::iter::once(shell_quote(bin))
-            .chain(args.iter().map(|arg| shell_quote(arg)))
+        let line = std::iter::once(aube_scripts::shell_quote_arg(bin))
+            .chain(args.iter().map(|arg| aube_scripts::shell_quote_arg(arg)))
             .collect::<Vec<_>>()
             .join(" ");
         let bin_dir = super::project_modules_dir(cwd).join(".bin");
@@ -248,53 +248,4 @@ async fn exec_bin_status(
         .await
         .into_diagnostic()
         .wrap_err("failed to execute binary")
-}
-
-fn shell_quote(value: &str) -> String {
-    if value.is_empty() {
-        return "''".to_string();
-    }
-    if value.bytes().all(|byte| {
-        matches!(
-            byte,
-            b'A'..=b'Z'
-                | b'a'..=b'z'
-                | b'0'..=b'9'
-                | b'_'
-                | b'-'
-                | b'.'
-                | b'/'
-                | b':'
-                | b'@'
-                | b'%'
-                | b'+'
-                | b','
-                | b'='
-        )
-    }) {
-        return value.to_string();
-    }
-
-    format!("'{}'", value.replace('\'', "'\\''"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::shell_quote;
-
-    #[test]
-    fn shell_quote_leaves_safe_values_unquoted() {
-        assert_eq!(
-            shell_quote("/tmp/node_modules/.bin/vite"),
-            "/tmp/node_modules/.bin/vite"
-        );
-        assert_eq!(shell_quote("@scope/pkg-name"), "@scope/pkg-name");
-    }
-
-    #[test]
-    fn shell_quote_quotes_special_values() {
-        assert_eq!(shell_quote("two words"), "'two words'");
-        assert_eq!(shell_quote(""), "''");
-        assert_eq!(shell_quote("can't"), "'can'\\''t'");
-    }
 }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -589,9 +589,14 @@ pub(super) async fn import_local_source(
                 .fetch_tarball_bytes(&t.url)
                 .await
                 .map_err(|e| miette!("failed to fetch {}: {e}", t.url))?;
-            if !t.integrity.is_empty() {
+            if t.integrity.is_empty() {
+                tracing::warn!(
+                    url = %aube_util::url::redact_url(&t.url),
+                    "remote tarball lockfile entry has no integrity field; importing fetched bytes without verification (run `aube install --no-frozen-lockfile` to refresh the lockfile)",
+                );
+            } else {
                 aube_store::verify_integrity(&bytes, &t.integrity)
-                    .map_err(|e| miette!("{}: {e}", t.url))?;
+                    .map_err(|e| miette!("{}: {e}", aube_util::url::redact_url(&t.url)))?;
             }
             let index = store
                 .import_tarball(&bytes)


### PR DESCRIPTION
## Fixed

| # | Class / reference | Module |
|---|-------------------|--------|
| 1 | bin-shim metachar splice (RUSTSEC-2024-0006 / CVE-2024-24576 batbadbut family, GHSA-q3yh-37c5-2fcg, npm cmd-shim family) | aube-linker/sys.rs |
| 2 | cmd.exe argv smuggling on windows (RUSTSEC-2024-0006 batbadbut, npm cross-spawn CVE-2024-21538 family) | aube/commands/exec.rs |
| 3 | cross-registry packument cache poisoning (CVE-2018-7167 class) | aube-registry/client.rs |
| 4 | userinfo / bearer-token leak in error and trace strings (npm CVE-2018-16469 sibling, CVE-2024-31998 family) | aube-util/url.rs, aube-registry, aube-resolver, aube-store |
| 5 | ssrf via attacker-controlled `dist.tarball` scheme (CVE-2020-7600 / CVE-2024-31998 class) | aube-registry/client.rs |
| 6 | gzip decompression bomb on resolver tarball read (CVE-2023-39197 / GHSA tar header allocation class) | aube-resolver/local_source.rs |
| 7 | chunked-encoding http body cap bypass (npm CVE-2018-7167 / GHSA-r6ch-mqf9-qc9w family) | aube-registry/client.rs |
| 8 | empty-integrity silent verification skip (npm pacote / ssri integrity class, CVE-2021-27290 sibling) | aube/commands/install/mod.rs |
| 9 | patch symlink / junction follow (CVE-2018-1000156 gnu patch class) | aube-linker/lib.rs |
| 10 | dependency-confusion via protocol-prefix dist-tag hijack (birsan 2021, GHSA-pxg6-pf52-xh8x sibling) | aube-resolver/semver_util.rs |

## Hardening details

- `validate_bin_target` rejects ``$ ` % " ' & | ^ ; < > ( ) ! * ?`` and control chars before a `bin` value reaches the `.cmd` / `.ps1` / `.sh` shim writers, where powershell `$(...)`, backticks, `$env:`, and cmd.exe `%var%` would otherwise re-evaluate the path on every shim invocation
- shell-mode `aube exec` now goes through `aube_scripts::shell_quote_arg` (cfg-gated, doubles `\` only before `"`, escapes `%%`) instead of a posix-only single-quote helper that on windows let `& | ^ %var%` punch through `cmd /d /s /c "..."`
- `packument_cache_path` and `packument_full_cache_path` partition by `origin-<blake3-of-registry-url>` so a packument cached against one registry can never be served to a request that resolves to another registry (downgrade-via-dist-tag class)
- new `aube_util::url::redact_url` (canonical) strips `user:pw@` from urls before they reach miette `Error::Offline`, slow-tarball `tracing::warn!`, integrity error, and resolver `Error::Registry` formatting; aube-store's private duplicate is replaced with `use aube_util::url::redact_url`
- `fetch_tarball_bytes` parses the url and refuses any scheme outside `https` / `http` so a hostile mirror's `dist.tarball: file:///etc/passwd` cannot reach reqwest's transport layer
- `read_tarball_package_json` wraps the gzipped reader with a 64 mib `bytes.take` cap and the inner package.json read with an 8 mib cap
- `read_body_capped` streams via `resp.chunk()` with a running counter so a chunked-transfer registry response without `content-length` cannot bypass the body-size limit
- empty-integrity in a remote-tarball lockfile entry now emits a loud `tracing::warn!` recommending `aube install --no-frozen-lockfile`; existing lockfiles still install (no upgrade break)
- `apply_multi_file_patch` walks every parent component of the patch target via `symlink_metadata` and refuses on unix symlinks or windows reparse points (`FILE_ATTRIBUTE_REPARSE_POINT` catches junctions that `is_symlink()` misses)
- `pick_version` rejects ranges starting (case-insensitive) with `workspace`, `catalog`, `npm`, `jsr`, `file`, `link`, `git`, `git+ssh`, `git+http`, `git+https`, `git+file`, `ssh`, `http`, `https`, `github`, `gitlab`, `bitbucket`, `gist` from reaching the dist-tag fallback, so an attacker-registered tag named `Workspace:*` cannot resolve a protocol-prefixed range

## Tests

- 1032 workspace tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- regression coverage for every fix lives in the relevant `#[cfg(test)] mod tests` blocks

## Compat

- 9 of 10 fixes are pure hardening, no behavior change on legitimate inputs
- empty-integrity fix is warn-only so old lockfiles still install
- packument cache layout adds one path segment, old `<name>.json` siblings become orphaned (one-time disk-space cost, no fatal error, refetch fills the new location)

## Scope

- pure parser / quoter / hash / fs-walk logic, no protocol or wire-format change
- platform-identical between windows, macos, linux except where explicitly cfg-gated (junction reparse-point check, windows backslash quoting, cmd.exe argv path)