### PR TITLE
fix(resolver): trust benchmark fixture churn packages

### DIFF
--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -227,7 +227,10 @@ fn cutoff_iso8601(minutes_ago: u64) -> Option<String> {
 /// ranges, no name globs combined with versions).
 pub const DEFAULT_TRUST_POLICY_EXCLUDES: &[&str] = &[
     "chokidar",
+    "eslint-config-prettier",
     "eslint-import-resolver-typescript",
+    "react-redux",
+    "reselect",
     "semver",
     "ua-parser-js",
     "undici-types",


### PR DESCRIPTION
## Summary

- add built-in trustPolicy exclusions for eslint-config-prettier, react-redux, and reselect
- keep the no-downgrade algorithm unchanged; these packages are registry provenance metadata churn cases surfaced by the benchmark fixture

## Validation

- cargo fmt --check
- cargo test -p aube-resolver trust::tests
- cargo build -p aube
- cargo clippy -p aube-resolver --all-targets -- -D warnings
- fresh-cache benchmark fixture install: `aube --disable-global-virtual-store install --no-side-effects-cache`

## Notes

`cargo clippy --all-targets -- -D warnings` currently fails outside this change on `clippy::items-after-test-module` in `crates/aube/src/commands/install/mod.rs`.

*This PR description was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts default trust-policy enforcement by globally excluding three additional packages, which can bypass downgrade failures for those dependencies. Low code complexity, but it touches a security-related guardrail and changes install acceptance for affected packages.
> 
> **Overview**
> Expands the built-in `DEFAULT_TRUST_POLICY_EXCLUDES` list to also exclude `eslint-config-prettier`, `react-redux`, and `reselect` from trust-downgrade checks, reducing benchmark/fixture churn caused by registry provenance metadata changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b11a39e5dd6c0ca2dd8c851475c72721fc15150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->