### PR TITLE
docs: clarify auto-install script workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 **[Existing lockfiles](https://aube.en.dev/package-manager/lockfiles).** Reads and writes `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock` in place.
 
-**[Cheap repeat commands](https://aube.en.dev/package-manager/scripts).** `aube run test`, `aube test`, and `aube exec vitest` auto-install when dependencies are stale, then skip that work when nothing changed.
+**[Cheap repeat commands](https://aube.en.dev/package-manager/scripts).** `aubr test`, `aube test`, and `aube exec vitest` auto-install when dependencies are stale, then skip that work when nothing changed. `aubx` runs one-off tools in a throwaway environment.
 
 **[Less disk use](https://aube.en.dev/package-manager/node-modules).** A global content-addressable store lets projects share package files instead of keeping a full copy of the same dependencies in every checkout.
 
@@ -66,13 +66,32 @@ brew install endevco/tap/aube
 
 See [other install methods](https://aube.en.dev/installation).
 
-## First Install
+## First Run
 
 Run aube in an existing Node.js project:
 
 ```sh
-aube install
+aubr test
 ```
+
+`aubr` is shorthand for `aube run`. Before it starts the script, aube checks
+whether `node_modules` is fresh for the current `package.json` and lockfile.
+If dependencies are missing or stale, it installs them first; otherwise it
+goes straight to the script.
+
+You usually do not need a separate `aube install` in day-to-day work. Run the
+script or binary you actually wanted:
+
+```sh
+aubr build
+aube test
+aube exec vitest
+aubx cowsay hi
+```
+
+Use `aube install` when the install itself is the task: first local setup
+without running a script, updating a lockfile, Docker layers, production-only
+installs, or CI flows.
 
 If the project already has a supported lockfile, aube reads it and writes updates back to the same file. That makes it easy to try aube locally without forcing the rest of the team to switch package managers first.
 
@@ -81,15 +100,15 @@ For a new project with no lockfile, aube creates `aube-lock.yaml`.
 ## Daily Commands
 
 ```sh
-aube install              # install dependencies
 aube add react            # add a dependency
 aube add -D vitest        # add a dev dependency
 aube remove react         # remove a dependency
 aube update               # update dependencies within package.json ranges
-aube run build            # run a package.json script
+aubr build                # run a package.json script, auto-installing first if needed
 aube test                 # run the test script, auto-installing first if needed
-aube exec vitest          # run a local binary
-aube dlx cowsay hi        # run a package in a throwaway environment
+aube exec vitest          # run a local binary, auto-installing first if needed
+aubx cowsay hi            # run a package in a throwaway environment
+aube install              # install only, for setup or lockfile/install modes
 aube ci                   # clean, frozen install for CI
 ```
 

--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -225,7 +225,7 @@ watch(progressBarEl, (el, previousEl) => {
         </p>
         <div class="aube-actions" aria-label="Primary links">
           <a class="aube-button aube-button-primary" href="/guide/">
-            Start installing
+            Start running
             <span aria-hidden="true">-></span>
           </a>
           <div class="aube-install-stack">
@@ -278,19 +278,19 @@ watch(progressBarEl, (el, previousEl) => {
         </dl>
       </div>
 
-      <div class="aube-stage" aria-label="Aube install preview">
-        <div class="aube-terminal" aria-label="Interactive install output">
+      <div class="aube-stage" aria-label="Aube script run preview">
+        <div class="aube-terminal" aria-label="Interactive script run output">
           <div class="aube-terminal-bar">
             <span></span>
             <span></span>
             <span></span>
-            <strong>aube install</strong>
+            <strong>aubr test</strong>
           </div>
           <div class="aube-clx" aria-hidden="true">
             <div class="aube-command">$ mise use aube</div>
             <div class="aube-mise-output">mise aube@{{ aubeVersion }}   ✓ installed</div>
             <div class="aube-mise-output">mise ./mise.toml tools: aube@{{ aubeVersion }}</div>
-            <div class="aube-command">$ aube install</div>
+            <div class="aube-command">$ aubr test</div>
             <template v-if="!done">
               <div class="aube-progress-root">
                 <span class="aube-name">aube</span>
@@ -318,6 +318,7 @@ watch(progressBarEl, (el, previousEl) => {
                 <span class="aube-done-check">✓</span>
                 <span>installed {{ installedPackageTotal }} packages in 3.7s</span>
               </div>
+              <div class="aube-run-ok">✓ ran 100 tests successfully</div>
               <div class="aube-command">$ <span class="aube-caret">▍</span></div>
             </template>
           </div>
@@ -379,14 +380,14 @@ watch(progressBarEl, (el, previousEl) => {
         <span class="aube-proof-number">03</span>
         <span class="aube-proof-tag">repeat</span>
         <span class="aube-proof-visual aube-proof-run" aria-hidden="true">
-          <span><b>$</b> aube run test</span>
-          <span class="aube-run-install">deps stale · aube install</span>
-          <span class="aube-run-ok">✓ test</span>
-          <span><b>$</b> aube run test</span>
-          <span class="aube-run-ok">deps fresh · test</span>
+          <span><b>$</b> aubr test</span>
+          <span class="aube-run-install">deps stale · install first</span>
+          <span class="aube-run-ok">✓ ran 100 tests successfully</span>
+          <span><b>$</b> aubr test</span>
+          <span class="aube-run-ok">deps fresh · ran 100 tests successfully</span>
         </span>
-        <strong>Run scripts before you install.</strong>
-        <span><code>aube run test</code> auto-installs first when dependencies changed, then skips that work on repeat runs.</span>
+        <strong>Run scripts instead of installing.</strong>
+        <span><code>aubr test</code> auto-installs first when dependencies changed, then skips that work on repeat runs. Use <code>aubx</code> for one-off tools.</span>
         <span class="aube-proof-link">Run scripts and binaries -></span>
       </a>
       <a class="aube-proof-item" href="/package-manager/node-modules">

--- a/docs/bun-users.md
+++ b/docs/bun-users.md
@@ -3,11 +3,16 @@
 aube can install directly from Bun lockfiles. You do not need to delete
 `bun.lock` or remove `node_modules` before trying aube.
 
-## Start from the Bun lockfile
+## Try the Bun lockfile
 
 ```sh
 aube install
 ```
+
+Run this once when you specifically want to verify that aube can read and
+write the existing Bun lockfile. For normal local work, run the command you
+wanted instead: `aubr build`, `aube test`, and `aube exec <bin>` auto-install
+first when dependencies are stale; `aubx <pkg>` handles one-off tools.
 
 aube reads and updates the text-format `bun.lock` at `lockfileVersion: 1`
 in place and installs packages into `node_modules/.aube/`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,24 +12,25 @@ See the [installation guide](/installation).
 ## Use it
 
 ```sh
-# install dependencies
-aube install
+# run a script from package.json
+aubr build
 
 # add a dependency
 aube add lodash
-
-# run a script from package.json
-aube run build
 
 # install + run the test script (equivalent to `pnpm install-test`)
 aube test
 ```
 
-::: tip Just run the script — aube handles install
-`aube run test`, `aube test`, and `aube exec vitest` all check install
-freshness before running. If `package.json` or the lockfile changed,
-aube installs first; otherwise it skips straight to the script. You
-rarely need a separate `aube install` step in day-to-day work.
+::: tip Just run the command you wanted
+`aubr build`, `aube test`, and `aube exec vitest` all check install freshness
+before running. If `package.json` or the lockfile changed, aube installs first;
+otherwise it skips straight to the script or binary. For one-off tools, use
+`aubx cowsay hi` instead of running an install step yourself.
+
+You rarely need a separate `aube install` step in day-to-day work. Use it when
+the install itself is the task: first local setup without running a script,
+lockfile updates, Docker layers, production-only installs, or CI flows.
 :::
 
 ::: tip Shortcut binaries: `aubr` and `aubx`

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -18,8 +18,12 @@ Existing projects keep their lockfile format. aube reads and writes
   source builds, and shell completions.
 - For existing projects, see the [pnpm](/pnpm-users), [npm](/npm-users),
   [yarn](/yarn-users), or [bun](/bun-users) guide.
-- [Install dependencies](/package-manager/install) covers the normal install
-  path, CI mode, production installs, offline installs, and lockfile modes.
+- [Run scripts and binaries](/package-manager/scripts) covers the normal local
+  workflow. `aubr <script>`, `aube test`, and `aube exec <bin>` install first
+  when dependencies are stale; `aubx <pkg>` handles one-off tools.
+- [Install dependencies](/package-manager/install) covers explicit install
+  work: setup-only installs, CI mode, production installs, offline installs,
+  and lockfile modes.
 - [Manage dependencies](/package-manager/dependencies) covers `add`, `remove`,
   `update`, `dedupe`, and `prune`.
 - [Workspaces](/package-manager/workspaces) covers `aube-workspace.yaml`,

--- a/docs/npm-users.md
+++ b/docs/npm-users.md
@@ -3,11 +3,16 @@
 aube can install directly from npm lockfiles. You do not need to delete
 `package-lock.json` or remove `node_modules` before trying aube.
 
-## Start from the npm lockfile
+## Try the npm lockfile
 
 ```sh
 aube install
 ```
+
+Run this once when you specifically want to verify that aube can read and
+write the existing npm lockfile. For normal local work, run the command you
+wanted instead: `aubr build`, `aube test`, and `aube exec <bin>` auto-install
+first when dependencies are stale; `aubx <pkg>` handles one-off tools.
 
 aube reads:
 

--- a/docs/package-manager/install.md
+++ b/docs/package-manager/install.md
@@ -1,12 +1,21 @@
 # Install dependencies
 
 `aube install` installs the dependencies declared in `package.json` and the
-workspace manifests. It is the command to use for local setup, CI, Docker
-layers, and lockfile updates.
+workspace manifests.
 
 ```sh
 aube install
 ```
+
+Most local work does not need a separate install command. `aubr <script>`,
+`aube test`, and `aube exec <bin>` check install freshness first. If
+`package.json` or the lockfile changed, aube installs before running the
+script or binary. For one-off tools, `aubx <pkg>` installs into a throwaway
+environment and runs the binary.
+
+Use `aube install` when the install itself is the task: first local setup
+without running a script, lockfile updates, Docker layers, production-only
+installs, offline installs, linker experiments, and CI flows.
 
 ## Lockfile modes
 
@@ -69,4 +78,3 @@ reflink, hardlink, then copy.
 - [Bun install](https://bun.com/docs/pm/cli/install)
 - [npm install](https://docs.npmjs.com/cli/v10/commands/npm-install)
 - [Yarn classic install](https://classic.yarnpkg.com/lang/en/docs/cli/install/)
-

--- a/docs/package-manager/scripts.md
+++ b/docs/package-manager/scripts.md
@@ -6,16 +6,16 @@ check before script execution.
 ## Scripts
 
 ```sh
-aube run build
+aubr build
 aube test
 aube start
 aube stop
 aube restart
 ```
 
-Before running a script, aube checks `node_modules/.aube-state`. If the
-manifest or lockfile changed, aube installs first. Use `--no-install` when you
-want to skip that check.
+`aubr` is shorthand for `aube run`. Before running a script, aube checks
+`node_modules/.aube-state`. If the manifest or lockfile changed, aube installs
+first. Use `--no-install` when you want to skip that check.
 
 ```sh
 aube run --no-install build
@@ -41,11 +41,12 @@ aube exec tsc -- --noEmit
 ## One-off binaries
 
 ```sh
-aube dlx cowsay hi
-aube dlx -p create-vite create-vite my-app
+aubx cowsay hi
+aubx -p create-vite create-vite my-app
 ```
 
-`dlx` installs into a throwaway project and runs the requested binary.
+`aubx` is shorthand for `aube dlx`. It installs into a throwaway project and
+runs the requested binary.
 
 ## Shortcuts: `aubr` and `aubx`
 

--- a/docs/pnpm-users.md
+++ b/docs/pnpm-users.md
@@ -20,6 +20,10 @@ Everything else — `add`, `remove`, `update`, `dlx`, `list`, `why`, `pack`,
 
 ## Command map
 
+Do not translate every `pnpm install && pnpm run ...` habit literally.
+`aubr <script>`, `aube test`, and `aube exec <bin>` check install freshness
+and install first only when needed. Use `aubx <pkg>` for one-off tools.
+
 | pnpm | aube | Notes |
 | --- | --- | --- |
 | `pnpm install` | `aube install` | Reads and updates an existing `pnpm-lock.yaml` in place. Only new projects (no supported lockfile on disk yet) default to `aube-lock.yaml`. |
@@ -29,7 +33,7 @@ Everything else — `add`, `remove`, `update`, `dlx`, `list`, `why`, `pack`,
 | `pnpm run build` | `aube run build` | Runs scripts with an auto-install staleness check first. |
 | `pnpm test` | `aube test` | Shortcut for the `test` script; aube auto-installs first (equivalent to `pnpm install-test`). |
 | `pnpm exec vitest` | `aube exec vitest` | Runs local binaries with project `node_modules/.bin` on `PATH`. |
-| `pnpm dlx cowsay hi` | `aube dlx cowsay hi` | Installs into a throwaway environment and runs the binary. |
+| `pnpm dlx cowsay hi` | `aubx cowsay hi` | Installs into a throwaway environment and runs the binary. |
 | `pnpm list` | `aube list` | Supports depth, JSON, parseable, long, prod/dev, and global modes. |
 | `pnpm why debug` | `aube why debug` | Shows reverse dependency paths. |
 | `pnpm pack` | `aube pack` | Creates a publishable tarball with npm-style file selection. |

--- a/docs/yarn-users.md
+++ b/docs/yarn-users.md
@@ -10,6 +10,11 @@ before trying aube.
 aube install
 ```
 
+Run this once when you specifically want to verify that aube can read and
+write the existing Yarn lockfile. For normal local work, run the command you
+wanted instead: `aubr build`, `aube test`, and `aube exec <bin>` auto-install
+first when dependencies are stale; `aubx <pkg>` handles one-off tools.
+
 aube reads and updates Yarn v1 `yarn.lock` in place and installs packages
 into `node_modules/.aube/`.
 


### PR DESCRIPTION
## Summary

- Reframe the README and getting-started flow around running the intended command (`aubr`, `aube test`, `aube exec`) instead of leading with `aube install`.
- Add `aubx` to the same guidance for one-off tools.
- Update the landing page hero and repeat-command card so the first visual example shows `aubr test` auto-installing before the script.
- Keep `aube install` documented as the explicit command for setup-only, lockfile, Docker, production, offline, linker, and CI workflows.

## Validation

- `npm --prefix docs run docs:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that update examples and guidance; no runtime or package-manager behavior is modified.
> 
> **Overview**
> Rewrites the README and multiple guides to lead with *running the command you wanted* (`aubr <script>`, `aube test`, `aube exec <bin>`) rather than starting with `aube install`, and adds consistent guidance to use `aubx` for one-off tools.
> 
> Updates the docs site landing page hero and “repeat” highlight to show `aubr test` as the primary example (including messaging that it installs first only when dependencies are stale), while keeping `aube install` documented as the explicit command for setup/lockfile/Docker/prod/offline/CI scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e91928b83e65d008047a08ed34945bb798d06b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->