### PR TITLE
fix(lockfile): parse scalar pnpm platform fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ version = "1.2.1"
 dependencies = [
  "blake3",
  "rustc-hash",
+ "serde",
  "serde_json",
 ]
 

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -1515,11 +1515,11 @@ struct RawPackageInfo {
     engines: BTreeMap<String, String>,
     peer_dependencies: Option<BTreeMap<String, String>>,
     peer_dependencies_meta: Option<BTreeMap<String, RawPeerDepMeta>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
     os: Vec<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
     cpu: Vec<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
     libc: Vec<String>,
     #[serde(default)]
     has_bin: bool,
@@ -1910,6 +1910,46 @@ snapshots:
         let host = graph.packages.get("host@1.0.0").unwrap();
         assert_eq!(host.dependencies.get("native").unwrap(), "1.0.0");
         assert_eq!(host.optional_dependencies.get("native").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn parse_package_platform_fields_accept_scalar_strings() {
+        let dir = tempfile::tempdir().unwrap();
+        let lockfile_path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &lockfile_path,
+            r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      sass-embedded-linux-arm64:
+        specifier: 1.99.0
+        version: 1.99.0
+
+packages:
+  sass-embedded-linux-arm64@1.99.0:
+    resolution: {integrity: sha512-native}
+    engines: {node: '>=14.0.0'}
+    cpu: arm64
+    os: linux
+    libc: glibc
+
+snapshots:
+  sass-embedded-linux-arm64@1.99.0: {}
+"#,
+        )
+        .unwrap();
+
+        let graph = parse(&lockfile_path).unwrap();
+        let pkg = graph
+            .packages
+            .get("sass-embedded-linux-arm64@1.99.0")
+            .unwrap();
+        assert_eq!(pkg.os.as_slice(), &["linux".to_string()]);
+        assert_eq!(pkg.cpu.as_slice(), &["arm64".to_string()]);
+        assert_eq!(pkg.libc.as_slice(), &["glibc".to_string()]);
     }
 
     #[test]

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -1,39 +1,6 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeMap;
 
-/// npm allows the `os`, `cpu`, and `libc` fields on a package version
-/// to be either a single string (e.g. `"libc": "glibc"`) or an array
-/// of strings (e.g. `"libc": ["glibc"]`). An explicit `null` is also
-/// treated as "no constraint", same as the field being absent — some
-/// packuments emit it. Napi-rs additionally publishes `"libc": [null]`
-/// on its Windows/macOS native-binding packages (e.g.
-/// `@oxc-parser/binding-win32-x64-msvc`), meaning "no libc constraint";
-/// drop null array entries so that shape round-trips to an empty vec
-/// instead of failing the whole packument parse. Normalize all shapes
-/// to a `Vec<String>` so the platform filter doesn't have to care.
-fn string_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum StringOrSeq {
-        String(String),
-        Seq(Vec<serde_json::Value>),
-    }
-    Ok(match Option::<StringOrSeq>::deserialize(deserializer)? {
-        None => Vec::new(),
-        Some(StringOrSeq::String(s)) => vec![s],
-        Some(StringOrSeq::Seq(v)) => v
-            .into_iter()
-            .filter_map(|e| match e {
-                serde_json::Value::String(s) => Some(s),
-                _ => None,
-            })
-            .collect(),
-    })
-}
-
 /// Deserialize a `BTreeMap<String, String>` tolerant to any non-string
 /// value — both at the whole-map level (`"dist-tags": null` → empty
 /// map) and at the value level (`{"latest": null}` or
@@ -153,11 +120,11 @@ pub struct VersionMetadata {
     #[serde(default, alias = "bundleDependencies")]
     pub bundled_dependencies: Option<BundledDependencies>,
     pub dist: Option<Dist>,
-    #[serde(default, deserialize_with = "string_or_seq")]
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
     pub os: Vec<String>,
-    #[serde(default, deserialize_with = "string_or_seq")]
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
     pub cpu: Vec<String>,
-    #[serde(default, deserialize_with = "string_or_seq")]
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
     pub libc: Vec<String>,
     /// `engines:` from the package manifest (e.g. `{node: ">=8"}`).
     /// Round-tripped into the lockfile so pnpm-compatible output can

--- a/crates/aube-util/Cargo.toml
+++ b/crates/aube-util/Cargo.toml
@@ -11,4 +11,5 @@ description = "Shared helpers reused across aube crates (semantic hashing, async
 [dependencies]
 rustc-hash = { workspace = true }
 blake3 = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -4,3 +4,27 @@ pub mod hash;
 pub mod path;
 pub mod pkg;
 pub mod url;
+
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize npm platform fields (`os`, `cpu`, `libc`) from either a
+/// string or an array of strings. Missing fields, nulls, and non-string
+/// array entries mean "no constraint" and are dropped.
+pub fn string_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(match value {
+        None | Some(serde_json::Value::Null) => Vec::new(),
+        Some(serde_json::Value::String(s)) => vec![s],
+        Some(serde_json::Value::Array(values)) => values
+            .into_iter()
+            .filter_map(|value| match value {
+                serde_json::Value::String(s) => Some(s),
+                _ => None,
+            })
+            .collect(),
+        Some(_) => Vec::new(),
+    })
+}


### PR DESCRIPTION
## What changed

- Accept scalar string values for pnpm lockfile package `os`, `cpu`, and `libc` metadata, normalizing them to the existing vector representation.
- Add a regression test for the `sass-embedded-linux-arm64@1.99.0` shape reported in Discussion #336.

## Why

pnpm can emit package platform fields as either arrays or scalar strings. Aube already handled this shape for registry packuments, but the pnpm lockfile parser expected arrays and failed on `libc: glibc`.

## Validation

- `cargo test -p aube-lockfile`
- `cargo fmt --check`
- commit hook: `cargo fmt --check` and clippy for the staged Rust file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small deserialization change limited to normalizing `os`/`cpu`/`libc` metadata, with added regression coverage; potential impact is only on platform-constraint parsing for pnpm inputs.
> 
> **Overview**
> pnpm lockfile parsing now accepts `os`, `cpu`, and `libc` platform fields as either a scalar string or an array, normalizing all forms to `Vec<String>`.
> 
> The shared `string_or_seq` deserializer was moved into `aube-util` (adding a `serde` dependency) and is now used by both the pnpm lockfile parser and registry packument parsing, with a new regression test covering the `sass-embedded-linux-arm64` lockfile shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ce5008d44a2cffaafbb2825a215a1d69b84248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->