### PR TITLE
test(add): pin manifest order regression input

### DIFF
--- a/test/add.bats
+++ b/test/add.bats
@@ -41,7 +41,7 @@ EOF
 }
 EOF
 
-	run aube add -D is-odd
+	run aube add -D is-odd@3.0.1
 	assert_success
 
 	# Should be in devDependencies, not dependencies
@@ -67,7 +67,7 @@ EOF
 }
 EOF
 
-	run aube add -D is-odd
+	run aube add -D is-odd@3.0.1
 	assert_success
 
 	cat >expected-package.json <<'EOF'
@@ -80,7 +80,7 @@ EOF
   },
   "devDependencies": {
     "is-even": "^1.0.0",
-    "is-odd": "^3.0.1"
+    "is-odd": "3.0.1"
   }
 }
 EOF


### PR DESCRIPTION
## Summary

- Address follow-up review feedback from #315.
- Pin `is-odd` in add-manifest-order BATS coverage so the byte-for-byte fixture checks package.json ordering, not latest registry resolution.
- Update the expected manifest specifier to the deterministic exact input result.

## Validation

- `cargo fmt --check`
- `cargo build`
- `cargo test -p aube`
- `mise run test:bats test/add.bats`
- `cargo clippy --all-targets -- -D warnings`
- commit hook staged checks: `shfmt`, `shellcheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that make assertions deterministic by avoiding registry-dependent version resolution.
> 
> **Overview**
> Makes the `aube add` BATS coverage deterministic by changing the `-D is-odd` test inputs to `is-odd@3.0.1`, so the byte-for-byte `package.json` order fixture validates manifest ordering rather than whatever version is currently resolved.
> 
> Updates the expected `devDependencies` entry in the ordering test to match the exact specifier (`"3.0.1"` instead of a caret range).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3461c909adae14098fd0f4fe5964cfce9cb777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->