### PR TITLE
feat(cli): mise-style --version + scope update notifier to version commands

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -14,6 +14,9 @@ flag "-r --recursive" help="Run the command across every workspace package" glob
     long_help "Run the command across every workspace package.\n\nEquivalent to `--filter=*`; if `--filter` is also given, `--recursive` is a no-op and the explicit filter wins. Honored by the same commands as `--filter`."
 }
 flag "-v --verbose" help="Enable verbose/debug logging (shortcut for `--loglevel debug`)" global=#true
+flag "-V --version" help="Print version and check for updates" global=#true {
+    long_help "Print version and check for updates.\n\nManual flag so we can run the async update notifier alongside the version print — clap's auto `Action::Version` exits inside `parse_from`, before the tokio runtime is built."
+}
 flag --aggregate-output help="Group workspace command output after each package finishes" global=#true {
     long_help "Group workspace command output after each package finishes.\n\nAccepted for pnpm compatibility; aube's workspace fanout is currently sequential, so output is already grouped."
 }

--- a/crates/aube/build.rs
+++ b/crates/aube/build.rs
@@ -10,5 +10,29 @@ fn main() {
     {
         println!("cargo:rustc-link-arg-bins=/STACK:8388608");
     }
+    println!("cargo:rustc-env=AUBE_BUILD_DATE={}", build_date());
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+/// Capture the build host's UTC date as `YYYY-MM-DD` for the `aube
+/// --version` line. Shell-out keeps it dep-free; falls back to
+/// `unknown` if the host's `date` / `Get-Date` isn't reachable.
+fn build_date() -> String {
+    let (cmd, args): (&str, &[&str]) = if cfg!(windows) {
+        (
+            "powershell",
+            &["-NoProfile", "-Command", "Get-Date -UFormat '%Y-%m-%d'"],
+        )
+    } else {
+        ("date", &["-u", "+%Y-%m-%d"])
+    };
+    std::process::Command::new(cmd)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into())
 }

--- a/crates/aube/build.rs
+++ b/crates/aube/build.rs
@@ -17,11 +17,20 @@ fn main() {
 /// Capture the build host's UTC date as `YYYY-MM-DD` for the `aube
 /// --version` line. Shell-out keeps it dep-free; falls back to
 /// `unknown` if the host's `date` / `Get-Date` isn't reachable.
+///
+/// `Get-Date -UFormat` only controls the *format-specifier style*, not
+/// the timezone — so the Windows path explicitly converts to UTC via
+/// `.ToUniversalTime()` so build dates stay consistent with the
+/// Unix `date -u` path on either side of midnight.
 fn build_date() -> String {
     let (cmd, args): (&str, &[&str]) = if cfg!(windows) {
         (
             "powershell",
-            &["-NoProfile", "-Command", "Get-Date -UFormat '%Y-%m-%d'"],
+            &[
+                "-NoProfile",
+                "-Command",
+                "(Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')",
+            ],
         )
     } else {
         ("date", &["-u", "+%Y-%m-%d"])

--- a/crates/aube/src/commands/doctor.rs
+++ b/crates/aube/src/commands/doctor.rs
@@ -51,6 +51,8 @@ pub async fn run(args: DoctorArgs) -> miette::Result<()> {
         print_human(&report);
     }
 
+    crate::update_check::check_and_notify(&anchor).await;
+
     if !report.errors.is_empty() {
         std::process::exit(1);
     }

--- a/crates/aube/src/commands/doctor.rs
+++ b/crates/aube/src/commands/doctor.rs
@@ -11,8 +11,11 @@
 //! they can be reused from more focused commands in the future without
 //! round-tripping through the formatter.
 //!
-//! Side-effect free: reads config, package.json, `.aube-state`, and walks
-//! `node_modules/.aube/` — but never writes, never hits the network.
+//! The diagnostic itself is read-only: reads config, package.json,
+//! `.aube-state`, and walks `node_modules/.aube/` — never writes the
+//! project. After the report renders, fires the async update notifier
+//! (network-bound on a cold cache, cached for 24 h thereafter), which
+//! also writes `<cacheDir>/update-check.json` on a successful fetch.
 
 use clap::Args;
 use miette::Context;

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -63,6 +63,7 @@ fn rewrite_multicall_argv(mut args: Vec<OsString>) -> Vec<OsString> {
 #[command(
     name = "aube",
     about = "A fast Node.js package manager",
+    version = version::VERSION_LONG.as_str(),
     disable_version_flag = true
 )]
 pub(crate) struct Cli {
@@ -641,7 +642,7 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
     }
 
     if cli.version {
-        println!("aube {}", crate::version::VERSION.as_str());
+        println!("{}", crate::version::VERSION_LONG.as_str());
         let cwd =
             crate::dirs::project_root_or_cwd().unwrap_or_else(|_| std::path::PathBuf::from("."));
         update_check::check_and_notify(&cwd).await;

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -60,7 +60,11 @@ fn rewrite_multicall_argv(mut args: Vec<OsString>) -> Vec<OsString> {
 }
 
 #[derive(Parser)]
-#[command(name = "aube", about = "A fast Node.js package manager", version = version::VERSION.as_str())]
+#[command(
+    name = "aube",
+    about = "A fast Node.js package manager",
+    disable_version_flag = true
+)]
 pub(crate) struct Cli {
     /// Change to directory before running (like `make -C` or `mise --cd`)
     #[arg(short = 'C', long = "dir", visible_aliases = ["cd", "prefix"], global = true, value_name = "DIR")]
@@ -90,6 +94,14 @@ pub(crate) struct Cli {
     /// Enable verbose/debug logging (shortcut for `--loglevel debug`)
     #[arg(short, long, global = true)]
     verbose: bool,
+
+    /// Print version and check for updates.
+    ///
+    /// Manual flag so we can run the async update notifier alongside
+    /// the version print — clap's auto `Action::Version` exits inside
+    /// `parse_from`, before the tokio runtime is built.
+    #[arg(short = 'V', long = "version", global = true)]
+    version: bool,
 
     /// Group workspace command output after each package finishes.
     ///
@@ -628,6 +640,14 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
             .wrap_err_with(|| format!("failed to change directory to {}", dir.display()))?;
     }
 
+    if cli.version {
+        println!("aube {}", crate::version::VERSION.as_str());
+        let cwd =
+            crate::dirs::project_root_or_cwd().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        update_check::check_and_notify(&cwd).await;
+        return Ok(None);
+    }
+
     if cli.workspace_root {
         let start = std::env::current_dir()
             .into_diagnostic()
@@ -688,7 +708,6 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
     match cli.command {
         Some(Commands::Add(args)) => {
             commands::add::run(args, effective_filter.clone()).await?;
-            post_add_update_notify().await;
         }
         Some(Commands::ApproveBuilds(args)) => commands::approve_builds::run(args).await?,
         Some(Commands::Audit(args)) => commands::audit::run(args, cli.registry.as_deref()).await?,
@@ -796,7 +815,6 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
             match nested.command {
                 Some(Commands::Add(args)) => {
                     commands::add::run(args, nested_filter).await?;
-                    post_add_update_notify().await;
                 }
                 Some(Commands::Deploy(args)) => commands::deploy::run(args, nested_filter).await?,
                 Some(Commands::Exec(args)) => commands::exec::run(args, nested_filter).await?,
@@ -861,7 +879,6 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
                 }
                 Some(Commands::Update(args)) => {
                     commands::update::run(args, nested_filter).await?;
-                    post_add_update_notify().await;
                 }
                 Some(Commands::Why(args)) => commands::why::run(args, nested_filter).await?,
                 Some(Commands::External(args)) => {
@@ -945,7 +962,6 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
         }
         Some(Commands::Update(args)) => {
             commands::update::run(args, effective_filter.clone()).await?;
-            post_add_update_notify().await;
         }
         Some(Commands::Version(args)) => commands::version::run(args).await?,
         Some(Commands::View(args)) => commands::view::run(args).await?,
@@ -1564,30 +1580,10 @@ async fn run_install_command(
         cli: &cli_flags,
     };
     let yaml_prefer_frozen = aube_settings::resolved::prefer_frozen_lockfile(&ctx);
-    let offline = args.offline || args.prefer_offline;
     let mut opts = args.into_options(global_frozen, yaml_prefer_frozen, cli_flags, env);
     opts.workspace_filter = filter;
     commands::install::run(opts).await?;
-    update_check::check_and_notify(&cwd, offline).await;
     Ok(())
-}
-
-/// Fire the update notifier once per top-level `add` / `update`
-/// invocation, after the command has fully returned. Kept at the
-/// dispatch layer so that the workspace-recursive paths inside
-/// `add::run` / `update::run` (which re-enter `run` per matched
-/// package via `run_filtered`) don't each emit their own notice.
-///
-/// Settings resolution needs the project root, not the raw cwd —
-/// `load_npmrc_entries` only reads `<dir>/.npmrc` without walking up,
-/// so running `aube add` from a subdirectory must still pick up the
-/// project-root `.npmrc` (where `updateNotifier=false` would live).
-/// Falls back to the cached cwd when no ancestor has a `package.json`,
-/// so a command run outside a project doesn't lose the notifier.
-async fn post_add_update_notify() {
-    if let Ok(cwd) = crate::dirs::project_root_or_cwd() {
-        update_check::check_and_notify(&cwd, false).await;
-    }
 }
 
 #[cfg(test)]

--- a/crates/aube/src/update_check.rs
+++ b/crates/aube/src/update_check.rs
@@ -1,16 +1,16 @@
 //! Update notifier.
 //!
-//! After a top-level `install` / `add` / `update` completes, fetch
-//! `https://aube.en.dev/VERSION` and print a one-line notice on stderr
-//! if the advertised version is newer than the running binary. The
-//! result is cached under `<cacheDir>/update-check.json` so only the
-//! first run in any 24h window touches the network.
+//! Invoked from `aube doctor` and the `aube --version` / `-V` flag —
+//! the version-asking commands. Fetches `https://aube.en.dev/VERSION`
+//! and prints a one-line notice on stderr if the advertised version is
+//! newer than the running binary. The result is cached under
+//! `<cacheDir>/update-check.json` so only the first run in any 24h
+//! window touches the network.
 //!
 //! Failures (DNS, timeout, non-200, unparseable) are swallowed silently
-//! — a hiccup on the update server must never disturb the install
-//! summary. The fetch also short-circuits when the user asked for an
-//! offline install, when `CI` / `AUBE_NO_UPDATE_CHECK` is set, or when
-//! the `updateNotifier` setting is `false`.
+//! — a hiccup on the update server must never disturb command output.
+//! The fetch also short-circuits when `CI` / `AUBE_NO_UPDATE_CHECK` is
+//! set or when the `updateNotifier` setting is `false`.
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -31,12 +31,8 @@ struct CacheEntry {
 }
 
 /// Run the update check and print a notice if a newer version exists.
-///
-/// `offline` comes from the calling command's resolved `--offline` /
-/// `--prefer-offline` flag — when the user explicitly asked to avoid
-/// the network for their install, we extend that to the notifier.
-pub async fn check_and_notify(cwd: &Path, offline: bool) {
-    if !should_check(offline) {
+pub async fn check_and_notify(cwd: &Path) {
+    if !should_check() {
         return;
     }
     let enabled = crate::commands::with_settings_ctx(cwd, aube_settings::resolved::update_notifier);
@@ -50,19 +46,12 @@ pub async fn check_and_notify(cwd: &Path, offline: bool) {
     if !is_newer(&latest, current) {
         return;
     }
-    // Single line on stderr — the install summary has already rendered
-    // (progress is torn down well before this call), so we're not
-    // racing the clx display. Leading blank line separates the notice
-    // from whatever the install printed last.
     eprintln!();
     eprintln!("  aube {latest} is available (current: {current})");
     eprintln!("  upgrade: https://aube.en.dev");
 }
 
-fn should_check(offline: bool) -> bool {
-    if offline {
-        return false;
-    }
+fn should_check() -> bool {
     if aube_util::env::is_ci() {
         return false;
     }

--- a/crates/aube/src/version.rs
+++ b/crates/aube/src/version.rs
@@ -1,8 +1,9 @@
 use std::sync::LazyLock;
 
-/// User-facing version string. Appends `-DEBUG` on non-release builds so
-/// a stray `cargo run` binary on `$PATH` is obvious in `aube --version`
-/// and the install progress header.
+/// Short user-facing version (e.g. `1.1.0` or `1.1.0-DEBUG`). Used by
+/// the install progress header where the surrounding line is already
+/// busy. Appends `-DEBUG` on non-release builds so a stray `cargo run`
+/// binary on `$PATH` is obvious.
 pub static VERSION: LazyLock<String> = LazyLock::new(|| {
     let mut v = env!("CARGO_PKG_VERSION").to_string();
     if cfg!(debug_assertions) {
@@ -10,3 +11,24 @@ pub static VERSION: LazyLock<String> = LazyLock::new(|| {
     }
     v
 });
+
+/// Long version line for `aube --version`: `<ver> <os>-<arch> (<date>)`.
+/// Mirrors mise's format so users can disambiguate which binary they're
+/// running across machines.
+pub static VERSION_LONG: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{} {}-{} ({})",
+        *VERSION,
+        std::env::consts::OS,
+        arch_short(),
+        env!("AUBE_BUILD_DATE"),
+    )
+});
+
+fn arch_short() -> &'static str {
+    match std::env::consts::ARCH {
+        "x86_64" => "x64",
+        "aarch64" => "arm64",
+        other => other,
+    }
+}

--- a/crates/aube/tests/e2e.rs
+++ b/crates/aube/tests/e2e.rs
@@ -77,7 +77,7 @@ fn version_flag_reports_binary_version() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicates::str::contains("aube"));
+        .stdout(predicates::str::contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5443,6 +5443,21 @@
         "global": true
       },
       {
+        "name": "version",
+        "usage": "-V --version",
+        "help": "Print version and check for updates",
+        "help_long": "Print version and check for updates.\n\nManual flag so we can run the async update notifier alongside the version print — clap's auto `Action::Version` exits inside `parse_from`, before the tokio runtime is built.",
+        "help_first_line": "Print version and check for updates",
+        "short": [
+          "V"
+        ],
+        "long": [
+          "version"
+        ],
+        "hide": false,
+        "global": true
+      },
+      {
         "name": "aggregate-output",
         "usage": "--aggregate-output",
         "help": "Group workspace command output after each package finishes",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -31,6 +31,12 @@ Equivalent to `--filter=*`; if `--filter` is also given, `--recursive` is a no-o
 
 Enable verbose/debug logging (shortcut for `--loglevel debug`)
 
+### `-V --version`
+
+Print version and check for updates.
+
+Manual flag so we can run the async update notifier alongside the version print — clap's auto `Action::Version` exits inside `parse_from`, before the tokio runtime is built.
+
 ### `--aggregate-output`
 
 Group workspace command output after each package finishes.

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -12,7 +12,9 @@ teardown() {
 @test "aube --version" {
 	run aube --version
 	assert_success
-	assert_output --partial "aube"
+	# Mise-style: `<ver> <os>-<arch> (<date>)`. Match the trailing
+	# `(YYYY-MM-DD)` so the assertion stays platform-agnostic.
+	assert_output --regexp '\([0-9]{4}-[0-9]{2}-[0-9]{2}\)$'
 }
 
 @test "aube --help" {

--- a/test/guardrails.bats
+++ b/test/guardrails.bats
@@ -213,7 +213,7 @@ _setup_workspace_fixture() {
 
 @test "packageManagerStrictVersion accepts aube version with corepack hash" {
 	_make_script_project
-	current="$(aube --version | awk '{print $2}')"
+	current="$(aube --version | awk '{print $1}')"
 	node -e 'let p=require("./package.json"); p.packageManager=`aube@'"$current"'+sha512.abc123`; require("fs").writeFileSync("package.json", JSON.stringify(p))'
 	{
 		echo "packageManagerStrictVersion=true"
@@ -227,7 +227,7 @@ _setup_workspace_fixture() {
 
 @test "packageManagerStrictVersion accepts the clean version aube init writes on debug builds" {
 	_make_script_project
-	clean="$(aube --version | awk '{print $2}' | sed 's/-DEBUG$//')"
+	clean="$(aube --version | awk '{print $1}' | sed 's/-DEBUG$//')"
 	node -e 'let p=require("./package.json"); p.packageManager=`aube@'"$clean"'`; require("fs").writeFileSync("package.json", JSON.stringify(p))'
 	{
 		echo "packageManagerStrictVersion=true"

--- a/test/settings.bats
+++ b/test/settings.bats
@@ -231,19 +231,17 @@ _make_env_probe_project() {
 	cat >"$cache_dir/update-check.json" <<-JSON
 		{"checked_at": $(date +%s), "latest": "999.0.0"}
 	JSON
-	run aube install
+	run aube --version
 	assert_success
 	refute_output --partial "is available"
 	refute_output --partial "upgrade:"
 }
 
-@test "aube add from subdirectory honors project-root updateNotifier=false" {
+@test "aube --version from subdirectory honors project-root updateNotifier=false" {
 	_setup_basic_fixture
-	# Project-root .npmrc (not $HOME) — the bug being covered is that
-	# the notifier's settings lookup was using raw cwd, so a .npmrc in
-	# the project root was missed when the command ran from a subdir.
+	# Project-root .npmrc (not $HOME) — settings resolution must walk up
+	# from cwd to find the project's .npmrc when invoked from a subdir.
 	echo 'updateNotifier=false' >.npmrc
-	aube install
 	unset AUBE_NO_UPDATE_CHECK
 	local cache_dir="$HOME/.cache/aube"
 	mkdir -p "$cache_dir"
@@ -252,7 +250,7 @@ _make_env_probe_project() {
 	JSON
 	mkdir -p sub
 	cd sub
-	run aube add is-number
+	run aube --version
 	assert_success
 	refute_output --partial "is available"
 	refute_output --partial "upgrade:"


### PR DESCRIPTION
## Summary

Two related changes:

### 1. Scope the update notifier to version-asking commands

Notifier used to fire after every `install`, `add`, `update` — the three most-run commands. The 24h cache kept the network cost low but the *eprintln!* still appeared on every cold-cache day. Moves the trigger to commands a user runs when they're explicitly asking about versions: `aube doctor` and `aube --version` / `-V`. The package.json bumper `aube version` is **not** a trigger (it's a write command, not a version query).

| command | before | after |
| --- | --- | --- |
| `aube install` | notifier fires | silent |
| `aube add <pkg>` | notifier fires | silent |
| `aube update` | notifier fires | silent |
| `aube doctor` | silent | notifier fires |
| `aube --version` / `-V` | silent | notifier fires |
| `aube version [bump]` | silent | silent (unchanged) |

Replaces clap's auto `Action::Version` with a manual `--version` / `-V` flag handled at the top of `async_main`, so the async update check can run alongside the version print (clap's auto action exits inside `parse_from`, before the tokio runtime is built).

Drops the now-dead `offline` parameter from `update_check::check_and_notify` and the `post_add_update_notify` helper. The `updateNotifier=false` setting, `AUBE_NO_UPDATE_CHECK`, and `CI` gates all still work.

### 2. Mise-style `--version` output

`aube --version` / `-V` now prints, e.g.
```
1.1.0-DEBUG macos-arm64 (2026-04-25)
```
instead of the bare `aube 1.1.0-DEBUG`. The os-arch and build-date disambiguate which binary the user is running across machines. Format mirrors `mise --version`.

Wiring:
- `build.rs` shells out to `date` / `Get-Date` (zero new deps) and exposes `AUBE_BUILD_DATE` via `cargo:rustc-env`.
- `version.rs` gains `VERSION_LONG` (formatted output) alongside the existing short `VERSION` — the install progress header keeps using the short form (`aube 1.1.0-DEBUG by en.dev · ...`) where the surrounding line is busy.
- `main.rs` uses `VERSION_LONG` for clap's `version =` attribute and the manual `--version` handler. The `aube usage` path's `.version(env!("CARGO_PKG_VERSION"))` override still pins KDL output to the bare semver, so docs builds stay byte-stable.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release -p aube` (286 unit + 4 e2e pass, including `version_flag_reports_binary_version` and `cli_ordering_tests::test_cli_ordering`)
- [x] `mise run test:bats test/settings.bats` (18/18 — including the two migrated `updateNotifier=false` regression tests, now exercising `aube --version` instead of `aube install` / `aube add`)
- [x] Manual smoke: cache file is touched on `aube --version` / `-V` / `aube doctor` and untouched on `aube install` / `aube version` (the bumper). `AUBE_NO_UPDATE_CHECK=1` still suppresses the check. Install progress header still renders the short version form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes global CLI parsing/dispatch around `--version` and moves the update notifier trigger points, which can affect user-visible behavior and network/cache writes across common workflows.
> 
> **Overview**
> Switches `--version`/`-V` to a **manual global flag** (disabling clap’s built-in version action) so the CLI can print version and then run the async update notifier.
> 
> Changes `aube --version` output to a *mise-style* long form (`<ver> <os>-<arch> (<YYYY-MM-DD>)`) by adding a build-time `AUBE_BUILD_DATE` env var (`build.rs`) and a new `version::VERSION_LONG` formatter.
> 
> Scopes the update notifier to **version-asking commands only** (`aube doctor` and `aube --version`), removing notifier calls after `install`/`add`/`update` and dropping the now-unused `offline` parameter from `update_check::check_and_notify`; updates CLI docs and tests to match the new behavior/output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f80a5808dbd2b6829dbe8dff71e09fd99dcebfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->