### PR TITLE
fix(resolver): accept abbreviated git commit SHAs in user specs

### DIFF
--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -244,9 +244,16 @@ pub(crate) async fn resolve_git_source(
     let subpath = git.subpath.clone();
     let name_owned = name.to_string();
     let (local, version, deps) = tokio::task::spawn_blocking(move || -> Result<_, Error> {
-        let resolved = aube_store::git_resolve_ref(&url, committish.as_deref())
+        // `git_resolve_ref` resolves branch / tag / HEAD names to a
+        // 40-char SHA via `ls-remote`, but passes hex prefixes (i.e.
+        // user-written abbreviated commit SHAs) through unchanged
+        // because abbreviated commits aren't advertised as refs. The
+        // canonical full SHA is recovered from `git_shallow_clone`'s
+        // post-checkout `rev-parse HEAD`, so the lockfile always
+        // pins the full form.
+        let resolve_seed = aube_store::git_resolve_ref(&url, committish.as_deref())
             .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
-        let clone_dir = aube_store::git_shallow_clone(&url, &resolved, shallow)
+        let (clone_dir, resolved) = aube_store::git_shallow_clone(&url, &resolve_seed, shallow)
             .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
         // `&path:/<sub>` narrows the package root to a subdirectory
         // of the cloned repo (pnpm-compatible). The manifest, version,

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1278,18 +1278,16 @@ pub fn git_resolve_ref(url: &str, committish: Option<&str>) -> Result<String, Er
         if let Some(sha) = tag_match.or(head_match) {
             return Ok(sha);
         }
-        // If the committish looks like a hex prefix but isn't a full
-        // SHA, the user likely copy-pasted an abbreviated commit from
-        // a git UI. ls-remote only lists advertised refs (branches /
-        // tags), so an abbreviated commit never matches — surface a
-        // clearer error instead of the generic "no ref matched".
+        // ls-remote only advertises branches and tags, so an
+        // abbreviated commit SHA never matches a ref name. Pass it
+        // through unchanged — `git_shallow_clone` resolves the prefix
+        // by fetching and running `git checkout`, and the resolver
+        // promotes the rev-parsed full SHA back into `GitSource`
+        // before writing the lockfile (see `resolve_git_source`).
         let looks_hex =
             want.len() >= 4 && want.len() < 40 && want.chars().all(|c| c.is_ascii_hexdigit());
         if looks_hex {
-            return Err(Error::Git(format!(
-                "git ls-remote {}: `#{want}` looks like an abbreviated commit SHA. aube requires a full 40-character SHA, or a branch/tag name",
-                redact_url(url)
-            )));
+            return Ok(want.to_ascii_lowercase());
         }
         Err(Error::Git(format!(
             "git ls-remote {}: no ref matched {want}",
@@ -1393,7 +1391,17 @@ pub fn git_url_host(url: &str) -> Option<&str> {
 /// straight to the full-fetch path. Callers decide shallow vs. full
 /// by consulting the `gitShallowHosts` setting via
 /// [`git_host_in_list`].
-pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathBuf, Error> {
+///
+/// Returns `(clone_dir, head_sha)` where `head_sha` is the 40-char
+/// `git rev-parse HEAD` of the checked-out tree. Callers can pass
+/// `commit` as either a full SHA or an abbreviated hex prefix; the
+/// returned SHA is always the canonical full-length form so the
+/// resolver can pin the lockfile to it.
+pub fn git_shallow_clone(
+    url: &str,
+    commit: &str,
+    shallow: bool,
+) -> Result<(PathBuf, String), Error> {
     use std::process::Command;
     validate_git_positional(url, "git url")?;
     validate_git_positional(commit, "git commit")?;
@@ -1459,9 +1467,11 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
             .current_dir(&target)
             .output()
         && out.status.success()
-        && git_commit_matches(String::from_utf8_lossy(&out.stdout).trim(), commit)
     {
-        return Ok(target);
+        let head = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if git_commit_matches(&head, commit) {
+            return Ok((target, head));
+        }
     }
 
     // Clone into a scratch dir first and atomically rename into
@@ -1501,7 +1511,7 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
         Ok(())
     };
 
-    let do_clone = || -> Result<(), Error> {
+    let do_clone = || -> Result<String, Error> {
         run_in(&scratch, &["init", "-q"])?;
         run_in(&scratch, &["remote", "add", "--", "origin", url])?;
         // Shallow fetch by raw SHA only works when the remote allows
@@ -1548,12 +1558,15 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
                 "git clone HEAD {actual} does not match requested commit {commit}"
             )));
         }
-        Ok(())
+        Ok(actual)
     };
-    if let Err(e) = do_clone() {
-        let _ = std::fs::remove_dir_all(&scratch);
-        return Err(e);
-    }
+    let head_sha = match do_clone() {
+        Ok(sha) => sha,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&scratch);
+            return Err(e);
+        }
+    };
 
     // `rename` is atomic on the same filesystem. Two outcomes:
     //  - Target doesn't exist → we win and it's ours.
@@ -1562,7 +1575,7 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
     //    with ENOTEMPTY/EEXIST. Verify the existing target has our
     //    commit and reuse it; otherwise remove it and retry once.
     match aube_util::fs_atomic::rename_with_retry(&scratch, &target) {
-        Ok(()) => Ok(target),
+        Ok(()) => Ok((target, head_sha)),
         Err(_) => {
             if target.join(".git").is_dir()
                 && let Ok(out) = Command::new("git")
@@ -1570,10 +1583,12 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
                     .current_dir(&target)
                     .output()
                 && out.status.success()
-                && git_commit_matches(String::from_utf8_lossy(&out.stdout).trim(), commit)
             {
-                let _ = std::fs::remove_dir_all(&scratch);
-                return Ok(target);
+                let head = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                if git_commit_matches(&head, commit) {
+                    let _ = std::fs::remove_dir_all(&scratch);
+                    return Ok((target, head));
+                }
             }
             // Stale target — clear and retry the rename. Any
             // remaining race here would be between two installs
@@ -1584,7 +1599,7 @@ pub fn git_shallow_clone(url: &str, commit: &str, shallow: bool) -> Result<PathB
                 let _ = std::fs::remove_dir_all(&scratch);
                 Error::Git(format!("rename clone into place: {e}"))
             })?;
-            Ok(target)
+            Ok((target, head_sha))
         }
     }
 }
@@ -2293,6 +2308,26 @@ mod tests {
         // the validation runs at the public entry point.
         let err = git_resolve_ref("--upload-pack=/tmp/evil", None).unwrap_err();
         assert!(matches!(err, Error::Git(_)));
+    }
+
+    #[test]
+    fn test_git_resolve_ref_full_sha_is_offline() {
+        // 40-char hex committish short-circuits `ls-remote`. Confirm
+        // by handing a non-existent URL — if the fast path regressed
+        // into a network call, the test would fail to spawn git.
+        let sha = "0123456789ABCDEF0123456789abcdef01234567";
+        let resolved = git_resolve_ref("https://example.invalid/missing.git", Some(sha)).unwrap();
+        assert_eq!(resolved, "0123456789abcdef0123456789abcdef01234567");
+    }
+
+    #[test]
+    fn test_git_commit_matches_prefix() {
+        let full = "0b6ea539609031977983f0b2393ebe81ee28c8ec";
+        assert!(git_commit_matches(full, full));
+        assert!(git_commit_matches(full, "0b6ea53"));
+        assert!(!git_commit_matches(full, "0b6ea5"));
+        assert!(!git_commit_matches(full, "abc1234"));
+        assert!(!git_commit_matches(full, "main"));
     }
 
     #[test]

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1426,18 +1426,6 @@ pub fn git_shallow_clone(
     // under different shallow settings can reuse each other's work,
     // and `import_directory` ignores `.git/` so the store sees
     // identical output either way.
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(url.as_bytes());
-    hasher.update(b"\0");
-    hasher.update(commit.as_bytes());
-    let digest = hasher.finalize();
-    let key: String = digest
-        .as_bytes()
-        .iter()
-        .take(8)
-        .map(|b| format!("{b:02x}"))
-        .collect();
-    let commit_short = commit.get(..commit.len().min(12)).unwrap_or(commit);
     // Keep git scratch out of world-writable /tmp. Predictable names
     // under $TMPDIR are the classic symlink pre-plant vector. Attacker
     // creates /tmp/aube-git-<k>-<c> as a symlink into $HOME/.ssh, then
@@ -1459,6 +1447,31 @@ pub fn git_shallow_clone(
             );
         }
     }
+    // Cache key derives from `(url, commit_input)`. When the caller
+    // passes an abbreviated SHA, the initial target lands under that
+    // key; after the clone, we re-key to the canonical full SHA so
+    // a follow-up call (typically the installer reading the
+    // lockfile-pinned full SHA) hits the same checkout instead of
+    // re-cloning.
+    let cache_key = |key_input: &str| -> (String, String) {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(url.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(key_input.as_bytes());
+        let digest = hasher.finalize();
+        let key: String = digest
+            .as_bytes()
+            .iter()
+            .take(8)
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        let short = key_input
+            .get(..key_input.len().min(12))
+            .unwrap_or(key_input)
+            .to_string();
+        (key, short)
+    };
+    let (key, commit_short) = cache_key(commit);
     let target = git_root.join(format!("aube-git-{key}-{commit_short}"));
 
     // Fast path: a previous call already finished this (url, commit)
@@ -1581,7 +1594,10 @@ pub fn git_shallow_clone(
     //    with ENOTEMPTY/EEXIST. Verify the existing target has our
     //    commit and reuse it; otherwise remove it and retry once.
     match aube_util::fs_atomic::rename_with_retry(&scratch, &target) {
-        Ok(()) => Ok((target, head_sha)),
+        Ok(()) => Ok((
+            canonicalize_clone_dir(&target, commit, &head_sha, &cache_key),
+            head_sha,
+        )),
         Err(_) => {
             if target.join(".git").is_dir()
                 && let Ok(out) = Command::new("git")
@@ -1593,7 +1609,10 @@ pub fn git_shallow_clone(
                 let head = String::from_utf8_lossy(&out.stdout).trim().to_string();
                 if git_commit_matches(&head, commit) {
                     let _ = std::fs::remove_dir_all(&scratch);
-                    return Ok((target, head));
+                    return Ok((
+                        canonicalize_clone_dir(&target, commit, &head, &cache_key),
+                        head,
+                    ));
                 }
             }
             // Stale target — clear and retry the rename. Any
@@ -1605,8 +1624,45 @@ pub fn git_shallow_clone(
                 let _ = std::fs::remove_dir_all(&scratch);
                 Error::Git(format!("rename clone into place: {e}"))
             })?;
-            Ok((target, head_sha))
+            Ok((
+                canonicalize_clone_dir(&target, commit, &head_sha, &cache_key),
+                head_sha,
+            ))
         }
+    }
+}
+
+/// Re-key an abbreviated-SHA cache directory to its canonical
+/// full-SHA path so a follow-up `git_shallow_clone` call (e.g. the
+/// installer reading the lockfile-pinned full SHA) reuses the
+/// existing checkout instead of cloning again. No-op when `commit`
+/// already matches `head_sha`. Best-effort: if the rename fails
+/// (cross-FS, race, perms), leaves the original path intact and
+/// the caller pays one extra clone next time.
+fn canonicalize_clone_dir(
+    target: &Path,
+    commit: &str,
+    head_sha: &str,
+    cache_key: &dyn Fn(&str) -> (String, String),
+) -> PathBuf {
+    if commit.eq_ignore_ascii_case(head_sha) {
+        return target.to_path_buf();
+    }
+    let parent = match target.parent() {
+        Some(p) => p,
+        None => return target.to_path_buf(),
+    };
+    let (key, short) = cache_key(head_sha);
+    let canonical = parent.join(format!("aube-git-{key}-{short}"));
+    if canonical.join(".git").is_dir() {
+        // Race: another caller already wrote the canonical entry.
+        // Drop our duplicate so disk doesn't bloat with two copies.
+        let _ = std::fs::remove_dir_all(target);
+        return canonical;
+    }
+    match aube_util::fs_atomic::rename_with_retry(target, &canonical) {
+        Ok(()) => canonical,
+        Err(_) => target.to_path_buf(),
     }
 }
 

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1284,8 +1284,14 @@ pub fn git_resolve_ref(url: &str, committish: Option<&str>) -> Result<String, Er
         // by fetching and running `git checkout`, and the resolver
         // promotes the rev-parsed full SHA back into `GitSource`
         // before writing the lockfile (see `resolve_git_source`).
+        //
+        // Lower bound is 7 to stay in lockstep with `git_commit_matches`:
+        // a shorter prefix would clear this gate but then trip the
+        // post-checkout verification with a confusing mismatch error.
+        // 7 is also git's own default `core.abbrev`, so anything users
+        // copy out of a git UI lands at or above the cutoff.
         let looks_hex =
-            want.len() >= 4 && want.len() < 40 && want.chars().all(|c| c.is_ascii_hexdigit());
+            want.len() >= 7 && want.len() < 40 && want.chars().all(|c| c.is_ascii_hexdigit());
         if looks_hex {
             return Ok(want.to_ascii_lowercase());
         }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -467,7 +467,7 @@ pub(super) async fn import_local_source(
             let resolved = g.resolved.clone();
             let spec = local.specifier();
             let shallow = aube_store::git_host_in_list(&url, git_shallow_hosts);
-            let clone_dir = tokio::task::spawn_blocking(move || {
+            let (clone_dir, _head_sha) = tokio::task::spawn_blocking(move || {
                 aube_store::git_shallow_clone(&url, &resolved, shallow)
             })
             .await


### PR DESCRIPTION
## Summary

- `github:owner/repo#<short>` (and other git specs that use an abbreviated hex commit) now install instead of erroring with `aube requires a full 40-character SHA`.
- The lockfile records the canonical 40-character SHA even when the user-written specifier was abbreviated, matching pnpm's behavior.

## Details

`git_resolve_ref` previously rejected hex prefixes upfront because `git ls-remote` only advertises branches and tags, so an abbreviated commit SHA never matched. But `git_shallow_clone` already checks abbreviated commits out fine via `git fetch` + `git checkout <prefix>`. The fix is to let the prefix flow through `git_resolve_ref` unchanged and recover the canonical full SHA from the post-checkout `git rev-parse HEAD` that `git_shallow_clone` already runs for verification.

`git_shallow_clone` now returns `(PathBuf, String)` where the second element is the 40-char HEAD SHA. `resolve_git_source` uses that to populate `GitSource.resolved`, so the lockfile pins the canonical form regardless of what the user wrote.

Reported in [#345](https://github.com/endevco/aube/discussions/345#discussioncomment-16732228).

## Test plan
- [x] `cargo test` (workspace, all green)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manual: `aube install` on `package.json` with `"vfs": "github:collinstevens/vfs#0b6ea53"` (abbreviated) → installs, lockfile pins `0b6ea539609031977983f0b2393ebe81ee28c8ec`
- [x] Manual: `aube install` on the same with the full 40-char SHA → still installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git ref resolution and clone caching semantics, which can affect reproducibility and cache reuse for git dependencies. Risk is mitigated by explicit HEAD verification and new tests covering abbreviated-SHA behavior.
> 
> **Overview**
> **Git dependencies now accept abbreviated commit SHAs.** `git_resolve_ref` no longer errors on 7–39 char hex prefixes and instead passes them through for `git_shallow_clone` to resolve.
> 
> **Lockfile and cache are canonicalized to full SHAs.** `git_shallow_clone` now returns `(clone_dir, head_sha)` from `rev-parse HEAD`, the resolver writes that full SHA into `GitSource.resolved`, and the clone cache directory is best-effort re-keyed from the abbreviated input to the canonical SHA to avoid re-cloning.
> 
> Adds targeted tests for offline full-SHA resolution and prefix matching, and updates install-time git cloning call sites for the new return type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 414f7bbbb9d58d9eff4881e00a548cb684be041f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->