### PR TITLE
feat(install): adopt pnpm 11 allowBuilds reviews

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -106,7 +106,7 @@ cmd add help="Add a dependency" {
     }
     arg "[PACKAGES]…" help="Package(s) to add" required=#false var=#true
 }
-cmd approve-builds help="Approve ignored dependency build scripts and record them in `pnpm-workspace.yaml`'s `onlyBuiltDependencies`" {
+cmd approve-builds help="Approve ignored dependency build scripts in `pnpm-workspace.yaml`'s `allowBuilds`" {
     flag --all help="Approve every pending ignored build without prompting"
     flag "-g --global" help="Operate on globally-installed packages instead of the current project"
     arg "[PKG]…" help="Packages to approve directly, skipping the picker. Each name must match a currently-ignored build. Unknown names are rejected so a typo cannot silently no-op" required=#false var=#true
@@ -861,4 +861,3 @@ cmd why help="Print reverse dependency chains explaining why a package is instal
     flag --parseable help="Tab-separated output: one line per chain, `importer\\tdep_type\\tname@ver\\t...`"
     arg <PACKAGE> help="Package name to search for (exact match against package names)"
 }
-

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -861,3 +861,4 @@ cmd why help="Print reverse dependency chains explaining why a package is instal
     flag --parseable help="Tab-separated output: one line per chain, `importer\\tdep_type\\tname@ver\\t...`"
     arg <PACKAGE> help="Package name to search for (exact match against package names)"
 }
+

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -628,7 +628,12 @@ fn write_to_yaml(
     })?;
 
     for name in names {
-        allow_builds.insert(Value::String(name.clone()), Value::Bool(allowed));
+        let key = Value::String(name.clone());
+        if allowed {
+            allow_builds.insert(key, Value::Bool(true));
+        } else {
+            allow_builds.entry(key).or_insert(Value::Bool(false));
+        }
     }
 
     let raw = yaml_serde::to_string(&doc)
@@ -894,6 +899,31 @@ patchedDependencies:
         let config = WorkspaceConfig::load(dir.path()).unwrap();
         assert!(matches!(
             config.allow_builds.get("esbuild"),
+            Some(yaml_serde::Value::Bool(false))
+        ));
+    }
+
+    #[test]
+    fn add_to_allow_builds_false_does_not_revoke_approved_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "allowBuilds:\n  esbuild: true\n",
+        )
+        .unwrap();
+        add_to_allow_builds(
+            dir.path(),
+            &["sharp".to_string(), "esbuild".to_string()],
+            false,
+        )
+        .unwrap();
+        let config = WorkspaceConfig::load(dir.path()).unwrap();
+        assert!(matches!(
+            config.allow_builds.get("esbuild"),
+            Some(yaml_serde::Value::Bool(true))
+        ));
+        assert!(matches!(
+            config.allow_builds.get("sharp"),
             Some(yaml_serde::Value::Bool(false))
         ));
     }

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -557,42 +557,44 @@ pub fn load_both(
     Ok((typed, raw))
 }
 
-/// Resolve which workspace-yaml path `add_to_only_built_dependencies`
-/// would mutate in `project_dir`. Returns `None` when no yaml exists —
-/// callers fall back to `package.json` so a stray `aube approve-builds`
-/// in a plain npm/yarn project doesn't fabricate a `pnpm-workspace.yaml`.
-pub fn workspace_yaml_target(project_dir: &Path) -> Option<std::path::PathBuf> {
+/// Resolve which workspace-yaml path `add_to_allow_builds` should
+/// mutate in `project_dir`. Existing `aube-workspace.yaml` wins over
+/// `pnpm-workspace.yaml`; when neither exists, create
+/// `pnpm-workspace.yaml` to match pnpm's build-review behavior.
+pub fn workspace_yaml_target(project_dir: &Path) -> std::path::PathBuf {
     for name in WORKSPACE_YAML_NAMES {
         let path = project_dir.join(name);
         if path.exists() {
-            return Some(path);
+            return path;
         }
     }
-    None
+    project_dir.join("pnpm-workspace.yaml")
 }
 
-/// Merge `names` into the workspace's `onlyBuiltDependencies` list.
+/// Merge `names` into the workspace's `allowBuilds` map.
 ///
 /// Write-target precedence:
-/// 1. `aube-workspace.yaml` if it exists — top-level `onlyBuiltDependencies`.
-/// 2. `pnpm-workspace.yaml` if it exists — top-level `onlyBuiltDependencies`.
-/// 3. Otherwise — `package.json` under `pnpm.onlyBuiltDependencies`.
+/// 1. `aube-workspace.yaml` if it exists — top-level `allowBuilds`.
+/// 2. `pnpm-workspace.yaml` if it exists — top-level `allowBuilds`.
+/// 3. Otherwise — create `pnpm-workspace.yaml` with top-level `allowBuilds`.
 ///
-/// The install-time build policy reads from all three sources (see
-/// `pnpm_only_built_dependencies` and `WorkspaceConfig::only_built_dependencies`),
-/// so the chosen target is honored regardless of which path the project
-/// uses. Returns the file that was written.
-pub fn add_to_only_built_dependencies(
+/// `allowed=true` is used by `aube approve-builds`; `allowed=false` is
+/// used by install to seed unreviewed packages for later review. Returns
+/// the file that was written.
+pub fn add_to_allow_builds(
     project_dir: &Path,
     names: &[String],
+    allowed: bool,
 ) -> Result<std::path::PathBuf, crate::Error> {
-    if let Some(path) = workspace_yaml_target(project_dir) {
-        return write_to_yaml(&path, names);
-    }
-    write_to_package_json(&project_dir.join("package.json"), names)
+    let path = workspace_yaml_target(project_dir);
+    write_to_yaml(&path, names, allowed)
 }
 
-fn write_to_yaml(path: &Path, names: &[String]) -> Result<std::path::PathBuf, crate::Error> {
+fn write_to_yaml(
+    path: &Path,
+    names: &[String],
+    allowed: bool,
+) -> Result<std::path::PathBuf, crate::Error> {
     use yaml_serde::{Mapping, Value};
 
     let mut doc: Value = if path.exists() {
@@ -614,25 +616,19 @@ fn write_to_yaml(path: &Path, names: &[String]) -> Result<std::path::PathBuf, cr
         )
     })?;
 
-    let key = Value::String("onlyBuiltDependencies".to_string());
+    let key = Value::String("allowBuilds".to_string());
     let existing = map
         .entry(key.clone())
-        .or_insert_with(|| Value::Sequence(Vec::new()));
-    let seq = existing.as_sequence_mut().ok_or_else(|| {
+        .or_insert_with(|| Value::Mapping(Mapping::new()));
+    let allow_builds = existing.as_mapping_mut().ok_or_else(|| {
         crate::Error::YamlParse(
             path.to_path_buf(),
-            "`onlyBuiltDependencies` must be a sequence".to_string(),
+            "`allowBuilds` must be a mapping".to_string(),
         )
     })?;
 
-    let mut have: std::collections::HashSet<String> = seq
-        .iter()
-        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-        .collect();
     for name in names {
-        if have.insert(name.clone()) {
-            seq.push(Value::String(name.clone()));
-        }
+        allow_builds.insert(Value::String(name.clone()), Value::Bool(allowed));
     }
 
     let raw = yaml_serde::to_string(&doc)
@@ -644,76 +640,6 @@ fn write_to_yaml(path: &Path, names: &[String]) -> Result<std::path::PathBuf, cr
     // column; bumping every sequence line by two is a consistent transform.
     let indented = indent_block_sequences(&raw);
     aube_util::fs_atomic::atomic_write(path, indented.as_bytes())
-        .map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
-    Ok(path.to_path_buf())
-}
-
-fn write_to_package_json(
-    path: &Path,
-    names: &[String],
-) -> Result<std::path::PathBuf, crate::Error> {
-    use serde_json::{Map, Value};
-
-    let content =
-        std::fs::read_to_string(path).map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
-    let mut doc: Value = crate::parse_json(path, content)?;
-
-    let obj = doc.as_object_mut().ok_or_else(|| {
-        crate::Error::parse_msg(
-            path,
-            String::new(),
-            "top-level package.json must be an object".to_string(),
-        )
-    })?;
-
-    let pnpm = obj
-        .entry("pnpm")
-        .or_insert_with(|| Value::Object(Map::new()));
-    let pnpm_obj = pnpm.as_object_mut().ok_or_else(|| {
-        crate::Error::parse_msg(
-            path,
-            String::new(),
-            "`pnpm` in package.json must be an object".to_string(),
-        )
-    })?;
-
-    let arr = pnpm_obj
-        .entry("onlyBuiltDependencies")
-        .or_insert_with(|| Value::Array(Vec::new()))
-        .as_array_mut()
-        .ok_or_else(|| {
-            crate::Error::parse_msg(
-                path,
-                String::new(),
-                "`pnpm.onlyBuiltDependencies` in package.json must be an array".to_string(),
-            )
-        })?;
-
-    let mut have: std::collections::HashSet<String> = arr
-        .iter()
-        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-        .collect();
-    for name in names {
-        if have.insert(name.clone()) {
-            arr.push(Value::String(name.clone()));
-        }
-    }
-
-    // Workspace Cargo.toml enables serde_json's `preserve_order` feature,
-    // so `Value::Object` is backed by IndexMap and `to_string_pretty`
-    // emits keys in original file order. Newly-inserted keys (`pnpm`
-    // when absent) are appended at the end. Without that feature the
-    // round-trip would alphabetize every key in package.json — noisy
-    // diffs the user didn't ask for.
-    //
-    // serde_json::to_string_pretty on a Value built from string keys,
-    // arrays, and primitives can't fail — the only documented errors
-    // (non-string map keys, infinite floats) are unreachable here.
-    let body = format!(
-        "{}\n",
-        serde_json::to_string_pretty(&doc).expect("well-formed Value never fails to serialize")
-    );
-    aube_util::fs_atomic::atomic_write(path, body.as_bytes())
         .map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
     Ok(path.to_path_buf())
 }
@@ -911,85 +837,98 @@ patchedDependencies:
     }
 
     #[test]
-    fn add_to_only_built_deps_writes_to_package_json_when_no_yaml() {
-        // Approve-builds in a plain npm/yarn project (no workspace yaml)
-        // must NOT fabricate a pnpm-workspace.yaml. The same data lives
-        // happily under `pnpm.onlyBuiltDependencies` in package.json,
-        // which the install-time policy already reads.
+    fn add_to_allow_builds_creates_pnpm_workspace_when_no_yaml() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("package.json"),
             r#"{"name":"solo","version":"0.0.0"}"#,
         )
         .unwrap();
-        let path = add_to_only_built_dependencies(
+        let path = add_to_allow_builds(
             dir.path(),
             &["esbuild".to_string(), "sharp".to_string()],
+            true,
         )
         .unwrap();
-        assert_eq!(path, dir.path().join("package.json"));
-        assert!(
-            !dir.path().join("pnpm-workspace.yaml").exists(),
-            "approve-builds must not create pnpm-workspace.yaml in a non-pnpm project",
-        );
-        let manifest = crate::PackageJson::from_path(&path).unwrap();
-        assert_eq!(
-            manifest.pnpm_only_built_dependencies(),
-            vec!["esbuild", "sharp"]
-        );
+        assert_eq!(path, dir.path().join("pnpm-workspace.yaml"));
+        let config = WorkspaceConfig::load(dir.path()).unwrap();
+        assert!(matches!(
+            config.allow_builds.get("esbuild"),
+            Some(yaml_serde::Value::Bool(true))
+        ));
+        assert!(matches!(
+            config.allow_builds.get("sharp"),
+            Some(yaml_serde::Value::Bool(true))
+        ));
     }
 
     #[test]
-    fn add_to_only_built_deps_appends_to_package_json_pnpm_namespace() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join("package.json"),
-            r#"{"name":"solo","pnpm":{"onlyBuiltDependencies":["esbuild"]}}"#,
-        )
-        .unwrap();
-        add_to_only_built_dependencies(dir.path(), &["sharp".to_string(), "esbuild".to_string()])
-            .unwrap();
-        let manifest = crate::PackageJson::from_path(&dir.path().join("package.json")).unwrap();
-        assert_eq!(
-            manifest.pnpm_only_built_dependencies(),
-            vec!["esbuild", "sharp"]
-        );
-    }
-
-    #[test]
-    fn add_to_only_built_deps_errors_without_yaml_or_package_json() {
-        let dir = tempfile::tempdir().unwrap();
-        let err = add_to_only_built_dependencies(dir.path(), &["esbuild".to_string()]).unwrap_err();
-        // No yaml + no package.json → I/O error reading package.json,
-        // not a silently-fabricated workspace yaml.
-        assert!(
-            matches!(err, crate::Error::Io(_, _)),
-            "expected Io error for missing package.json, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn add_to_only_built_deps_appends_and_dedupes() {
+    fn add_to_allow_builds_flips_existing_workspace_entries() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("pnpm-workspace.yaml"),
-            "packages:\n  - 'packages/*'\nonlyBuiltDependencies:\n  - esbuild\n",
+            "allowBuilds:\n  esbuild: false\n",
         )
         .unwrap();
-        add_to_only_built_dependencies(dir.path(), &["sharp".to_string(), "esbuild".to_string()])
-            .unwrap();
+        add_to_allow_builds(
+            dir.path(),
+            &["sharp".to_string(), "esbuild".to_string()],
+            true,
+        )
+        .unwrap();
         let config = WorkspaceConfig::load(dir.path()).unwrap();
-        assert_eq!(config.packages, vec!["packages/*"]);
-        assert_eq!(config.only_built_dependencies, vec!["esbuild", "sharp"]);
-        // Formatting sanity: emitted lines must be `  - <name>` so tools
-        // grepping `  - foo` (and human readers) see the expected shape.
-        let on_disk = std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml")).unwrap();
-        assert!(on_disk.contains("\n  - esbuild"), "got:\n{on_disk}");
-        assert!(on_disk.contains("\n  - sharp"), "got:\n{on_disk}");
+        assert!(matches!(
+            config.allow_builds.get("esbuild"),
+            Some(yaml_serde::Value::Bool(true))
+        ));
+        assert!(matches!(
+            config.allow_builds.get("sharp"),
+            Some(yaml_serde::Value::Bool(true))
+        ));
     }
 
     #[test]
-    fn add_to_only_built_deps_writes_to_aube_file_when_present() {
+    fn add_to_allow_builds_writes_false_for_review() {
+        let dir = tempfile::tempdir().unwrap();
+        add_to_allow_builds(dir.path(), &["esbuild".to_string()], false).unwrap();
+        let config = WorkspaceConfig::load(dir.path()).unwrap();
+        assert!(matches!(
+            config.allow_builds.get("esbuild"),
+            Some(yaml_serde::Value::Bool(false))
+        ));
+    }
+
+    #[test]
+    fn add_to_allow_builds_appends_and_dedupes() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'\nallowBuilds:\n  esbuild: true\n",
+        )
+        .unwrap();
+        add_to_allow_builds(
+            dir.path(),
+            &["sharp".to_string(), "esbuild".to_string()],
+            true,
+        )
+        .unwrap();
+        let config = WorkspaceConfig::load(dir.path()).unwrap();
+        assert_eq!(config.packages, vec!["packages/*"]);
+        assert!(matches!(
+            config.allow_builds.get("esbuild"),
+            Some(yaml_serde::Value::Bool(true))
+        ));
+        assert!(matches!(
+            config.allow_builds.get("sharp"),
+            Some(yaml_serde::Value::Bool(true))
+        ));
+        let on_disk = std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml")).unwrap();
+        assert!(on_disk.contains("\n  esbuild: true"), "got:\n{on_disk}");
+        assert!(on_disk.contains("\n  sharp: true"), "got:\n{on_disk}");
+    }
+
+    #[test]
+    fn add_to_allow_builds_writes_to_aube_file_when_present() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("aube-workspace.yaml"),
@@ -1001,10 +940,10 @@ patchedDependencies:
             "packages:\n  - 'p/*'\n",
         )
         .unwrap();
-        let path = add_to_only_built_dependencies(dir.path(), &["esbuild".to_string()]).unwrap();
+        let path = add_to_allow_builds(dir.path(), &["esbuild".to_string()], true).unwrap();
         assert_eq!(path, dir.path().join("aube-workspace.yaml"));
         let pnpm = std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml")).unwrap();
-        assert!(!pnpm.contains("onlyBuiltDependencies"));
+        assert!(!pnpm.contains("allowBuilds"));
     }
 
     #[test]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1806,9 +1806,9 @@ aube never runs dependency lifecycle scripts unless the package is
 listed in `allowBuilds` or `--dangerously-allow-all-builds` is set.
 With `strictDepBuilds = true`, an install that sees unreviewed build
 scripts fails after linking and before any dependency build scripts run.
-Add reviewed packages to `allowBuilds` / `onlyBuiltDependencies`, add
-intentionally skipped packages to `neverBuiltDependencies`, or leave the
-default `strictDepBuilds=false` behavior to skip unreviewed builds.
+Add reviewed packages to `allowBuilds` with `true`, keep intentionally
+skipped packages as `false`, or leave the default `strictDepBuilds=false`
+behavior to skip unreviewed builds.
 """
 sources.cli = []
 sources.env = ["npm_config_strict_dep_builds", "NPM_CONFIG_STRICT_DEP_BUILDS", "AUBE_STRICT_DEP_BUILDS"]
@@ -1820,12 +1820,14 @@ description = "Explicitly allow or disallow script execution per package."
 type = "object"
 default = "undefined"
 docs = """
-Per-package allowlist for dependency lifecycle scripts. Read from
-`package.json`'s `pnpm.allowBuilds` field and `aube-workspace.yaml`'s
+Per-package review map for dependency lifecycle scripts. Read from
+`package.json`'s `pnpm.allowBuilds` field and workspace yaml's
 `allowBuilds`. Keys are package name patterns (`esbuild`, `@scope/*`,
 `pkg@1.0.0 || 2.0.0`); values are `true` to allow `preinstall` /
-`install` / `postinstall` scripts for that package or `false` to block
-them. Packages not listed are skipped by default (aube's safe default).
+`install` / `postinstall` scripts for that package or `false` to record
+an intentional skip. Packages not listed are skipped by default, and
+install adds unreviewed build packages to workspace `allowBuilds` as
+`false` for later review.
 """
 sources.cli = []
 sources.env = []

--- a/crates/aube/src/commands/approve_builds.rs
+++ b/crates/aube/src/commands/approve_builds.rs
@@ -1,20 +1,14 @@
-//! `aube approve-builds` — write packages into
-//! `pnpm-workspace.yaml`'s `onlyBuiltDependencies` so their install
-//! scripts run on the next `aube install`.
+//! `aube approve-builds` — flip packages to `true` in
+//! `pnpm-workspace.yaml`'s `allowBuilds` map so their install scripts
+//! run on the next `aube install`.
 //!
 //! Walks the lockfile via `ignored_builds::collect_ignored`, presents an
 //! interactive multi-select picker (or approves everything under
 //! `--all`), then merges the selections into the workspace yaml's
-//! `onlyBuiltDependencies` sequence. Matches pnpm v10+, which moved
-//! build approvals out of `package.json`'s `pnpm.allowBuilds` and
-//! into `pnpm-workspace.yaml`. Entries are added as bare package names
-//! so a future resolution of the same dep under a different version
-//! keeps working without re-prompting.
-//!
-//! Existing projects with `pnpm.allowBuilds` in `package.json` still
-//! have those entries honored at install time — the install-time
-//! build policy reads both sources — so this change is a write-target
-//! swap, not a read-side break.
+//! `allowBuilds` map. Matches pnpm v11, which collapsed the old
+//! allow/deny list keys into one review map. Entries are added as bare
+//! package names so a future resolution of the same dep under a
+//! different version keeps working without re-prompting.
 
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
@@ -63,7 +57,7 @@ fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<(
         return Ok(());
     }
 
-    let written = aube_manifest::workspace::add_to_only_built_dependencies(cwd, &selected)
+    let written = aube_manifest::workspace::add_to_allow_builds(cwd, &selected, true)
         .into_diagnostic()
         .wrap_err("failed to update workspace yaml")?;
 
@@ -120,10 +114,9 @@ fn run_global(args: ApproveBuildsArgs) -> miette::Result<()> {
     let mut approved = 0usize;
     let mut written_dirs = 0usize;
     for (install_dir, names) in selected {
-        let written =
-            aube_manifest::workspace::add_to_only_built_dependencies(&install_dir, &names)
-                .into_diagnostic()
-                .wrap_err("failed to update global install workspace yaml")?;
+        let written = aube_manifest::workspace::add_to_allow_builds(&install_dir, &names, true)
+            .into_diagnostic()
+            .wrap_err("failed to update global install workspace yaml")?;
         written_dirs += 1;
         approved += names.len();
         println!(

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3324,8 +3324,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             placements_ref,
         )?;
         if !unreviewed.is_empty() {
+            let review_names = allow_build_review_names(&unreviewed);
+            aube_manifest::workspace::add_to_allow_builds(&cwd, &review_names, false)
+                .into_diagnostic()
+                .wrap_err("failed to update allowBuilds review entries")?;
             return Err(miette!(
-                "dependencies with build scripts must be reviewed before install:\n{}\nhelp: add them to `allowBuilds` / `onlyBuiltDependencies`, set `neverBuiltDependencies`, or set `strictDepBuilds=false`",
+                "dependencies with build scripts must be reviewed before install:\n{}\nhelp: set them to true or false in `allowBuilds`, or set `strictDepBuilds=false`",
                 unreviewed
                     .into_iter()
                     .map(|pkg| format!("  - {pkg}"))
@@ -3626,6 +3630,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             placements_ref,
         )?;
         if !unreviewed.is_empty() {
+            let review_names = allow_build_review_names(&unreviewed);
+            aube_manifest::workspace::add_to_allow_builds(&cwd, &review_names, false)
+                .into_diagnostic()
+                .wrap_err("failed to update allowBuilds review entries")?;
             // Cap the inline list so a napi-rs / prebuilt-variants tree
             // (tens of per-platform binding packages) doesn't splat into
             // one hard-to-scan line. Users who want the full list run
@@ -3649,6 +3657,27 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+fn allow_build_review_names(specs: &[String]) -> Vec<String> {
+    specs
+        .iter()
+        .map(|spec| package_name_from_spec_key(spec))
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn package_name_from_spec_key(spec: &str) -> String {
+    if spec.starts_with('@') {
+        return spec
+            .rsplit_once('@')
+            .map(|(name, _)| name.to_string())
+            .unwrap_or_else(|| spec.to_string());
+    }
+    spec.split_once('@')
+        .map(|(name, _)| name.to_string())
+        .unwrap_or_else(|| spec.to_string())
 }
 
 fn print_already_up_to_date() {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3670,14 +3670,33 @@ fn allow_build_review_names(specs: &[String]) -> Vec<String> {
 
 fn package_name_from_spec_key(spec: &str) -> String {
     if spec.starts_with('@') {
-        return spec
-            .rsplit_once('@')
-            .map(|(name, _)| name.to_string())
-            .unwrap_or_else(|| spec.to_string());
+        if let Some((name, _)) = spec.rsplit_once('@')
+            && !name.is_empty()
+        {
+            return name.to_string();
+        }
+        return spec.to_string();
     }
     spec.split_once('@')
         .map(|(name, _)| name.to_string())
         .unwrap_or_else(|| spec.to_string())
+}
+
+#[cfg(test)]
+mod allow_build_review_tests {
+    use super::package_name_from_spec_key;
+
+    #[test]
+    fn package_name_from_spec_key_handles_scoped_names() {
+        assert_eq!(package_name_from_spec_key("@scope/pkg@1.2.3"), "@scope/pkg");
+        assert_eq!(package_name_from_spec_key("@scope/pkg"), "@scope/pkg");
+    }
+
+    #[test]
+    fn package_name_from_spec_key_handles_unscoped_names() {
+        assert_eq!(package_name_from_spec_key("esbuild@1.2.3"), "esbuild");
+        assert_eq!(package_name_from_spec_key("esbuild"), "esbuild");
+    }
 }
 
 fn print_already_up_to_date() {

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -347,7 +347,7 @@ enum Commands {
     /// Add a dependency
     #[command(visible_alias = "a")]
     Add(commands::add::AddArgs),
-    /// Approve ignored dependency build scripts and record them in `pnpm-workspace.yaml`'s `onlyBuiltDependencies`
+    /// Approve ignored dependency build scripts in `pnpm-workspace.yaml`'s `allowBuilds`
     ApproveBuilds(commands::approve_builds::ApproveBuildsArgs),
     /// Check installed packages against the registry advisory DB
     #[command(after_long_help = commands::audit::AFTER_LONG_HELP)]

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .vitepress/dist
 .vitepress/cache
 .pnpm-store
+pnpm-workspace.yaml

--- a/docs/bun-users.md
+++ b/docs/bun-users.md
@@ -50,10 +50,9 @@ future installs keep writing `aube-lock.yaml`.
   `trustedDependencies` array in addition to pnpm's
   `pnpm.allowBuilds` / `pnpm.onlyBuiltDependencies`, so an existing
   Bun manifest keeps running its install scripts without edits.
-  `aube approve-builds` writes new entries into
-  `pnpm-workspace.yaml`'s `onlyBuiltDependencies`; a package in
-  `pnpm.neverBuiltDependencies` is denied even if it appears in
-  `trustedDependencies`. Approved dependency builds can also run in a
+  Install writes unreviewed packages into `pnpm-workspace.yaml`'s
+  `allowBuilds` with `false`; `aube approve-builds` flips reviewed entries
+  to `true`. Approved dependency builds can also run in a
   [jail](/package-manager/jailed-builds) with package-specific env, path,
   and network permissions.
 

--- a/docs/cli/approve-builds.md
+++ b/docs/cli/approve-builds.md
@@ -3,7 +3,7 @@
 
 - **Usage**: `aube approve-builds [--all] [-g --global] [PKG]…`
 
-Approve ignored dependency build scripts and record them in `pnpm-workspace.yaml`'s `onlyBuiltDependencies`
+Approve ignored dependency build scripts in `pnpm-workspace.yaml`'s `allowBuilds`
 
 ## Arguments
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -208,7 +208,7 @@
         ],
         "mounts": [],
         "hide": false,
-        "help": "Approve ignored dependency build scripts and record them in `pnpm-workspace.yaml`'s `onlyBuiltDependencies`",
+        "help": "Approve ignored dependency build scripts in `pnpm-workspace.yaml`'s `allowBuilds`",
         "name": "approve-builds",
         "aliases": [],
         "hidden_aliases": [],

--- a/docs/npm-users.md
+++ b/docs/npm-users.md
@@ -42,8 +42,8 @@ installs keep writing `aube-lock.yaml`.
   [`nodeLinker: hoisted`](/settings/#setting-nodelinker).
 - Dependency lifecycle scripts (`preinstall`, `install`, `postinstall`) do
   not run by default. npm runs them for every dependency; aube runs them
-  only for packages you've explicitly allowlisted via `pnpm.allowBuilds`,
-  `pnpm.onlyBuiltDependencies`, or `aube approve-builds`. This follows
+  only for packages approved in `allowBuilds`; legacy
+  `pnpm.onlyBuiltDependencies` entries are still honored. This follows
   the pnpm v11 model. Approved dependency builds can also run in a
   [jail](/package-manager/jailed-builds) with package-specific env, path,
   and network permissions.

--- a/docs/package-manager/configuration.md
+++ b/docs/package-manager/configuration.md
@@ -93,7 +93,7 @@ piggy-backing on the pnpm namespace:
     "overrides": { "lodash": "4.17.21" },
     "catalog": { "react": "^18.0.0" },
     "supportedArchitectures": { "os": ["current", "linux"] },
-    "onlyBuiltDependencies": ["sharp"],
+    "allowBuilds": { "sharp": true },
     "patchedDependencies": { "foo@1.0.0": "patches/foo.patch" },
     "peerDependencyRules": { "ignoreMissing": ["react-native"] }
   }
@@ -111,7 +111,9 @@ Merge semantics when both namespaces are present:
   `neverBuiltDependencies`, `ignoredOptionalDependencies`,
   `peerDependencyRules.ignoreMissing`, `peerDependencyRules.allowAny`,
   `updateConfig.ignoreDependencies`, `supportedArchitectures.{os,cpu,libc}`):
-  entries from both namespaces union.
+  entries from both namespaces union. `onlyBuiltDependencies` and
+  `neverBuiltDependencies` are legacy build-policy inputs; new review state is
+  written to `allowBuilds`.
 - Top-level npm-standard keys (`overrides`, `packageExtensions`,
   `allowedDeprecatedVersions`, `updateConfig`) still take highest
   precedence, so the `aube.*` alias doesn't change existing npm /

--- a/docs/package-manager/jailed-builds.md
+++ b/docs/package-manager/jailed-builds.md
@@ -2,7 +2,7 @@
 
 Dependency lifecycle scripts are one of the sharpest supply-chain edges in a
 JavaScript install. aube already keeps dependency scripts skipped until a
-project approves them with `allowBuilds` / `onlyBuiltDependencies`. Jailed
+project approves them with `allowBuilds`. Jailed
 builds add a second boundary: approved packages may build, but they do
 not automatically get the user's full filesystem, network, and environment.
 
@@ -48,8 +48,8 @@ jailBuildPermissions:
 
 ## Default profile
 
-When `jailBuilds` is enabled and a dependency is approved through `allowBuilds` or
-`onlyBuiltDependencies`, aube runs its `preinstall`, `install`, and
+When `jailBuilds` is enabled and a dependency is approved through `allowBuilds`,
+aube runs its `preinstall`, `install`, and
 `postinstall` scripts with a default native jail profile:
 
 | Capability | Default |

--- a/docs/package-manager/lifecycle-scripts.md
+++ b/docs/package-manager/lifecycle-scripts.md
@@ -25,19 +25,23 @@ aube rebuild
 
 Supported policy fields — aube reads all of these at install time:
 
-In `pnpm-workspace.yaml` (pnpm v10+ home for these settings, and what
-`aube approve-builds` writes to):
+In `pnpm-workspace.yaml` (pnpm v11's build-review map, and what aube writes
+to):
 
 ```yaml
-onlyBuiltDependencies:
-  - sharp
-neverBuiltDependencies:
-  - untrusted-package
 allowBuilds:
   esbuild: true
+  sharp: true
+  untrusted-package: false
 ```
 
-In `package.json` (pnpm v9 / legacy — still honored as a read source).
+The old `onlyBuiltDependencies` and `neverBuiltDependencies` list keys are
+still honored as read-only compatibility inputs, but new approvals go into
+`allowBuilds`. When install sees an unreviewed dependency build, it adds that
+package to `allowBuilds` with `false`; `aube approve-builds` flips reviewed
+entries to `true`.
+
+In `package.json` (legacy — still honored as a read source).
 Every key under `pnpm.*` is also accepted under `aube.*`; when both are
 present for the same key, `aube.*` wins. Disjoint entries from either
 namespace merge.
@@ -46,10 +50,9 @@ namespace merge.
 {
   "aube": {
     "allowBuilds": {
-      "esbuild": true
-    },
-    "onlyBuiltDependencies": ["sharp"],
-    "neverBuiltDependencies": ["untrusted-package"]
+      "esbuild": true,
+      "untrusted-package": false
+    }
   }
 }
 ```

--- a/docs/pnpm-users.md
+++ b/docs/pnpm-users.md
@@ -72,10 +72,10 @@ projects).
   yet gets `aube-lock.yaml`. If it already has `pnpm-lock.yaml` (or any
   other supported lockfile — `package-lock.json`, `npm-shrinkwrap.json`,
   `yarn.lock`, `bun.lock`), aube reads and writes that file in place.
-  Install / add / remove / update never touch workspace YAML. The one
-  exception is `aube approve-builds`, which writes approvals into
-  `pnpm-workspace.yaml`'s `onlyBuiltDependencies` (matching pnpm v10+),
-  creating the file if missing. aube does not generate an
+  Install auto-adds unreviewed dependency builds to
+  `pnpm-workspace.yaml`'s `allowBuilds` with `false`; `aube approve-builds`
+  flips reviewed entries to `true` (matching pnpm v11), creating the file
+  if missing. aube does not generate an
   `aube-workspace.yaml` for you — create it yourself if you want the
   aube-named variant.
 - **Build approvals.** Dependency lifecycle script approval follows pnpm

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: false
+  sharp: false

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  esbuild: false
-  sharp: false

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,9 +36,9 @@ lifecycle scripts unless you've approved them explicitly:
 
 ```yaml
 # pnpm-workspace.yaml
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
+allowBuilds:
+  esbuild: true
+  sharp: true
 ```
 
 Or interactively:
@@ -50,9 +50,9 @@ aube approve-builds
 Root-package lifecycle scripts (your own project's) still run normally — the
 boundary is dependency code.
 
-Settings: [`allowBuilds`](/settings/#setting-allowbuilds). The
-`onlyBuiltDependencies` and `neverBuiltDependencies` allowlists live in
-`package.json` or `pnpm-workspace.yaml`, mirroring pnpm's shape.
+Settings: [`allowBuilds`](/settings/#setting-allowbuilds). Install adds
+unreviewed build packages to `pnpm-workspace.yaml` as `false`; approving them
+flips the entry to `true`.
 
 ## Jailed lifecycle scripts
 
@@ -193,9 +193,9 @@ For most projects, the following is a good starting point:
 ```yaml
 # pnpm-workspace.yaml
 paranoid: true             # bundles jailBuilds, no-downgrade, strict gates
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
+allowBuilds:
+  esbuild: true
+  sharp: true
   # ...whatever your project actually needs to build
 ```
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1827,9 +1827,9 @@ aube never runs dependency lifecycle scripts unless the package is
 listed in `allowBuilds` or `--dangerously-allow-all-builds` is set.
 With `strictDepBuilds = true`, an install that sees unreviewed build
 scripts fails after linking and before any dependency build scripts run.
-Add reviewed packages to `allowBuilds` / `onlyBuiltDependencies`, add
-intentionally skipped packages to `neverBuiltDependencies`, or leave the
-default `strictDepBuilds=false` behavior to skip unreviewed builds.
+Add reviewed packages to `allowBuilds` with `true`, keep intentionally
+skipped packages as `false`, or leave the default `strictDepBuilds=false`
+behavior to skip unreviewed builds.
 
 ### `allowBuilds` {#setting-allowbuilds}
 
@@ -1840,12 +1840,14 @@ Explicitly allow or disallow script execution per package.
 - .npmrc keys: `allowBuilds`, `allow-builds`
 - Workspace YAML keys: `allowBuilds`
 
-Per-package allowlist for dependency lifecycle scripts. Read from
-`package.json`'s `pnpm.allowBuilds` field and `aube-workspace.yaml`'s
+Per-package review map for dependency lifecycle scripts. Read from
+`package.json`'s `pnpm.allowBuilds` field and workspace yaml's
 `allowBuilds`. Keys are package name patterns (`esbuild`, `@scope/*`,
 `pkg@1.0.0 || 2.0.0`); values are `true` to allow `preinstall` /
-`install` / `postinstall` scripts for that package or `false` to block
-them. Packages not listed are skipped by default (aube's safe default).
+`install` / `postinstall` scripts for that package or `false` to record
+an intentional skip. Packages not listed are skipped by default, and
+install adds unreviewed build packages to workspace `allowBuilds` as
+`false` for later review.
 
 Examples:
 

--- a/docs/yarn-users.md
+++ b/docs/yarn-users.md
@@ -66,8 +66,8 @@ can drop in against the same `yarn.lock`.
   `pnpm-workspace.yaml` when the project already has one).
 - Dependency lifecycle scripts (`preinstall`, `install`, `postinstall`) do
   not run by default. Yarn runs them for every dependency; aube runs them
-  only for packages you've explicitly allowlisted via `pnpm.allowBuilds`,
-  `pnpm.onlyBuiltDependencies`, or `aube approve-builds`. This follows
+  only for packages approved in `allowBuilds`; legacy
+  `pnpm.onlyBuiltDependencies` entries are still honored. This follows
   the pnpm v11 model. Approved dependency builds can also run in a
   [jail](/package-manager/jailed-builds) with package-specific env, path,
   and network permissions.

--- a/test/approve_builds.bats
+++ b/test/approve_builds.bats
@@ -4,7 +4,7 @@
 # same `aube-test-builds-marker` fixture package as `allow_builds.bats`:
 # it declares a `postinstall` that writes a marker file, so its
 # presence after a second install proves the approve-builds write
-# round-tripped into the project's `onlyBuiltDependencies`.
+# round-tripped into the project's `allowBuilds`.
 
 setup() {
 	load 'test_helper/common_setup'
@@ -108,11 +108,7 @@ JSON
 	assert_output --partial "No ignored builds"
 }
 
-@test "approve-builds --all writes onlyBuiltDependencies to package.json when no workspace yaml" {
-	# A plain npm/yarn project (no pnpm-workspace.yaml) must NOT have
-	# one fabricated by approve-builds. The same data lives under
-	# `pnpm.onlyBuiltDependencies` in package.json, which the
-	# install-time policy already reads.
+@test "install writes unreviewed builds to allowBuilds as false" {
 	cat >package.json <<'JSON'
 {
   "name": "approve-builds-all-test",
@@ -125,21 +121,21 @@ JSON
 	run aube install
 	assert_success
 	assert_file_not_exists aube-builds-marker.txt
+	assert_file_exists pnpm-workspace.yaml
+	run grep -q 'allowBuilds:' pnpm-workspace.yaml
+	assert_success
+	run grep -q 'aube-test-builds-marker: false' pnpm-workspace.yaml
+	assert_success
 
 	run aube approve-builds --all
 	assert_success
 	assert_output --partial "aube-test-builds-marker"
-	assert_output --partial "package.json"
+	assert_output --partial "pnpm-workspace.yaml"
 
-	# No yaml should be created.
-	assert_file_not_exists pnpm-workspace.yaml
-	assert_file_not_exists aube-workspace.yaml
-
-	# The entry should land under pnpm.onlyBuiltDependencies in package.json.
+	run grep -q 'aube-test-builds-marker: true' pnpm-workspace.yaml
+	assert_success
 	run grep -q 'onlyBuiltDependencies' package.json
-	assert_success
-	run grep -q 'aube-test-builds-marker' package.json
-	assert_success
+	assert_failure
 
 	# A re-install should run the previously-ignored postinstall.
 	run aube install
@@ -147,7 +143,7 @@ JSON
 	assert_file_exists aube-builds-marker.txt
 }
 
-@test "approve-builds --all in npm-style monorepo doesn't fabricate pnpm-workspace.yaml" {
+@test "approve-builds --all in npm-style monorepo writes pnpm-workspace allowBuilds" {
 	# An npm/yarn-style monorepo carries `workspaces` directly in
 	# package.json. approve-builds in that shape must not pollute
 	# the tree with a pnpm-workspace.yaml the user never asked for.
@@ -176,15 +172,16 @@ JSON
 	assert_success
 	assert_output --partial "aube-test-builds-marker"
 
-	assert_file_not_exists pnpm-workspace.yaml
+	assert_file_exists pnpm-workspace.yaml
 	assert_file_not_exists aube-workspace.yaml
 
-	run grep -q 'onlyBuiltDependencies' package.json
+	run grep -q 'allowBuilds:' pnpm-workspace.yaml
+	assert_success
+	run grep -q 'aube-test-builds-marker: true' pnpm-workspace.yaml
 	assert_success
 
 	# Round-trip: a re-install must honor the policy stored under
-	# pnpm.onlyBuiltDependencies and run the previously-skipped
-	# postinstall.
+	# allowBuilds and run the previously-skipped postinstall.
 	run aube install
 	assert_success
 	assert_file_exists aube-builds-marker.txt
@@ -200,11 +197,11 @@ JSON
   }
 }
 JSON
-	cat >pnpm-workspace.yaml <<'YAML'
+cat >pnpm-workspace.yaml <<'YAML'
 packages:
   - 'packages/*'
-onlyBuiltDependencies:
-  - some-other-pkg
+allowBuilds:
+  some-other-pkg: true
 YAML
 	run aube install
 	assert_success
@@ -216,9 +213,9 @@ YAML
 	# entry isn't duplicated.
 	run grep -q '^packages:' pnpm-workspace.yaml
 	assert_success
-	run grep -q '  - some-other-pkg' pnpm-workspace.yaml
+	run grep -q '  some-other-pkg: true' pnpm-workspace.yaml
 	assert_success
-	run grep -q '  - aube-test-builds-marker' pnpm-workspace.yaml
+	run grep -q '  aube-test-builds-marker: true' pnpm-workspace.yaml
 	assert_success
 }
 

--- a/test/approve_builds.bats
+++ b/test/approve_builds.bats
@@ -145,8 +145,8 @@ JSON
 
 @test "approve-builds --all in npm-style monorepo writes pnpm-workspace allowBuilds" {
 	# An npm/yarn-style monorepo carries `workspaces` directly in
-	# package.json. approve-builds in that shape must not pollute
-	# the tree with a pnpm-workspace.yaml the user never asked for.
+	# package.json. Under pnpm v11 semantics aube creates
+	# pnpm-workspace.yaml to hold the allowBuilds review map.
 	mkdir -p packages/app
 	cat >package.json <<'JSON'
 {

--- a/test/approve_builds.bats
+++ b/test/approve_builds.bats
@@ -197,7 +197,7 @@ JSON
   }
 }
 JSON
-cat >pnpm-workspace.yaml <<'YAML'
+	cat >pnpm-workspace.yaml <<'YAML'
 packages:
   - 'packages/*'
 allowBuilds:

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -162,12 +162,11 @@ teardown() {
 	assert_output --partial "aube-test-builds-marker"
 	assert_output --partial "global install"
 
-	# Global installs have no workspace yaml, so the approval lands in
-	# package.json#pnpm.onlyBuiltDependencies — not a fabricated yaml.
-	assert_file_not_exists "$install_dir/pnpm-workspace.yaml"
-	run grep -q 'onlyBuiltDependencies' "$install_dir/package.json"
+	# Global installs use the same pnpm v11 review map as projects.
+	assert_file_exists "$install_dir/pnpm-workspace.yaml"
+	run grep -q 'allowBuilds:' "$install_dir/pnpm-workspace.yaml"
 	assert_success
-	run grep -q 'aube-test-builds-marker' "$install_dir/package.json"
+	run grep -q 'aube-test-builds-marker: true' "$install_dir/pnpm-workspace.yaml"
 	assert_success
 
 	run aube -C "$install_dir" rebuild

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -117,6 +117,9 @@ JSON
 	assert_failure
 	assert_output --partial "dependencies with build scripts must be reviewed"
 	assert_output --partial "dep-with-build@1.0.0"
+	assert_file_exists pnpm-workspace.yaml
+	run grep -q 'dep-with-build: false' pnpm-workspace.yaml
+	assert_success
 }
 
 @test "strictDepBuilds=false keeps unreviewed dependency build scripts skipped" {


### PR DESCRIPTION
## Summary

- Switch build approval writes from `onlyBuiltDependencies` to pnpm 11-style `allowBuilds` entries.
- Auto-seed unreviewed dependency builds into workspace `allowBuilds` as `false`, and have `aube approve-builds` flip selected entries to `true`.
- Keep legacy `onlyBuiltDependencies` / `neverBuiltDependencies` as read-compatible inputs, and update docs, generated CLI help, and BATS coverage.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-manifest workspace::tests::add_to_allow_builds -- --nocapture`
- `cargo test -p aube --bin aube`
- `cargo clippy --all-targets -- -D warnings`
- `mise run test:bats test/approve_builds.bats`
- `mise run test:bats test/lifecycle_scripts.bats`
- `mise run test:bats test/global_install.bats`
- `mise run docs:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency-build approval persistence and makes `install` write/update `pnpm-workspace.yaml`, which could affect build-script execution behavior and create new files in repos. Logic is localized but touches install-time safety gates and policy state transitions.
> 
> **Overview**
> Switches build-script review/approval persistence to pnpm v11’s `allowBuilds` *review map* (writing `true`/`false` entries) instead of appending to `onlyBuiltDependencies`.
> 
> `aube install` now auto-seeds unreviewed build-script packages into workspace `allowBuilds` as `false` (and errors/warns accordingly), while `aube approve-builds` flips selected entries to `true`; when no workspace YAML exists, the code now creates `pnpm-workspace.yaml` rather than writing to `package.json`.
> 
> Updates CLI help text, settings/docs, and BATS/unit tests to reflect the new review workflow and file-writing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f76b880e9bc74568ebfd4509f8f5e6e94a439fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->