### PR TITLE
feat(pnpmfile): support esm pnpmfiles

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -413,7 +413,7 @@ cmd install help="Install all dependencies" {
     flag --force help="Force reinstall: bypass the `node_modules/.aube-state` freshness check and re-resolve the lockfile even when nothing has drifted" {
         long_help "Force reinstall: bypass the `node_modules/.aube-state` freshness check and re-resolve the lockfile even when nothing has drifted.\n\nMirrors pnpm's `install --force`."
     }
-    flag --ignore-pnpmfile help="Skip running `.pnpmfile.cjs` hooks for this install"
+    flag --ignore-pnpmfile help="Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this install"
     flag --ignore-scripts help="Skip lifecycle scripts (no-op; aube already skips by default)"
     flag --lockfile-only help="Resolve dependencies and write the lockfile, but don't link `node_modules`" {
         long_help "Resolve dependencies and write the lockfile, but don't link `node_modules`.\n\nUseful for CI workflows that only update the lockfile."

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -186,8 +186,9 @@ pub struct WorkspaceConfig {
     #[serde(default, rename = "ignoredOptionalDependencies")]
     pub ignored_optional_dependencies: Vec<String>,
 
-    /// Override for the `.pnpmfile.cjs` path. pnpm v10 lets users
-    /// point at a non-default location; aube's default is `cwd/.pnpmfile.cjs`.
+    /// Override for the pnpmfile path. pnpm lets users point at a
+    /// non-default location; aube's default is `cwd/.pnpmfile.mjs`
+    /// when present, otherwise `cwd/.pnpmfile.cjs`.
     /// Relative paths resolve against the workspace root.
     #[serde(default, rename = "pnpmfilePath")]
     pub pnpmfile_path: Option<String>,

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -156,15 +156,16 @@ examples = []
 typedAccessorUnused = true
 
 [pnpmfilePath]
-description = "Location of the pnpmfile.cjs hook file."
+description = "Location of the pnpmfile hook file."
 type = "string"
 default = "undefined"
 docs = """
-Workspace-scoped override for the `.pnpmfile.cjs` discovery path.
-Defaults to `<project>/.pnpmfile.cjs`. Relative paths resolve against
-the workspace root; absolute paths are used as-is. A path that points
-at a missing file is a hard miss — aube emits a warning and runs with
-no pnpmfile rather than silently falling back to the default.
+Workspace-scoped override for the pnpmfile discovery path. Defaults to
+`<project>/.pnpmfile.mjs` when present, otherwise `<project>/.pnpmfile.cjs`.
+Relative paths resolve against the workspace root; absolute paths are used
+as-is. A path that points at a missing file is a hard miss — aube emits a
+warning and runs with no pnpmfile rather than silently falling back to the
+default.
 """
 sources.cli = []
 sources.env = ["AUBE_PNPMFILE_PATH"]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -70,7 +70,7 @@ pub struct InstallArgs {
     /// Mirrors pnpm's `install --force`.
     #[arg(long)]
     pub force: bool,
-    /// Skip running `.pnpmfile.cjs` hooks for this install
+    /// Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this install
     #[arg(long)]
     pub ignore_pnpmfile: bool,
     /// Skip lifecycle scripts (no-op; aube already skips by default)
@@ -305,7 +305,7 @@ pub struct InstallOptions {
     /// Which dep sections to keep in the materialized graph
     /// (`--prod` / `--dev` / `--no-optional`, in any valid combo).
     pub dep_selection: DepSelection,
-    /// `--ignore-pnpmfile`: don't load or execute `.pnpmfile.cjs`
+    /// `--ignore-pnpmfile`: don't load or execute `.pnpmfile.mjs` / `.pnpmfile.cjs`
     /// hooks for this install, even if one exists in the project root.
     pub ignore_pnpmfile: bool,
     /// `--ignore-scripts`: skip root lifecycle scripts (`preinstall`,

--- a/crates/aube/src/pnpmfile.rs
+++ b/crates/aube/src/pnpmfile.rs
@@ -315,10 +315,6 @@ const pnpmfile = process.env.AUBE_PNPMFILE;
 const ctx = {
   log: (...args) => console.error('[pnpmfile]', ...args),
 };
-const rl = readline.createInterface({
-  input: process.stdin,
-  crlfDelay: Infinity,
-});
 process.stdout.on('error', (e) => {
   if (e && e.code === 'EPIPE') process.exit(0);
 });
@@ -326,6 +322,10 @@ async function main() {
   const mod = await loadPnpmfile(pnpmfile);
   const hooks = (mod && mod.hooks) || {};
   const readPackage = hooks.readPackage;
+  const rl = readline.createInterface({
+    input: process.stdin,
+    crlfDelay: Infinity,
+  });
   for await (const line of rl) {
     if (!line) continue;
     let id = null;

--- a/crates/aube/src/pnpmfile.rs
+++ b/crates/aube/src/pnpmfile.rs
@@ -1,6 +1,7 @@
 //! pnpmfile.js hook support.
 //!
-//! Shells out to `node` to run hooks from a project's `.pnpmfile.cjs`,
+//! Shells out to `node` to run hooks from a project's `.pnpmfile.mjs`
+//! or `.pnpmfile.cjs`,
 //! matching pnpm's hook interface closely enough that existing
 //! pnpmfiles that use `hooks.afterAllResolved` work unchanged. We
 //! pipe a JSON representation of the resolved lockfile to a small
@@ -34,19 +35,21 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout};
 
-pub const PNPMFILE_NAME: &str = ".pnpmfile.cjs";
+pub const PNPMFILE_MJS_NAME: &str = ".pnpmfile.mjs";
+pub const PNPMFILE_CJS_NAME: &str = ".pnpmfile.cjs";
 
 /// Return the path to the project's pnpmfile if one exists.
 ///
 /// `workspace_pnpmfile_path` is the `pnpmfilePath` override from
 /// `pnpm-workspace.yaml` (pnpm v10 lets users keep the hook file
 /// outside the project root). When set, it wins over the default
-/// `cwd/.pnpmfile.cjs`; relative paths resolve against `cwd`. An
+/// `cwd/.pnpmfile.mjs` (preferred) or `cwd/.pnpmfile.cjs`; relative paths
+/// resolve against `cwd`. An
 /// override that points at a missing file is a hard miss (returns
 /// `None`) rather than silently falling back, and emits a warning —
 /// without the log the user can't tell their typo from "no pnpmfile
 /// configured at all". The missing-default case stays silent because
-/// "no .pnpmfile.cjs" is the common case, not a misconfiguration.
+/// "no pnpmfile" is the common case, not a misconfiguration.
 pub fn detect(cwd: &Path, workspace_pnpmfile_path: Option<&str>) -> Option<PathBuf> {
     if let Some(rel) = workspace_pnpmfile_path {
         let p = cwd.join(rel);
@@ -59,8 +62,13 @@ pub fn detect(cwd: &Path, workspace_pnpmfile_path: Option<&str>) -> Option<PathB
         }
         return Some(p);
     }
-    let p = cwd.join(PNPMFILE_NAME);
-    p.is_file().then_some(p)
+    for name in [PNPMFILE_MJS_NAME, PNPMFILE_CJS_NAME] {
+        let p = cwd.join(name);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    None
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -175,14 +183,22 @@ fn apply(wire: LockfileWire, graph: &mut LockfileGraph) {
 
 const SHIM: &str = r#"
 const path = require('path');
+const { pathToFileURL } = require('url');
 const pnpmfile = process.env.AUBE_PNPMFILE;
 const hookName = process.env.AUBE_HOOK;
 let chunks = [];
+async function loadPnpmfile(file) {
+  const resolved = path.resolve(file);
+  const mod = resolved.endsWith('.mjs')
+    ? await import(pathToFileURL(resolved).href)
+    : require(resolved);
+  return (mod && (mod.default || mod)) || {};
+}
 process.stdin.on('data', (c) => chunks.push(c));
 process.stdin.on('end', async () => {
   try {
     const input = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-    const mod = require(path.resolve(pnpmfile));
+    const mod = await loadPnpmfile(pnpmfile);
     const hooks = (mod && mod.hooks) || {};
     const fn = hooks[hookName];
     let result = input;
@@ -284,11 +300,16 @@ pub async fn run_after_all_resolved(pnpmfile: &Path, graph: &mut LockfileGraph) 
 /// callbacks.
 const READ_PACKAGE_SHIM: &str = r#"
 const path = require('path');
+const { pathToFileURL } = require('url');
 const readline = require('readline');
 const pnpmfile = process.env.AUBE_PNPMFILE;
-const mod = require(path.resolve(pnpmfile));
-const hooks = (mod && mod.hooks) || {};
-const readPackage = hooks.readPackage;
+async function loadPnpmfile(file) {
+  const resolved = path.resolve(file);
+  const mod = resolved.endsWith('.mjs')
+    ? await import(pathToFileURL(resolved).href)
+    : require(resolved);
+  return (mod && (mod.default || mod)) || {};
+}
 const ctx = {
   log: (...args) => console.error('[pnpmfile]', ...args),
 };
@@ -300,6 +321,9 @@ process.stdout.on('error', (e) => {
   if (e && e.code === 'EPIPE') process.exit(0);
 });
 async function main() {
+  const mod = await loadPnpmfile(pnpmfile);
+  const hooks = (mod && mod.hooks) || {};
+  const readPackage = hooks.readPackage;
   for await (const line of rl) {
     if (!line) continue;
     let id = null;
@@ -481,11 +505,23 @@ mod tests {
     #[test]
     fn detect_returns_default_when_present_and_no_override() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join(PNPMFILE_NAME), "").unwrap();
+        std::fs::write(dir.path().join(PNPMFILE_CJS_NAME), "").unwrap();
         let found = detect(dir.path(), None);
         assert_eq!(
             found.as_deref(),
-            Some(dir.path().join(PNPMFILE_NAME).as_path())
+            Some(dir.path().join(PNPMFILE_CJS_NAME).as_path())
+        );
+    }
+
+    #[test]
+    fn detect_prefers_mjs_over_cjs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(PNPMFILE_MJS_NAME), "").unwrap();
+        std::fs::write(dir.path().join(PNPMFILE_CJS_NAME), "").unwrap();
+        let found = detect(dir.path(), None);
+        assert_eq!(
+            found.as_deref(),
+            Some(dir.path().join(PNPMFILE_MJS_NAME).as_path())
         );
     }
 
@@ -515,7 +551,7 @@ mod tests {
         // than silently falling back to `.pnpmfile.cjs` — otherwise the
         // user thinks their hooks are running when they aren't.
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join(PNPMFILE_NAME), "").unwrap();
+        std::fs::write(dir.path().join(PNPMFILE_CJS_NAME), "").unwrap();
         assert!(detect(dir.path(), Some("typo/missing.cjs")).is_none());
     }
 }

--- a/crates/aube/src/pnpmfile.rs
+++ b/crates/aube/src/pnpmfile.rs
@@ -181,19 +181,26 @@ fn apply(wire: LockfileWire, graph: &mut LockfileGraph) {
     }
 }
 
-const SHIM: &str = r#"
+const LOAD_PNPMFILE_JS: &str = r#"
 const path = require('path');
 const { pathToFileURL } = require('url');
-const pnpmfile = process.env.AUBE_PNPMFILE;
-const hookName = process.env.AUBE_HOOK;
-let chunks = [];
 async function loadPnpmfile(file) {
   const resolved = path.resolve(file);
   const mod = resolved.endsWith('.mjs')
     ? await import(pathToFileURL(resolved).href)
     : require(resolved);
+  if (mod && mod.default && !mod.default.hooks && mod.hooks) {
+    console.error('[pnpmfile] default export has no hooks; using named hooks export');
+    return mod;
+  }
   return (mod && (mod.default || mod)) || {};
 }
+"#;
+
+const SHIM: &str = r#"
+const pnpmfile = process.env.AUBE_PNPMFILE;
+const hookName = process.env.AUBE_HOOK;
+let chunks = [];
 process.stdin.on('data', (c) => chunks.push(c));
 process.stdin.on('end', async () => {
   try {
@@ -217,6 +224,10 @@ process.stdin.on('end', async () => {
 });
 "#;
 
+fn after_all_resolved_shim() -> String {
+    format!("{LOAD_PNPMFILE_JS}{SHIM}")
+}
+
 /// Run the `afterAllResolved` hook against a resolved lockfile graph.
 /// Mutations to `packages[].dependencies` and `packages[].peerDependencies`
 /// are applied in place. All other fields are round-tripped but
@@ -234,7 +245,7 @@ pub async fn run_after_all_resolved(pnpmfile: &Path, graph: &mut LockfileGraph) 
 
     let mut cmd = tokio::process::Command::new("node");
     cmd.arg("-e")
-        .arg(SHIM)
+        .arg(after_all_resolved_shim())
         .env("AUBE_PNPMFILE", pnpmfile)
         .env("AUBE_HOOK", "afterAllResolved")
         .stdin(std::process::Stdio::piped())
@@ -299,17 +310,8 @@ pub async fn run_after_all_resolved(pnpmfile: &Path, graph: &mut LockfileGraph) 
 /// the interleaving hazards you'd otherwise get from async readline
 /// callbacks.
 const READ_PACKAGE_SHIM: &str = r#"
-const path = require('path');
-const { pathToFileURL } = require('url');
 const readline = require('readline');
 const pnpmfile = process.env.AUBE_PNPMFILE;
-async function loadPnpmfile(file) {
-  const resolved = path.resolve(file);
-  const mod = resolved.endsWith('.mjs')
-    ? await import(pathToFileURL(resolved).href)
-    : require(resolved);
-  return (mod && (mod.default || mod)) || {};
-}
 const ctx = {
   log: (...args) => console.error('[pnpmfile]', ...args),
 };
@@ -347,6 +349,10 @@ main().catch((err) => {
   process.exit(1);
 });
 "#;
+
+fn read_package_shim() -> String {
+    format!("{LOAD_PNPMFILE_JS}{READ_PACKAGE_SHIM}")
+}
 
 /// Long-lived node child that answers `readPackage` calls one at a
 /// time. Owned by the install command for the span of a single
@@ -395,7 +401,7 @@ impl ReadPackageHost {
         );
         let mut cmd = tokio::process::Command::new("node");
         cmd.arg("-e")
-            .arg(READ_PACKAGE_SHIM)
+            .arg(read_package_shim())
             .env("AUBE_PNPMFILE", pnpmfile)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
@@ -510,6 +516,17 @@ mod tests {
         assert_eq!(
             found.as_deref(),
             Some(dir.path().join(PNPMFILE_CJS_NAME).as_path())
+        );
+    }
+
+    #[test]
+    fn detect_returns_mjs_when_only_mjs_present() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(PNPMFILE_MJS_NAME), "").unwrap();
+        let found = detect(dir.path(), None);
+        assert_eq!(
+            found.as_deref(),
+            Some(dir.path().join(PNPMFILE_MJS_NAME).as_path())
         );
     }
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2291,8 +2291,8 @@
           {
             "name": "ignore-pnpmfile",
             "usage": "--ignore-pnpmfile",
-            "help": "Skip running `.pnpmfile.cjs` hooks for this install",
-            "help_first_line": "Skip running `.pnpmfile.cjs` hooks for this install",
+            "help": "Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this install",
+            "help_first_line": "Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this install",
             "short": [],
             "long": [
               "ignore-pnpmfile"

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -35,7 +35,7 @@ Mirrors pnpm's `install --force`.
 
 ### `--ignore-pnpmfile`
 
-Skip running `.pnpmfile.cjs` hooks for this install
+Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this install
 
 ### `--ignore-scripts`
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -17,7 +17,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
 | [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
 | [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
-| [`pnpmfilePath`](#setting-pnpmfilepath) | `string` | Location of the pnpmfile.cjs hook file. |
+| [`pnpmfilePath`](#setting-pnpmfilepath) | `string` | Location of the pnpmfile hook file. |
 | [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
 | [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
 | [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
@@ -242,18 +242,19 @@ from `--no-optional`, which drops *all* optional deps at install time.
 
 ### `pnpmfilePath` {#setting-pnpmfilepath}
 
-Location of the pnpmfile.cjs hook file.
+Location of the pnpmfile hook file.
 
 - Type: `string`
 - Default: `undefined`
 - Environment: `AUBE_PNPMFILE_PATH`
 - Workspace YAML keys: `pnpmfilePath`
 
-Workspace-scoped override for the `.pnpmfile.cjs` discovery path.
-Defaults to `<project>/.pnpmfile.cjs`. Relative paths resolve against
-the workspace root; absolute paths are used as-is. A path that points
-at a missing file is a hard miss — aube emits a warning and runs with
-no pnpmfile rather than silently falling back to the default.
+Workspace-scoped override for the pnpmfile discovery path. Defaults to
+`<project>/.pnpmfile.mjs` when present, otherwise `<project>/.pnpmfile.cjs`.
+Relative paths resolve against the workspace root; absolute paths are used
+as-is. A path that points at a missing file is a hard miss — aube emits a
+warning and runs with no pnpmfile rather than silently falling back to the
+default.
 
 ### `minimumReleaseAge` {#setting-minimumreleaseage}
 

--- a/test/pnpmfile.bats
+++ b/test/pnpmfile.bats
@@ -111,6 +111,33 @@ EOF
 	refute_output --partial 'cjs pnpmfile should not have run'
 }
 
+@test "pnpmfile: .pnpmfile.mjs named hooks win when default has no hooks" {
+	cat >package.json <<'EOF'
+{
+  "name": "test-pnpmfile-mjs-mixed-exports",
+  "version": "0.0.0",
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}
+EOF
+
+	cat >.pnpmfile.mjs <<'EOF'
+export const hooks = {
+  afterAllResolved(lockfile, context) {
+    context.log('named hooks export ran');
+    return lockfile;
+  },
+};
+export default { source: 'tooling-only' };
+EOF
+
+	run aube install
+	assert_success
+	assert_output --partial 'default export has no hooks; using named hooks export'
+	assert_output --partial 'named hooks export ran'
+}
+
 @test "pnpmfile: readPackage hook mutates transitive dependencies before enqueue" {
 	cat >package.json <<'EOF'
 {

--- a/test/pnpmfile.bats
+++ b/test/pnpmfile.bats
@@ -75,6 +75,42 @@ EOF
 	assert_success
 }
 
+@test "pnpmfile: .pnpmfile.mjs takes priority over .pnpmfile.cjs" {
+	cat >package.json <<'EOF'
+{
+  "name": "test-pnpmfile-mjs",
+  "version": "0.0.0",
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}
+EOF
+
+	cat >.pnpmfile.cjs <<'EOF'
+module.exports = {
+  hooks: {
+    afterAllResolved() {
+      throw new Error('cjs pnpmfile should not have run');
+    },
+  },
+};
+EOF
+
+	cat >.pnpmfile.mjs <<'EOF'
+export const hooks = {
+  afterAllResolved(lockfile, context) {
+    context.log('hello from mjs pnpmfile');
+    return lockfile;
+  },
+};
+EOF
+
+	run aube install
+	assert_success
+	assert_output --partial 'hello from mjs pnpmfile'
+	refute_output --partial 'cjs pnpmfile should not have run'
+}
+
 @test "pnpmfile: readPackage hook mutates transitive dependencies before enqueue" {
 	cat >package.json <<'EOF'
 {
@@ -110,6 +146,41 @@ EOF
 	assert_output --partial 'is-odd@3.0.1: {}'
 	# is-number must never have been resolved, since the hook removed
 	# the edge before transitives were enqueued.
+	run grep 'is-number' aube-lock.yaml
+	assert_failure
+}
+
+@test "pnpmfile: readPackage hook runs from .pnpmfile.mjs" {
+	cat >package.json <<'EOF'
+{
+  "name": "test-read-package-mjs",
+  "version": "0.0.0",
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}
+EOF
+
+	cat >.pnpmfile.mjs <<'EOF'
+export default {
+  hooks: {
+    readPackage(pkg, context) {
+      if (pkg.name === 'is-odd') {
+        context.log('mjs readPackage saw is-odd');
+        pkg.dependencies = {};
+      }
+      return pkg;
+    },
+  },
+};
+EOF
+
+	run aube install
+	assert_success
+	assert_output --partial 'mjs readPackage saw is-odd'
+
+	run bash -c "awk '/^snapshots:/,0' aube-lock.yaml | grep 'is-odd@3.0.1'"
+	assert_output --partial 'is-odd@3.0.1: {}'
 	run grep 'is-number' aube-lock.yaml
 	assert_failure
 }


### PR DESCRIPTION
## Summary

- prefer `.pnpmfile.mjs` over `.pnpmfile.cjs` during default pnpmfile discovery
- load ESM pnpmfiles with dynamic import while preserving CommonJS `require()` support
- document the new default lookup order and cover `.mjs` afterAllResolved/readPackage hooks

## Validation

- `cargo test -p aube pnpmfile::tests`
- `cargo build -p aube`
- `mise run test:bats test/pnpmfile.bats`
- `mise run docs:build`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how pnpmfile hooks are discovered and executed (including dynamic ESM loading), which can affect dependency resolution behavior during installs if projects rely on existing hook semantics.
> 
> **Overview**
> Adds support for ESM pnpmfiles by **discovering and preferring** `.pnpmfile.mjs` over `.pnpmfile.cjs`, while still honoring `pnpmfilePath` overrides.
> 
> Updates the Node hook shims to **dynamically load** `.mjs` via `import()` (and `.cjs` via `require()`), including a fallback when an ESM default export lacks `hooks`. Documentation/CLI help text and bats/unit tests are updated to reflect the new lookup order and to cover `.mjs` for both `afterAllResolved` and `readPackage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f6eb1872f6d00ab9e74ad54143952952284081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->