### PR TITLE
perf(resolver): avoid full packuments for aged metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ clap = { version = "4", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 
 # HTTP
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "http2", "charset", "system-proxy", "brotli", "zstd"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "http2", "charset", "system-proxy", "gzip", "brotli", "zstd"] }
 
 # Hashing
 sha1 = "0.10"

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -107,6 +107,8 @@ pub enum NetworkMode {
 pub struct Packument {
     pub name: String,
     #[serde(default)]
+    pub modified: Option<String>,
+    #[serde(default)]
     pub versions: BTreeMap<String, VersionMetadata>,
     #[serde(
         rename = "dist-tags",
@@ -569,6 +571,17 @@ mod tests {
     fn packument_dist_tags_null_whole_field_is_empty() {
         let p = parse_packument(r#"{"name":"pkg","dist-tags":null}"#);
         assert!(p.dist_tags.is_empty());
+    }
+
+    #[test]
+    fn packument_preserves_modified_timestamp() {
+        let p = parse_packument(
+            r#"{
+                "name": "pkg",
+                "modified": "2026-04-14T14:26:11.557Z"
+            }"#,
+        );
+        assert_eq!(p.modified.as_deref(), Some("2026-04-14T14:26:11.557Z"));
     }
 
     #[test]

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -147,6 +147,8 @@ impl Resolver {
         let needs_time = (self.resolution_mode == ResolutionMode::TimeBased
             || self.minimum_release_age.is_some())
             && !self.registry_supports_time_field;
+        let minimum_release_age_only =
+            self.resolution_mode != ResolutionMode::TimeBased && self.minimum_release_age.is_some();
         // In-flight packument fetches. The spawned task returns the
         // `(name, packument)` tuple so `join_next` gives us back the
         // identity of whichever fetch landed next without a side
@@ -205,6 +207,7 @@ impl Resolver {
                     let client = self.client.clone();
                     let cache_dir = self.packument_cache_dir.clone();
                     let full_cache_dir = self.packument_full_cache_dir.clone();
+                    let cutoff = published_by.clone();
                     let sem = shared_semaphore.clone();
                     in_flight.spawn(async move {
                         let _permit = sem
@@ -212,6 +215,23 @@ impl Resolver {
                             .await
                             .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
                         let packument = if needs_time {
+                            if minimum_release_age_only
+                                && let (Some(dir), Some(cutoff)) =
+                                    (cache_dir.as_ref(), cutoff.as_deref())
+                                && full_cache_dir.is_some()
+                            {
+                                let packument = client
+                                    .fetch_packument_cached(&name_owned, dir)
+                                    .await
+                                    .map_err(|e| {
+                                        Error::Registry(name_owned.clone(), e.to_string())
+                                    })?;
+                                if packument.modified.as_deref().is_some_and(|modified| {
+                                    modified_allows_short_circuit(modified, cutoff)
+                                }) {
+                                    return Ok::<_, Error>((name_owned, packument));
+                                }
+                            }
                             match full_cache_dir.as_ref() {
                                 Some(dir) => {
                                     client
@@ -1830,6 +1850,10 @@ impl Resolver {
         );
         Ok(contextualized)
     }
+}
+
+pub(crate) fn modified_allows_short_circuit(modified: &str, cutoff: &str) -> bool {
+    modified.ends_with('Z') && modified <= cutoff
 }
 
 /// Seed the BFS queue with direct deps from every importer manifest.

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::resolve::modified_allows_short_circuit;
 use aube_registry::{Dist, Packument, VersionMetadata};
 use miette::Diagnostic;
 
@@ -596,6 +597,7 @@ fn make_packument(name: &str, versions: &[&str], latest: &str) -> Packument {
     dist_tags.insert("latest".to_string(), latest.to_string());
     Packument {
         name: name.to_string(),
+        modified: None,
         versions: ver_map,
         dist_tags,
         time: BTreeMap::new(),
@@ -744,6 +746,86 @@ fn test_minimum_release_age_cutoff_format() {
 fn test_minimum_release_age_zero_disables() {
     let mra = MinimumReleaseAge::default();
     assert!(mra.cutoff().is_none());
+}
+
+#[test]
+fn minimum_release_age_modified_short_circuit_requires_utc_timestamp() {
+    let cutoff = "2024-06-01T10:00:00.000Z";
+
+    assert!(modified_allows_short_circuit(
+        "2024-06-01T09:59:59.000Z",
+        cutoff
+    ));
+    assert!(!modified_allows_short_circuit(
+        "2024-06-01T10:00:00-05:00",
+        cutoff
+    ));
+}
+
+#[tokio::test]
+async fn minimum_release_age_uses_modified_to_skip_full_packument() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut packument = make_packument("foo", &["1.0.0"], "1.0.0");
+    packument.modified = Some("2024-01-01T00:00:00.000Z".to_string());
+    let body = serde_json::to_vec(&packument).unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let requests = Arc::new(AtomicUsize::new(0));
+    let request_count = requests.clone();
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            request_count.fetch_add(1, Ordering::Relaxed);
+            let body = body.clone();
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 2048];
+                let _ = socket.read(&mut buf).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+                socket.write_all(&body).await.unwrap();
+            });
+        }
+    });
+
+    let base = std::env::temp_dir().join(format!(
+        "aube-resolver-mra-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let cache_dir = base.join("packuments");
+    let full_cache_dir = base.join("packuments-full");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::create_dir_all(&full_cache_dir).unwrap();
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let mut resolver = Resolver::new(client)
+        .with_packument_cache(cache_dir)
+        .with_packument_full_cache(full_cache_dir)
+        .with_minimum_release_age(Some(MinimumReleaseAge {
+            minutes: 60,
+            ..Default::default()
+        }));
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("foo".to_string(), "1.0.0".to_string());
+
+    let graph = resolver.resolve(&manifest, None).await.unwrap();
+
+    assert!(graph_has_package(&graph, "foo", "1.0.0"));
+    assert_eq!(requests.load(Ordering::Relaxed), 1);
+    server.abort();
+    let _ = std::fs::remove_dir_all(base);
 }
 
 #[test]

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -587,6 +587,7 @@ mod tests {
     fn packument_with_versions(versions: &[&str]) -> Packument {
         let mut packument = Packument {
             name: "demo".to_string(),
+            modified: None,
             versions: BTreeMap::new(),
             dist_tags: BTreeMap::new(),
             time: BTreeMap::new(),


### PR DESCRIPTION
## Summary

Avoid fetching full npm packuments for the default `minimumReleaseAge` path when the abbreviated packument already proves the package is old enough.

npm's abbreviated install metadata includes a top-level `modified` timestamp. If that timestamp is older than the minimum-release-age cutoff, then every version in that packument is necessarily older than the cutoff, so the resolver can safely use the small abbreviated payload without fetching the full packument just to read the per-version `time` map.

This keeps aube's secure default intact while removing a large amount of cold clean-install metadata traffic on public npm registry benchmarks. The PR also enables reqwest's `gzip` feature; the npm registry serves full packuments with gzip compression, and our custom reqwest feature set had accidentally opted out of that decoder.

## Review feedback addressed

- Avoid the extra abbreviated-packument probe when there is no full-packument fallback cache configured.
- Add a resolver-level test proving an old-enough `modified` timestamp short-circuits full packument fetches.
- Require `modified` to be in UTC `...Z` form before using lexicographic comparison; offset timestamps fall back to full packument metadata.

## Validation

- `cargo fmt --check`
- `cargo check -p aube-resolver -p aube-registry -p aube`
- `cargo check -p aube-resolver`
- `cargo test -p aube-registry packument_preserves_modified_timestamp -- --nocapture`
- `cargo test -p aube-resolver minimum_release_age -- --nocapture`
- `cargo tree -p aube-registry -e features -i reqwest` confirms the `gzip` feature is active
- pre-commit hook ran crate-local `cargo fmt --check` and `cargo clippy` for touched Rust files

## vlt clean benchmark

Important caveat: my first full local table used isolated `XDG_CACHE_HOME`/`XDG_DATA_HOME`, but vlt's `clean_aube_cache` only removes `$HOME/.cache/aube` and legacy `$HOME/.aube-store`. That made aube's metadata cache warmer than the hosted-style run, so those full-table numbers are directional only.

Targeted CI-shaped rerun before the gzip feature: `CI=1`, no XDG overrides, isolated `HOME`, `--runs=2 --warmup=0`, aube-only. Pre-base aube was built from `ba6b62b`; PR aube was built from this branch.

| fixture | aube PR | aube pre-base |
| --- | ---: | ---: |
| svelte | 523.4 ms ± 67.2 ms | 1247.0 ms ± 87.7 ms |
| vue | 2518.7 ms ± 653.5 ms | 7546.8 ms ± 7114.2 ms |

Corrected comparison run before the gzip feature: `CI=1`, no XDG overrides, isolated `HOME`, `--runs=2 --warmup=0`, `--pms=aube,pnpm,bun`.

| fixture | aube PR | bun | pnpm | aube vs bun | aube vs pnpm |
| --- | ---: | ---: | ---: | ---: | ---: |
| svelte | 668.7 ms ± 6.3 ms | 325.5 ms ± 13.8 ms | 1042.6 ms ± 83.8 ms | 2.05x slower | 1.56x faster |
| vue | 3041.8 ms ± 79.5 ms | 937.6 ms ± 46.4 ms | 2412.6 ms ± 32.3 ms | 3.24x slower | 1.26x slower |

Corrected comparison rerun after enabling reqwest gzip support. This rerun was noisier, so I ran it twice and kept the second set below.

| fixture | aube PR | bun | pnpm | aube vs bun | aube vs pnpm |
| --- | ---: | ---: | ---: | ---: | ---: |
| svelte | 575.0 ms ± 48.1 ms | 374.4 ms ± 95.3 ms | 994.5 ms ± 35.2 ms | 1.54x slower | 1.73x faster |
| vue | 3285.6 ms ± 170.0 ms | 977.0 ms ± 0.2 ms | 2435.2 ms ± 58.3 ms | 3.36x slower | 1.35x slower |

The published vlt regression is explained by full packuments under `minimumReleaseAge`: on the latest published data, `svelte clean` and `vue clean` were 21.35s and 34.73s for aube. In a local phase run on `vue`, this PR reduced the path to 462 abbreviated packuments plus 18 full packuments; those 18 remaining full packuments are packages genuinely modified after the 24-hour cutoff (`playwright`, `@typescript-eslint/*`, `caniuse-lite`, `lodash`, etc.). The gzip change is still worth keeping for that remaining path, even though this tiny benchmark sample does not show a clean `vue` win.