### PR TITLE
ci(release): add cmake to PPA Build-Depends for libz-ng-sys

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -159,7 +159,7 @@ jobs:
           Section: utils
           Priority: optional
           Maintainer: ${MAINTAINER_NAME} <${MAINTAINER_EMAIL}>
-          Build-Depends: debhelper-compat (= 13), rustc (>= 1.93), cargo, libssl-dev, pkgconf
+          Build-Depends: debhelper-compat (= 13), rustc (>= 1.93), cargo, libssl-dev, pkgconf, cmake
           Standards-Version: 4.6.2
           Homepage: https://aube.en.dev
           Vcs-Git: https://github.com/endevco/aube.git


### PR DESCRIPTION
## Summary

- Add `cmake` to the `Build-Depends` line in the dynamically-generated `debian/control` inside the PPA publish workflow.
- Fixes the Launchpad source-build failure for `aube 1.2.0~resolute1` ([buildlog 858850599](https://launchpadlibrarian.net/858850599/buildlog_ubuntu-resolute-amd64v3.aube_1.2.0~resolute1_BUILDING.txt.gz)) where `cargo build --frozen` halted while compiling `libz-ng-sys v1.1.28` with `is \`cmake\` not installed?`.
- `libz-ng-sys` is pulled in by `flate2` with the `zlib-ng` feature enabled at [Cargo.toml:102](https://github.com/endevco/aube/blob/main/Cargo.toml#L102), introduced in #254 for tarball-extraction perf. Keeping the feature and adding the system build dep is cheaper than reverting the perf win to the pure-Rust `miniz_oxide` backend.

## Republish

This won't help the already-failed `1.2.0~resolute1` build. After merge, the workflow needs a manual `workflow_dispatch` against tag `v1.2.0` with an incremented build revision (e.g. `resolute2`) to re-upload to Launchpad. Future releases pick it up automatically.

## Test plan

- [x] `grep -n "Build-Depends:" .github/workflows/ppa-publish.yml` shows the new line
- [x] YAML still parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ppa-publish.yml'))"`)
- [ ] Re-trigger PPA publish for `v1.2.0` with bumped build revision and confirm Launchpad build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the change is limited to the GitHub Actions PPA packaging workflow and only adds a missing build dependency to avoid Launchpad build failures.
> 
> **Overview**
> Adds `cmake` to the dynamically-generated `debian/control` `Build-Depends` in `.github/workflows/ppa-publish.yml` so PPA source builds have the tooling needed for crates that invoke CMake during compilation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3df0347bb9564933121b8657dd8a3ff62d0467af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->