### PR TITLE
feat(cli): add short command aliases

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -81,6 +81,7 @@ flag "-y --yes" help="Automatically answer yes to prompts" global=#true {
     long_help "Automatically answer yes to prompts.\n\nParsed for pnpm compatibility; aube does not currently prompt on these paths."
 }
 cmd add help="Add a dependency" {
+    alias a
     flag "-D --save-dev" help="Add as dev dependency"
     flag "-E --save-exact" help="Pin the exact resolved version (no `^` prefix)"
     flag "-g --global" help="Install the package globally (into the aube/pnpm global directory) and link its binaries into the global bin directory" {
@@ -296,6 +297,7 @@ cmd doctor help="Run broad install-health diagnostics" {
     flag "-J --json" help="Emit a machine-readable JSON report instead of the grouped text"
 }
 cmd exec help="Execute a locally installed binary" {
+    alias x
     flag --no-bail help="Continue recursive execution after a command fails" {
         long_help "Continue recursive execution after a command fails.\n\nParsed for pnpm compatibility; aube currently stops on the first failure."
     }
@@ -824,6 +826,7 @@ cmd whoami hide=#true help="Report the current registry user (not implemented �
     arg "[ARGS]…" help="Unused; captured so `aube <cmd> foo bar` parses instead of erroring on unexpected args before the fallback message prints" required=#false double_dash=automatic var=#true hide=#true
 }
 cmd why help="Print reverse dependency chains explaining why a package is installed" {
+    alias w
     after_long_help "Examples:\n\n  $ aube why debug\n  my-app@1.0.0 /home/user/project\n\n  dependencies:\n  express 4.19.2\n  └── debug 2.6.9\n  body-parser 1.20.2\n  └── debug 2.6.9\n\n  # Only follow chains starting at a devDependency\n  $ aube why --dev typescript\n\n  # Include each node's store path\n  $ aube why --long debug\n\n  # Tab-separated, one chain per line (pipe-friendly)\n  $ aube why --parseable debug\n\n  # JSON: an array of chain objects\n  $ aube why --json debug\n"
     flag "-D --dev" help="Only follow chains that start at a devDependency"
     flag "-P --prod --production" help="Only follow chains that start at a production (or optional) dependency"

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -332,6 +332,7 @@ impl Drop for SilentStderrGuard {
 #[derive(Subcommand)]
 enum Commands {
     /// Add a dependency
+    #[command(visible_alias = "a")]
     Add(commands::add::AddArgs),
     /// Approve ignored dependency build scripts and record them in `pnpm-workspace.yaml`'s `onlyBuiltDependencies`
     ApproveBuilds(commands::approve_builds::ApproveBuildsArgs),
@@ -384,6 +385,7 @@ enum Commands {
     #[command(after_long_help = commands::doctor::AFTER_LONG_HELP)]
     Doctor(commands::doctor::DoctorArgs),
     /// Execute a locally installed binary
+    #[command(visible_alias = "x")]
     Exec(commands::exec::ExecArgs),
     /// Download lockfile dependencies into the store without linking node_modules
     Fetch(commands::fetch::FetchArgs),
@@ -517,7 +519,7 @@ enum Commands {
     #[command(hide = true)]
     Whoami(commands::npm_fallback::FallbackArgs),
     /// Print reverse dependency chains explaining why a package is installed
-    #[command(after_long_help = commands::why::AFTER_LONG_HELP)]
+    #[command(visible_alias = "w", after_long_help = commands::why::AFTER_LONG_HELP)]
     Why(commands::why::WhyArgs),
     /// Catch-all for implicit script execution (e.g., `aube dev` = `aube run dev`)
     #[command(external_subcommand)]
@@ -1607,6 +1609,23 @@ mod cli_spec_tests {
             Some("https://registry.example.com/")
         );
         assert!(matches!(cli.command, Some(Commands::Install(_))));
+    }
+
+    #[test]
+    fn short_command_aliases_parse() {
+        let cli = Cli::try_parse_from(["aube", "a", "react"]).expect("a should parse as add");
+        assert!(matches!(cli.command, Some(Commands::Add(_))));
+
+        let cli =
+            Cli::try_parse_from(["aube", "x", "vitest", "--run"]).expect("x should parse as exec");
+        let Some(Commands::Exec(args)) = cli.command else {
+            panic!("x should dispatch to exec");
+        };
+        assert_eq!(args.bin, "vitest");
+        assert_eq!(args.args, vec!["--run"]);
+
+        let cli = Cli::try_parse_from(["aube", "w", "react"]).expect("w should parse as why");
+        assert!(matches!(cli.command, Some(Commands::Why(_))));
     }
 }
 

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -2,6 +2,7 @@
 # `aube add`
 
 - **Usage**: `aube add [FLAGS] [PACKAGES]…`
+- **Aliases**: `a`
 
 Add a dependency
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -154,7 +154,9 @@
         "hide": false,
         "help": "Add a dependency",
         "name": "add",
-        "aliases": [],
+        "aliases": [
+          "a"
+        ],
         "hidden_aliases": [],
         "examples": []
       },
@@ -1743,7 +1745,9 @@
         "hide": false,
         "help": "Execute a locally installed binary",
         "name": "exec",
-        "aliases": [],
+        "aliases": [
+          "x"
+        ],
         "hidden_aliases": [],
         "examples": []
       },
@@ -5353,7 +5357,9 @@
         "hide": false,
         "help": "Print reverse dependency chains explaining why a package is installed",
         "name": "why",
-        "aliases": [],
+        "aliases": [
+          "w"
+        ],
         "hidden_aliases": [],
         "after_help_long": "Examples:\n\n  $ aube why debug\n  my-app@1.0.0 /home/user/project\n\n  dependencies:\n  express 4.19.2\n  └── debug 2.6.9\n  body-parser 1.20.2\n  └── debug 2.6.9\n\n  # Only follow chains starting at a devDependency\n  $ aube why --dev typescript\n\n  # Include each node's store path\n  $ aube why --long debug\n\n  # Tab-separated, one chain per line (pipe-friendly)\n  $ aube why --parseable debug\n\n  # JSON: an array of chain objects\n  $ aube why --json debug\n",
         "examples": []

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -2,6 +2,7 @@
 # `aube exec`
 
 - **Usage**: `aube exec [FLAGS] <BIN> [ARGS]…`
+- **Aliases**: `x`
 
 Execute a locally installed binary
 

--- a/docs/cli/why.md
+++ b/docs/cli/why.md
@@ -2,6 +2,7 @@
 # `aube why`
 
 - **Usage**: `aube why [FLAGS] <PACKAGE>`
+- **Aliases**: `w`
 
 Print reverse dependency chains explaining why a package is installed
 


### PR DESCRIPTION
## Summary

- Add visible short aliases for common commands:
  - `aube a` -> `aube add`
  - `aube x` -> `aube exec`
  - `aube w` -> `aube why`
- Cover the aliases with CLI parser tests.
- Regenerate the usage spec and CLI docs so the aliases appear in the reference.

## Validation

- `cargo fmt --check`
- `cargo test -p aube cli_spec_tests`
- Commit hook ran `cargo clippy` for the touched Rust file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds clap-visible command aliases and regenerates generated CLI docs/metadata; behavior change is limited to new accepted command names.
> 
> **Overview**
> Adds **short, visible CLI aliases** so `aube a` routes to `add`, `aube x` routes to `exec`, and `aube w` routes to `why` (wired in both the usage spec and clap command definitions).
> 
> Updates CLI parser tests to cover the new aliases (including argument passthrough for `exec`) and regenerates generated CLI reference outputs so the aliases appear in `docs/cli/*.md` and `docs/cli/commands.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad4174088b348eacc1a1bfe56b0c3cff340f0361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->