### PR TITLE
fix(lockfile): preserve package and bun lock compatibility

### DIFF
--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -674,6 +674,15 @@ fn classify_bun_ident(
         };
         return Ok((name, raw_version.to_string(), Some(kind), alias_of));
     }
+    let raw_path = std::path::PathBuf::from(raw_version);
+    if LocalSource::path_looks_like_tarball(&raw_path) {
+        return Ok((
+            name,
+            raw_version.to_string(),
+            Some(LocalSource::Tarball(raw_path)),
+            alias_of,
+        ));
+    }
     if let Some(rest) = raw_version.strip_prefix("link:") {
         return Ok((
             name,
@@ -1891,6 +1900,33 @@ mod tests {
 
         let root = graph.importers.get(".").unwrap();
         assert!(root.iter().any(|d| d.name == "vfs"));
+    }
+
+    #[test]
+    fn test_parse_prefixless_local_tarball() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sri = fake_sri('t');
+        let content = r#"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": { "local-helper": "file:tarballs/local-helper-1.0.0.tgz" }
+    }
+  },
+  "packages": {
+    "local-helper": ["local-helper@tarballs/local-helper-1.0.0.tgz", {}, "SRI"]
+  }
+}"#
+        .replace("SRI", &sri);
+        std::fs::write(tmp.path(), &content).unwrap();
+
+        let graph = parse(tmp.path()).unwrap();
+        let pkg = &graph.packages["local-helper@tarballs/local-helper-1.0.0.tgz"];
+        assert!(
+            matches!(pkg.local_source, Some(LocalSource::Tarball(_))),
+            "prefixless bun tarball ident must be LocalSource::Tarball, got {:?}",
+            pkg.local_source
+        );
     }
 
     /// Round-trip the same multi-version shape the npm writer test

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1459,7 +1459,7 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
             .current_dir(&target)
             .output()
         && out.status.success()
-        && String::from_utf8_lossy(&out.stdout).trim() == commit
+        && git_commit_matches(String::from_utf8_lossy(&out.stdout).trim(), commit)
     {
         return Ok(target);
     }
@@ -1543,7 +1543,7 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
             )));
         }
         let actual = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        if actual != commit {
+        if !git_commit_matches(&actual, commit) {
             return Err(Error::Git(format!(
                 "git clone HEAD {actual} does not match requested commit {commit}"
             )));
@@ -1570,7 +1570,7 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
                     .current_dir(&target)
                     .output()
                 && out.status.success()
-                && String::from_utf8_lossy(&out.stdout).trim() == commit
+                && git_commit_matches(String::from_utf8_lossy(&out.stdout).trim(), commit)
             {
                 let _ = std::fs::remove_dir_all(&scratch);
                 return Ok(target);
@@ -1589,9 +1589,33 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
     }
 }
 
+fn git_commit_matches(actual: &str, requested: &str) -> bool {
+    actual == requested
+        || (requested.len() >= 7
+            && requested.len() < 40
+            && requested.chars().all(|c| c.is_ascii_hexdigit())
+            && actual.starts_with(requested))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn git_commit_matches_abbreviated_sha() {
+        assert!(git_commit_matches(
+            "98e8ff1da1a89f93d1397a24d7413ed15421c139",
+            "98e8ff1"
+        ));
+        assert!(!git_commit_matches(
+            "98e8ff1da1a89f93d1397a24d7413ed15421c139",
+            "98e8ff2"
+        ));
+        assert!(!git_commit_matches(
+            "98e8ff1da1a89f93d1397a24d7413ed15421c139",
+            "main"
+        ));
+    }
 
     #[test]
     fn test_integrity_to_hex() {

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -723,54 +723,12 @@ async fn update_manifest_for_add(
     // write the mutated manifest to disk for the duration of the
     // resolver + install pipeline (both re-read from disk), then
     // restore the original bytes from their snapshot before returning.
-    write_manifest_json_for_add(&manifest_path, &manifest)?;
+    super::write_manifest_dep_sections(&manifest_path, &manifest)?;
     if print_updated {
         eprintln!("Updated package.json");
     }
 
     Ok((manifest, workspace_catalogs))
-}
-
-fn write_manifest_json_for_add(
-    path: &Path,
-    manifest: &aube_manifest::PackageJson,
-) -> miette::Result<()> {
-    let content = std::fs::read_to_string(path)
-        .into_diagnostic()
-        .wrap_err("failed to read package.json")?;
-    let mut json: serde_json::Value = serde_json::from_str(&content)
-        .into_diagnostic()
-        .wrap_err("failed to parse package.json")?;
-    let serde_json::Value::Object(obj) = &mut json else {
-        return Err(miette!("package.json must contain a JSON object"));
-    };
-
-    sync_dep_section(obj, "dependencies", &manifest.dependencies);
-    sync_dep_section(obj, "devDependencies", &manifest.dev_dependencies);
-    sync_dep_section(obj, "peerDependencies", &manifest.peer_dependencies);
-    sync_dep_section(obj, "optionalDependencies", &manifest.optional_dependencies);
-
-    let json = serde_json::to_string_pretty(&json)
-        .into_diagnostic()
-        .wrap_err("failed to serialize package.json")?;
-    super::write_manifest_atomic(path, format!("{json}\n").as_bytes())
-}
-
-fn sync_dep_section(
-    obj: &mut serde_json::Map<String, serde_json::Value>,
-    key: &str,
-    deps: &BTreeMap<String, String>,
-) {
-    if deps.is_empty() {
-        obj.remove(key);
-        return;
-    }
-
-    let section = deps
-        .iter()
-        .map(|(name, spec)| (name.clone(), serde_json::Value::String(spec.clone())))
-        .collect();
-    obj.insert(key.to_string(), serde_json::Value::Object(section));
 }
 
 /// Resolve the on-disk lockfile path that a normal `add` would write

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -762,6 +762,65 @@ pub(crate) fn write_manifest_json<T: serde::Serialize>(
         .wrap_err("failed to write package.json")
 }
 
+pub(crate) fn update_manifest_json_object<F>(path: &Path, update: F) -> miette::Result<()>
+where
+    F: FnOnce(&mut serde_json::Map<String, serde_json::Value>) -> miette::Result<()>,
+{
+    let content = std::fs::read_to_string(path)
+        .into_diagnostic()
+        .wrap_err("failed to read package.json")?;
+    let mut json: serde_json::Value = serde_json::from_str(&content)
+        .into_diagnostic()
+        .wrap_err("failed to parse package.json")?;
+    let serde_json::Value::Object(obj) = &mut json else {
+        return Err(miette!("package.json must contain a JSON object"));
+    };
+
+    update(obj)?;
+
+    let json = serde_json::to_string_pretty(&json)
+        .into_diagnostic()
+        .wrap_err("failed to serialize package.json")?;
+    write_manifest_atomic(path, format!("{json}\n").as_bytes())
+}
+
+pub(crate) fn write_manifest_dep_sections(
+    path: &Path,
+    manifest: &aube_manifest::PackageJson,
+) -> miette::Result<()> {
+    update_manifest_json_object(path, |obj| {
+        sync_manifest_dep_sections(obj, manifest);
+        Ok(())
+    })
+}
+
+pub(crate) fn sync_manifest_dep_sections(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    manifest: &aube_manifest::PackageJson,
+) {
+    sync_dep_section(obj, "dependencies", &manifest.dependencies);
+    sync_dep_section(obj, "devDependencies", &manifest.dev_dependencies);
+    sync_dep_section(obj, "peerDependencies", &manifest.peer_dependencies);
+    sync_dep_section(obj, "optionalDependencies", &manifest.optional_dependencies);
+}
+
+fn sync_dep_section(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    deps: &std::collections::BTreeMap<String, String>,
+) {
+    if deps.is_empty() {
+        obj.remove(key);
+        return;
+    }
+
+    let section = deps
+        .iter()
+        .map(|(name, spec)| (name.clone(), serde_json::Value::String(spec.clone())))
+        .collect();
+    obj.insert(key.to_string(), serde_json::Value::Object(section));
+}
+
 /// Atomic write for `package.json` (and any sibling JSON we care
 /// about): write to a tempfile in the same directory then rename.
 /// The old `fs::write` truncates in place and a crash mid-write left
@@ -1265,5 +1324,80 @@ mod dep_filter_tests {
     #[test]
     fn package_manager_mismatch_skip_auto_install_defaults_off() {
         assert!(!skip_auto_install_on_package_manager_mismatch());
+    }
+}
+
+#[cfg(test)]
+mod manifest_write_tests {
+    use super::*;
+
+    #[test]
+    fn write_manifest_dep_sections_preserves_existing_top_level_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "name": "example",
+  "version": "1.0.0",
+  "license": "MIT",
+  "scripts": {
+    "test": "echo test"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        let mut manifest = aube_manifest::PackageJson::from_path(&path).unwrap();
+        manifest
+            .dev_dependencies
+            .insert("tstyche".to_string(), "^7.1.0".to_string());
+
+        write_manifest_dep_sections(&path, &manifest).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            root_key_order(&written),
+            ["name", "version", "license", "scripts", "devDependencies"]
+        );
+        assert!(written.contains(r#""tstyche": "^7.1.0""#));
+    }
+
+    #[test]
+    fn write_manifest_dep_sections_removes_empty_sections_without_reordering() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "name": "example",
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  },
+  "license": "MIT"
+}
+"#,
+        )
+        .unwrap();
+
+        let mut manifest = aube_manifest::PackageJson::from_path(&path).unwrap();
+        manifest.dev_dependencies.remove("typescript");
+
+        write_manifest_dep_sections(&path, &manifest).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(root_key_order(&written), ["name", "license"]);
+        assert!(!written.contains("devDependencies"));
+    }
+
+    fn root_key_order(raw: &str) -> Vec<String> {
+        let serde_json::Value::Object(obj) = serde_json::from_str(raw).unwrap() else {
+            panic!("expected object");
+        };
+        obj.keys().cloned().collect()
     }
 }

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -104,7 +104,13 @@ pub async fn run(
     // Write updated package.json atomically. Crash mid-write would
     // otherwise truncate the user manifest, worst-case aube failure
     // mode. Tempfile + persist keeps the swap atomic.
-    super::write_manifest_json(&manifest_path, &manifest)?;
+    super::update_manifest_json_object(&manifest_path, |obj| {
+        super::sync_manifest_dep_sections(obj, &manifest);
+        for name in packages {
+            prune_sidecar_entries_json(obj, name);
+        }
+        Ok(())
+    })?;
     eprintln!("Updated package.json");
 
     // Re-resolve dependency tree without the removed packages
@@ -174,6 +180,54 @@ fn run_global(packages: &[String]) -> miette::Result<()> {
         return Err(miette!("no matching global packages were removed"));
     }
     Ok(())
+}
+
+fn prune_sidecar_entries_json(obj: &mut serde_json::Map<String, serde_json::Value>, name: &str) {
+    for ns_key in ["pnpm", "aube"] {
+        let remove_ns = if let Some(ns) = obj.get_mut(ns_key).and_then(|v| v.as_object_mut()) {
+            for map_key in ["allowBuilds", "overrides", "peerDependencyRules"] {
+                if let Some(inner) = ns.get_mut(map_key).and_then(|v| v.as_object_mut()) {
+                    inner.remove(name);
+                    if inner.is_empty() {
+                        ns.remove(map_key);
+                    }
+                }
+            }
+            for arr_key in [
+                "onlyBuiltDependencies",
+                "neverBuiltDependencies",
+                "trustedDependencies",
+            ] {
+                if let Some(arr) = ns.get_mut(arr_key).and_then(|v| v.as_array_mut()) {
+                    arr.retain(|entry| match entry.as_str() {
+                        Some(s) => s.rsplit_once('@').map(|(base, _)| base).unwrap_or(s) != name,
+                        None => true,
+                    });
+                    if arr.is_empty() {
+                        ns.remove(arr_key);
+                    }
+                }
+            }
+            ns.is_empty()
+        } else {
+            false
+        };
+        if remove_ns {
+            obj.remove(ns_key);
+        }
+    }
+
+    for top_key in ["overrides", "resolutions"] {
+        let remove_top = if let Some(top) = obj.get_mut(top_key).and_then(|v| v.as_object_mut()) {
+            top.remove(name);
+            top.is_empty()
+        } else {
+            false
+        };
+        if remove_top {
+            obj.remove(top_key);
+        }
+    }
 }
 
 /// Prune aube/pnpm sidecar metadata entries that reference `name`.

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -303,7 +303,7 @@ pub async fn run(
                 wrote_any = true;
             }
             if wrote_any {
-                super::write_manifest_json(&manifest_path, &manifest)?;
+                super::write_manifest_dep_sections(&manifest_path, &manifest)?;
                 eprintln!("Updated package.json");
             }
         }

--- a/test/remove.bats
+++ b/test/remove.bats
@@ -38,6 +38,33 @@ EOF
 	assert_file_exists node_modules/is-even/index.js
 }
 
+@test "aube remove: preserves package.json top-level key order" {
+	cat >package.json <<'EOF'
+{
+  "name": "test-remove-order",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "test": "echo test"
+  },
+  "dependencies": {
+    "is-even": "^1.0.0",
+    "is-odd": "^3.0.1"
+  }
+}
+EOF
+
+	run aube install
+	assert_success
+
+	run aube remove is-odd
+	assert_success
+
+	run node -e 'console.log(Object.keys(require("./package.json")).join(","))'
+	assert_success
+	assert_output 'name,version,license,scripts,dependencies'
+}
+
 @test "aube remove: errors on unknown package" {
 	cat >package.json <<'EOF'
 {


### PR DESCRIPTION
## Summary

- Preserve existing top-level `package.json` key order when commands rewrite dependency sections.
- Parse Bun lockfile local tarball entries whose package ident omits the `file:` prefix.
- Accept abbreviated git commit SHAs from existing Bun GitHub-shorthand lockfile entries during checkout verification.

## Details

`aube add` already preserved manifest order by editing the parsed raw `package.json` object and syncing only dependency sections. This PR moves that targeted raw-JSON dependency-section writer into the shared command helpers so `add`, `remove`, and `update --latest` use the same order-preserving path.

`remove` still prunes pnpm/aube sidecar metadata, but now applies those removals directly to the parsed raw JSON object instead of replacing unrelated fields from the typed `PackageJson.extra` map. That keeps existing key positions and avoids churn in unrelated or nested manifest data.

The Bun regression matrix also exposed two plain-install failures not covered by the currently open lockfile PRs:

- Bun can write local tarball package entries as `local-helper@tarballs/local-helper-1.0.0.tgz` while the workspace dependency remains `file:tarballs/local-helper-1.0.0.tgz`. Aube now recognizes that prefixless `.tgz` ident as `LocalSource::Tarball` instead of treating it as a registry version.
- Bun records GitHub shorthand lock entries with abbreviated commit IDs. Aube's clone verifier now accepts a checked-out full SHA when it starts with the abbreviated lockfile SHA, while still rejecting non-hex refs and mismatched SHAs.

I checked the other open lockfile PRs before adding these: #337 covers pnpm scalar platform fields, and #338 covers package-lock git resolved URLs plus pnpm/Bun scalar platform metadata. Those fixes are intentionally not duplicated here.

## Validation

- `cargo fmt --check`
- `cargo build`
- `cargo test -p aube write_manifest_dep_sections`
- `cargo test -p aube-lockfile test_parse_prefixless_local_tarball`
- `cargo test -p aube-lockfile test_parse_github_dep`
- `cargo test -p aube-store git_commit_matches_abbreviated_sha`
- `mise run test:bats test/remove.bats`
- `mise run test:bats test/update.bats`
- Bun regression matrix from `johnpyp/2026-04-23-aube-bun-lock-regression-matrix` against `target/debug/aube`; `github-shorthand` and `local-tarball` now pass plain install as `plain-aube-unchanged`
- pre-commit hook: cargo fmt and cargo clippy for staged Rust files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `package.json` is rewritten across multiple commands and relaxes git checkout verification to accept abbreviated SHAs, which could affect correctness of dependency updates and git-sourced installs.
> 
> **Overview**
> Improves compatibility and reduces churn when working with Bun and when editing `package.json`.
> 
> Commands that mutate dependencies (`add`, `remove`, `update --latest`) now update only the dependency sections in the existing parsed `package.json` object (via shared helpers) so **top-level key order is preserved** and empty dep sections are removed without reserializing unrelated fields; `remove` also prunes pnpm/aube sidecar metadata directly in raw JSON to avoid reordering.
> 
> Bun lockfile parsing now treats prefixless local tarball idents (e.g. `pkg@tarballs/foo.tgz` without `file:`) as `LocalSource::Tarball`, and git dependency checkouts now accept **abbreviated hex SHAs** by verifying the full HEAD starts with the requested short SHA. Added targeted unit tests and a bats test to lock in these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edcf9200e9ec6788dd1df8ef54a872dc7b11dacc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->