### PR TITLE
perf(add): drop redundant pre-install resolve, use FrozenMode::Fix

### DIFF
--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -366,7 +366,7 @@ pub async fn run(
     ))
     .await;
 
-    // 6. Under `--no-save`, restore the snapshotted `package.json` and
+    // 5. Under `--no-save`, restore the snapshotted `package.json` and
     // lockfile so neither shows up in `git status`. The user's
     // `node_modules` keeps the freshly linked package — matching
     // pnpm's `--no-save` semantics. We do this regardless of whether
@@ -462,7 +462,7 @@ async fn update_manifest_for_add(
     packages: &[String],
     opts: AddManifestOptions,
     print_updated: bool,
-) -> miette::Result<(aube_manifest::PackageJson, super::CatalogMap)> {
+) -> miette::Result<()> {
     // Resolve settings (savePrefix, tag, catalogMode) from .npmrc /
     // workspace yaml. `catalog_mode` decides whether a newly-added dep
     // that already lives in the default workspace catalog gets rewritten
@@ -717,7 +717,7 @@ async fn update_manifest_for_add(
         eprintln!("Updated package.json");
     }
 
-    Ok((manifest, workspace_catalogs))
+    Ok(())
 }
 
 /// Resolve the on-disk lockfile path that a normal `add` would write

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -339,7 +339,7 @@ pub async fn run(
     } else {
         None
     };
-    let (manifest, workspace_catalogs) = update_manifest_for_add(
+    update_manifest_for_add(
         &cwd,
         packages,
         AddManifestOptions {
@@ -352,29 +352,18 @@ pub async fn run(
     )
     .await?;
 
-    // 4 + 5. Resolve, write the lockfile, and run install. We collect
-    // the entire pipeline into a single `Result` so the restore step
-    // below runs even if the resolver, lockfile writer, or install
-    // bails out — without this wrapper a network failure mid-resolve
-    // would leave the mutated `package.json` (and any partially
-    // written lockfile) on disk, breaking the `--no-save` promise.
-    let pipeline_result: miette::Result<()> = async {
-        let existing = aube_lockfile::parse_lockfile(&cwd, &manifest).ok();
-        let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
-        let graph = resolver
-            .resolve(&manifest, existing.as_ref())
-            .await
-            .map_err(miette::Report::new)
-            .wrap_err("failed to resolve dependencies")?;
-        eprintln!("Resolved {} packages", graph.packages.len());
-
-        super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
-
-        install::run(install::InstallOptions::with_mode(
-            super::chained_frozen_mode(install::FrozenMode::Prefer),
-        ))
-        .await
-    }
+    // 4. Run install. It re-reads the mutated package.json, runs the
+    // resolver (reusing locked entries for unchanged specs), writes the
+    // lockfile, and links node_modules in one pipeline. `Fix` mode is
+    // the right semantic here: package.json just gained a new spec,
+    // so the lockfile is by definition stale on that one entry — Prefer
+    // would risk taking the from-lockfile fast path and missing the
+    // new dep. Wrapping in a `Result` so the restore step below runs
+    // even on failure — a network error mid-resolve would otherwise
+    // leave the mutated `package.json` on disk, breaking `--no-save`.
+    let pipeline_result: miette::Result<()> = install::run(install::InstallOptions::with_mode(
+        super::chained_frozen_mode(install::FrozenMode::Fix),
+    ))
     .await;
 
     // 6. Under `--no-save`, restore the snapshotted `package.json` and
@@ -803,7 +792,7 @@ async fn run_filtered(
         }
 
         let mut install_opts = install::InstallOptions::with_mode(super::chained_frozen_mode(
-            install::FrozenMode::Prefer,
+            install::FrozenMode::Fix,
         ));
         install_opts.workspace_filter = filter.clone();
         install::run(install_opts).await?;


### PR DESCRIPTION
## Summary

`aube add` was running the resolver twice — once in `add.rs` to compute a pre-install graph for the eprintln + lockfile write, and again inside `install::run` for the actual install. Drop the pre-install resolve+write; let `install::run` handle it. Switch chained mode from `Prefer` to `Fix` so the resolver still reuses locked entries for unchanged specs but never takes the from-lockfile fast path (which can miss the just-added dep when the on-disk lockfile is empty).

## Why this matters

Came out of a benchmark comparison against `pnpm/pacquet`'s `add fastify` scenario. With the redundant resolve, aube was ~1.4x slower than pacquet/bun on this fixture. Profiling pinpointed two full BFS resolves over fastify's 47-package graph back-to-back.

For comparison, `aube install` against an equivalent hand-edited `package.json` was already faster than pacquet/bun — the loss was entirely in `add`'s extra pass.

## Benchmark — `add fastify` (pacquet's own benchmark methodology)

`hyperfine -w 5 -m 20 -M 20`, store/cache pruned between every iteration, real npmjs registry, `lockfile=false` + `auto-install-peers=false` per pacquet's `.npmrc`.

| PM        | Before     | After      |
|---        |---:        |---:        |
| **aube**      | 380.0 ms   | **136.0 ms** |
| pacquet   | 265.1 ms   | 262.9 ms   |
| bun       | 257.9 ms   | 269.1 ms   |
| pnpm      | 453.9 ms   | 454.5 ms   |
| yarn      | 684.6 ms   | 670.2 ms   |

aube goes from ~1.4x slower than pacquet to ~1.9x faster (2.79x speedup on this scenario).

## Why `Fix` not `Prefer`

`Prefer` mode tries the from-lockfile fast path before falling back to a fresh resolve. After `update_manifest_for_add` mutates `package.json`, the lockfile is by definition stale on the new entry. The fast path can silently skip the new dep when the on-disk lockfile has empty `packages` — exposed by the `aube add --no-save: restores a non-aube lockfile` bats test once the pre-resolve was removed.

`Fix` re-resolves but reuses locked entries for unchanged specs (cheap), which is exactly what `add` wants.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test` — passes (one pre-existing unrelated failure in `aube-resolver::platform::tests::linux_glibc_host_rejects_musl_only_package`, also fails on `origin/main`)
- [x] `cargo test --bin aube add` — 18/18 unit tests pass
- [x] `bats test/add.bats` — 25/25 pass
- [x] `bats test/install.bats test/update.bats test/remove.bats test/catalogs.bats` — 101/101 pass
- [x] Benchmarked vs pacquet, bun, pnpm, yarn (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency resolution/lockfile update semantics for `aube add`, which could affect correctness in edge cases (e.g., stale/empty lockfiles) despite being limited in scope to the add workflow.
> 
> **Overview**
> `aube add` no longer performs its own pre-install resolve/lockfile write; it now only updates `package.json` and then delegates the full resolve→lockfile→link pipeline to `install::run`.
> 
> The install invocation is switched from `FrozenMode::Prefer` to `FrozenMode::Fix` (including workspace-filtered adds) to avoid the from-lockfile fast path missing the just-added dependency while still reusing existing locked entries. `update_manifest_for_add` is simplified to return `()` since its results are no longer needed by the caller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcf46d8d67dd90d3a09f7a3053df0b44514f68fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->