### PR TITLE
perf(install): skip unused dep bin links

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3275,14 +3275,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 }
             }
         }
-        link_dep_bins(
-            &aube_dir,
-            &graph_for_link,
-            virtual_store_dir_max_length,
-            placements_ref,
-            shim_opts,
-            &mut pkg_json_cache,
-        )?;
+        if !opts.ignore_scripts && build_policy.has_any_allow_rule() {
+            link_dep_bins(
+                &aube_dir,
+                &graph_for_link,
+                virtual_store_dir_max_length,
+                placements_ref,
+                shim_opts,
+                &mut pkg_json_cache,
+            )?;
+        }
         tracing::debug!("phase:link_bins {:.1?}", phase_start.elapsed());
     }
 


### PR DESCRIPTION
## Summary

Skip the per-dependency `.bin` linking pass when dependency lifecycle scripts cannot run. Root and workspace `.bin` entries are still linked as before; the dep-local `.bin` directories are only needed for allowed dependency build scripts.

## Why

The default install policy denies dependency lifecycle scripts unless `allowBuilds` / `onlyBuiltDependencies` opts packages in. On benchmark-style installs with no allow rules, aube was still walking dependency edges and reading package manifests to create dep-local bin shims that nothing would use.

In a local VLT-shaped Vue lockfile repro (`CI=1`, release build, `trustPolicy=off` to work around the current fresh-resolve trust downgrade), `phase:link_bins` dropped from about 105 ms to about 10 ms.

## Validation

- `cargo fmt --check`
- `cargo build`
- `cargo build --release -p aube`
- `mise run test:bats test/lifecycle_scripts.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only gates the per-dependency `.bin` linking pass behind existing script/build-policy conditions, affecting install performance more than behavior. Potential risk is missing transitive bin shims in edge cases where they’re needed without lifecycle scripts, but the code comments indicate they’re primarily for dep script execution.
> 
> **Overview**
> **Skips the per-dependency `.bin` linking pass** (`link_dep_bins`) during install unless dependency lifecycle scripts are allowed to run (i.e., `!--ignore-scripts` and the build policy has at least one allow rule).
> 
> Root and workspace `.bin` linking remains unchanged; this reduces unnecessary graph walking/manifest reads on installs where dependency build scripts are effectively disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab5fd2685d71bee92b0bcf2848576deb13da29b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->