### PR TITLE
docs: warn about npm install caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ The recommended path is mise:
 mise use -g aube
 ```
 
+mise can also manage the [Node.js versions](https://mise.jdx.dev/lang/node.html)
+your projects need. If your projects already pin Node through `package.json`
+(`devEngines.runtime`), `.nvmrc`, or `.node-version`, enable mise's
+idiomatic version-file support for Node:
+
+```sh
+mise settings add idiomatic_version_file_enable_tools node
+```
+
 Check that it is on your `PATH`:
 
 ```sh
@@ -55,8 +64,14 @@ mise use aube
 aube is also published on npm:
 
 ```sh
-npm install -g @endevco/aube
+npm install -g --ignore-scripts=false @endevco/aube
+npx --ignore-scripts=false @endevco/aube --version
 ```
+
+The npm package uses an install script to fetch native binaries for
+performance. The npm commands above include the flag that keeps that
+working even if your npm config disables scripts. We still recommend mise
+for the smoothest install and runtime management path.
 
 Homebrew installs come from the Endev tap:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,6 +10,18 @@ mise use -g aube
 
 This installs `aube` on your PATH and lets mise manage future upgrades.
 
+::: tip
+We recommend mise because it can manage `aube` and your
+[Node.js runtime](https://mise.jdx.dev/lang/node.html) from the same
+toolchain. If your projects already pin Node through `package.json`
+(`devEngines.runtime`) or files such as `.nvmrc` and
+`.node-version`, opt mise into reading those idiomatic version files:
+
+```sh
+mise settings add idiomatic_version_file_enable_tools node
+```
+:::
+
 ## From crates.io
 
 If you already have a Rust toolchain installed, you can install the
@@ -40,18 +52,21 @@ The tap formula builds from source and installs shell completions.
 aube is also published on npm as `@endevco/aube`:
 
 ```sh
-npm install -g @endevco/aube
-# or
-npx @endevco/aube --version
+npm install -g --ignore-scripts=false @endevco/aube
+npx --ignore-scripts=false @endevco/aube --version
 ```
 
 ::: warning
-The `preinstall` script drops the platform-appropriate native binary
-into place. If you install with `--ignore-scripts`, that step is
-skipped and every `aube` invocation goes through a node shim instead
-— which defeats the whole point of having a fast, native CLI. It also
-won't work in offline/air-gapped caches. Use any other install method
-for those environments.
+The npm package relies on its `preinstall` script to fetch the
+platform-specific native binary and wire up the `aube`, `aubr`, and `aubx`
+commands. That native binary is what gives aube its startup and install
+performance; without the script, npm can leave the package installed
+without working commands. The npm commands above pass
+`--ignore-scripts=false` so it still works for users with
+`ignore-scripts=true` in their npm config.
+
+We recommend installing with mise if you want the native binary without npm
+lifecycle-script behavior.
 :::
 
 ## Ubuntu (PPA)


### PR DESCRIPTION
## Summary

- Add an installation-page warning that the npm package depends on lifecycle scripts and can fail to expose commands when scripts are disabled or PowerShell blocks `npm.ps1`.
- Add a mise tip explaining why it remains the recommended path and how to enable idiomatic Node version files with `idiomatic_version_file_enable_tools`.
- Mirror the npm caveat and mise Node-version note in the README install section.

## Validation

- `git diff --check`
- `npm.cmd run docs:build` *(fails before docs render: active toolchain is `rustc 1.88.0-beta.3`, but `aube-settings` requires rustc 1.93)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; no product logic is modified, but incorrect guidance could impact install success for npm users.
> 
> **Overview**
> Updates the install docs to further **recommend mise** by calling out Node runtime/version-file management, including the `mise settings add idiomatic_version_file_enable_tools node` guidance.
> 
> Clarifies **npm install caveats** by switching examples to pass `--ignore-scripts=false` and adding warnings that the npm package depends on its `preinstall` lifecycle script to fetch the native binary and wire up `aube`/`aubr`/`aubx` commands (mirrored in both `README.md` and `docs/installation.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2fa6853466979b58497fc4bc30523697378a79b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->