### PR TITLE
fix(install): keep transitive peers out of root modules

### DIFF
--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -2,10 +2,10 @@
 //!
 //! Two user-visible passes live here:
 //!
-//! * [`hoist_auto_installed_peers`] — promotes declared-but-unmet peers
-//!   up to importer direct deps, matching pnpm's `auto-install-peers=true`
-//!   behavior. Idempotent on graphs that already ship with those hoists
-//!   (npm v7+ output, lockfile-driven installs).
+//! * [`hoist_auto_installed_peers`] — promotes peers declared by direct
+//!   dependencies up to importer direct deps, matching pnpm's
+//!   `auto-install-peers=true` behavior. Idempotent on graphs that already
+//!   ship with those hoists (npm v7+ output, lockfile-driven installs).
 //! * [`apply_peer_contexts`] — computes pnpm-style `(peer@ver)` suffixes
 //!   on contextualized `dep_path`s. Drives the sibling-symlink wiring in
 //!   `aube-linker` so each subtree that pins different peer versions gets
@@ -95,17 +95,15 @@ pub fn detect_unmet_peers(graph: &LockfileGraph) -> Vec<UnmetPeer> {
     unmet
 }
 
-/// Promote unmet peers to importer direct deps.
+/// Promote direct dependencies' unmet peers to importer direct deps.
 ///
-/// Walks every resolved package's declared peer deps and hoists any
-/// peer that isn't already a direct dep of the importer up to the
+/// Walks each importer's direct dependencies and hoists any peer they
+/// declare that isn't already a direct dep of the importer up to the
 /// importer's `dependencies` list — what pnpm's
-/// `auto-install-peers=true` produces in its v9 lockfile. If you
-/// depend on a package whose `peerDependencies` declares `react` and
-/// you don't list `react` yourself, pnpm (and now aube) adds it to
-/// your importer's dependencies with the declared peer range as the
-/// specifier, and the linker creates a top-level
-/// `node_modules/react` symlink you can import from your own code.
+/// `auto-install-peers=true` produces in its v9 lockfile. Peers declared by
+/// transitive dependencies stay in the resolved graph for peer-context
+/// sibling wiring, but they are not surfaced as top-level
+/// `node_modules/<peer>` entries.
 ///
 /// Public so lockfile-driven installs that need to re-derive peer
 /// wiring (npm/yarn/bun formats, which don't record peer contexts)
@@ -117,12 +115,11 @@ pub fn detect_unmet_peers(graph: &LockfileGraph) -> Vec<UnmetPeer> {
 /// Algorithm:
 ///   1. For each importer, collect the set of names already in its
 ///      direct deps. Those are "satisfied" and need no hoist.
-///   2. DFS the reachable graph from the importer, visiting each package
-///      and examining its `peer_dependencies` declarations. For each
-///      declared peer not already satisfied by the importer, find a
-///      resolved version somewhere in the graph and synthesize a
-///      `DirectDep` entry. Mark it as satisfied so a second encounter
-///      doesn't add a duplicate.
+///   2. Visit only those direct dependency packages and examine their
+///      `peer_dependencies` declarations. For each declared peer not
+///      already satisfied by the importer, find a resolved version somewhere
+///      in the graph and synthesize a `DirectDep` entry. Mark it as
+///      satisfied so a second direct dep doesn't add a duplicate.
 ///   3. Stable: we walk in-order and take the first declared peer range
 ///      encountered per name as the specifier. Conflicting ranges across
 ///      the tree are not reconciled — first one wins. This matches pnpm
@@ -138,18 +135,12 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
         };
         let mut satisfied: FxHashSet<String> = direct_deps.iter().map(|d| d.name.clone()).collect();
 
-        let mut queue: std::collections::VecDeque<String> =
-            direct_deps.iter().map(|d| d.dep_path.clone()).collect();
-        let mut walked: FxHashSet<String> = FxHashSet::default();
         // Additions are gathered into a separate vec so we don't mutate
         // the importer's direct-dep list while still borrowing from it.
         let mut additions: Vec<DirectDep> = Vec::new();
 
-        while let Some(dep_path) = queue.pop_front() {
-            if !walked.insert(dep_path.clone()) {
-                continue;
-            }
-            let Some(pkg) = graph.packages.get(&dep_path) else {
+        for dep_path in direct_deps.iter().map(|d| &d.dep_path) {
+            let Some(pkg) = graph.packages.get(dep_path) else {
                 continue;
             };
 
@@ -171,7 +162,6 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
                 // otherwise two resolved `react` entries like `18.0.0`
                 // and `18.3.1` would pick the lexicographically-earlier
                 // (older) one.
-                let resolved_via_pkg_deps = pkg.dependencies.contains_key(peer_name);
                 let resolved_version = pkg.dependencies.get(peer_name).cloned().or_else(|| {
                     // Filter to parseable semver versions *before* the
                     // max_by — returning `Equal` on parse failure makes
@@ -203,14 +193,6 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
                     continue;
                 }
                 satisfied.insert(peer_name.clone());
-                // Peer reached via the fallback path isn't in
-                // `pkg.dependencies`, so the normal "walk pkg's deps"
-                // loop at the bottom of the while block would skip it.
-                // Push it onto the queue directly so its own declared
-                // peers get hoisted too.
-                if !resolved_via_pkg_deps {
-                    queue.push_back(synth_dep_path.clone());
-                }
                 additions.push(DirectDep {
                     name: peer_name.clone(),
                     dep_path: synth_dep_path,
@@ -219,15 +201,6 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
                     dep_type: DepType::Production,
                     specifier: Some(peer_range.clone()),
                 });
-            }
-
-            // Queue the package's own resolved deps for further walking.
-            for (child_name, child_version_tail) in &pkg.dependencies {
-                let canonical = child_version_tail
-                    .split('(')
-                    .next()
-                    .unwrap_or(child_version_tail);
-                queue.push_back(format!("{child_name}@{canonical}"));
             }
         }
 

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -1890,6 +1890,93 @@ fn hoist_auto_installed_peers_hoists_unmet_peers_to_importer() {
     assert_eq!(root[1].specifier.as_deref(), Some("^17 || ^18"));
 }
 
+// Peers declared by transitive dependencies are still resolved and
+// sibling-linked by the peer-context pass, but pnpm does not expose
+// them as root importer deps or top-level node_modules entries.
+#[test]
+fn hoist_auto_installed_peers_does_not_hoist_transitive_peers_to_importer() {
+    let parent = mk_locked("parent", "1.0.0", &[("consumer", "1.0.0")], &[]);
+    let consumer = mk_locked(
+        "consumer",
+        "1.0.0",
+        &[("react", "18.2.0")],
+        &[("react", "^17 || ^18")],
+    );
+    let react = mk_locked("react", "18.2.0", &[], &[]);
+
+    let mut packages = BTreeMap::new();
+    packages.insert("parent@1.0.0".to_string(), parent);
+    packages.insert("consumer@1.0.0".to_string(), consumer);
+    packages.insert("react@18.2.0".to_string(), react);
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "parent".to_string(),
+            dep_path: "parent@1.0.0".to_string(),
+            dep_type: DepType::Production,
+            specifier: Some("^1".to_string()),
+        }],
+    );
+
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+    let hoisted = hoist_auto_installed_peers(graph);
+    let root = hoisted.importers.get(".").unwrap();
+
+    assert_eq!(root.len(), 1);
+    assert_eq!(root[0].name, "parent");
+}
+
+// pnpm 11 keeps peers of auto-installed peers contextual to the
+// virtual store. If direct dep `consumer` peers on `plugin`, and the
+// auto-installed `plugin` peers on `host`, only `plugin` becomes an
+// importer dep; `host` is wired later by `apply_peer_contexts`.
+#[test]
+fn hoist_auto_installed_peers_does_not_hoist_auto_peer_peers_to_importer() {
+    let consumer = mk_locked(
+        "consumer",
+        "1.0.0",
+        &[("plugin", "2.0.0")],
+        &[("plugin", "^2")],
+    );
+    let plugin = mk_locked("plugin", "2.0.0", &[("host", "3.0.0")], &[("host", "^3")]);
+    let host = mk_locked("host", "3.0.0", &[], &[]);
+
+    let mut packages = BTreeMap::new();
+    packages.insert("consumer@1.0.0".to_string(), consumer);
+    packages.insert("plugin@2.0.0".to_string(), plugin);
+    packages.insert("host@3.0.0".to_string(), host);
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "consumer".to_string(),
+            dep_path: "consumer@1.0.0".to_string(),
+            dep_type: DepType::Production,
+            specifier: Some("^1".to_string()),
+        }],
+    );
+
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+    let hoisted = hoist_auto_installed_peers(graph);
+    let root = hoisted.importers.get(".").unwrap();
+
+    assert_eq!(root.len(), 2);
+    assert_eq!(root[0].name, "consumer");
+    assert_eq!(root[1].name, "plugin");
+    assert_eq!(root[1].dep_path, "plugin@2.0.0");
+}
+
 // If the peer is already in the importer's direct deps, hoist is a
 // no-op — we don't duplicate or shadow the user's own specifier.
 #[test]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -377,7 +377,7 @@ examples = []
 [publicHoistPattern]
 description = "Packages to hoist directly to the root node_modules."
 type = "list<string>"
-default = "[\"*types*\", \"*eslint*\", \"@prettier/plugin-*\", \"*prettier-plugin-*\"]"
+default = "[]"
 docs = """
 Glob list matched against package names. Any non-local package in the
 resolved graph whose name matches at least one positive pattern (and
@@ -385,12 +385,6 @@ no `!`-prefixed negation) gets a top-level `node_modules/<name>`
 symlink in addition to the usual direct-dep entries, so frameworks
 like Next.js, Storybook, and Jest can resolve transitive deps from the
 project root without adding them to `package.json`.
-
-The default patterns match pnpm: `*types*` hoists `@types/*` and similar
-type-definition packages so TypeScript can resolve them from the project
-root; `*eslint*` hoists ESLint configs and plugins; `@prettier/plugin-*`
-and `*prettier-plugin-*` hoist Prettier plugins. Setting this option in
-`.npmrc` or `pnpm-workspace.yaml` replaces the defaults entirely.
 
 Matching is case-insensitive; direct deps always win on name clashes,
 and the pattern pass runs before `shamefullyHoist`. Use sparingly --

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -444,7 +444,7 @@ leaving `hoist=true` (equivalent to setting `hoist=false`).
 Packages to hoist directly to the root node_modules.
 
 - Type: `list<string>`
-- Default: `["*types*", "*eslint*", "@prettier/plugin-*", "*prettier-plugin-*"]`
+- Default: `[]`
 - CLI flags: `public-hoist-pattern`
 - Environment: `npm_config_public_hoist_pattern`, `NPM_CONFIG_PUBLIC_HOIST_PATTERN`, `AUBE_PUBLIC_HOIST_PATTERN`
 - .npmrc keys: `public-hoist-pattern`, `publicHoistPattern`
@@ -456,12 +456,6 @@ no `!`-prefixed negation) gets a top-level `node_modules/<name>`
 symlink in addition to the usual direct-dep entries, so frameworks
 like Next.js, Storybook, and Jest can resolve transitive deps from the
 project root without adding them to `package.json`.
-
-The default patterns match pnpm: `*types*` hoists `@types/*` and similar
-type-definition packages so TypeScript can resolve them from the project
-root; `*eslint*` hoists ESLint configs and plugins; `@prettier/plugin-*`
-and `*prettier-plugin-*` hoist Prettier plugins. Setting this option in
-`.npmrc` or `pnpm-workspace.yaml` replaces the defaults entirely.
 
 Matching is case-insensitive; direct deps always win on name clashes,
 and the pattern pass runs before `shamefullyHoist`. Use sparingly --

--- a/test/public_hoist_pattern.bats
+++ b/test/public_hoist_pattern.bats
@@ -108,23 +108,21 @@ JSON
 	assert_not_exists node_modules/is-number
 }
 
-@test "default public-hoist-pattern hoists *types* transitives" {
+@test "default public-hoist-pattern leaves transitives private" {
 	cat >package.json <<'JSON'
 {
-  "name": "default-hoist-types",
+  "name": "default-public-hoist-empty",
   "version": "1.0.0",
   "dependencies": {
     "@types/react": "18.3.28"
   }
 }
 JSON
-	# No .npmrc override — the built-in default ["*types*", ...] applies.
-	# @types/react depends on @types/prop-types (matches *types*) and
-	# csstype (does NOT match *types*). Only the former should be hoisted.
+	# No .npmrc override — pnpm's current default is [].
 	run aube install
 	assert_success
 	assert_link_exists node_modules/@types/react
-	assert_link_exists node_modules/@types/prop-types
+	assert_not_exists node_modules/@types/prop-types
 	assert_not_exists node_modules/csstype
 }
 


### PR DESCRIPTION
## Summary

Fixes the `aube add -D cspell` layout reported in discussion #310.

- Stop promoting peers declared only by transitive dependencies into the root importer.
- Revert `publicHoistPattern` back to `[]`, matching current pnpm 10 and pnpm 11 behavior.
- Update generated settings docs and the public-hoist regression test.

## Root Cause

There were two separate ways transitive packages could become visible at the root:

1. `hoist_auto_installed_peers` walked the whole reachable graph and promoted every encountered peer into the importer, instead of only peers declared by direct dependencies.
2. PR #258 changed `publicHoistPattern` to the older default pattern set, which hoisted packages like `@cspell/cspell-types` and `@cspell/dict-typescript` into root `node_modules`.

Current pnpm behavior is stricter. `pnpm@10.28.0`, `pnpm@11.0.0-alpha.0`, and `pnpm@11.0.0-rc.5` all report `public-hoist-pattern` as `undefined` and expose only `node_modules/cspell` for `pnpm add -D cspell`.

## References

- pnpm 10 docs: `publicHoistPattern` default is `[]` — https://pnpm.io/settings#publichoistpattern
- pnpm 11 docs: `publicHoistPattern` default is `[]` — https://pnpm.io/11.x/settings#publichoistpattern
- pnpm 10 release notes: `public-hoist-pattern`: nothing is hoisted by default — https://github.com/orgs/pnpm/discussions/8945
- Related pnpm issue removing default public hoisting: https://github.com/pnpm/pnpm/issues/8378

## Validation

- `cargo fmt --check`
- `cargo test -p aube-resolver hoist_auto_installed_peers --lib`
- `mise run test:bats test/public_hoist_pattern.bats`
- Earlier smoke check: `aube add -D cspell` leaves only `node_modules/cspell` visible at the root.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes peer auto-hoisting and the default `publicHoistPattern`, which can alter root `node_modules` contents and potentially break or fix runtime resolution for some projects. Scope is contained and covered by new unit + BATS regression tests.
> 
> **Overview**
> Tightens `hoist_auto_installed_peers` to **only hoist peers declared by an importer’s direct dependencies**, instead of walking the full reachable graph; this prevents transitive (and “peer-of-auto-installed-peer”) packages from being promoted into the importer/root.
> 
> Resets the default `publicHoistPattern` to `[]` (no public hoisting by default) and updates docs/tests accordingly, including new resolver unit tests for the transitive-peer hoist behavior and an updated BATS regression asserting transitives remain private at the root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da492cbd07fc33b66beac9c45a35feb40174d23e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->