### PR TITLE
chore: release v1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aube-util",
  "miette",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aube-manifest",
  "landlock",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "blake3",
  "rustc-hash",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -2106,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3293,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4686,9 +4686,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4699,9 +4699,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4709,9 +4709,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4719,9 +4719,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4732,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -4788,9 +4788,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -115,14 +115,14 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.3.0" }
-aube-settings = { path = "crates/aube-settings", version = "1.3.0" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.3.0" }
-aube-registry = { path = "crates/aube-registry", version = "1.3.0" }
-aube-store = { path = "crates/aube-store", version = "1.3.0" }
-aube-linker = { path = "crates/aube-linker", version = "1.3.0" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.3.0" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.3.0" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.3.0" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.3.0" }
-aube-util = { path = "crates/aube-util", version = "1.3.0" }
+aube = { path = "crates/aube", version = "1.4.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.4.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.4.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.4.0" }
+aube-store = { path = "crates/aube-store", version = "1.4.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.4.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.4.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.4.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.4.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.4.0" }
+aube-util = { path = "crates/aube-util", version = "1.4.0" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.3.0"
+version "1.4.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/aube-linker-v1.3.0...aube-linker-v1.4.0) - 2026-04-28
+
+### Fixed
+
+- *(linker)* expose hidden hoist from global store ([#358](https://github.com/endevco/aube/pull/358))
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.2.1](https://github.com/endevco/aube/compare/aube-linker-v1.2.0...aube-linker-v1.2.1) - 2026-04-26
 
 ### Fixed

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.3.0...aube-lockfile-v1.4.0) - 2026-04-28
+
+### Fixed
+
+- *(lockfile)* store bun dependency tails ([#355](https://github.com/endevco/aube/pull/355))
+- *(lockfile)* apply overrides before frozen-lockfile spec comparison ([#354](https://github.com/endevco/aube/pull/354))
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.3.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.2.1...aube-lockfile-v1.3.0) - 2026-04-27
 
 ### Fixed

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/aube-manifest-v1.3.0...aube-manifest-v1.4.0) - 2026-04-28
+
+### Added
+
+- *(install)* adopt pnpm 11 allowBuilds reviews ([#364](https://github.com/endevco/aube/pull/364))
+- *(pnpmfile)* support esm pnpmfiles ([#362](https://github.com/endevco/aube/pull/362))
+
+### Fixed
+
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.3.0](https://github.com/endevco/aube/compare/aube-manifest-v1.2.1...aube-manifest-v1.3.0) - 2026-04-27
 
 ### Added

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/aube-registry-v1.3.0...aube-registry-v1.4.0) - 2026-04-28
+
+### Fixed
+
+- *(registry)* request identity encoding for tarballs ([#356](https://github.com/endevco/aube/pull/356))
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.3.0](https://github.com/endevco/aube/compare/aube-registry-v1.2.1...aube-registry-v1.3.0) - 2026-04-27
 
 ### Added

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/aube-resolver-v1.3.0...aube-resolver-v1.4.0) - 2026-04-28
+
+### Added
+
+- *(audit)* support update fix mode ([#363](https://github.com/endevco/aube/pull/363))
+
+### Fixed
+
+- *(resolver)* trust benchmark fixture churn packages ([#370](https://github.com/endevco/aube/pull/370))
+- roundup of critical/high audit findings ([#361](https://github.com/endevco/aube/pull/361))
+- *(resolver)* exclude provenance churn packages ([#360](https://github.com/endevco/aube/pull/360))
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.3.0](https://github.com/endevco/aube/compare/aube-resolver-v1.2.1...aube-resolver-v1.3.0) - 2026-04-27
 
 ### Added

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/aube-scripts-v1.3.0...aube-scripts-v1.4.0) - 2026-04-28
+
+### Added
+
+- *(scripts)* enforce build jails on linux ([#350](https://github.com/endevco/aube/pull/350))
+
+### Fixed
+
+- roundup of critical/high audit findings ([#361](https://github.com/endevco/aube/pull/361))
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.3.0](https://github.com/endevco/aube/compare/aube-scripts-v1.2.1...aube-scripts-v1.3.0) - 2026-04-27
 
 ### Added

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/aube-settings-v1.3.0...aube-settings-v1.4.0) - 2026-04-28
+
+### Added
+
+- *(install)* adopt pnpm 11 allowBuilds reviews ([#364](https://github.com/endevco/aube/pull/364))
+- *(pnpmfile)* support esm pnpmfiles ([#362](https://github.com/endevco/aube/pull/362))
+- *(scripts)* enforce build jails on linux ([#350](https://github.com/endevco/aube/pull/350))
+
+### Fixed
+
+- *(resolver)* exclude provenance churn packages ([#360](https://github.com/endevco/aube/pull/360))
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.3.0](https://github.com/endevco/aube/compare/aube-settings-v1.2.1...aube-settings-v1.3.0) - 2026-04-27
 
 ### Added

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/aube-store-v1.3.0...aube-store-v1.4.0) - 2026-04-28
+
+### Fixed
+
+- *(store)* repair truncated CAS entries ([#357](https://github.com/endevco/aube/pull/357))
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.3.0](https://github.com/endevco/aube/compare/aube-store-v1.2.1...aube-store-v1.3.0) - 2026-04-27
 
 ### Fixed

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/aube-util-v1.3.0...aube-util-v1.4.0) - 2026-04-28
+
+### Fixed
+
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.3.0](https://github.com/endevco/aube/compare/aube-util-v1.2.1...aube-util-v1.3.0) - 2026-04-27
 
 ### Fixed

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/aube-workspace-v1.3.0...aube-workspace-v1.4.0) - 2026-04-28
+
+### Fixed
+
+- roundup of critical/high audit findings ([#361](https://github.com/endevco/aube/pull/361))
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.2.1](https://github.com/endevco/aube/compare/aube-workspace-v1.2.0...aube-workspace-v1.2.1) - 2026-04-26
 
 ### Fixed

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/endevco/aube/compare/v1.3.0...v1.4.0) - 2026-04-28
+
+### Added
+
+- *(audit)* support update fix mode ([#363](https://github.com/endevco/aube/pull/363))
+- *(install)* adopt pnpm 11 allowBuilds reviews ([#364](https://github.com/endevco/aube/pull/364))
+- *(pnpmfile)* support esm pnpmfiles ([#362](https://github.com/endevco/aube/pull/362))
+- *(scripts)* enforce build jails on linux ([#350](https://github.com/endevco/aube/pull/350))
+
+### Fixed
+
+- *(npm)* preserve extensionless bin shims ([#369](https://github.com/endevco/aube/pull/369))
+- roundup of critical/high audit findings ([#361](https://github.com/endevco/aube/pull/361))
+- *(resolver)* exclude provenance churn packages ([#360](https://github.com/endevco/aube/pull/360))
+- *(linker)* link workspace bins into dependent packages ([#353](https://github.com/endevco/aube/pull/353))
+- *(packaging)* include README on published aube crate ([#349](https://github.com/endevco/aube/pull/349))
+
+### Other
+
+- warn about npm install caveats ([#368](https://github.com/endevco/aube/pull/368))
+
 ## [1.3.0](https://github.com/endevco/aube/compare/v1.2.1...v1.3.0) - 2026-04-27
 
 ### Added

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5955,7 +5955,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.3.0
+**Version**: 1.4.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.3.0",
-  "releasedAt": "2026-04-27T20:00:50Z"
+  "version": "1.4.0",
+  "releasedAt": "2026-04-28T23:09:06Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.4.0`

This PR bumps the workspace to `v1.4.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
