### PR TITLE
feat(security)!: enforce trustPolicy by default, add paranoid bundle, security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 **[Less disk use](https://aube.en.dev/package-manager/node-modules).** A global content-addressable store lets projects share package files instead of keeping a full copy of the same dependencies in every checkout.
 
-**[Secure defaults](https://aube.en.dev/security).** Out of the box, exotic transitive dependencies are blocked and dependency lifecycle scripts are denied unless approved. One `paranoid: true` line adds trust-downgrade detection at resolve and runs approved scripts in a package-scoped jail.
+**[Secure defaults](https://aube.en.dev/security).** Out of the box, exotic transitive deps are blocked, lifecycle scripts wait for approval, trust downgrades fail at resolve, and brand-new releases sit in a 24h cooling window. One `paranoid: true` line adds the build jail and turns the soft gates into hard fails.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 **[Less disk use](https://aube.en.dev/package-manager/node-modules).** A global content-addressable store lets projects share package files instead of keeping a full copy of the same dependencies in every checkout.
 
-**[Secure defaults](https://aube.en.dev/package-manager/jailed-builds).** aube defaults to safer installs: new releases wait out a minimum age, exotic transitive dependencies are blocked, and approved lifecycle scripts can run in a package-scoped jail.
+**[Secure defaults](https://aube.en.dev/security).** aube defaults to safer installs: exotic transitive dependencies are blocked, dependency lifecycle scripts are denied unless approved, trust downgrades fail loudly, and approved scripts can run in a package-scoped jail. Set `paranoid: true` to turn on every supply-chain protection in one line.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 **[Less disk use](https://aube.en.dev/package-manager/node-modules).** A global content-addressable store lets projects share package files instead of keeping a full copy of the same dependencies in every checkout.
 
-**[Secure defaults](https://aube.en.dev/security).** aube defaults to safer installs: exotic transitive dependencies are blocked, dependency lifecycle scripts are denied unless approved, trust downgrades fail loudly, and approved scripts can run in a package-scoped jail. Set `paranoid: true` to turn on every supply-chain protection in one line.
+**[Secure defaults](https://aube.en.dev/security).** Out of the box, exotic transitive dependencies are blocked and dependency lifecycle scripts are denied unless approved. One `paranoid: true` line adds trust-downgrade detection at resolve and runs approved scripts in a package-scoped jail.
 
 ## Install
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,10 +19,10 @@ several more available as one-line opt-ins. Full reference:
 | --- | --- | --- |
 | `blockExoticSubdeps` | `true` | Transitive deps from `git+`, `file:`, or raw tarball URLs |
 | `allowBuilds` (deny-by-default) | `true` | Lifecycle scripts running without explicit approval |
-| `jailBuilds` | `false` (planned default `true` in v2) | Approved scripts with full filesystem / network / env |
-| `trustPolicy = no-downgrade` | `false` (planned default in v2) | Versions that lost provenance or trusted-publisher evidence |
-| `minimumReleaseAge` | `0` | Newly published versions before they have aged in the registry |
-| `paranoid` | `false` | Master switch — forces `jailBuilds` and `trustPolicy=no-downgrade` |
+| `trustPolicy = no-downgrade` | `true` | Versions that lost provenance or trusted-publisher evidence |
+| `minimumReleaseAge` | `1440` (24h) | Newly published versions before they have aged in the registry |
+| `jailBuilds` | `false` (planned `true` in v2) | Approved scripts with full filesystem / network / env |
+| `paranoid` | `false` | Master switch — forces `jailBuilds`, `trustPolicy=no-downgrade`, `minimumReleaseAgeStrict`, `strictStoreIntegrity`, `strictDepBuilds` |
 | Tarball integrity (SHA-512) | always on | Tampered tarballs in the registry or proxy cache |
 | Content-addressed store (BLAKE3) | always on | Drift between the store and the linked `node_modules` |
 | `aube audit` | n/a | Known CVEs against the resolved dependency tree |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ several more available as one-line opt-ins. Full reference:
 | --- | --- | --- |
 | `blockExoticSubdeps` | `true` | Transitive deps from `git+`, `file:`, or raw tarball URLs |
 | `allowBuilds` (deny-by-default) | `true` | Lifecycle scripts running without explicit approval |
-| `trustPolicy = no-downgrade` | `true` | Versions that lost provenance or trusted-publisher evidence |
+| `trustPolicy` | `"no-downgrade"` | Versions that lost provenance or trusted-publisher evidence |
 | `minimumReleaseAge` | `1440` (24h) | Newly published versions before they have aged in the registry |
 | `jailBuilds` | `false` (planned `true` in v2) | Approved scripts with full filesystem / network / env |
 | `paranoid` | `false` | Master switch — forces `jailBuilds`, `trustPolicy=no-downgrade`, `minimumReleaseAgeStrict`, `strictStoreIntegrity`, `strictDepBuilds` |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security
+
+## Reporting a vulnerability
+
+Please report security issues privately via GitHub's security advisory form:
+**[github.com/endevco/aube/security/advisories/new](https://github.com/endevco/aube/security/advisories/new)**
+
+Do not file a public discussion for vulnerabilities. We will acknowledge
+receipt within a few business days, work with you on a fix, and credit you in
+the release notes unless you prefer otherwise.
+
+## Security features at a glance
+
+aube ships with several supply-chain protections enabled by default and
+several more available as one-line opt-ins. Full reference:
+**[aube.en.dev/security](https://aube.en.dev/security)**.
+
+| Setting | Default | What it protects against |
+| --- | --- | --- |
+| `blockExoticSubdeps` | `true` | Transitive deps from `git+`, `file:`, or raw tarball URLs |
+| `allowBuilds` (deny-by-default) | `true` | Lifecycle scripts running without explicit approval |
+| `jailBuilds` | `false` (planned default `true` in v2) | Approved scripts with full filesystem / network / env |
+| `trustPolicy = no-downgrade` | `false` (planned default in v2) | Versions that lost provenance or trusted-publisher evidence |
+| `minimumReleaseAge` | `0` | Newly published versions before they have aged in the registry |
+| `paranoid` | `false` | Master switch — forces `jailBuilds` and `trustPolicy=no-downgrade` |
+| Tarball integrity (SHA-512) | always on | Tampered tarballs in the registry or proxy cache |
+| Content-addressed store (BLAKE3) | always on | Drift between the store and the linked `node_modules` |
+| `aube audit` | n/a | Known CVEs against the resolved dependency tree |
+
+## Supported versions
+
+Security fixes target the latest minor of the current major release. Older
+majors do not receive backports.

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -325,6 +325,12 @@ pub struct WorkspaceConfig {
     #[serde(default, rename = "jailBuilds")]
     pub jail_builds: Option<bool>,
 
+    /// Master switch that forces both `jailBuilds=true` and
+    /// `trustPolicy=no-downgrade`. Same typed/raw duality as
+    /// `child_concurrency`.
+    #[serde(default)]
+    pub paranoid: Option<bool>,
+
     /// Dependency package patterns that should run outside the jail even
     /// when `jailBuilds` is enabled. Same typed/raw duality as
     /// `child_concurrency`.

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -209,6 +209,14 @@ pub struct VersionMetadata {
     /// Deprecation message from the registry, if this version is deprecated.
     #[serde(default, deserialize_with = "deprecated_string")]
     pub deprecated: Option<String>,
+    /// `_npmUser` block from the packument, when present. The
+    /// trust-policy check reads `_npmUser.trustedPublisher` as the
+    /// strongest trust-evidence signal (npm's "trusted publishers"
+    /// feature, OIDC-backed). Some old packuments emit `_npmUser` as
+    /// a `"name <email>"` string rather than an object — that shape
+    /// degrades to `None` instead of failing the whole packument.
+    #[serde(default, rename = "_npmUser", deserialize_with = "npm_user_tolerant")]
+    pub npm_user: Option<NpmUser>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -217,11 +225,33 @@ pub struct PeerDepMeta {
     pub optional: bool,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct NpmUser {
+    /// Truthy when the publish came from an npm "trusted publisher"
+    /// (e.g. GitHub Actions OIDC). Pnpm's trust-policy check treats
+    /// presence of any non-null value here as the strongest evidence
+    /// (rank 2, above provenance attestations).
+    #[serde(default, rename = "trustedPublisher")]
+    pub trusted_publisher: Option<serde_json::Value>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Dist {
     pub tarball: String,
     pub integrity: Option<String>,
     pub shasum: Option<String>,
+    /// Sigstore attestations block. The trust-policy check reads
+    /// `dist.attestations.provenance` as a rank-1 trust-evidence
+    /// signal (`npm publish --provenance`). Existence is the only
+    /// signal we read — neither pnpm nor aube validates the bundle.
+    #[serde(default)]
+    pub attestations: Option<Attestations>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct Attestations {
+    #[serde(default)]
+    pub provenance: Option<serde_json::Value>,
 }
 
 fn deprecated_string<'de, D>(de: D) -> Result<Option<String>, D::Error>
@@ -282,6 +312,23 @@ where
                 .map(String::from),
             _ => None,
         }),
+        _ => None,
+    })
+}
+
+/// Accept the packument's `_npmUser:` field in its documented shapes
+/// and degrade to `None` for anything else. Modern packuments emit an
+/// object (`{name, email, trustedPublisher?}`); pre-2010 publishes
+/// emit `"name <email>"` strings. We only care about
+/// `trustedPublisher`, so unparseable shapes don't fail the packument
+/// — they just lose the trusted-publisher signal for that version.
+fn npm_user_tolerant<'de, D>(de: D) -> Result<Option<NpmUser>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(de)?;
+    Ok(match value {
+        Some(v @ serde_json::Value::Object(_)) => serde_json::from_value(v).ok(),
         _ => None,
     })
 }
@@ -460,6 +507,7 @@ mod tests {
             bin,
             has_install_script: false,
             deprecated: None,
+            npm_user: None,
         };
         let json = serde_json::to_string(&v).unwrap();
         let back: VersionMetadata = serde_json::from_str(&json).unwrap();
@@ -476,6 +524,57 @@ mod tests {
         assert!(v.os.is_empty());
         assert!(v.cpu.is_empty());
         assert!(v.libc.is_empty());
+    }
+
+    #[test]
+    fn attestations_provenance_is_extracted() {
+        let v = parse(
+            r#"{"name":"x","version":"1.0.0",
+                "dist":{"tarball":"t","attestations":{"provenance":{"predicateType":"slsa"}}}}"#,
+        );
+        let dist = v.dist.expect("dist present");
+        let att = dist.attestations.expect("attestations present");
+        assert!(att.provenance.is_some(), "provenance present");
+    }
+
+    #[test]
+    fn attestations_missing_is_none() {
+        let v = parse(r#"{"name":"x","version":"1.0.0","dist":{"tarball":"t"}}"#);
+        let dist = v.dist.expect("dist present");
+        assert!(dist.attestations.is_none());
+    }
+
+    #[test]
+    fn npm_user_object_with_trusted_publisher_is_parsed() {
+        let v = parse(
+            r#"{"name":"x","version":"1.0.0",
+                "_npmUser":{"name":"u","email":"u@x","trustedPublisher":{"id":"gh"}}}"#,
+        );
+        let user = v.npm_user.expect("_npmUser present");
+        assert!(user.trusted_publisher.is_some());
+    }
+
+    #[test]
+    fn npm_user_object_without_trusted_publisher_is_parsed() {
+        let v = parse(r#"{"name":"x","version":"1.0.0","_npmUser":{"name":"u","email":"u@x"}}"#);
+        let user = v.npm_user.expect("_npmUser present");
+        assert!(user.trusted_publisher.is_none());
+    }
+
+    /// Pre-2010 publishes serialize `_npmUser` as a `"name <email>"`
+    /// string. Degrade to `None` instead of failing the whole packument.
+    #[test]
+    fn npm_user_string_form_degrades_to_none() {
+        let v = parse(r#"{"name":"x","version":"1.0.0","_npmUser":"isaacs <i@npmjs.com>"}"#);
+        assert!(v.npm_user.is_none());
+    }
+
+    #[test]
+    fn npm_user_null_or_missing_is_none() {
+        let v_null = parse(r#"{"name":"x","version":"1.0.0","_npmUser":null}"#);
+        assert!(v_null.npm_user.is_none());
+        let v_missing = parse(r#"{"name":"x","version":"1.0.0"}"#);
+        assert!(v_missing.npm_user.is_none());
     }
 
     #[test]

--- a/crates/aube-resolver/src/builder.rs
+++ b/crates/aube-resolver/src/builder.rs
@@ -118,7 +118,9 @@ impl Resolver {
     /// two `resolved_times.insert` call sites on this predicate so
     /// Highest-mode installs never populate the map.
     pub(crate) fn should_record_times(&self) -> bool {
-        self.resolution_mode == ResolutionMode::TimeBased || self.minimum_release_age.is_some()
+        self.resolution_mode == ResolutionMode::TimeBased
+            || self.minimum_release_age.is_some()
+            || self.dependency_policy.trust_policy == crate::TrustPolicy::NoDowngrade
     }
 
     /// Override the default `auto-install-peers=true` behavior. pnpm reads

--- a/crates/aube-resolver/src/error.rs
+++ b/crates/aube-resolver/src/error.rs
@@ -1,5 +1,6 @@
 use crate::ResolveTask;
 use crate::semver_util::highest_stable_version;
+use crate::trust::{MissingTimeDetails, TrustDowngradeDetails};
 use aube_registry::Packument;
 
 #[derive(Debug, thiserror::Error)]
@@ -28,6 +29,17 @@ pub enum Error {
         .0.name, .0.spec, .0.parent
     )]
     BlockedExoticSubdep(Box<ExoticSubdepDetails>),
+    #[error(
+        "trust downgrade for {}@{} (trustPolicy=no-downgrade): earlier published version {} had {} but this version has {}",
+        .0.name, .0.picked_version, .0.prior_version, .0.prior_evidence.label(),
+        .0.current_evidence.map_or("no trust evidence", |e| e.label())
+    )]
+    TrustDowngrade(Box<TrustDowngradeDetails>),
+    #[error(
+        "trust check failed for {}@{} (trustPolicy=no-downgrade): registry packument has no `time` entry for the picked version",
+        .0.name, .0.version
+    )]
+    TrustCheckMissingTime(Box<MissingTimeDetails>),
 }
 
 /// Context attached to a `NoMatch` error so the miette `help()` output can
@@ -107,8 +119,31 @@ impl miette::Diagnostic for Error {
             Self::UnknownCatalog(d) => Some(Box::new(format_unknown_catalog_help(d))),
             Self::UnknownCatalogEntry(d) => Some(Box::new(format_unknown_catalog_entry_help(d))),
             Self::BlockedExoticSubdep(d) => Some(Box::new(format_exotic_subdep_help(d))),
+            Self::TrustDowngrade(d) => Some(Box::new(format_trust_downgrade_help(d))),
+            Self::TrustCheckMissingTime(d) => Some(Box::new(format_trust_missing_time_help(d))),
         }
     }
+}
+
+fn format_trust_downgrade_help(d: &TrustDowngradeDetails) -> String {
+    format!(
+        "a trust downgrade may indicate a supply-chain incident — the publisher's previous releases carried {evidence} but {name}@{ver} does not.\n\
+         to bypass: pin a version that retains evidence, set `trustPolicy = off` in .npmrc / pnpm-workspace.yaml, \
+         or add `{name}` (or `{name}@{ver}`) to `trustPolicyExclude`.",
+        evidence = d.prior_evidence.label(),
+        name = d.name,
+        ver = d.picked_version,
+    )
+}
+
+fn format_trust_missing_time_help(d: &MissingTimeDetails) -> String {
+    format!(
+        "trustPolicy=no-downgrade compares against per-version publish times in the packument. \
+         The registry serving {name} omitted `time[{ver}]` — check the registry config in .npmrc, \
+         or set `trustPolicy = off` to skip the check.",
+        name = d.name,
+        ver = d.version,
+    )
 }
 
 /// Build a `NoMatchDetails` snapshot from the task that failed and the

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -12,15 +12,13 @@ mod trust;
 mod types;
 
 pub use error::{AgeGateDetails, CatalogDetails, Error, ExoticSubdepDetails, NoMatchDetails};
-pub use trust::{
-    MissingTimeDetails as MissingTrustTimeDetails, TrustDowngradeDetails,
-};
 pub use package_ext::is_deprecation_allowed;
 pub use peer_context::{
     PeerContextOptions, UnmetPeer, apply_peer_contexts, detect_unmet_peers,
     hoist_auto_installed_peers,
 };
 pub use platform::{SupportedArchitectures, is_supported};
+pub use trust::{MissingTimeDetails as MissingTrustTimeDetails, TrustDowngradeDetails};
 pub use trust::{TrustEvidence, TrustExcludeParseError, TrustExcludeRules};
 pub use types::{
     DependencyPolicy, MinimumReleaseAge, PackageExtension, ReadPackageHook, ResolutionMode,

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -8,15 +8,20 @@ mod peer_context;
 pub mod platform;
 mod resolve;
 mod semver_util;
+mod trust;
 mod types;
 
 pub use error::{AgeGateDetails, CatalogDetails, Error, ExoticSubdepDetails, NoMatchDetails};
+pub use trust::{
+    MissingTimeDetails as MissingTrustTimeDetails, TrustDowngradeDetails,
+};
 pub use package_ext::is_deprecation_allowed;
 pub use peer_context::{
     PeerContextOptions, UnmetPeer, apply_peer_contexts, detect_unmet_peers,
     hoist_auto_installed_peers,
 };
 pub use platform::{SupportedArchitectures, is_supported};
+pub use trust::{TrustEvidence, TrustExcludeParseError, TrustExcludeRules};
 pub use types::{
     DependencyPolicy, MinimumReleaseAge, PackageExtension, ReadPackageHook, ResolutionMode,
     ResolvedPackage, TrustPolicy,

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -145,7 +145,8 @@ impl Resolver {
         // cheaper abbreviated path stays on the hot path and we save
         // one full-packument fetch per distinct package.
         let needs_time = (self.resolution_mode == ResolutionMode::TimeBased
-            || self.minimum_release_age.is_some())
+            || self.minimum_release_age.is_some()
+            || self.dependency_policy.trust_policy == crate::TrustPolicy::NoDowngrade)
             && !self.registry_supports_time_field;
         let minimum_release_age_only =
             self.resolution_mode != ResolutionMode::TimeBased && self.minimum_release_age.is_some();
@@ -1268,6 +1269,31 @@ impl Resolver {
                         ))));
                     }
                 };
+                // Trust-policy enforcement runs *before* any other
+                // post-pick processing (mirrors pnpm's placement
+                // immediately after `pickPackage`). Skip when policy is
+                // off so the off-by-default case is a single enum
+                // compare. The check needs the live packument's `time`
+                // map and all version metadata, both of which are still
+                // in scope here from L1191.
+                if self.dependency_policy.trust_policy == crate::TrustPolicy::NoDowngrade {
+                    crate::trust::check_no_downgrade(
+                        packument,
+                        &picked_ref.version,
+                        picked_ref,
+                        &self.dependency_policy.trust_policy_exclude,
+                        self.dependency_policy.trust_policy_ignore_after,
+                    )
+                    .map_err(|e| match e {
+                        crate::trust::TrustCheckError::Downgrade(d) => {
+                            Error::TrustDowngrade(Box::new(d))
+                        }
+                        crate::trust::TrustCheckError::MissingTime(d) => {
+                            Error::TrustCheckMissingTime(Box::new(d))
+                        }
+                    })?;
+                }
+
                 // Clone the picked metadata into an owned value so we can
                 // both run the `readPackage` hook (which needs a
                 // disjoint `&mut self` borrow) and, later, mutate the

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -148,8 +148,17 @@ impl Resolver {
             || self.minimum_release_age.is_some()
             || self.dependency_policy.trust_policy == crate::TrustPolicy::NoDowngrade)
             && !self.registry_supports_time_field;
-        let minimum_release_age_only =
-            self.resolution_mode != ResolutionMode::TimeBased && self.minimum_release_age.is_some();
+        // Gate for the corgi-shortcircuit at L219-235: when the only
+        // reason we need `time` is `minimumReleaseAge` AND the
+        // packument's top-level `modified` predates the cutoff, every
+        // version is old enough so we can skip the full-packument
+        // fetch. trustPolicy=NoDowngrade adds a second time requirement
+        // (per-version compare), so the shortcircuit must NOT fire when
+        // it's on — otherwise the trust check falls through to a
+        // spurious TrustCheckMissingTime on every version.
+        let minimum_release_age_only = self.resolution_mode != ResolutionMode::TimeBased
+            && self.minimum_release_age.is_some()
+            && self.dependency_policy.trust_policy != crate::TrustPolicy::NoDowngrade;
         // In-flight packument fetches. The spawned task returns the
         // `(name, packument)` tuple so `join_next` gives us back the
         // identity of whichever fetch landed next without a side

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -830,6 +830,108 @@ async fn minimum_release_age_uses_modified_to_skip_full_packument() {
     let _ = std::fs::remove_dir_all(base);
 }
 
+/// Regression: when both `minimumReleaseAge` and `trustPolicy=NoDowngrade`
+/// are active, the corgi-shortcircuit in `Resolver::resolve` must NOT
+/// fire — it would return an abbreviated packument without `time`,
+/// causing the trust check to fail with a spurious
+/// `TrustCheckMissingTime` for every version. Reported by Cursor Bugbot
+/// on PR #333.
+#[tokio::test]
+async fn trust_policy_disables_minimum_release_age_short_circuit() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // Two packument bodies sharing one name. The corgi body (served to
+    // requests carrying the corgi Accept header) has `modified` set to
+    // an old timestamp and an empty `time` map — exactly what a real
+    // npmjs.org corgi response looks like. The full body has the same
+    // versions but a populated `time` map. With the bug present,
+    // `minimum_release_age_only` is true, the corgi response satisfies
+    // `modified_allows_short_circuit`, the corgi packument is returned
+    // early, and the trust check fails because `time["1.0.0"]` is
+    // missing. With the fix, `minimum_release_age_only` is forced
+    // false by `trust_policy == NoDowngrade`, the resolver bypasses
+    // the corgi-shortcircuit branch and goes straight to the full
+    // fetch, the trust check sees a populated `time`, finds no prior
+    // versions to compare against, and resolves cleanly.
+    let mut corgi = make_packument("foo", &["1.0.0"], "1.0.0");
+    corgi.modified = Some("2024-01-01T00:00:00.000Z".to_string());
+    let corgi_body = serde_json::to_vec(&corgi).unwrap();
+
+    let mut full = make_packument("foo", &["1.0.0"], "1.0.0");
+    full.modified = Some("2024-01-01T00:00:00.000Z".to_string());
+    full.time
+        .insert("1.0.0".to_string(), "2024-01-01T00:00:00.000Z".to_string());
+    let full_body = serde_json::to_vec(&full).unwrap();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            let corgi_body = corgi_body.clone();
+            let full_body = full_body.clone();
+            tokio::spawn(async move {
+                let mut buf = vec![0_u8; 4096];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let body = if request.contains("application/vnd.npm.install-v1+json") {
+                    corgi_body
+                } else {
+                    full_body
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+                socket.write_all(&body).await.unwrap();
+            });
+        }
+    });
+
+    let base = std::env::temp_dir().join(format!(
+        "aube-resolver-trust-mra-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(base.join("packuments")).unwrap();
+    std::fs::create_dir_all(base.join("packuments-full")).unwrap();
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let policy = crate::DependencyPolicy {
+        trust_policy: crate::TrustPolicy::NoDowngrade,
+        ..crate::DependencyPolicy::default()
+    };
+    let mut resolver = Resolver::new(client)
+        .with_packument_cache(base.join("packuments"))
+        .with_packument_full_cache(base.join("packuments-full"))
+        .with_minimum_release_age(Some(MinimumReleaseAge {
+            minutes: 60,
+            ..Default::default()
+        }))
+        .with_dependency_policy(policy);
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("foo".to_string(), "1.0.0".to_string());
+
+    let result = resolver.resolve(&manifest, None).await;
+    assert!(
+        !matches!(result, Err(Error::TrustCheckMissingTime(_))),
+        "shortcircuit must be suppressed when trustPolicy=NoDowngrade — got {result:?}"
+    );
+    let graph = result.expect("clean resolve");
+    assert!(graph_has_package(&graph, "foo", "1.0.0"));
+
+    server.abort();
+    let _ = std::fs::remove_dir_all(base);
+}
+
 #[tokio::test]
 async fn trust_policy_no_downgrade_blocks_downgraded_install() {
     use aube_registry::Attestations;

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -575,6 +575,7 @@ fn make_version(name: &str, version: &str) -> VersionMetadata {
             tarball: format!("https://registry.npmjs.org/{name}/-/{name}-{version}.tgz"),
             integrity: Some(format!("sha512-fake-{name}-{version}")),
             shasum: None,
+            attestations: None,
         }),
         os: vec![],
         cpu: vec![],
@@ -585,6 +586,7 @@ fn make_version(name: &str, version: &str) -> VersionMetadata {
         bin: BTreeMap::new(),
         has_install_script: false,
         deprecated: None,
+        npm_user: None,
     }
 }
 
@@ -824,6 +826,122 @@ async fn minimum_release_age_uses_modified_to_skip_full_packument() {
 
     assert!(graph_has_package(&graph, "foo", "1.0.0"));
     assert_eq!(requests.load(Ordering::Relaxed), 1);
+    server.abort();
+    let _ = std::fs::remove_dir_all(base);
+}
+
+#[tokio::test]
+async fn trust_policy_no_downgrade_blocks_downgraded_install() {
+    use aube_registry::Attestations;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // Three versions of `foo`. 2.0.0 has provenance attestation;
+    // 3.0.0 lost it (the supply-chain incident shape pnpm's check is
+    // designed for). With trustPolicy=no-downgrade, picking 3.0.0
+    // must fail with Error::TrustDowngrade.
+    let mut packument = make_packument("foo", &["1.0.0", "2.0.0", "3.0.0"], "3.0.0");
+    packument
+        .time
+        .insert("1.0.0".to_string(), "2025-01-01T00:00:00.000Z".to_string());
+    packument
+        .time
+        .insert("2.0.0".to_string(), "2025-02-01T00:00:00.000Z".to_string());
+    packument
+        .time
+        .insert("3.0.0".to_string(), "2025-03-01T00:00:00.000Z".to_string());
+    let v2 = packument.versions.get_mut("2.0.0").unwrap();
+    v2.dist.as_mut().unwrap().attestations = Some(Attestations {
+        provenance: Some(serde_json::json!({"predicateType": "slsa"})),
+    });
+    let body = serde_json::to_vec(&packument).unwrap();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let requests = Arc::new(AtomicUsize::new(0));
+    let request_count = requests.clone();
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            request_count.fetch_add(1, Ordering::Relaxed);
+            let body = body.clone();
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 2048];
+                let _ = socket.read(&mut buf).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+                socket.write_all(&body).await.unwrap();
+            });
+        }
+    });
+
+    let base = std::env::temp_dir().join(format!(
+        "aube-resolver-trust-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(base.join("packuments")).unwrap();
+    std::fs::create_dir_all(base.join("packuments-full")).unwrap();
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let policy = crate::DependencyPolicy {
+        trust_policy: crate::TrustPolicy::NoDowngrade,
+        ..crate::DependencyPolicy::default()
+    };
+    let mut resolver = Resolver::new(client)
+        .with_packument_cache(base.join("packuments"))
+        .with_packument_full_cache(base.join("packuments-full"))
+        .with_dependency_policy(policy);
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("foo".to_string(), "3.0.0".to_string());
+
+    let err = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect_err("3.0.0 must be rejected as a trust downgrade");
+    match err {
+        Error::TrustDowngrade(d) => {
+            assert_eq!(d.name, "foo");
+            assert_eq!(d.picked_version, "3.0.0");
+            assert_eq!(d.prior_version, "2.0.0");
+            assert!(matches!(
+                d.prior_evidence,
+                crate::trust::TrustEvidence::Provenance
+            ));
+            assert!(d.current_evidence.is_none());
+        }
+        other => panic!("expected TrustDowngrade, got {other:?}"),
+    }
+
+    // Verify the suggested fix path actually unblocks the install.
+    let mut excluded_policy = crate::DependencyPolicy {
+        trust_policy: crate::TrustPolicy::NoDowngrade,
+        ..crate::DependencyPolicy::default()
+    };
+    excluded_policy.trust_policy_exclude =
+        crate::TrustExcludeRules::parse(["foo@3.0.0"]).unwrap();
+    let mut resolver = Resolver::new(Arc::new(aube_registry::client::RegistryClient::new(
+        &registry,
+    )))
+    .with_packument_cache(base.join("packuments"))
+    .with_packument_full_cache(base.join("packuments-full"))
+    .with_dependency_policy(excluded_policy);
+    let graph = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect("excluded version installs cleanly");
+    assert!(graph_has_package(&graph, "foo", "3.0.0"));
+
     server.abort();
     let _ = std::fs::remove_dir_all(base);
 }

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -928,8 +928,7 @@ async fn trust_policy_no_downgrade_blocks_downgraded_install() {
         trust_policy: crate::TrustPolicy::NoDowngrade,
         ..crate::DependencyPolicy::default()
     };
-    excluded_policy.trust_policy_exclude =
-        crate::TrustExcludeRules::parse(["foo@3.0.0"]).unwrap();
+    excluded_policy.trust_policy_exclude = crate::TrustExcludeRules::parse(["foo@3.0.0"]).unwrap();
     let mut resolver = Resolver::new(Arc::new(aube_registry::client::RegistryClient::new(
         &registry,
     )))

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -128,6 +128,19 @@ pub fn check_no_downgrade(
         return Ok(());
     }
 
+    // Registry doesn't publish `time` at all — local Verdaccio fixtures,
+    // some private mirrors, ancient registry forks. Without per-version
+    // publish times we can't compare evidence chronologically, so skip
+    // the check rather than fail every install. This degrades the
+    // protection but preserves install behavior against compliant
+    // registries (npmjs.org, JSR, modern Verdaccio). Diverges from
+    // pnpm's strict-throw behavior because trustPolicy is default-on
+    // in aube — strict-throw against the long tail of registries that
+    // omit `time` would make aube unusable on first install.
+    if packument.time.is_empty() {
+        return Ok(());
+    }
+
     let Some(picked_time) = packument.time.get(picked_version) else {
         return Err(TrustCheckError::MissingTime(MissingTimeDetails {
             name: packument.name.clone(),
@@ -742,6 +755,34 @@ mod tests {
             result.is_err(),
             "prerelease pick should compare against prior prereleases"
         );
+    }
+
+    /// Registries that don't publish `time` at all (Verdaccio without
+    /// the `--store-info` middleware, private mirrors that strip it,
+    /// old registry forks) must not break every install. Verified by
+    /// constructing a packument with versions but no `time` map.
+    #[test]
+    fn empty_time_map_skips_check() {
+        let p = Packument {
+            name: "foo".to_string(),
+            modified: None,
+            versions: {
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "1.0.0".to_string(),
+                    with_provenance(version("foo", "1.0.0")),
+                );
+                m.insert("2.0.0".to_string(), version("foo", "2.0.0"));
+                m
+            },
+            dist_tags: BTreeMap::new(),
+            time: BTreeMap::new(), // Empty — registry doesn't ship time at all.
+        };
+        let picked = p.versions.get("2.0.0").unwrap();
+        // Would normally be a downgrade (2.0.0 lost provenance), but
+        // without `time` we can't establish chronology and degrade safely.
+        let result = check_no_downgrade(&p, "2.0.0", picked, &TrustExcludeRules::default(), None);
+        assert!(result.is_ok(), "empty time map should skip the check");
     }
 
     #[test]

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -1,0 +1,824 @@
+//! Trust-policy enforcement.
+//!
+//! Mirrors pnpm's `failIfTrustDowngraded`
+//! (resolving/npm-resolver/src/trustChecks.ts), verified against pnpm's
+//! own test suite. Two trust-evidence sources, ranked
+//! `TrustedPublisher (2) > Provenance (1)`. The check runs immediately
+//! after a version is picked from a packument: if any strictly older
+//! version of the same package had stronger trust evidence, the install
+//! fails. Pre-2010 packuments without per-version `time` entries error
+//! when the picked version isn't excluded — same as pnpm.
+
+use aube_registry::{Packument, VersionMetadata};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Trust-evidence ranks. Higher is stronger. Variants intentionally do
+/// not derive `Ord` — the variant declaration order does not match the
+/// rank order, so callers must go through [`Self::rank`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustEvidence {
+    TrustedPublisher,
+    Provenance,
+}
+
+impl TrustEvidence {
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::TrustedPublisher => 2,
+            Self::Provenance => 1,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::TrustedPublisher => "trusted publisher",
+            Self::Provenance => "provenance attestation",
+        }
+    }
+}
+
+/// Strongest trust evidence carried by a single version's metadata.
+/// Mirrors pnpm's `getTrustEvidence`: `_npmUser.trustedPublisher`
+/// outranks `dist.attestations.provenance`. JS-style truthiness on the
+/// trustedPublisher value: any non-null, non-`false` value counts.
+pub fn evidence_for(meta: &VersionMetadata) -> Option<TrustEvidence> {
+    if meta
+        .npm_user
+        .as_ref()
+        .and_then(|u| u.trusted_publisher.as_ref())
+        .is_some_and(is_truthy)
+    {
+        return Some(TrustEvidence::TrustedPublisher);
+    }
+    if meta
+        .dist
+        .as_ref()
+        .and_then(|d| d.attestations.as_ref())
+        .and_then(|a| a.provenance.as_ref())
+        .is_some()
+    {
+        return Some(TrustEvidence::Provenance);
+    }
+    None
+}
+
+fn is_truthy(v: &serde_json::Value) -> bool {
+    !matches!(v, serde_json::Value::Null | serde_json::Value::Bool(false))
+}
+
+#[derive(Debug)]
+pub enum TrustCheckError {
+    Downgrade(TrustDowngradeDetails),
+    MissingTime(MissingTimeDetails),
+}
+
+#[derive(Debug)]
+pub struct TrustDowngradeDetails {
+    pub name: String,
+    pub picked_version: String,
+    pub current_evidence: Option<TrustEvidence>,
+    pub prior_evidence: TrustEvidence,
+    pub prior_version: String,
+}
+
+#[derive(Debug)]
+pub struct MissingTimeDetails {
+    pub name: String,
+    pub version: String,
+}
+
+/// Run the trust-downgrade check. Returns `Ok(())` when the picked
+/// version is acceptable (excluded, missing-evidence-everywhere, older
+/// than `ignore_after_minutes`, or carrying evidence at least as strong
+/// as the strongest prior version's). Errors otherwise.
+///
+/// Step ordering matters: exclude check runs *before* the time lookup
+/// so an excluded `name@version` does not surface a `MissingTime` error
+/// when the registry omits the `time` field. Verified against pnpm's
+/// `does not fail with ERR_PNPM_MISSING_TIME when ... excluded` tests.
+pub fn check_no_downgrade(
+    packument: &Packument,
+    picked_version: &str,
+    picked_meta: &VersionMetadata,
+    exclude: &TrustExcludeRules,
+    ignore_after_minutes: Option<u64>,
+) -> Result<(), TrustCheckError> {
+    let picked_parsed = node_semver::Version::parse(picked_version).ok();
+
+    if let Some(ref pv) = picked_parsed {
+        if exclude.matches(&packument.name, pv) {
+            return Ok(());
+        }
+    } else if exclude.matches_name_only(&packument.name) {
+        return Ok(());
+    }
+
+    let Some(picked_time) = packument.time.get(picked_version) else {
+        return Err(TrustCheckError::MissingTime(MissingTimeDetails {
+            name: packument.name.clone(),
+            version: picked_version.to_string(),
+        }));
+    };
+
+    if let Some(minutes) = ignore_after_minutes
+        && minutes > 0
+        && let Some(cutoff) = cutoff_iso8601(minutes)
+        && picked_time.as_str() < cutoff.as_str()
+    {
+        return Ok(());
+    }
+
+    // pnpm v10.24.0+: when the picked version is a stable release,
+    // ignore prior prerelease evidence — a trusted alpha shouldn't
+    // block a stable that omits attestation.
+    let exclude_prereleases = picked_parsed
+        .as_ref()
+        .map(|v| v.pre_release.is_empty())
+        .unwrap_or(false);
+
+    let mut best: Option<(TrustEvidence, &str)> = None;
+    for (other_ver, other_meta) in &packument.versions {
+        if other_ver == picked_version {
+            continue;
+        }
+        let Some(other_time) = packument.time.get(other_ver) else {
+            continue;
+        };
+        if other_time.as_str() >= picked_time.as_str() {
+            continue;
+        }
+        if exclude_prereleases
+            && let Ok(parsed) = node_semver::Version::parse(other_ver)
+            && !parsed.pre_release.is_empty()
+        {
+            continue;
+        }
+        let Some(evidence) = evidence_for(other_meta) else {
+            continue;
+        };
+        match best {
+            None => best = Some((evidence, other_ver.as_str())),
+            Some((cur, _)) if evidence.rank() > cur.rank() => {
+                best = Some((evidence, other_ver.as_str()));
+            }
+            _ => {}
+        }
+        if matches!(best, Some((TrustEvidence::TrustedPublisher, _))) {
+            break;
+        }
+    }
+
+    let Some((prior_evidence, prior_version)) = best else {
+        return Ok(());
+    };
+
+    let current = evidence_for(picked_meta);
+    let current_rank = current.map_or(0, TrustEvidence::rank);
+    if current_rank < prior_evidence.rank() {
+        return Err(TrustCheckError::Downgrade(TrustDowngradeDetails {
+            name: packument.name.clone(),
+            picked_version: picked_version.to_string(),
+            current_evidence: current,
+            prior_evidence,
+            prior_version: prior_version.to_string(),
+        }));
+    }
+    Ok(())
+}
+
+fn cutoff_iso8601(minutes_ago: u64) -> Option<String> {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+    let cutoff_secs = now.saturating_sub(minutes_ago * 60);
+    Some(crate::types::format_iso8601_utc(cutoff_secs))
+}
+
+/// Parsed `trustPolicyExclude` rules. Mirrors pnpm's
+/// `createPackageVersionPolicy` (config/version-policy/src/index.ts).
+/// Each rule is `<name>` (matches all versions, supports `*` glob in
+/// the name) or `<name>@<exact-version>[ || <exact-version>]…` (no
+/// ranges, no name globs combined with versions).
+#[derive(Debug, Clone, Default)]
+pub struct TrustExcludeRules {
+    rules: Vec<TrustExcludeRule>,
+}
+
+#[derive(Debug, Clone)]
+struct TrustExcludeRule {
+    name_matcher: NameMatcher,
+    /// `None` → rule matches every version of any name match.
+    /// `Some(versions)` → rule matches only those exact versions.
+    exact_versions: Option<Vec<node_semver::Version>>,
+}
+
+#[derive(Debug, Clone)]
+enum NameMatcher {
+    Exact(String),
+    Glob(GlobMatcher),
+    Any,
+}
+
+#[derive(Debug, Clone)]
+struct GlobMatcher {
+    parts: Vec<String>,
+    leading_wildcard: bool,
+    trailing_wildcard: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TrustExcludeParseError {
+    #[error("invalid trustPolicyExclude pattern `{pattern}`: only exact versions are allowed in version unions, ranges (^/~/>=) are not supported")]
+    InvalidVersionUnion { pattern: String },
+    #[error(
+        "invalid trustPolicyExclude pattern `{pattern}`: name patterns (`*`) cannot be combined with version unions"
+    )]
+    NameGlobWithVersions { pattern: String },
+}
+
+impl TrustExcludeRules {
+    pub fn parse<I, S>(patterns: I) -> Result<Self, TrustExcludeParseError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut rules = Vec::new();
+        for pattern in patterns {
+            let pattern = pattern.as_ref();
+            if pattern.is_empty() {
+                continue;
+            }
+            rules.push(parse_one(pattern)?);
+        }
+        Ok(Self { rules })
+    }
+
+    fn matches(&self, name: &str, version: &node_semver::Version) -> bool {
+        for rule in &self.rules {
+            if !rule.name_matcher.matches(name) {
+                continue;
+            }
+            match &rule.exact_versions {
+                None => return true,
+                Some(versions) => {
+                    if versions.iter().any(|v| v == version) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Used when the picked version string fails semver parse — only a
+    /// no-version rule can match in that case (pnpm behavior:
+    /// `evaluateVersionPolicy` returns `true` for name-only rules
+    /// before the version array branch is taken).
+    fn matches_name_only(&self, name: &str) -> bool {
+        self.rules
+            .iter()
+            .any(|r| r.exact_versions.is_none() && r.name_matcher.matches(name))
+    }
+}
+
+fn parse_one(pattern: &str) -> Result<TrustExcludeRule, TrustExcludeParseError> {
+    let scoped = pattern.starts_with('@');
+    let at_index = if scoped {
+        pattern[1..].find('@').map(|i| i + 1)
+    } else {
+        pattern.find('@')
+    };
+
+    let (name_part, versions_part) = match at_index {
+        Some(i) => (&pattern[..i], Some(&pattern[i + 1..])),
+        None => (pattern, None),
+    };
+
+    let exact_versions = match versions_part {
+        None => None,
+        Some(versions_str) => {
+            if name_part.contains('*') {
+                return Err(TrustExcludeParseError::NameGlobWithVersions {
+                    pattern: pattern.to_string(),
+                });
+            }
+            let mut parsed = Vec::new();
+            for chunk in versions_str.split("||") {
+                let trimmed = chunk.trim();
+                if trimmed.is_empty() {
+                    return Err(TrustExcludeParseError::InvalidVersionUnion {
+                        pattern: pattern.to_string(),
+                    });
+                }
+                let v = node_semver::Version::parse(trimmed).map_err(|_| {
+                    TrustExcludeParseError::InvalidVersionUnion {
+                        pattern: pattern.to_string(),
+                    }
+                })?;
+                parsed.push(v);
+            }
+            Some(parsed)
+        }
+    };
+
+    Ok(TrustExcludeRule {
+        name_matcher: NameMatcher::compile(name_part),
+        exact_versions,
+    })
+}
+
+impl NameMatcher {
+    fn compile(pattern: &str) -> Self {
+        if pattern == "*" {
+            return Self::Any;
+        }
+        if !pattern.contains('*') {
+            return Self::Exact(pattern.to_string());
+        }
+        let parts: Vec<String> = pattern.split('*').map(str::to_string).collect();
+        Self::Glob(GlobMatcher {
+            leading_wildcard: parts.first().is_some_and(String::is_empty),
+            trailing_wildcard: parts.last().is_some_and(String::is_empty),
+            parts: parts.into_iter().filter(|s| !s.is_empty()).collect(),
+        })
+    }
+
+    fn matches(&self, input: &str) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Exact(s) => s == input,
+            Self::Glob(g) => g.matches(input),
+        }
+    }
+}
+
+impl GlobMatcher {
+    fn matches(&self, input: &str) -> bool {
+        if self.parts.is_empty() {
+            return true;
+        }
+        let mut cursor = 0usize;
+        for (i, segment) in self.parts.iter().enumerate() {
+            let search_window = &input[cursor..];
+            let is_first = i == 0;
+            let is_last = i == self.parts.len() - 1;
+            if is_first && !self.leading_wildcard {
+                if !search_window.starts_with(segment.as_str()) {
+                    return false;
+                }
+                cursor += segment.len();
+            } else if is_last && !self.trailing_wildcard {
+                if !search_window.ends_with(segment.as_str()) {
+                    return false;
+                }
+                if search_window.len() < segment.len() {
+                    return false;
+                }
+                cursor = input.len();
+            } else {
+                let Some(idx) = search_window.find(segment.as_str()) else {
+                    return false;
+                };
+                cursor += idx + segment.len();
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aube_registry::{Attestations, Dist, NpmUser};
+    use std::collections::BTreeMap;
+
+    fn version(name: &str, ver: &str) -> VersionMetadata {
+        VersionMetadata {
+            name: name.to_string(),
+            version: ver.to_string(),
+            dependencies: BTreeMap::new(),
+            dev_dependencies: BTreeMap::new(),
+            peer_dependencies: BTreeMap::new(),
+            peer_dependencies_meta: BTreeMap::new(),
+            optional_dependencies: BTreeMap::new(),
+            bundled_dependencies: None,
+            dist: Some(Dist {
+                tarball: format!("https://r/{name}/-/{name}-{ver}.tgz"),
+                integrity: None,
+                shasum: None,
+                attestations: None,
+            }),
+            os: vec![],
+            cpu: vec![],
+            libc: vec![],
+            engines: BTreeMap::new(),
+            license: None,
+            funding_url: None,
+            bin: BTreeMap::new(),
+            has_install_script: false,
+            deprecated: None,
+            npm_user: None,
+        }
+    }
+
+    fn with_provenance(mut v: VersionMetadata) -> VersionMetadata {
+        let dist = v.dist.as_mut().unwrap();
+        dist.attestations = Some(Attestations {
+            provenance: Some(serde_json::json!({"predicateType": "slsa"})),
+        });
+        v
+    }
+
+    fn with_trusted_publisher(mut v: VersionMetadata) -> VersionMetadata {
+        v.npm_user = Some(NpmUser {
+            trusted_publisher: Some(serde_json::json!({"id": "gh"})),
+        });
+        v
+    }
+
+    fn packument(
+        name: &str,
+        versions: Vec<(&str, &str, VersionMetadata)>,
+    ) -> Packument {
+        let mut p = Packument {
+            name: name.to_string(),
+            modified: None,
+            versions: BTreeMap::new(),
+            dist_tags: BTreeMap::new(),
+            time: BTreeMap::new(),
+        };
+        for (ver, time, meta) in versions {
+            p.versions.insert(ver.to_string(), meta);
+            p.time.insert(ver.to_string(), time.to_string());
+        }
+        p
+    }
+
+    #[test]
+    fn evidence_trusted_publisher_outranks_provenance() {
+        let v = with_trusted_publisher(with_provenance(version("foo", "1.0.0")));
+        assert_eq!(evidence_for(&v), Some(TrustEvidence::TrustedPublisher));
+    }
+
+    #[test]
+    fn evidence_provenance_only() {
+        let v = with_provenance(version("foo", "1.0.0"));
+        assert_eq!(evidence_for(&v), Some(TrustEvidence::Provenance));
+    }
+
+    #[test]
+    fn evidence_npm_user_without_trusted_publisher_is_none() {
+        let mut v = version("foo", "1.0.0");
+        v.npm_user = Some(NpmUser {
+            trusted_publisher: None,
+        });
+        assert_eq!(evidence_for(&v), None);
+    }
+
+    #[test]
+    fn evidence_falsy_trusted_publisher_is_none() {
+        let mut v = version("foo", "1.0.0");
+        v.npm_user = Some(NpmUser {
+            trusted_publisher: Some(serde_json::Value::Bool(false)),
+        });
+        assert_eq!(evidence_for(&v), None);
+        v.npm_user = Some(NpmUser {
+            trusted_publisher: Some(serde_json::Value::Null),
+        });
+        assert_eq!(evidence_for(&v), None);
+    }
+
+    #[test]
+    fn evidence_none_when_neither() {
+        let v = version("foo", "1.0.0");
+        assert_eq!(evidence_for(&v), None);
+    }
+
+    #[test]
+    fn no_evidence_anywhere_passes() {
+        let p = packument(
+            "foo",
+            vec![
+                ("1.0.0", "2025-01-01T00:00:00.000Z", version("foo", "1.0.0")),
+                ("2.0.0", "2025-02-01T00:00:00.000Z", version("foo", "2.0.0")),
+            ],
+        );
+        let picked = p.versions.get("2.0.0").unwrap();
+        let result = check_no_downgrade(&p, "2.0.0", picked, &TrustExcludeRules::default(), None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn first_attested_version_passes() {
+        let p = packument(
+            "foo",
+            vec![
+                ("1.0.0", "2025-01-01T00:00:00.000Z", version("foo", "1.0.0")),
+                (
+                    "2.0.0",
+                    "2025-02-01T00:00:00.000Z",
+                    with_provenance(version("foo", "2.0.0")),
+                ),
+            ],
+        );
+        let picked = p.versions.get("1.0.0").unwrap();
+        let result = check_no_downgrade(&p, "1.0.0", picked, &TrustExcludeRules::default(), None);
+        assert!(result.is_ok(), "version 1.0.0 was published first; it has nothing prior to compare against");
+    }
+
+    #[test]
+    fn downgrade_provenance_to_none_fails() {
+        let p = packument(
+            "foo",
+            vec![
+                ("1.0.0", "2025-01-01T00:00:00.000Z", version("foo", "1.0.0")),
+                (
+                    "2.0.0",
+                    "2025-02-01T00:00:00.000Z",
+                    with_provenance(version("foo", "2.0.0")),
+                ),
+                ("3.0.0", "2025-03-01T00:00:00.000Z", version("foo", "3.0.0")),
+            ],
+        );
+        let picked = p.versions.get("3.0.0").unwrap();
+        let err = check_no_downgrade(&p, "3.0.0", picked, &TrustExcludeRules::default(), None)
+            .expect_err("3.0.0 should fail: prior version had provenance, this one has none");
+        match err {
+            TrustCheckError::Downgrade(d) => {
+                assert_eq!(d.prior_evidence, TrustEvidence::Provenance);
+                assert_eq!(d.prior_version, "2.0.0");
+                assert_eq!(d.current_evidence, None);
+            }
+            _ => panic!("expected Downgrade"),
+        }
+    }
+
+    #[test]
+    fn downgrade_trusted_publisher_to_provenance_fails() {
+        let p = packument(
+            "foo",
+            vec![
+                ("1.0.0", "2025-01-01T00:00:00.000Z", version("foo", "1.0.0")),
+                (
+                    "2.0.0",
+                    "2025-02-01T00:00:00.000Z",
+                    with_trusted_publisher(version("foo", "2.0.0")),
+                ),
+                (
+                    "3.0.0",
+                    "2025-03-01T00:00:00.000Z",
+                    with_provenance(version("foo", "3.0.0")),
+                ),
+            ],
+        );
+        let picked = p.versions.get("3.0.0").unwrap();
+        let err = check_no_downgrade(&p, "3.0.0", picked, &TrustExcludeRules::default(), None)
+            .expect_err("trustedPublisher → provenance is a downgrade");
+        match err {
+            TrustCheckError::Downgrade(d) => {
+                assert_eq!(d.prior_evidence, TrustEvidence::TrustedPublisher);
+                assert_eq!(d.current_evidence, Some(TrustEvidence::Provenance));
+            }
+            _ => panic!("expected Downgrade"),
+        }
+    }
+
+    #[test]
+    fn same_trust_level_passes() {
+        let p = packument(
+            "foo",
+            vec![
+                (
+                    "2.0.0",
+                    "2025-02-01T00:00:00.000Z",
+                    with_trusted_publisher(version("foo", "2.0.0")),
+                ),
+                (
+                    "3.0.0",
+                    "2025-03-01T00:00:00.000Z",
+                    with_trusted_publisher(version("foo", "3.0.0")),
+                ),
+            ],
+        );
+        let picked = p.versions.get("3.0.0").unwrap();
+        let result = check_no_downgrade(&p, "3.0.0", picked, &TrustExcludeRules::default(), None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn prior_prerelease_ignored_when_picking_stable() {
+        let p = packument(
+            "foo",
+            vec![
+                ("1.0.0", "2025-01-01T00:00:00.000Z", version("foo", "1.0.0")),
+                (
+                    "2.0.0-0",
+                    "2025-02-01T00:00:00.000Z",
+                    with_provenance(version("foo", "2.0.0-0")),
+                ),
+                ("3.0.0", "2025-03-01T00:00:00.000Z", version("foo", "3.0.0")),
+            ],
+        );
+        let picked = p.versions.get("3.0.0").unwrap();
+        let result = check_no_downgrade(&p, "3.0.0", picked, &TrustExcludeRules::default(), None);
+        assert!(
+            result.is_ok(),
+            "trusted prerelease shouldn't block a stable that omits attestation"
+        );
+    }
+
+    #[test]
+    fn prior_prerelease_counts_when_picking_prerelease() {
+        let p = packument(
+            "foo",
+            vec![
+                (
+                    "2.0.0-0",
+                    "2025-02-01T00:00:00.000Z",
+                    with_provenance(version("foo", "2.0.0-0")),
+                ),
+                (
+                    "3.0.0-0",
+                    "2025-03-01T00:00:00.000Z",
+                    version("foo", "3.0.0-0"),
+                ),
+            ],
+        );
+        let picked = p.versions.get("3.0.0-0").unwrap();
+        let result = check_no_downgrade(&p, "3.0.0-0", picked, &TrustExcludeRules::default(), None);
+        assert!(
+            result.is_err(),
+            "prerelease pick should compare against prior prereleases"
+        );
+    }
+
+    #[test]
+    fn missing_time_for_picked_version_errors() {
+        let mut p = packument(
+            "foo",
+            vec![
+                (
+                    "1.0.0",
+                    "2025-01-01T00:00:00.000Z",
+                    with_provenance(version("foo", "1.0.0")),
+                ),
+                ("2.0.0", "2025-02-01T00:00:00.000Z", version("foo", "2.0.0")),
+            ],
+        );
+        // Drop the time entry for 2.0.0.
+        p.time.remove("2.0.0");
+        let picked = p.versions.get("2.0.0").unwrap();
+        let err = check_no_downgrade(&p, "2.0.0", picked, &TrustExcludeRules::default(), None)
+            .expect_err("missing time should error");
+        assert!(matches!(err, TrustCheckError::MissingTime(_)));
+    }
+
+    #[test]
+    fn exclude_name_at_version_bypasses_missing_time() {
+        // No time field anywhere — would normally error.
+        let p = Packument {
+            name: "baz".to_string(),
+            modified: None,
+            versions: {
+                let mut m = BTreeMap::new();
+                m.insert("1.0.0".to_string(), version("baz", "1.0.0"));
+                m
+            },
+            dist_tags: BTreeMap::new(),
+            time: BTreeMap::new(),
+        };
+        let picked = p.versions.get("1.0.0").unwrap();
+        let exclude = TrustExcludeRules::parse(["baz@1.0.0"]).unwrap();
+        let result = check_no_downgrade(&p, "1.0.0", picked, &exclude, None);
+        assert!(result.is_ok(), "excluded version must skip the time lookup");
+    }
+
+    #[test]
+    fn exclude_name_only_bypasses_missing_time() {
+        let p = Packument {
+            name: "qux".to_string(),
+            modified: None,
+            versions: {
+                let mut m = BTreeMap::new();
+                m.insert("2.0.0".to_string(), version("qux", "2.0.0"));
+                m
+            },
+            dist_tags: BTreeMap::new(),
+            time: BTreeMap::new(),
+        };
+        let picked = p.versions.get("2.0.0").unwrap();
+        let exclude = TrustExcludeRules::parse(["qux"]).unwrap();
+        let result = check_no_downgrade(&p, "2.0.0", picked, &exclude, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn exclude_blocks_downgrade_failure() {
+        let p = packument(
+            "foo",
+            vec![
+                (
+                    "2.0.0",
+                    "2025-02-01T00:00:00.000Z",
+                    with_provenance(version("foo", "2.0.0")),
+                ),
+                ("3.0.0", "2025-03-01T00:00:00.000Z", version("foo", "3.0.0")),
+            ],
+        );
+        let picked = p.versions.get("3.0.0").unwrap();
+        let exclude = TrustExcludeRules::parse(["foo@3.0.0"]).unwrap();
+        let result = check_no_downgrade(&p, "3.0.0", picked, &exclude, None);
+        assert!(result.is_ok(), "exclude should bypass the downgrade");
+    }
+
+    #[test]
+    fn ignore_after_skips_old_versions() {
+        let p = packument(
+            "foo",
+            vec![
+                (
+                    "2.0.0",
+                    "2025-02-01T00:00:00.000Z",
+                    with_provenance(version("foo", "2.0.0")),
+                ),
+                ("3.0.0", "2025-03-01T00:00:00.000Z", version("foo", "3.0.0")),
+            ],
+        );
+        let picked = p.versions.get("3.0.0").unwrap();
+        // 1 minute cutoff — both versions are way older, should skip.
+        let result = check_no_downgrade(&p, "3.0.0", picked, &TrustExcludeRules::default(), Some(1));
+        assert!(result.is_ok());
+    }
+
+    // ---------- TrustExcludeRules parsing ----------
+
+    #[test]
+    fn exclude_parses_name_only() {
+        let r = TrustExcludeRules::parse(["foo"]).unwrap();
+        assert!(r.matches("foo", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(r.matches("foo", &node_semver::Version::parse("99.0.0").unwrap()));
+        assert!(!r.matches("bar", &node_semver::Version::parse("1.0.0").unwrap()));
+    }
+
+    #[test]
+    fn exclude_parses_name_at_version() {
+        let r = TrustExcludeRules::parse(["foo@1.0.0"]).unwrap();
+        assert!(r.matches("foo", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(!r.matches("foo", &node_semver::Version::parse("1.0.1").unwrap()));
+    }
+
+    #[test]
+    fn exclude_parses_version_union() {
+        let r = TrustExcludeRules::parse(["foo@1.0.0 || 2.0.0 || 3.0.0"]).unwrap();
+        assert!(r.matches("foo", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(r.matches("foo", &node_semver::Version::parse("2.0.0").unwrap()));
+        assert!(r.matches("foo", &node_semver::Version::parse("3.0.0").unwrap()));
+        assert!(!r.matches("foo", &node_semver::Version::parse("4.0.0").unwrap()));
+    }
+
+    #[test]
+    fn exclude_parses_scoped_name() {
+        let r = TrustExcludeRules::parse(["@babel/core@7.20.0"]).unwrap();
+        assert!(r.matches("@babel/core", &node_semver::Version::parse("7.20.0").unwrap()));
+        assert!(!r.matches("@babel/core", &node_semver::Version::parse("7.20.1").unwrap()));
+    }
+
+    #[test]
+    fn exclude_parses_scoped_name_only() {
+        let r = TrustExcludeRules::parse(["@babel/core"]).unwrap();
+        assert!(r.matches("@babel/core", &node_semver::Version::parse("9.9.9").unwrap()));
+    }
+
+    #[test]
+    fn exclude_parses_glob() {
+        let r = TrustExcludeRules::parse(["is-*"]).unwrap();
+        assert!(r.matches("is-odd", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(r.matches("is-even", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(!r.matches("lodash", &node_semver::Version::parse("1.0.0").unwrap()));
+    }
+
+    #[test]
+    fn exclude_parses_star_matches_all() {
+        let r = TrustExcludeRules::parse(["*"]).unwrap();
+        assert!(r.matches("anything", &node_semver::Version::parse("0.0.1").unwrap()));
+    }
+
+    #[test]
+    fn exclude_rejects_range_operators() {
+        for bad in ["foo@^1.0.0", "foo@~1.0.0", "foo@>=1.0.0"] {
+            let err = TrustExcludeRules::parse([bad]).expect_err(bad);
+            assert!(matches!(err, TrustExcludeParseError::InvalidVersionUnion { .. }));
+        }
+    }
+
+    #[test]
+    fn exclude_rejects_glob_with_version() {
+        let err = TrustExcludeRules::parse(["is-*@1.0.0"]).expect_err("glob+version");
+        assert!(matches!(err, TrustExcludeParseError::NameGlobWithVersions { .. }));
+    }
+
+    #[test]
+    fn exclude_skips_empty_patterns() {
+        // npm config arrays sometimes include empty entries; ignore them.
+        let r = TrustExcludeRules::parse(["", "foo", ""]).unwrap();
+        assert!(r.matches("foo", &node_semver::Version::parse("1.0.0").unwrap()));
+    }
+}

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -62,8 +62,23 @@ pub fn evidence_for(meta: &VersionMetadata) -> Option<TrustEvidence> {
     None
 }
 
+/// JS-style truthiness for `_npmUser.trustedPublisher`. Pnpm's check
+/// is `manifest._npmUser?.trustedPublisher`, which evaluates the value
+/// in a boolean context — so we have to reject every JS falsy value,
+/// not just `null`/`false`. Falsy: `null`, `false`, `0`, `""`, `NaN`.
+/// Truthy: every object (including `{}`), every array (including `[]`),
+/// every non-zero number, every non-empty string. In practice the
+/// field is always either an object or absent, but matching JS
+/// semantics keeps a hostile registry from sneaking trust evidence
+/// past us via `0` or an empty string.
 fn is_truthy(v: &serde_json::Value) -> bool {
-    !matches!(v, serde_json::Value::Null | serde_json::Value::Bool(false))
+    match v {
+        serde_json::Value::Null => false,
+        serde_json::Value::Bool(b) => *b,
+        serde_json::Value::Number(n) => n.as_f64().is_none_or(|f| f != 0.0 && !f.is_nan()),
+        serde_json::Value::String(s) => !s.is_empty(),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => true,
+    }
 }
 
 #[derive(Debug)]
@@ -251,6 +266,32 @@ impl TrustExcludeRules {
             rules.push(parse_one(pattern)?);
         }
         Ok(Self { rules })
+    }
+
+    /// Parse a list of patterns, keeping every rule that succeeds and
+    /// returning the per-pattern errors for everything that didn't.
+    /// Lets the caller log malformed entries individually without
+    /// dropping the rules that did parse — a strict batch `parse` would
+    /// turn one typo into a silent security regression where every
+    /// exclude vanishes.
+    pub fn parse_lossy<I, S>(patterns: I) -> (Self, Vec<TrustExcludeParseError>)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut rules = Vec::new();
+        let mut errors = Vec::new();
+        for pattern in patterns {
+            let pattern = pattern.as_ref();
+            if pattern.is_empty() {
+                continue;
+            }
+            match parse_one(pattern) {
+                Ok(rule) => rules.push(rule),
+                Err(err) => errors.push(err),
+            }
+        }
+        (Self { rules }, errors)
     }
 
     fn matches(&self, name: &str, version: &node_semver::Version) -> bool {
@@ -475,14 +516,43 @@ mod tests {
     #[test]
     fn evidence_falsy_trusted_publisher_is_none() {
         let mut v = version("foo", "1.0.0");
-        v.npm_user = Some(NpmUser {
-            trusted_publisher: Some(serde_json::Value::Bool(false)),
-        });
-        assert_eq!(evidence_for(&v), None);
-        v.npm_user = Some(NpmUser {
-            trusted_publisher: Some(serde_json::Value::Null),
-        });
-        assert_eq!(evidence_for(&v), None);
+        for falsy in [
+            serde_json::Value::Bool(false),
+            serde_json::Value::Null,
+            serde_json::json!(0),
+            serde_json::json!(0.0),
+            serde_json::json!(""),
+        ] {
+            v.npm_user = Some(NpmUser {
+                trusted_publisher: Some(falsy.clone()),
+            });
+            assert_eq!(evidence_for(&v), None, "{falsy:?} should be falsy");
+        }
+    }
+
+    #[test]
+    fn evidence_truthy_non_object_trusted_publisher_counts() {
+        // JS truthy values that aren't objects: non-zero numbers,
+        // non-empty strings, empty arrays/objects. Real registries only
+        // ever emit an object here, but match JS semantics for
+        // defense-in-depth against a hostile/buggy registry.
+        let mut v = version("foo", "1.0.0");
+        for truthy in [
+            serde_json::json!(true),
+            serde_json::json!(1),
+            serde_json::json!("oidc:gh"),
+            serde_json::json!([]),
+            serde_json::json!({}),
+        ] {
+            v.npm_user = Some(NpmUser {
+                trusted_publisher: Some(truthy.clone()),
+            });
+            assert_eq!(
+                evidence_for(&v),
+                Some(TrustEvidence::TrustedPublisher),
+                "{truthy:?} should be truthy"
+            );
+        }
     }
 
     #[test]
@@ -831,6 +901,23 @@ mod tests {
             err,
             TrustExcludeParseError::NameGlobWithVersions { .. }
         ));
+    }
+
+    #[test]
+    fn parse_lossy_keeps_valid_drops_invalid() {
+        let (rules, errors) = TrustExcludeRules::parse_lossy([
+            "good",
+            "bad@^1.0.0",
+            "@scope/also-good@1.0.0",
+            "is-*@nope",
+        ]);
+        // Two valid rules survive; two invalid surface as separate errors.
+        assert!(rules.matches("good", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(rules.matches(
+            "@scope/also-good",
+            &node_semver::Version::parse("1.0.0").unwrap()
+        ));
+        assert_eq!(errors.len(), 2, "two malformed entries reported");
     }
 
     #[test]

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -55,7 +55,7 @@ pub fn evidence_for(meta: &VersionMetadata) -> Option<TrustEvidence> {
         .as_ref()
         .and_then(|d| d.attestations.as_ref())
         .and_then(|a| a.provenance.as_ref())
-        .is_some()
+        .is_some_and(is_truthy)
     {
         return Some(TrustEvidence::Provenance);
     }

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -226,7 +226,9 @@ struct GlobMatcher {
 
 #[derive(Debug, thiserror::Error)]
 pub enum TrustExcludeParseError {
-    #[error("invalid trustPolicyExclude pattern `{pattern}`: only exact versions are allowed in version unions, ranges (^/~/>=) are not supported")]
+    #[error(
+        "invalid trustPolicyExclude pattern `{pattern}`: only exact versions are allowed in version unions, ranges (^/~/>=) are not supported"
+    )]
     InvalidVersionUnion { pattern: String },
     #[error(
         "invalid trustPolicyExclude pattern `{pattern}`: name patterns (`*`) cannot be combined with version unions"
@@ -434,10 +436,7 @@ mod tests {
         v
     }
 
-    fn packument(
-        name: &str,
-        versions: Vec<(&str, &str, VersionMetadata)>,
-    ) -> Packument {
+    fn packument(name: &str, versions: Vec<(&str, &str, VersionMetadata)>) -> Packument {
         let mut p = Packument {
             name: name.to_string(),
             modified: None,
@@ -521,7 +520,10 @@ mod tests {
         );
         let picked = p.versions.get("1.0.0").unwrap();
         let result = check_no_downgrade(&p, "1.0.0", picked, &TrustExcludeRules::default(), None);
-        assert!(result.is_ok(), "version 1.0.0 was published first; it has nothing prior to compare against");
+        assert!(
+            result.is_ok(),
+            "version 1.0.0 was published first; it has nothing prior to compare against"
+        );
     }
 
     #[test]
@@ -744,7 +746,8 @@ mod tests {
         );
         let picked = p.versions.get("3.0.0").unwrap();
         // 1 minute cutoff — both versions are way older, should skip.
-        let result = check_no_downgrade(&p, "3.0.0", picked, &TrustExcludeRules::default(), Some(1));
+        let result =
+            check_no_downgrade(&p, "3.0.0", picked, &TrustExcludeRules::default(), Some(1));
         assert!(result.is_ok());
     }
 
@@ -777,14 +780,23 @@ mod tests {
     #[test]
     fn exclude_parses_scoped_name() {
         let r = TrustExcludeRules::parse(["@babel/core@7.20.0"]).unwrap();
-        assert!(r.matches("@babel/core", &node_semver::Version::parse("7.20.0").unwrap()));
-        assert!(!r.matches("@babel/core", &node_semver::Version::parse("7.20.1").unwrap()));
+        assert!(r.matches(
+            "@babel/core",
+            &node_semver::Version::parse("7.20.0").unwrap()
+        ));
+        assert!(!r.matches(
+            "@babel/core",
+            &node_semver::Version::parse("7.20.1").unwrap()
+        ));
     }
 
     #[test]
     fn exclude_parses_scoped_name_only() {
         let r = TrustExcludeRules::parse(["@babel/core"]).unwrap();
-        assert!(r.matches("@babel/core", &node_semver::Version::parse("9.9.9").unwrap()));
+        assert!(r.matches(
+            "@babel/core",
+            &node_semver::Version::parse("9.9.9").unwrap()
+        ));
     }
 
     #[test]
@@ -805,14 +817,20 @@ mod tests {
     fn exclude_rejects_range_operators() {
         for bad in ["foo@^1.0.0", "foo@~1.0.0", "foo@>=1.0.0"] {
             let err = TrustExcludeRules::parse([bad]).expect_err(bad);
-            assert!(matches!(err, TrustExcludeParseError::InvalidVersionUnion { .. }));
+            assert!(matches!(
+                err,
+                TrustExcludeParseError::InvalidVersionUnion { .. }
+            ));
         }
     }
 
     #[test]
     fn exclude_rejects_glob_with_version() {
         let err = TrustExcludeRules::parse(["is-*@1.0.0"]).expect_err("glob+version");
-        assert!(matches!(err, TrustExcludeParseError::NameGlobWithVersions { .. }));
+        assert!(matches!(
+            err,
+            TrustExcludeParseError::NameGlobWithVersions { .. }
+        ));
     }
 
     #[test]

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -531,6 +531,28 @@ mod tests {
     }
 
     #[test]
+    fn evidence_falsy_provenance_is_none() {
+        // Symmetric with the trustedPublisher truthiness check —
+        // `dist.attestations.provenance` is also evaluated in JS
+        // boolean context in pnpm, so falsy values must not count
+        // as evidence. Real registries always emit an object here,
+        // but this guards against a hostile registry shipping
+        // `provenance: false` to bypass the no-downgrade check.
+        let mut v = version("foo", "1.0.0");
+        for falsy in [
+            serde_json::Value::Bool(false),
+            serde_json::Value::Null,
+            serde_json::json!(0),
+            serde_json::json!(""),
+        ] {
+            v.dist.as_mut().unwrap().attestations = Some(Attestations {
+                provenance: Some(falsy.clone()),
+            });
+            assert_eq!(evidence_for(&v), None, "{falsy:?} should be falsy");
+        }
+    }
+
+    #[test]
     fn evidence_truthy_non_object_trusted_publisher_counts() {
         // JS truthy values that aren't objects: non-zero numbers,
         // non-empty strings, empty arrays/objects. Real registries only

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -74,10 +74,15 @@ pub struct PackageExtension {
     pub peer_dependencies_meta: BTreeMap<String, aube_registry::PeerDepMeta>,
 }
 
+/// Default is `NoDowngrade` to match the user-facing default in
+/// `crates/aube-settings/settings.toml`. The install command overrides
+/// this from the resolved settings anyway, but library consumers
+/// constructing a `Resolver` via [`Resolver::new`] inherit the
+/// documented default behavior without extra plumbing.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum TrustPolicy {
-    NoDowngrade,
     #[default]
+    NoDowngrade,
     Off,
 }
 

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -1,5 +1,5 @@
 use aube_lockfile::LocalSource;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -47,7 +47,7 @@ pub struct DependencyPolicy {
     pub package_extensions: Vec<PackageExtension>,
     pub allowed_deprecated_versions: BTreeMap<String, String>,
     pub trust_policy: TrustPolicy,
-    pub trust_policy_exclude: BTreeSet<String>,
+    pub trust_policy_exclude: crate::trust::TrustExcludeRules,
     pub trust_policy_ignore_after: Option<u64>,
     pub block_exotic_subdeps: bool,
 }
@@ -58,7 +58,7 @@ impl Default for DependencyPolicy {
             package_extensions: Vec::new(),
             allowed_deprecated_versions: BTreeMap::new(),
             trust_policy: TrustPolicy::default(),
-            trust_policy_exclude: BTreeSet::new(),
+            trust_policy_exclude: crate::trust::TrustExcludeRules::default(),
             trust_policy_ignore_after: None,
             block_exotic_subdeps: true,
         }

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -232,9 +232,15 @@ description = "Turn on the strict-security setting bundle in one switch."
 type = "bool"
 default = "false"
 docs = """
-When true, aube forces `trustPolicy = no-downgrade` and `jailBuilds = true`
-regardless of how those settings are configured individually. Use this when
-you want the strictest supply-chain posture without listing each setting.
+When true, aube forces every individual setting in the strict-security
+bundle on, regardless of how each is configured individually:
+
+- `trustPolicy = no-downgrade` (overrides explicit `off`)
+- `jailBuilds = true`
+- `minimumReleaseAgeStrict = true` (makes the age gate hard, not advisory)
+- `strictStoreIntegrity = true` (fail on missing `dist.integrity`)
+- `strictDepBuilds = true` (fail when deps have unreviewed build scripts)
+
 Set to `false` (the default) to honor the underlying settings as-is.
 """
 sources.cli = []
@@ -246,15 +252,14 @@ examples = []
 [trustPolicy]
 description = "Fail install when a package's trust evidence weakens between releases."
 type = '"no-downgrade" | "off"'
-default = "\"off\""
+default = "\"no-downgrade\""
 docs = """
-When `no-downgrade`, aube rejects a version that carries weaker trust evidence
-than any earlier-published version of the same package. Recognized evidence:
-npm trusted-publisher (`_npmUser.trustedPublisher`) outranks sigstore provenance
-(`dist.attestations.provenance`). Set to `off` to disable.
-
-This defaults to `off` today and is planned to default to `no-downgrade` in
-the next major version.
+When `no-downgrade` (the default), aube rejects a version that carries weaker
+trust evidence than any earlier-published version of the same package.
+Recognized evidence: npm trusted-publisher (`_npmUser.trustedPublisher`)
+outranks sigstore provenance (`dist.attestations.provenance`). Set to `off`
+to disable, or use `trustPolicyExclude` to whitelist specific packages or
+versions.
 """
 sources.cli = []
 sources.env = ["npm_config_trust_policy", "NPM_CONFIG_TRUST_POLICY", "AUBE_TRUST_POLICY"]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -227,6 +227,22 @@ sources.workspaceYaml = ["minimumReleaseAgeStrict"]
 precedence = ["workspaceYaml", "npmrc"]
 examples = []
 
+[paranoid]
+description = "Turn on the strict-security setting bundle in one switch."
+type = "bool"
+default = "false"
+docs = """
+When true, aube forces `trustPolicy = no-downgrade` and `jailBuilds = true`
+regardless of how those settings are configured individually. Use this when
+you want the strictest supply-chain posture without listing each setting.
+Set to `false` (the default) to honor the underlying settings as-is.
+"""
+sources.cli = []
+sources.env = ["npm_config_paranoid", "NPM_CONFIG_PARANOID", "AUBE_PARANOID"]
+sources.npmrc = ["paranoid"]
+sources.workspaceYaml = ["paranoid"]
+examples = []
+
 [trustPolicy]
 description = "Fail install when a package's trust evidence weakens between releases."
 type = '"no-downgrade" | "off"'

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -228,14 +228,17 @@ precedence = ["workspaceYaml", "npmrc"]
 examples = []
 
 [trustPolicy]
-description = "Behavior when a package's trust level decreases between installs."
+description = "Fail install when a package's trust evidence weakens between releases."
 type = '"no-downgrade" | "off"'
 default = "\"off\""
 docs = """
-When set to `no-downgrade`, aube accepts and preserves the policy in the
-resolver configuration. Registry trust metadata is not exposed through
-aube's packument path yet, so no downgrade failure can fire until that
-metadata source lands.
+When `no-downgrade`, aube rejects a version that carries weaker trust evidence
+than any earlier-published version of the same package. Recognized evidence:
+npm trusted-publisher (`_npmUser.trustedPublisher`) outranks sigstore provenance
+(`dist.attestations.provenance`). Set to `off` to disable.
+
+This defaults to `off` today and is planned to default to `no-downgrade` in
+the next major version.
 """
 sources.cli = []
 sources.env = ["npm_config_trust_policy", "NPM_CONFIG_TRUST_POLICY", "AUBE_TRUST_POLICY"]
@@ -244,10 +247,14 @@ sources.workspaceYaml = ["trustPolicy"]
 examples = []
 
 [trustPolicyExclude]
-description = "Packages exempt from trust policy checks."
+description = "Packages exempt from `trustPolicy` checks."
 type = "list<string>"
 default = "[]"
-docs = "Whitelist for `trustPolicy`. Entries skip the downgrade check."
+docs = """
+Patterns: `name`, `name@1.0.0`, `name@1.0.0 || 1.0.1` (exact versions only —
+no `^`/`~`/`>=`), `is-*` (name glob, no version), `@scope/name@1.0.0`.
+Empty list disables exclusions.
+"""
 sources.cli = []
 sources.env = ["npm_config_trust_policy_exclude", "NPM_CONFIG_TRUST_POLICY_EXCLUDE", "AUBE_TRUST_POLICY_EXCLUDE"]
 sources.npmrc = ["trustPolicyExclude"]
@@ -255,11 +262,12 @@ sources.workspaceYaml = ["trustPolicyExclude"]
 examples = []
 
 [trustPolicyIgnoreAfter]
-description = "Ignore trust policy for packages older than this age (minutes)."
+description = "Skip the trust check for versions older than this many minutes."
 type = "int"
 default = "undefined"
 docs = """
-Useful for pinning very old versions that predate signing infrastructure.
+Versions whose publish time is older than the cutoff are exempted from
+`trustPolicy`. Leave unset to apply the check to every version.
 """
 sources.cli = []
 sources.env = ["npm_config_trust_policy_ignore_after", "NPM_CONFIG_TRUST_POLICY_IGNORE_AFTER", "AUBE_TRUST_POLICY_IGNORE_AFTER"]

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -614,6 +614,7 @@ mod tests {
                     bin: BTreeMap::new(),
                     has_install_script: false,
                     deprecated: None,
+                    npm_user: None,
                 },
             );
         }

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -90,7 +90,9 @@ impl JailBuildPolicy {
         ctx: &aube_settings::ResolveCtx<'_>,
         workspace: &aube_manifest::WorkspaceConfig,
     ) -> (Self, Vec<String>) {
-        let enabled = aube_settings::resolved::jail_builds(ctx);
+        // `paranoid=true` forces the jail on regardless of `jailBuilds`.
+        let enabled =
+            aube_settings::resolved::jail_builds(ctx) || aube_settings::resolved::paranoid(ctx);
         let jail_exclusions = aube_settings::resolved::jail_build_exclusions(ctx);
         let (denylist, denylist_warnings) = aube_scripts::BuildPolicy::denylist(&jail_exclusions);
         let mut warnings = denylist_warnings

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1364,7 +1364,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         resolve_strict_store_pkg_content_check(&settings_ctx);
     let side_effects_cache_setting = resolve_side_effects_cache(&settings_ctx);
     let side_effects_cache_readonly_setting = resolve_side_effects_cache_readonly(&settings_ctx);
-    let strict_dep_builds_setting = aube_settings::resolved::strict_dep_builds(&settings_ctx);
+    // `paranoid=true` forces unreviewed dep build scripts to error
+    // instead of being silently skipped.
+    let strict_dep_builds_setting = aube_settings::resolved::strict_dep_builds(&settings_ctx)
+        || aube_settings::resolved::paranoid(&settings_ctx);
     let required_scripts =
         aube_settings::resolved::required_scripts(&settings_ctx).unwrap_or_default();
     validate_required_scripts(&cwd, &manifest, &required_scripts)?;

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -80,7 +80,9 @@ fn resolve_minimum_release_age(
             .unwrap_or_default()
             .into_iter()
             .collect();
-    let strict = aube_settings::resolved::minimum_release_age_strict(ctx);
+    // `paranoid=true` forces the gate to be hard, not advisory.
+    let strict = aube_settings::resolved::minimum_release_age_strict(ctx)
+        || aube_settings::resolved::paranoid(ctx);
     Some(aube_resolver::MinimumReleaseAge {
         minutes,
         exclude,
@@ -270,7 +272,8 @@ pub(super) fn resolve_verify_store_integrity(ctx: &aube_settings::ResolveCtx<'_>
 /// promotes the warning to a hard error, which matters when a
 /// registry proxy or MITM could be stripping the integrity field.
 pub(super) fn resolve_strict_store_integrity(ctx: &aube_settings::ResolveCtx<'_>) -> bool {
-    aube_settings::resolved::strict_store_integrity(ctx)
+    // `paranoid=true` promotes "missing dist.integrity" to a hard fail.
+    aube_settings::resolved::strict_store_integrity(ctx) || aube_settings::resolved::paranoid(ctx)
 }
 
 /// Resolve `strictStorePkgContentCheck` from `.npmrc`. Defaults to

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -395,13 +395,15 @@ pub(crate) fn resolve_dependency_policy(
     let trust_excludes = aube_settings::resolved::trust_policy_exclude(ctx);
     let valid: Vec<String> = trust_excludes
         .into_iter()
-        .filter(|p| match aube_resolver::TrustExcludeRules::parse(std::iter::once(p.as_str())) {
-            Ok(_) => true,
-            Err(err) => {
-                tracing::warn!(error = %err, "ignoring malformed trustPolicyExclude entry");
-                false
-            }
-        })
+        .filter(
+            |p| match aube_resolver::TrustExcludeRules::parse(std::iter::once(p.as_str())) {
+                Ok(_) => true,
+                Err(err) => {
+                    tracing::warn!(error = %err, "ignoring malformed trustPolicyExclude entry");
+                    false
+                }
+            },
+        )
         .collect();
     policy.trust_policy_exclude =
         aube_resolver::TrustExcludeRules::parse(valid).unwrap_or_default();

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -382,11 +382,18 @@ pub(crate) fn resolve_dependency_policy(
     merge_string_map_setting(ctx, "allowedDeprecatedVersions", &mut allowed_deprecated);
     policy.allowed_deprecated_versions = allowed_deprecated;
 
-    policy.trust_policy = match aube_settings::resolved::trust_policy(ctx) {
-        aube_settings::resolved::TrustPolicy::NoDowngrade => {
-            aube_resolver::TrustPolicy::NoDowngrade
+    // `paranoid=true` forces no-downgrade regardless of the explicit
+    // `trustPolicy` value — that's the whole point of the bundle switch.
+    let paranoid = aube_settings::resolved::paranoid(ctx);
+    policy.trust_policy = if paranoid {
+        aube_resolver::TrustPolicy::NoDowngrade
+    } else {
+        match aube_settings::resolved::trust_policy(ctx) {
+            aube_settings::resolved::TrustPolicy::NoDowngrade => {
+                aube_resolver::TrustPolicy::NoDowngrade
+            }
+            aube_settings::resolved::TrustPolicy::Off => aube_resolver::TrustPolicy::Off,
         }
-        aube_settings::resolved::TrustPolicy::Off => aube_resolver::TrustPolicy::Off,
     };
     // Parse trustPolicyExclude pattern-by-pattern so one malformed entry
     // doesn't drop the rest. The user needs visible feedback when their

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -388,9 +388,23 @@ pub(crate) fn resolve_dependency_policy(
         }
         aube_settings::resolved::TrustPolicy::Off => aube_resolver::TrustPolicy::Off,
     };
-    policy.trust_policy_exclude = aube_settings::resolved::trust_policy_exclude(ctx)
+    // Parse trustPolicyExclude pattern-by-pattern so one malformed entry
+    // doesn't drop the rest. The user needs visible feedback when their
+    // exclude isn't being applied — silently dropping all rules would
+    // turn what looked like an opt-in into a security regression.
+    let trust_excludes = aube_settings::resolved::trust_policy_exclude(ctx);
+    let valid: Vec<String> = trust_excludes
         .into_iter()
+        .filter(|p| match aube_resolver::TrustExcludeRules::parse(std::iter::once(p.as_str())) {
+            Ok(_) => true,
+            Err(err) => {
+                tracing::warn!(error = %err, "ignoring malformed trustPolicyExclude entry");
+                false
+            }
+        })
         .collect();
+    policy.trust_policy_exclude =
+        aube_resolver::TrustExcludeRules::parse(valid).unwrap_or_default();
     policy.trust_policy_ignore_after = aube_settings::resolved::trust_policy_ignore_after(ctx);
     policy.block_exotic_subdeps = aube_settings::resolved::block_exotic_subdeps(ctx);
 

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -396,24 +396,14 @@ pub(crate) fn resolve_dependency_policy(
         }
     };
     // Parse trustPolicyExclude pattern-by-pattern so one malformed entry
-    // doesn't drop the rest. The user needs visible feedback when their
-    // exclude isn't being applied — silently dropping all rules would
-    // turn what looked like an opt-in into a security regression.
+    // doesn't drop the rest. Silently dropping every rule on a typo
+    // would turn the opt-in into a security regression.
     let trust_excludes = aube_settings::resolved::trust_policy_exclude(ctx);
-    let valid: Vec<String> = trust_excludes
-        .into_iter()
-        .filter(
-            |p| match aube_resolver::TrustExcludeRules::parse(std::iter::once(p.as_str())) {
-                Ok(_) => true,
-                Err(err) => {
-                    tracing::warn!(error = %err, "ignoring malformed trustPolicyExclude entry");
-                    false
-                }
-            },
-        )
-        .collect();
-    policy.trust_policy_exclude =
-        aube_resolver::TrustExcludeRules::parse(valid).unwrap_or_default();
+    let (rules, parse_errors) = aube_resolver::TrustExcludeRules::parse_lossy(trust_excludes);
+    for err in parse_errors {
+        tracing::warn!(error = %err, "ignoring malformed trustPolicyExclude entry");
+    }
+    policy.trust_policy_exclude = rules;
     policy.trust_policy_ignore_after = aube_settings::resolved::trust_policy_ignore_after(ctx);
     policy.block_exotic_subdeps = aube_settings::resolved::block_exotic_subdeps(ctx);
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -131,6 +131,13 @@ gtag('config', 'G-WD1RRC0F8C');`,
         ],
       },
       {
+        text: "Security",
+        items: [
+          { text: "Overview", link: "/security" },
+          { text: "Jailed builds", link: "/package-manager/jailed-builds" },
+        ],
+      },
+      {
         text: "Performance",
         items: [
           { text: "Benchmarks", link: "/benchmarks" },

--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -404,16 +404,16 @@ watch(progressBarEl, (el, previousEl) => {
         </span>
         <span class="aube-proof-link">node_modules layout -></span>
       </a>
-      <a class="aube-proof-item" href="/package-manager/jailed-builds">
+      <a class="aube-proof-item" href="/security">
         <span class="aube-proof-number">05</span>
         <span class="aube-proof-tag">secure</span>
         <span class="aube-proof-visual aube-proof-scripts" aria-hidden="true">
           <span class="aube-script-row aube-script-row-root">
-            <b>minimum age</b>
-            <i>on</i>
+            <b>exotic deps</b>
+            <i>blocked</i>
           </span>
           <span class="aube-script-row">
-            <b>exotic deps</b>
+            <b>trust downgrades</b>
             <i>blocked</i>
           </span>
           <span class="aube-script-row">
@@ -421,12 +421,13 @@ watch(progressBarEl, (el, previousEl) => {
             <i>opt in</i>
           </span>
         </span>
-        <strong>Jailed builds for dependency scripts.</strong>
+        <strong>Supply-chain defaults across the install path.</strong>
         <span>
-          Approve the packages that may build, then run lifecycle scripts with
-          a scrubbed env, temporary HOME, and package-glob permissions.
+          Lifecycle scripts denied until approved, trust downgrades caught at
+          resolve, and approved scripts run in a package-scoped jail. One
+          <code>paranoid: true</code> flips on the strict bundle.
         </span>
-        <span class="aube-proof-link">Jailed builds -></span>
+        <span class="aube-proof-link">Security overview -></span>
       </a>
     </section>
   </main>

--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -409,24 +409,24 @@ watch(progressBarEl, (el, previousEl) => {
         <span class="aube-proof-tag">secure</span>
         <span class="aube-proof-visual aube-proof-scripts" aria-hidden="true">
           <span class="aube-script-row aube-script-row-root">
-            <b>exotic deps</b>
+            <b>trust downgrades</b>
             <i>blocked</i>
+          </span>
+          <span class="aube-script-row">
+            <b>new releases</b>
+            <i>24h cooling</i>
           </span>
           <span class="aube-script-row">
             <b>build scripts</b>
             <i>deny by default</i>
           </span>
-          <span class="aube-script-row">
-            <b>paranoid</b>
-            <i>opt in</i>
-          </span>
         </span>
         <strong>Supply-chain defaults across the install path.</strong>
         <span>
-          Out of the box, exotic transitive deps are blocked and lifecycle
-          scripts wait for approval. One <code>paranoid: true</code> adds
-          trust-downgrade detection at resolve and runs approved scripts in a
-          package-scoped jail.
+          Trust downgrades fail at resolve, new releases sit out a 24h cooling
+          window, lifecycle scripts wait for approval, and exotic transitive
+          deps are blocked. <code>paranoid: true</code> adds the build jail
+          and turns the soft gates into hard fails.
         </span>
         <span class="aube-proof-link">Security overview -></span>
       </a>

--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -413,19 +413,20 @@ watch(progressBarEl, (el, previousEl) => {
             <i>blocked</i>
           </span>
           <span class="aube-script-row">
-            <b>trust downgrades</b>
-            <i>blocked</i>
+            <b>build scripts</b>
+            <i>deny by default</i>
           </span>
           <span class="aube-script-row">
-            <b>jailed builds</b>
+            <b>paranoid</b>
             <i>opt in</i>
           </span>
         </span>
         <strong>Supply-chain defaults across the install path.</strong>
         <span>
-          Lifecycle scripts denied until approved, trust downgrades caught at
-          resolve, and approved scripts run in a package-scoped jail. One
-          <code>paranoid: true</code> flips on the strict bundle.
+          Out of the box, exotic transitive deps are blocked and lifecycle
+          scripts wait for approval. One <code>paranoid: true</code> adds
+          trust-downgrade detection at resolve and runs approved scripts in a
+          package-scoped jail.
         </span>
         <span class="aube-proof-link">Security overview -></span>
       </a>

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,193 @@
+# Security
+
+aube treats supply-chain protection as a first-class concern. This page lists
+every security-relevant feature, its default, and the one-line config to turn
+it on or off.
+
+To report a vulnerability, see the [security policy](https://github.com/endevco/aube/security/policy).
+
+## The `paranoid` switch
+
+The fastest way to opt into the strict-security posture is one line:
+
+```yaml
+paranoid: true
+```
+
+This forces both [`jailBuilds = true`](#jailed-lifecycle-scripts) and
+[`trustPolicy = no-downgrade`](#trust-policy) regardless of how those settings
+are configured individually. Use it when you want maximum protection without
+remembering each underlying setting name.
+
+## Default-deny lifecycle scripts
+
+Lifecycle scripts (`preinstall`, `install`, `postinstall`) are the sharpest
+supply-chain edge in a JavaScript install. aube does not run dependency
+lifecycle scripts unless you've approved them explicitly:
+
+```yaml
+# pnpm-workspace.yaml
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+```
+
+Or interactively:
+
+```sh
+aube approve-builds
+```
+
+Root-package lifecycle scripts (your own project's) still run normally — the
+boundary is dependency code.
+
+Settings: [`allowBuilds`](/settings/#setting-allowbuilds). The
+`onlyBuiltDependencies` and `neverBuiltDependencies` allowlists live in
+`package.json` or `pnpm-workspace.yaml`, mirroring pnpm's shape.
+
+## Jailed lifecycle scripts
+
+When a dependency is approved to build, jailing keeps it from getting your
+full filesystem, network, and environment. On macOS aube wraps the script with
+a Seatbelt profile that denies network and limits writes to the package
+directory; on Linux and Windows the env is scrubbed and `HOME` is redirected
+to a temporary directory.
+
+```yaml
+jailBuilds: true
+```
+
+Grant narrow exceptions per-package instead of disabling the jail wholesale:
+
+```yaml
+jailBuilds: true
+jailBuildPermissions:
+  sharp:
+    env: [SHARP_DIST_BASE_URL]
+    write: ["~/.cache/sharp"]
+    network: true
+```
+
+Default: `false` today, planned to flip to `true` in the next major.
+
+Full reference: [Jailed builds](/package-manager/jailed-builds).
+
+## Trust policy
+
+`trustPolicy = no-downgrade` blocks installs of a version that carries weaker
+trust evidence than any earlier-published version of the same package. Two
+evidence sources, ranked:
+
+1. **npm trusted-publisher** — package was published via OIDC from a trusted
+   CI provider (`_npmUser.trustedPublisher`).
+2. **Sigstore provenance** — package was published with `npm publish
+   --provenance` (`dist.attestations.provenance`).
+
+A trust downgrade may indicate a supply-chain incident: publisher account
+takeover, repository tampering, or a malicious co-maintainer publishing
+without the original CI flow.
+
+```yaml
+trustPolicy: no-downgrade
+```
+
+Exempt specific packages or versions when needed (only exact versions, no
+ranges):
+
+```yaml
+trustPolicyExclude:
+  - "@vendor/legacy-pkg"            # all versions
+  - "old-thing@1.0.0"                # one version
+  - "things@1.0.0 || 1.0.1"          # version union
+  - "is-*"                           # name glob (no version)
+```
+
+Default: `off` today, planned to flip to `no-downgrade` in the next major.
+
+Settings: [`trustPolicy`](/settings/#setting-trustpolicy),
+[`trustPolicyExclude`](/settings/#setting-trustpolicyexclude),
+[`trustPolicyIgnoreAfter`](/settings/#setting-trustpolicyignoreafter).
+
+## Minimum release age
+
+Wait a configurable period before installing newly published versions. Catches
+typo-squat and dependency-confusion attacks that get unpublished within hours.
+
+```yaml
+minimumReleaseAge: 4320  # 3 days
+```
+
+`minimumReleaseAgeStrict: true` fails the install when no version satisfies
+the range; otherwise the resolver falls back to the lowest satisfying version
+ignoring the cutoff for that pick only.
+
+Default: `0` (disabled).
+
+Settings: [`minimumReleaseAge`](/settings/#setting-minimumreleaseage),
+[`minimumReleaseAgeExclude`](/settings/#setting-minimumreleaseageexclude),
+[`minimumReleaseAgeStrict`](/settings/#setting-minimumreleaseagestrict).
+
+## Block exotic transitive dependencies
+
+Reject transitive dependencies that resolve to `git+`, `file:`, or direct
+tarball URLs — those skip the registry and its integrity verification. Direct
+deps you pin yourself in `package.json` are still allowed.
+
+```yaml
+blockExoticSubdeps: true   # default
+```
+
+Settings: [`blockExoticSubdeps`](/settings/#setting-blockexoticsubdeps).
+
+## Tarball integrity
+
+Every registry tarball is verified against the SHA-512 hash recorded in the
+packument's `dist.integrity` field before it is added to the store. Mismatches
+fail the install loudly. The hash is preserved in the lockfile, so subsequent
+installs reverify on every fetch.
+
+The content-addressable store itself uses BLAKE3 for the on-disk index — fast
+to compute and immune to length-extension. Linked `node_modules` files are
+reflinks (APFS/btrfs), hardlinks (ext4), or copies; none of those paths can
+modify the canonical store entry.
+
+## Auth tokens
+
+Registry tokens are read from `.npmrc` (the npm convention) or environment
+variables (`NPM_TOKEN`, `AUBE_AUTH_TOKEN`, etc.) and **never written to the
+lockfile, tarball cache, or logs**. `aube login` and `aube logout` manage
+tokens via the standard npm config file.
+
+Inside jailed lifecycle scripts, common token env vars (`NPM_TOKEN`,
+`NODE_AUTH_TOKEN`, `GITHUB_TOKEN`, `SSH_AUTH_SOCK`, `AWS_*`, etc.) are
+scrubbed from the script environment unless explicitly granted via
+`jailBuildPermissions`.
+
+## Auditing installed dependencies
+
+```sh
+aube audit                # list known CVEs at moderate+ severity
+aube audit --audit-level high
+aube audit --fix          # write package.json overrides to patched versions
+aube audit --json | jq    # machine-readable for CI
+```
+
+Same advisory data source as `npm audit` and `pnpm audit`; same response
+schema.
+
+## Recommended baseline
+
+For most projects, the following is a good starting point:
+
+```yaml
+# pnpm-workspace.yaml
+paranoid: true             # jailBuilds + trustPolicy=no-downgrade
+minimumReleaseAge: 1440    # 1 day
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  # ...whatever your project actually needs to build
+```
+
+Add `aube audit` to your CI pipeline so a newly disclosed CVE in a dependency
+fails the build instead of silently shipping.

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,10 +14,19 @@ The fastest way to opt into the strict-security posture is one line:
 paranoid: true
 ```
 
-This forces both [`jailBuilds = true`](#jailed-lifecycle-scripts) and
-[`trustPolicy = no-downgrade`](#trust-policy) regardless of how those settings
-are configured individually. Use it when you want maximum protection without
-remembering each underlying setting name.
+This forces every setting in the strict bundle on, regardless of how each is
+configured individually:
+
+- [`jailBuilds = true`](#jailed-lifecycle-scripts)
+- [`trustPolicy = no-downgrade`](#trust-policy) (overrides explicit `off`)
+- `minimumReleaseAgeStrict = true` — turns the age gate into a hard fail
+  instead of "fall back to the lowest satisfying version"
+- `strictStoreIntegrity = true` — fail when a tarball ships without
+  `dist.integrity` instead of warning
+- `strictDepBuilds = true` — fail the install when a dep has unreviewed
+  build scripts instead of silently skipping
+
+Use it when you want maximum protection without listing each setting.
 
 ## Default-deny lifecycle scripts
 
@@ -102,7 +111,8 @@ trustPolicyExclude:
   - "is-*"                           # name glob (no version)
 ```
 
-Default: `off` today, planned to flip to `no-downgrade` in the next major.
+Default: `no-downgrade`. Set `trustPolicy: off` to disable, or use
+`trustPolicyExclude` for per-package opt-outs.
 
 Settings: [`trustPolicy`](/settings/#setting-trustpolicy),
 [`trustPolicyExclude`](/settings/#setting-trustpolicyexclude),
@@ -181,13 +191,14 @@ For most projects, the following is a good starting point:
 
 ```yaml
 # pnpm-workspace.yaml
-paranoid: true             # jailBuilds + trustPolicy=no-downgrade
-minimumReleaseAge: 1440    # 1 day
+paranoid: true             # bundles jailBuilds, no-downgrade, strict gates
 onlyBuiltDependencies:
   - esbuild
   - sharp
   # ...whatever your project actually needs to build
 ```
 
-Add `aube audit` to your CI pipeline so a newly disclosed CVE in a dependency
-fails the build instead of silently shipping.
+`trustPolicy=no-downgrade` and `minimumReleaseAge: 1440` (24h) are already
+default-on; `paranoid: true` adds the rest of the bundle on top. Pair this
+with `aube audit` in CI so a newly disclosed CVE fails the build instead of
+silently shipping.

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -21,9 +21,9 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
 | [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
 | [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
-| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Behavior when a package's trust level decreases between installs. |
-| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from trust policy checks. |
-| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Ignore trust policy for packages older than this age (minutes). |
+| [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Fail install when a package's trust evidence weakens between releases. |
+| [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from `trustPolicy` checks. |
+| [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Skip the trust check for versions older than this many minutes. |
 | [`blockExoticSubdeps`](#setting-blockexoticsubdeps) | `bool` | Restrict transitive dependencies to trusted sources (registries, not git/tarball URLs). |
 | [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
 | [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
@@ -300,7 +300,7 @@ resolver fails the install instead.
 
 ### `trustPolicy` {#setting-trustpolicy}
 
-Behavior when a package's trust level decreases between installs.
+Fail install when a package's trust evidence weakens between releases.
 
 - Type: `"no-downgrade" | "off"`
 - Default: `"off"`
@@ -308,14 +308,17 @@ Behavior when a package's trust level decreases between installs.
 - .npmrc keys: `trustPolicy`, `trust-policy`
 - Workspace YAML keys: `trustPolicy`
 
-When set to `no-downgrade`, aube accepts and preserves the policy in the
-resolver configuration. Registry trust metadata is not exposed through
-aube's packument path yet, so no downgrade failure can fire until that
-metadata source lands.
+When `no-downgrade`, aube rejects a version that carries weaker trust evidence
+than any earlier-published version of the same package. Recognized evidence:
+npm trusted-publisher (`_npmUser.trustedPublisher`) outranks sigstore provenance
+(`dist.attestations.provenance`). Set to `off` to disable.
+
+This defaults to `off` today and is planned to default to `no-downgrade` in
+the next major version.
 
 ### `trustPolicyExclude` {#setting-trustpolicyexclude}
 
-Packages exempt from trust policy checks.
+Packages exempt from `trustPolicy` checks.
 
 - Type: `list<string>`
 - Default: `[]`
@@ -323,11 +326,13 @@ Packages exempt from trust policy checks.
 - .npmrc keys: `trustPolicyExclude`, `trust-policy-exclude`
 - Workspace YAML keys: `trustPolicyExclude`
 
-Whitelist for `trustPolicy`. Entries skip the downgrade check.
+Patterns: `name`, `name@1.0.0`, `name@1.0.0 || 1.0.1` (exact versions only —
+no `^`/`~`/`>=`), `is-*` (name glob, no version), `@scope/name@1.0.0`.
+Empty list disables exclusions.
 
 ### `trustPolicyIgnoreAfter` {#setting-trustpolicyignoreafter}
 
-Ignore trust policy for packages older than this age (minutes).
+Skip the trust check for versions older than this many minutes.
 
 - Type: `int`
 - Default: `undefined`
@@ -335,7 +340,8 @@ Ignore trust policy for packages older than this age (minutes).
 - .npmrc keys: `trustPolicyIgnoreAfter`, `trust-policy-ignore-after`
 - Workspace YAML keys: `trustPolicyIgnoreAfter`
 
-Useful for pinning very old versions that predate signing infrastructure.
+Versions whose publish time is older than the cutoff are exempted from
+`trustPolicy`. Leave unset to apply the check to every version.
 
 ### `blockExoticSubdeps` {#setting-blockexoticsubdeps}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -21,6 +21,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
 | [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
 | [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
+| [`paranoid`](#setting-paranoid) | `bool` | Turn on the strict-security setting bundle in one switch. |
 | [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Fail install when a package's trust evidence weakens between releases. |
 | [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from `trustPolicy` checks. |
 | [`trustPolicyIgnoreAfter`](#setting-trustpolicyignoreafter) | `int` | Skip the trust check for versions older than this many minutes. |
@@ -297,6 +298,21 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 By default the resolver falls back to the lowest satisfying version when
 every candidate is younger than `minimumReleaseAge`. With this set, the
 resolver fails the install instead.
+
+### `paranoid` {#setting-paranoid}
+
+Turn on the strict-security setting bundle in one switch.
+
+- Type: `bool`
+- Default: `false`
+- Environment: `npm_config_paranoid`, `NPM_CONFIG_PARANOID`, `AUBE_PARANOID`
+- .npmrc keys: `paranoid`
+- Workspace YAML keys: `paranoid`
+
+When true, aube forces `trustPolicy = no-downgrade` and `jailBuilds = true`
+regardless of how those settings are configured individually. Use this when
+you want the strictest supply-chain posture without listing each setting.
+Set to `false` (the default) to honor the underlying settings as-is.
 
 ### `trustPolicy` {#setting-trustpolicy}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -309,9 +309,15 @@ Turn on the strict-security setting bundle in one switch.
 - .npmrc keys: `paranoid`
 - Workspace YAML keys: `paranoid`
 
-When true, aube forces `trustPolicy = no-downgrade` and `jailBuilds = true`
-regardless of how those settings are configured individually. Use this when
-you want the strictest supply-chain posture without listing each setting.
+When true, aube forces every individual setting in the strict-security
+bundle on, regardless of how each is configured individually:
+
+- `trustPolicy = no-downgrade` (overrides explicit `off`)
+- `jailBuilds = true`
+- `minimumReleaseAgeStrict = true` (makes the age gate hard, not advisory)
+- `strictStoreIntegrity = true` (fail on missing `dist.integrity`)
+- `strictDepBuilds = true` (fail when deps have unreviewed build scripts)
+
 Set to `false` (the default) to honor the underlying settings as-is.
 
 ### `trustPolicy` {#setting-trustpolicy}
@@ -319,18 +325,17 @@ Set to `false` (the default) to honor the underlying settings as-is.
 Fail install when a package's trust evidence weakens between releases.
 
 - Type: `"no-downgrade" | "off"`
-- Default: `"off"`
+- Default: `"no-downgrade"`
 - Environment: `npm_config_trust_policy`, `NPM_CONFIG_TRUST_POLICY`, `AUBE_TRUST_POLICY`
 - .npmrc keys: `trustPolicy`, `trust-policy`
 - Workspace YAML keys: `trustPolicy`
 
-When `no-downgrade`, aube rejects a version that carries weaker trust evidence
-than any earlier-published version of the same package. Recognized evidence:
-npm trusted-publisher (`_npmUser.trustedPublisher`) outranks sigstore provenance
-(`dist.attestations.provenance`). Set to `off` to disable.
-
-This defaults to `off` today and is planned to default to `no-downgrade` in
-the next major version.
+When `no-downgrade` (the default), aube rejects a version that carries weaker
+trust evidence than any earlier-published version of the same package.
+Recognized evidence: npm trusted-publisher (`_npmUser.trustedPublisher`)
+outranks sigstore provenance (`dist.attestations.provenance`). Set to `off`
+to disable, or use `trustPolicyExclude` to whitelist specific packages or
+versions.
 
 ### `trustPolicyExclude` {#setting-trustpolicyexclude}
 


### PR DESCRIPTION
## Summary

Activates `trustPolicy=no-downgrade` end-to-end (previously a documented but no-op setting), adds a `paranoid` bundle switch for the strict-security posture, ships a security overview doc + GitHub-recognized `SECURITY.md`, and flips the `trustPolicy` default to on. Mirrors pnpm's [`failIfTrustDowngraded`](https://github.com/pnpm/pnpm/blob/main/resolving/npm-resolver/src/trustChecks.ts) algorithm exactly — verified against pnpm's source + test suite at `/tmp/pnpm`.

> **BREAKING CHANGE**: installs of packages whose newest version lost trust evidence (provenance attestation or trusted-publisher OIDC link) compared to any earlier published version will now fail unless the user opts out via `trustPolicy = off`, `trustPolicyExclude`, or `trustPolicyIgnoreAfter`. Drop the `!` from the title before merge to delay this to a later major.

## Trust enforcement

Trust evidence ranks: `_npmUser.trustedPublisher` (2) > `dist.attestations.provenance` (1). Install fails when any earlier-published version of the same package carried stronger evidence than the picked one.

- **Algorithm in [`crates/aube-resolver/src/trust.rs`](crates/aube-resolver/src/trust.rs)** — exact mirror of pnpm's `failIfTrustDowngraded` including the v10.24.0+ "skip prior prereleases when picking stable" rule and the JS-style truthiness on both evidence fields.
- **`trustPolicyExclude` parser** supports the full pnpm syntax: `name`, `name@1.0.0`, `name@1.0.0 || 1.0.1` (exact versions only — `^`/`~`/`>=` rejected), `is-*` name glob, scoped names. Exclude check runs before the time lookup so excluded packages don't error on registries that omit `time`.
- **Resolver integration** at [resolve.rs:1271](crates/aube-resolver/src/resolve.rs#L1271) — fires immediately after `PickResult::Found`, mirrors pnpm's placement. Forces the full-packument fetch path so per-version `time` is available, including suppressing the corgi-shortcircuit when both `minimumReleaseAge` and `trustPolicy` are active.
- **Graceful degradation** when the registry doesn't ship `time` at all (Verdaccio fixtures, private mirrors). Per-version time gaps still error — that's the registry-quirk shape pnpm's check catches.

## `paranoid` master switch

`paranoid: true` forces every setting in the strict-security bundle on, regardless of how each is configured individually:

| Setting | Without paranoid | With paranoid |
| --- | --- | --- |
| `trustPolicy` | `no-downgrade` (default) | `no-downgrade` (forced) |
| `jailBuilds` | `false` | `true` |
| `minimumReleaseAgeStrict` | falls back to lowest satisfying version | fails the install |
| `strictStoreIntegrity` | warns on missing `dist.integrity` | fails the install |
| `strictDepBuilds` | silently skips unreviewed dep build scripts | fails after link |

## Default flip

`trustPolicy` defaults to `no-downgrade`. Both the codegen settings layer and `TrustPolicy::default()` agree (the latter aligned with the former in [`30e3cd8`](https://github.com/endevco/aube/commit/30e3cd8) so library consumers calling `Resolver::new` directly inherit the documented behavior).

Cost analysis: trust check itself is microseconds (a few `BTreeMap::get` lookups). Cold-cache installs pay one full-packument fetch instead of corgi (~3-5× larger response); warm-cache installs are free. Same hit `minimumReleaseAge` already takes today.

## Documentation

- **`SECURITY.md`** at the repo root — GitHub-recognized vulnerability disclosure path (private advisory form, since issues are disabled) + at-a-glance feature table.
- **[`docs/security.md`](docs/security.md)** — comprehensive overview covering `paranoid`, default-deny lifecycle scripts, jailed builds, trust policy, minimum release age, exotic-deps blocking, tarball/CAS integrity, auth-token handling, `aube audit`. Each section links to the relevant setting.
- **VitePress sidebar** gets a new "Security" section.
- **README + landing-hero copy** point at `/security` and accurately list defaults vs opt-ins.
- **Settings docstrings** rewritten in `settings.toml` and regenerated into `docs/settings/index.md`.

## Test plan

- [x] `cargo test --workspace` — 297 + 162 + ~700 more tests pass, including 30+ new trust unit tests (truthiness, exclude parsing, prerelease handling, exclude-bypasses-missing-time, empty-time-map skip, ignore-after cutoff, downgrade detection)
- [x] Two resolver-level integration tests using a TCP test server: one asserts `Error::TrustDowngrade` fires + `trustPolicyExclude` unblocks, one is the regression test for the corgi-shortcircuit interaction with `minimumReleaseAge`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] All bats files affected by the default flip pass locally (`bundled_dependencies`, `add`, `global_install`, `node_gyp_rebuild`)
- [ ] End-to-end smoke against npmjs.org with a real package known to have lost provenance between versions

## Review-comment fixes landed

- Cursor Bugbot — corgi-shortcircuit suppression with concurrent `minimumReleaseAge` + `trustPolicy`
- Cursor Bugbot — `provenance` evidence now `is_truthy`-gated to match `trustedPublisher`
- Cursor Bugbot — `TrustPolicy::default()` aligned with settings.toml default
- Greptile — `is_truthy` covers all JS falsy values (`0`, `""`, `NaN`)
- Greptile — `TrustExcludeRules::parse_lossy` returns `(rules, errors)` so we don't double-parse with a silent fail-open fallback
- Greptile — README/hero copy no longer implies trust-downgrade detection is default-on (it is now, after the default flip — copy updated again accordingly)
- Greptile — `SECURITY.md` table corrected (`trustPolicy` is a string enum, not a bool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)