### PR TITLE
feat(scripts): enforce build jails on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,9 @@ name = "aube-scripts"
 version = "1.3.0"
 dependencies = [
  "aube-manifest",
+ "landlock",
+ "libc",
+ "seccompiler",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1231,6 +1234,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2123,6 +2146,17 @@ dependencies = [
  "miette",
  "num",
  "winnow 0.6.24",
+]
+
+[[package]]
+name = "landlock"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3368,6 +3402,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "secrecy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ hex = "0.4"
 xx = { version = "2", features = ["fslock"] }
 reflink-copy = "0.1"
 glob = "0.3"
+landlock = "0.4"
 # NTFS junctions (Windows-only) — used for `node_modules` directory
 # links so installs work without Developer Mode or admin rights.
 # Matches what pnpm does via Node's `fs.symlink(..., 'junction')`.
@@ -89,6 +90,8 @@ ambient-id = "=0.0.11"
 # Error handling
 thiserror = "2"
 miette = { version = "7", features = ["fancy"] }
+libc = "0.2"
+seccompiler = "0.5"
 
 # Progress UI
 clx = "1"

--- a/crates/aube-scripts/Cargo.toml
+++ b/crates/aube-scripts/Cargo.toml
@@ -14,3 +14,8 @@ aube-manifest = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = { workspace = true }
+libc = { workspace = true }
+seccompiler = { workspace = true }

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -14,6 +14,9 @@
 
 pub mod policy;
 
+#[cfg(target_os = "linux")]
+mod linux_jail;
+
 pub use policy::{AllowDecision, BuildPolicy, BuildPolicyError, pattern_matches};
 
 use aube_manifest::PackageJson;
@@ -263,7 +266,29 @@ fn spawn_jailed_shell(
     cmd
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+fn spawn_jailed_shell(
+    script_cmd: &str,
+    settings: &ScriptSettings,
+    jail: &ScriptJail,
+    home: &Path,
+) -> tokio::process::Command {
+    let mut cmd = spawn_shell_with_settings(script_cmd, settings);
+    let jail = jail.clone();
+    let home = home.to_path_buf();
+    unsafe {
+        cmd.pre_exec(move || {
+            linux_jail::apply_landlock(&jail, &home).map_err(std::io::Error::other)?;
+            if !jail.network {
+                linux_jail::apply_seccomp_net_filter().map_err(std::io::Error::other)?;
+            }
+            Ok(())
+        });
+    }
+    cmd
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn spawn_jailed_shell(
     script_cmd: &str,
     settings: &ScriptSettings,
@@ -476,6 +501,9 @@ fn apply_jail_env(
     cmd.env_clear();
     cmd.env("PATH", path_env)
         .env("HOME", home)
+        .env("TMPDIR", home)
+        .env("TMP", home)
+        .env("TEMP", home)
         .env("npm_lifecycle_event", script_name);
     if std::env::var_os("INIT_CWD").is_none() {
         cmd.env("INIT_CWD", project_root);

--- a/crates/aube-scripts/src/linux_jail.rs
+++ b/crates/aube-scripts/src/linux_jail.rs
@@ -1,0 +1,123 @@
+use crate::ScriptJail;
+use landlock::{
+    ABI, AccessFs, BitFlags, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
+    RulesetCreated, RulesetCreatedAttr, RulesetStatus,
+};
+use seccompiler::{
+    BpfProgram, SeccompAction, SeccompCmpArgLen, SeccompCmpOp, SeccompCondition, SeccompFilter,
+    SeccompRule, TargetArch,
+};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+fn add_rule(
+    ruleset: RulesetCreated,
+    path: &Path,
+    access: BitFlags<AccessFs>,
+) -> Result<RulesetCreated, String> {
+    let fd = PathFd::new(path)
+        .map_err(|e| format!("failed to open jail allow path {}: {e}", path.display()))?;
+    ruleset
+        .add_rule(PathBeneath::new(fd, access))
+        .map_err(|e| format!("failed to add jail allow path {}: {e}", path.display()))
+}
+
+fn add_rule_with_canonical(
+    mut ruleset: RulesetCreated,
+    path: &Path,
+    access: BitFlags<AccessFs>,
+) -> Result<RulesetCreated, String> {
+    ruleset = add_rule(ruleset, path, access)?;
+    if let Ok(canonical) = path.canonicalize()
+        && canonical != path
+    {
+        ruleset = add_rule(ruleset, &canonical, access)?;
+    }
+    Ok(ruleset)
+}
+
+pub(crate) fn apply_landlock(jail: &ScriptJail, home: &Path) -> Result<(), String> {
+    let abi = ABI::V3;
+    let read_access = AccessFs::from_read(abi);
+    let full_access = read_access | AccessFs::from_write(abi);
+    let mut ruleset = Ruleset::default()
+        .set_compatibility(CompatLevel::HardRequirement)
+        .handle_access(full_access)
+        .map_err(|e| format!("failed to create jail ruleset: {e}"))?
+        .create()
+        .map_err(|e| format!("failed to create jail ruleset: {e}"))?;
+
+    ruleset = add_rule(ruleset, Path::new("/"), read_access)?;
+    for path in [Path::new("/dev"), jail.package_dir.as_path(), home] {
+        ruleset = add_rule_with_canonical(ruleset, path, full_access)?;
+    }
+    for path in &jail.write_paths {
+        ruleset = add_rule_with_canonical(ruleset, path, full_access)?;
+    }
+
+    let status = ruleset
+        .restrict_self()
+        .map_err(|e| format!("failed to apply jail filesystem rules: {e}"))?;
+    if status.ruleset != RulesetStatus::FullyEnforced {
+        return Err(format!(
+            "jail filesystem rules were not fully enforced: {:?}",
+            status.landlock
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn apply_seccomp_net_filter() -> Result<(), String> {
+    let ret = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
+    if ret != 0 {
+        return Err(format!(
+            "failed to set PR_SET_NO_NEW_PRIVS: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    let target_arch = TargetArch::try_from(std::env::consts::ARCH)
+        .map_err(|e| format!("unsupported architecture for jail network filter: {e}"))?;
+    let socket_rule_inet = SeccompRule::new(vec![
+        SeccompCondition::new(
+            0,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            libc::AF_INET as u64,
+        )
+        .map_err(|e| format!("failed to build jail network filter: {e}"))?,
+    ])
+    .map_err(|e| format!("failed to build jail network filter: {e}"))?;
+    let socket_rule_inet6 = SeccompRule::new(vec![
+        SeccompCondition::new(
+            0,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            libc::AF_INET6 as u64,
+        )
+        .map_err(|e| format!("failed to build jail network filter: {e}"))?,
+    ])
+    .map_err(|e| format!("failed to build jail network filter: {e}"))?;
+
+    let mut rules = BTreeMap::new();
+    #[allow(clippy::useless_conversion)]
+    for syscall in [libc::SYS_socket, libc::SYS_socketpair].map(i64::from) {
+        rules.insert(
+            syscall,
+            vec![socket_rule_inet.clone(), socket_rule_inet6.clone()],
+        );
+    }
+
+    let filter: BpfProgram = SeccompFilter::new(
+        rules,
+        SeccompAction::Allow,
+        SeccompAction::Errno(libc::EPERM as u32),
+        target_arch,
+    )
+    .map_err(|e| format!("failed to build jail network filter: {e}"))?
+    .try_into()
+    .map_err(|e| format!("failed to compile jail network filter: {e}"))?;
+    seccompiler::apply_filter(&filter)
+        .map_err(|e| format!("failed to apply jail network filter: {e}"))?;
+    Ok(())
+}

--- a/crates/aube-scripts/src/linux_jail.rs
+++ b/crates/aube-scripts/src/linux_jail.rs
@@ -37,7 +37,21 @@ fn add_rule_with_canonical(
 }
 
 pub(crate) fn apply_landlock(jail: &ScriptJail, home: &Path) -> Result<(), String> {
-    let abi = ABI::V3;
+    // Must run before restrict_self() so a setuid exec inside the jail
+    // cannot pick up privileges that would shadow the Landlock domain.
+    // Also needed on the network: true path, where the seccomp filter
+    // (which used to set this) is skipped.
+    let ret = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
+    if ret != 0 {
+        return Err(format!(
+            "failed to set PR_SET_NO_NEW_PRIVS: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    // ABI v2 (kernel >= 5.19) covers every write-restriction this policy
+    // needs and unblocks the LTS kernels that ship 5.15-6.1 (Ubuntu 22.04,
+    // Debian 12, RHEL 9). v3 only adds LANDLOCK_ACCESS_FS_TRUNCATE.
+    let abi = ABI::V2;
     let read_access = AccessFs::from_read(abi);
     let full_access = read_access | AccessFs::from_write(abi);
     let mut ruleset = Ruleset::default()
@@ -48,7 +62,12 @@ pub(crate) fn apply_landlock(jail: &ScriptJail, home: &Path) -> Result<(), Strin
         .map_err(|e| format!("failed to create jail ruleset: {e}"))?;
 
     ruleset = add_rule(ruleset, Path::new("/"), read_access)?;
-    for path in [Path::new("/dev"), jail.package_dir.as_path(), home] {
+    for path in [
+        Path::new("/dev"),
+        jail.package_dir.as_path(),
+        home,
+        std::env::temp_dir().as_path(),
+    ] {
         ruleset = add_rule_with_canonical(ruleset, path, full_access)?;
     }
     for path in &jail.write_paths {
@@ -68,14 +87,6 @@ pub(crate) fn apply_landlock(jail: &ScriptJail, home: &Path) -> Result<(), Strin
 }
 
 pub(crate) fn apply_seccomp_net_filter() -> Result<(), String> {
-    let ret = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
-    if ret != 0 {
-        return Err(format!(
-            "failed to set PR_SET_NO_NEW_PRIVS: {}",
-            std::io::Error::last_os_error()
-        ));
-    }
-
     let target_arch = TargetArch::try_from(std::env::consts::ARCH)
         .map_err(|e| format!("unsupported architecture for jail network filter: {e}"))?;
     let socket_rule_inet = SeccompRule::new(vec![

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1691,9 +1691,10 @@ default = "false"
 docs = """
 When enabled, dependency lifecycle scripts that pass the active
 `allowBuilds` / `onlyBuiltDependencies` policy run with a scrubbed
-environment and temporary HOME. On macOS, aube also wraps the script
-with a native Seatbelt profile that denies network access and limits
-filesystem writes to the package directory and temporary directories.
+environment and temporary HOME. On macOS, aube wraps the script with a
+native Seatbelt profile. On Linux, aube applies Landlock and seccomp in
+the child before exec. Both deny network access and limit filesystem
+writes to the package directory and temporary directories.
 Root lifecycle scripts are not jailed.
 
 This defaults to `false` today and is planned to default to `true` in
@@ -1742,8 +1743,8 @@ extra readable paths, extra writable paths, or network access.
 
 `env` entries are exact variable names inherited from the parent process.
 Use this sparingly: explicit env grants can expose secrets. `write` entries
-are added to the macOS Seatbelt write allowlist today. `read` entries are
-accepted now and reserved for the stricter read-deny profile; reads are
+are added to the native write allowlist on macOS and Linux. `read` entries
+are accepted now and reserved for the stricter read-deny profile; reads are
 currently unrestricted.
 """
 sources.cli = []

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -71,7 +71,7 @@ rayon = { workspace = true }
 tar = { workspace = true }
 tempfile = "3"
 diffy = { workspace = true }
-libc = "0.2"
+libc = { workspace = true }
 pathdiff = "0.2"
 is_ci = "1"
 ci_info = "0.14"

--- a/docs/package-manager/jailed-builds.md
+++ b/docs/package-manager/jailed-builds.md
@@ -103,9 +103,11 @@ The jail uses the same lightweight strategy as mise:
 
 - macOS: generate a Seatbelt profile and run scripts through `sandbox-exec` to
   deny network access and writes outside the package / temporary directories.
-- Linux: apply Landlock write restrictions and a seccomp network filter in the
-  child process before it execs the script. If the kernel cannot enforce the
-  requested jail, the script fails instead of running unsandboxed.
+- Linux: apply Landlock write restrictions (kernel ≥ 5.19, Landlock ABI v2) and
+  a seccomp network filter in the child process before it execs the script. If
+  the kernel cannot enforce the requested jail, the script fails instead of
+  running unsandboxed. Landlock v2 does not gate `truncate()` on otherwise
+  read-only paths; build scripts that need that protection require kernel ≥ 6.2.
 - Windows: start with environment scrubbing, a temporary home directory, and an
   unsupported-native-jail warning until there is a good OS-native policy.
 

--- a/docs/package-manager/jailed-builds.md
+++ b/docs/package-manager/jailed-builds.md
@@ -99,12 +99,13 @@ disables the jail, and does not bypass the build approval policy.
 
 ## Native enforcement
 
-The jail uses the same lightweight strategy as mise on macOS:
+The jail uses the same lightweight strategy as mise:
 
 - macOS: generate a Seatbelt profile and run scripts through `sandbox-exec` to
   deny network access and writes outside the package / temporary directories.
-- Linux: environment and HOME isolation are enabled today. Landlock and seccomp
-  native enforcement are planned.
+- Linux: apply Landlock write restrictions and a seccomp network filter in the
+  child process before it execs the script. If the kernel cannot enforce the
+  requested jail, the script fails instead of running unsandboxed.
 - Windows: start with environment scrubbing, a temporary home directory, and an
   unsupported-native-jail warning until there is a good OS-native policy.
 

--- a/docs/package-manager/lifecycle-scripts.md
+++ b/docs/package-manager/lifecycle-scripts.md
@@ -77,8 +77,8 @@ jailBuilds: true
 
 With `jailBuilds` enabled, approved dependency `preinstall`, `install`, and
 `postinstall` scripts run with a scrubbed environment and a temporary `HOME`.
-On macOS, aube also applies a native Seatbelt profile that denies network
-access and restricts filesystem writes to the package directory and temporary
+On macOS and Linux, aube also applies a native jail that denies network access
+and restricts filesystem writes to the package directory and temporary
 directories.
 
 `jailBuilds` defaults to `false` today and is planned to default to `true` in

--- a/docs/security.md
+++ b/docs/security.md
@@ -58,9 +58,10 @@ Settings: [`allowBuilds`](/settings/#setting-allowbuilds). The
 
 When a dependency is approved to build, jailing keeps it from getting your
 full filesystem, network, and environment. On macOS aube wraps the script with
-a Seatbelt profile that denies network and limits writes to the package
-directory; on Linux and Windows the env is scrubbed and `HOME` is redirected
-to a temporary directory.
+a Seatbelt profile; on Linux it applies Landlock and seccomp before exec. Both
+deny network access and limit writes to package and jail-owned temporary
+directories. On Windows the env is scrubbed and `HOME` is redirected to a
+temporary directory.
 
 ```yaml
 jailBuilds: true

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1712,9 +1712,10 @@ Run approved dependency lifecycle scripts in a restricted build jail.
 
 When enabled, dependency lifecycle scripts that pass the active
 `allowBuilds` / `onlyBuiltDependencies` policy run with a scrubbed
-environment and temporary HOME. On macOS, aube also wraps the script
-with a native Seatbelt profile that denies network access and limits
-filesystem writes to the package directory and temporary directories.
+environment and temporary HOME. On macOS, aube wraps the script with a
+native Seatbelt profile. On Linux, aube applies Landlock and seccomp in
+the child before exec. Both deny network access and limit filesystem
+writes to the package directory and temporary directories.
 Root lifecycle scripts are not jailed.
 
 This defaults to `false` today and is planned to default to `true` in
@@ -1765,8 +1766,8 @@ extra readable paths, extra writable paths, or network access.
 
 `env` entries are exact variable names inherited from the parent process.
 Use this sparingly: explicit env grants can expose secrets. `write` entries
-are added to the macOS Seatbelt write allowlist today. `read` entries are
-accepted now and reserved for the stricter read-deny profile; reads are
+are added to the native write allowlist on macOS and Linux. `read` entries
+are accepted now and reserved for the stricter read-deny profile; reads are
 currently unrestricted.
 
 Examples:

--- a/test/allow_builds.bats
+++ b/test/allow_builds.bats
@@ -177,7 +177,7 @@ jailBuilds: true
 jailBuildExclusions:
   - aube-test-*
 YAML
-	run aube install
+	run env AUBE_AUTH_TOKEN= NPM_TOKEN= NODE_AUTH_TOKEN= GITHUB_TOKEN= aube install
 	assert_success
 	run sh -c 'cat $(find -L node_modules -name jail-package-marker.txt -type f | head -n1)'
 	assert_success
@@ -215,9 +215,9 @@ YAML
 	assert_output --partial "aube-jail"
 }
 
-@test "jailBuilds prevents dep scripts from writing to INIT_CWD on macOS" {
-	if [ "$(uname -s)" != "Darwin" ]; then
-		skip "native build jail filesystem enforcement is macOS-only today"
+@test "jailBuilds prevents dep scripts from writing to INIT_CWD on supported platforms" {
+	if [ "$(uname -s)" != "Darwin" ] && [ "$(uname -s)" != "Linux" ]; then
+		skip "native build jail filesystem enforcement is only supported on macOS and Linux today"
 	fi
 	cat >package.json <<'JSON'
 {
@@ -239,9 +239,9 @@ YAML
 	assert_file_not_exists aube-builds-marker.txt
 }
 
-@test "jailBuildPermissions glob can grant matching packages write access on macOS" {
-	if [ "$(uname -s)" != "Darwin" ]; then
-		skip "native build jail filesystem enforcement is macOS-only today"
+@test "jailBuildPermissions glob can grant matching packages write access on supported platforms" {
+	if [ "$(uname -s)" != "Darwin" ] && [ "$(uname -s)" != "Linux" ]; then
+		skip "native build jail filesystem enforcement is only supported on macOS and Linux today"
 	fi
 	cat >package.json <<'JSON'
 {
@@ -267,9 +267,9 @@ YAML
 	assert_file_exists aube-builds-marker.txt
 }
 
-@test "jailBuilds denies dep script network sockets on macOS" {
-	if [ "$(uname -s)" != "Darwin" ]; then
-		skip "native build jail network enforcement is macOS-only today"
+@test "jailBuilds denies dep script network sockets on supported platforms" {
+	if [ "$(uname -s)" != "Darwin" ] && [ "$(uname -s)" != "Linux" ]; then
+		skip "native build jail network enforcement is only supported on macOS and Linux today"
 	fi
 	cat >package.json <<'JSON'
 {


### PR DESCRIPTION
## Summary

- add Linux native jailed-build enforcement with Landlock write restrictions and a seccomp network filter
- run Linux jail setup in the child process before exec so the parent aube process is not restricted
- keep `network: true` as the package-level escape hatch and fail closed when the Linux jail cannot be fully enforced
- update jailed-build docs/settings reference and extend allow-builds BATS coverage to Linux

## Validation

- `cargo check -p aube-scripts`
- `cargo test -p aube-scripts`
- `cargo test -p aube-settings meta::tests::workspace_yaml_keys_deserialize_onto_workspace_config`
- `cargo build -p aube`
- `mise run test:bats test/allow_builds.bats`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- `AUBE_ENABLE_GLOBAL_VIRTUAL_STORE=false mise run docs:build`

Note: plain `mise run docs:build` failed before VitePress because docs install hit the existing global virtual store missing-index path for `@algolia/abtesting@1.16.2`; rerunning with the documented per-project install override passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds Linux-native sandboxing for dependency lifecycle scripts using `landlock` and seccomp, which is security-sensitive and could break builds on kernels/architectures that can’t fully enforce the policy.
> 
> **Overview**
> Adds **Linux-native enforcement** for `jailBuilds` by applying Landlock filesystem rules and a seccomp network filter in the child process via `pre_exec`, so the parent `aube` process stays unrestricted and scripts fail closed if the jail can’t be fully enforced.
> 
> Updates the jailed-build environment to point `TMPDIR`/`TMP`/`TEMP` at the temporary jail home, wires in new Linux-only deps (`landlock`, `seccompiler`, `libc`), and refreshes docs/settings/tests to treat native jail enforcement as supported on **macOS and Linux** (including BATS coverage for write/network denial and permission grants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd29edf4e2fc5e2d82c3c30f336bca28d3274570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->