### PR TITLE
chore(deps): replace serde_yaml with yaml_serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,6 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha1",
  "sha2 0.10.9",
  "sigstore-oidc",
@@ -261,6 +260,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xx",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -300,13 +300,13 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha2 0.10.9",
  "simd-json",
  "smallvec",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -317,10 +317,10 @@ dependencies = [
  "miette",
  "serde",
  "serde_json",
- "serde_yaml",
  "simd-json",
  "tempfile",
  "thiserror 2.0.18",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -338,7 +338,6 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_yaml",
  "simd-json",
  "tar",
  "tempfile",
@@ -346,6 +345,7 @@ dependencies = [
  "tokio",
  "tracing",
  "wiremock",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -389,8 +389,8 @@ version = "1.2.1"
 dependencies = [
  "aube-manifest",
  "serde",
- "serde_yaml",
  "toml",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -1998,6 +1998,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "libz-ng-sys"
 version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,19 +3176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4147,12 +4140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5100,6 +5087,19 @@ dependencies = [
  "sha2 0.11.0",
  "strsim",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1", features = ["full"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
-serde_yaml = "0.9"
+yaml_serde = "0.10.4"
 simd-json = "0.17"
 toml = "0.8"
 

--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -19,7 +19,7 @@ node-semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 simd-json = { workspace = true }
-serde_yaml = { workspace = true }
+yaml_serde = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -1826,7 +1826,7 @@ pub enum Error {
     Io(std::path::PathBuf, std::io::Error),
     /// Structural/serialization lockfile errors that have no source
     /// location — shape checks (`must be a mapping`), version guards
-    /// (`lockfileVersion N unsupported`), and `serde_yaml::to_string`
+    /// (`lockfileVersion N unsupported`), and `yaml_serde::to_string`
     /// failures during write.
     #[error("failed to parse lockfile {0}: {1}")]
     Parse(std::path::PathBuf, String),
@@ -1879,7 +1879,7 @@ impl Error {
     pub fn parse_yaml_err(
         path: &std::path::Path,
         content: String,
-        err: &serde_yaml::Error,
+        err: &yaml_serde::Error,
     ) -> Self {
         Error::ParseDiag(Box::new(aube_manifest::ParseError::from_yaml_err(
             path, content, err,
@@ -1909,7 +1909,7 @@ mod parse_diag_tests {
         assert_eq!(pe.path, path);
     }
 
-    /// Same story for YAML — serde_yaml reports a `Location` with a
+    /// Same story for YAML — yaml_serde reports a `Location` with a
     /// byte index directly, so no line/col conversion is exercised
     /// here. Both production sites (`pnpm.rs`, `yarn.rs`) call
     /// `Error::parse_yaml_err` directly (one iterates multiple YAML
@@ -1919,7 +1919,7 @@ mod parse_diag_tests {
     fn parse_yaml_err_attaches_span_for_bad_input() {
         let path = Path::new("yarn.lock");
         let content = "packages:\n\t- pkg\n".to_string();
-        let yaml_err: serde_yaml::Error = serde_yaml::from_str::<serde_yaml::Value>(&content)
+        let yaml_err: yaml_serde::Error = yaml_serde::from_str::<yaml_serde::Value>(&content)
             .expect_err("tab-indented YAML must fail");
         let Error::ParseDiag(pe) = Error::parse_yaml_err(path, content.clone(), &yaml_err) else {
             panic!("parse_yaml_err must produce ParseDiag");

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -999,7 +999,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         snapshots,
     };
 
-    let yaml = serde_yaml::to_string(&lockfile).map_err(|e| Error::parse(path, e.to_string()))?;
+    let yaml = yaml_serde::to_string(&lockfile).map_err(|e| Error::parse(path, e.to_string()))?;
     let yaml = reformat_for_pnpm_parity(&yaml);
     // Atomic via tempfile + persist. Crash, Ctrl+C, or AV
     // quarantine during the write used to leave the user with a
@@ -1010,12 +1010,12 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
     Ok(())
 }
 
-/// Post-process a `serde_yaml`-emitted pnpm-lock.yaml into the exact
+/// Post-process a `yaml_serde`-emitted pnpm-lock.yaml into the exact
 /// shape real pnpm writes. Two tweaks:
 ///
 ///   1. Collapse `resolution:` / `engines:` block maps into flow form
 ///      (`resolution: {integrity: sha512-…}`). pnpm writes both inline
-///      and `serde_yaml` can't be coerced into flow style per-field
+///      and `yaml_serde` can't be coerced into flow style per-field
 ///      without a custom emitter.
 ///   2. Insert blank-line separators above every top-level section
 ///      (`settings:`, `importers:`, `packages:`, `snapshots:`, …) and
@@ -1143,7 +1143,7 @@ struct WritablePnpmLockfile {
     settings: WritableSettings,
     // pnpm v9 places `overrides:` immediately after `settings:` and
     // before `importers:`. Field order matters because we serialize
-    // through serde_yaml and want byte-for-byte parity with pnpm output
+    // through yaml_serde and want byte-for-byte parity with pnpm output
     // for the no-overrides case (the field is skipped when empty).
     #[serde(skip_serializing_if = "Option::is_none")]
     overrides: Option<BTreeMap<String, String>>,
@@ -1337,18 +1337,18 @@ struct WritableSnapshot {
 /// overrides + packages/snapshots count) and take the highest. If only
 /// one document is present (pnpm v9/v10 and older) this reduces to the
 /// previous single-document parse.
-fn parse_raw_lockfile(content: &str) -> Result<RawPnpmLockfile, serde_yaml::Error> {
+fn parse_raw_lockfile(content: &str) -> Result<RawPnpmLockfile, yaml_serde::Error> {
     // Hard cap on documents inspected. pnpm v11 emits exactly two;
     // anything beyond a handful is pathological. This also guards
     // against malformed YAML that puts
-    // `serde_yaml::Deserializer::from_str`'s iterator into an
+    // `yaml_serde::Deserializer::from_str`'s iterator into an
     // infinite-yield state — `test_parse_invalid_yaml` tripped that
     // mode on Windows CI with an unbounded loop.
     const MAX_DOCUMENTS: usize = 16;
 
     let mut best: Option<(u64, RawPnpmLockfile)> = None;
-    let mut first_err: Option<serde_yaml::Error> = None;
-    for (idx, doc) in serde_yaml::Deserializer::from_str(content)
+    let mut first_err: Option<yaml_serde::Error> = None;
+    for (idx, doc) in yaml_serde::Deserializer::from_str(content)
         .enumerate()
         .take(MAX_DOCUMENTS)
     {
@@ -1365,7 +1365,7 @@ fn parse_raw_lockfile(content: &str) -> Result<RawPnpmLockfile, serde_yaml::Erro
                 // lockfile where every document fails surfaces all the
                 // diagnostic signal at `RUST_LOG=aube_lockfile=debug`.
                 // Break on the first failure: a malformed document
-                // typically puts serde_yaml's iterator into a state
+                // typically puts yaml_serde's iterator into a state
                 // where further iteration is either more garbage or an
                 // infinite loop (see `test_parse_invalid_yaml`). The
                 // returned error is the first failure, which is both
@@ -1382,7 +1382,7 @@ fn parse_raw_lockfile(content: &str) -> Result<RawPnpmLockfile, serde_yaml::Erro
         (None, Some(e)) => Err(e),
         // No documents at all — defer to the single-doc parser so the
         // error surface matches what callers saw before.
-        (None, None) => serde_yaml::from_str(content),
+        (None, None) => yaml_serde::from_str(content),
     }
 }
 
@@ -1424,7 +1424,7 @@ fn project_lockfile_score(raw: &RawPnpmLockfile) -> u64 {
 #[serde(rename_all = "camelCase")]
 struct RawPnpmLockfile {
     #[allow(dead_code)]
-    lockfile_version: serde_yaml::Value,
+    lockfile_version: yaml_serde::Value,
     #[serde(default)]
     settings: Option<RawSettings>,
     #[serde(default)]

--- a/crates/aube-lockfile/src/yarn.rs
+++ b/crates/aube-lockfile/src/yarn.rs
@@ -617,13 +617,10 @@ fn parse_berry_str(
             continue;
         }
 
-        // Berry writes versions unquoted (`version: 1.0.0`), so
-        // YAML 1.2 core-schema resolution kicks in: three-component
-        // semver parses as a plain string, but a bare integer
-        // (`version: 5`) or two-component value (`version: 1.0`)
-        // parses as number. Coerce both back to a string rather than
-        // reporting "has no version" against a spec that obviously
-        // does.
+        // Berry writes versions unquoted (`version: 1.0.0`). Depending
+        // on the YAML resolver, scalar-looking versions may parse as
+        // non-string values, so coerce them back to strings rather than
+        // reporting "has no version" against a spec that obviously does.
         let version = block
             .get("version")
             .and_then(yaml_scalar_as_string)
@@ -914,22 +911,15 @@ fn range_has_protocol(range: &str) -> bool {
 
 /// Render a scalar YAML value as its source-text-equivalent string.
 ///
-/// Berry emits `version: 1.0.0` unquoted. Under YAML 1.2 core-schema
-/// resolution (what `yaml_serde` uses), that bare token parses
-/// as a string *only because* it has two dots — a bare integer
-/// (`version: 5`) comes out as `Value::Number(5)`, a two-component
-/// value (`version: 1.0`) as a float. Returning those back as
-/// strings matches what a quote-everything serializer would have
-/// produced, so rare packages with one- or two-component versions
-/// don't break parsing against a lockfile yarn itself wrote.
-///
-/// Booleans would behave the same way (`version: yes`), but no real
-/// version string collides with YAML 1.2's bool tokens (`true` /
-/// `false`), so we don't bother unfolding them.
+/// Berry emits scalar fields unquoted in several places. YAML parsers
+/// may resolve integer-, float-, or boolean-looking tokens to typed
+/// values; returning those as strings preserves the graph edge instead
+/// of silently dropping an otherwise valid lockfile entry.
 fn yaml_scalar_as_string(v: &yaml_serde::Value) -> Option<String> {
     match v {
         yaml_serde::Value::String(s) => Some(s.clone()),
         yaml_serde::Value::Number(n) => Some(n.to_string()),
+        yaml_serde::Value::Bool(b) => Some(b.to_string()),
         _ => None,
     }
 }
@@ -1665,11 +1655,10 @@ __metadata:
         assert!(!graph.packages.contains_key("my-project@0.0.0-use.local"));
     }
 
-    /// Berry emits `version:` unquoted, and under YAML 1.2 core-schema
-    /// resolution a bare integer (`version: 5`) comes out as a
-    /// number, not a string. Our parser must unfold those back to
-    /// strings instead of failing with "has no version" — real
-    /// packages with fewer-than-three-component versions do exist
+    /// Berry emits `version:` unquoted, so scalar-looking values can
+    /// parse as numbers instead of strings. Our parser must unfold
+    /// those back to strings instead of failing with "has no version" —
+    /// real packages with fewer-than-three-component versions do exist
     /// (even if rare).
     #[test]
     fn test_parse_berry_unquoted_numeric_version() {
@@ -1700,14 +1689,14 @@ __metadata:
         assert_eq!(graph.packages["two-part@1.0"].version, "1.0");
     }
 
-    /// Same numeric-scalar hazard applies to dependency values:
+    /// Same scalar hazard applies to dependency values:
     /// `peerDependencies: { foo: 5 }` writes a YAML number, and
-    /// `as_str()` would silently drop the edge. The fix routes dep
-    /// values through `yaml_scalar_as_string`; this test exercises
-    /// that path end-to-end so a future regression would show up as
-    /// a missing peer edge rather than a parse error.
+    /// boolean-looking tags or ranges can parse as booleans. The parser
+    /// routes dep values through `yaml_scalar_as_string` so a future
+    /// regression shows up as a missing peer edge rather than a parse
+    /// error.
     #[test]
-    fn test_parse_berry_numeric_dep_value() {
+    fn test_parse_berry_typed_dep_values() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let content = r#"__metadata:
   version: 8
@@ -1718,6 +1707,7 @@ __metadata:
   resolution: "foo@npm:1.0.0"
   peerDependencies:
     numeric-peer: 5
+    bool-peer: true
   languageName: node
   linkType: hard
 "#;
@@ -1730,6 +1720,10 @@ __metadata:
                 .get("numeric-peer")
                 .map(String::as_str),
             Some("5")
+        );
+        assert_eq!(
+            foo.peer_dependencies.get("bool-peer").map(String::as_str),
+            Some("true")
         );
     }
 

--- a/crates/aube-lockfile/src/yarn.rs
+++ b/crates/aube-lockfile/src/yarn.rs
@@ -563,7 +563,7 @@ fn parse_berry_str(
     content: &str,
     manifest: &aube_manifest::PackageJson,
 ) -> Result<LockfileGraph, Error> {
-    let doc: serde_yaml::Value = serde_yaml::from_str(content)
+    let doc: yaml_serde::Value = yaml_serde::from_str(content)
         .map_err(|e| Error::parse_yaml_err(path, content.to_string(), &e))?;
     let map = doc
         .as_mapping()
@@ -915,7 +915,7 @@ fn range_has_protocol(range: &str) -> bool {
 /// Render a scalar YAML value as its source-text-equivalent string.
 ///
 /// Berry emits `version: 1.0.0` unquoted. Under YAML 1.2 core-schema
-/// resolution (what `serde_yaml` 0.9 uses), that bare token parses
+/// resolution (what `yaml_serde` uses), that bare token parses
 /// as a string *only because* it has two dots — a bare integer
 /// (`version: 5`) comes out as `Value::Number(5)`, a two-component
 /// value (`version: 1.0`) as a float. Returning those back as
@@ -926,10 +926,10 @@ fn range_has_protocol(range: &str) -> bool {
 /// Booleans would behave the same way (`version: yes`), but no real
 /// version string collides with YAML 1.2's bool tokens (`true` /
 /// `false`), so we don't bother unfolding them.
-fn yaml_scalar_as_string(v: &serde_yaml::Value) -> Option<String> {
+fn yaml_scalar_as_string(v: &yaml_serde::Value) -> Option<String> {
     match v {
-        serde_yaml::Value::String(s) => Some(s.clone()),
-        serde_yaml::Value::Number(n) => Some(n.to_string()),
+        yaml_serde::Value::String(s) => Some(s.clone()),
+        yaml_serde::Value::Number(n) => Some(n.to_string()),
         _ => None,
     }
 }
@@ -940,7 +940,7 @@ fn yaml_scalar_as_string(v: &serde_yaml::Value) -> Option<String> {
 /// `yaml_scalar_as_string` for the same reason `version` does — a
 /// bare `dep: 5` would otherwise silently drop the edge instead of
 /// recording `"5"` as the range.
-fn collect_dep_map(block: &serde_yaml::Mapping, key: &str) -> BTreeMap<String, String> {
+fn collect_dep_map(block: &yaml_serde::Mapping, key: &str) -> BTreeMap<String, String> {
     block
         .get(key)
         .and_then(|v| v.as_mapping())
@@ -955,7 +955,7 @@ fn collect_dep_map(block: &serde_yaml::Mapping, key: &str) -> BTreeMap<String, S
 /// Pull `peerDependenciesMeta` into our structured form. Only the
 /// `optional` flag round-trips through aube's model; other keys in
 /// the meta block (if any) are ignored.
-fn collect_peer_meta(block: &serde_yaml::Mapping) -> BTreeMap<String, crate::PeerDepMeta> {
+fn collect_peer_meta(block: &yaml_serde::Mapping) -> BTreeMap<String, crate::PeerDepMeta> {
     block
         .get("peerDependenciesMeta")
         .and_then(|v| v.as_mapping())
@@ -1012,7 +1012,7 @@ fn strip_commit_hash(url: &str) -> String {
 /// repo (if it has a commit hash suffix or a `.git` path) or a plain
 /// tarball download. Checksum / integrity lives on the `checksum:`
 /// field and round-trips through `yarn_checksum`.
-fn classify_remote(url: &str, _block: &serde_yaml::Mapping) -> Option<LocalSource> {
+fn classify_remote(url: &str, _block: &yaml_serde::Mapping) -> Option<LocalSource> {
     if url.ends_with(".git") || url.contains(".git#") {
         Some(LocalSource::Git(GitSource {
             url: strip_commit_hash(url),
@@ -1935,7 +1935,7 @@ __metadata:
     /// from a parsed berry file (berry itself doesn't emit them on
     /// macOS/Linux), so we construct a package with a `file:` source
     /// that contains a backslash directly and assert the output
-    /// escapes it and round-trips through `serde_yaml::from_str`.
+    /// escapes it and round-trips through `yaml_serde::from_str`.
     #[test]
     fn test_write_berry_escapes_resolution_and_header() {
         let mut packages = BTreeMap::new();
@@ -1971,7 +1971,7 @@ __metadata:
 
         // The emitted file must parse as YAML — any missing escape
         // blows up here instead of corrupting a real install.
-        let _doc: serde_yaml::Value = serde_yaml::from_str(&written)
+        let _doc: yaml_serde::Value = yaml_serde::from_str(&written)
             .unwrap_or_else(|e| panic!("berry writer produced malformed YAML: {e}\n{written}"));
     }
 }

--- a/crates/aube-manifest/Cargo.toml
+++ b/crates/aube-manifest/Cargo.toml
@@ -15,7 +15,7 @@ miette = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 simd-json = { workspace = true }
-serde_yaml = { workspace = true }
+yaml_serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -889,13 +889,13 @@ impl ParseError {
         Self::new(path, content, err.to_string(), offset, len)
     }
 
-    /// Build a `ParseError` from a `serde_yaml::Error`.
-    /// `serde_yaml::Location::index` is already a byte offset, so no
+    /// Build a `ParseError` from a `yaml_serde::Error`.
+    /// `yaml_serde::Location::index` is already a byte offset, so no
     /// line/col conversion is needed. Errors without a location
-    /// (notably those bubbling from `serde_yaml::from_value`) collapse
+    /// (notably those bubbling from `yaml_serde::from_value`) collapse
     /// to an empty span at offset 0 — miette still renders the file
     /// name + message, just without a pointer.
-    pub fn from_yaml_err(path: &Path, content: String, err: &serde_yaml::Error) -> Self {
+    pub fn from_yaml_err(path: &Path, content: String, err: &yaml_serde::Error) -> Self {
         let (offset, len) = match err.location() {
             Some(loc) => {
                 let idx = loc.index().min(content.len());
@@ -958,7 +958,7 @@ pub fn parse_json<T: serde::de::DeserializeOwned>(
 }
 
 /// Parse a YAML document from `content`, returning an [`Error::Parse`] on
-/// failure with the source content + span attached. `serde_yaml` reports
+/// failure with the source content + span attached. `yaml_serde` reports
 /// errors with a `Location { index, line, column }` we can feed straight
 /// into a miette span; type-mismatch errors raised after `from_str`
 /// succeeds (e.g. via `from_value`) have no location and render without
@@ -967,7 +967,7 @@ pub fn parse_yaml<T: serde::de::DeserializeOwned>(
     path: &Path,
     content: String,
 ) -> Result<T, Error> {
-    match serde_yaml::from_str(&content) {
+    match yaml_serde::from_str(&content) {
         Ok(v) => Ok(v),
         Err(e) => Err(Error::parse_yaml_err(path, content, &e)),
     }
@@ -982,9 +982,9 @@ impl Error {
         Error::Parse(Box::new(ParseError::from_json_err(path, content, err)))
     }
 
-    /// Build an [`Error::Parse`] from a `serde_yaml::Error`. Delegates
+    /// Build an [`Error::Parse`] from a `yaml_serde::Error`. Delegates
     /// to [`ParseError::from_yaml_err`].
-    pub fn parse_yaml_err(path: &Path, content: String, err: &serde_yaml::Error) -> Self {
+    pub fn parse_yaml_err(path: &Path, content: String, err: &yaml_serde::Error) -> Self {
         Error::Parse(Box::new(ParseError::from_yaml_err(path, content, err)))
     }
 
@@ -1148,9 +1148,9 @@ mod tests {
     fn parse_yaml_attaches_source_span() {
         let path = Path::new("pnpm-workspace.yaml");
         // Tab as the first indent char is a spec-level YAML error;
-        // serde_yaml reports a location for it.
+        // yaml_serde reports a location for it.
         let content = "packages:\n\t- pkg\n".to_string();
-        let res: Result<serde_yaml::Value, Error> = parse_yaml(path, content.clone());
+        let res: Result<yaml_serde::Value, Error> = parse_yaml(path, content.clone());
         let Err(Error::Parse(pe)) = res else {
             panic!("parse_yaml must produce Parse variant on malformed input");
         };
@@ -1160,15 +1160,15 @@ mod tests {
         assert_eq!(pe.path, path);
     }
 
-    /// `serde_yaml::from_value` errors have no `location()`. The helper
+    /// `yaml_serde::from_value` errors have no `location()`. The helper
     /// should still produce an `Error::Parse` (with a zero-length span)
     /// so the file name survives into miette's render.
     #[test]
     fn parse_yaml_err_without_location_falls_back_to_empty_span() {
         let path = Path::new("pnpm-workspace.yaml");
         let content = String::new();
-        let yaml_err: serde_yaml::Error =
-            serde_yaml::from_value::<BTreeMap<String, String>>(serde_yaml::Value::Bool(true))
+        let yaml_err: yaml_serde::Error =
+            yaml_serde::from_value::<BTreeMap<String, String>>(yaml_serde::Value::Bool(true))
                 .expect_err("bool cannot coerce to a map");
         assert!(yaml_err.location().is_none());
         let Error::Parse(pe) = Error::parse_yaml_err(path, content, &yaml_err) else {
@@ -1694,7 +1694,7 @@ mod tests {
                 }
             }"#,
         );
-        let ws: workspace::WorkspaceConfig = serde_yaml::from_str(
+        let ws: workspace::WorkspaceConfig = yaml_serde::from_str(
             r#"
 supportedArchitectures:
   os: ["win32"]
@@ -1725,7 +1725,7 @@ supportedArchitectures:
                 "pnpm": { "ignoredOptionalDependencies": ["fsevents"] }
             }"#,
         );
-        let ws: workspace::WorkspaceConfig = serde_yaml::from_str(
+        let ws: workspace::WorkspaceConfig = yaml_serde::from_str(
             r#"
 ignoredOptionalDependencies:
   - dtrace-provider

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -194,7 +194,7 @@ pub struct WorkspaceConfig {
 
     /// Extend package metadata during resolution.
     #[serde(default)]
-    pub package_extensions: BTreeMap<String, serde_yaml::Value>,
+    pub package_extensions: BTreeMap<String, yaml_serde::Value>,
 
     /// Package deprecation ranges whose warnings should be muted.
     #[serde(default)]
@@ -259,7 +259,7 @@ pub struct WorkspaceConfig {
     /// `package.json`'s `pnpm.allowBuilds` — workspace-level entries
     /// take precedence for the same key.
     #[serde(default)]
-    pub allow_builds: BTreeMap<String, serde_yaml::Value>,
+    pub allow_builds: BTreeMap<String, yaml_serde::Value>,
 
     /// pnpm's canonical allowlist format: a flat list of package names
     /// whose lifecycle scripts are allowed to run. Merged with
@@ -411,11 +411,11 @@ pub struct WorkspaceConfig {
     /// field (not falling into `extra`). Leaves of the map are
     /// deserialized lazily on demand.
     #[serde(default)]
-    pub peer_dependency_rules: Option<serde_yaml::Value>,
+    pub peer_dependency_rules: Option<yaml_serde::Value>,
 
     /// Capture unknown fields for forward compatibility.
     #[serde(flatten)]
-    pub extra: BTreeMap<String, serde_yaml::Value>,
+    pub extra: BTreeMap<String, yaml_serde::Value>,
 }
 
 /// `supportedArchitectures.{os,cpu,libc}` arrays from
@@ -447,14 +447,14 @@ impl WorkspaceConfig {
             .iter()
             .map(|(k, v)| {
                 let raw = match v {
-                    serde_yaml::Value::Bool(b) => crate::AllowBuildRaw::Bool(*b),
+                    yaml_serde::Value::Bool(b) => crate::AllowBuildRaw::Bool(*b),
                     other => {
                         // Render via YAML serialization so the user sees
                         // the same text they wrote (`maybe`, `[a, b]`)
-                        // rather than serde_yaml's Debug form
+                        // rather than yaml_serde's Debug form
                         // (`String("maybe")`). Matches the JSON side in
                         // `AllowBuildRaw::from_json`.
-                        let rendered = serde_yaml::to_string(other)
+                        let rendered = yaml_serde::to_string(other)
                             .unwrap_or_default()
                             .trim()
                             .to_string();
@@ -498,22 +498,22 @@ impl WorkspaceConfig {
 // `load_raw` and `load_both` populate + read this cache so a later
 // `load_raw` after `load_both` doesn't re-read the file.
 type RawCacheMap =
-    std::collections::HashMap<std::path::PathBuf, BTreeMap<String, serde_yaml::Value>>;
+    std::collections::HashMap<std::path::PathBuf, BTreeMap<String, yaml_serde::Value>>;
 static RAW_CACHE: std::sync::OnceLock<std::sync::Mutex<RawCacheMap>> = std::sync::OnceLock::new();
 
-fn raw_cache_lookup(project_dir: &Path) -> Option<BTreeMap<String, serde_yaml::Value>> {
+fn raw_cache_lookup(project_dir: &Path) -> Option<BTreeMap<String, yaml_serde::Value>> {
     let cache = RAW_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
     cache.lock().ok()?.get(project_dir).cloned()
 }
 
-fn raw_cache_insert(project_dir: &Path, value: BTreeMap<String, serde_yaml::Value>) {
+fn raw_cache_insert(project_dir: &Path, value: BTreeMap<String, yaml_serde::Value>) {
     let cache = RAW_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
     if let Ok(mut map) = cache.lock() {
         map.insert(project_dir.to_path_buf(), value);
     }
 }
 
-pub fn load_raw(project_dir: &Path) -> Result<BTreeMap<String, serde_yaml::Value>, crate::Error> {
+pub fn load_raw(project_dir: &Path) -> Result<BTreeMap<String, yaml_serde::Value>, crate::Error> {
     if let Some(hit) = raw_cache_lookup(project_dir) {
         return Ok(hit);
     }
@@ -525,7 +525,7 @@ pub fn load_raw(project_dir: &Path) -> Result<BTreeMap<String, serde_yaml::Value
         raw_cache_insert(project_dir, BTreeMap::new());
         return Ok(BTreeMap::new());
     }
-    let parsed: BTreeMap<String, serde_yaml::Value> = crate::parse_yaml(&path, content)?;
+    let parsed: BTreeMap<String, yaml_serde::Value> = crate::parse_yaml(&path, content)?;
     raw_cache_insert(project_dir, parsed.clone());
     Ok(parsed)
 }
@@ -539,7 +539,7 @@ pub fn load_raw(project_dir: &Path) -> Result<BTreeMap<String, serde_yaml::Value
 #[allow(clippy::type_complexity)]
 pub fn load_both(
     project_dir: &Path,
-) -> Result<(WorkspaceConfig, BTreeMap<String, serde_yaml::Value>), crate::Error> {
+) -> Result<(WorkspaceConfig, BTreeMap<String, yaml_serde::Value>), crate::Error> {
     let Some((path, content)) = find_and_read(project_dir)? else {
         raw_cache_insert(project_dir, BTreeMap::new());
         return Ok((WorkspaceConfig::default(), BTreeMap::new()));
@@ -548,10 +548,10 @@ pub fn load_both(
         raw_cache_insert(project_dir, BTreeMap::new());
         return Ok((WorkspaceConfig::default(), BTreeMap::new()));
     }
-    let value: serde_yaml::Value = crate::parse_yaml(&path, content.clone())?;
-    let typed: WorkspaceConfig = serde_yaml::from_value(value.clone())
+    let value: yaml_serde::Value = crate::parse_yaml(&path, content.clone())?;
+    let typed: WorkspaceConfig = yaml_serde::from_value(value.clone())
         .map_err(|e| crate::Error::parse_yaml_err(&path, content.clone(), &e))?;
-    let raw: BTreeMap<String, serde_yaml::Value> = serde_yaml::from_value(value)
+    let raw: BTreeMap<String, yaml_serde::Value> = yaml_serde::from_value(value)
         .map_err(|e| crate::Error::parse_yaml_err(&path, content, &e))?;
     raw_cache_insert(project_dir, raw.clone());
     Ok((typed, raw))
@@ -593,7 +593,7 @@ pub fn add_to_only_built_dependencies(
 }
 
 fn write_to_yaml(path: &Path, names: &[String]) -> Result<std::path::PathBuf, crate::Error> {
-    use serde_yaml::{Mapping, Value};
+    use yaml_serde::{Mapping, Value};
 
     let mut doc: Value = if path.exists() {
         let content =
@@ -635,12 +635,12 @@ fn write_to_yaml(path: &Path, names: &[String]) -> Result<std::path::PathBuf, cr
         }
     }
 
-    let raw = serde_yaml::to_string(&doc)
+    let raw = yaml_serde::to_string(&doc)
         .map_err(|e| crate::Error::YamlParse(path.to_path_buf(), e.to_string()))?;
-    // serde_yaml emits block sequences flush-left (`- foo`) while pnpm's
+    // yaml_serde emits block sequences flush-left (`- foo`) while pnpm's
     // canonical workspace yaml indents them by two (`  - foo`). Reindent
     // so the output matches what a human or pnpm would write. Safe because
-    // serde_yaml's block style always starts sequence items at the parent's
+    // yaml_serde's block style always starts sequence items at the parent's
     // column; bumping every sequence line by two is a consistent transform.
     let indented = indent_block_sequences(&raw);
     aube_util::fs_atomic::atomic_write(path, indented.as_bytes())
@@ -719,7 +719,7 @@ fn write_to_package_json(
 }
 
 /// Bump every block-sequence item line (`- ...`) by two spaces. Leaves
-/// already-indented lines and non-sequence lines alone. serde_yaml's
+/// already-indented lines and non-sequence lines alone. yaml_serde's
 /// output uses a single indent step per nesting level, so this produces
 /// the `parent:\n  - item` shape humans expect.
 fn indent_block_sequences(input: &str) -> String {
@@ -740,7 +740,7 @@ mod tests {
 
     #[test]
     fn test_empty_config() {
-        let config: WorkspaceConfig = serde_yaml::from_str("{}").unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str("{}").unwrap();
         assert!(config.packages.is_empty());
         assert!(config.enable_global_virtual_store.is_none());
     }
@@ -752,7 +752,7 @@ packages:
   - 'packages/*'
   - 'apps/*'
 "#;
-        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
         assert_eq!(config.packages, vec!["packages/*", "apps/*"]);
     }
 
@@ -766,7 +766,7 @@ shamefullyHoist: false
 packageImportMethod: hardlink
 storeDir: /tmp/my-store
 "#;
-        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
         assert_eq!(config.packages, vec!["packages/*"]);
         assert_eq!(config.enable_global_virtual_store, Some(true));
         assert_eq!(config.shamefully_hoist, Some(false));
@@ -784,7 +784,7 @@ catalogs:
   react16:
     react: ^16.7.0
 "#;
-        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
         assert_eq!(config.catalog.get("chalk").unwrap(), "^4.1.2");
         assert_eq!(
             config
@@ -804,7 +804,7 @@ overrides:
   foo: 1.0.0
   bar: npm:baz@^2
 "#;
-        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
         assert_eq!(config.overrides.get("foo").unwrap(), "1.0.0");
         assert_eq!(config.overrides.get("bar").unwrap(), "npm:baz@^2");
     }
@@ -817,7 +817,7 @@ supportedArchitectures:
   cpu: ["current", "x64"]
   libc: ["glibc"]
 "#;
-        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
         let sa = config.supported_architectures.as_ref().unwrap();
         assert_eq!(sa.os, vec!["current", "linux"]);
         assert_eq!(sa.cpu, vec!["current", "x64"]);
@@ -832,7 +832,7 @@ ignoredOptionalDependencies:
   - fsevents
   - dtrace-provider
 "#;
-        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
         assert_eq!(
             config.ignored_optional_dependencies,
             vec!["fsevents", "dtrace-provider"]
@@ -844,7 +844,7 @@ ignoredOptionalDependencies:
         let yaml = r#"
 pnpmfilePath: config/pnpmfile.cjs
 "#;
-        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
         assert_eq!(config.pnpmfile_path.as_deref(), Some("config/pnpmfile.cjs"));
     }
 
@@ -859,7 +859,7 @@ patchedDependencies:
   "is-positive@3.1.0": patches/is-positive@3.1.0.patch
   "@scope/pkg@1.0.0": patches/scope-pkg.patch
 "#;
-        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
         assert_eq!(
             config
                 .patched_dependencies
@@ -1025,7 +1025,7 @@ patchedDependencies:
 someNewField: true
 anotherSetting: value
 "#;
-        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
         assert!(config.extra.contains_key("someNewField"));
     }
 
@@ -1036,7 +1036,7 @@ updateConfig:
   ignoreDependencies:
     - is-odd
 "#;
-        let config: WorkspaceConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
         assert_eq!(
             config
                 .update_config

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -28,6 +28,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 tempfile = "3"
 flate2 = { workspace = true }
-serde_yaml = { workspace = true }
+yaml_serde = { workspace = true }
 tar = { workspace = true }
 wiremock = "0.6"

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -2532,7 +2532,7 @@ mod tests {
             ("fetch-retry-mintimeout".to_string(), "250".to_string()),
             ("fetch-retry-maxtimeout".to_string(), "9_999".to_string()),
         ];
-        let ws: std::collections::BTreeMap<String, serde_yaml::Value> =
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
             std::collections::BTreeMap::new();
         let ctx = aube_settings::ResolveCtx::files_only(&entries, &ws);
         let p = FetchPolicy::from_ctx(&ctx);
@@ -2556,7 +2556,7 @@ mod tests {
             ("fetchWarnTimeoutMs".to_string(), "500".to_string()),
             ("fetchMinSpeedKiBps".to_string(), "123".to_string()),
         ];
-        let ws: std::collections::BTreeMap<String, serde_yaml::Value> =
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
             std::collections::BTreeMap::new();
         let ctx = aube_settings::ResolveCtx::files_only(&entries, &ws);
         let p = FetchPolicy::from_ctx(&ctx);
@@ -2714,7 +2714,7 @@ mod tests {
         // A user writing `fetch-retries=99999999999` should not panic;
         // the retry loop just caps at u32::MAX attempts.
         let entries = vec![("fetch-retries".to_string(), "99999999999999".to_string())];
-        let ws: std::collections::BTreeMap<String, serde_yaml::Value> =
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
             std::collections::BTreeMap::new();
         let ctx = aube_settings::ResolveCtx::files_only(&entries, &ws);
         let p = FetchPolicy::from_ctx(&ctx);

--- a/crates/aube-settings/Cargo.toml
+++ b/crates/aube-settings/Cargo.toml
@@ -19,7 +19,7 @@ serde = { workspace = true }
 toml = { workspace = true }
 
 [dependencies]
-serde_yaml = { workspace = true }
+yaml_serde = { workspace = true }
 
 [dev-dependencies]
 aube-manifest = { workspace = true }

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -2267,7 +2267,7 @@ docs = """
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
 `pnpm-workspace.yaml`, whichever is present) after resolution to drop
 entries no importer references. A catalog that ends up empty is
-removed entirely. The rewrite goes through `serde_yaml`, so comments
+removed entirely. The rewrite goes through `yaml_serde`, so comments
 and custom formatting in the workspace file are not preserved — turn
 this on only when you're happy to keep the workspace YAML
 machine-generated.

--- a/crates/aube-settings/src/meta.rs
+++ b/crates/aube-settings/src/meta.rs
@@ -123,7 +123,7 @@ mod tests {
                 let top_level_key = key.split('.').next().unwrap_or(key);
                 for shape in shapes {
                     let yaml = format!("{top_level_key}: {shape}\n");
-                    if let Ok(cfg) = serde_yaml::from_str::<aube_manifest::WorkspaceConfig>(&yaml)
+                    if let Ok(cfg) = yaml_serde::from_str::<aube_manifest::WorkspaceConfig>(&yaml)
                         && !cfg.extra.contains_key(top_level_key)
                     {
                         recognized = true;

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -37,7 +37,7 @@ pub struct ResolveCtx<'a> {
     /// Raw top-level map from `pnpm-workspace.yaml` /
     /// `aube-workspace.yaml`, as returned by
     /// `aube_manifest::workspace::load_raw`.
-    pub workspace_yaml: &'a std::collections::BTreeMap<String, serde_yaml::Value>,
+    pub workspace_yaml: &'a std::collections::BTreeMap<String, yaml_serde::Value>,
     /// Captured environment variables relevant to settings. In
     /// production this is populated by [`capture_env`]; tests build a
     /// literal slice. `sources.env` alias order defines priority; within
@@ -57,7 +57,7 @@ impl<'a> ResolveCtx<'a> {
     /// through yet.
     pub fn files_only(
         npmrc: &'a [(String, String)],
-        workspace_yaml: &'a std::collections::BTreeMap<String, serde_yaml::Value>,
+        workspace_yaml: &'a std::collections::BTreeMap<String, yaml_serde::Value>,
     ) -> Self {
         Self {
             npmrc,
@@ -155,7 +155,7 @@ pub fn string_from_npmrc(setting: &str, entries: &[(String, String)]) -> Option<
 /// whichever one is present wins.
 pub(crate) fn bool_from_workspace_yaml(
     setting: &str,
-    raw: &std::collections::BTreeMap<String, serde_yaml::Value>,
+    raw: &std::collections::BTreeMap<String, yaml_serde::Value>,
 ) -> Option<bool> {
     let meta = meta::find(setting)?;
     if meta.type_ != "bool" {
@@ -166,8 +166,8 @@ pub(crate) fn bool_from_workspace_yaml(
             continue;
         };
         match val {
-            serde_yaml::Value::Bool(b) => return Some(*b),
-            serde_yaml::Value::String(s) => {
+            yaml_serde::Value::Bool(b) => return Some(*b),
+            yaml_serde::Value::String(s) => {
                 if let Some(b) = parse_bool(s) {
                     return Some(b);
                 }
@@ -188,7 +188,7 @@ pub(crate) fn bool_from_workspace_yaml(
 /// rather than a bogus rendering.
 pub fn string_from_workspace_yaml(
     setting: &str,
-    raw: &std::collections::BTreeMap<String, serde_yaml::Value>,
+    raw: &std::collections::BTreeMap<String, yaml_serde::Value>,
 ) -> Option<String> {
     let meta = meta::find(setting)?;
     if !is_stringish(meta.type_) {
@@ -199,9 +199,9 @@ pub fn string_from_workspace_yaml(
             continue;
         };
         match val {
-            serde_yaml::Value::String(s) => return Some(s.clone()),
-            serde_yaml::Value::Number(n) => return Some(n.to_string()),
-            serde_yaml::Value::Bool(b) => return Some(b.to_string()),
+            yaml_serde::Value::String(s) => return Some(s.clone()),
+            yaml_serde::Value::Number(n) => return Some(n.to_string()),
+            yaml_serde::Value::Bool(b) => return Some(b.to_string()),
             _ => {}
         }
     }
@@ -237,7 +237,7 @@ pub(crate) fn u64_from_npmrc(setting: &str, entries: &[(String, String)]) -> Opt
 /// Accepts YAML integers and stringified numbers.
 pub(crate) fn u64_from_workspace_yaml(
     setting: &str,
-    raw: &std::collections::BTreeMap<String, serde_yaml::Value>,
+    raw: &std::collections::BTreeMap<String, yaml_serde::Value>,
 ) -> Option<u64> {
     let meta = meta::find(setting)?;
     if meta.type_ != "int" {
@@ -248,12 +248,12 @@ pub(crate) fn u64_from_workspace_yaml(
             continue;
         };
         match val {
-            serde_yaml::Value::Number(n) => {
+            yaml_serde::Value::Number(n) => {
                 if let Some(u) = n.as_u64() {
                     return Some(u);
                 }
             }
-            serde_yaml::Value::String(s) => {
+            yaml_serde::Value::String(s) => {
                 if let Ok(u) = s.trim().parse::<u64>() {
                     return Some(u);
                 }
@@ -289,7 +289,7 @@ pub(crate) fn string_list_from_npmrc(
 /// that stringify the list).
 pub(crate) fn string_list_from_workspace_yaml(
     setting: &str,
-    raw: &std::collections::BTreeMap<String, serde_yaml::Value>,
+    raw: &std::collections::BTreeMap<String, yaml_serde::Value>,
 ) -> Option<Vec<String>> {
     let meta = meta::find(setting)?;
     if meta.type_ != "list<string>" {
@@ -300,14 +300,14 @@ pub(crate) fn string_list_from_workspace_yaml(
             continue;
         };
         match val {
-            serde_yaml::Value::Sequence(seq) => {
+            yaml_serde::Value::Sequence(seq) => {
                 let items: Vec<String> = seq
                     .iter()
                     .filter_map(|v| v.as_str().map(|s| s.to_string()))
                     .collect();
                 return Some(items);
             }
-            serde_yaml::Value::String(s) => return Some(parse_string_list(s)),
+            yaml_serde::Value::String(s) => return Some(parse_string_list(s)),
             _ => {}
         }
     }
@@ -315,17 +315,17 @@ pub(crate) fn string_list_from_workspace_yaml(
 }
 
 pub fn workspace_yaml_value<'a>(
-    raw: &'a std::collections::BTreeMap<String, serde_yaml::Value>,
+    raw: &'a std::collections::BTreeMap<String, yaml_serde::Value>,
     key: &str,
-) -> Option<&'a serde_yaml::Value> {
+) -> Option<&'a yaml_serde::Value> {
     let mut parts = key.split('.');
     let first = parts.next()?;
     let mut value = raw.get(first)?;
     for part in parts {
-        let serde_yaml::Value::Mapping(map) = value else {
+        let yaml_serde::Value::Mapping(map) = value else {
             return None;
         };
-        value = map.get(serde_yaml::Value::String(part.to_string()))?;
+        value = map.get(yaml_serde::Value::String(part.to_string()))?;
     }
     Some(value)
 }
@@ -495,8 +495,8 @@ mod tests {
 
     #[test]
     fn workspace_yaml_value_resolves_dotted_paths() {
-        let raw: BTreeMap<String, serde_yaml::Value> =
-            serde_yaml::from_str("outer:\n  inner:\n    key: value\n").unwrap();
+        let raw: BTreeMap<String, yaml_serde::Value> =
+            yaml_serde::from_str("outer:\n  inner:\n    key: value\n").unwrap();
 
         assert_eq!(
             workspace_yaml_value(&raw, "outer.inner.key").and_then(|v| v.as_str()),
@@ -625,8 +625,8 @@ mod tests {
         assert_eq!(bool_from_npmrc("autoInstallPeers", &e), Some(false));
     }
 
-    fn raw_yaml(src: &str) -> std::collections::BTreeMap<String, serde_yaml::Value> {
-        serde_yaml::from_str(src).expect("test fixture is valid yaml")
+    fn raw_yaml(src: &str) -> std::collections::BTreeMap<String, yaml_serde::Value> {
+        yaml_serde::from_str(src).expect("test fixture is valid yaml")
     }
 
     #[test]
@@ -706,7 +706,7 @@ mod tests {
     #[test]
     fn generated_accessor_returns_declared_default_when_no_source_matches() {
         let npmrc: Vec<(String, String)> = Vec::new();
-        let ws: std::collections::BTreeMap<String, serde_yaml::Value> =
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
             std::collections::BTreeMap::new();
         let ctx = ResolveCtx::files_only(&npmrc, &ws);
         assert!(resolved::auto_install_peers(&ctx));
@@ -800,7 +800,7 @@ mod tests {
         // Callers match on the variant rather than hand-parsing the raw
         // string.
         let npmrc = entries(&[("resolutionMode", "time-based")]);
-        let ws: std::collections::BTreeMap<String, serde_yaml::Value> =
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
             std::collections::BTreeMap::new();
         let ctx = ResolveCtx::files_only(&npmrc, &ws);
         assert_eq!(
@@ -814,7 +814,7 @@ mod tests {
         // An unrecognized value should not pollute the result — the
         // accessor falls back to the declared default when it has one.
         let npmrc = entries(&[("nodeLinker", "totally-fake")]);
-        let ws: std::collections::BTreeMap<String, serde_yaml::Value> =
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
             std::collections::BTreeMap::new();
         let ctx = ResolveCtx::files_only(&npmrc, &ws);
         assert_eq!(resolved::node_linker(&ctx), resolved::NodeLinker::Isolated);
@@ -844,7 +844,7 @@ mod tests {
         // pnpm normalizes enum values before matching; the generated
         // `from_str_normalized` mirrors that.
         let npmrc = entries(&[("nodeLinker", "Hoisted")]);
-        let ws: std::collections::BTreeMap<String, serde_yaml::Value> =
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
             std::collections::BTreeMap::new();
         let ctx = ResolveCtx::files_only(&npmrc, &ws);
         assert_eq!(resolved::node_linker(&ctx), resolved::NodeLinker::Hoisted);
@@ -857,7 +857,7 @@ mod tests {
         // otherwise the setting is silently ignored for anyone copying
         // from pnpm docs.
         let npmrc = entries(&[("node-linker", "hoisted")]);
-        let ws: std::collections::BTreeMap<String, serde_yaml::Value> =
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
             std::collections::BTreeMap::new();
         let ctx = ResolveCtx::files_only(&npmrc, &ws);
         assert_eq!(resolved::node_linker(&ctx), resolved::NodeLinker::Hoisted);
@@ -871,7 +871,7 @@ mod tests {
         // `virtual-store-dir-max-length` so users copying from pnpm's
         // `.npmrc` docs get the expected behaviour.
         let npmrc = entries(&[("virtual-store-dir-max-length", "40")]);
-        let ws: std::collections::BTreeMap<String, serde_yaml::Value> =
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
             std::collections::BTreeMap::new();
         let ctx = ResolveCtx::files_only(&npmrc, &ws);
         assert_eq!(resolved::virtual_store_dir_max_length(&ctx), Some(40));
@@ -884,7 +884,7 @@ mod tests {
         // `.npmrc` (the pnpm-workspace.yaml spelling) were silently
         // ignored. Auto-synth fills in the camelCase alias too.
         let npmrc = entries(&[("preferFrozenLockfile", "false")]);
-        let ws: std::collections::BTreeMap<String, serde_yaml::Value> =
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
             std::collections::BTreeMap::new();
         let ctx = ResolveCtx::files_only(&npmrc, &ws);
         assert_eq!(resolved::prefer_frozen_lockfile(&ctx), Some(false));

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { workspace = true }
 miette = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
+yaml_serde = { workspace = true }
 base64 = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/aube/src/commands/catalogs.rs
+++ b/crates/aube/src/commands/catalogs.rs
@@ -136,7 +136,7 @@ pub(crate) fn workspace_yaml_path(project_dir: &Path) -> Option<PathBuf> {
 /// package)` pairs that were dropped so the caller can surface a
 /// one-line summary.
 ///
-/// The rewrite is a plain `serde_yaml` round trip: comments and custom
+/// The rewrite is a plain `yaml_serde` round trip: comments and custom
 /// layout are not preserved. Callers gate this on `cleanupUnusedCatalogs`
 /// so the destructive rewrite only happens when the user opted in.
 pub(crate) fn prune_unused_catalog_entries(
@@ -170,7 +170,7 @@ pub(crate) fn prune_unused_catalog_entries(
                 workspace_path.display()
             )
         })?;
-    let mut value: serde_yaml::Value = serde_yaml::from_str(&text)
+    let mut value: yaml_serde::Value = yaml_serde::from_str(&text)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to parse {}", workspace_path.display()))?;
 
@@ -185,36 +185,36 @@ pub(crate) fn prune_unused_catalog_entries(
     for (cat_name, pkg_name) in &unused {
         if cat_name == "default" {
             if let Some(map) = root
-                .get_mut(serde_yaml::Value::String("catalog".to_string()))
-                .and_then(serde_yaml::Value::as_mapping_mut)
+                .get_mut(yaml_serde::Value::String("catalog".to_string()))
+                .and_then(yaml_serde::Value::as_mapping_mut)
             {
-                map.remove(serde_yaml::Value::String(pkg_name.clone()));
+                map.remove(yaml_serde::Value::String(pkg_name.clone()));
             }
         } else if let Some(catalogs) = root
-            .get_mut(serde_yaml::Value::String("catalogs".to_string()))
-            .and_then(serde_yaml::Value::as_mapping_mut)
+            .get_mut(yaml_serde::Value::String("catalogs".to_string()))
+            .and_then(yaml_serde::Value::as_mapping_mut)
             && let Some(map) = catalogs
-                .get_mut(serde_yaml::Value::String(cat_name.clone()))
-                .and_then(serde_yaml::Value::as_mapping_mut)
+                .get_mut(yaml_serde::Value::String(cat_name.clone()))
+                .and_then(yaml_serde::Value::as_mapping_mut)
         {
-            map.remove(serde_yaml::Value::String(pkg_name.clone()));
+            map.remove(yaml_serde::Value::String(pkg_name.clone()));
         }
     }
 
     // Drop now-empty catalog containers so the file doesn't grow
     // meaningless `catalog: {}` / `catalogs:` headers.
     let empty_default = root
-        .get(serde_yaml::Value::String("catalog".to_string()))
-        .and_then(serde_yaml::Value::as_mapping)
-        .is_some_and(serde_yaml::Mapping::is_empty);
+        .get(yaml_serde::Value::String("catalog".to_string()))
+        .and_then(yaml_serde::Value::as_mapping)
+        .is_some_and(yaml_serde::Mapping::is_empty);
     if empty_default {
-        root.remove(serde_yaml::Value::String("catalog".to_string()));
+        root.remove(yaml_serde::Value::String("catalog".to_string()));
     }
     if let Some(catalogs) = root
-        .get_mut(serde_yaml::Value::String("catalogs".to_string()))
-        .and_then(serde_yaml::Value::as_mapping_mut)
+        .get_mut(yaml_serde::Value::String("catalogs".to_string()))
+        .and_then(yaml_serde::Value::as_mapping_mut)
     {
-        let to_drop: Vec<serde_yaml::Value> = catalogs
+        let to_drop: Vec<yaml_serde::Value> = catalogs
             .iter()
             .filter_map(|(k, v)| match v.as_mapping() {
                 Some(m) if m.is_empty() => Some(k.clone()),
@@ -226,14 +226,14 @@ pub(crate) fn prune_unused_catalog_entries(
         }
     }
     let empty_named = root
-        .get(serde_yaml::Value::String("catalogs".to_string()))
-        .and_then(serde_yaml::Value::as_mapping)
-        .is_some_and(serde_yaml::Mapping::is_empty);
+        .get(yaml_serde::Value::String("catalogs".to_string()))
+        .and_then(yaml_serde::Value::as_mapping)
+        .is_some_and(yaml_serde::Mapping::is_empty);
     if empty_named {
-        root.remove(serde_yaml::Value::String("catalogs".to_string()));
+        root.remove(yaml_serde::Value::String("catalogs".to_string()));
     }
 
-    let new_text = serde_yaml::to_string(&value)
+    let new_text = yaml_serde::to_string(&value)
         .into_diagnostic()
         .wrap_err("failed to serialize workspace yaml after cleanupUnusedCatalogs")?;
     aube_util::fs_atomic::atomic_write(workspace_path, new_text.as_bytes())

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -473,7 +473,7 @@ fn object_setting_from_env(
 
 fn object_setting_from_workspace_yaml(
     setting: &str,
-    raw: &BTreeMap<String, serde_yaml::Value>,
+    raw: &BTreeMap<String, yaml_serde::Value>,
 ) -> Option<BTreeMap<String, serde_json::Value>> {
     let meta = aube_settings::find(setting)?;
     for key in meta.workspace_yaml_keys {

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -398,7 +398,7 @@ fn home_dir_os() -> Option<std::ffi::OsString> {
 
 /// Build a file-only `ResolveCtx` for `cwd` and call `f` with it.
 /// Handles the temporary ownership of npmrc/workspace/env data so
-/// callers don't need to import `serde_yaml`.
+/// callers don't need to import `yaml_serde`.
 pub(crate) fn with_settings_ctx<T>(
     cwd: &std::path::Path,
     f: impl FnOnce(&aube_settings::ResolveCtx<'_>) -> T,

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -2275,7 +2275,7 @@ Remove unused catalog entries during install.
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
 `pnpm-workspace.yaml`, whichever is present) after resolution to drop
 entries no importer references. A catalog that ends up empty is
-removed entirely. The rewrite goes through `serde_yaml`, so comments
+removed entirely. The rewrite goes through `yaml_serde`, so comments
 and custom formatting in the workspace file are not preserved — turn
 this on only when you're happy to keep the workspace YAML
 machine-generated.


### PR DESCRIPTION
## What changed

- Replaced the workspace `serde_yaml` dependency with `yaml_serde` 0.10.4.
- Updated crate manifests and Rust call sites to use `yaml_serde::` directly.
- Refreshed `Cargo.lock`, removing `serde_yaml` and `unsafe-libyaml` and adding `yaml_serde` / `libyaml-rs`.

## Why

`serde_yaml` is deprecated. `yaml_serde` is the maintained fork with the same Serde-facing API shape, which lets aube keep its existing YAML parsing and emitting behavior without a broader parser rewrite.

## Validation

- `cargo check`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- Targeted YAML suites for pnpm, Yarn Berry, workspace config, settings, and parse diagnostics

`cargo test` was also run and reached one existing environment-sensitive resolver platform failure: `aube-resolver::platform::tests::linux_glibc_host_rejects_musl_only_package`. The same test fails by itself on this host and is unrelated to the YAML dependency swap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps the YAML parser/emitter across lockfile/workspace/settings code paths; while largely API-compatible, it can change YAML scalar resolution and serialization output, affecting lockfile/workspace parsing and byte-for-byte parity tests.
> 
> **Overview**
> Replaces the deprecated `serde_yaml` dependency with `yaml_serde` across the workspace, updating all YAML parsing/serialization call sites and related error plumbing.
> 
> This also adjusts Yarn Berry parsing to coerce additional typed scalars (notably booleans) back into strings when reading version/dependency fields, and refreshes `Cargo.lock` to drop `serde_yaml`/`unsafe-libyaml` in favor of `yaml_serde`/`libyaml-rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a825e137c6e2d0fc6ccbfdf205882881894fb9fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->