### PR TITLE
chore: release v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1daa54020e05aa0b163ee10434fff35a0f18d28a1cafa142bd1290e1abe630e"
 dependencies = [
  "astral-reqwest-middleware",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "secrecy",
  "serde",
  "serde_json",
@@ -172,7 +172,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "thiserror 2.0.18",
  "tower-service",
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "aube-util",
  "miette",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "aube-manifest",
  "thiserror 2.0.18",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "blake3",
  "rustc-hash",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -610,12 +610,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1898,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2030,27 +2024,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -3167,9 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -3297,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -3652,7 +3651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c813a3bb8997ebd2ed01564bf23318960dc1ca88104c72bd5719c629522c5"
 dependencies = [
  "base64",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -3685,7 +3684,7 @@ dependencies = [
  "base64",
  "open",
  "rand 0.10.1",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -3703,7 +3702,7 @@ checksum = "c012c1a119e2533d236d5d4244fec16e3be1243ce3fa0e0e9130cb6fc5f830c9"
 dependencies = [
  "base64",
  "hex",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -3766,7 +3765,7 @@ dependencies = [
  "der",
  "hex",
  "rand 0.10.1",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rustls-pki-types",
  "rustls-webpki",
  "sigstore-crypto",
@@ -3810,6 +3809,16 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "value-trait",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
 ]
 
 [[package]]
@@ -5003,15 +5012,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5035,21 +5035,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5105,12 +5090,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5123,12 +5102,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5138,12 +5111,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5171,12 +5138,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5186,12 +5147,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5207,12 +5162,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5222,12 +5171,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.2.1"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -111,14 +111,14 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.2.1" }
-aube-settings = { path = "crates/aube-settings", version = "1.2.1" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.2.1" }
-aube-registry = { path = "crates/aube-registry", version = "1.2.1" }
-aube-store = { path = "crates/aube-store", version = "1.2.1" }
-aube-linker = { path = "crates/aube-linker", version = "1.2.1" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.2.1" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.2.1" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.2.1" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.2.1" }
-aube-util = { path = "crates/aube-util", version = "1.2.1" }
+aube = { path = "crates/aube", version = "1.3.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.3.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.3.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.3.0" }
+aube-store = { path = "crates/aube-store", version = "1.3.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.3.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.3.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.3.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.3.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.3.0" }
+aube-util = { path = "crates/aube-util", version = "1.3.0" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.2.1"
+version "1.3.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.2.1...aube-lockfile-v1.3.0) - 2026-04-27
+
+### Fixed
+
+- *(lockfile)* preserve non-registry and bun platform entries ([#338](https://github.com/endevco/aube/pull/338))
+- *(lockfile)* preserve package and bun lock compatibility ([#339](https://github.com/endevco/aube/pull/339))
+- *(lockfile)* parse scalar pnpm platform fields ([#337](https://github.com/endevco/aube/pull/337))
+- *(lockfile)* preserve npm platform optional metadata ([#329](https://github.com/endevco/aube/pull/329))
+- bun.lock parity for workspaces, platforms, and locked versions ([#327](https://github.com/endevco/aube/pull/327))
+
+### Other
+
+- *(deps)* replace serde_yaml with yaml_serde ([#340](https://github.com/endevco/aube/pull/340))
+
 ## [1.2.1](https://github.com/endevco/aube/compare/aube-lockfile-v1.2.0...aube-lockfile-v1.2.1) - 2026-04-26
 
 ### Fixed

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/endevco/aube/compare/aube-manifest-v1.2.1...aube-manifest-v1.3.0) - 2026-04-27
+
+### Added
+
+- *(security)* enforce trustPolicy by default, add paranoid bundle, security docs ([#333](https://github.com/endevco/aube/pull/333))
+- *(scripts)* add jailed dependency builds ([#306](https://github.com/endevco/aube/pull/306))
+
+### Other
+
+- *(deps)* replace serde_yaml with yaml_serde ([#340](https://github.com/endevco/aube/pull/340))
+
 ## [1.2.0](https://github.com/endevco/aube/compare/aube-manifest-v1.1.0...aube-manifest-v1.2.0) - 2026-04-25
 
 ### Fixed

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/endevco/aube/compare/aube-registry-v1.2.1...aube-registry-v1.3.0) - 2026-04-27
+
+### Added
+
+- *(security)* enforce trustPolicy by default, add paranoid bundle, security docs ([#333](https://github.com/endevco/aube/pull/333))
+
+### Fixed
+
+- *(lockfile)* parse scalar pnpm platform fields ([#337](https://github.com/endevco/aube/pull/337))
+- *(registry)* surface retry warnings and cap timeout retries at 1 ([#331](https://github.com/endevco/aube/pull/331))
+
+### Other
+
+- *(deps)* replace serde_yaml with yaml_serde ([#340](https://github.com/endevco/aube/pull/340))
+
 ## [1.2.1](https://github.com/endevco/aube/compare/aube-registry-v1.2.0...aube-registry-v1.2.1) - 2026-04-26
 
 ### Fixed

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/endevco/aube/compare/aube-resolver-v1.2.1...aube-resolver-v1.3.0) - 2026-04-27
+
+### Added
+
+- *(security)* enforce trustPolicy by default, add paranoid bundle, security docs ([#333](https://github.com/endevco/aube/pull/333))
+
+### Fixed
+
+- *(resolver)* accept abbreviated git commit SHAs in user specs ([#346](https://github.com/endevco/aube/pull/346))
+- *(lockfile)* preserve npm platform optional metadata ([#329](https://github.com/endevco/aube/pull/329))
+- bun.lock parity for workspaces, platforms, and locked versions ([#327](https://github.com/endevco/aube/pull/327))
+
 ## [1.2.1](https://github.com/endevco/aube/compare/aube-resolver-v1.2.0...aube-resolver-v1.2.1) - 2026-04-26
 
 ### Fixed

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/endevco/aube/compare/aube-scripts-v1.2.1...aube-scripts-v1.3.0) - 2026-04-27
+
+### Added
+
+- *(scripts)* add jailed dependency builds ([#306](https://github.com/endevco/aube/pull/306))
+
 ## [1.2.0](https://github.com/endevco/aube/compare/aube-scripts-v1.1.0...aube-scripts-v1.2.0) - 2026-04-25
 
 ### Fixed

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/endevco/aube/compare/aube-settings-v1.2.1...aube-settings-v1.3.0) - 2026-04-27
+
+### Added
+
+- *(security)* enforce trustPolicy by default, add paranoid bundle, security docs ([#333](https://github.com/endevco/aube/pull/333))
+- *(scripts)* add jailed dependency builds ([#306](https://github.com/endevco/aube/pull/306))
+
+### Other
+
+- *(deps)* replace serde_yaml with yaml_serde ([#340](https://github.com/endevco/aube/pull/340))
+
 ## [1.2.1](https://github.com/endevco/aube/compare/aube-settings-v1.2.0...aube-settings-v1.2.1) - 2026-04-26
 
 ### Fixed

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/endevco/aube/compare/aube-store-v1.2.1...aube-store-v1.3.0) - 2026-04-27
+
+### Fixed
+
+- *(resolver)* accept abbreviated git commit SHAs in user specs ([#346](https://github.com/endevco/aube/pull/346))
+- *(lockfile)* preserve package and bun lock compatibility ([#339](https://github.com/endevco/aube/pull/339))
+
 ## [1.2.0](https://github.com/endevco/aube/compare/aube-store-v1.1.0...aube-store-v1.2.0) - 2026-04-25
 
 ### Security

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/endevco/aube/compare/aube-util-v1.2.1...aube-util-v1.3.0) - 2026-04-27
+
+### Fixed
+
+- *(lockfile)* parse scalar pnpm platform fields ([#337](https://github.com/endevco/aube/pull/337))
+
 ## [1.2.0](https://github.com/endevco/aube/compare/aube-util-v1.1.0...aube-util-v1.2.0) - 2026-04-25
 
 ### Security

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/endevco/aube/compare/v1.2.1...v1.3.0) - 2026-04-27
+
+### Added
+
+- *(config)* add settings discovery ([#347](https://github.com/endevco/aube/pull/347))
+- *(security)* enforce trustPolicy by default, add paranoid bundle, security docs ([#333](https://github.com/endevco/aube/pull/333))
+- *(scripts)* add jailed dependency builds ([#306](https://github.com/endevco/aube/pull/306))
+
+### Fixed
+
+- *(resolver)* accept abbreviated git commit SHAs in user specs ([#346](https://github.com/endevco/aube/pull/346))
+- *(lockfile)* preserve package and bun lock compatibility ([#339](https://github.com/endevco/aube/pull/339))
+- *(registry)* surface retry warnings and cap timeout retries at 1 ([#331](https://github.com/endevco/aube/pull/331))
+- bun.lock parity for workspaces, platforms, and locked versions ([#327](https://github.com/endevco/aube/pull/327))
+
+### Other
+
+- *(add)* drop redundant pre-install resolve, use FrozenMode::Fix ([#348](https://github.com/endevco/aube/pull/348))
+- *(install)* skip unused dep bin links ([#343](https://github.com/endevco/aube/pull/343))
+- *(deps)* replace serde_yaml with yaml_serde ([#340](https://github.com/endevco/aube/pull/340))
+
 ## [1.2.1](https://github.com/endevco/aube/compare/v1.2.0...v1.2.1) - 2026-04-26
 
 ### Fixed

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5927,7 +5927,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.2.1",
+  "version": "1.3.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.2.1
+**Version**: 1.3.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.2.1",
-  "releasedAt": "2026-04-26T19:13:33Z"
+  "version": "1.3.0",
+  "releasedAt": "2026-04-27T20:00:50Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.3.0`

This PR bumps the workspace to `v1.3.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
