### PR TITLE
fix(add): preserve package manifest field order

### DIFF
--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -723,12 +723,54 @@ async fn update_manifest_for_add(
     // write the mutated manifest to disk for the duration of the
     // resolver + install pipeline (both re-read from disk), then
     // restore the original bytes from their snapshot before returning.
-    super::write_manifest_json(&manifest_path, &manifest)?;
+    write_manifest_json_for_add(&manifest_path, &manifest)?;
     if print_updated {
         eprintln!("Updated package.json");
     }
 
     Ok((manifest, workspace_catalogs))
+}
+
+fn write_manifest_json_for_add(
+    path: &Path,
+    manifest: &aube_manifest::PackageJson,
+) -> miette::Result<()> {
+    let content = std::fs::read_to_string(path)
+        .into_diagnostic()
+        .wrap_err("failed to read package.json")?;
+    let mut json: serde_json::Value = serde_json::from_str(&content)
+        .into_diagnostic()
+        .wrap_err("failed to parse package.json")?;
+    let serde_json::Value::Object(obj) = &mut json else {
+        return Err(miette!("package.json must contain a JSON object"));
+    };
+
+    sync_dep_section(obj, "dependencies", &manifest.dependencies);
+    sync_dep_section(obj, "devDependencies", &manifest.dev_dependencies);
+    sync_dep_section(obj, "peerDependencies", &manifest.peer_dependencies);
+    sync_dep_section(obj, "optionalDependencies", &manifest.optional_dependencies);
+
+    let json = serde_json::to_string_pretty(&json)
+        .into_diagnostic()
+        .wrap_err("failed to serialize package.json")?;
+    super::write_manifest_atomic(path, format!("{json}\n").as_bytes())
+}
+
+fn sync_dep_section(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    deps: &BTreeMap<String, String>,
+) {
+    if deps.is_empty() {
+        obj.remove(key);
+        return;
+    }
+
+    let section = deps
+        .iter()
+        .map(|(name, spec)| (name.clone(), serde_json::Value::String(spec.clone())))
+        .collect();
+    obj.insert(key.to_string(), serde_json::Value::Object(section));
 }
 
 /// Resolve the on-disk lockfile path that a normal `add` would write

--- a/test/add.bats
+++ b/test/add.bats
@@ -52,6 +52,42 @@ EOF
 	refute_output --partial '"dependencies"'
 }
 
+@test "aube add: preserves existing package.json top-level order" {
+	cat >package.json <<'EOF'
+{
+  "name": "test-add-order",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "test": "echo ok"
+  },
+  "devDependencies": {
+    "is-even": "^1.0.0"
+  }
+}
+EOF
+
+	run aube add -D is-odd
+	assert_success
+
+	cat >expected-package.json <<'EOF'
+{
+  "name": "test-add-order",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "test": "echo ok"
+  },
+  "devDependencies": {
+    "is-even": "^1.0.0",
+    "is-odd": "^3.0.1"
+  }
+}
+EOF
+	run diff -u expected-package.json package.json
+	assert_success
+}
+
 @test "aube add: adds specific version" {
 	cat >package.json <<'EOF'
 {


### PR DESCRIPTION
## Summary

- Preserve the existing top-level `package.json` field order when `aube add` writes dependency changes.
- Mutate the original parsed JSON object for add writes instead of round-tripping the whole typed `PackageJson` struct.
- Keep dependency sections aggressively sorted by package name, matching npm, pnpm, Yarn, and Bun add behavior.
- Add BATS coverage for the minimal top-level diff behavior reported in Discussion 313.

## Validation

- `cargo fmt --check`
- `cargo build`
- `cargo test -p aube`
- `mise run test:bats test/add.bats`
- `cargo clippy --all-targets -- -D warnings`
- commit hook staged checks: `cargo-fmt`, `cargo-clippy`, `shfmt`, `shellcheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to how `aube add` rewrites `package.json`, but could subtly affect manifest output/formatting if the existing JSON is unusual (non-object root or unexpected types).
> 
> **Overview**
> `aube add` now preserves the existing top-level `package.json` key order by re-reading the current JSON and only syncing the dependency sections (`dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`) instead of re-serializing the full manifest struct.
> 
> Adds a BATS test to assert the minimal-diff behavior, ensuring added deps don’t reorder unrelated top-level fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8246ab92559b02184b157c0f2cbc18ce2d91867b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->