### PR TITLE
fix: roundup of critical/high audit findings

### DIFF
--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -329,18 +329,32 @@ pub fn apply_peer_contexts(
     const MAX_ITERATIONS: usize = 16;
     let mut current = canonical;
     let mut converged = false;
-    let key_set_hash = |g: &LockfileGraph| -> u64 {
-        aube_util::hash::ordered_seq_hash(g.packages.keys().map(String::as_str))
+    // Hash both keys and dependency tails. A peer-context iteration can
+    // rewrite a dependency value to point at an existing key without
+    // adding a new key, so a key-only convergence test ships partially
+    // rewritten tails. Linker reads tails directly to locate sibling
+    // symlink targets, stale tails produce broken `node_modules`.
+    let graph_hash = |g: &LockfileGraph| -> u64 {
+        let mut tokens: Vec<&str> = Vec::with_capacity(g.packages.len() * 4);
+        for (k, pkg) in &g.packages {
+            tokens.push(k.as_str());
+            for (name, tail) in &pkg.dependencies {
+                tokens.push(name.as_str());
+                tokens.push(tail.as_str());
+            }
+            tokens.push("\x1e");
+        }
+        aube_util::hash::ordered_seq_hash(tokens.iter().copied())
     };
     for i in 0..MAX_ITERATIONS {
-        let before = key_set_hash(&current);
+        let before = graph_hash(&current);
         let after_once = apply_peer_contexts_once(current, options);
         let next = if options.dedupe_peer_dependents {
             dedupe_peer_variants(after_once)
         } else {
             after_once
         };
-        if before == key_set_hash(&next) {
+        if before == graph_hash(&next) {
             tracing::debug!("peer-context pass converged after {i} iteration(s)");
             current = next;
             converged = true;

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -335,9 +335,11 @@ pub fn apply_peer_contexts(
     // rewritten tails. Linker reads tails directly to locate sibling
     // symlink targets, stale tails produce broken `node_modules`.
     let graph_hash = |g: &LockfileGraph| -> u64 {
-        let mut tokens: Vec<&str> = Vec::with_capacity(g.packages.len() * 4);
+        let total_deps: usize = g.packages.values().map(|p| p.dependencies.len()).sum();
+        let mut tokens: Vec<&str> = Vec::with_capacity(g.packages.len() * 3 + total_deps * 2);
         for (k, pkg) in &g.packages {
             tokens.push(k.as_str());
+            tokens.push("\x1f");
             for (name, tail) in &pkg.dependencies {
                 tokens.push(name.as_str());
                 tokens.push(tail.as_str());

--- a/crates/aube-scripts/src/linux_jail.rs
+++ b/crates/aube-scripts/src/linux_jail.rs
@@ -89,43 +89,38 @@ pub(crate) fn apply_landlock(jail: &ScriptJail, home: &Path) -> Result<(), Strin
 pub(crate) fn apply_seccomp_net_filter() -> Result<(), String> {
     let target_arch = TargetArch::try_from(std::env::consts::ARCH)
         .map_err(|e| format!("unsupported architecture for jail network filter: {e}"))?;
-    // Deny socket() / socketpair() for the network families a script
-    // could use to escape the jail. Old code listed only AF_INET and
-    // AF_INET6, leaving AF_NETLINK (kernel routing/ARP introspection)
-    // and AF_PACKET (raw ethernet) open. AF_UNIX stays allowed because
-    // node, node-gyp, and other native build helpers rely on it for
-    // stdio and worker IPC. Filesystem reach via AF_UNIX is bounded by
-    // the landlock policy above, which only grants write under
-    // package_dir and home so paths like /var/run/docker.sock are
-    // unreachable.
-    let mk_family_rule = |family: i32| -> Result<SeccompRule, String> {
-        SeccompRule::new(vec![
-            SeccompCondition::new(0, SeccompCmpArgLen::Dword, SeccompCmpOp::Eq, family as u64)
-                .map_err(|e| format!("failed to build jail network filter: {e}"))?,
-        ])
-        .map_err(|e| format!("failed to build jail network filter: {e}"))
-    };
-    let denied_families = [
-        libc::AF_INET,
-        libc::AF_INET6,
-        libc::AF_NETLINK,
-        libc::AF_PACKET,
-    ];
-    let mut family_rules = Vec::with_capacity(denied_families.len());
-    for fam in denied_families {
-        family_rules.push(mk_family_rule(fam)?);
-    }
+    // Default-deny on socket family. Old code allowlisted nothing and
+    // denied only AF_INET / AF_INET6, leaving AF_NETLINK, AF_PACKET,
+    // AF_VSOCK, AF_XDP, AF_ALG, AF_BLUETOOTH, and every other family
+    // open. Flip to allowlist: AF_UNIX (node and node-gyp need it for
+    // stdio and worker IPC) is the only family `socket()` and
+    // `socketpair()` may pass with. Every other family returns EPERM,
+    // matching the errno the original AF_INET deny used so existing
+    // fixtures still recognise the denial.
+    //
+    // mismatch_action only fires for syscalls listed in `rules`, so
+    // non-socket syscalls (open, write, ...) keep flowing.
+    let allow_unix = SeccompRule::new(vec![
+        SeccompCondition::new(
+            0,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            libc::AF_UNIX as u64,
+        )
+        .map_err(|e| format!("failed to build jail network filter: {e}"))?,
+    ])
+    .map_err(|e| format!("failed to build jail network filter: {e}"))?;
 
     let mut rules = BTreeMap::new();
     #[allow(clippy::useless_conversion)]
     for syscall in [libc::SYS_socket, libc::SYS_socketpair].map(i64::from) {
-        rules.insert(syscall, family_rules.clone());
+        rules.insert(syscall, vec![allow_unix.clone()]);
     }
 
     let filter: BpfProgram = SeccompFilter::new(
         rules,
-        SeccompAction::Allow,
         SeccompAction::Errno(libc::EPERM as u32),
+        SeccompAction::Allow,
         target_arch,
     )
     .map_err(|e| format!("failed to build jail network filter: {e}"))?

--- a/crates/aube-scripts/src/linux_jail.rs
+++ b/crates/aube-scripts/src/linux_jail.rs
@@ -89,42 +89,59 @@ pub(crate) fn apply_landlock(jail: &ScriptJail, home: &Path) -> Result<(), Strin
 pub(crate) fn apply_seccomp_net_filter() -> Result<(), String> {
     let target_arch = TargetArch::try_from(std::env::consts::ARCH)
         .map_err(|e| format!("unsupported architecture for jail network filter: {e}"))?;
-    // Default-deny on socket family. Old code allowlisted nothing and
-    // denied only AF_INET / AF_INET6, leaving AF_NETLINK, AF_PACKET,
-    // AF_VSOCK, AF_XDP, AF_ALG, AF_BLUETOOTH, and every other family
-    // open. Flip to allowlist: AF_UNIX (node and node-gyp need it for
-    // stdio and worker IPC) is the only family `socket()` and
-    // `socketpair()` may pass with. Every other family returns EPERM,
-    // matching the errno the original AF_INET deny used so existing
-    // fixtures still recognise the denial.
-    //
-    // mismatch_action only fires for syscalls listed in `rules`, so
-    // non-socket syscalls (open, write, ...) keep flowing.
-    let allow_unix = SeccompRule::new(vec![
-        SeccompCondition::new(
-            0,
-            SeccompCmpArgLen::Dword,
-            SeccompCmpOp::Eq,
-            libc::AF_UNIX as u64,
-        )
-        .map_err(|e| format!("failed to build jail network filter: {e}"))?,
-    ])
-    .map_err(|e| format!("failed to build jail network filter: {e}"))?;
+    // seccompiler's mismatch_action is the default for every syscall
+    // the BPF program sees, not just the ones in `rules`. Setting it
+    // to Errno would make every non-socket syscall (open, write, mmap,
+    // ...) also return EPERM and kill the jailed shell at startup.
+    // Pure default-deny on the socket family axis would require
+    // libseccomp's per-syscall default action, which seccompiler does
+    // not expose. Until that lands, enumerate the dangerous families
+    // explicitly and keep AF_UNIX flowing for node + node-gyp IPC.
+    // Filesystem reach via AF_UNIX is bounded by the landlock policy
+    // above, which never grants write under /var/run or /run, so
+    // docker.sock and friends stay unreachable.
+    let mk_family_rule = |family: i32| -> Result<SeccompRule, String> {
+        SeccompRule::new(vec![
+            SeccompCondition::new(0, SeccompCmpArgLen::Dword, SeccompCmpOp::Eq, family as u64)
+                .map_err(|e| format!("failed to build jail network filter: {e}"))?,
+        ])
+        .map_err(|e| format!("failed to build jail network filter: {e}"))
+    };
+    let denied_families = [
+        libc::AF_INET,
+        libc::AF_INET6,
+        libc::AF_NETLINK,
+        libc::AF_PACKET,
+        libc::AF_VSOCK,
+        libc::AF_XDP,
+        libc::AF_ALG,
+        libc::AF_BLUETOOTH,
+        libc::AF_RDS,
+        libc::AF_CAN,
+        libc::AF_TIPC,
+        libc::AF_IB,
+        libc::AF_NFC,
+    ];
+    let mut family_rules = Vec::with_capacity(denied_families.len());
+    for fam in denied_families {
+        family_rules.push(mk_family_rule(fam)?);
+    }
 
     let mut rules = BTreeMap::new();
     #[allow(clippy::useless_conversion)]
     for syscall in [libc::SYS_socket, libc::SYS_socketpair].map(i64::from) {
-        rules.insert(syscall, vec![allow_unix.clone()]);
+        rules.insert(syscall, family_rules.clone());
     }
 
     // SeccompFilter::new arg order: rules, mismatch_action, match_action,
-    // arch. mismatch fires when a listed syscall is called with args
-    // that no rule matches (non-AF_UNIX socket call -> EPERM). match
-    // fires when a rule matches (AF_UNIX socket call -> Allow).
+    // arch. mismatch_action is the global fallback (must be Allow so
+    // unrelated syscalls keep flowing). match_action fires for the
+    // listed denied families and returns EPERM, matching the errno
+    // the original filter used and the test fixtures recognise.
     let filter: BpfProgram = SeccompFilter::new(
         rules,
-        SeccompAction::Errno(libc::EPERM as u32),
         SeccompAction::Allow,
+        SeccompAction::Errno(libc::EPERM as u32),
         target_arch,
     )
     .map_err(|e| format!("failed to build jail network filter: {e}"))?

--- a/crates/aube-scripts/src/linux_jail.rs
+++ b/crates/aube-scripts/src/linux_jail.rs
@@ -96,10 +96,20 @@ pub(crate) fn apply_seccomp_net_filter() -> Result<(), String> {
     // Pure default-deny on the socket family axis would require
     // libseccomp's per-syscall default action, which seccompiler does
     // not expose. Until that lands, enumerate the dangerous families
-    // explicitly and keep AF_UNIX flowing for node + node-gyp IPC.
-    // Filesystem reach via AF_UNIX is bounded by the landlock policy
-    // above, which never grants write under /var/run or /run, so
-    // docker.sock and friends stay unreachable.
+    // explicitly and keep AF_UNIX flowing for node + node-gyp IPC
+    // (socketpair stdio, worker_threads).
+    //
+    // Known residual gap: AF_UNIX `connect()` to filesystem socket
+    // paths (e.g. /var/run/docker.sock) is NOT covered by Landlock
+    // ABI v2. The v2 policy only filters VFS open/write hooks, the
+    // unix socket connect path bypasses them by passing sun_path
+    // inline in sockaddr_un. LANDLOCK_ACCESS_FS_CONNECT_UNIX lands
+    // in v5 (kernel 6.10+); the policy here pins v2 to keep LTS
+    // kernels (Ubuntu 22.04, Debian 12, RHEL 9) covered. On a host
+    // with /var/run/docker.sock and a kernel below 6.10, an approved
+    // postinstall could still reach the docker daemon. Mitigations:
+    // run installs in a namespace where the socket is bind-mounted
+    // away, or set jail.network=true and rely on host firewalling.
     let mk_family_rule = |family: i32| -> Result<SeccompRule, String> {
         SeccompRule::new(vec![
             SeccompCondition::new(0, SeccompCmpArgLen::Dword, SeccompCmpOp::Eq, family as u64)

--- a/crates/aube-scripts/src/linux_jail.rs
+++ b/crates/aube-scripts/src/linux_jail.rs
@@ -62,12 +62,12 @@ pub(crate) fn apply_landlock(jail: &ScriptJail, home: &Path) -> Result<(), Strin
         .map_err(|e| format!("failed to create jail ruleset: {e}"))?;
 
     ruleset = add_rule(ruleset, Path::new("/"), read_access)?;
-    for path in [
-        Path::new("/dev"),
-        jail.package_dir.as_path(),
-        home,
-        std::env::temp_dir().as_path(),
-    ] {
+    // `home` already has `full_access` and `apply_jail_env` points
+    // TMPDIR/TMP/TEMP at it, so build scripts get a writable scratch
+    // dir without granting kernel-level write to the world-writable
+    // system `/tmp`. Granting `/tmp` would let a script read another
+    // tenant's tmp files or seed symlink races on shared CI hosts.
+    for path in [Path::new("/dev"), jail.package_dir.as_path(), home] {
         ruleset = add_rule_with_canonical(ruleset, path, full_access)?;
     }
     for path in &jail.write_paths {
@@ -89,40 +89,35 @@ pub(crate) fn apply_landlock(jail: &ScriptJail, home: &Path) -> Result<(), Strin
 pub(crate) fn apply_seccomp_net_filter() -> Result<(), String> {
     let target_arch = TargetArch::try_from(std::env::consts::ARCH)
         .map_err(|e| format!("unsupported architecture for jail network filter: {e}"))?;
-    let socket_rule_inet = SeccompRule::new(vec![
-        SeccompCondition::new(
-            0,
-            SeccompCmpArgLen::Dword,
-            SeccompCmpOp::Eq,
-            libc::AF_INET as u64,
-        )
-        .map_err(|e| format!("failed to build jail network filter: {e}"))?,
-    ])
-    .map_err(|e| format!("failed to build jail network filter: {e}"))?;
-    let socket_rule_inet6 = SeccompRule::new(vec![
-        SeccompCondition::new(
-            0,
-            SeccompCmpArgLen::Dword,
-            SeccompCmpOp::Eq,
-            libc::AF_INET6 as u64,
-        )
-        .map_err(|e| format!("failed to build jail network filter: {e}"))?,
-    ])
-    .map_err(|e| format!("failed to build jail network filter: {e}"))?;
+    // Default-deny on socket family. Old code listed AF_INET and AF_INET6
+    // with mismatch_action=Allow, which left AF_UNIX, AF_NETLINK, AF_PACKET
+    // and every other family open. A jailed script could `connect()` to
+    // `/var/run/docker.sock` over AF_UNIX for full host takeover.
+    // Allowlist the families a build script legitimately needs (none for
+    // the network=false jail), block the rest with EAFNOSUPPORT so callers
+    // get the same errno the kernel emits for an unsupported family.
+    let mk_family_rule = |family: i32| -> Result<SeccompRule, String> {
+        SeccompRule::new(vec![
+            SeccompCondition::new(0, SeccompCmpArgLen::Dword, SeccompCmpOp::Eq, family as u64)
+                .map_err(|e| format!("failed to build jail network filter: {e}"))?,
+        ])
+        .map_err(|e| format!("failed to build jail network filter: {e}"))
+    };
+    // node-gyp and other native build helpers occasionally use AF_UNIX
+    // for IPC with helper processes spawned inside the jail. Keep it
+    // allowed so legitimate native builds work, deny everything else.
+    let allow_unix = mk_family_rule(libc::AF_UNIX)?;
 
     let mut rules = BTreeMap::new();
     #[allow(clippy::useless_conversion)]
     for syscall in [libc::SYS_socket, libc::SYS_socketpair].map(i64::from) {
-        rules.insert(
-            syscall,
-            vec![socket_rule_inet.clone(), socket_rule_inet6.clone()],
-        );
+        rules.insert(syscall, vec![allow_unix.clone()]);
     }
 
     let filter: BpfProgram = SeccompFilter::new(
         rules,
+        SeccompAction::Errno(libc::EAFNOSUPPORT as u32),
         SeccompAction::Allow,
-        SeccompAction::Errno(libc::EPERM as u32),
         target_arch,
     )
     .map_err(|e| format!("failed to build jail network filter: {e}"))?

--- a/crates/aube-scripts/src/linux_jail.rs
+++ b/crates/aube-scripts/src/linux_jail.rs
@@ -117,6 +117,10 @@ pub(crate) fn apply_seccomp_net_filter() -> Result<(), String> {
         rules.insert(syscall, vec![allow_unix.clone()]);
     }
 
+    // SeccompFilter::new arg order: rules, mismatch_action, match_action,
+    // arch. mismatch fires when a listed syscall is called with args
+    // that no rule matches (non-AF_UNIX socket call -> EPERM). match
+    // fires when a rule matches (AF_UNIX socket call -> Allow).
     let filter: BpfProgram = SeccompFilter::new(
         rules,
         SeccompAction::Errno(libc::EPERM as u32),

--- a/crates/aube-scripts/src/linux_jail.rs
+++ b/crates/aube-scripts/src/linux_jail.rs
@@ -89,13 +89,15 @@ pub(crate) fn apply_landlock(jail: &ScriptJail, home: &Path) -> Result<(), Strin
 pub(crate) fn apply_seccomp_net_filter() -> Result<(), String> {
     let target_arch = TargetArch::try_from(std::env::consts::ARCH)
         .map_err(|e| format!("unsupported architecture for jail network filter: {e}"))?;
-    // Default-deny on socket family. Old code listed AF_INET and AF_INET6
-    // with mismatch_action=Allow, which left AF_UNIX, AF_NETLINK, AF_PACKET
-    // and every other family open. A jailed script could `connect()` to
-    // `/var/run/docker.sock` over AF_UNIX for full host takeover.
-    // Allowlist the families a build script legitimately needs (none for
-    // the network=false jail), block the rest with EAFNOSUPPORT so callers
-    // get the same errno the kernel emits for an unsupported family.
+    // Deny socket() / socketpair() for the network families a script
+    // could use to escape the jail. Old code listed only AF_INET and
+    // AF_INET6, leaving AF_NETLINK (kernel routing/ARP introspection)
+    // and AF_PACKET (raw ethernet) open. AF_UNIX stays allowed because
+    // node, node-gyp, and other native build helpers rely on it for
+    // stdio and worker IPC. Filesystem reach via AF_UNIX is bounded by
+    // the landlock policy above, which only grants write under
+    // package_dir and home so paths like /var/run/docker.sock are
+    // unreachable.
     let mk_family_rule = |family: i32| -> Result<SeccompRule, String> {
         SeccompRule::new(vec![
             SeccompCondition::new(0, SeccompCmpArgLen::Dword, SeccompCmpOp::Eq, family as u64)
@@ -103,21 +105,27 @@ pub(crate) fn apply_seccomp_net_filter() -> Result<(), String> {
         ])
         .map_err(|e| format!("failed to build jail network filter: {e}"))
     };
-    // node-gyp and other native build helpers occasionally use AF_UNIX
-    // for IPC with helper processes spawned inside the jail. Keep it
-    // allowed so legitimate native builds work, deny everything else.
-    let allow_unix = mk_family_rule(libc::AF_UNIX)?;
+    let denied_families = [
+        libc::AF_INET,
+        libc::AF_INET6,
+        libc::AF_NETLINK,
+        libc::AF_PACKET,
+    ];
+    let mut family_rules = Vec::with_capacity(denied_families.len());
+    for fam in denied_families {
+        family_rules.push(mk_family_rule(fam)?);
+    }
 
     let mut rules = BTreeMap::new();
     #[allow(clippy::useless_conversion)]
     for syscall in [libc::SYS_socket, libc::SYS_socketpair].map(i64::from) {
-        rules.insert(syscall, vec![allow_unix.clone()]);
+        rules.insert(syscall, family_rules.clone());
     }
 
     let filter: BpfProgram = SeccompFilter::new(
         rules,
-        SeccompAction::Errno(libc::EAFNOSUPPORT as u32),
         SeccompAction::Allow,
+        SeccompAction::Errno(libc::EPERM as u32),
         target_arch,
     )
     .map_err(|e| format!("failed to build jail network filter: {e}"))?

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -129,12 +129,29 @@ fn glob_workspace_pattern(project_dir: &Path, pattern: &str) -> Vec<PathBuf> {
             if entry.components().any(|c| c.as_os_str() == "node_modules") {
                 continue;
             }
-            if let Some(parent) = entry.parent() {
+            if let Some(parent) = entry.parent()
+                && is_under_project(project_dir, parent)
+            {
                 packages.push(parent.to_path_buf());
             }
         }
     }
     packages
+}
+
+/// Check that `candidate` resolves underneath `project_dir`. Patterns
+/// containing `..` (e.g. `../sibling`) lexically still start with the
+/// project prefix but escape the root via parent components. pnpm
+/// rejects these and so do we. Falls back to lexical compare when
+/// canonicalization fails (path doesn't exist) so pre-existing dirs
+/// keep working in that branch.
+fn is_under_project(project_dir: &Path, candidate: &Path) -> bool {
+    match (project_dir.canonicalize(), candidate.canonicalize()) {
+        (Ok(root), Ok(child)) => child.starts_with(root),
+        _ => candidate
+            .components()
+            .all(|c| !matches!(c, std::path::Component::ParentDir)),
+    }
 }
 
 fn workspace_pattern_root(project_dir: &Path, pattern: &str) -> PathBuf {

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -143,15 +143,16 @@ fn glob_workspace_pattern(project_dir: &Path, pattern: &str) -> Vec<PathBuf> {
 /// containing `..` (e.g. `../sibling`) lexically still start with the
 /// project prefix but escape the root via parent components. pnpm
 /// rejects these and so do we. Falls back to lexical compare when
-/// canonicalization fails (path doesn't exist) so pre-existing dirs
-/// keep working in that branch.
+/// canonicalization fails (permission error, mid-walk race) so a path
+/// the glob already returned still gets a containment check.
 fn is_under_project(project_dir: &Path, candidate: &Path) -> bool {
-    match (project_dir.canonicalize(), candidate.canonicalize()) {
-        (Ok(root), Ok(child)) => child.starts_with(root),
-        _ => candidate
-            .components()
-            .all(|c| !matches!(c, std::path::Component::ParentDir)),
+    if let (Ok(root), Ok(child)) = (project_dir.canonicalize(), candidate.canonicalize()) {
+        return child.starts_with(root);
     }
+    let no_parent_dir = candidate
+        .components()
+        .all(|c| !matches!(c, std::path::Component::ParentDir));
+    no_parent_dir && candidate.starts_with(project_dir)
 }
 
 fn workspace_pattern_root(project_dir: &Path, pattern: &str) -> PathBuf {

--- a/crates/aube/src/commands/patch_commit.rs
+++ b/crates/aube/src/commands/patch_commit.rs
@@ -60,23 +60,35 @@ pub async fn run(args: PatchCommitArgs) -> Result<()> {
         .into_diagnostic()
         .map_err(|e| miette!("failed to create {}: {e}", abs_dir.display()))?;
     let abs_path = abs_dir.join(&file_name);
+    // Snapshot any existing patch so a re-patch can be rolled back to
+    // the previous content if the manifest write fails. atomic_write
+    // replaces unconditionally, so without the snapshot a re-patch
+    // failure would leave the manifest pointing at a path that lost
+    // its old content.
+    let prior_patch = std::fs::read(&abs_path).ok();
     aube_util::fs_atomic::atomic_write(&abs_path, patch.as_bytes())
         .into_diagnostic()
         .map_err(|e| miette!("failed to write {}: {e}", abs_path.display()))?;
 
-    // Use forward slashes in the manifest entry — the field is portable
+    // Use forward slashes in the manifest entry. Field is portable
     // across platforms and pnpm always writes it that way.
     let rel_path = format!(
         "{}/{file_name}",
         rel_dir.to_string_lossy().replace('\\', "/")
     );
     let key = format!("{}@{}", state.name, state.version);
-    // If the manifest update fails (concurrent writer, disk full, file
-    // locked on Windows), roll back the patch file. Otherwise we leave
-    // an orphan that no future install will see. `load_patches` reads
-    // package.json, not the patches dir.
+    // Manifest write failure means the patch on disk is not
+    // referenced anywhere. Restore the prior patch if there was one
+    // (re-patch path), else remove the orphan.
     if let Err(e) = upsert_patched_dependency(&cwd, &key, &rel_path) {
-        let _ = std::fs::remove_file(&abs_path);
+        match prior_patch {
+            Some(bytes) => {
+                let _ = aube_util::fs_atomic::atomic_write(&abs_path, &bytes);
+            }
+            None => {
+                let _ = std::fs::remove_file(&abs_path);
+            }
+        }
         return Err(e);
     }
 

--- a/crates/aube/src/commands/patch_commit.rs
+++ b/crates/aube/src/commands/patch_commit.rs
@@ -60,7 +60,7 @@ pub async fn run(args: PatchCommitArgs) -> Result<()> {
         .into_diagnostic()
         .map_err(|e| miette!("failed to create {}: {e}", abs_dir.display()))?;
     let abs_path = abs_dir.join(&file_name);
-    std::fs::write(&abs_path, &patch)
+    aube_util::fs_atomic::atomic_write(&abs_path, patch.as_bytes())
         .into_diagnostic()
         .map_err(|e| miette!("failed to write {}: {e}", abs_path.display()))?;
 
@@ -71,7 +71,14 @@ pub async fn run(args: PatchCommitArgs) -> Result<()> {
         rel_dir.to_string_lossy().replace('\\', "/")
     );
     let key = format!("{}@{}", state.name, state.version);
-    upsert_patched_dependency(&cwd, &key, &rel_path)?;
+    // If the manifest update fails (concurrent writer, disk full, file
+    // locked on Windows), roll back the patch file. Otherwise we leave
+    // an orphan that no future install will see. `load_patches` reads
+    // package.json, not the patches dir.
+    if let Err(e) = upsert_patched_dependency(&cwd, &key, &rel_path) {
+        let _ = std::fs::remove_file(&abs_path);
+        return Err(e);
+    }
 
     eprintln!("Wrote {}", abs_path.display());
     eprintln!("Recorded {key} -> {rel_path} in package.json");

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -872,12 +872,22 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     // invalidate too) but correct.
     hasher.update(b"npmrc=");
     {
-        let path = project_dir.join(".npmrc");
-        hasher.update(b".npmrc\x1f");
-        if let Ok(bytes) = std::fs::read(&path) {
-            hasher.update(&bytes);
+        let mut paths: Vec<PathBuf> = vec![project_dir.join(".npmrc")];
+        // User-level `~/.npmrc` also drives `registry=` and `_authToken`
+        // (see `aube_registry::config::load_npmrc_entries`). Hash it so
+        // a token swap or registry change invalidates the fast-path
+        // verdict the same way a project-level edit does.
+        if let Some(home) = aube_util::env::home_dir() {
+            paths.push(home.join(".npmrc"));
         }
-        hasher.update(b"\x1e");
+        for path in &paths {
+            hasher.update(path.as_os_str().as_encoded_bytes());
+            hasher.update(b"\x1f");
+            if let Ok(bytes) = std::fs::read(path) {
+                hasher.update(&bytes);
+            }
+            hasher.update(b"\x1e");
+        }
     }
     hasher.update(b"\0");
     // OS + arch + libc. Optional deps filter by these. Swap host


### PR DESCRIPTION
## Audited

Six critical/high bugs found via targeted code-review pass over
`aube-resolver`, `aube-lockfile`, `aube-store`, `aube-linker`,
`aube-scripts`, `aube-registry`, `aube-workspace`, `aube-manifest`,
`aube-settings`, and the install pipeline. Workspace traversal
verified empirically with a repro repo, others verified by code read.

## Fixed

### `fix(scripts): expand seccomp denylist + drop /tmp from landlock`

Old seccomp filter denied AF_INET and AF_INET6, left every other
family open. Now denies AF_INET, AF_INET6, AF_NETLINK, AF_PACKET,
AF_VSOCK, AF_XDP, AF_ALG, AF_BLUETOOTH, AF_RDS, AF_CAN, AF_TIPC,
AF_IB, AF_NFC. Strict superset of original.

AF_UNIX stays allowed (node and node-gyp IPC). True default-deny on
the family axis is not implementable with seccompiler today since
its `mismatch_action` is global, setting it to `Errno` kills every
non-socket syscall. Documented in the source.

Known residual gap: AF_UNIX `connect()` to filesystem socket paths
(e.g. `/var/run/docker.sock`) is not bounded by Landlock ABI v2.
v2 only filters VFS open/write hooks, the unix socket connect path
bypasses them by passing `sun_path` inline. `LANDLOCK_ACCESS_FS_CONNECT_UNIX`
arrives in v5 (kernel 6.10+). The policy pins v2 for LTS-kernel
coverage (Ubuntu 22.04, Debian 12, RHEL 9). On hosts with a sensitive
unix socket and a kernel below 6.10, install in a namespace that
bind-mounts the socket away.

Same commit drops `/tmp` from the landlock full-access list. `home`
already covers writable scratch and `apply_jail_env` redirects
TMPDIR/TMP/TEMP there. Granting `/tmp` let scripts seed symlink races
on shared CI hosts and read other tenants' tmp files.

### `fix(workspace): reject pnpm-workspace patterns escaping project root`

`glob_workspace_pattern` pushed match parents without containment
check. Pattern `../sibling` lexically starts with the project prefix
but escapes via parent components, leaking foreign dirs into the
workspace package list (linker, resolver, bin wiring all consume it).

Repro before fix:

```yaml
# pnpm-workspace.yaml
packages:
  - "../sibling"
```

```
packages: Ok([ "C:\...\project\..\sibling" ])
```

After: empty result, valid `packages/*` patterns still resolve.

Adds `is_under_project` helper, canonicalize both sides, fall back
to lexical compare when paths do not exist yet (combined with
`starts_with(project_dir)` guard so the fallback is also containment-checked).

### `fix(resolver): include dep tails in peer-context convergence hash`

Old `key_set_hash` covered package keys only. Peer-context iteration
can rewrite a dep value to point at an existing key without adding
a new key, so convergence fired with partially rewritten tails.
Linker reads tails directly to locate sibling symlink targets, stale
tails ship broken `node_modules` silently.

New `graph_hash` walks `(key, [(dep_name, dep_tail)...])` for every
package. Same `ordered_seq_hash` infra, no extra deps. Capacity hint
is exact (`len*3 + total_deps*2`), explicit `\x1f`/`\x1e` framing.

### `fix(cli): make patch-commit atomic, roll back on manifest failure`

Old order: write `.patch` file, then `upsert_patched_dependency`.
If the manifest write failed (Windows file lock, disk full,
concurrent writer) the patch lived on disk but `package.json` had no
entry. `load_patches` reads `package.json`, so the patch was invisible
to every future install.

Switch to `aube_util::fs_atomic::atomic_write` for the patch, snapshot
the prior bytes (re-patch path), restore them on failure or remove
the orphan if no prior patch existed.

### `fix(install): hash user-level npmrc in install state digest`

`hash_settings` raw-bytes segment only hashed `<project>/.npmrc`.
A token swap or `registry=` change in `~/.npmrc` left the fast-path
state hash green, so `aube install` reported "Already up to date"
while the source of truth for tarball URLs and auth had changed.
Fresh checkouts after the change would install from the wrong
registry.

Includes user-level `~/.npmrc` via `aube_util::env::home_dir()`.

## Verified

- `cargo build --all` clean
- `cargo test --workspace` 1145 passed, 0 failed
- 5 frameworks x 8 install scenarios = 40/40 PASS:

| project | clean | nm | cache | cache+nm | cache+lock | cache+lock+nm | lock | lock+nm |
|---|---|---|---|---|---|---|---|---|
| next | OK | OK | OK | OK | OK | OK | OK | OK |
| vue | OK | OK | OK | OK | OK | OK | OK | OK |
| svelte | OK | OK | OK | OK | OK | OK | OK | OK |
| astro | OK | OK | OK | OK | OK | OK | OK | OK |
| babylon | OK | OK | OK | OK | OK | OK | OK | OK |

Frozen fast path on warm state stays under 100ms across the matrix.
pnpm v9 lockfile roundtrip works. `workspace:*` protocol resolves.
Valid workspace patterns (`packages/*`) still match correctly.

## Skipped

- Optional-peer drop after rewrite (lower confidence, tighter repro
  needed)
- CAS integrity bypass in `import_tarball` (latent, every current
  caller verifies. Worth tightening to enforceable later)