### PR TITLE
fix(registry): raise fetch timeout default

### DIFF
--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -521,7 +521,7 @@ impl Default for FetchPolicy {
     /// sensible retry + timeout behavior.
     fn default() -> Self {
         Self {
-            timeout_ms: 60_000,
+            timeout_ms: 300_000,
             retries: 2,
             retry_factor: 10,
             retry_min_timeout_ms: 10_000,
@@ -2462,9 +2462,9 @@ mod tests {
     fn fetch_policy_default_matches_settings_toml_declared_defaults() {
         // `settings.toml` declares these defaults; `FetchPolicy::default`
         // must match them verbatim so callers that skip
-        // `FetchPolicy::from_ctx` still get pnpm-compatible behavior.
+        // `FetchPolicy::from_ctx` still get the same behavior.
         let p = FetchPolicy::default();
-        assert_eq!(p.timeout_ms, 60_000);
+        assert_eq!(p.timeout_ms, 300_000);
         assert_eq!(p.retries, 2);
         assert_eq!(p.retry_factor, 10);
         assert_eq!(p.retry_min_timeout_ms, 10_000);
@@ -2526,7 +2526,7 @@ mod tests {
         // just proves the composite struct wires each field through to
         // the right generated accessor.
         let entries = vec![
-            ("fetchTimeout".to_string(), "1234".to_string()),
+            ("fetch-timeout".to_string(), "1234".to_string()),
             ("fetch-retries".to_string(), "5".to_string()),
             ("fetch-retry-factor".to_string(), "3".to_string()),
             ("fetch-retry-mintimeout".to_string(), "250".to_string()),

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1216,16 +1216,16 @@ examples = []
 [fetchTimeout]
 description = "Max time (ms) to wait for an HTTP request."
 type = "int"
-default = "60000"
+default = "300000"
 docs = """
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
 `.timeout()` so it covers headers + body together. A request that
 exceeds this limit fails with a transport error, which is then
-retriable (see `fetchRetries`). Default matches pnpm / npm's 60s.
+retriable (see `fetchRetries`). Default matches npm's 5 minutes.
 """
 sources.cli = []
 sources.env = ["npm_config_fetch_timeout", "NPM_CONFIG_FETCH_TIMEOUT", "AUBE_FETCH_TIMEOUT"]
-sources.npmrc = ["fetchTimeout"]
+sources.npmrc = ["fetch-timeout", "fetchTimeout"]
 examples = []
 
 [fetchWarnTimeoutMs]

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1257,14 +1257,14 @@ Upper bound on the computed retry backoff. See `fetchRetryFactor`.
 Max time (ms) to wait for an HTTP request.
 
 - Type: `int`
-- Default: `60000`
+- Default: `300000`
 - Environment: `npm_config_fetch_timeout`, `NPM_CONFIG_FETCH_TIMEOUT`, `AUBE_FETCH_TIMEOUT`
-- .npmrc keys: `fetchTimeout`, `fetch-timeout`
+- .npmrc keys: `fetch-timeout`, `fetchTimeout`
 
 Per-request HTTP timeout, applied via `reqwest`'s single-knob
 `.timeout()` so it covers headers + body together. A request that
 exceeds this limit fails with a transport error, which is then
-retriable (see `fetchRetries`). Default matches pnpm / npm's 60s.
+retriable (see `fetchRetries`). Default matches npm's 5 minutes.
 
 ### `fetchWarnTimeoutMs` {#setting-fetchwarntimeoutms}
 


### PR DESCRIPTION
## Summary

- raise the default registry `fetchTimeout` from 60s to 5 minutes
- accept both `fetch-timeout` and `fetchTimeout` from `.npmrc`
- regenerate the settings docs for the new default

## Why

The Next fixture benchmark hit a registry metadata body decode/timeout failure while fetching the `@typescript-eslint/eslint-plugin` packument in GitHub Actions. That path succeeded locally, so this hardens the default for slow CI and large metadata responses instead of requiring users to know to override the timeout first.

## Validation

- `cargo test -p aube-registry config::tests::fetch_policy`
- `mise run render`
- Next fixture smoke: `aube install --ignore-scripts` with `npm_config_enable_global_virtual_store=true`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates configuration defaults and docs only, with the main behavioral change being longer waits before failing slow registry HTTP requests.
> 
> **Overview**
> Raises the default registry `fetchTimeout` from 60s to 5 minutes by updating `FetchPolicy::default` and the declared default in `settings.toml`, and adjusts tests accordingly.
> 
> Expands `.npmrc` support for the timeout setting to accept both `fetch-timeout` and `fetchTimeout`, and regenerates the settings documentation to reflect the new default and key ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb26d3590876a724a047495a5b9d11f3133d005c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->