### PR TITLE
fix(npm): preserve extensionless bin shims

### DIFF
--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -1670,8 +1670,7 @@ mod multicall_tests {
 
     fn temp_shim(name: &str) -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("temp dir should be created");
-        std::fs::write(dir.path().join(name), "#!/tmp/aube.exe\n")
-            .expect("shim should be written");
+        std::fs::write(dir.path().join(name), "#!/tmp/aube.exe\n").expect("shim should be written");
         dir
     }
 

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -31,6 +31,7 @@ use tracing_subscriber::prelude::*;
 /// Shims are installed as hardlinks (or copies on Windows) that point at the
 /// same `aube` executable; dispatch happens purely at runtime via basename.
 fn rewrite_multicall_argv(mut args: Vec<OsString>) -> Vec<OsString> {
+    normalize_npm_interpreter_shim_argv(&mut args);
     let Some(argv0) = args.first() else {
         return args;
     };
@@ -57,6 +58,32 @@ fn rewrite_multicall_argv(mut args: Vec<OsString>) -> Vec<OsString> {
     }
     args.insert(1, OsString::from(subcommand));
     args
+}
+
+/// npm's Windows `.cmd` shim can only execute extensioned native binaries.
+/// The npm package keeps extensionless `bin` targets for Unix, so on Windows
+/// `bin/aube` is a tiny shebang file whose interpreter is `bin/aube.exe`.
+/// npm invokes that as `aube.exe bin/aube ...`; drop the shebang file and use
+/// it as argv[0] so multicall dispatch still sees `aubr` / `aubx`.
+fn normalize_npm_interpreter_shim_argv(args: &mut Vec<OsString>) {
+    let Some(shim) = args.get(1).cloned() else {
+        return;
+    };
+    let shim_path = std::path::Path::new(&shim);
+    let Some(stem) = shim_path.file_stem().and_then(|s| s.to_str()) else {
+        return;
+    };
+    if !matches!(stem, "aube" | "aubr" | "aubx") {
+        return;
+    }
+    let Ok(bytes) = std::fs::read(shim_path) else {
+        return;
+    };
+    if !bytes.starts_with(b"#!") {
+        return;
+    }
+    args[0] = shim;
+    args.remove(1);
 }
 
 #[derive(Parser)]
@@ -1641,6 +1668,13 @@ mod multicall_tests {
         strs.iter().map(OsString::from).collect()
     }
 
+    fn temp_shim(name: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        std::fs::write(dir.path().join(name), "#!/tmp/aube.exe\n")
+            .expect("shim should be written");
+        dir
+    }
+
     #[test]
     fn aube_passes_through_unchanged() {
         assert_eq!(
@@ -1707,6 +1741,35 @@ mod multicall_tests {
         assert_eq!(
             rewrite_multicall_argv(os(&["aubx.exe", "-V"])),
             os(&["aube", "-V"])
+        );
+    }
+
+    #[test]
+    fn npm_interpreter_shim_path_is_dropped() {
+        let dir = temp_shim("aube");
+        let shim = dir.path().join("aube");
+        let shim_os = shim.clone().into_os_string();
+        assert_eq!(
+            rewrite_multicall_argv(vec![
+                OsString::from("aube.exe"),
+                shim.into_os_string(),
+                OsString::from("--version"),
+            ]),
+            vec![shim_os, OsString::from("--version")]
+        );
+    }
+
+    #[test]
+    fn npm_interpreter_shim_preserves_multicall_dispatch() {
+        let dir = temp_shim("aubr");
+        let shim = dir.path().join("aubr");
+        assert_eq!(
+            rewrite_multicall_argv(vec![
+                OsString::from("aubr.exe"),
+                shim.into_os_string(),
+                OsString::from("build"),
+            ]),
+            os(&["aube", "run", "build"])
         );
     }
 }

--- a/npm/installArchSpecificPackage.js
+++ b/npm/installArchSpecificPackage.js
@@ -1,9 +1,13 @@
 // Fetch the platform-matching @endevco/aube-<os>-<arch> sub-package at
 // install time and hardlink (or copy) its three binaries into ./bin so
-// npm's `bin` wrapper resolves directly to the native executable. This
+// npm's `bin` wrapper resolves directly to the native executable. The root
+// package's bin targets are stable `./bin/<name>` paths so npm/npx can create
+// shims without reading a rewritten package.json. On Windows, npm's generated
+// `.cmd` shim needs a shebang target it can execute, so `./bin/<name>` is a
+// tiny text file whose interpreter is the native `./bin/<name>.exe`. This
 // mirrors https://www.npmjs.com/package/@jdxcode/mise — the preinstall
-// approach avoids the JS shim at runtime and keeps `package-lock.json`
-// free of six optional-dependency entries that are mostly skipped.
+// approach avoids the JS shim at runtime and keeps `package-lock.json` free
+// of six optional-dependency entries that are mostly skipped.
 //
 // Must stay CommonJS and use only the Node.js stdlib — it runs *before*
 // any dependency is installed, so nothing from node_modules is reachable.
@@ -51,7 +55,7 @@ function main() {
             return;
         }
         try {
-            linkSubpkgBins(subpkgName, platform, pjson);
+            linkSubpkgBins(subpkgName, platform);
             process.exit(0);
         } catch (e) {
             console.error('[@endevco/aube] preinstall failed: ' + (e && e.message ? e.message : e));
@@ -60,7 +64,7 @@ function main() {
     });
 }
 
-function linkSubpkgBins(subpkgName, platform, pjson) {
+function linkSubpkgBins(subpkgName, platform) {
     var subpkgJsonPath = require.resolve(subpkgName + '/package.json');
     var subpkg = JSON.parse(fs.readFileSync(subpkgJsonPath, 'utf8'));
     var subpkgDir = path.dirname(subpkgJsonPath);
@@ -68,14 +72,10 @@ function linkSubpkgBins(subpkgName, platform, pjson) {
     var binDir = path.resolve(__dirname, 'bin');
     try { fs.mkdirSync(binDir); } catch (e) { if (e.code !== 'EEXIST') throw e; }
 
-    var rootPkgJsonPath = path.resolve(__dirname, 'package.json');
-    var rootPkg = JSON.parse(fs.readFileSync(rootPkgJsonPath, 'utf8'));
-    var rootPkgChanged = false;
-
     Object.keys(subpkg.bin).forEach(function(name) {
         var srcRel = subpkg.bin[name];
         var src = path.resolve(subpkgDir, srcRel);
-        var destBasename = path.basename(srcRel);
+        var destBasename = platform === 'win32' ? name + '.exe' : name;
         var dest = path.resolve(binDir, destBasename);
 
         try { fs.unlinkSync(dest); } catch (e) { if (e.code !== 'ENOENT') throw e; }
@@ -89,22 +89,12 @@ function linkSubpkgBins(subpkgName, platform, pjson) {
         }
         if (platform !== 'win32') {
             try { fs.chmodSync(dest, 0o755); } catch (_) {}
-        }
-
-        // Keep root package.json's `bin` entry aligned with the filename
-        // we actually wrote. Matters on Windows, where the sub-package's
-        // bin ends in `.exe` — the root's original `./bin/<name>` entry
-        // would leave the npm bin wrapper pointing at a missing file.
-        var desiredBin = './bin/' + destBasename;
-        if (rootPkg.bin[name] !== desiredBin) {
-            rootPkg.bin[name] = desiredBin;
-            rootPkgChanged = true;
+        } else {
+            var shim = path.resolve(binDir, name);
+            try { fs.unlinkSync(shim); } catch (e) { if (e.code !== 'ENOENT') throw e; }
+            fs.writeFileSync(shim, '#!' + dest.replace(/\\/g, '/') + '\n');
         }
     });
-
-    if (rootPkgChanged) {
-        fs.writeFileSync(rootPkgJsonPath, JSON.stringify(rootPkg, null, 2) + '\n');
-    }
 }
 
 main();


### PR DESCRIPTION
## Summary

- Keep the root npm package's published `bin` entries stable and extensionless: `./bin/aube`, `./bin/aubr`, and `./bin/aubx`.
- On Unix, continue copying or hardlinking the selected native binaries directly to those extensionless paths.
- On Windows, copy or hardlink native binaries to sibling `.exe` files, then write the extensionless `bin/<name>` files as tiny shebang files pointing at those native `.exe` files. This gives npm's generated `.cmd` shims a stable target without adding a Node wrapper.
- Normalize npm's Windows interpreter-shim argv shape in the native CLI, so `aube.exe bin/aube ...` parses as the intended `aube ...`, and `aubr` / `aubx` multicall dispatch still works.

## Why

The current published npm package downloads/copies the platform binary during `preinstall`, then rewrites `package.json` from `./bin/aube` to `./bin/aube.exe` on Windows. npm/npx appear to resolve executable metadata before that rewrite matters, so global installs and fresh-cache `npx` installs can leave no runnable `aube` command.

This keeps the published bin paths stable for npm/npx while preserving extensionless command targets on Unix and keeping the runtime path native-only.

## Validation

- `git diff --check`
- `node -c npm/installArchSpecificPackage.js`
- `rustup run 1.93.0 cargo test -p aube multicall_tests --bin aube`
- `rustup run 1.93.0 cargo build -p aube --bin aube --bin aubr --bin aubx`
- Windows global-prefix smoke using a temp root package and temp local `@endevco/aube-win32-x64` package built from the updated debug binaries: `npm.cmd install --global --prefix <tmp> --ignore-scripts=false <pkg>`, then `<tmp>\\aube.cmd --version`, `<tmp>\\aubr.cmd --version`, and `<tmp>\\aubx.cmd --version` all printed `1.3.0-DEBUG windows-arm64 (2026-04-28)`.
- Windows npx smoke using a fresh cache and temp local platform package: `npx.cmd --yes --package <fixed local package> aube --version` printed `1.3.0-DEBUG windows-arm64 (2026-04-28)`.