### PR TITLE
docs: add sponsor feed to docs

### DIFF
--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -1,0 +1,122 @@
+<template>
+  <section
+    v-if="sponsors.length"
+    aria-labelledby="endev-sponsors-title"
+    class="EndevSponsors"
+  >
+    <div class="EndevSponsorsInner">
+      <p id="endev-sponsors-title" class="EndevSponsorsTitle">
+        Company sponsors
+      </p>
+      <div class="EndevSponsorsLogos">
+        <a
+          v-for="sponsor in sponsors"
+          :key="sponsor.name"
+          :aria-label="sponsor.name"
+          class="EndevSponsorsLogo"
+          :href="sponsor.url"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <img :alt="sponsor.name" :src="sponsor.logo" />
+        </a>
+      </div>
+      <a class="EndevSponsorsCta" href="https://en.dev/#contact">
+        Sponsor the work
+      </a>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { onMounted, ref } from "vue";
+
+const sponsors = ref([]);
+
+onMounted(async () => {
+  try {
+    const res = await fetch("https://en.dev/sponsors.json", {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return;
+
+    const payload = await res.json();
+    sponsors.value = (Array.isArray(payload.sponsors) ? payload.sponsors : [])
+      .filter((sponsor) =>
+        sponsor?.kind !== "infrastructure" &&
+        sponsor?.name &&
+        sponsor?.url &&
+        sponsor?.logo
+      );
+  } catch {
+    sponsors.value = [];
+  }
+});
+</script>
+
+<style scoped>
+.EndevSponsors {
+  border-top: 1px solid var(--vp-c-divider);
+  padding: 22px 24px;
+}
+
+.EndevSponsorsInner {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  justify-content: center;
+  margin: 0 auto;
+  max-width: 960px;
+}
+
+.EndevSponsorsTitle {
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.EndevSponsorsLogos {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.EndevSponsorsLogo {
+  align-items: center;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  display: inline-flex;
+  height: 40px;
+  justify-content: center;
+  padding: 8px 12px;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.EndevSponsorsLogo:hover {
+  background: var(--vp-c-bg-soft);
+  border-color: var(--vp-c-brand-1);
+}
+
+.EndevSponsorsLogo img {
+  display: block;
+  max-height: 22px;
+  max-width: 120px;
+}
+
+.EndevSponsorsCta {
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.EndevSponsorsCta:hover {
+  color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import { h } from "vue";
 import AubeSocialLinks from "./AubeSocialLinks.vue";
 import BenchChart from "./BenchChart.vue";
 import EndevFooter from "./EndevFooter.vue";
+import EndevSponsors from "./EndevSponsors.vue";
 import HomeLanding from "./HomeLanding.vue";
 import { initBanner } from "./banner";
 import "./custom.css";
@@ -12,7 +13,7 @@ export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
-      "layout-bottom": () => h(EndevFooter),
+      "layout-bottom": () => [h(EndevSponsors), h(EndevFooter)],
       "nav-bar-content-after": () => h(AubeSocialLinks),
       "nav-screen-content-after": () => h(AubeSocialLinks),
     });


### PR DESCRIPTION
## Summary

Adds an en.dev company sponsor block to the docs footer.

## Changes

- Adds `EndevSponsors.vue`, which fetches `https://en.dev/sponsors.json` client-side.
- Renders the feed's default `sponsors` list, which is paid company sponsors only.
- Places the sponsor block above the existing en.dev footer.

## Validation

- `npm install --no-package-lock --ignore-scripts` in `docs/`
- `npm run docs:build` in `docs/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only UI with a read-only public JSON fetch; no auth, data writes, or app logic changes.
> 
> **Overview**
> Adds a **company sponsors** strip to the VitePress docs site footer, loaded at runtime from `https://en.dev/sponsors.json`.
> 
> The new `EndevSponsors` block shows paid sponsors (excluding `infrastructure` entries), links each logo to the sponsor URL, and includes a “Sponsor the work” CTA. It only renders when the feed returns at least one valid sponsor; fetch failures leave the section hidden.
> 
> The theme’s `layout-bottom` slot now stacks **sponsors above** the existing en.dev footer instead of footer alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e977eaba1b044567dc809fd036e198b659e00e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->