### PR TITLE
chore: release v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aube-util",
  "miette",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aube-util",
  "base64",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "blake3",
  "rustc-hash",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -111,14 +111,14 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.2.0" }
-aube-settings = { path = "crates/aube-settings", version = "1.2.0" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.2.0" }
-aube-registry = { path = "crates/aube-registry", version = "1.2.0" }
-aube-store = { path = "crates/aube-store", version = "1.2.0" }
-aube-linker = { path = "crates/aube-linker", version = "1.2.0" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.2.0" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.2.0" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.2.0" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.2.0" }
-aube-util = { path = "crates/aube-util", version = "1.2.0" }
+aube = { path = "crates/aube", version = "1.2.1" }
+aube-settings = { path = "crates/aube-settings", version = "1.2.1" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.2.1" }
+aube-registry = { path = "crates/aube-registry", version = "1.2.1" }
+aube-store = { path = "crates/aube-store", version = "1.2.1" }
+aube-linker = { path = "crates/aube-linker", version = "1.2.1" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.2.1" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.2.1" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.2.1" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.2.1" }
+aube-util = { path = "crates/aube-util", version = "1.2.1" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.2.0"
+version "1.2.1"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/endevco/aube/compare/aube-linker-v1.2.0...aube-linker-v1.2.1) - 2026-04-26
+
+### Fixed
+
+- *(linker)* skip self-named deps regardless of version ([#321](https://github.com/endevco/aube/pull/321))
+
 ## [1.2.0](https://github.com/endevco/aube/compare/aube-linker-v1.1.0...aube-linker-v1.2.0) - 2026-04-25
 
 ### Fixed

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/endevco/aube/compare/aube-lockfile-v1.2.0...aube-lockfile-v1.2.1) - 2026-04-26
+
+### Fixed
+
+- pnpm snapshot round-trip + workspace negation patterns ([#312](https://github.com/endevco/aube/pull/312))
+
 ## [1.2.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.1.0...aube-lockfile-v1.2.0) - 2026-04-25
 
 ### Fixed

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/endevco/aube/compare/aube-registry-v1.2.0...aube-registry-v1.2.1) - 2026-04-26
+
+### Fixed
+
+- *(registry)* raise fetch timeout default ([#323](https://github.com/endevco/aube/pull/323))
+
+### Other
+
+- *(resolver)* avoid full packuments for aged metadata ([#314](https://github.com/endevco/aube/pull/314))
+
 ## [1.2.0](https://github.com/endevco/aube/compare/aube-registry-v1.1.0...aube-registry-v1.2.0) - 2026-04-25
 
 ### Added

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/endevco/aube/compare/aube-resolver-v1.2.0...aube-resolver-v1.2.1) - 2026-04-26
+
+### Fixed
+
+- *(install)* keep transitive peers out of root modules ([#316](https://github.com/endevco/aube/pull/316))
+- pnpm snapshot round-trip + workspace negation patterns ([#312](https://github.com/endevco/aube/pull/312))
+
+### Other
+
+- *(resolver)* avoid full packuments for aged metadata ([#314](https://github.com/endevco/aube/pull/314))
+
 ## [1.2.0](https://github.com/endevco/aube/compare/aube-resolver-v1.1.0...aube-resolver-v1.2.0) - 2026-04-25
 
 ### Fixed

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/endevco/aube/compare/aube-settings-v1.2.0...aube-settings-v1.2.1) - 2026-04-26
+
+### Fixed
+
+- *(registry)* raise fetch timeout default ([#323](https://github.com/endevco/aube/pull/323))
+- *(install)* keep transitive peers out of root modules ([#316](https://github.com/endevco/aube/pull/316))
+
 ## [1.2.0](https://github.com/endevco/aube/compare/aube-settings-v1.1.0...aube-settings-v1.2.0) - 2026-04-25
 
 ### Added

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/endevco/aube/compare/aube-workspace-v1.2.0...aube-workspace-v1.2.1) - 2026-04-26
+
+### Fixed
+
+- pnpm snapshot round-trip + workspace negation patterns ([#312](https://github.com/endevco/aube/pull/312))
+
 ## [1.0.0](https://github.com/endevco/aube/compare/aube-workspace-v1.0.0-beta.12...aube-workspace-v1.0.0) - 2026-04-23
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/endevco/aube/compare/v1.2.0...v1.2.1) - 2026-04-26
+
+### Fixed
+
+- *(add)* preserve package manifest field order ([#315](https://github.com/endevco/aube/pull/315))
+
+### Other
+
+- *(resolver)* avoid full packuments for aged metadata ([#314](https://github.com/endevco/aube/pull/314))
+
 ## [1.2.0](https://github.com/endevco/aube/compare/v1.1.0...v1.2.0) - 2026-04-25
 
 ### Added

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5789,7 +5789,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.2.0
+**Version**: 1.2.1
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.2.0",
-  "releasedAt": "2026-04-25T18:16:41Z"
+  "version": "1.2.1",
+  "releasedAt": "2026-04-26T19:13:33Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.2.1`

This PR bumps the workspace to `v1.2.1` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
