### PR TITLE
fix(packaging): include README on published aube crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rust-version = "1.93"
 license = "MIT"
 repository = "https://github.com/endevco/aube"
 homepage = "https://github.com/endevco/aube"
+readme = "README.md"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/crates/aube-linker/Cargo.toml
+++ b/crates/aube-linker/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/crates/aube-manifest/Cargo.toml
+++ b/crates/aube-manifest/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/crates/aube-resolver/Cargo.toml
+++ b/crates/aube-resolver/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/crates/aube-scripts/Cargo.toml
+++ b/crates/aube-scripts/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/crates/aube-settings/Cargo.toml
+++ b/crates/aube-settings/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 build = "build.rs"
 include = ["src/**/*.rs", "build.rs", "settings.toml"]
 

--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/crates/aube-util/Cargo.toml
+++ b/crates/aube-util/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 description = "Shared helpers reused across aube crates (semantic hashing, async dedup, atomic filesystem ops, bincode sidecars)."
 
 [dependencies]

--- a/crates/aube-workspace/Cargo.toml
+++ b/crates/aube-workspace/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 include = ["src/**/*.rs"]
 
 [dependencies]

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
 include = ["src/**/*.rs", "build.rs"]
 
 [[bin]]


### PR DESCRIPTION
## Summary
- Add `readme = \"README.md\"` to `[workspace.package]` and inherit it on the aube binary crate so crates.io renders the project README. Currently the [crates.io page](https://crates.io/crates/aube) has no README because the binary crate's `include` whitelist (`[\"src/**/*.rs\", \"build.rs\"]`) excluded it and no `readme` field was set.
- Cargo always bundles the README when `readme` is set, regardless of `include`; verified with `cargo package --list -p aube` (README.md now appears in the file list).
- Takes effect on the next publish (1.3.0+); 1.2.1 is already up without one.

## Test plan
- [x] `cargo package --list -p aube --no-verify` shows `README.md` in the tarball
- [ ] After release-plz publishes the next version, confirm the README renders on crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts Cargo package metadata for publishing and should not affect runtime behavior or dependencies.
> 
> **Overview**
> Ensures crates published from this workspace include and render the repository `README.md` by setting `readme = "README.md"` in `[workspace.package]` and having each crate inherit it via `readme.workspace = true` (including the `aube` binary crate that previously whitelisted files via `include`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3134282daeaf62d56211de8a8d0a4220b514a8d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->