### PR TITLE
fix(install): link bins with mixed metadata

### DIFF
--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -743,23 +743,6 @@ impl LockfileGraph {
         self.packages.get(dep_path)
     }
 
-    /// `true` when at least one package in the graph carries a
-    /// non-empty `bin` map — a cheap signal that the source (lockfile
-    /// parser or fresh resolve) populated bin metadata. Bin-linking
-    /// passes use this to short-circuit the `package.json` read on
-    /// packages whose `bin` is empty (95%+ of a typical graph).
-    ///
-    /// The pnpm, bun, npm, and aube parsers all fill `bin`; a fresh
-    /// resolve fills it from packument data. The yarn-classic parser
-    /// leaves it empty, so a graph loaded exclusively from `yarn.lock`
-    /// returns `false` here and bin linking falls back to the full
-    /// `package.json` read. That's a correctness-over-speed choice:
-    /// misreading "empty" as "no bin" on yarn would silently drop
-    /// executables from `node_modules/.bin/`.
-    pub fn has_bin_metadata(&self) -> bool {
-        self.packages.values().any(|p| !p.bin.is_empty())
-    }
-
     /// BFS the transitive closure of `roots` through `self.packages`,
     /// returning every reachable dep_path (roots included). Missing
     /// roots are skipped silently — a root without a matching package
@@ -1851,59 +1834,6 @@ impl Error {
         Error::ParseDiag(Box::new(aube_manifest::ParseError::from_yaml_err(
             path, content, err,
         )))
-    }
-}
-
-#[cfg(test)]
-mod has_bin_metadata_tests {
-    use super::*;
-
-    fn pkg_with_bin(bin: BTreeMap<String, String>) -> LockedPackage {
-        LockedPackage {
-            name: "p".to_string(),
-            version: "1.0.0".to_string(),
-            dep_path: "p@1.0.0".to_string(),
-            bin,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn empty_graph_has_no_bin_metadata() {
-        let g = LockfileGraph::default();
-        assert!(!g.has_bin_metadata());
-    }
-
-    #[test]
-    fn graph_with_no_bins_returns_false() {
-        let mut g = LockfileGraph::default();
-        g.packages
-            .insert("a@1.0.0".to_string(), pkg_with_bin(BTreeMap::new()));
-        g.packages
-            .insert("b@2.0.0".to_string(), pkg_with_bin(BTreeMap::new()));
-        assert!(!g.has_bin_metadata());
-    }
-
-    #[test]
-    fn any_non_empty_bin_flips_to_true() {
-        let mut g = LockfileGraph::default();
-        g.packages
-            .insert("a@1.0.0".to_string(), pkg_with_bin(BTreeMap::new()));
-        let mut bin = BTreeMap::new();
-        bin.insert("tool".to_string(), "bin/tool.js".to_string());
-        g.packages.insert("b@2.0.0".to_string(), pkg_with_bin(bin));
-        assert!(g.has_bin_metadata());
-    }
-
-    /// pnpm parsers record `hasBin: true` as a one-entry placeholder
-    /// map (empty key + empty value). That still flips the flag.
-    #[test]
-    fn pnpm_placeholder_bin_counts() {
-        let mut g = LockfileGraph::default();
-        let mut bin = BTreeMap::new();
-        bin.insert(String::new(), String::new());
-        g.packages.insert("a@1.0.0".to_string(), pkg_with_bin(bin));
-        assert!(g.has_bin_metadata());
     }
 }
 

--- a/crates/aube/src/commands/install/bin_linking.rs
+++ b/crates/aube/src/commands/install/bin_linking.rs
@@ -1,5 +1,8 @@
 use aube_lockfile::dep_path_filename::dep_path_to_filename;
 use miette::{Context, IntoDiagnostic, miette};
+use std::collections::BTreeMap;
+
+pub(crate) type PkgJsonCache = BTreeMap<String, Option<serde_json::Value>>;
 
 /// Link bin entries from packages to node_modules/.bin/
 /// Compute the on-disk directory a dep's materialized package lives
@@ -114,11 +117,35 @@ fn read_materialized_pkg_json(
     Ok(Some(value))
 }
 
+#[allow(clippy::too_many_arguments)]
+fn read_materialized_pkg_json_cached(
+    cache: &mut PkgJsonCache,
+    aube_dir: &std::path::Path,
+    dep_path: &str,
+    name: &str,
+    virtual_store_dir_max_length: usize,
+    placements: Option<&aube_linker::HoistedPlacements>,
+) -> miette::Result<Option<serde_json::Value>> {
+    if let Some(value) = cache.get(dep_path) {
+        return Ok(value.clone());
+    }
+    let value = read_materialized_pkg_json(
+        aube_dir,
+        dep_path,
+        name,
+        virtual_store_dir_max_length,
+        placements,
+    )?;
+    cache.insert(dep_path.to_string(), value.clone());
+    Ok(value)
+}
+
 /// Create top-level + bundled bin symlinks for one dep. Extracted so
 /// both the root-importer pass (`link_bins`) and the per-workspace
 /// loop use the same code path.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn link_bins_for_dep(
+    cache: &mut PkgJsonCache,
     aube_dir: &std::path::Path,
     bin_dir: &std::path::Path,
     graph: &aube_lockfile::LockfileGraph,
@@ -127,7 +154,6 @@ pub(super) fn link_bins_for_dep(
     virtual_store_dir_max_length: usize,
     placements: Option<&aube_linker::HoistedPlacements>,
     shim_opts: aube_linker::BinShimOptions,
-    has_bin_metadata: bool,
 ) -> miette::Result<()> {
     let pkg_dir = materialized_pkg_dir(
         aube_dir,
@@ -136,23 +162,8 @@ pub(super) fn link_bins_for_dep(
         virtual_store_dir_max_length,
         placements,
     );
-    // Fast path: when the lockfile carries bin metadata and says this
-    // package ships none, skip the package.json read + JSON parse.
-    // 95%+ of a typical graph falls into this bucket; the saving
-    // scales with every bin-linking caller (root, per-dep,
-    // per-workspace). `local_source` packages (file:/link:) bypass
-    // the lockfile's bin info so we still consult their on-disk
-    // manifest. Bundled dependencies contribute bins from child
-    // tarballs regardless of the parent's own `bin` field, so
-    // `link_bundled_bins` runs unconditionally below.
-    let skip_bin_read = has_bin_metadata
-        && graph
-            .get_package(dep_path)
-            .is_some_and(|p| p.bin.is_empty() && p.local_source.is_none());
-    if skip_bin_read {
-        return link_bundled_bins(bin_dir, &pkg_dir, graph, dep_path, shim_opts);
-    }
-    if let Some(pkg_json) = read_materialized_pkg_json(
+    if let Some(pkg_json) = read_materialized_pkg_json_cached(
+        cache,
         aube_dir,
         dep_path,
         name,
@@ -175,13 +186,14 @@ pub(super) fn link_bins(
     virtual_store_dir_max_length: usize,
     placements: Option<&aube_linker::HoistedPlacements>,
     shim_opts: aube_linker::BinShimOptions,
-    has_bin_metadata: bool,
+    cache: &mut PkgJsonCache,
 ) -> miette::Result<()> {
     let bin_dir = project_dir.join(modules_dir_name).join(".bin");
     std::fs::create_dir_all(&bin_dir).into_diagnostic()?;
 
     for dep in graph.root_deps() {
         link_bins_for_dep(
+            cache,
             aube_dir,
             &bin_dir,
             graph,
@@ -190,7 +202,6 @@ pub(super) fn link_bins(
             virtual_store_dir_max_length,
             placements,
             shim_opts,
-            has_bin_metadata,
         )?;
     }
 
@@ -218,7 +229,7 @@ pub(crate) fn link_dep_bins(
     virtual_store_dir_max_length: usize,
     placements: Option<&aube_linker::HoistedPlacements>,
     shim_opts: aube_linker::BinShimOptions,
-    has_bin_metadata: bool,
+    cache: &mut PkgJsonCache,
 ) -> miette::Result<()> {
     if placements.is_some() {
         // Hoisted — skip. See function doc.
@@ -226,30 +237,6 @@ pub(crate) fn link_dep_bins(
     }
     for (dep_path, pkg) in &graph.packages {
         if pkg.dependencies.is_empty() {
-            continue;
-        }
-        // Fast path: when lockfile bin metadata is trustworthy and
-        // none of this package's children declare bins, the whole dep
-        // contributes nothing to a local `.bin/`. Skipping here avoids
-        // both the `pkg_dir.exists()` stat and the per-child
-        // `link_bins_for_dep` dispatch on ~95% of entries in a typical
-        // graph. Escape hatches: a child with `local_source`
-        // (file:/link:) bypasses the lockfile's bin map; a child with
-        // its *own* `bundled_dependencies` can ship bins from its
-        // nested tarballs that `link_bins_for_dep` -> `link_bundled_bins`
-        // surfaces into the parent's `.bin/`, so we must dispatch
-        // normally for it.
-        if has_bin_metadata
-            && pkg.bundled_dependencies.is_empty()
-            && pkg.dependencies.iter().all(|(child_name, child_version)| {
-                let child_dep_path = format!("{child_name}@{child_version}");
-                graph.get_package(&child_dep_path).is_some_and(|c| {
-                    c.bin.is_empty()
-                        && c.local_source.is_none()
-                        && c.bundled_dependencies.is_empty()
-                })
-            })
-        {
             continue;
         }
         let pkg_dir = materialized_pkg_dir(
@@ -286,6 +273,7 @@ pub(crate) fn link_dep_bins(
             // platform); `link_bins_for_dep` already returns Ok when
             // the target pkg_json is absent, so just call through.
             link_bins_for_dep(
+                cache,
                 aube_dir,
                 &bin_dir,
                 graph,
@@ -294,7 +282,6 @@ pub(crate) fn link_dep_bins(
                 virtual_store_dir_max_length,
                 placements,
                 shim_opts,
-                has_bin_metadata,
             )?;
         }
     }
@@ -431,4 +418,80 @@ fn create_bin_link(
             )
         })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aube_lockfile::{DepType, DirectDep, LockedPackage, LockfileGraph};
+
+    fn locked(name: &str, version: &str, bin: BTreeMap<String, String>) -> LockedPackage {
+        LockedPackage {
+            name: name.to_string(),
+            version: version.to_string(),
+            dep_path: format!("{name}@{version}"),
+            bin,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn link_bins_reads_manifest_when_lockfile_metadata_is_mixed() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = dir.path();
+        let aube_dir = project_dir.join("node_modules/.aube");
+        let dep_path = "vitepress@1.6.4";
+        let pkg_dir = materialized_pkg_dir(&aube_dir, dep_path, "vitepress", 120, None);
+        std::fs::create_dir_all(pkg_dir.join("bin")).unwrap();
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            r#"{"name":"vitepress","bin":{"vitepress":"bin/vitepress.js"}}"#,
+        )
+        .unwrap();
+        std::fs::write(pkg_dir.join("bin/vitepress.js"), "#!/usr/bin/env node\n").unwrap();
+
+        let mut semver_bin = BTreeMap::new();
+        semver_bin.insert("semver".to_string(), "bin/semver.js".to_string());
+
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            dep_path.to_string(),
+            locked("vitepress", "1.6.4", BTreeMap::new()),
+        );
+        packages.insert(
+            "semver@7.7.4".to_string(),
+            locked("semver", "7.7.4", semver_bin),
+        );
+
+        let mut importers = BTreeMap::new();
+        importers.insert(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "vitepress".to_string(),
+                dep_path: dep_path.to_string(),
+                dep_type: DepType::Dev,
+                specifier: Some("^1.5.0".to_string()),
+            }],
+        );
+
+        let graph = LockfileGraph {
+            importers,
+            packages,
+            ..Default::default()
+        };
+
+        link_bins(
+            project_dir,
+            "node_modules",
+            &aube_dir,
+            &graph,
+            120,
+            None,
+            aube_linker::BinShimOptions::default(),
+            &mut PkgJsonCache::new(),
+        )
+        .unwrap();
+
+        assert!(project_dir.join("node_modules/.bin/vitepress").exists());
+    }
 }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -17,8 +17,8 @@ mod node_gyp_bootstrap;
 mod settings;
 mod side_effects_cache;
 
+pub(crate) use bin_linking::{PkgJsonCache, link_dep_bins, materialized_pkg_dir};
 use bin_linking::{link_bin_entries, link_bins, link_bins_for_dep};
-pub(crate) use bin_linking::{link_dep_bins, materialized_pkg_dir};
 pub use dep_selection::DepSelection;
 pub use frozen::{FrozenMode, FrozenOverride, GlobalVirtualStoreFlags};
 use git_prepare::{prepare_scratch_copy, run_git_dep_prepare};
@@ -3142,12 +3142,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         prefer_symlinked_executables,
     };
     if !virtual_store_only {
-        // Computed once up front: scans the packages map (~1350 entries
-        // on the vlt `large` fixture) to see if any carry `bin` info.
-        // pnpm/bun/npm parsers and fresh resolves populate `bin`;
-        // yarn-classic leaves it empty. The bin-linking fast path
-        // trusts empty `bin` as "no bins" only when this flag is set.
-        let has_bin_metadata = graph_for_link.has_bin_metadata();
+        let mut pkg_json_cache = bin_linking::PkgJsonCache::new();
         link_bins(
             &cwd,
             &modules_dir_name,
@@ -3156,7 +3151,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             virtual_store_dir_max_length,
             placements_ref,
             shim_opts,
-            has_bin_metadata,
+            &mut pkg_json_cache,
         )?;
         // Root importer's own `bin` (discussion #228). Runs after
         // `link_bins` so a self-bin overrides a same-named dep bin.
@@ -3200,6 +3195,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 std::fs::create_dir_all(&bin_dir).into_diagnostic()?;
                 for dep in deps {
                     link_bins_for_dep(
+                        &mut pkg_json_cache,
                         &aube_dir,
                         &bin_dir,
                         &graph_for_link,
@@ -3208,7 +3204,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         virtual_store_dir_max_length,
                         placements_ref,
                         shim_opts,
-                        has_bin_metadata,
                     )?;
                 }
                 // Workspace member's own `bin` (discussion #228). `manifests`
@@ -3239,7 +3234,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             virtual_store_dir_max_length,
             placements_ref,
             shim_opts,
-            has_bin_metadata,
+            &mut pkg_json_cache,
         )?;
         tracing::debug!("phase:link_bins {:.1?}", phase_start.elapsed());
     }

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -100,13 +100,14 @@ pub async fn run(
                     &settings_ctx,
                 ),
             };
+            let mut pkg_json_cache = super::install::PkgJsonCache::new();
             super::install::link_dep_bins(
                 &aube_dir,
                 &graph,
                 super::resolve_virtual_store_dir_max_length(&settings_ctx),
                 hoisted_placements.as_ref(),
                 shim_opts,
-                graph.has_bin_metadata(),
+                &mut pkg_json_cache,
             )?;
             super::install::run_dep_lifecycle_scripts(
                 &cwd,


### PR DESCRIPTION
## Summary

- Fix bin linking when a lockfile graph has only partial `bin` metadata.
- Read materialized package manifests for bin linking instead of trusting an empty lockfile `bin` map as definitive.
- Cache manifest reads during bin-linking so repeated dependency edges do not reread the same `package.json`.
- Add a regression test covering the mixed-metadata case that dropped the `vitepress` shim after adding `sharp`.

## Root Cause

`aube add -D sharp` produced a graph where one package carried `hasBin` metadata but `vitepress` still had an empty lockfile bin map. The installer treated that global signal as proof that every empty package bin map meant "no bins", skipped reading `vitepress/package.json`, and did not create `node_modules/.bin/vitepress`.

## Validation

- `cargo fmt --check`
- `cargo test -p aube link_bins_reads_manifest_when_lockfile_metadata_is_mixed`
- `cargo clippy -p aube -p aube-lockfile --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install-time bin-linking in both `install` and `rebuild`, which is a core part of dependency setup; behavior changes could impact performance or bin shim generation across projects.
> 
> **Overview**
> Fixes a bin-linking correctness bug where a graph with *partial* lockfile `bin` metadata could cause packages with empty `bin` maps to be treated as having no executables, skipping their `package.json` read and dropping shims.
> 
> This removes `LockfileGraph::has_bin_metadata` and the associated fast-path skips, introduces a shared `PkgJsonCache` to avoid repeated manifest reads, and threads that cache through `install`, workspace bin linking, `link_dep_bins`, and `rebuild`. Adds a regression test ensuring `link_bins` still creates the `vitepress` shim when lockfile bin metadata is mixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564c22b72c299e0d437acc8eea5ad133a47948f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->