### PR TITLE
fix(linker): link workspace bins into dependent packages

### DIFF
--- a/crates/aube/src/commands/install/bin_linking.rs
+++ b/crates/aube/src/commands/install/bin_linking.rs
@@ -5,6 +5,11 @@ use std::path::{Path, PathBuf};
 
 pub(crate) type PkgJsonCache = BTreeMap<String, Option<serde_json::Value>>;
 
+/// Per-install cache of workspace-package `package.json` reads. Keyed
+/// by the workspace dir on disk so a popular tooling package consumed
+/// by many importers gets read and parsed once, not once per consumer.
+pub(crate) type WsPkgJsonCache = BTreeMap<PathBuf, Option<serde_json::Value>>;
+
 /// Link bin entries from packages to node_modules/.bin/
 /// Compute the on-disk directory a dep's materialized package lives
 /// in. Matches the path `aube-linker` writes under
@@ -189,13 +194,14 @@ pub(super) fn link_bins(
     shim_opts: aube_linker::BinShimOptions,
     cache: &mut PkgJsonCache,
     ws_dirs: Option<&BTreeMap<String, PathBuf>>,
+    ws_cache: &mut WsPkgJsonCache,
 ) -> miette::Result<()> {
     let bin_dir = project_dir.join(modules_dir_name).join(".bin");
     std::fs::create_dir_all(&bin_dir).into_diagnostic()?;
 
     for dep in graph.root_deps() {
         if let Some(ws_dir) = ws_dirs.and_then(|m| m.get(&dep.name)) {
-            link_bins_for_workspace_dep(&bin_dir, ws_dir, &dep.name, shim_opts)?;
+            link_bins_for_workspace_dep(ws_cache, &bin_dir, ws_dir, &dep.name, shim_opts)?;
         } else {
             link_bins_for_dep(
                 cache,
@@ -221,27 +227,43 @@ pub(super) fn link_bins(
 /// the workspace package's own `package.json` and shim each bin entry,
 /// matching pnpm's behavior of exposing workspace bins to dependent
 /// packages' npm scripts.
+///
+/// `cache` deduplicates the read+parse across importers — without it,
+/// a popular tooling package consumed by N workspace members gets its
+/// `package.json` read N times during a single install.
 pub(super) fn link_bins_for_workspace_dep(
+    cache: &mut WsPkgJsonCache,
     bin_dir: &Path,
     ws_dir: &Path,
     name: &str,
     shim_opts: aube_linker::BinShimOptions,
 ) -> miette::Result<()> {
-    let pkg_json_path = ws_dir.join("package.json");
-    let content = match std::fs::read_to_string(&pkg_json_path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => {
-            return Err(miette!(
-                "failed to read package.json for workspace dep {name} at {}: {e}",
-                pkg_json_path.display()
-            ));
-        }
+    let pkg_json = if let Some(cached) = cache.get(ws_dir) {
+        cached.clone()
+    } else {
+        let pkg_json_path = ws_dir.join("package.json");
+        let parsed = match std::fs::read_to_string(&pkg_json_path) {
+            Ok(content) => Some(
+                aube_manifest::parse_json::<serde_json::Value>(&pkg_json_path, content)
+                    .map_err(miette::Report::new)
+                    .wrap_err_with(|| {
+                        format!("failed to parse package.json for workspace dep {name}")
+                    })?,
+            ),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            Err(e) => {
+                return Err(miette!(
+                    "failed to read package.json for workspace dep {name} at {}: {e}",
+                    pkg_json_path.display()
+                ));
+            }
+        };
+        cache.insert(ws_dir.to_path_buf(), parsed.clone());
+        parsed
     };
-    let pkg_json = aube_manifest::parse_json::<serde_json::Value>(&pkg_json_path, content)
-        .map_err(miette::Report::new)
-        .wrap_err_with(|| format!("failed to parse package.json for workspace dep {name}"))?;
-    if let Some(bin) = pkg_json.get("bin") {
+    if let Some(pkg_json) = pkg_json
+        && let Some(bin) = pkg_json.get("bin")
+    {
         link_bin_entries(bin_dir, ws_dir, Some(name), bin, shim_opts)?;
     }
     Ok(())
@@ -529,6 +551,7 @@ mod tests {
             aube_linker::BinShimOptions::default(),
             &mut PkgJsonCache::new(),
             None,
+            &mut WsPkgJsonCache::new(),
         )
         .unwrap();
 

--- a/crates/aube/src/commands/install/bin_linking.rs
+++ b/crates/aube/src/commands/install/bin_linking.rs
@@ -1,6 +1,7 @@
 use aube_lockfile::dep_path_filename::dep_path_to_filename;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 pub(crate) type PkgJsonCache = BTreeMap<String, Option<serde_json::Value>>;
 
@@ -187,24 +188,62 @@ pub(super) fn link_bins(
     placements: Option<&aube_linker::HoistedPlacements>,
     shim_opts: aube_linker::BinShimOptions,
     cache: &mut PkgJsonCache,
+    ws_dirs: Option<&BTreeMap<String, PathBuf>>,
 ) -> miette::Result<()> {
     let bin_dir = project_dir.join(modules_dir_name).join(".bin");
     std::fs::create_dir_all(&bin_dir).into_diagnostic()?;
 
     for dep in graph.root_deps() {
-        link_bins_for_dep(
-            cache,
-            aube_dir,
-            &bin_dir,
-            graph,
-            &dep.dep_path,
-            &dep.name,
-            virtual_store_dir_max_length,
-            placements,
-            shim_opts,
-        )?;
+        if let Some(ws_dir) = ws_dirs.and_then(|m| m.get(&dep.name)) {
+            link_bins_for_workspace_dep(&bin_dir, ws_dir, &dep.name, shim_opts)?;
+        } else {
+            link_bins_for_dep(
+                cache,
+                aube_dir,
+                &bin_dir,
+                graph,
+                &dep.dep_path,
+                &dep.name,
+                virtual_store_dir_max_length,
+                placements,
+                shim_opts,
+            )?;
+        }
     }
 
+    Ok(())
+}
+
+/// Link bins declared by a `workspace:` dep into the importer's
+/// `.bin/`. Workspace deps don't get a `.aube/<dep_path>/` materialization
+/// (the linker symlinks them straight into the importer's `node_modules/`),
+/// so `link_bins_for_dep` finds nothing on disk and silently skips. Read
+/// the workspace package's own `package.json` and shim each bin entry,
+/// matching pnpm's behavior of exposing workspace bins to dependent
+/// packages' npm scripts.
+pub(super) fn link_bins_for_workspace_dep(
+    bin_dir: &Path,
+    ws_dir: &Path,
+    name: &str,
+    shim_opts: aube_linker::BinShimOptions,
+) -> miette::Result<()> {
+    let pkg_json_path = ws_dir.join("package.json");
+    let content = match std::fs::read_to_string(&pkg_json_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(miette!(
+                "failed to read package.json for workspace dep {name} at {}: {e}",
+                pkg_json_path.display()
+            ));
+        }
+    };
+    let pkg_json = aube_manifest::parse_json::<serde_json::Value>(&pkg_json_path, content)
+        .map_err(miette::Report::new)
+        .wrap_err_with(|| format!("failed to parse package.json for workspace dep {name}"))?;
+    if let Some(bin) = pkg_json.get("bin") {
+        link_bin_entries(bin_dir, ws_dir, Some(name), bin, shim_opts)?;
+    }
     Ok(())
 }
 
@@ -489,6 +528,7 @@ mod tests {
             None,
             aube_linker::BinShimOptions::default(),
             &mut PkgJsonCache::new(),
+            None,
         )
         .unwrap();
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3190,6 +3190,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     };
     if !virtual_store_only {
         let mut pkg_json_cache = bin_linking::PkgJsonCache::new();
+        let mut ws_pkg_json_cache = bin_linking::WsPkgJsonCache::new();
         let ws_dirs_for_bins = has_workspace.then_some(&ws_dirs);
         link_bins(
             &cwd,
@@ -3201,6 +3202,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             shim_opts,
             &mut pkg_json_cache,
             ws_dirs_for_bins,
+            &mut ws_pkg_json_cache,
         )?;
         // Root importer's own `bin` (discussion #228). Runs after
         // `link_bins` so a self-bin overrides a same-named dep bin.
@@ -3245,7 +3247,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 for dep in deps {
                     if let Some(ws_dir) = ws_dirs.get(&dep.name) {
                         bin_linking::link_bins_for_workspace_dep(
-                            &bin_dir, ws_dir, &dep.name, shim_opts,
+                            &mut ws_pkg_json_cache,
+                            &bin_dir,
+                            ws_dir,
+                            &dep.name,
+                            shim_opts,
                         )?;
                     } else {
                         link_bins_for_dep(

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3190,6 +3190,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     };
     if !virtual_store_only {
         let mut pkg_json_cache = bin_linking::PkgJsonCache::new();
+        let ws_dirs_for_bins = has_workspace.then_some(&ws_dirs);
         link_bins(
             &cwd,
             &modules_dir_name,
@@ -3199,6 +3200,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             placements_ref,
             shim_opts,
             &mut pkg_json_cache,
+            ws_dirs_for_bins,
         )?;
         // Root importer's own `bin` (discussion #228). Runs after
         // `link_bins` so a self-bin overrides a same-named dep bin.
@@ -3241,17 +3243,23 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 let bin_dir = pkg_dir.join(&modules_dir_name).join(".bin");
                 std::fs::create_dir_all(&bin_dir).into_diagnostic()?;
                 for dep in deps {
-                    link_bins_for_dep(
-                        &mut pkg_json_cache,
-                        &aube_dir,
-                        &bin_dir,
-                        &graph_for_link,
-                        &dep.dep_path,
-                        &dep.name,
-                        virtual_store_dir_max_length,
-                        placements_ref,
-                        shim_opts,
-                    )?;
+                    if let Some(ws_dir) = ws_dirs.get(&dep.name) {
+                        bin_linking::link_bins_for_workspace_dep(
+                            &bin_dir, ws_dir, &dep.name, shim_opts,
+                        )?;
+                    } else {
+                        link_bins_for_dep(
+                            &mut pkg_json_cache,
+                            &aube_dir,
+                            &bin_dir,
+                            &graph_for_link,
+                            &dep.dep_path,
+                            &dep.name,
+                            virtual_store_dir_max_length,
+                            placements_ref,
+                            shim_opts,
+                        )?;
+                    }
                 }
                 // Workspace member's own `bin` (discussion #228). `manifests`
                 // was parsed once upstream and keys by importer relpath.

--- a/test/workspace.bats
+++ b/test/workspace.bats
@@ -464,8 +464,9 @@ _setup_shared_direct_dep_workspace() {
 	# package B depends on A via `workspace:*`. pnpm symlinks A's bin
 	# into B/node_modules/.bin so npm scripts in B can call it; aube
 	# previously skipped these because workspace deps have no
-	# `.aube/<dep_path>` materialization.
-	mkdir -p packages/app tools/dev/bin
+	# `.aube/<dep_path>` materialization. Multiple consumers exercise
+	# the per-install ws-package-json read cache.
+	mkdir -p packages/app1 packages/app2 tools/dev/bin
 	cat >package.json <<-'EOF'
 		{"name": "root", "private": true, "version": "1.0.0"}
 	EOF
@@ -483,9 +484,16 @@ _setup_shared_direct_dep_workspace() {
 	EOF
 	printf '#!/usr/bin/env node\nconsole.log("ok")\n' >tools/dev/bin/my-tool.mjs
 	chmod +x tools/dev/bin/my-tool.mjs
-	cat >packages/app/package.json <<-'EOF'
+	cat >packages/app1/package.json <<-'EOF'
 		{
-		  "name": "@test/app",
+		  "name": "@test/app1",
+		  "version": "1.0.0",
+		  "devDependencies": {"@test/dev": "workspace:*"}
+		}
+	EOF
+	cat >packages/app2/package.json <<-'EOF'
+		{
+		  "name": "@test/app2",
 		  "version": "1.0.0",
 		  "devDependencies": {"@test/dev": "workspace:*"}
 		}
@@ -494,12 +502,14 @@ _setup_shared_direct_dep_workspace() {
 	run aube install
 	assert_success
 
-	# Shim must exist in the consumer's .bin and resolve to the
+	# Shim exists in each consumer's .bin and resolves to the
 	# workspace package's bin script.
-	run test -e packages/app/node_modules/.bin/my-tool
-	assert_success
-	target="$(readlink -f packages/app/node_modules/.bin/my-tool)"
-	[[ "$target" == *"tools/dev/bin/my-tool.mjs" ]]
+	for app in app1 app2; do
+		run test -e "packages/$app/node_modules/.bin/my-tool"
+		assert_success
+		target="$(readlink -f "packages/$app/node_modules/.bin/my-tool")"
+		[[ "$target" == *"tools/dev/bin/my-tool.mjs" ]]
+	done
 }
 
 @test "aube install: dedupeDirectDeps=true keeps child symlink when versions differ" {

--- a/test/workspace.bats
+++ b/test/workspace.bats
@@ -459,6 +459,49 @@ _setup_shared_direct_dep_workspace() {
 	assert_failure
 }
 
+@test "aube install: workspace dep bins land in dependent's node_modules/.bin" {
+	# discussion #352: workspace package A declares a `bin`, workspace
+	# package B depends on A via `workspace:*`. pnpm symlinks A's bin
+	# into B/node_modules/.bin so npm scripts in B can call it; aube
+	# previously skipped these because workspace deps have no
+	# `.aube/<dep_path>` materialization.
+	mkdir -p packages/app tools/dev/bin
+	cat >package.json <<-'EOF'
+		{"name": "root", "private": true, "version": "1.0.0"}
+	EOF
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/*
+		  - tools/*
+	EOF
+	cat >tools/dev/package.json <<-'EOF'
+		{
+		  "name": "@test/dev",
+		  "version": "1.0.0",
+		  "bin": {"my-tool": "./bin/my-tool.mjs"}
+		}
+	EOF
+	printf '#!/usr/bin/env node\nconsole.log("ok")\n' >tools/dev/bin/my-tool.mjs
+	chmod +x tools/dev/bin/my-tool.mjs
+	cat >packages/app/package.json <<-'EOF'
+		{
+		  "name": "@test/app",
+		  "version": "1.0.0",
+		  "devDependencies": {"@test/dev": "workspace:*"}
+		}
+	EOF
+
+	run aube install
+	assert_success
+
+	# Shim must exist in the consumer's .bin and resolve to the
+	# workspace package's bin script.
+	run test -e packages/app/node_modules/.bin/my-tool
+	assert_success
+	target="$(readlink -f packages/app/node_modules/.bin/my-tool)"
+	[[ "$target" == *"tools/dev/bin/my-tool.mjs" ]]
+}
+
 @test "aube install: dedupeDirectDeps=true keeps child symlink when versions differ" {
 	mkdir -p packages/app
 	# Root pins is-number@3.0.0, child pins is-number@6.0.0 — both are


### PR DESCRIPTION
## Summary

When workspace package A declares `bin` and B depends on A via `workspace:*`, pnpm symlinks A's bin into `B/node_modules/.bin/` so B's npm scripts can call it. aube didn't, breaking any workspace package that runs a bin provided by another workspace package.

Root cause: workspace deps have no `.aube/<dep_path>/<name>/` materialization — the linker symlinks them straight into the importer's `node_modules/`, so `link_bins_for_dep` reads `package.json` from a path that doesn't exist and returns `Ok(None)` silently.

Fix: route workspace deps through a new `link_bins_for_workspace_dep` helper that reads `package.json` from the workspace package's own directory (already known via `ws_dirs`) and shims each bin entry. Both the root pass (`link_bins`) and the per-importer workspace loop pick up the change.

Reported in #352 (item 6, `workspace-bin-not-linked`).

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --package aube install::bin_linking`
- [x] `./test/bats/bin/bats test/workspace.bats` — all 17 tests pass, including new "workspace dep bins land in dependent's node_modules/.bin"
- [x] Related: `test/root_bin.bats`, `test/workspace_member_install_walks_up.bats`, `test/optimistic_and_bin_settings.bats` all pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bin-linking behavior during installs by adding a separate code path for `workspace:` dependencies, which could affect which executables appear in `.bin` across workspaces. Risk is moderate due to touching core install/linking logic but is localized and covered by a new integration test.
> 
> **Overview**
> Fixes aube installs to **link executables (`bin` entries) from `workspace:` dependencies** into each dependent package’s `node_modules/.bin`, matching pnpm behavior (previously skipped because workspace deps aren’t materialized under `.aube/<dep_path>`).
> 
> Adds a dedicated `link_bins_for_workspace_dep` helper that reads the workspace package’s own `package.json`, shims its `bin` entries, and uses a per-install `WsPkgJsonCache` to avoid repeated reads across multiple importers; wires this path into both the root bin-link pass and the per-workspace-importer bin-link loop, and adds a bats test asserting the bins land in multiple consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c17f3e5734e1de867ec06e85a465059d4852b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->