### PR TITLE
chore: switch analytics from gtm to plausible

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -77,7 +77,7 @@ export default defineConfig({
       "script",
       {
         defer: "",
-        "data-domain": "pa-pKoppeTCBJKVlCRf8Mxk_",
+        "data-domain": "aube.en.dev",
         "data-api": "https://shrill.en.dev/f5f1/event",
         src: "https://shrill.en.dev/shrill/script.js",
       },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -76,18 +76,11 @@ export default defineConfig({
     [
       "script",
       {
-        async: "",
-        src: "https://www.googletagmanager.com/gtag/js?id=G-WD1RRC0F8C",
+        defer: "",
+        "data-domain": "pa-pKoppeTCBJKVlCRf8Mxk_",
+        "data-api": "https://shrill.en.dev/f5f1/event",
+        src: "https://shrill.en.dev/shrill/script.js",
       },
-    ],
-    [
-      "script",
-      {},
-      `window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-
-gtag('config', 'G-WD1RRC0F8C');`,
     ],
   ],
   themeConfig: {


### PR DESCRIPTION
## Summary

- Drops Google Tag Manager from the docs site
- Adds Plausible Analytics via the shrill.en.dev Cloudflare worker proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that swaps a third-party analytics embed; main risk is misconfigured tracking or added external script load affecting docs page performance/privacy.
> 
> **Overview**
> Replaces the docs site analytics snippet in `docs/.vitepress/config.mts`, removing the Google Tag Manager/`gtag` setup and injecting a Plausible-compatible script loaded from `shrill.en.dev` with `data-domain` and `data-api` configured for proxying events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458979062a293c550a300482ab28672905eef827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->