### PR TITLE
feat(audit): support update fix mode

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -120,7 +120,12 @@ cmd audit help="Check installed packages against the registry advisory DB" {
         }
     }
     flag "-D --dev" help="Only audit `devDependencies`"
-    flag --fix help="Write package.json overrides that force vulnerable packages to patched versions"
+    flag --fix help="Fix advisories" {
+        long_help "Fix advisories.\n\nBare `--fix` writes package.json overrides for backwards compatibility. `--fix=update` refreshes the lockfile without writing overrides."
+        arg <FIX> {
+            choices update override
+        }
+    }
     flag --ignore help="Drop advisories whose ID matches one of these values" var=#true {
         long_help "Drop advisories whose ID matches one of these values.\n\nMatches against the numeric npm advisory `id`, `github_advisory_id` (`GHSA-…`), and any entry in `cves[]` (case-insensitive). Repeatable; comma-separated values are also accepted."
         arg <ID>
@@ -131,6 +136,7 @@ cmd audit help="Check installed packages against the registry advisory DB" {
     flag --ignore-unfixable help="Drop advisories for which no non-vulnerable version is available in the package's packument" {
         long_help "Drop advisories for which no non-vulnerable version is available in the package's packument.\n\nSame \"best non-vulnerable\" logic as `--fix`: an advisory is kept only when an upgrade path exists."
     }
+    flag "-i --interactive" help="Pick which advisories to fix interactively"
     flag --json help="Emit the report as JSON (pnpm-compatible shape) instead of a table"
     flag --no-optional help="Skip `optionalDependencies`"
     flag "-P --prod --production" help="Only audit `dependencies` and `optionalDependencies`"

--- a/crates/aube-resolver/src/builder.rs
+++ b/crates/aube-resolver/src/builder.rs
@@ -29,6 +29,7 @@ impl Resolver {
             catalogs: BTreeMap::new(),
             read_package_hook: None,
             dependency_policy: DependencyPolicy::default(),
+            vulnerable_ranges: BTreeMap::new(),
             git_shallow_hosts: Vec::new(),
             peers_suffix_max_length: 1000,
             dedupe_peer_dependents: true,
@@ -65,6 +66,7 @@ impl Resolver {
                 catalogs: BTreeMap::new(),
                 read_package_hook: None,
                 dependency_policy: DependencyPolicy::default(),
+                vulnerable_ranges: BTreeMap::new(),
                 git_shallow_hosts: Vec::new(),
                 peers_suffix_max_length: 1000,
                 dedupe_peer_dependents: true,
@@ -255,6 +257,14 @@ impl Resolver {
     /// and `blockExoticSubdeps`.
     pub fn with_dependency_policy(mut self, policy: DependencyPolicy) -> Self {
         self.dependency_policy = policy;
+        self
+    }
+
+    /// Prefer non-vulnerable versions for the supplied audit ranges.
+    /// Used by `audit --fix=update` to reuse the normal resolver while
+    /// steering only vulnerable packages away from affected versions.
+    pub fn with_vulnerable_ranges(mut self, ranges: BTreeMap<String, Vec<String>>) -> Self {
+        self.vulnerable_ranges = ranges;
         self
     }
 

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -131,6 +131,13 @@ pub struct Resolver {
     /// `--ignore-pnpmfile` was not set.
     read_package_hook: Option<Box<dyn ReadPackageHook>>,
     dependency_policy: DependencyPolicy,
+    /// Advisory ranges to avoid when resolving audit fixes. The map is
+    /// keyed by registry package name and values are npm semver ranges
+    /// from `vulnerable_versions`. When a clean satisfying version
+    /// exists, it wins over locked/sibling reuse and the normal highest
+    /// pick; if not, resolution falls back to the ordinary pick so the
+    /// caller can report the advisory as remaining.
+    vulnerable_ranges: BTreeMap<String, Vec<String>>,
     /// Hosts for which aube performs shallow git clones, mirroring
     /// pnpm's `git-shallow-hosts`. When a git dep's URL host is in
     /// this list, the store attempts `git fetch --depth 1 origin

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -899,6 +899,9 @@ impl Resolver {
                     versions
                         .iter()
                         .find(|v| version_satisfies(v, &task.range))
+                        .filter(|v| {
+                            !is_vulnerable(task.registry_name(), v, &self.vulnerable_ranges)
+                        })
                         .cloned()
                 }) {
                     let dep_path = dep_path_for(&task.name, &matched_ver);
@@ -938,7 +941,13 @@ impl Resolver {
                 {
                     if let Some(locked_pkg) = existing.and_then(|g| {
                         g.packages.values().find(|p| {
-                            p.name == task.name && version_satisfies(&p.version, &task.range)
+                            p.name == task.name
+                                && version_satisfies(&p.version, &task.range)
+                                && !is_vulnerable(
+                                    task.registry_name(),
+                                    &p.version,
+                                    &self.vulnerable_ranges,
+                                )
                         })
                     }) {
                         // Drop optional deps whose platform constraints
@@ -1211,6 +1220,9 @@ impl Resolver {
                         .values()
                         .find(|p| p.name == task.name && version_satisfies(&p.version, &task.range))
                         .map(|p| p.version.as_str())
+                        .filter(|v| {
+                            !is_vulnerable(task.registry_name(), v, &self.vulnerable_ranges)
+                        })
                 });
 
                 // Direct deps in time-based mode pick the lowest
@@ -1278,6 +1290,15 @@ impl Resolver {
                         ))));
                     }
                 };
+                let picked_ref = prefer_non_vulnerable_pick(
+                    task.registry_name(),
+                    packument,
+                    &task.range,
+                    picked_ref,
+                    pick_lowest,
+                    cutoff_for_pkg,
+                    &self.vulnerable_ranges,
+                );
                 // Trust-policy enforcement runs *before* any other
                 // post-pick processing (mirrors pnpm's placement
                 // immediately after `pickPackage`). Skip when policy is
@@ -1893,6 +1914,71 @@ impl Resolver {
         );
         Ok(contextualized)
     }
+}
+
+fn is_vulnerable(
+    package_name: &str,
+    version: &str,
+    vulnerable_ranges: &BTreeMap<String, Vec<String>>,
+) -> bool {
+    let Some(ranges) = vulnerable_ranges.get(package_name) else {
+        return false;
+    };
+    let Ok(version) = node_semver::Version::parse(version) else {
+        return false;
+    };
+    ranges
+        .iter()
+        .filter_map(|range| node_semver::Range::parse(range).ok())
+        .any(|range| version.satisfies(&range))
+}
+
+fn prefer_non_vulnerable_pick<'a>(
+    package_name: &str,
+    packument: &'a Packument,
+    range_str: &str,
+    fallback: &'a aube_registry::VersionMetadata,
+    pick_lowest: bool,
+    cutoff: Option<&str>,
+    vulnerable_ranges: &BTreeMap<String, Vec<String>>,
+) -> &'a aube_registry::VersionMetadata {
+    if !is_vulnerable(package_name, &fallback.version, vulnerable_ranges) {
+        return fallback;
+    }
+    let Ok(range) = node_semver::Range::parse(crate::semver_util::normalize_range(range_str))
+    else {
+        return fallback;
+    };
+    let passes_cutoff = |ver: &str| -> bool {
+        let Some(c) = cutoff else { return true };
+        match packument.time.get(ver) {
+            Some(t) => t.as_str() <= c,
+            None => true,
+        }
+    };
+    let mut best: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> = None;
+    for (ver_str, meta) in &packument.versions {
+        let Ok(version) = node_semver::Version::parse(ver_str) else {
+            continue;
+        };
+        if !version.satisfies(&range)
+            || !passes_cutoff(ver_str)
+            || is_vulnerable(package_name, ver_str, vulnerable_ranges)
+        {
+            continue;
+        }
+        let replace = best.as_ref().is_none_or(|(cur, _)| {
+            if pick_lowest {
+                version < *cur
+            } else {
+                version > *cur
+            }
+        });
+        if replace {
+            best = Some((version, meta));
+        }
+    }
+    best.map(|(_, meta)| meta).unwrap_or(fallback)
 }
 
 pub(crate) fn modified_allows_short_circuit(modified: &str, cutoff: &str) -> bool {

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -898,9 +898,9 @@ impl Resolver {
                 if let Some(matched_ver) = resolved_versions.get(&task.name).and_then(|versions| {
                     versions
                         .iter()
-                        .find(|v| version_satisfies(v, &task.range))
-                        .filter(|v| {
-                            !is_vulnerable(task.registry_name(), v, &self.vulnerable_ranges)
+                        .find(|v| {
+                            version_satisfies(v, &task.range)
+                                && !is_vulnerable(task.registry_name(), v, &self.vulnerable_ranges)
                         })
                         .cloned()
                 }) {

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -14,7 +14,7 @@ use aube_registry::config::normalize_registry_url_pub;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::{IsTerminal, Write};
+use std::io::IsTerminal;
 
 pub const AFTER_LONG_HELP: &str = "\
 Examples:
@@ -288,58 +288,31 @@ fn select_fix_rows(rows: &[Row]) -> miette::Result<Vec<Row>> {
         return Ok(rows.to_vec());
     }
 
-    eprintln!("Select advisories to fix:");
+    let mut picker = demand::MultiSelect::new("Choose which vulnerabilities to fix")
+        .description("Space to toggle, Enter to confirm")
+        .filterable(true)
+        .min(1);
     for (idx, row) in rows.iter().enumerate() {
-        eprintln!("  {}. {} {} {}", idx + 1, row.severity, row.name, row.title);
-    }
-    eprint!("Advisories to fix (comma-separated, blank for all): ");
-    std::io::stderr().flush().into_diagnostic()?;
-
-    let mut input = String::new();
-    std::io::stdin().read_line(&mut input).into_diagnostic()?;
-    let input = input.trim();
-    if input.is_empty() {
-        return Ok(rows.to_vec());
-    }
-
-    let mut selected = Vec::new();
-    let mut seen = BTreeSet::new();
-    for part in input.split(',').map(str::trim).filter(|s| !s.is_empty()) {
-        let (start, end) = parse_selection_part(part, rows.len())?;
-        for idx in start..=end {
-            if seen.insert(idx) {
-                selected.push(rows[idx - 1].clone());
-            }
+        let label = format!(
+            "{} {} {} {}",
+            row.severity, row.name, row.vulnerable_versions, row.title
+        );
+        let mut option = demand::DemandOption::new(idx).label(&label).selected(true);
+        if !row.url.is_empty() {
+            option = option.description(&row.url);
         }
+        picker = picker.option(option);
     }
-    if selected.is_empty() {
-        return Err(miette!("no advisories selected"));
-    }
-    Ok(selected)
-}
-
-fn parse_selection_part(part: &str, len: usize) -> miette::Result<(usize, usize)> {
-    let parse_idx = |raw: &str| -> miette::Result<usize> {
-        let idx = raw
-            .parse::<usize>()
-            .into_diagnostic()
-            .wrap_err_with(|| format!("invalid advisory selection `{raw}`"))?;
-        if idx == 0 || idx > len {
-            return Err(miette!("advisory selection `{idx}` is out of range"));
+    let picked = match picker.run() {
+        Ok(picked) => picked,
+        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => std::process::exit(130),
+        Err(e) => {
+            return Err(e)
+                .into_diagnostic()
+                .wrap_err("failed to read audit selection");
         }
-        Ok(idx)
     };
-    if let Some((start, end)) = part.split_once('-') {
-        let start = parse_idx(start.trim())?;
-        let end = parse_idx(end.trim())?;
-        if start > end {
-            return Err(miette!("invalid advisory selection range `{part}`"));
-        }
-        Ok((start, end))
-    } else {
-        let idx = parse_idx(part)?;
-        Ok((idx, idx))
-    }
+    Ok(picked.into_iter().map(|idx| rows[idx].clone()).collect())
 }
 
 fn render_fix_remaining(selected: &[Row], remaining: &[Row]) {

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -5,7 +5,7 @@
 //! `/-/npm/v1/security/advisories/bulk` endpoint, and prints the matching
 //! advisories. Mirrors `pnpm audit`'s default table layout and `--json` shape.
 //!
-//! Pure read: no lockfile writes, no `node_modules/` touches, no project lock.
+//! Read-only unless `--fix` is passed.
 
 use super::DepFilter;
 use aube_registry::Packument;
@@ -14,6 +14,7 @@ use aube_registry::config::normalize_registry_url_pub;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::{IsTerminal, Write};
 
 pub const AFTER_LONG_HELP: &str = "\
 Examples:
@@ -51,9 +52,12 @@ pub struct AuditArgs {
     #[arg(short = 'D', long, conflicts_with = "prod")]
     pub dev: bool,
 
-    /// Write package.json overrides that force vulnerable packages to patched versions.
-    #[arg(long)]
-    pub fix: bool,
+    /// Fix advisories.
+    ///
+    /// Bare `--fix` writes package.json overrides for backwards compatibility.
+    /// `--fix=update` refreshes the lockfile without writing overrides.
+    #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "override")]
+    pub fix: Option<FixMode>,
 
     /// Drop advisories whose ID matches one of these values.
     ///
@@ -77,6 +81,10 @@ pub struct AuditArgs {
     /// only when an upgrade path exists.
     #[arg(long)]
     pub ignore_unfixable: bool,
+
+    /// Pick which advisories to fix interactively.
+    #[arg(short = 'i', long)]
+    pub interactive: bool,
 
     /// Emit the report as JSON (pnpm-compatible shape) instead of a table.
     #[arg(long)]
@@ -115,6 +123,15 @@ pub enum Severity {
     Moderate,
     High,
     Critical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[value(rename_all = "lowercase")]
+pub enum FixMode {
+    /// Refresh the lockfile to patched versions allowed by existing ranges.
+    Update,
+    /// Write package.json overrides that force patched versions.
+    Override,
 }
 
 pub async fn run(args: AuditArgs, registry_override: Option<&str>) -> miette::Result<()> {
@@ -211,8 +228,41 @@ pub async fn run(args: AuditArgs, registry_override: Option<&str>) -> miette::Re
 
     let rows = flatten_advisories(&raw, args.audit_level);
 
-    if args.fix && !rows.is_empty() {
-        write_fix_overrides(&cwd, &rows, &client).await?;
+    if args.interactive && args.json {
+        return Err(miette!("--interactive cannot be used with --json"));
+    }
+
+    let fix_mode = args.fix.or(args.interactive.then_some(FixMode::Override));
+    if let Some(mode) = fix_mode
+        && !rows.is_empty()
+    {
+        let selected = if args.interactive {
+            select_fix_rows(&rows)?
+        } else {
+            rows.clone()
+        };
+        match mode {
+            FixMode::Update => {
+                let remaining = write_fix_lockfile_update(
+                    &cwd,
+                    &manifest,
+                    &graph,
+                    filter,
+                    args.no_optional,
+                    &selected,
+                )
+                .await?;
+                if remaining.is_empty() {
+                    return Ok(());
+                }
+                render_fix_remaining(&selected, &remaining);
+                std::process::exit(1);
+            }
+            FixMode::Override => {
+                write_fix_overrides(&cwd, &selected, &client).await?;
+                return Ok(());
+            }
+        }
     }
 
     if args.json {
@@ -230,6 +280,81 @@ pub async fn run(args: AuditArgs, registry_override: Option<&str>) -> miette::Re
     } else {
         // pnpm-compat: exit 1 when any advisory matches the threshold.
         std::process::exit(1);
+    }
+}
+
+fn select_fix_rows(rows: &[Row]) -> miette::Result<Vec<Row>> {
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return Ok(rows.to_vec());
+    }
+
+    eprintln!("Select advisories to fix:");
+    for (idx, row) in rows.iter().enumerate() {
+        eprintln!("  {}. {} {} {}", idx + 1, row.severity, row.name, row.title);
+    }
+    eprint!("Advisories to fix (comma-separated, blank for all): ");
+    std::io::stderr().flush().into_diagnostic()?;
+
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input).into_diagnostic()?;
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(rows.to_vec());
+    }
+
+    let mut selected = Vec::new();
+    let mut seen = BTreeSet::new();
+    for part in input.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        let (start, end) = parse_selection_part(part, rows.len())?;
+        for idx in start..=end {
+            if seen.insert(idx) {
+                selected.push(rows[idx - 1].clone());
+            }
+        }
+    }
+    if selected.is_empty() {
+        return Err(miette!("no advisories selected"));
+    }
+    Ok(selected)
+}
+
+fn parse_selection_part(part: &str, len: usize) -> miette::Result<(usize, usize)> {
+    let parse_idx = |raw: &str| -> miette::Result<usize> {
+        let idx = raw
+            .parse::<usize>()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("invalid advisory selection `{raw}`"))?;
+        if idx == 0 || idx > len {
+            return Err(miette!("advisory selection `{idx}` is out of range"));
+        }
+        Ok(idx)
+    };
+    if let Some((start, end)) = part.split_once('-') {
+        let start = parse_idx(start.trim())?;
+        let end = parse_idx(end.trim())?;
+        if start > end {
+            return Err(miette!("invalid advisory selection range `{part}`"));
+        }
+        Ok((start, end))
+    } else {
+        let idx = parse_idx(part)?;
+        Ok((idx, idx))
+    }
+}
+
+fn render_fix_remaining(selected: &[Row], remaining: &[Row]) {
+    let fixed = selected.len().saturating_sub(remaining.len());
+    eprintln!(
+        "{} fixed, {} remain.",
+        pluralizer::pluralize("vulnerability", fixed as isize, true),
+        remaining.len()
+    );
+    if !remaining.is_empty() {
+        eprintln!();
+        eprintln!("Remaining vulnerabilities:");
+        for row in remaining {
+            eprintln!("- ({}) \"{}\" {}", row.severity, row.title, row.name);
+        }
     }
 }
 
@@ -433,6 +558,269 @@ async fn write_fix_overrides(
     Ok(())
 }
 
+async fn write_fix_lockfile_update(
+    cwd: &std::path::Path,
+    manifest: &aube_manifest::PackageJson,
+    graph: &aube_lockfile::LockfileGraph,
+    filter: DepFilter,
+    no_optional: bool,
+    rows: &[Row],
+) -> miette::Result<Vec<Row>> {
+    let vulnerable_ranges = vulnerable_ranges_by_name(rows);
+    let vulnerable_names: BTreeSet<String> = vulnerable_ranges.keys().cloned().collect();
+    let before = resolved_versions_by_name(graph, filter, no_optional, &vulnerable_names);
+    let mut resolver_manifest = manifest.clone();
+    widen_vulnerable_direct_pins(&mut resolver_manifest, graph, &vulnerable_ranges);
+
+    let workspace_catalogs = super::load_workspace_catalogs(cwd)?;
+    let mut resolver = super::build_resolver(cwd, &resolver_manifest, workspace_catalogs)
+        .with_vulnerable_ranges(vulnerable_ranges.clone());
+    let new_graph = resolver
+        .resolve(&resolver_manifest, Some(graph))
+        .await
+        .map_err(miette::Report::new)
+        .wrap_err("failed to resolve audit fixes")?;
+
+    let after = resolved_versions_by_name(&new_graph, filter, no_optional, &vulnerable_names);
+    let remaining: Vec<Row> = rows
+        .iter()
+        .filter(|row| {
+            after.get(&row.name).is_some_and(|versions| {
+                versions.iter().any(|version| {
+                    version_is_vulnerable(version, std::slice::from_ref(&row.vulnerable_versions))
+                })
+            })
+        })
+        .cloned()
+        .collect();
+    let fixed = fixed_package_names(rows, &remaining, &before, &after);
+
+    if fixed.is_empty() {
+        eprintln!("No audit lockfile updates available.");
+        return Ok(remaining);
+    }
+
+    let mut output_manifest = manifest.clone();
+    if update_direct_manifest_specs(&mut output_manifest, graph, &new_graph, &fixed) {
+        let manifest_path = cwd.join("package.json");
+        super::write_manifest_dep_sections(&manifest_path, &output_manifest)?;
+        eprintln!("Updated package.json");
+    }
+
+    super::write_and_log_lockfile(cwd, &new_graph, &output_manifest)?;
+    for name in &fixed {
+        let old = before
+            .get(name)
+            .map(|v| v.iter().cloned().collect::<Vec<_>>().join(", "))
+            .unwrap_or_else(|| "(not locked)".to_string());
+        let new = after
+            .get(name)
+            .map(|v| v.iter().cloned().collect::<Vec<_>>().join(", "))
+            .unwrap_or_else(|| "(removed)".to_string());
+        eprintln!("  {name}: {old} -> {new}");
+    }
+    eprintln!("Updated lockfile for {} package(s).", fixed.len());
+    Ok(remaining)
+}
+
+fn vulnerable_ranges_by_name(rows: &[Row]) -> BTreeMap<String, Vec<String>> {
+    let mut vulnerable_ranges: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for row in rows {
+        vulnerable_ranges
+            .entry(row.name.clone())
+            .or_default()
+            .push(row.vulnerable_versions.clone());
+    }
+    vulnerable_ranges
+}
+
+fn fixed_package_names(
+    selected: &[Row],
+    remaining: &[Row],
+    before: &BTreeMap<String, BTreeSet<String>>,
+    after: &BTreeMap<String, BTreeSet<String>>,
+) -> BTreeSet<String> {
+    let remaining_names: BTreeSet<&str> = remaining.iter().map(|row| row.name.as_str()).collect();
+    selected
+        .iter()
+        .filter(|row| !remaining_names.contains(row.name.as_str()))
+        .filter(|row| before.get(&row.name) != after.get(&row.name))
+        .map(|row| row.name.clone())
+        .collect()
+}
+
+fn widen_vulnerable_direct_pins(
+    manifest: &mut aube_manifest::PackageJson,
+    graph: &aube_lockfile::LockfileGraph,
+    vulnerable_ranges: &BTreeMap<String, Vec<String>>,
+) {
+    let direct_versions = direct_versions_by_name(graph);
+    for (key, spec) in mutable_manifest_dep_entries(manifest) {
+        let real_name = real_name_for_spec(&key, spec);
+        let Some(version) = direct_versions.get(&real_name) else {
+            continue;
+        };
+        let Some(ranges) = vulnerable_ranges.get(&real_name) else {
+            continue;
+        };
+        if !version_is_vulnerable(version, ranges) || !looks_like_exact_version(spec_range(spec)) {
+            continue;
+        }
+        *spec = rewrite_specifier(spec, &real_name, version, Some("^"));
+    }
+}
+
+fn update_direct_manifest_specs(
+    manifest: &mut aube_manifest::PackageJson,
+    old_graph: &aube_lockfile::LockfileGraph,
+    new_graph: &aube_lockfile::LockfileGraph,
+    fixed_names: &BTreeSet<String>,
+) -> bool {
+    let before = direct_versions_by_name(old_graph);
+    let after = direct_versions_by_name(new_graph);
+    let mut wrote_any = false;
+    for (key, spec) in mutable_manifest_dep_entries(manifest) {
+        let real_name = real_name_for_spec(&key, spec);
+        if !fixed_names.contains(&real_name) {
+            continue;
+        }
+        let (Some(old), Some(new)) = (before.get(&real_name), after.get(&real_name)) else {
+            continue;
+        };
+        if old == new {
+            continue;
+        }
+        let next = rewrite_specifier(spec, &real_name, new, None);
+        if next != *spec {
+            *spec = next;
+            wrote_any = true;
+        }
+    }
+    wrote_any
+}
+
+fn direct_versions_by_name(graph: &aube_lockfile::LockfileGraph) -> BTreeMap<String, String> {
+    graph
+        .root_deps()
+        .iter()
+        .filter_map(|dep| {
+            graph
+                .get_package(&dep.dep_path)
+                .map(|pkg| (pkg.registry_name().to_string(), pkg.version.clone()))
+        })
+        .collect()
+}
+
+fn mutable_manifest_dep_entries(
+    manifest: &mut aube_manifest::PackageJson,
+) -> impl Iterator<Item = (String, &mut String)> {
+    manifest
+        .dependencies
+        .iter_mut()
+        .chain(manifest.dev_dependencies.iter_mut())
+        .chain(manifest.optional_dependencies.iter_mut())
+        .map(|(key, spec)| (key.clone(), spec))
+}
+
+fn real_name_for_spec(manifest_key: &str, spec: &str) -> String {
+    if let Some(rest) = spec.strip_prefix("npm:") {
+        if let Some(at_idx) = rest.rfind('@') {
+            return rest[..at_idx].to_string();
+        }
+        return rest.to_string();
+    }
+    manifest_key.to_string()
+}
+
+fn rewrite_specifier(
+    original: &str,
+    real_name: &str,
+    resolved_version: &str,
+    force_prefix: Option<&str>,
+) -> String {
+    let (range, is_alias) = if let Some(rest) = original.strip_prefix("npm:") {
+        (rest.rsplit_once('@').map(|(_, r)| r).unwrap_or(""), true)
+    } else {
+        (original, false)
+    };
+    let prefix = force_prefix.unwrap_or_else(|| range_prefix(range));
+    let versioned = format!("{prefix}{resolved_version}");
+    if is_alias {
+        format!("npm:{real_name}@{versioned}")
+    } else {
+        versioned
+    }
+}
+
+fn spec_range(spec: &str) -> &str {
+    if let Some(rest) = spec.strip_prefix("npm:") {
+        rest.rsplit_once('@').map(|(_, range)| range).unwrap_or("")
+    } else {
+        spec
+    }
+}
+
+fn range_prefix(spec: &str) -> &'static str {
+    let trimmed = spec.trim_start();
+    if trimmed.starts_with('^') {
+        "^"
+    } else if trimmed.starts_with('~') {
+        "~"
+    } else if trimmed.starts_with(">=") {
+        ">="
+    } else if trimmed.starts_with("<=") {
+        "<="
+    } else if trimmed.starts_with('>') {
+        ">"
+    } else if trimmed.starts_with('<') {
+        "<"
+    } else if trimmed.starts_with('=') {
+        "="
+    } else {
+        ""
+    }
+}
+
+fn looks_like_exact_version(spec: &str) -> bool {
+    let mut chars = spec.trim_start().chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_digit() {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+'))
+}
+
+fn resolved_versions_by_name(
+    graph: &aube_lockfile::LockfileGraph,
+    filter: DepFilter,
+    no_optional: bool,
+    names: &BTreeSet<String>,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let closure = super::collect_dep_closure(graph, filter, no_optional);
+    let mut out: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for pkg in closure.values() {
+        let name = pkg.registry_name();
+        if names.contains(name) {
+            out.entry(name.to_string())
+                .or_default()
+                .insert(pkg.version.clone());
+        }
+    }
+    out
+}
+
+fn version_is_vulnerable(version: &str, vulnerable_versions: &[String]) -> bool {
+    let Ok(version) = node_semver::Version::parse(version) else {
+        return false;
+    };
+    vulnerable_versions
+        .iter()
+        .filter_map(|range| node_semver::Range::parse(range).ok())
+        .any(|range| version.satisfies(&range))
+}
+
 /// Atomic package.json write via tempfile + rename. Crash or Ctrl+C
 fn best_non_vulnerable(packument: &Packument, vulnerable_versions: &[String]) -> Option<String> {
     let vulnerable: Vec<node_semver::Range> = vulnerable_versions
@@ -459,7 +847,7 @@ fn best_non_vulnerable(packument: &Packument, vulnerable_versions: &[String]) ->
 
 /// Reachable packages from the filtered roots, keyed by `dep_path`.
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Row {
     name: String,
     severity: Severity,

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -552,7 +552,7 @@ async fn write_fix_lockfile_update(
     let workspace_catalogs = super::load_workspace_catalogs(cwd)?;
     let mut resolver = super::build_resolver(cwd, &resolver_manifest, workspace_catalogs)
         .with_vulnerable_ranges(vulnerable_ranges.clone());
-    let new_graph = resolver
+    let mut new_graph = resolver
         .resolve(&resolver_manifest, Some(graph))
         .await
         .map_err(miette::Report::new)
@@ -584,6 +584,7 @@ async fn write_fix_lockfile_update(
         eprintln!("Updated package.json");
     }
 
+    sync_root_dep_specifiers(&mut new_graph, &output_manifest);
     super::write_and_log_lockfile(cwd, &new_graph, &output_manifest)?;
     for name in &fixed {
         let old = before
@@ -643,7 +644,7 @@ fn widen_vulnerable_direct_pins(
         if !version_is_vulnerable(version, ranges) || !looks_like_exact_version(spec_range(spec)) {
             continue;
         }
-        *spec = rewrite_specifier(spec, &real_name, version, Some("^"));
+        *spec = rewrite_specifier(spec, &real_name, version, Some(">="));
     }
 }
 
@@ -677,6 +678,37 @@ fn update_direct_manifest_specs(
         }
     }
     wrote_any
+}
+
+fn sync_root_dep_specifiers(
+    graph: &mut aube_lockfile::LockfileGraph,
+    manifest: &aube_manifest::PackageJson,
+) {
+    let Some(deps) = graph.importers.get_mut(".") else {
+        return;
+    };
+    for dep in deps {
+        if let Some(spec) = manifest_spec_for_dep(manifest, dep) {
+            dep.specifier = Some(spec);
+        }
+    }
+}
+
+fn manifest_spec_for_dep(
+    manifest: &aube_manifest::PackageJson,
+    dep: &aube_lockfile::DirectDep,
+) -> Option<String> {
+    let section = match dep.dep_type {
+        aube_lockfile::DepType::Production => &manifest.dependencies,
+        aube_lockfile::DepType::Dev => &manifest.dev_dependencies,
+        aube_lockfile::DepType::Optional => &manifest.optional_dependencies,
+    };
+    section.get(&dep.name).cloned().or_else(|| {
+        section
+            .iter()
+            .find(|(key, spec)| real_name_for_spec(key, spec) == dep.name)
+            .map(|(_, spec)| spec.clone())
+    })
 }
 
 fn direct_versions_by_name(graph: &aube_lockfile::LockfileGraph) -> BTreeMap<String, String> {
@@ -723,13 +755,25 @@ fn rewrite_specifier(
     } else {
         (original, false)
     };
-    let prefix = force_prefix.unwrap_or_else(|| range_prefix(range));
+    let prefix = force_prefix.unwrap_or_else(|| rewrite_prefix(range));
     let versioned = format!("{prefix}{resolved_version}");
     if is_alias {
         format!("npm:{real_name}@{versioned}")
     } else {
         versioned
     }
+}
+
+fn rewrite_prefix(spec: &str) -> &'static str {
+    if is_compound_range(spec) {
+        ">="
+    } else {
+        range_prefix(spec)
+    }
+}
+
+fn is_compound_range(spec: &str) -> bool {
+    spec.contains("||") || spec.split_whitespace().nth(1).is_some()
 }
 
 fn spec_range(spec: &str) -> &str {
@@ -1050,6 +1094,22 @@ mod tests {
         assert!(spec_satisfies_version(">=0.1.0", "7.0.0"));
         assert!(spec_satisfies_version("npm:is-number@>=0.1.0", "7.0.0"));
         assert!(!spec_satisfies_version("3.0.0", "7.0.0"));
+    }
+
+    #[test]
+    fn audit_update_rewrites_compound_ranges_to_safe_floor() {
+        assert_eq!(
+            rewrite_specifier("^1.0.0 || ^2.0.0", "is-number", "7.0.0", None),
+            ">=7.0.0"
+        );
+        assert_eq!(
+            rewrite_specifier(">=1.0.0 <7.0.0", "is-number", "7.0.0", None),
+            ">=7.0.0"
+        );
+        assert_eq!(
+            rewrite_specifier("npm:is-number@^1.0.0 || ^2.0.0", "is-number", "7.0.0", None),
+            "npm:is-number@>=7.0.0"
+        );
     }
 
     #[test]

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -288,6 +288,19 @@ fn select_fix_rows(rows: &[Row]) -> miette::Result<Vec<Row>> {
         return Ok(rows.to_vec());
     }
 
+    let picked = match advisory_picker(rows).run() {
+        Ok(picked) => picked,
+        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => std::process::exit(130),
+        Err(e) => {
+            return Err(e)
+                .into_diagnostic()
+                .wrap_err("failed to read audit selection");
+        }
+    };
+    Ok(picked.into_iter().map(|idx| rows[idx].clone()).collect())
+}
+
+fn advisory_picker(rows: &[Row]) -> demand::MultiSelect<'_, usize> {
     let mut picker = demand::MultiSelect::new("Choose which vulnerabilities to fix")
         .description("Space to toggle, Enter to confirm")
         .filterable(true)
@@ -303,16 +316,7 @@ fn select_fix_rows(rows: &[Row]) -> miette::Result<Vec<Row>> {
         }
         picker = picker.option(option);
     }
-    let picked = match picker.run() {
-        Ok(picked) => picked,
-        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => std::process::exit(130),
-        Err(e) => {
-            return Err(e)
-                .into_diagnostic()
-                .wrap_err("failed to read audit selection");
-        }
-    };
-    Ok(picked.into_iter().map(|idx| rows[idx].clone()).collect())
+    picker
 }
 
 fn render_fix_remaining(selected: &[Row], remaining: &[Row]) {
@@ -663,6 +667,9 @@ fn update_direct_manifest_specs(
         if old == new {
             continue;
         }
+        if spec_satisfies_version(spec, new) {
+            continue;
+        }
         let next = rewrite_specifier(spec, &real_name, new, None);
         if next != *spec {
             *spec = next;
@@ -731,6 +738,15 @@ fn spec_range(spec: &str) -> &str {
     } else {
         spec
     }
+}
+
+fn spec_satisfies_version(spec: &str, version: &str) -> bool {
+    let Ok(version) = node_semver::Version::parse(version) else {
+        return false;
+    };
+    node_semver::Range::parse(spec_range(spec))
+        .ok()
+        .is_some_and(|range| version.satisfies(&range))
 }
 
 fn range_prefix(spec: &str) -> &'static str {
@@ -990,6 +1006,50 @@ mod tests {
             best_non_vulnerable(&packument, &["<1.5.0".to_string()]),
             Some("1.5.0".to_string())
         );
+    }
+
+    #[test]
+    fn audit_picker_preselects_every_advisory() {
+        let rows = vec![
+            Row {
+                name: "is-number".to_string(),
+                severity: Severity::High,
+                title: "number advisory".to_string(),
+                vulnerable_versions: "<7.0.0".to_string(),
+                url: "https://example.test/number".to_string(),
+            },
+            Row {
+                name: "is-odd".to_string(),
+                severity: Severity::Moderate,
+                title: "odd advisory".to_string(),
+                vulnerable_versions: "<3.0.0".to_string(),
+                url: String::new(),
+            },
+        ];
+
+        let picker = advisory_picker(&rows);
+
+        assert_eq!(picker.min, 1);
+        assert!(picker.filterable);
+        assert_eq!(picker.options.len(), 2);
+        assert!(picker.options.iter().all(|option| option.selected));
+        assert_eq!(picker.options[0].item, 0);
+        assert_eq!(
+            picker.options[0].label,
+            "high is-number <7.0.0 number advisory"
+        );
+        assert_eq!(
+            picker.options[0].description.as_deref(),
+            Some("https://example.test/number")
+        );
+        assert_eq!(picker.options[1].item, 1);
+    }
+
+    #[test]
+    fn audit_update_keeps_manifest_range_when_new_version_satisfies_it() {
+        assert!(spec_satisfies_version(">=0.1.0", "7.0.0"));
+        assert!(spec_satisfies_version("npm:is-number@>=0.1.0", "7.0.0"));
+        assert!(!spec_satisfies_version("3.0.0", "7.0.0"));
     }
 
     #[test]

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -570,15 +570,15 @@ async fn write_fix_lockfile_update(
         })
         .cloned()
         .collect();
-    let fixed = fixed_package_names(rows, &remaining, &before, &after);
+    let updated = updated_package_names(rows, &before, &after);
 
-    if fixed.is_empty() {
+    if updated.is_empty() {
         eprintln!("No audit lockfile updates available.");
         return Ok(remaining);
     }
 
     let mut output_manifest = manifest.clone();
-    if update_direct_manifest_specs(&mut output_manifest, graph, &new_graph, &fixed) {
+    if update_direct_manifest_specs(&mut output_manifest, graph, &new_graph, &updated) {
         let manifest_path = cwd.join("package.json");
         super::write_manifest_dep_sections(&manifest_path, &output_manifest)?;
         eprintln!("Updated package.json");
@@ -586,7 +586,7 @@ async fn write_fix_lockfile_update(
 
     sync_root_dep_specifiers(&mut new_graph, &output_manifest);
     super::write_and_log_lockfile(cwd, &new_graph, &output_manifest)?;
-    for name in &fixed {
+    for name in &updated {
         let old = before
             .get(name)
             .map(|v| v.iter().cloned().collect::<Vec<_>>().join(", "))
@@ -597,7 +597,7 @@ async fn write_fix_lockfile_update(
             .unwrap_or_else(|| "(removed)".to_string());
         eprintln!("  {name}: {old} -> {new}");
     }
-    eprintln!("Updated lockfile for {} package(s).", fixed.len());
+    eprintln!("Updated lockfile for {} package(s).", updated.len());
     Ok(remaining)
 }
 
@@ -612,16 +612,13 @@ fn vulnerable_ranges_by_name(rows: &[Row]) -> BTreeMap<String, Vec<String>> {
     vulnerable_ranges
 }
 
-fn fixed_package_names(
+fn updated_package_names(
     selected: &[Row],
-    remaining: &[Row],
     before: &BTreeMap<String, BTreeSet<String>>,
     after: &BTreeMap<String, BTreeSet<String>>,
 ) -> BTreeSet<String> {
-    let remaining_names: BTreeSet<&str> = remaining.iter().map(|row| row.name.as_str()).collect();
     selected
         .iter()
-        .filter(|row| !remaining_names.contains(row.name.as_str()))
         .filter(|row| before.get(&row.name) != after.get(&row.name))
         .map(|row| row.name.clone())
         .collect()
@@ -652,14 +649,14 @@ fn update_direct_manifest_specs(
     manifest: &mut aube_manifest::PackageJson,
     old_graph: &aube_lockfile::LockfileGraph,
     new_graph: &aube_lockfile::LockfileGraph,
-    fixed_names: &BTreeSet<String>,
+    updated_names: &BTreeSet<String>,
 ) -> bool {
     let before = direct_versions_by_name(old_graph);
     let after = direct_versions_by_name(new_graph);
     let mut wrote_any = false;
     for (key, spec) in mutable_manifest_dep_entries(manifest) {
         let real_name = real_name_for_spec(&key, spec);
-        if !fixed_names.contains(&real_name) {
+        if !updated_names.contains(&real_name) {
             continue;
         }
         let (Some(old), Some(new)) = (before.get(&real_name), after.get(&real_name)) else {
@@ -1109,6 +1106,30 @@ mod tests {
         assert_eq!(
             rewrite_specifier("npm:is-number@^1.0.0 || ^2.0.0", "is-number", "7.0.0", None),
             "npm:is-number@>=7.0.0"
+        );
+    }
+
+    #[test]
+    fn audit_update_tracks_partially_fixed_package_updates() {
+        let rows = vec![Row {
+            name: "is-number".to_string(),
+            severity: Severity::High,
+            title: "number advisory".to_string(),
+            vulnerable_versions: "<7.0.0".to_string(),
+            url: String::new(),
+        }];
+        let before = BTreeMap::from([(
+            "is-number".to_string(),
+            BTreeSet::from(["3.0.0".to_string()]),
+        )]);
+        let after = BTreeMap::from([(
+            "is-number".to_string(),
+            BTreeSet::from(["7.0.0".to_string()]),
+        )]);
+
+        assert_eq!(
+            updated_package_names(&rows, &before, &after),
+            BTreeSet::from(["is-number".to_string()])
         );
     }
 

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -26,9 +26,16 @@ One of: `low`, `moderate`, `high`, `critical`. Default: `low`.
 
 Only audit `devDependencies`
 
-### `--fix`
+### `--fix <FIX>`
 
-Write package.json overrides that force vulnerable packages to patched versions
+Fix advisories.
+
+Bare `--fix` writes package.json overrides for backwards compatibility. `--fix=update` refreshes the lockfile without writing overrides.
+
+**Choices:**
+
+- `update`
+- `override`
 
 ### `--ignore… <ID>`
 
@@ -47,6 +54,10 @@ Useful when audit checks run in CI and the registry has a hiccup.
 Drop advisories for which no non-vulnerable version is available in the package's packument.
 
 Same "best non-vulnerable" logic as `--fix`: an advisory is kept only when an upgrade path exists.
+
+### `-i --interactive`
+
+Pick which advisories to fix interactively
 
 ### `--json`
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -269,15 +269,29 @@
           },
           {
             "name": "fix",
-            "usage": "--fix",
-            "help": "Write package.json overrides that force vulnerable packages to patched versions",
-            "help_first_line": "Write package.json overrides that force vulnerable packages to patched versions",
+            "usage": "--fix <FIX>",
+            "help": "Fix advisories",
+            "help_long": "Fix advisories.\n\nBare `--fix` writes package.json overrides for backwards compatibility. `--fix=update` refreshes the lockfile without writing overrides.",
+            "help_first_line": "Fix advisories",
             "short": [],
             "long": [
               "fix"
             ],
             "hide": false,
-            "global": false
+            "global": false,
+            "arg": {
+              "name": "FIX",
+              "usage": "<FIX>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false,
+              "choices": {
+                "choices": [
+                  "update",
+                  "override"
+                ]
+              }
+            }
           },
           {
             "name": "ignore",
@@ -322,6 +336,20 @@
             "short": [],
             "long": [
               "ignore-unfixable"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "interactive",
+            "usage": "-i --interactive",
+            "help": "Pick which advisories to fix interactively",
+            "help_first_line": "Pick which advisories to fix interactively",
+            "short": [
+              "i"
+            ],
+            "long": [
+              "interactive"
             ],
             "hide": false,
             "global": false

--- a/test/audit.bats
+++ b/test/audit.bats
@@ -198,6 +198,37 @@ _write_audit_update_fixture() {
 	EOF
 }
 
+_write_audit_update_exact_fixture() {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "audit-update-exact-fixture",
+		  "version": "1.0.0",
+		  "dependencies": { "is-number": "3.0.0" }
+		}
+	EOF
+	cat >aube-lock.yaml <<-'EOF'
+		lockfileVersion: '9.0'
+
+		settings:
+		  autoInstallPeers: true
+		  excludeLinksFromLockfile: false
+
+		importers:
+		  .:
+		    dependencies:
+		      is-number:
+		        specifier: 3.0.0
+		        version: 3.0.0
+
+		packages:
+		  is-number@3.0.0:
+		    resolution: {integrity: sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==}
+
+		snapshots:
+		  is-number@3.0.0: {}
+	EOF
+}
+
 @test "aube audit --fix writes package.json overrides" {
 	_install_audit_fixture
 	_start_audit_server
@@ -258,6 +289,24 @@ _write_audit_update_fixture() {
 	assert_success
 
 	run node -e 'const p=require("./package.json"); if (p.overrides) process.exit(1)'
+	assert_success
+}
+
+@test "aube audit --fix=update keeps exact pins aligned with lockfile specifiers" {
+	_write_audit_update_exact_fixture
+	_start_audit_server
+	port="$(cat audit-server-port)"
+	echo "registry=http://127.0.0.1:${port}/" >.npmrc
+
+	run aube audit --fix=update
+	_stop_audit_server
+	assert_success
+	assert_output --partial "Updated lockfile for 1 package"
+
+	run node -e 'const p=require("./package.json"); if (p.dependencies["is-number"] !== "7.0.0") process.exit(1)'
+	assert_success
+
+	run grep 'specifier: 7.0.0' aube-lock.yaml
 	assert_success
 }
 

--- a/test/audit.bats
+++ b/test/audit.bats
@@ -167,6 +167,37 @@ _install_audit_fixture() {
 	assert_success
 }
 
+_write_audit_update_fixture() {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "audit-update-fixture",
+		  "version": "1.0.0",
+		  "dependencies": { "is-number": ">=0.1.0" }
+		}
+	EOF
+	cat >aube-lock.yaml <<-'EOF'
+		lockfileVersion: '9.0'
+
+		settings:
+		  autoInstallPeers: true
+		  excludeLinksFromLockfile: false
+
+		importers:
+		  .:
+		    dependencies:
+		      is-number:
+		        specifier: '>=0.1.0'
+		        version: 3.0.0
+
+		packages:
+		  is-number@3.0.0:
+		    resolution: {integrity: sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==}
+
+		snapshots:
+		  is-number@3.0.0: {}
+	EOF
+}
+
 @test "aube audit --fix writes package.json overrides" {
 	_install_audit_fixture
 	_start_audit_server
@@ -175,11 +206,58 @@ _install_audit_fixture() {
 
 	run aube audit --fix
 	_stop_audit_server
-	assert_failure
-	[ "$status" -eq 1 ]
+	assert_success
 	assert_output --partial "Updated package.json overrides"
 
 	run node -e 'const p=require("./package.json"); if (p.overrides["is-number"] !== "7.0.0") process.exit(1)'
+	assert_success
+}
+
+@test "aube audit --fix=override writes package.json overrides" {
+	_install_audit_fixture
+	_start_audit_server
+	port="$(cat audit-server-port)"
+	echo "registry=http://127.0.0.1:${port}/" >.npmrc
+
+	run aube audit --fix=override
+	_stop_audit_server
+	assert_success
+	assert_output --partial "Updated package.json overrides"
+
+	run node -e 'const p=require("./package.json"); if (p.overrides["is-number"] !== "7.0.0") process.exit(1)'
+	assert_success
+}
+
+@test "aube audit -i defaults to override fix mode" {
+	_install_audit_fixture
+	_start_audit_server
+	port="$(cat audit-server-port)"
+	echo "registry=http://127.0.0.1:${port}/" >.npmrc
+
+	run aube audit -i
+	_stop_audit_server
+	assert_success
+	assert_output --partial "Updated package.json overrides"
+
+	run node -e 'const p=require("./package.json"); if (p.overrides["is-number"] !== "7.0.0") process.exit(1)'
+	assert_success
+}
+
+@test "aube audit --fix=update refreshes the lockfile without overrides" {
+	_write_audit_update_fixture
+	_start_audit_server
+	port="$(cat audit-server-port)"
+	echo "registry=http://127.0.0.1:${port}/" >.npmrc
+
+	run aube audit --fix=update
+	_stop_audit_server
+	assert_success
+	assert_output --partial "Updated lockfile for 1 package"
+
+	run grep 'is-number@7.0.0' aube-lock.yaml
+	assert_success
+
+	run node -e 'const p=require("./package.json"); if (p.overrides) process.exit(1)'
 	assert_success
 }
 


### PR DESCRIPTION
## What changed

- Adds pnpm-compatible `aube audit --fix=update` to update vulnerable packages through the lockfile instead of writing overrides.
- Changes `--fix` into pnpm's optional method form: bare `--fix` defaults to `override`, and `--fix=override` / `--fix=update` are accepted.
- Allows `aube audit -i` to default into override fix mode, matching pnpm's interactive behavior.
- Adds resolver support for advisory ranges so audit update mode avoids vulnerable versions during sibling reuse, lockfile reuse, and version picking.

## Why

pnpm 11 added `audit --fix=update` as the user-visible path for fixing advisories without generating override entries. Aube's previous audit fix path was override-only, so users coming from pnpm 11 got the wrong behavior.

## Validation

- `cargo check -q`
- `cargo build -q`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p aube-resolver test_pick_version_prefers_locked -- --nocapture`
- `mise run test:bats test/audit.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `aube audit` from read-only to optionally rewriting `package.json` and the lockfile, and alters resolver version-picking behavior when vulnerable ranges are provided; this can impact dependency graphs and reproducibility if the avoidance logic is wrong.
> 
> **Overview**
> Adds pnpm-compatible audit fixing modes: `--fix` now accepts optional values (`override` default, `update` to refresh the lockfile) and introduces `-i/--interactive` to select which advisories to fix.
> 
> Implements `--fix=update` by re-running resolution while steering specific packages away from advisory semver ranges, then writing updated `aube-lock.yaml` and (when needed) adjusting direct dependency specifiers to match the new resolved versions.
> 
> Extends the resolver with `vulnerable_ranges` support so sibling reuse, lockfile reuse, and version picking prefer non-vulnerable versions when available, while falling back to the original pick if no safe version exists; updates CLI docs/usage metadata and expands bats/unit tests to cover the new behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3a4398c80c50b58ebe9b8db429325936662be9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->