### PR TITLE
fix(lockfile): preserve npm platform optional metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,7 @@ dependencies = [
  "sha2 0.10.9",
  "simd-json",
  "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -70,6 +70,12 @@ struct RawNpmPackage {
     peer_dependencies: BTreeMap<String, String>,
     #[serde(default)]
     peer_dependencies_meta: BTreeMap<String, RawNpmPeerDepMeta>,
+    #[serde(default)]
+    os: Vec<String>,
+    #[serde(default)]
+    cpu: Vec<String>,
+    #[serde(default)]
+    libc: Vec<String>,
     /// Captured verbatim for round-trip. npm writes these on every
     /// package entry; dropping them on re-emit is one of the
     /// remaining sources of `aube install --no-frozen-lockfile`
@@ -384,6 +390,9 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 peer_dependencies_meta,
                 dep_path,
                 local_source,
+                os: package_entry.os.iter().cloned().collect(),
+                cpu: package_entry.cpu.iter().cloned().collect(),
+                libc: package_entry.libc.iter().cloned().collect(),
                 alias_of,
                 tarball_url,
                 declared_dependencies: declared,
@@ -414,7 +423,9 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     // (name, version) but have different resolved transitives —
     // npm.rs's data model doesn't express that, and in practice npm
     // dedupes only when the transitives match anyway.
-    let mut resolved_by_dep_path: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    type ResolvedDepMap = BTreeMap<String, String>;
+    let mut resolved_by_dep_path: BTreeMap<String, (ResolvedDepMap, ResolvedDepMap)> =
+        BTreeMap::new();
     for (install_path, entry) in &raw.packages {
         if install_path.is_empty() {
             continue;
@@ -450,26 +461,35 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         }
 
         let mut resolved: BTreeMap<String, String> = BTreeMap::new();
-        for dep_name in package_entry
+        let mut resolved_optional: BTreeMap<String, String> = BTreeMap::new();
+        for (dep_name, is_optional) in package_entry
             .dependencies
             .keys()
-            .chain(package_entry.optional_dependencies.keys())
+            .map(|name| (name, false))
+            .chain(
+                package_entry
+                    .optional_dependencies
+                    .keys()
+                    .map(|name| (name, true)),
+            )
         {
             if let Some(target_install_path) =
                 resolve_nested(lookup_path, dep_name, &install_path_info)
                 && let Some(target_info) = install_path_info.get(&target_install_path)
             {
-                resolved.insert(
-                    dep_name.clone(),
-                    dep_path_tail(&target_info.name, &target_info.dep_path).to_string(),
-                );
+                let tail = dep_path_tail(&target_info.name, &target_info.dep_path).to_string();
+                resolved.insert(dep_name.clone(), tail.clone());
+                if is_optional {
+                    resolved_optional.insert(dep_name.clone(), tail);
+                }
             }
         }
-        resolved_by_dep_path.insert(dep_path, resolved);
+        resolved_by_dep_path.insert(dep_path, (resolved, resolved_optional));
     }
-    for (dep_path, deps) in resolved_by_dep_path {
+    for (dep_path, (deps, optional_deps)) in resolved_by_dep_path {
         if let Some(pkg) = graph.packages.get_mut(&dep_path) {
             pkg.dependencies = deps;
+            pkg.optional_dependencies = optional_deps;
         }
     }
 
@@ -594,8 +614,8 @@ struct WriteNpmLockfile<'a> {
 // Field order mirrors npm's own package-lock.json output, so a
 // parse → write round-trip diffs cleanly against what `npm install`
 // would produce: `name`, `version`, `resolved`, `integrity`,
-// `license`, then the dep sections, then `bin`, `engines`, `funding`,
-// then the dev/optional flags. Don't reorder — the JSON is
+// `license`, then the dep sections, then `bin`, `engines`, platform
+// fields, `funding`, then the dev/optional flags. Don't reorder — the JSON is
 // serialized as a `BTreeMap`-like structure but serde preserves
 // struct field order for us, which is what npm readers (and git
 // diffs) expect.
@@ -632,6 +652,12 @@ struct WriteNpmPackage<'a> {
     bin: BTreeMap<&'a str, &'a str>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     engines: BTreeMap<&'a str, &'a str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    os: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    cpu: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    libc: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     funding: Option<WriteNpmFunding<'a>>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
@@ -768,8 +794,8 @@ pub fn write(
         // treats that as a corrupt lockfile, and `npm install`
         // would refetch the dropped package. Matches the bun and
         // yarn writers, which filter the same way.
-        let deps: BTreeMap<&str, &str> = pkg
-            .dependencies
+        let optional_deps: BTreeMap<&str, &str> = pkg
+            .optional_dependencies
             .iter()
             .filter(|(n, value)| canonical.contains_key(&child_canonical_key(n, value)))
             .map(|(n, value)| {
@@ -778,6 +804,22 @@ pub fn write(
                 // pin. Falls back to the pin for entries where the
                 // source lockfile didn't carry declared ranges (e.g.
                 // pnpm → npm conversion).
+                let rendered = pkg
+                    .declared_dependencies
+                    .get(n)
+                    .map(String::as_str)
+                    .unwrap_or_else(|| dep_value_as_version(n, value));
+                (n.as_str(), rendered)
+            })
+            .collect();
+        let deps: BTreeMap<&str, &str> = pkg
+            .dependencies
+            .iter()
+            .filter(|(n, value)| {
+                !pkg.optional_dependencies.contains_key(*n)
+                    && canonical.contains_key(&child_canonical_key(n, value))
+            })
+            .map(|(n, value)| {
                 let rendered = pkg
                     .declared_dependencies
                     .get(n)
@@ -854,6 +896,7 @@ pub fn write(
                 integrity: pkg.integrity.as_deref(),
                 license: pkg.license.as_deref(),
                 dependencies: deps,
+                optional_dependencies: optional_deps,
                 peer_dependencies: peer_deps,
                 peer_dependencies_meta: peer_deps_meta,
                 bin: pkg
@@ -867,6 +910,9 @@ pub fn write(
                     .iter()
                     .map(|(k, v)| (k.as_str(), v.as_str()))
                     .collect(),
+                os: pkg.os.to_vec(),
+                cpu: pkg.cpu.to_vec(),
+                libc: pkg.libc.to_vec(),
                 funding: pkg
                     .funding_url
                     .as_deref()
@@ -1530,6 +1576,169 @@ mod tests {
             baz.dependencies.get("bar").map(String::as_str),
             Some("2.0.0"),
             "baz's bar dep was shadowed by foo/bar@1.0.0 — shadow-nest fix regressed",
+        );
+    }
+
+    #[test]
+    fn test_parse_npm_preserves_platform_optional_metadata() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+            "name": "platform-optional-root",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "platform-optional-root",
+                    "version": "1.0.0",
+                    "dependencies": { "host": "file:host" }
+                },
+                "node_modules/host": {
+                    "resolved": "host",
+                    "link": true
+                },
+                "host": {
+                    "name": "host",
+                    "version": "1.0.0",
+                    "optionalDependencies": { "native-win": "1.0.0" }
+                },
+                "node_modules/native-win": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/native-win/-/native-win-1.0.0.tgz",
+                    "integrity": "sha512-native",
+                    "optional": true,
+                    "os": ["win32"],
+                    "cpu": ["x64"],
+                    "libc": ["glibc"]
+                }
+            }
+        }"#;
+        std::fs::write(tmp.path(), content).unwrap();
+
+        let graph = parse(tmp.path()).unwrap();
+        let host_dep_path = &graph.importers["."][0].dep_path;
+        let host = &graph.packages[host_dep_path];
+        assert_eq!(
+            host.dependencies.get("native-win").map(String::as_str),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            host.optional_dependencies
+                .get("native-win")
+                .map(String::as_str),
+            Some("1.0.0")
+        );
+
+        let native = &graph.packages["native-win@1.0.0"];
+        assert_eq!(
+            native.os.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["win32"]
+        );
+        assert_eq!(
+            native.cpu.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["x64"]
+        );
+        assert_eq!(
+            native.libc.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["glibc"]
+        );
+    }
+
+    #[test]
+    fn test_write_npm_preserves_platform_optional_metadata() {
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            "host@1.0.0".to_string(),
+            LockedPackage {
+                name: "host".to_string(),
+                version: "1.0.0".to_string(),
+                integrity: Some("sha512-host".to_string()),
+                dep_path: "host@1.0.0".to_string(),
+                dependencies: [("native-win".to_string(), "1.0.0".to_string())]
+                    .into_iter()
+                    .collect(),
+                optional_dependencies: [("native-win".to_string(), "1.0.0".to_string())]
+                    .into_iter()
+                    .collect(),
+                declared_dependencies: [("native-win".to_string(), "1.0.0".to_string())]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "native-win@1.0.0".to_string(),
+            LockedPackage {
+                name: "native-win".to_string(),
+                version: "1.0.0".to_string(),
+                integrity: Some("sha512-native".to_string()),
+                dep_path: "native-win@1.0.0".to_string(),
+                os: vec!["win32".to_string()].into(),
+                cpu: vec!["x64".to_string()].into(),
+                libc: vec!["glibc".to_string()].into(),
+                ..Default::default()
+            },
+        );
+        graph.importers.insert(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "host".to_string(),
+                dep_path: "host@1.0.0".to_string(),
+                dep_type: DepType::Production,
+                specifier: Some("1.0.0".to_string()),
+            }],
+        );
+        let manifest = aube_manifest::PackageJson {
+            name: Some("platform-optional-root".to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: [("host".to_string(), "1.0.0".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+
+        let out = tempfile::NamedTempFile::new().unwrap();
+        write(out.path(), &graph, &manifest).unwrap();
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(out.path()).unwrap()).unwrap();
+
+        let host = &json["packages"]["node_modules/host"];
+        assert_eq!(host["optionalDependencies"]["native-win"], "1.0.0");
+        assert!(
+            host.get("dependencies")
+                .and_then(|deps| deps.get("native-win"))
+                .is_none(),
+            "optional child must not be duplicated as a required dependency: {host}",
+        );
+
+        let native = &json["packages"]["node_modules/native-win"];
+        assert_eq!(native["os"], serde_json::json!(["win32"]));
+        assert_eq!(native["cpu"], serde_json::json!(["x64"]));
+        assert_eq!(native["libc"], serde_json::json!(["glibc"]));
+
+        let reparsed = parse(out.path()).unwrap();
+        let host = &reparsed.packages["host@1.0.0"];
+        assert_eq!(
+            host.optional_dependencies
+                .get("native-win")
+                .map(String::as_str),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            host.dependencies.get("native-win").map(String::as_str),
+            Some("1.0.0")
+        );
+        let native = &reparsed.packages["native-win@1.0.0"];
+        assert_eq!(
+            native.os.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["win32"]
+        );
+        assert_eq!(
+            native.cpu.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["x64"]
+        );
+        assert_eq!(
+            native.libc.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["glibc"]
         );
     }
 

--- a/crates/aube-resolver/Cargo.toml
+++ b/crates/aube-resolver/Cargo.toml
@@ -28,3 +28,6 @@ thiserror = { workspace = true }
 miette = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/aube-resolver/src/platform.rs
+++ b/crates/aube-resolver/src/platform.rs
@@ -522,6 +522,70 @@ mod tests {
         assert!(!graph.packages.contains_key("native-linux@1.0.0"));
     }
 
+    #[test]
+    fn filter_graph_prunes_npm_lockfile_transitive_optional_platform_mismatch() {
+        let content = r#"{
+            "name": "platform-optional-root",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "platform-optional-root",
+                    "version": "1.0.0",
+                    "dependencies": { "host": "file:host" }
+                },
+                "node_modules/host": {
+                    "resolved": "host",
+                    "link": true
+                },
+                "host": {
+                    "name": "host",
+                    "version": "1.0.0",
+                    "optionalDependencies": { "native-win": "1.0.0" }
+                },
+                "node_modules/native-win": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/native-win/-/native-win-1.0.0.tgz",
+                    "integrity": "sha512-native",
+                    "optional": true,
+                    "os": ["win32"],
+                    "cpu": ["x64"],
+                    "libc": ["glibc"]
+                }
+            }
+        }"#;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), content).unwrap();
+        let mut graph = aube_lockfile::npm::parse(tmp.path()).unwrap();
+
+        let host_dep_path = graph.importers["."][0].dep_path.clone();
+        assert!(
+            graph.packages.contains_key(&host_dep_path),
+            "fixture must contain the host package before filtering"
+        );
+        assert!(
+            graph.packages.contains_key("native-win@1.0.0"),
+            "fixture must contain native-win before filtering"
+        );
+        let host = &graph.packages[&host_dep_path];
+        assert!(host.dependencies.contains_key("native-win"));
+        assert!(host.optional_dependencies.contains_key("native-win"));
+
+        let supported = SupportedArchitectures {
+            os: s(&["linux"]),
+            cpu: s(&["x64"]),
+            libc: s(&["glibc"]),
+            ..Default::default()
+        };
+        filter_graph(&mut graph, &supported, &Default::default());
+
+        assert!(graph.packages.contains_key(&host_dep_path));
+        assert!(!graph.packages.contains_key("native-win@1.0.0"));
+        let host = &graph.packages[&host_dep_path];
+        assert!(!host.dependencies.contains_key("native-win"));
+        assert!(!host.optional_dependencies.contains_key("native-win"));
+    }
+
     #[cfg(not(target_os = "linux"))]
     #[test]
     fn libc_ignored_off_linux() {

--- a/test/npm_package_lock_platform.bats
+++ b/test/npm_package_lock_platform.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "npm package-lock transitive win32 optional is pruned before fetch on non-win32" {
+	case "$(uname -s)" in
+	MINGW* | MSYS* | CYGWIN* | Windows_NT)
+		skip "win32 host should keep the win32 optional dependency"
+		;;
+	esac
+
+	mkdir -p host
+	cat >host/package.json <<-'JSON'
+		{
+		  "name": "host",
+		  "version": "1.0.0",
+		  "optionalDependencies": {
+		    "native-win": "1.0.0"
+		  }
+		}
+	JSON
+	cat >package.json <<-'JSON'
+		{
+		  "name": "npm-lock-platform-root",
+		  "version": "1.0.0",
+		  "dependencies": {
+		    "host": "file:host"
+		  }
+		}
+	JSON
+	cat >package-lock.json <<-'JSON'
+		{
+		  "name": "npm-lock-platform-root",
+		  "version": "1.0.0",
+		  "lockfileVersion": 3,
+		  "requires": true,
+		  "packages": {
+		    "": {
+		      "name": "npm-lock-platform-root",
+		      "version": "1.0.0",
+		      "dependencies": {
+		        "host": "file:host"
+		      }
+		    },
+		    "node_modules/host": {
+		      "resolved": "host",
+		      "link": true
+		    },
+		    "host": {
+		      "name": "host",
+		      "version": "1.0.0",
+		      "optionalDependencies": {
+		        "native-win": "1.0.0"
+		      }
+		    },
+		    "node_modules/native-win": {
+		      "version": "1.0.0",
+		      "resolved": "http://127.0.0.1:9/native-win/-/native-win-1.0.0.tgz",
+		      "integrity": "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg==",
+		      "optional": true,
+		      "os": ["win32"]
+		    }
+		  }
+		}
+	JSON
+
+	run aube ci --ignore-scripts
+	assert_success
+	assert_exists node_modules/host
+	assert_not_exists node_modules/native-win
+}


### PR DESCRIPTION
## Summary

Fixes `aube ci` failing on Linux/macOS for projects whose npm `package-lock.json` contains Windows-only (or otherwise platform-gated) transitive optional dependencies. The lockfile-reuse install path already calls `aube_resolver::platform::filter_graph` before any tarball fetch, but the npm parser was starving the filter of the metadata it needs:

1. `RawNpmPackage` dropped `os` / `cpu` / `libc` arrays.
2. The nested-resolve pass mirrored optional edges into `LockedPackage.dependencies` but never populated `LockedPackage.optional_dependencies`, so transitive optionals (e.g. `lightningcss → lightningcss-win32-x64-msvc`) looked like required edges.
3. `WriteNpmPackage` round-tripped neither piece of metadata.

After this change `filter_graph` can prune Linux-mismatched optionals before any registry fetch, which is what causes the `aube ci` failure to disappear (no fetch, no decode error).

## Changes

| File | Δ | Notes |
|---|---|---|
| `crates/aube-lockfile/src/npm.rs` | +235 / −13 | `RawNpmPackage` gains `os`/`cpu`/`libc` (defaulted, mirrors pnpm parser). Nested resolve builds `resolved` and `resolved_optional` maps; populates `LockedPackage.optional_dependencies` for transitive optionals while keeping the existing `dependencies` mirror. `WriteNpmPackage` gains `os`/`cpu`/`libc` (skipped when empty) and emits nested `optionalDependencies` without duplicating those edges as required `dependencies`. |
| `crates/aube-resolver/src/platform.rs` | +72 | Regression test `filter_graph_prunes_npm_lockfile_transitive_optional_platform_mismatch` parses an npm fixture and verifies pruning end-to-end. |
| `test/npm_package_lock_platform.bats` | +78 | Integration test `aube ci --ignore-scripts` against a fixture whose win32-only optional has an invalid tarball URL — pre-fix it would attempt the fetch and fail; post-fix it succeeds and `node_modules/native-win` is absent. |

No changes to the resolver's matching logic, the install scheduler, or the registry client — only the npm parser/writer were missing data.

## Non-goals

- Other lockfile formats (pnpm/yarn/bun/aube-lock/npm-shrinkwrap) — already carry platform fields.
- npm per-entry `optional` / `dev` / `devOptional` flags — these are reachability flags, not edge metadata, and using them for pruning could incorrectly drop packages reachable through a required edge.
- Network/retry hardening — the desired behavior is not to request incompatible optional tarballs at all.

## Validation

All targeted acceptance tests + repo gates pass:

```
cargo test -p aube-lockfile test_parse_npm_preserves_platform_optional_metadata    ✅
cargo test -p aube-lockfile test_write_npm_preserves_platform_optional_metadata    ✅
cargo test -p aube-resolver filter_graph_prunes_npm_lockfile_transitive_optional_platform_mismatch  ✅
bats test/npm_package_lock_platform.bats                                           ✅
cargo build                                                                        ✅
cargo test                                                                         ✅
cargo fmt --check                                                                  ✅
cargo clippy --all-targets -- -D warnings                                          ✅ (zero warnings)
```

## Risk / compatibility

- **Cross-platform:** Windows-only optionals with `os: ["win32"]` are now skipped on Linux/macOS and remain installable on Windows. Empty platform arrays remain unconstrained.
- **Required platform-mismatched deps:** unchanged — `filter_graph` only prunes optional edges.
- **`pnpm.supportedArchitectures` / `aube.supportedArchitectures`:** can now intentionally widen the kept set for npm lockfiles, matching existing design.
- **`pnpm.ignoredOptionalDependencies`:** now also works for npm-lockfile transitive optionals.
- **Lockfile output:** `aube ci` is frozen and does not write the lockfile. `aube install --no-frozen-lockfile` will round-trip nested `optionalDependencies` and `os`/`cpu`/`libc`, producing package-lock output closer to npm's.


---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: fix npm `package-lock.json` platform-optional pruning for `aube ci`

## Goal and acceptance criteria

Fix the `aube ci` lockfile-reuse path so npm `package-lock.json` entries for platform-specific optional dependencies remain represented as optional, platform-constrained packages in `LockfileGraph`, allowing existing platform filtering to prune incompatible packages before any tarball fetch.

Acceptance criteria:

- On Linux, a package-lock graph containing a production package whose `optionalDependencies` include a Windows-only package is filtered before fetch; the Windows-only package is absent from the final fetch/link graph.
- `RawNpmPackage` parsing preserves `os`, `cpu`, and `libc` arrays into `LockedPackage`.
- npm parser preserves transitive `optionalDependencies` as `LockedPackage.optional_dependencies`, while continuing to mirror active optional edges in `LockedPackage.dependencies` for graph traversal/linking.
- npm writer round-trips platform metadata and nested `optionalDependencies` for packages still present in the graph.
- No retry/network-only change is used as the fix; registry decode failures remain a symptom avoided by not fetching incompatible optional packages.

## Verified root cause on current main

Read-only exploration confirmed the hypothesis and found one additional required root cause.

1. **`aube ci` uses the lockfile-reuse install path.**
   - `crates/aube/src/commands/ci.rs:32-71` constructs `InstallOptions` with `FrozenMode::Frozen`, deletes `node_modules`, and calls `install::run`.
   - In the lockfile-reuse branch, `crates/aube/src/commands/install/mod.rs:1956-1977` calls `aube_resolver::platform::filter_graph(...)` immediately after parsing the lockfile.
   - Fetch scheduling happens later over `graph.packages` via `fetch_packages_with_root(...)` at `crates/aube/src/commands/install/mod.rs:2040-2075`. So the architecture is already correct: filtering is intended to happen before fetch.

2. **`filter_graph` depends on platform fields and optional edge metadata.**
   - `crates/aube-resolver/src/platform.rs:216-235`: `field_matches` treats empty `os` / `cpu` / `libc` arrays as unconstrained.
   - `crates/aube-resolver/src/platform.rs:241-260`: `is_supported` checks `LockedPackage.os`, `.cpu`, and `.libc` against `SupportedArchitectures`.
   - `crates/aube-resolver/src/platform.rs:272-358`: `filter_graph` removes:
     - root optional deps via `DirectDep.dep_type == DepType::Optional`, and
     - transitive optional deps via each package’s `LockedPackage.optional_dependencies`, removing matching entries from both `optional_dependencies` and the mirrored `dependencies` map before garbage collection.

3. **npm parser currently drops `os`, `cpu`, and `libc`.**
   - `crates/aube-lockfile/src/npm.rs:32-93` defines `RawNpmPackage`; it has `dependencies`, `optional_dependencies`, peers, engines, bin, license, funding, etc., but no `os`, `cpu`, or `libc` fields.
   - `crates/aube-lockfile/src/npm.rs:378-396` constructs `LockedPackage` with `..Default::default()`, leaving `LockedPackage.os`, `.cpu`, and `.libc` empty.
   - `crates/aube-lockfile/src/lib.rs:574-612` documents these platform arrays as the metadata used to filter optional deps by platform.

4. **npm parser also fails to preserve transitive optional edge metadata.**
   - `crates/aube-lockfile/src/npm.rs:320-341` and `452-474` merge `package_entry.optional_dependencies` into `LockedPackage.dependencies` but never populate `LockedPackage.optional_dependencies`.
   - `crates/aube-lockfile/src/npm.rs:498-500` does correctly mark root `optionalDependencies` as `DirectDep { dep_type: DepType::Optional }`.
   - Impact: direct root optionals can be pruned, but transitive optionals like `lightningcss -> lightningcss-win32-x64-msvc` are treated as required dependency edges. Even after adding `os` / `cpu` / `libc`, `filter_graph` would not remove the edge unless `LockedPackage.optional_dependencies` is populated.

5. **npm writer loses related metadata on output.**
   - `crates/aube-lockfile/src/npm.rs:604-649` defines `WriteNpmPackage`; it already has an `optional_dependencies` field but no `os`, `cpu`, or `libc` fields.
   - The nested package writer construction at `crates/aube-lockfile/src/npm.rs:850-875` sets `dependencies` but leaves `optional_dependencies` at default, so nested package `optionalDependencies` are not round-tripped today.

## Minimal implementation proposal

Keep the implementation narrow and localized to npm lockfile read/write logic. Do not refactor install scheduling, resolver platform matching, or registry retries.

### Phase 1: preserve platform fields in npm parser

File: `crates/aube-lockfile/src/npm.rs`

- Add defaulted platform fields to `RawNpmPackage`, following the existing pnpm parser pattern in `crates/aube-lockfile/src/pnpm.rs:1512-1521`:

  ```rust
  #[serde(default)]
  os: Vec<String>,
  #[serde(default)]
  cpu: Vec<String>,
  #[serde(default)]
  libc: Vec<String>,
  ```

- When constructing `LockedPackage`, copy those arrays into the `PlatformList` fields:

  ```rust
  os: package_entry.os.iter().cloned().collect(),
  cpu: package_entry.cpu.iter().cloned().collect(),
  libc: package_entry.libc.iter().cloned().collect(),
  ```

- Leave empty arrays as empty; `platform::field_matches` already treats empty arrays as unconstrained.

Quality gate after Phase 1:

- Add/adjust a parser unit test first, then run `cargo test -p aube-lockfile test_parse_npm_preserves_platform_optional_metadata`.

### Phase 2: preserve npm transitive `optionalDependencies` edge maps

File: `crates/aube-lockfile/src/npm.rs`

- In the second pass that resolves nested dependencies, split resolved edges into two maps:
  - `resolved`: all dependency edges (`dependencies` + `optionalDependencies`), preserving the existing mirror behavior needed for graph traversal/linking.
  - `resolved_optional`: only edges that came from `package_entry.optional_dependencies`.

Concrete shape:

```rust
let mut resolved: BTreeMap<String, String> = BTreeMap::new();
let mut resolved_optional: BTreeMap<String, String> = BTreeMap::new();

for dep_name in package_entry
    .dependencies
    .keys()
    .chain(package_entry.optional_dependencies.keys())
{
    // existing resolve_nested logic
    let tail = dep_path_tail(&target_info.name, &target_info.dep_path).to_string();
    if package_entry.optional_dependencies.contains_key(dep_name) {
        resolved_optional.insert(dep_name.clone(), tail.clone());
    }
    resolved.insert(dep_name.clone(), tail);
}
```

- Change `resolved_by_dep_path` to carry both maps and assign both in the final update:

```rust
pkg.dependencies = deps;
pkg.optional_dependencies = optional_deps;
```

- Keep root importer handling unchanged; root `optionalDependencies` are already converted to `DepType::Optional`.

- Do **not** parse npm per-entry `optional`, `dev`, or `devOptional` flags for this bug. They are reachability flags, not edge metadata; using them for pruning could incorrectly drop a package that is also reachable through a required edge.

Quality gate after Phase 2:

- Add a parser test where a production root depends on `host`, `host` has `optionalDependencies: { "native-win": "1.0.0" }`, and `native-win` has `os: ["win32"]`. Assert:
  - `host.dependencies["native-win"]` is present,
  - `host.optional_dependencies["native-win"]` is present,
  - `native-win.os == ["win32"]` (plus `cpu` / `libc` if included).

### Phase 3: preserve platform metadata and nested optional deps in npm writer

File: `crates/aube-lockfile/src/npm.rs`

- Add `os`, `cpu`, and `libc` to `WriteNpmPackage`, skipped when empty, similar to pnpm’s writer fields in `crates/aube-lockfile/src/pnpm.rs:1280-1290`.

  ```rust
  #[serde(skip_serializing_if = "Vec::is_empty")]
  os: Vec<String>,
  #[serde(skip_serializing_if = "Vec::is_empty")]
  cpu: Vec<String>,
  #[serde(skip_serializing_if = "Vec::is_empty")]
  libc: Vec<String>,
  ```

- In nested package writer construction:
  - Emit `optional_dependencies` from `pkg.optional_dependencies`, filtered against `canonical` the same way `dependencies` is filtered today.
  - Exclude names present in `pkg.optional_dependencies` from the normal `dependencies` object to avoid serializing an optional edge as both required and optional.
  - Use `pkg.declared_dependencies` for the rendered specifier exactly as current `dependencies` rendering does.
  - Set `os: pkg.os.to_vec()`, `cpu: pkg.cpu.to_vec()`, and `libc: pkg.libc.to_vec()`.

- Keep the root package entry behavior unchanged: root `dependencies` / `devDependencies` / `optionalDependencies` should still come from the root manifest.

Quality gate after Phase 3:

- Add a writer/round-trip test that writes a graph with a nested optional platform package and verifies:
  - parent entry has `optionalDependencies`, not a duplicated required `dependencies` entry for that child,
  - child entry has `os`, `cpu`, and `libc` arrays when non-empty,
  - parsing the written package-lock restores both `optional_dependencies` and platform fields.

### Phase 4: no install-path refactor unless tests reveal a gap

No code change is expected in:

- `crates/aube-resolver/src/platform.rs`
- `crates/aube/src/commands/install/mod.rs`
- `crates/aube-registry/src/client.rs`

Reason: current install flow already runs `filter_graph` before tarball fetch on the lockfile path. The bug is that npm parsing starves `filter_graph` of platform and optional-edge metadata.

## Test plan

### Unit tests: npm parser/writer

Add tests in the existing `#[cfg(test)]` module in `crates/aube-lockfile/src/npm.rs`.

1. `test_parse_npm_preserves_platform_optional_metadata`
   - Create a temp `package-lock.json` v3 with:
     - root `dependencies: { "host": "file:host" }`,
     - `node_modules/host` as a link to `host`,
     - `host` entry with `optionalDependencies: { "native-win": "1.0.0" }`,
     - `node_modules/native-win` with `version`, `resolved`, `integrity`, `optional: true`, `os: ["win32"]`, `cpu: ["x64"]`, and optionally `libc: ["glibc"]`.
   - Parse with `npm::parse`.
   - Assert host dependency mirror and `optional_dependencies` map are both populated.
   - Assert native package platform fields are populated.

2. `test_write_npm_preserves_platform_optional_metadata`
   - Build or parse the same graph, write it with `npm::write`, inspect JSON, and reparse.
   - Assert nested `optionalDependencies` and `os` / `cpu` / `libc` survive the write/read cycle.

### Platform-filter regression test using an npm parsed lockfile

Add a resolver/platform test, likely in `crates/aube-resolver/src/platform.rs` tests or `crates/aube-resolver/src/tests.rs`:

- Test name: `filter_graph_prunes_npm_lockfile_transitive_optional_platform_mismatch`.
- Parse the same npm lockfile fixture from a temp file.
- Run `aube_resolver::platform::filter_graph` with Linux x64 glibc `SupportedArchitectures`.
- Assert:
  - `host` remains reachable,
  - `native-win` is removed from `graph.packages`,
  - `host.dependencies` no longer contains `native-win`,
  - `host.optional_dependencies` no longer contains `native-win`.

This directly proves the fixed npm parser provides the metadata `filter_graph` already knows how to use.

### BATS integration/fetch regression

Add a deterministic integration test, either in a new `test/npm_package_lock_platform.bats` or as a focused section in `test/optional_platform.bats`.

Suggested test: `npm package-lock transitive win32 optional is pruned before fetch on non-win32`.

Fixture shape:

- Create a local linked `host` package in the test temp directory with a minimal `host/package.json`.
- Create `package.json` depending on `host` via `file:host`.
- Create a `package-lock.json` v3 matching npm’s link shape:
  - `"node_modules/host": { "resolved": "host", "link": true }`
  - `"host": { "name": "host", "version": "1.0.0", "optionalDependencies": { "native-win": "1.0.0" } }`
  - `"node_modules/native-win": { "version": "1.0.0", "resolved": "http://127.0.0.1:9/native-win/-/native-win-1.0.0.tgz", "optional": true, "os": ["win32"] }`

Run `aube ci --ignore-scripts` on Linux/macOS. The invalid URL makes this a deterministic fetch guard:

- Before the fix, aube keeps `native-win` reachable and attempts the invalid fetch.
- After the fix, `native-win` is pruned before fetch, so the install succeeds and `node_modules/native-win` is absent.

Keep the test non-serial if it does not mutate shared registry state.

## Validation commands

Targeted commands during implementation:

```sh
cargo test -p aube-lockfile test_parse_npm_preserves_platform_optional_metadata
cargo test -p aube-lockfile test_write_npm_preserves_platform_optional_metadata
cargo test -p aube-resolver filter_graph_prunes_npm_lockfile_transitive_optional_platform_mismatch
mise run test:bats test/npm_package_lock_platform.bats
```

Regression/nearby coverage:

```sh
cargo test -p aube-lockfile npm
cargo test -p aube-resolver platform
mise run test:bats test/optional_platform.bats test/package_lock_write.bats test/npm_package_lock_platform.bats
```

Repo quality gates before claiming success:

```sh
cargo build
cargo test
cargo fmt --check
cargo clippy --all-targets -- -D warnings
```

Use the debug build only; this repo’s BATS harness prepends `target/debug` to `PATH`.

## Dogfooding / reproduction plan

### Deterministic local reproduction

1. Build the debug binary:

   ```sh
   cargo build
   export PATH="$PWD/target/debug:$PATH"
   ```

2. In a temp directory, create the synthetic package described in the BATS test above: a local linked `host` package with a Windows-only optional `native-win` child whose `resolved` URL points at `http://127.0.0.1:9/...`.

3. Record the terminal session and save artifacts for review:

   ```sh
   script -q dogfood-aube-ci.log
   # or, if available:
   asciinema rec dogfood-aube-ci.cast
   ```

   Also capture a screenshot of the terminal after the success/failure assertions. If running in an environment with screen recording, record the short before/after `aube ci` run so reviewers can verify the command and output.

4. Before the fix, run:

   ```sh
   aube ci --ignore-scripts
   ```

   Expected pre-fix behavior: failure caused by attempting to fetch the invalid Windows-only optional tarball.

5. After the fix, rerun:

   ```sh
   rm -rf node_modules
   aube ci --ignore-scripts
   test ! -e node_modules/native-win
   ```

   Expected fixed behavior: install succeeds, `native-win` is absent, and the invalid URL is never requested.

### npm comparison

- Run `npm ci --ignore-scripts` on the same synthetic fixture if npm accepts the local-link package-lock shape.
- If npm rejects the synthetic fixture format, use the real `coder/agent-tty` `package.json` + `package-lock.json` comparison instead:

  ```sh
  npm ci --ignore-scripts
  test ! -e node_modules/lightningcss-win32-x64-msvc
  test -e node_modules/lightningcss-linux-x64-gnu
  ```

### Real-world smoke with `agent-tty`

After targeted tests pass, use an isolated temp copy of `coder/agent-tty`’s `package.json` and `package-lock.json`:

```sh
aube ci --ignore-scripts
test ! -e node_modules/lightningcss-win32-x64-msvc
test -e node_modules/lightningcss-linux-x64-gnu
```

Prefer the deterministic local fixture for CI and regression tests; use the real `agent-tty` fixture only as a smoke test because it can depend on npm registry/CDN availability.

## Risk assessment

- **Cross-platform behavior:** On Linux/macOS, Windows-only optional packages with `os: ["win32"]` should now be skipped. On Windows, the same package should remain installable. Packages with empty platform arrays remain unconstrained.
- **`pnpm.supportedArchitectures` / `aube.supportedArchitectures`:** These settings already flow into `SupportedArchitectures` before `filter_graph`. Once npm platform metadata is parsed, widening the supported architecture set can intentionally keep additional platform optional packages, matching the existing design.
- **`pnpm.ignoredOptionalDependencies`:** This improves npm-lockfile behavior for transitive optional deps because `filter_graph` can finally see `LockedPackage.optional_dependencies` and remove named optional edges.
- **`--no-optional`:** This patch should not change `DepSelection` behavior. Current install filtering for `--no-optional` happens later for the link graph and is outside the observed CI failure. Avoid broadening this patch into a separate `--no-optional` fetch-policy change unless tests expose an immediate regression.
- **Required platform-mismatched deps:** `filter_graph` only prunes optional edges. Required deps with platform constraints should remain, preserving the existing catch-up/required-dep semantics.
- **Lockfile output:** `aube ci` is frozen and should not write the lockfile. `aube install --no-frozen-lockfile` may now preserve/emits nested `optionalDependencies` and `os` / `cpu` / `libc`, producing package-lock output closer to npm and reducing metadata loss. Tests should pin the intended output shape.
- **Other lockfile formats:** Changes should be localized to `crates/aube-lockfile/src/npm.rs`. `aube-lock.yaml`, `pnpm-lock.yaml`, and `bun.lock` already carry platform fields and should be unaffected.
- **Network robustness:** Do not treat reqwest/gzip retry changes as the fix. The desired behavior is not to request incompatible optional tarballs at all.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-opus-4-7` • Thinking: `max`_
