### PR TITLE
fix(lockfile): synthesize npm-alias entries when reading pnpm v9 lockfiles

### DIFF
--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -21,80 +21,114 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     let mut local_packages: BTreeMap<String, LockedPackage> = BTreeMap::new();
     let mut skipped_optional_dependencies: BTreeMap<String, BTreeMap<String, String>> =
         BTreeMap::new();
+    // pnpm v9 encodes npm-aliases implicitly: the importer key is
+    // the alias (`express-fork`), `specifier:` carries `npm:<real>@<range>`,
+    // and `version:` is `<real>@<resolved>`. There is no `aliasOf:`
+    // field — that's an aube-specific writer extension. We record
+    // each alias here and synthesize an alias-keyed LockedPackage
+    // after the canonical packages loop, mirroring the shape the
+    // resolver-fresh path emits so the linker stays single-shape.
+    // Tuple: (alias_dep_path, real_dep_path, real_name).
+    let mut alias_remaps: Vec<(String, String, String)> = Vec::new();
 
-    let mut push_direct =
-        |deps: &mut Vec<DirectDep>, name: &str, info: &RawDepSpec, dep_type: DepType| {
-            // pnpm appends a `(peer@ver)` suffix to the importer
-            // `version:` of URL- and git-based direct deps when the
-            // resolved snapshot carries peer context, the same way it
-            // does for semver versions. `LocalSource::parse` treats the
-            // whole string as the URL, so a RemoteTarballSource built
-            // from the raw value fetches `…/tar.gz/SHA(peer@ver)` and
-            // 404s. Strip it here so the URL that reaches the fetcher
-            // and the dep_path hash are both peer-context-free —
-            // consistent with what `parse_dep_path` does for snapshot
-            // keys downstream.
-            let classify_version = info.version.split('(').next().unwrap_or(&info.version);
-            if let Some(local) = LocalSource::parse(classify_version, Path::new("")) {
-                // `Path::new("")` means tarball-vs-dir classification is
-                // skipped; we default to Directory and rely on the
-                // resolver's on-disk re-read for the authoritative source
-                // type during a subsequent `aube install` (lockfile-only
-                // path never materializes local deps anyway before the
-                // fetch step re-classifies).
-                //
-                // Re-classify Directory → Tarball if the path looks
-                // like a tarball filename, so `.tgz`/`.tar.gz`
-                // targets round-trip correctly even when the file
-                // isn't present at parse time. The filename
-                // heuristic lives on `LocalSource` so this stays in
-                // lockstep with `LocalSource::parse`.
-                let local = match local {
-                    LocalSource::Directory(p) if LocalSource::path_looks_like_tarball(&p) => {
-                        LocalSource::Tarball(p)
+    let mut push_direct = |deps: &mut Vec<DirectDep>,
+                           alias_remaps: &mut Vec<(String, String, String)>,
+                           name: &str,
+                           info: &RawDepSpec,
+                           dep_type: DepType| {
+        // pnpm appends a `(peer@ver)` suffix to the importer
+        // `version:` of URL- and git-based direct deps when the
+        // resolved snapshot carries peer context, the same way it
+        // does for semver versions. `LocalSource::parse` treats the
+        // whole string as the URL, so a RemoteTarballSource built
+        // from the raw value fetches `…/tar.gz/SHA(peer@ver)` and
+        // 404s. Strip it here so the URL that reaches the fetcher
+        // and the dep_path hash are both peer-context-free —
+        // consistent with what `parse_dep_path` does for snapshot
+        // keys downstream.
+        let classify_version = info.version.split('(').next().unwrap_or(&info.version);
+        if let Some(local) = LocalSource::parse(classify_version, Path::new("")) {
+            // `Path::new("")` means tarball-vs-dir classification is
+            // skipped; we default to Directory and rely on the
+            // resolver's on-disk re-read for the authoritative source
+            // type during a subsequent `aube install` (lockfile-only
+            // path never materializes local deps anyway before the
+            // fetch step re-classifies).
+            //
+            // Re-classify Directory → Tarball if the path looks
+            // like a tarball filename, so `.tgz`/`.tar.gz`
+            // targets round-trip correctly even when the file
+            // isn't present at parse time. The filename
+            // heuristic lives on `LocalSource` so this stays in
+            // lockstep with `LocalSource::parse`.
+            let local = match local {
+                LocalSource::Directory(p) if LocalSource::path_looks_like_tarball(&p) => {
+                    LocalSource::Tarball(p)
+                }
+                // Importer `version:` for git deps is the canonical
+                // `<url>#<commit>` form pnpm writes. The parser
+                // puts the `<commit>` into `committish`; since
+                // this is a lockfile round-trip (not a raw user
+                // spec), treat it as the pinned commit.
+                LocalSource::Git(mut g) if g.resolved.is_empty() => {
+                    if let Some(c) = g.committish.take() {
+                        g.resolved = c;
                     }
-                    // Importer `version:` for git deps is the canonical
-                    // `<url>#<commit>` form pnpm writes. The parser
-                    // puts the `<commit>` into `committish`; since
-                    // this is a lockfile round-trip (not a raw user
-                    // spec), treat it as the pinned commit.
-                    LocalSource::Git(mut g) if g.resolved.is_empty() => {
-                        if let Some(c) = g.committish.take() {
-                            g.resolved = c;
-                        }
-                        LocalSource::Git(g)
-                    }
-                    other => other,
-                };
-                let dep_path = local.dep_path(name);
-                deps.push(DirectDep {
+                    LocalSource::Git(g)
+                }
+                other => other,
+            };
+            let dep_path = local.dep_path(name);
+            deps.push(DirectDep {
+                name: name.to_string(),
+                dep_path: dep_path.clone(),
+                dep_type,
+                specifier: Some(info.specifier.clone()),
+            });
+            local_packages
+                .entry(dep_path.clone())
+                .or_insert_with(|| LockedPackage {
                     name: name.to_string(),
-                    dep_path: dep_path.clone(),
-                    dep_type,
-                    specifier: Some(info.specifier.clone()),
+                    version: "0.0.0".to_string(),
+                    integrity: None,
+                    dependencies: BTreeMap::new(),
+                    peer_dependencies: BTreeMap::new(),
+                    peer_dependencies_meta: BTreeMap::new(),
+                    dep_path,
+                    local_source: Some(local),
+                    ..Default::default()
                 });
-                local_packages
-                    .entry(dep_path.clone())
-                    .or_insert_with(|| LockedPackage {
-                        name: name.to_string(),
-                        version: "0.0.0".to_string(),
-                        integrity: None,
-                        dependencies: BTreeMap::new(),
-                        peer_dependencies: BTreeMap::new(),
-                        peer_dependencies_meta: BTreeMap::new(),
-                        dep_path,
-                        local_source: Some(local),
-                        ..Default::default()
-                    });
+        } else {
+            let dep_path = if info.specifier.starts_with("npm:")
+                && let Some((real_name, resolved)) = parse_dep_path(&info.version)
+                && real_name != name
+            {
+                // npm-alias: importer key is the alias, `version:`
+                // is `<real>@<resolved>`. Re-key the dep_path under
+                // the alias so it lines up with the resolver-fresh
+                // shape; record the remap so the canonical-packages
+                // loop can synthesize a matching LockedPackage with
+                // `alias_of: Some(real_name)`.
+                let peer_suffix = info
+                    .version
+                    .find('(')
+                    .map(|i| &info.version[i..])
+                    .unwrap_or("");
+                let alias_dep_path = format!("{name}@{resolved}{peer_suffix}");
+                let real_dep_path = info.version.clone();
+                alias_remaps.push((alias_dep_path.clone(), real_dep_path, real_name));
+                alias_dep_path
             } else {
-                deps.push(DirectDep {
-                    name: name.to_string(),
-                    dep_path: version_to_dep_path(name, &info.version),
-                    dep_type,
-                    specifier: Some(info.specifier.clone()),
-                });
-            }
-        };
+                version_to_dep_path(name, &info.version)
+            };
+            deps.push(DirectDep {
+                name: name.to_string(),
+                dep_path,
+                dep_type,
+                specifier: Some(info.specifier.clone()),
+            });
+        }
+    };
 
     for (importer_path, importer) in &raw.importers {
         // pnpm writes the workspace root as either `'.'` (most
@@ -123,17 +157,23 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
 
         if let Some(ref d) = importer.dependencies {
             for (name, info) in d {
-                push_direct(&mut deps, name, info, DepType::Production);
+                push_direct(
+                    &mut deps,
+                    &mut alias_remaps,
+                    name,
+                    info,
+                    DepType::Production,
+                );
             }
         }
         if let Some(ref d) = importer.dev_dependencies {
             for (name, info) in d {
-                push_direct(&mut deps, name, info, DepType::Dev);
+                push_direct(&mut deps, &mut alias_remaps, name, info, DepType::Dev);
             }
         }
         if let Some(ref d) = importer.optional_dependencies {
             for (name, info) in d {
-                push_direct(&mut deps, name, info, DepType::Optional);
+                push_direct(&mut deps, &mut alias_remaps, name, info, DepType::Optional);
             }
         }
 
@@ -421,6 +461,37 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 extra_meta: BTreeMap::new(),
             },
         );
+    }
+
+    // Synthesize alias-keyed LockedPackages for npm-aliased importer
+    // deps. pnpm v9 only writes the canonical (real-name-keyed) entry
+    // in `packages:`; we clone it under the alias dep_path with
+    // `name=alias` and `alias_of=Some(real)` so the linker — which
+    // already supports this shape via the resolver-fresh path — can
+    // create `node_modules/<alias>` symlinks correctly.
+    for (alias_dep_path, real_dep_path, real_name) in alias_remaps {
+        // Skip if the alias entry already exists (aube-written
+        // lockfile that emitted both `aliasOf:` and an alias-keyed
+        // packages entry).
+        if packages.contains_key(&alias_dep_path) {
+            continue;
+        }
+        let Some(real_pkg) = packages.get(&real_dep_path) else {
+            return Err(Error::parse(
+                path,
+                format!(
+                    "npm-alias importer references missing package {real_dep_path} (alias dep_path: {alias_dep_path})"
+                ),
+            ));
+        };
+        let (alias_name, _) = parse_dep_path(&alias_dep_path).ok_or_else(|| {
+            Error::parse(path, format!("invalid alias dep path: {alias_dep_path}"))
+        })?;
+        let mut aliased = real_pkg.clone();
+        aliased.name = alias_name;
+        aliased.dep_path = alias_dep_path.clone();
+        aliased.alias_of = Some(real_name);
+        packages.insert(alias_dep_path, aliased);
     }
 
     for (k, v) in local_packages {
@@ -2844,5 +2915,65 @@ snapshots:
             !names.contains(&"pnpm"),
             "bootstrap doc's packageManagerDependencies should not leak in, got {names:?}"
         );
+    }
+
+    #[test]
+    fn parse_synthesizes_npm_alias_from_pnpm_v9_lockfile() {
+        // pnpm v9 encodes npm-aliases implicitly (importer key is the
+        // alias, `version:` is `<real>@<resolved>`, no `aliasOf:`
+        // field on the package entry). The reader must reconstruct
+        // an alias-keyed LockedPackage with `alias_of=Some(real)` so
+        // the linker creates `node_modules/<alias>` correctly.
+        // Repro: https://github.com/rubnogueira/aube-exotic-bug
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &path,
+            r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      express-fork:
+        specifier: npm:express@^4.22.1
+        version: express@4.22.1
+
+packages:
+  express@4.22.1:
+    resolution: {integrity: sha512-fake}
+    engines: {node: '>= 0.10.0'}
+
+snapshots:
+  express@4.22.1: {}
+"#,
+        )
+        .unwrap();
+
+        let graph = parse(&path).unwrap();
+
+        let root = graph.importers.get(".").expect("root importer");
+        assert_eq!(root.len(), 1);
+        let dep = &root[0];
+        assert_eq!(dep.name, "express-fork", "DirectDep keeps the alias name");
+        assert_eq!(
+            dep.dep_path, "express-fork@4.22.1",
+            "DirectDep dep_path is alias-keyed (not the malformed express-fork@express@4.22.1)"
+        );
+        assert_eq!(dep.specifier.as_deref(), Some("npm:express@^4.22.1"));
+
+        let pkg = graph
+            .packages
+            .get("express-fork@4.22.1")
+            .expect("synthesized alias-keyed package");
+        assert_eq!(pkg.name, "express-fork");
+        assert_eq!(pkg.alias_of.as_deref(), Some("express"));
+        assert_eq!(pkg.dep_path, "express-fork@4.22.1");
+        // Real-keyed entry stays in place — other importers may
+        // reference the package directly, and the canonical entry is
+        // needed for byte-identical round-trips back to pnpm format.
+        let real = graph.packages.get("express@4.22.1").expect("real entry");
+        assert_eq!(real.name, "express");
+        assert!(real.alias_of.is_none());
     }
 }

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -28,11 +28,11 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     // each alias here and synthesize an alias-keyed LockedPackage
     // after the canonical packages loop, mirroring the shape the
     // resolver-fresh path emits so the linker stays single-shape.
-    // Tuple: (alias_dep_path, real_dep_path, real_name).
-    let mut alias_remaps: Vec<(String, String, String)> = Vec::new();
+    // Tuple: (alias_dep_path, real_dep_path, alias_name, real_name).
+    let mut alias_remaps: Vec<(String, String, String, String)> = Vec::new();
 
     let mut push_direct = |deps: &mut Vec<DirectDep>,
-                           alias_remaps: &mut Vec<(String, String, String)>,
+                           alias_remaps: &mut Vec<(String, String, String, String)>,
                            name: &str,
                            info: &RawDepSpec,
                            dep_type: DepType| {
@@ -116,7 +116,12 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                     .unwrap_or("");
                 let alias_dep_path = format!("{name}@{resolved}{peer_suffix}");
                 let real_dep_path = info.version.clone();
-                alias_remaps.push((alias_dep_path.clone(), real_dep_path, real_name));
+                alias_remaps.push((
+                    alias_dep_path.clone(),
+                    real_dep_path,
+                    name.to_string(),
+                    real_name,
+                ));
                 alias_dep_path
             } else {
                 version_to_dep_path(name, &info.version)
@@ -469,7 +474,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     // `name=alias` and `alias_of=Some(real)` so the linker — which
     // already supports this shape via the resolver-fresh path — can
     // create `node_modules/<alias>` symlinks correctly.
-    for (alias_dep_path, real_dep_path, real_name) in alias_remaps {
+    for (alias_dep_path, real_dep_path, alias_name, real_name) in alias_remaps {
         // Skip if the alias entry already exists (aube-written
         // lockfile that emitted both `aliasOf:` and an alias-keyed
         // packages entry).
@@ -484,9 +489,6 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 ),
             ));
         };
-        let (alias_name, _) = parse_dep_path(&alias_dep_path).ok_or_else(|| {
-            Error::parse(path, format!("invalid alias dep path: {alias_dep_path}"))
-        })?;
         let mut aliased = real_pkg.clone();
         aliased.name = alias_name;
         aliased.dep_path = alias_dep_path.clone();
@@ -2974,6 +2976,55 @@ snapshots:
         // needed for byte-identical round-trips back to pnpm format.
         let real = graph.packages.get("express@4.22.1").expect("real entry");
         assert_eq!(real.name, "express");
+        assert!(real.alias_of.is_none());
+    }
+
+    #[test]
+    fn parse_synthesizes_npm_alias_when_real_name_is_scoped() {
+        // Scoped real package + non-scoped alias: `parse_dep_path` must
+        // correctly split `@scope/pkg` from the version when the
+        // version field is `@scope/pkg@1.0.0`.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &path,
+            r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      types-alias:
+        specifier: npm:@types/node@^20.0.0
+        version: '@types/node@20.11.0'
+
+packages:
+  '@types/node@20.11.0':
+    resolution: {integrity: sha512-fake}
+
+snapshots:
+  '@types/node@20.11.0': {}
+"#,
+        )
+        .unwrap();
+
+        let graph = parse(&path).unwrap();
+
+        let root = graph.importers.get(".").expect("root importer");
+        assert_eq!(root[0].name, "types-alias");
+        assert_eq!(root[0].dep_path, "types-alias@20.11.0");
+
+        let pkg = graph
+            .packages
+            .get("types-alias@20.11.0")
+            .expect("synthesized alias-keyed package");
+        assert_eq!(pkg.name, "types-alias");
+        assert_eq!(pkg.alias_of.as_deref(), Some("@types/node"));
+        let real = graph
+            .packages
+            .get("@types/node@20.11.0")
+            .expect("real entry");
+        assert_eq!(real.name, "@types/node");
         assert!(real.alias_of.is_none());
     }
 }

--- a/test/install.bats
+++ b/test/install.bats
@@ -946,3 +946,71 @@ JSON
 	assert_link_exists node_modules/odd-alias
 	assert_not_exists node_modules/is-odd
 }
+
+@test "aube install handles npm-alias from a pnpm v9 lockfile" {
+	# Repro: https://github.com/rubnogueira/aube-exotic-bug
+	#
+	# pnpm v9 encodes npm-aliases implicitly — importer key is the
+	# alias, `version:` is `<real>@<resolved>`, no `aliasOf:` field
+	# on the package entry. Hand-write that exact shape so we exercise
+	# the lockfile-read path (not the resolver-fresh path the sibling
+	# test above covers).
+	cat >package.json <<'JSON'
+{
+  "name": "alias-frozen",
+  "version": "1.0.0",
+  "dependencies": {
+    "odd-renamed": "npm:is-odd@^3.0.1"
+  }
+}
+JSON
+	cat >pnpm-lock.yaml <<'YAML'
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      odd-renamed:
+        specifier: npm:is-odd@^3.0.1
+        version: is-odd@3.0.1
+
+packages:
+
+  is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+
+snapshots:
+
+  is-number@6.0.0: {}
+
+  is-odd@3.0.1:
+    dependencies:
+      is-number: 6.0.0
+YAML
+
+	run aube install --frozen-lockfile
+	assert_success
+
+	# The bug: aube was building dep_path `odd-renamed@is-odd@3.0.1`
+	# and the linker silently skipped it. With the fix, the alias
+	# folder must exist as a symlink in node_modules.
+	assert_link_exists node_modules/odd-renamed
+	assert_not_exists node_modules/is-odd
+
+	# Resolves to the real `is-odd` package.json — its `name:` field
+	# stays `is-odd` even though the symlink is `odd-renamed`. Node's
+	# resolver keys off the symlink path, not the package.json name.
+	run cat node_modules/odd-renamed/package.json
+	assert_success
+	assert_output --partial '"name": "is-odd"'
+}


### PR DESCRIPTION
## Summary

- Fix npm-alias deps (e.g. `"express-fork": "npm:express@^4.22.1"`) silently failing to link when reading a pnpm v9 lockfile — `node_modules/<alias>` was never created.
- The pnpm v9 reader was building a malformed dep_path (`express-fork@express@4.22.1`) because pnpm v9 encodes aliases implicitly with no `aliasOf:` field on the package entry. The reader now detects `npm:` specifiers, re-keys the dep_path under the alias, and synthesizes an alias-keyed `LockedPackage` matching the shape the resolver-fresh path already emits.
- Repro: https://github.com/rubnogueira/aube-exotic-bug — `aube install && node index.js` was failing with `MODULE_NOT_FOUND` while `pnpm install && node index.js` worked. Now both work.

## Why

pnpm v9 lockfiles encode aliases as:
```yaml
importers:
  .:
    dependencies:
      express-fork:                       # alias = importer key
        specifier: npm:express@^4.22.1    # real name lives in specifier
        version: express@4.22.1           # <real>@<resolved>
packages:
  express@4.22.1: { ... }                 # canonical key uses real name
```

Aube already supported aliases on the **fresh-resolve** path (commit 2f6d6776 introduced `task.real_name` + the `aliasOf:` writer extension), and aube's own emitted lockfiles round-trip correctly via that field. The bug only surfaced when consuming a pnpm-authored lockfile where the alias has to be reconstructed from the importer key + `npm:` specifier + `<real>@<resolved>` shape of the `version:` field.

## What changed

`crates/aube-lockfile/src/pnpm.rs`
- `push_direct` now detects `info.specifier.starts_with("npm:")` plus `parsed_real_name != importer_key` and builds `DirectDep.dep_path = "<alias>@<resolved>"` (peer-suffix-preserving), recording a remap for the canonical loop.
- After the canonical packages loop, alias remaps are walked: for each one, the canonical (real-keyed) `LockedPackage` is cloned under the alias dep_path with `name=alias` and `alias_of=Some(real)`. The original real-keyed entry is preserved so other importers can still reference it directly and pnpm round-trips stay byte-identical.
- No linker changes — the linker already handles the alias-keyed shape correctly via the resolver-fresh path.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` — 1025+ tests pass, 0 failures (incl. new unit test `parse_synthesizes_npm_alias_from_pnpm_v9_lockfile` in `crates/aube-lockfile/src/pnpm.rs`)
- [x] `mise run test:bats test/install.bats` — all 60 tests pass, including the new `aube install handles npm-alias from a pnpm v9 lockfile` test (mirrors the user's repro with a hand-written pnpm v9 lockfile + `--frozen-lockfile`)
- [x] End-to-end on the user's repro: `git clone rubnogueira/aube-exotic-bug && cd renamed-dep && aube install && node index.js` → exit 0; `import express from 'express-fork'` resolves to the express function. Verified in both default mode and the user's `enableGlobalVirtualStore: true` mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pnpm v9 lockfile parsing to rewrite alias dep paths and synthesize extra package entries, which can affect how direct dependencies are keyed and linked during installs. Risk is moderate but scoped to `npm:` alias importer entries and guarded by new unit/e2e tests.
> 
> **Overview**
> Fixes reading pnpm v9 lockfiles that contain `npm:` aliases (e.g. `alias: npm:real@^range`) so installs correctly create `node_modules/<alias>`.
> 
> During importer parsing, the reader now detects `npm:` specifiers and re-keys `DirectDep.dep_path` to an alias-shaped `<alias>@<resolved>` (preserving any peer-context suffix) while recording a remap to the real package entry. After building the `packages` map, it clones the real `LockedPackage` under the alias dep_path and sets `alias_of`, matching the resolver-produced shape.
> 
> Adds unit tests for unscoped and scoped real-package aliases, plus a Bats regression test exercising `aube install --frozen-lockfile` from a hand-written pnpm v9 lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcc4bc545ff6ae5c9c4e21b37eb2397354334cfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->