### PR TITLE
ci(bench): summarize benchmark refresh changes

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -78,10 +78,14 @@ jobs:
         run: |
           git config user.name "release-plz[bot]"
           git config user.email "release-plz+bot@users.noreply.github.com"
+      - name: Snapshot previous benchmarks
+        run: cp benchmarks/results.json /tmp/bench-results-before.json
       - name: Refresh benchmarks
         run: mise run bench:bump
       - name: Validate benchmark claims
         run: node benchmarks/validate-results.mjs
+      - name: Summarize benchmark changes
+        run: node benchmarks/summarize-results-change.mjs /tmp/bench-results-before.json benchmarks/results.json > /tmp/bench_summary.md
 
       # Guard against a bench run that produced no diff — e.g. the version
       # moved but the numbers are byte-identical. No diff, no PR churn.
@@ -122,6 +126,8 @@ jobs:
           ## 🤖 Refreshed benchmarks
 
           \`benchmarks/results.json\` was pinned to aube \`${BENCH:-<unset>}\` but the workspace is now \`${WORKSPACE}\`. Re-ran \`mise run bench:bump\` on the hermetic Verdaccio registry (throttled per the mise task) and regenerated \`benchmarks/results.json\` plus the README \`BENCH_RATIOS\` block. The benchmark matrix pins aube's GVS mode via \`npm_config_enable_global_virtual_store=true|false\` (the auto-synthesized env alias for the \`enableGlobalVirtualStore\` setting), so GitHub Actions' inherited \`CI=true\` environment does not change whether aube runs with GVS enabled or disabled.
+
+          $(cat /tmp/bench_summary.md)
 
           **Review the numbers** before merging — if anything looks wildly off vs. the previous release, investigate before landing. Hermetic proxy jitter or an npmjs uplink hiccup can occasionally skew results.
 

--- a/benchmarks/summarize-results-change.mjs
+++ b/benchmarks/summarize-results-change.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+
+const [beforePath, afterPath] = process.argv.slice(2)
+if (!beforePath || !afterPath) {
+  console.error('usage: summarize-results-change.mjs <before-results.json> <after-results.json>')
+  process.exit(1)
+}
+
+const before = JSON.parse(readFileSync(beforePath, 'utf8'))
+const after = JSON.parse(readFileSync(afterPath, 'utf8'))
+
+const beforeRows = new Map(before.rows.map((row) => [row.key, row]))
+const afterRows = new Map(after.rows.map((row) => [row.key, row]))
+const tools = ['aube', 'bun', 'pnpm']
+
+function ms(value) {
+  return `${value}ms`
+}
+
+function pct(beforeValue, afterValue) {
+  const change = ((afterValue - beforeValue) / beforeValue) * 100
+  const sign = change > 0 ? '+' : ''
+  return `${sign}${Math.round(change)}%`
+}
+
+function ratio(row, tool) {
+  const values = row.values
+  const speedup = values[tool] / values.aube
+  return speedup < 2 ? `${speedup.toFixed(1)}x` : `${Math.round(speedup)}x`
+}
+
+function ratioChange(key, tool) {
+  const beforeRow = beforeRows.get(key)
+  const afterRow = afterRows.get(key)
+  if (!beforeRow || !afterRow) return null
+  return `${ratio(beforeRow, tool)} -> ${ratio(afterRow, tool)}`
+}
+
+const versionChanges = Object.keys(after.versions)
+  .filter((name) => before.versions[name] !== after.versions[name])
+  .map((name) => `- ${name}: ${before.versions[name] ?? '<unset>'} -> ${after.versions[name]}`)
+
+const table = []
+for (const row of after.rows) {
+  const oldRow = beforeRows.get(row.key)
+  if (!oldRow) {
+    table.push(`| ${row.label} | ${tools.map((tool) => `new ${ms(row.values[tool])}`).join(' | ')} |`)
+    continue
+  }
+
+  table.push(
+    `| ${row.label} | ${tools
+      .map((tool) => `${ms(oldRow.values[tool])} -> ${ms(row.values[tool])} (${pct(oldRow.values[tool], row.values[tool])})`)
+      .join(' | ')} |`,
+  )
+}
+
+console.log('## Benchmark changes')
+console.log()
+if (versionChanges.length > 0) {
+  console.log('Versions:')
+  console.log(versionChanges.join('\n'))
+  console.log()
+}
+console.log(`Public ratios: warm installs vs Bun ${ratioChange('gvs-warm', 'bun')}, vs pnpm ${ratioChange('gvs-warm', 'pnpm')}; repeat test vs Bun ${ratioChange('install-test', 'bun')}, vs pnpm ${ratioChange('install-test', 'pnpm')}.`)
+console.log()
+console.log('| Benchmark | aube | Bun | pnpm |')
+console.log('| --- | ---: | ---: | ---: |')
+console.log(table.join('\n'))


### PR DESCRIPTION
## Summary
- snapshot previous benchmark results before `bench:bump`
- generate a benchmark-change section for future refresh PR descriptions
- include public ratio changes plus before/after deltas for aube, Bun, and pnpm

## Validation
- `node benchmarks/summarize-results-change.mjs /tmp/aube-bench-before-1.1.json benchmarks/results.json`
- `node benchmarks/validate-results.mjs`
- `git diff --check`
- `mise x actionlint -- actionlint .github/workflows/bench-refresh.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI automation and a reporting script, with no impact on production/runtime code paths. Main risk is workflow/script failure causing benchmark refresh PRs to fail or have incomplete summaries.
> 
> **Overview**
> Automatically includes a **benchmark delta summary** in `bench-refresh` PR descriptions by snapshotting the pre-run `benchmarks/results.json`, running `bench:bump`, then generating `/tmp/bench_summary.md` and injecting it into the PR body.
> 
> Adds `benchmarks/summarize-results-change.mjs`, which compares before/after `results.json` to print version changes, public ratio deltas (Bun/pnpm vs aube), and a markdown table of per-benchmark timing changes for aube/Bun/pnpm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d2c4c2b0d21438a9c8a5d307aa81d96f34e710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->