### PR TITLE
perf(store): re-introduce sqlite indexes with mmap'd sidecar blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "flate2",
  "hex",
  "log",
+ "memmap2",
  "rayon",
  "rmp-serde",
  "rusqlite",
@@ -2326,6 +2327,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miette"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "flate2",
  "hex",
  "log",
+ "rayon",
  "rmp-serde",
  "rusqlite",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,8 @@ dependencies = [
  "flate2",
  "hex",
  "log",
+ "rmp-serde",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha1",
@@ -1283,6 +1285,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1641,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heck"
@@ -2202,6 +2225,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3252,10 +3286,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "roff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -3919,6 +3997,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4615,6 +4705,12 @@ dependencies = [
  "itoa",
  "ryu",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
 yaml_serde = "0.10.4"
 simd-json = "0.17"
+rmp-serde = "1"
+rusqlite = { version = "0.39", features = ["bundled"] }
 toml = "0.8"
 
 # CLI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
 yaml_serde = "0.10.4"
 simd-json = "0.17"
 rmp-serde = "1"
+memmap2 = "0.9"
 rusqlite = { version = "0.39", features = ["bundled"] }
 toml = "0.8"
 

--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -22,6 +22,7 @@ tar = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 simd-json = { workspace = true }
+rayon = { workspace = true }
 rmp-serde = { workspace = true }
 rusqlite = { workspace = true }
 xx = { workspace = true }

--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme.workspace = true
-include = ["src/**/*.rs"]
+include = ["build.rs", "src/**/*.rs"]
 
 [dependencies]
 aube-util = { workspace = true }
@@ -22,6 +22,8 @@ tar = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 simd-json = { workspace = true }
+rmp-serde = { workspace = true }
+rusqlite = { workspace = true }
 xx = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }

--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -22,6 +22,7 @@ tar = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 simd-json = { workspace = true }
+memmap2 = { workspace = true }
 rayon = { workspace = true }
 rmp-serde = { workspace = true }
 rusqlite = { workspace = true }

--- a/crates/aube-store/build.rs
+++ b/crates/aube-store/build.rs
@@ -1,0 +1,105 @@
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+    let today = today_utc();
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    for (date, cfg) in remove_after_markers(Path::new(&manifest_dir).join("src").as_path()) {
+        println!("cargo::rustc-check-cfg=cfg({cfg})");
+        if today >= date {
+            println!("cargo::rustc-cfg={cfg}");
+        }
+    }
+}
+
+fn remove_after_markers(src: &Path) -> Vec<((i32, u32, u32), String)> {
+    let mut out = Vec::new();
+    collect_remove_after_markers(src, &mut out);
+    out
+}
+
+fn collect_remove_after_markers(path: &Path, out: &mut Vec<((i32, u32, u32), String)>) {
+    println!("cargo::rerun-if-changed={}", path.display());
+    let Ok(metadata) = fs::metadata(path) else {
+        return;
+    };
+    if metadata.is_dir() {
+        let Ok(entries) = fs::read_dir(path) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            collect_remove_after_markers(&entry.path(), out);
+        }
+        return;
+    }
+    if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+        return;
+    }
+    let Ok(source) = fs::read_to_string(path) else {
+        return;
+    };
+    out.extend(parse_remove_after_markers(&source));
+}
+
+fn parse_remove_after_markers(source: &str) -> Vec<((i32, u32, u32), String)> {
+    let mut out = Vec::new();
+    let mut rest = source;
+    while let Some(offset) = rest.find("remove_after!(") {
+        rest = &rest[offset + "remove_after!(".len()..];
+        if let Some((date, cfg)) = parse_remove_after_marker(rest) {
+            out.push((date, cfg));
+        }
+    }
+    out
+}
+
+fn parse_remove_after_marker(source: &str) -> Option<((i32, u32, u32), String)> {
+    let source = source.trim_start();
+    let (date, source) = parse_string_literal(source)?;
+    let source = source.trim_start().strip_prefix(',')?.trim_start();
+    let cfg_len = source
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .unwrap_or(source.len());
+    let cfg = source[..cfg_len].to_string();
+    Some((parse_date(&date)?, cfg))
+}
+
+fn parse_string_literal(source: &str) -> Option<(String, &str)> {
+    let source = source.strip_prefix('"')?;
+    let end = source.find('"')?;
+    Some((source[..end].to_string(), &source[end + 1..]))
+}
+
+fn parse_date(date: &str) -> Option<(i32, u32, u32)> {
+    let mut parts = date.split('-');
+    let year = parts.next()?.parse().ok()?;
+    let month = parts.next()?.parse().ok()?;
+    let day = parts.next()?.parse().ok()?;
+    (parts.next().is_none()).then_some((year, month, day))
+}
+
+fn today_utc() -> (i32, u32, u32) {
+    let days = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        / 86_400;
+    let days = i64::try_from(days).unwrap_or(i64::MAX);
+    civil_from_days(days)
+}
+
+fn civil_from_days(days: i64) -> (i32, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = mp + if mp < 10 { 3 } else { -9 };
+    let year = y + i64::from(m <= 2);
+    (year as i32, m as u32, d as u32)
+}

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -9,6 +9,8 @@ use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
 
 pub const SHA512_INTEGRITY_PREFIX: &str = "sha512-";
 
@@ -57,7 +59,33 @@ pub const PACKUMENT_FULL_CACHE_SUBDIR: &str = "packuments-full-v1";
 thread_local! {
     static B3_HASHER: RefCell<blake3::Hasher> = RefCell::new(blake3::Hasher::new());
     static SHA512_HASHER: RefCell<Sha512> = RefCell::new(Sha512::new());
+    static INDEX_DBS: RefCell<BTreeMap<PathBuf, rusqlite::Connection>> = const { RefCell::new(BTreeMap::new()) };
 }
+
+static INDEX_DB_INIT_LOCK: Mutex<()> = Mutex::new(());
+static INDEX_DB_WRITE_LOCKS: LazyLock<Mutex<BTreeMap<PathBuf, Arc<Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
+// build.rs scans these markers and flips the cfg once the date is reached.
+macro_rules! remove_after {
+    ($date:literal, $cfg:ident, $message:literal) => {
+        #[cfg($cfg)]
+        compile_error!(concat!(
+            "temporary compatibility code [",
+            stringify!($cfg),
+            "] reached removal date ",
+            $date,
+            ": ",
+            $message
+        ));
+    };
+}
+
+remove_after!(
+    "2026-05-19",
+    aube_remove_after_legacy_json_index_cache,
+    "remove legacy package index JSON fallback"
+);
 
 fn blake3_hex(content: &[u8]) -> String {
     B3_HASHER.with(|cell| {
@@ -97,6 +125,20 @@ pub struct StoredFile {
 
 /// Index of all files in a package, keyed by relative path within the package.
 pub type PackageIndex = BTreeMap<String, StoredFile>;
+
+#[derive(Debug, Clone)]
+pub struct CachedIndexEntry {
+    pub name: String,
+    pub version: String,
+    pub integrity: Option<String>,
+    pub index: PackageIndex,
+}
+
+pub struct PackageIndexLookup<'a> {
+    pub name: &'a str,
+    pub version: &'a str,
+    pub integrity: Option<&'a str>,
+}
 
 fn index_files_match_metadata(index: &PackageIndex, verify_all: bool) -> bool {
     let mut files = index.values();
@@ -155,6 +197,80 @@ impl Store {
     /// commands (`aube find-hash`) can walk it directly.
     pub fn index_dir(&self) -> PathBuf {
         self.cache_dir.join(INDEX_SUBDIR)
+    }
+
+    fn index_db_path(&self) -> PathBuf {
+        self.cache_dir.join("index-v2.sqlite")
+    }
+
+    fn open_index_db(&self) -> Result<rusqlite::Connection, Error> {
+        let db_path = self.index_db_path();
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.to_path_buf(), e))?;
+        }
+        let conn = rusqlite::Connection::open(&db_path).map_err(|e| Error::Xx(e.to_string()))?;
+        conn.busy_timeout(Duration::from_secs(5))
+            .map_err(|e| Error::Xx(e.to_string()))?;
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA synchronous=NORMAL;
+             CREATE TABLE IF NOT EXISTS package_index (
+               name TEXT NOT NULL,
+               version TEXT NOT NULL,
+               integrity TEXT NOT NULL,
+               data BLOB NOT NULL,
+               PRIMARY KEY (name, version, integrity)
+             );",
+        )
+        .map_err(|e| Error::Xx(e.to_string()))?;
+        Ok(conn)
+    }
+
+    fn with_index_db<T>(
+        &self,
+        f: impl FnOnce(&rusqlite::Connection) -> rusqlite::Result<T>,
+    ) -> Result<T, Error> {
+        let db_path = self.index_db_path();
+        INDEX_DBS.with(|dbs| {
+            if !dbs.borrow().contains_key(&db_path) {
+                {
+                    // Connections are thread-local, but opening several
+                    // connections to the same new DB concurrently can race
+                    // SQLite's WAL/schema initialization and surface spurious
+                    // `database is locked` errors during parallel imports.
+                    let _guard = INDEX_DB_INIT_LOCK
+                        .lock()
+                        .map_err(|e| Error::Xx(e.to_string()))?;
+                    dbs.borrow_mut()
+                        .insert(db_path.clone(), self.open_index_db()?);
+                }
+            }
+            let dbs = dbs.borrow();
+            let conn = dbs.get(&db_path).expect("connection inserted above");
+            f(conn).map_err(|e| Error::Xx(e.to_string()))
+        })
+    }
+
+    fn with_index_db_write<T>(
+        &self,
+        f: impl FnOnce(&rusqlite::Connection) -> rusqlite::Result<T>,
+    ) -> Result<T, Error> {
+        let db_path = self.index_db_path();
+        let lock = INDEX_DB_WRITE_LOCKS
+            .lock()
+            .map_err(|e| Error::Xx(e.to_string()))?
+            .entry(db_path)
+            .or_default()
+            .clone();
+        let _guard = lock.lock().map_err(|e| Error::Xx(e.to_string()))?;
+        self.with_index_db(f)
+    }
+
+    fn index_integrity_key(integrity: Option<&str>) -> Option<String> {
+        match integrity {
+            Some(integrity) => integrity_to_hex(integrity),
+            None => Some(String::new()),
+        }
     }
 
     /// Directory for the global virtual store (materialized packages).
@@ -229,7 +345,43 @@ impl Store {
         self.load_index_inner(name, version, integrity, true)
     }
 
+    /// Load package indexes for install/fetch hot paths.
+    ///
+    /// Like [`load_index`](Self::load_index), this is allowed to clean
+    /// up stale legacy JSON fallback entries. Read-only callers should
+    /// use the `cached_indices*_unverified` APIs instead.
+    pub fn load_indices(&self, lookups: &[PackageIndexLookup<'_>]) -> Vec<Option<PackageIndex>> {
+        let mut indices = self.load_indices_sqlite(lookups).unwrap_or_else(|| {
+            std::iter::repeat_with(|| None)
+                .take(lookups.len())
+                .collect()
+        });
+        for (lookup, index) in lookups.iter().zip(&mut indices) {
+            if index.is_none() {
+                *index = self.load_index_json(lookup.name, lookup.version, lookup.integrity, false);
+            }
+        }
+        indices
+    }
+
     fn load_index_inner(
+        &self,
+        name: &str,
+        version: &str,
+        integrity: Option<&str>,
+        verify_files: bool,
+    ) -> Option<PackageIndex> {
+        if validate_and_encode_name(name).is_some()
+            && validate_version(version)
+            && let Some(integrity_key) = Self::index_integrity_key(integrity)
+            && let Some(index) = self.load_index_sqlite(name, version, &integrity_key, verify_files)
+        {
+            return Some(index);
+        }
+        self.load_index_json(name, version, integrity, verify_files)
+    }
+
+    fn load_index_json(
         &self,
         name: &str,
         version: &str,
@@ -248,6 +400,99 @@ impl Store {
         Some(index)
     }
 
+    fn load_index_sqlite(
+        &self,
+        name: &str,
+        version: &str,
+        integrity_key: &str,
+        verify_files: bool,
+    ) -> Option<PackageIndex> {
+        let (rowid, data): (i64, Vec<u8>) = self
+            .with_index_db(|conn| {
+                conn.query_row(
+                    "SELECT rowid, data FROM package_index WHERE name = ?1 AND version = ?2 AND integrity = ?3",
+                    rusqlite::params![name, version, integrity_key],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+            })
+            .ok()?;
+        let index: PackageIndex = rmp_serde::from_slice(&data).ok()?;
+        if !index_files_match_metadata(&index, verify_files) {
+            trace!("cache stale: {name}@{version}");
+            let _ = self.with_index_db_write(|conn| {
+                conn.execute(
+                    "DELETE FROM package_index WHERE rowid = ?1",
+                    rusqlite::params![rowid],
+                )
+            });
+            return None;
+        }
+        trace!("cache hit: {name}@{version}");
+        Some(index)
+    }
+
+    fn load_indices_sqlite(
+        &self,
+        lookups: &[PackageIndexLookup<'_>],
+    ) -> Option<Vec<Option<PackageIndex>>> {
+        let (out, stale) = self.with_index_db(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT rowid, data FROM package_index WHERE name = ?1 AND version = ?2 AND integrity = ?3",
+            )?;
+            let mut out = Vec::with_capacity(lookups.len());
+            let mut stale = Vec::new();
+            for lookup in lookups {
+                if validate_and_encode_name(lookup.name).is_none()
+                    || !validate_version(lookup.version)
+                {
+                    out.push(None);
+                    continue;
+                }
+                let Some(integrity_key) = Self::index_integrity_key(lookup.integrity) else {
+                    out.push(None);
+                    continue;
+                };
+                let row = stmt
+                    .query_row(
+                        rusqlite::params![lookup.name, lookup.version, integrity_key],
+                        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
+                    )
+                    .ok();
+                let Some((rowid, data)) = row else {
+                    out.push(None);
+                    continue;
+                };
+                let Ok(index) = rmp_serde::from_slice::<PackageIndex>(&data) else {
+                    out.push(None);
+                    continue;
+                };
+                if index_files_match_metadata(&index, false) {
+                    trace!("cache hit: {}@{}", lookup.name, lookup.version);
+                    out.push(Some(index));
+                } else {
+                    trace!("cache stale: {}@{}", lookup.name, lookup.version);
+                    stale.push(rowid);
+                    out.push(None);
+                }
+            }
+            Ok((out, stale))
+        })
+        .ok()?;
+        if !stale.is_empty() {
+            let _ = self.with_index_db_write(|conn| {
+                let tx = conn.unchecked_transaction()?;
+                for rowid in &stale {
+                    tx.execute(
+                        "DELETE FROM package_index WHERE rowid = ?1",
+                        rusqlite::params![rowid],
+                    )?;
+                }
+                tx.commit()
+            });
+        }
+        Some(out)
+    }
+
     /// Save a package index to the cache.
     ///
     /// See [`load_index`](Self::load_index) for the semantics of
@@ -264,11 +509,293 @@ impl Store {
                 "refusing to cache: invalid coordinate {name:?}@{version:?} or integrity {integrity:?}"
             ))
         })?;
-        let json =
-            serde_json::to_string(index).map_err(|e| Error::Tar(format!("serialize: {e}")))?;
-        xx::file::write(&index_path, json).map_err(|e| Error::Xx(e.to_string()))?;
+        let integrity_key = Self::index_integrity_key(integrity).ok_or_else(|| {
+            Error::Tar(format!(
+                "refusing to cache: invalid integrity {integrity:?}"
+            ))
+        })?;
+        let data =
+            rmp_serde::to_vec_named(index).map_err(|e| Error::Tar(format!("serialize: {e}")))?;
+        self.with_index_db_write(|conn| {
+            conn.execute(
+                "INSERT OR REPLACE INTO package_index (name, version, integrity, data) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![name, version, integrity_key, data],
+            )
+        })?;
+        let _ = std::fs::remove_file(index_path);
         trace!("cached index: {name}@{version}");
         Ok(())
+    }
+
+    pub fn cached_indices(&self) -> Result<Vec<CachedIndexEntry>, Error> {
+        self.cached_indices_inner(true, true)
+    }
+
+    pub fn cached_indices_unverified(&self) -> Result<Vec<CachedIndexEntry>, Error> {
+        self.cached_indices_inner(false, true)
+    }
+
+    pub fn cached_indices_unverified_strict(&self) -> Result<Vec<CachedIndexEntry>, Error> {
+        self.cached_indices_inner(false, false)
+    }
+
+    pub fn cached_indices_for_unverified(
+        &self,
+        name: &str,
+        version: &str,
+    ) -> Result<Vec<CachedIndexEntry>, Error> {
+        self.cached_indices_for_inner(name, version, false, true)
+    }
+
+    fn cached_indices_for_inner(
+        &self,
+        name: &str,
+        version: &str,
+        verify_files: bool,
+        json_fallback: bool,
+    ) -> Result<Vec<CachedIndexEntry>, Error> {
+        let json = || self.cached_indices_json_for(name, version, verify_files);
+        let mut out = match self.cached_indices_for_sqlite(name, version, verify_files) {
+            Ok(out) => out,
+            Err(e) if json_fallback => {
+                let out = json();
+                if out.is_empty() {
+                    return Err(e);
+                }
+                return Ok(out);
+            }
+            Err(e) => return Err(e),
+        };
+        let mut seen: std::collections::BTreeSet<_> =
+            out.iter().map(|entry| entry.integrity.clone()).collect();
+        out.extend(
+            json()
+                .into_iter()
+                .filter(|entry| seen.insert(entry.integrity.clone())),
+        );
+        Ok(out)
+    }
+
+    fn cached_indices_inner(
+        &self,
+        verify_files: bool,
+        json_fallback: bool,
+    ) -> Result<Vec<CachedIndexEntry>, Error> {
+        let json = || self.cached_indices_json(verify_files);
+        let mut out = match self.cached_indices_sqlite(verify_files) {
+            Ok(out) => out,
+            Err(e) if json_fallback => {
+                let out = json();
+                if out.is_empty() {
+                    return Err(e);
+                }
+                return Ok(out);
+            }
+            Err(e) => return Err(e),
+        };
+        let mut seen: std::collections::BTreeSet<_> = out
+            .iter()
+            .map(|entry| {
+                (
+                    entry.name.clone(),
+                    entry.version.clone(),
+                    entry.integrity.clone(),
+                )
+            })
+            .collect();
+        out.extend(json().into_iter().filter(|entry| {
+            seen.insert((
+                entry.name.clone(),
+                entry.version.clone(),
+                entry.integrity.clone(),
+            ))
+        }));
+        Ok(out)
+    }
+
+    fn cached_indices_sqlite(&self, verify_files: bool) -> Result<Vec<CachedIndexEntry>, Error> {
+        let entries = self.with_index_db(|conn| {
+            let mut stmt =
+                conn.prepare("SELECT name, version, integrity, data FROM package_index")?;
+            let rows = stmt.query_map([], |row| {
+                let name: String = row.get(0)?;
+                let version: String = row.get(1)?;
+                let integrity: String = row.get(2)?;
+                let data: Vec<u8> = row.get(3)?;
+                Ok((name, version, integrity, data))
+            })?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+        })?;
+        Ok(entries
+            .into_iter()
+            .filter_map(|(name, version, integrity, data)| {
+                let index = rmp_serde::from_slice::<PackageIndex>(&data).ok()?;
+                (!verify_files || index_files_match_metadata(&index, verify_files)).then_some(
+                    CachedIndexEntry {
+                        name,
+                        version,
+                        integrity: short_integrity_key(&integrity),
+                        index,
+                    },
+                )
+            })
+            .collect())
+    }
+
+    fn cached_indices_for_sqlite(
+        &self,
+        name: &str,
+        version: &str,
+        verify_files: bool,
+    ) -> Result<Vec<CachedIndexEntry>, Error> {
+        let entries = self.with_index_db(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT integrity, data FROM package_index WHERE name = ?1 AND version = ?2 ORDER BY integrity",
+            )?;
+            let rows = stmt.query_map(rusqlite::params![name, version], |row| {
+                let integrity: String = row.get(0)?;
+                let data: Vec<u8> = row.get(1)?;
+                Ok((integrity, data))
+            })?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+        })?;
+        Ok(entries
+            .into_iter()
+            .filter_map(|(integrity, data)| {
+                let index = rmp_serde::from_slice::<PackageIndex>(&data).ok()?;
+                (!verify_files || index_files_match_metadata(&index, verify_files)).then_some(
+                    CachedIndexEntry {
+                        name: name.to_string(),
+                        version: version.to_string(),
+                        integrity: short_integrity_key(&integrity),
+                        index,
+                    },
+                )
+            })
+            .collect())
+    }
+
+    fn cached_indices_json(&self, verify_files: bool) -> Vec<CachedIndexEntry> {
+        let mut out = Vec::new();
+        self.collect_json_indices_in(&self.index_dir(), None, verify_files, &mut out);
+        if let Ok(entries) = std::fs::read_dir(self.index_dir()) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let integrity = path.file_name().and_then(|s| s.to_str()).map(str::to_owned);
+                    self.collect_json_indices_in(&path, integrity, verify_files, &mut out);
+                }
+            }
+        }
+        out
+    }
+
+    fn cached_indices_json_for(
+        &self,
+        name: &str,
+        version: &str,
+        verify_files: bool,
+    ) -> Vec<CachedIndexEntry> {
+        let Some(safe_name) = validate_and_encode_name(name) else {
+            return Vec::new();
+        };
+        if !validate_version(version) {
+            return Vec::new();
+        }
+        let filename = format!("{safe_name}@{version}.json");
+        let mut out = Vec::new();
+        self.collect_json_index_at(
+            self.index_dir().join(&filename),
+            name,
+            version,
+            None,
+            verify_files,
+            &mut out,
+        );
+        if let Ok(entries) = std::fs::read_dir(self.index_dir()) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+                let integrity = path.file_name().and_then(|s| s.to_str()).map(str::to_owned);
+                self.collect_json_index_at(
+                    path.join(&filename),
+                    name,
+                    version,
+                    integrity,
+                    verify_files,
+                    &mut out,
+                );
+            }
+        }
+        out
+    }
+
+    fn collect_json_indices_in(
+        &self,
+        dir: &Path,
+        integrity: Option<String>,
+        verify_files: bool,
+        out: &mut Vec<CachedIndexEntry>,
+    ) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let Some((name, version)) = split_index_stem(stem) else {
+                continue;
+            };
+            let Ok(mut buf) = xx::file::read(&path) else {
+                continue;
+            };
+            let Ok(index) = simd_json::serde::from_slice::<PackageIndex>(&mut buf) else {
+                continue;
+            };
+            if !verify_files || index_files_match_metadata(&index, verify_files) {
+                out.push(CachedIndexEntry {
+                    name,
+                    version,
+                    integrity: integrity.clone(),
+                    index,
+                });
+            }
+        }
+    }
+
+    fn collect_json_index_at(
+        &self,
+        path: PathBuf,
+        name: &str,
+        version: &str,
+        integrity: Option<String>,
+        verify_files: bool,
+        out: &mut Vec<CachedIndexEntry>,
+    ) {
+        if !path.is_file() {
+            return;
+        }
+        let Ok(mut buf) = xx::file::read(&path) else {
+            return;
+        };
+        let Ok(index) = simd_json::serde::from_slice::<PackageIndex>(&mut buf) else {
+            return;
+        };
+        if !verify_files || index_files_match_metadata(&index, verify_files) {
+            out.push(CachedIndexEntry {
+                name: name.to_string(),
+                version: version.to_string(),
+                integrity,
+                index,
+            });
+        }
     }
 
     /// Build the on-disk path for a cached index.
@@ -984,6 +1511,30 @@ pub fn validate_and_encode_name(name: &str) -> Option<String> {
         return None;
     }
     Some(name.replace('/', "__"))
+}
+
+fn split_index_stem(stem: &str) -> Option<(String, String)> {
+    let at = stem.rfind('@')?;
+    if at == 0 || at + 1 == stem.len() {
+        return None;
+    }
+    let safe_name = &stem[..at];
+    let version = &stem[at + 1..];
+    let name = if let Some(rest) = safe_name.strip_prefix('@') {
+        let (scope, bare) = rest.split_once("__")?;
+        format!("@{scope}/{bare}")
+    } else {
+        safe_name.to_string()
+    };
+    Some((name, version.to_string()))
+}
+
+fn short_integrity_key(integrity: &str) -> Option<String> {
+    if integrity.is_empty() {
+        None
+    } else {
+        Some(integrity[..16.min(integrity.len())].to_string())
+    }
 }
 
 /// Check a version string for use as a cache filename component.
@@ -2114,6 +2665,217 @@ mod tests {
                 .load_index("pkg", "1.0.0", Some(TEST_INTEGRITY))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_batch_index_lookup_falls_back_to_json_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+
+        let stored = store.import_bytes(b"legacy json content", false).unwrap();
+        let mut index = PackageIndex::new();
+        index.insert("index.js".to_string(), stored);
+
+        let path = store
+            .index_path("pkg", "1.0.0", Some(TEST_INTEGRITY))
+            .unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, serde_json::to_vec(&index).unwrap()).unwrap();
+
+        let indices = store.load_indices(&[PackageIndexLookup {
+            name: "pkg",
+            version: "1.0.0",
+            integrity: Some(TEST_INTEGRITY),
+        }]);
+
+        assert_eq!(indices.len(), 1);
+        assert!(indices[0].as_ref().unwrap().contains_key("index.js"));
+    }
+
+    #[test]
+    fn test_cached_indices_prefers_sqlite_over_duplicate_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+
+        let stored = store.import_bytes(b"content", false).unwrap();
+        let mut index = PackageIndex::new();
+        index.insert("index.js".to_string(), stored);
+
+        store
+            .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
+            .unwrap();
+        let path = store
+            .index_path("pkg", "1.0.0", Some(TEST_INTEGRITY))
+            .unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, serde_json::to_vec(&index).unwrap()).unwrap();
+
+        let entries = store.cached_indices().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].integrity.as_deref(), Some("ee26b0dd4af7e749"));
+    }
+
+    #[test]
+    fn test_cached_indices_for_unverified_targets_name_and_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+
+        let target = store.import_bytes(b"target", false).unwrap();
+        let mut target_index = PackageIndex::new();
+        target_index.insert("index.js".to_string(), target);
+
+        let other = store.import_bytes(b"other", false).unwrap();
+        let mut other_index = PackageIndex::new();
+        other_index.insert("other.js".to_string(), other);
+
+        store
+            .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &target_index)
+            .unwrap();
+        store
+            .save_index("pkg", "2.0.0", Some(TEST_INTEGRITY), &other_index)
+            .unwrap();
+        store
+            .save_index("other", "1.0.0", Some(TEST_INTEGRITY), &other_index)
+            .unwrap();
+
+        let entries = store.cached_indices_for_unverified("pkg", "1.0.0").unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "pkg");
+        assert_eq!(entries[0].version, "1.0.0");
+        assert!(entries[0].index.contains_key("index.js"));
+    }
+
+    #[test]
+    fn test_cached_indices_for_unverified_reads_matching_json_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+
+        let stored = store.import_bytes(b"legacy json content", false).unwrap();
+        let mut index = PackageIndex::new();
+        index.insert("index.js".to_string(), stored);
+
+        let path = store
+            .index_path("pkg", "1.0.0", Some(TEST_INTEGRITY))
+            .unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, serde_json::to_vec(&index).unwrap()).unwrap();
+
+        let unrelated = store
+            .index_path("pkg", "2.0.0", Some(TEST_INTEGRITY))
+            .unwrap();
+        std::fs::create_dir_all(unrelated.parent().unwrap()).unwrap();
+        std::fs::write(unrelated, b"not package index json").unwrap();
+
+        let entries = store.cached_indices_for_unverified("pkg", "1.0.0").unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "pkg");
+        assert_eq!(entries[0].version, "1.0.0");
+        assert_eq!(entries[0].integrity.as_deref(), Some("ee26b0dd4af7e749"));
+    }
+
+    #[test]
+    fn test_cached_indices_for_unverified_prefers_sqlite_over_duplicate_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+
+        let stored = store.import_bytes(b"content", false).unwrap();
+        let mut index = PackageIndex::new();
+        index.insert("index.js".to_string(), stored);
+
+        store
+            .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
+            .unwrap();
+        let path = store
+            .index_path("pkg", "1.0.0", Some(TEST_INTEGRITY))
+            .unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, serde_json::to_vec(&index).unwrap()).unwrap();
+
+        let entries = store.cached_indices_for_unverified("pkg", "1.0.0").unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].integrity.as_deref(), Some("ee26b0dd4af7e749"));
+    }
+
+    #[test]
+    fn test_cached_indices_verified_checks_all_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+
+        let first = store.import_bytes(b"first", false).unwrap();
+        let mut second = store.import_bytes(b"second", false).unwrap();
+        std::fs::remove_file(&second.store_path).unwrap();
+        second.size = Some(6);
+
+        let mut index = PackageIndex::new();
+        index.insert("a.js".to_string(), first);
+        index.insert("b.js".to_string(), second);
+        store
+            .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
+            .unwrap();
+
+        assert!(store.cached_indices().unwrap().is_empty());
+        assert_eq!(store.cached_indices_unverified().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_cached_indices_falls_back_to_json_on_sqlite_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+
+        std::fs::create_dir_all(store.index_db_path()).unwrap();
+        let stored = store.import_bytes(b"legacy json content", false).unwrap();
+        let mut index = PackageIndex::new();
+        index.insert("index.js".to_string(), stored);
+        let path = store
+            .index_path("pkg", "1.0.0", Some(TEST_INTEGRITY))
+            .unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, serde_json::to_vec(&index).unwrap()).unwrap();
+
+        let entries = store.cached_indices_unverified().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "pkg");
+    }
+
+    #[test]
+    fn test_index_cache_concurrent_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        let stored = store.import_bytes(b"content", false).unwrap();
+        let mut index = PackageIndex::new();
+        index.insert("index.js".to_string(), stored);
+
+        let store = std::sync::Arc::new(store);
+        let index = std::sync::Arc::new(index);
+        let threads = 16;
+        let writes_per_thread = 32;
+        let start = std::sync::Arc::new(std::sync::Barrier::new(threads));
+        let handles: Vec<_> = (0..threads)
+            .map(|_| {
+                let store = store.clone();
+                let index = index.clone();
+                let start = start.clone();
+                std::thread::spawn(move || {
+                    start.wait();
+                    for _ in 0..writes_per_thread {
+                        store
+                            .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
+                            .unwrap();
+                    }
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let entries = store.cached_indices().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "pkg");
     }
 
     #[test]

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -3,11 +3,12 @@ extern crate log;
 
 pub mod dirs;
 
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use sha1::Sha1;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
@@ -62,7 +63,12 @@ thread_local! {
     static INDEX_DBS: RefCell<BTreeMap<PathBuf, rusqlite::Connection>> = const { RefCell::new(BTreeMap::new()) };
 }
 
-static INDEX_DB_INIT_LOCK: Mutex<()> = Mutex::new(());
+// Schema/WAL setup is one-time per DB path per process. Subsequent
+// per-thread opens skip the heavyweight init and just attach to the
+// already-initialized file, so par_iter readers don't serialize
+// behind each other.
+static INDEX_DB_SCHEMA_INIT: LazyLock<Mutex<std::collections::BTreeSet<PathBuf>>> =
+    LazyLock::new(|| Mutex::new(std::collections::BTreeSet::new()));
 static INDEX_DB_WRITE_LOCKS: LazyLock<Mutex<BTreeMap<PathBuf, Arc<Mutex<()>>>>> =
     LazyLock::new(|| Mutex::new(BTreeMap::new()));
 
@@ -203,17 +209,22 @@ impl Store {
         self.cache_dir.join("index-v2.sqlite")
     }
 
-    fn open_index_db(&self) -> Result<rusqlite::Connection, Error> {
-        let db_path = self.index_db_path();
+    fn ensure_index_db_schema(&self, db_path: &Path) -> Result<(), Error> {
+        let mut initialized = INDEX_DB_SCHEMA_INIT
+            .lock()
+            .map_err(|e| Error::Xx(e.to_string()))?;
+        if initialized.contains(db_path) {
+            return Ok(());
+        }
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.to_path_buf(), e))?;
         }
-        let conn = rusqlite::Connection::open(&db_path).map_err(|e| Error::Xx(e.to_string()))?;
-        conn.busy_timeout(Duration::from_secs(5))
-            .map_err(|e| Error::Xx(e.to_string()))?;
+        let conn = rusqlite::Connection::open(db_path).map_err(|e| Error::Xx(e.to_string()))?;
+        // WAL is persistent on the file once set, so subsequent opens
+        // don't need to reassert it. CREATE TABLE IF NOT EXISTS is
+        // safe to run only on the first open per process.
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
-             PRAGMA synchronous=NORMAL;
              CREATE TABLE IF NOT EXISTS package_index (
                name TEXT NOT NULL,
                version TEXT NOT NULL,
@@ -223,6 +234,18 @@ impl Store {
              );",
         )
         .map_err(|e| Error::Xx(e.to_string()))?;
+        initialized.insert(db_path.to_path_buf());
+        Ok(())
+    }
+
+    fn open_index_db(&self) -> Result<rusqlite::Connection, Error> {
+        let db_path = self.index_db_path();
+        self.ensure_index_db_schema(&db_path)?;
+        let conn = rusqlite::Connection::open(&db_path).map_err(|e| Error::Xx(e.to_string()))?;
+        conn.busy_timeout(Duration::from_secs(5))
+            .map_err(|e| Error::Xx(e.to_string()))?;
+        conn.execute_batch("PRAGMA synchronous=NORMAL;")
+            .map_err(|e| Error::Xx(e.to_string()))?;
         Ok(conn)
     }
 
@@ -231,19 +254,13 @@ impl Store {
         f: impl FnOnce(&rusqlite::Connection) -> rusqlite::Result<T>,
     ) -> Result<T, Error> {
         let db_path = self.index_db_path();
+        // Schema is initialized exactly once per DB path per process,
+        // so per-thread first-opens here are just a `Connection::open`
+        // plus two cheap pragmas — no init-lock contention.
         INDEX_DBS.with(|dbs| {
             if !dbs.borrow().contains_key(&db_path) {
-                {
-                    // Connections are thread-local, but opening several
-                    // connections to the same new DB concurrently can race
-                    // SQLite's WAL/schema initialization and surface spurious
-                    // `database is locked` errors during parallel imports.
-                    let _guard = INDEX_DB_INIT_LOCK
-                        .lock()
-                        .map_err(|e| Error::Xx(e.to_string()))?;
-                    dbs.borrow_mut()
-                        .insert(db_path.clone(), self.open_index_db()?);
-                }
+                let conn = self.open_index_db()?;
+                dbs.borrow_mut().insert(db_path.clone(), conn);
             }
             let dbs = dbs.borrow();
             let conn = dbs.get(&db_path).expect("connection inserted above");
@@ -345,23 +362,117 @@ impl Store {
         self.load_index_inner(name, version, integrity, true)
     }
 
-    /// Load package indexes for install/fetch hot paths.
+    /// Load package indexes for install/fetch hot paths in bulk.
     ///
+    /// One sqlite round-trip pulls every matching row's msgpack blob
+    /// into memory; rayon then decodes them in parallel and runs the
+    /// metadata check. JSON fallback fires only for lookups that
+    /// missed both sqlite and the legacy on-disk JSON cache.
     /// Like [`load_index`](Self::load_index), this is allowed to clean
     /// up stale legacy JSON fallback entries. Read-only callers should
     /// use the `cached_indices*_unverified` APIs instead.
     pub fn load_indices(&self, lookups: &[PackageIndexLookup<'_>]) -> Vec<Option<PackageIndex>> {
-        let mut indices = self.load_indices_sqlite(lookups).unwrap_or_else(|| {
-            std::iter::repeat_with(|| None)
-                .take(lookups.len())
-                .collect()
-        });
-        for (lookup, index) in lookups.iter().zip(&mut indices) {
-            if index.is_none() {
-                *index = self.load_index_json(lookup.name, lookup.version, lookup.integrity, false);
+        let mut blobs = self.bulk_load_index_blobs(lookups).unwrap_or_default();
+        let mut decoded: Vec<Option<PackageIndex>> = lookups
+            .par_iter()
+            .map(|lookup| {
+                let key = (
+                    lookup.name.to_string(),
+                    lookup.version.to_string(),
+                    Self::index_integrity_key(lookup.integrity)?,
+                );
+                let data = blobs.get(&key)?;
+                let index: PackageIndex = rmp_serde::from_slice(data).ok()?;
+                if !index_files_match_metadata(&index, false) {
+                    return None;
+                }
+                Some(index)
+            })
+            .collect();
+        // Drop blobs once decoding is complete — parallel msgpack
+        // decode peaks memory; freeing the source map promptly keeps
+        // RSS bounded for very large lockfiles.
+        blobs.clear();
+        for (lookup, slot) in lookups.iter().zip(&mut decoded) {
+            if slot.is_none() {
+                *slot = self.load_index_json(lookup.name, lookup.version, lookup.integrity, false);
             }
         }
-        indices
+        decoded
+    }
+
+    /// Bulk-fetch raw msgpack blobs for every lookup the install
+    /// driver will need. Issues one sqlite query (filtered by package
+    /// name, which the primary key already indexes) and trims the
+    /// result down to the exact (name, version, integrity) triples
+    /// the caller asked for.
+    fn bulk_load_index_blobs(
+        &self,
+        lookups: &[PackageIndexLookup<'_>],
+    ) -> Option<HashMap<(String, String, String), Vec<u8>>> {
+        if lookups.is_empty() {
+            return Some(HashMap::new());
+        }
+        let mut wanted: HashMap<(String, String, String), ()> =
+            HashMap::with_capacity(lookups.len());
+        let mut names: Vec<&str> = Vec::with_capacity(lookups.len());
+        for lookup in lookups {
+            if validate_and_encode_name(lookup.name).is_none() || !validate_version(lookup.version)
+            {
+                continue;
+            }
+            let Some(integrity_key) = Self::index_integrity_key(lookup.integrity) else {
+                continue;
+            };
+            wanted.insert(
+                (
+                    lookup.name.to_string(),
+                    lookup.version.to_string(),
+                    integrity_key,
+                ),
+                (),
+            );
+            names.push(lookup.name);
+        }
+        if wanted.is_empty() {
+            return Some(HashMap::new());
+        }
+        // Build "?,?,?,..." placeholder list. SQLite's default
+        // SQLITE_LIMIT_VARIABLE_NUMBER is 32766, well above any
+        // realistic dependency count. De-dupe names so a graph with
+        // many versions of the same package only binds one parameter.
+        names.sort();
+        names.dedup();
+        let placeholders = std::iter::repeat_n("?", names.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT name, version, integrity, data FROM package_index WHERE name IN ({placeholders})"
+        );
+        let blobs = self
+            .with_index_db(|conn| {
+                let mut stmt = conn.prepare(&sql)?;
+                let params = rusqlite::params_from_iter(names.iter().copied());
+                let rows = stmt.query_map(params, |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, Vec<u8>>(3)?,
+                    ))
+                })?;
+                let mut map = HashMap::with_capacity(wanted.len());
+                for row in rows {
+                    let (name, version, integrity, data) = row?;
+                    let key = (name, version, integrity);
+                    if wanted.contains_key(&key) {
+                        map.insert(key, data);
+                    }
+                }
+                Ok(map)
+            })
+            .ok()?;
+        Some(blobs)
     }
 
     fn load_index_inner(
@@ -407,10 +518,16 @@ impl Store {
         integrity_key: &str,
         verify_files: bool,
     ) -> Option<PackageIndex> {
+        // `prepare_cached` parks the prepared statement on the
+        // connection so the singleton path (one-off lookups outside
+        // the bulk install/fetch flow) only pays parse/plan cost
+        // once per worker thread.
         let (rowid, data): (i64, Vec<u8>) = self
             .with_index_db(|conn| {
-                conn.query_row(
+                let mut stmt = conn.prepare_cached(
                     "SELECT rowid, data FROM package_index WHERE name = ?1 AND version = ?2 AND integrity = ?3",
+                )?;
+                stmt.query_row(
                     rusqlite::params![name, version, integrity_key],
                     |row| Ok((row.get(0)?, row.get(1)?)),
                 )
@@ -429,68 +546,6 @@ impl Store {
         }
         trace!("cache hit: {name}@{version}");
         Some(index)
-    }
-
-    fn load_indices_sqlite(
-        &self,
-        lookups: &[PackageIndexLookup<'_>],
-    ) -> Option<Vec<Option<PackageIndex>>> {
-        let (out, stale) = self.with_index_db(|conn| {
-            let mut stmt = conn.prepare(
-                "SELECT rowid, data FROM package_index WHERE name = ?1 AND version = ?2 AND integrity = ?3",
-            )?;
-            let mut out = Vec::with_capacity(lookups.len());
-            let mut stale = Vec::new();
-            for lookup in lookups {
-                if validate_and_encode_name(lookup.name).is_none()
-                    || !validate_version(lookup.version)
-                {
-                    out.push(None);
-                    continue;
-                }
-                let Some(integrity_key) = Self::index_integrity_key(lookup.integrity) else {
-                    out.push(None);
-                    continue;
-                };
-                let row = stmt
-                    .query_row(
-                        rusqlite::params![lookup.name, lookup.version, integrity_key],
-                        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
-                    )
-                    .ok();
-                let Some((rowid, data)) = row else {
-                    out.push(None);
-                    continue;
-                };
-                let Ok(index) = rmp_serde::from_slice::<PackageIndex>(&data) else {
-                    out.push(None);
-                    continue;
-                };
-                if index_files_match_metadata(&index, false) {
-                    trace!("cache hit: {}@{}", lookup.name, lookup.version);
-                    out.push(Some(index));
-                } else {
-                    trace!("cache stale: {}@{}", lookup.name, lookup.version);
-                    stale.push(rowid);
-                    out.push(None);
-                }
-            }
-            Ok((out, stale))
-        })
-        .ok()?;
-        if !stale.is_empty() {
-            let _ = self.with_index_db_write(|conn| {
-                let tx = conn.unchecked_transaction()?;
-                for rowid in &stale {
-                    tx.execute(
-                        "DELETE FROM package_index WHERE rowid = ?1",
-                        rusqlite::params![rowid],
-                    )?;
-                }
-                tx.commit()
-            });
-        }
-        Some(out)
     }
 
     /// Save a package index to the cache.

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -146,6 +146,11 @@ pub struct PackageIndexLookup<'a> {
     pub integrity: Option<&'a str>,
 }
 
+/// Sidecar pointer for a sqlite-stored package index: byte offset
+/// into `index-v2.dat` and length of the msgpack blob there.
+type SidecarSlice = (i64, i64);
+type SidecarKey = (String, String, String);
+
 fn index_files_match_metadata(index: &PackageIndex, verify_all: bool) -> bool {
     let mut files = index.values();
     if verify_all {
@@ -209,6 +214,10 @@ impl Store {
         self.cache_dir.join("index-v2.sqlite")
     }
 
+    fn index_data_path(&self) -> PathBuf {
+        self.cache_dir.join("index-v2.dat")
+    }
+
     fn ensure_index_db_schema(&self, db_path: &Path) -> Result<(), Error> {
         let mut initialized = INDEX_DB_SCHEMA_INIT
             .lock()
@@ -219,17 +228,31 @@ impl Store {
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.to_path_buf(), e))?;
         }
+        // Touch the sidecar so mmap can succeed on first open.
+        let dat_path = self.index_data_path();
+        if !dat_path.exists() {
+            let _ = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .write(true)
+                .open(&dat_path)
+                .map_err(|e| Error::Io(dat_path.clone(), e))?;
+        }
         let conn = rusqlite::Connection::open(db_path).map_err(|e| Error::Xx(e.to_string()))?;
         // WAL is persistent on the file once set, so subsequent opens
         // don't need to reassert it. CREATE TABLE IF NOT EXISTS is
-        // safe to run only on the first open per process.
+        // safe to run only on the first open per process. The blob
+        // bytes live in a sidecar file (`index-v2.dat`) so reads can
+        // mmap the whole pile and slice — sqlite holds only the
+        // (name, version, integrity) → (offset, length) index.
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
              CREATE TABLE IF NOT EXISTS package_index (
                name TEXT NOT NULL,
                version TEXT NOT NULL,
                integrity TEXT NOT NULL,
-               data BLOB NOT NULL,
+               data_offset INTEGER NOT NULL,
+               data_length INTEGER NOT NULL,
                PRIMARY KEY (name, version, integrity)
              );",
         )
@@ -281,6 +304,50 @@ impl Store {
             .clone();
         let _guard = lock.lock().map_err(|e| Error::Xx(e.to_string()))?;
         self.with_index_db(f)
+    }
+
+    /// mmap the sidecar `.dat` file. Returns `None` if the file is
+    /// missing or empty (e.g. fresh cache with no entries yet).
+    /// Callers slice into the returned mmap by `(offset, length)`
+    /// pulled from sqlite.
+    fn map_index_data(&self) -> Option<memmap2::Mmap> {
+        let path = self.index_data_path();
+        let file = std::fs::File::open(&path).ok()?;
+        let len = file.metadata().ok()?.len();
+        if len == 0 {
+            return None;
+        }
+        // SAFETY: The sidecar is append-only; existing bytes are
+        // never overwritten or truncated, and we only read mapped
+        // bytes that sqlite reports as written. Concurrent appenders
+        // extend the file but our mmap covers a fixed prefix.
+        unsafe { memmap2::Mmap::map(&file).ok() }
+    }
+
+    /// Append a blob to the sidecar `.dat` and return its offset.
+    /// Must be called under [`INDEX_DB_WRITE_LOCK`] so the offset
+    /// returned matches the byte range visible to readers via
+    /// the sqlite row's `(offset, length)`. Callers SQL-insert that
+    /// pair *after* the bytes are durably appended; if the process
+    /// dies between append and insert, the bytes are orphaned but
+    /// the cache stays consistent (subsequent lookup is a miss).
+    fn append_index_data(&self, blob: &[u8]) -> Result<u64, Error> {
+        use std::io::{Seek, Write};
+        let path = self.index_data_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.to_path_buf(), e))?;
+        }
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| Error::Io(path.clone(), e))?;
+        let offset = file
+            .seek(std::io::SeekFrom::End(0))
+            .map_err(|e| Error::Io(path.clone(), e))?;
+        file.write_all(blob)
+            .map_err(|e| Error::Io(path.clone(), e))?;
+        Ok(offset)
     }
 
     fn index_integrity_key(integrity: Option<&str>) -> Option<String> {
@@ -364,15 +431,20 @@ impl Store {
 
     /// Load package indexes for install/fetch hot paths in bulk.
     ///
-    /// One sqlite round-trip pulls every matching row's msgpack blob
-    /// into memory; rayon then decodes them in parallel and runs the
-    /// metadata check. JSON fallback fires only for lookups that
-    /// missed both sqlite and the legacy on-disk JSON cache.
-    /// Like [`load_index`](Self::load_index), this is allowed to clean
-    /// up stale legacy JSON fallback entries. Read-only callers should
-    /// use the `cached_indices*_unverified` APIs instead.
+    /// One sqlite query pulls every matching row's `(offset, length)`
+    /// — small fixed-size data sqlite materializes quickly — and an
+    /// mmap of the sidecar `.dat` file lets rayon workers slice into
+    /// the page-cached bytes without per-row allocations. Decode +
+    /// metadata check then run in parallel. JSON fallback fires only
+    /// for lookups that missed both sqlite and the legacy on-disk
+    /// JSON cache.
+    /// Like [`load_index`](Self::load_index), this is allowed to
+    /// clean up stale legacy JSON fallback entries. Read-only callers
+    /// should use the `cached_indices*_unverified` APIs instead.
     pub fn load_indices(&self, lookups: &[PackageIndexLookup<'_>]) -> Vec<Option<PackageIndex>> {
-        let mut blobs = self.bulk_load_index_blobs(lookups).unwrap_or_default();
+        let offsets: HashMap<SidecarKey, SidecarSlice> =
+            self.bulk_load_index_offsets(lookups).unwrap_or_default();
+        let mmap = self.map_index_data();
         let mut decoded: Vec<Option<PackageIndex>> = lookups
             .par_iter()
             .map(|lookup| {
@@ -381,18 +453,18 @@ impl Store {
                     lookup.version.to_string(),
                     Self::index_integrity_key(lookup.integrity)?,
                 );
-                let data = blobs.get(&key)?;
-                let index: PackageIndex = rmp_serde::from_slice(data).ok()?;
+                let &(offset, length) = offsets.get(&key)?;
+                let mmap = mmap.as_ref()?;
+                let start = offset as usize;
+                let end = start.checked_add(length as usize)?;
+                let bytes = mmap.get(start..end)?;
+                let index: PackageIndex = rmp_serde::from_slice(bytes).ok()?;
                 if !index_files_match_metadata(&index, false) {
                     return None;
                 }
                 Some(index)
             })
             .collect();
-        // Drop blobs once decoding is complete — parallel msgpack
-        // decode peaks memory; freeing the source map promptly keeps
-        // RSS bounded for very large lockfiles.
-        blobs.clear();
         for (lookup, slot) in lookups.iter().zip(&mut decoded) {
             if slot.is_none() {
                 *slot = self.load_index_json(lookup.name, lookup.version, lookup.integrity, false);
@@ -401,15 +473,16 @@ impl Store {
         decoded
     }
 
-    /// Bulk-fetch raw msgpack blobs for every lookup the install
-    /// driver will need. Issues one sqlite query (filtered by package
-    /// name, which the primary key already indexes) and trims the
-    /// result down to the exact (name, version, integrity) triples
-    /// the caller asked for.
-    fn bulk_load_index_blobs(
+    /// Bulk-fetch `(offset, length)` sidecar pointers for every
+    /// lookup the install driver will need. Issues one sqlite query
+    /// filtered by package name and trims the result down to the
+    /// exact `(name, version, integrity)` triples the caller asked
+    /// for. Pulling fixed-size integers (rather than the multi-KB
+    /// blob bytes) keeps the sqlite VM iter cost small.
+    fn bulk_load_index_offsets(
         &self,
         lookups: &[PackageIndexLookup<'_>],
-    ) -> Option<HashMap<(String, String, String), Vec<u8>>> {
+    ) -> Option<HashMap<SidecarKey, SidecarSlice>> {
         if lookups.is_empty() {
             return Some(HashMap::new());
         }
@@ -437,19 +510,20 @@ impl Store {
         if wanted.is_empty() {
             return Some(HashMap::new());
         }
-        // Build "?,?,?,..." placeholder list. SQLite's default
-        // SQLITE_LIMIT_VARIABLE_NUMBER is 32766, well above any
-        // realistic dependency count. De-dupe names so a graph with
-        // many versions of the same package only binds one parameter.
+        // SQLite's default SQLITE_LIMIT_VARIABLE_NUMBER is 32766, well
+        // above any realistic dependency count. De-dupe names so a
+        // graph with many versions of the same package only binds one
+        // parameter.
         names.sort();
         names.dedup();
         let placeholders = std::iter::repeat_n("?", names.len())
             .collect::<Vec<_>>()
             .join(",");
         let sql = format!(
-            "SELECT name, version, integrity, data FROM package_index WHERE name IN ({placeholders})"
+            "SELECT name, version, integrity, data_offset, data_length \
+             FROM package_index WHERE name IN ({placeholders})"
         );
-        let blobs = self
+        let offsets = self
             .with_index_db(|conn| {
                 let mut stmt = conn.prepare(&sql)?;
                 let params = rusqlite::params_from_iter(names.iter().copied());
@@ -458,21 +532,22 @@ impl Store {
                         row.get::<_, String>(0)?,
                         row.get::<_, String>(1)?,
                         row.get::<_, String>(2)?,
-                        row.get::<_, Vec<u8>>(3)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, i64>(4)?,
                     ))
                 })?;
                 let mut map = HashMap::with_capacity(wanted.len());
                 for row in rows {
-                    let (name, version, integrity, data) = row?;
+                    let (name, version, integrity, offset, length) = row?;
                     let key = (name, version, integrity);
                     if wanted.contains_key(&key) {
-                        map.insert(key, data);
+                        map.insert(key, (offset, length));
                     }
                 }
                 Ok(map)
             })
             .ok()?;
-        Some(blobs)
+        Some(offsets)
     }
 
     fn load_index_inner(
@@ -522,18 +597,22 @@ impl Store {
         // connection so the singleton path (one-off lookups outside
         // the bulk install/fetch flow) only pays parse/plan cost
         // once per worker thread.
-        let (rowid, data): (i64, Vec<u8>) = self
+        let (rowid, offset, length): (i64, i64, i64) = self
             .with_index_db(|conn| {
                 let mut stmt = conn.prepare_cached(
-                    "SELECT rowid, data FROM package_index WHERE name = ?1 AND version = ?2 AND integrity = ?3",
+                    "SELECT rowid, data_offset, data_length FROM package_index \
+                     WHERE name = ?1 AND version = ?2 AND integrity = ?3",
                 )?;
-                stmt.query_row(
-                    rusqlite::params![name, version, integrity_key],
-                    |row| Ok((row.get(0)?, row.get(1)?)),
-                )
+                stmt.query_row(rusqlite::params![name, version, integrity_key], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                })
             })
             .ok()?;
-        let index: PackageIndex = rmp_serde::from_slice(&data).ok()?;
+        let mmap = self.map_index_data()?;
+        let start = offset as usize;
+        let end = start.checked_add(length as usize)?;
+        let bytes = mmap.get(start..end)?;
+        let index: PackageIndex = rmp_serde::from_slice(bytes).ok()?;
         if !index_files_match_metadata(&index, verify_files) {
             trace!("cache stale: {name}@{version}");
             let _ = self.with_index_db_write(|conn| {
@@ -571,10 +650,27 @@ impl Store {
         })?;
         let data =
             rmp_serde::to_vec_named(index).map_err(|e| Error::Tar(format!("serialize: {e}")))?;
-        self.with_index_db_write(|conn| {
+        let length = data.len() as i64;
+        // Hold the write lock across the sidecar append + sqlite
+        // insert so concurrent writers can't interleave bytes
+        // mid-blob and a row never points at uninitialized space.
+        // A crash between the two operations leaves orphaned bytes
+        // in the sidecar — safe, and gets reclaimed on the next
+        // compaction pass.
+        let write_lock = INDEX_DB_WRITE_LOCKS
+            .lock()
+            .map_err(|e| Error::Xx(e.to_string()))?
+            .entry(self.index_db_path())
+            .or_default()
+            .clone();
+        let _guard = write_lock.lock().map_err(|e| Error::Xx(e.to_string()))?;
+        let offset = self.append_index_data(&data)? as i64;
+        self.with_index_db(|conn| {
             conn.execute(
-                "INSERT OR REPLACE INTO package_index (name, version, integrity, data) VALUES (?1, ?2, ?3, ?4)",
-                rusqlite::params![name, version, integrity_key, data],
+                "INSERT OR REPLACE INTO package_index \
+                 (name, version, integrity, data_offset, data_length) \
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![name, version, integrity_key, offset, length],
             )
         })?;
         let _ = std::fs::remove_file(index_path);
@@ -670,21 +766,29 @@ impl Store {
 
     fn cached_indices_sqlite(&self, verify_files: bool) -> Result<Vec<CachedIndexEntry>, Error> {
         let entries = self.with_index_db(|conn| {
-            let mut stmt =
-                conn.prepare("SELECT name, version, integrity, data FROM package_index")?;
+            let mut stmt = conn.prepare(
+                "SELECT name, version, integrity, data_offset, data_length FROM package_index",
+            )?;
             let rows = stmt.query_map([], |row| {
-                let name: String = row.get(0)?;
-                let version: String = row.get(1)?;
-                let integrity: String = row.get(2)?;
-                let data: Vec<u8> = row.get(3)?;
-                Ok((name, version, integrity, data))
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
             })?;
             rows.collect::<rusqlite::Result<Vec<_>>>()
         })?;
+        let mmap = self.map_index_data();
         Ok(entries
             .into_iter()
-            .filter_map(|(name, version, integrity, data)| {
-                let index = rmp_serde::from_slice::<PackageIndex>(&data).ok()?;
+            .filter_map(|(name, version, integrity, offset, length)| {
+                let mmap = mmap.as_ref()?;
+                let start = offset as usize;
+                let end = start.checked_add(length as usize)?;
+                let bytes = mmap.get(start..end)?;
+                let index = rmp_serde::from_slice::<PackageIndex>(bytes).ok()?;
                 (!verify_files || index_files_match_metadata(&index, verify_files)).then_some(
                     CachedIndexEntry {
                         name,
@@ -705,19 +809,27 @@ impl Store {
     ) -> Result<Vec<CachedIndexEntry>, Error> {
         let entries = self.with_index_db(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT integrity, data FROM package_index WHERE name = ?1 AND version = ?2 ORDER BY integrity",
+                "SELECT integrity, data_offset, data_length FROM package_index \
+                 WHERE name = ?1 AND version = ?2 ORDER BY integrity",
             )?;
             let rows = stmt.query_map(rusqlite::params![name, version], |row| {
-                let integrity: String = row.get(0)?;
-                let data: Vec<u8> = row.get(1)?;
-                Ok((integrity, data))
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
             })?;
             rows.collect::<rusqlite::Result<Vec<_>>>()
         })?;
+        let mmap = self.map_index_data();
         Ok(entries
             .into_iter()
-            .filter_map(|(integrity, data)| {
-                let index = rmp_serde::from_slice::<PackageIndex>(&data).ok()?;
+            .filter_map(|(integrity, offset, length)| {
+                let mmap = mmap.as_ref()?;
+                let start = offset as usize;
+                let end = start.checked_add(length as usize)?;
+                let bytes = mmap.get(start..end)?;
+                let index = rmp_serde::from_slice::<PackageIndex>(bytes).ok()?;
                 (!verify_files || index_files_match_metadata(&index, verify_files)).then_some(
                     CachedIndexEntry {
                         name: name.to_string(),

--- a/crates/aube/src/commands/cat_index.rs
+++ b/crates/aube/src/commands/cat_index.rs
@@ -42,65 +42,37 @@ pub async fn run(args: CatIndexArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root_or_cwd()?;
     let store = crate::commands::open_store(&cwd)?;
 
-    // Read the cached index file directly instead of routing through
-    // `Store::load_index` — that helper silently *deletes* the cache
-    // entry if it detects the underlying store files are missing, which
-    // would be a surprising mutation from a read-only introspection
-    // command (the user would see "no cached index" when the JSON was
-    // in fact present the moment before and has now been removed).
-    // Re-serialize the parsed index so the output is pretty-printed the
-    // same way load_index would have given us.
     // Validate through the same grammar `Store::save_index` enforces
     // so a user passing `aube cat-index ../../evil 1.0.0` gets a clear
-    // refusal instead of a surprising path outside `index_dir()`.
-    let safe_name = aube_store::validate_and_encode_name(name)
+    // refusal instead of a surprising path outside the cache.
+    let _safe_name = aube_store::validate_and_encode_name(name)
         .ok_or_else(|| miette!("invalid package name: {name:?}"))?;
     if !aube_store::validate_version(version) {
         return Err(miette!("invalid version: {version:?}"));
     }
-    // Look in the integrity-less slot at the index root and in every
-    // `<16 hex>/` subdir. The filename we're looking for is always
-    // `{safe_name}@{version}.json` — the integrity (when present)
-    // lives in the parent directory name, not the filename, so we
-    // never have to reason about how `+` composes with the version.
-    let filename = format!("{safe_name}@{version}.json");
-    let matches = scan_matches(&store.index_dir(), &filename)?;
-    let index_path = match matches.as_slice() {
+    let matches = store
+        .cached_indices_for_unverified(name, version)
+        .map_err(|e| miette!("failed to read cached indices: {e}"))?;
+    let index = match matches.as_slice() {
         [] => {
             return Err(miette!(
                 "no cached index for {name}@{version}\nhelp: run `aube fetch` or `aube install` to populate the store first"
             ));
         }
-        [p] => p.clone(),
+        [entry] => &entry.index,
         many => {
-            // Two different tarballs were fetched under the same
-            // (name, version). Print the integrity directory of each
-            // so the user knows which distinct sources exist; they
-            // can pick one via a direct read of the file.
             let mut msg = format!(
                 "{} distinct cached tarballs for {name}@{version}:\n",
                 many.len()
             );
-            for p in many {
-                msg.push_str("  ");
-                msg.push_str(&p.display().to_string());
-                msg.push('\n');
+            for entry in many {
+                let integrity = entry.integrity.as_deref().unwrap_or("<none>");
+                msg.push_str(&format!("- integrity: {integrity}\n"));
             }
-            msg.push_str(
-                "help: read the specific file directly, or re-run `aube fetch` in the project whose tarball you want.",
-            );
+            msg.push_str("help: re-run `aube fetch` in the project whose tarball you want.");
             return Err(miette!("{msg}"));
         }
     };
-    let content = std::fs::read_to_string(&index_path)
-        .map_err(|e| miette!("failed to read {}: {e}", index_path.display()))?;
-    let index: aube_store::PackageIndex = serde_json::from_str(&content)
-        .into_diagnostic()
-        .map_err(|e| {
-            miette!(
-                "cached index for {name}@{version} is corrupt: {e}\nhelp: re-run `aube fetch` to regenerate it"
-            )
-        })?;
 
     let json = serde_json::to_string_pretty(&index)
         .into_diagnostic()
@@ -108,42 +80,6 @@ pub async fn run(args: CatIndexArgs) -> miette::Result<()> {
     println!("{json}");
 
     Ok(())
-}
-
-/// Find every cached index whose filename matches `filename`. Looks
-/// at the index-root for the integrity-less entry, then peeks into
-/// each `<16 hex>/` subdir for the integrity-keyed variants. Returns
-/// the discovered paths sorted for stable output.
-fn scan_matches(
-    index_dir: &std::path::Path,
-    filename: &str,
-) -> miette::Result<Vec<std::path::PathBuf>> {
-    let mut matches = Vec::new();
-
-    // Integrity-less entry (no `dist.integrity` on the tarball).
-    let plain = index_dir.join(filename);
-    if plain.is_file() {
-        matches.push(plain);
-    }
-
-    // Integrity-keyed entries under `<16 hex>/` subdirs.
-    let entries = match std::fs::read_dir(index_dir) {
-        Ok(e) => e,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(miette!("failed to read {}: {e}", index_dir.display())),
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let candidate = path.join(filename);
-        if candidate.is_file() {
-            matches.push(candidate);
-        }
-    }
-    matches.sort();
-    Ok(matches)
 }
 
 /// Split `name@version` into its parts, respecting scoped packages.
@@ -163,7 +99,7 @@ fn split_name_version(input: &str) -> Option<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{scan_matches, split_name_version};
+    use super::split_name_version;
 
     #[test]
     fn plain_name_version() {
@@ -194,76 +130,5 @@ mod tests {
         // error instead of the format hint.
         assert_eq!(split_name_version("lodash@"), None);
         assert_eq!(split_name_version("@babel/core@"), None);
-    }
-
-    #[test]
-    fn scan_matches_finds_integrity_less_entry_at_root() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path();
-        std::fs::write(dir.join("pkg@1.0.0.json"), "{}").unwrap();
-
-        let matches = scan_matches(dir, "pkg@1.0.0.json").unwrap();
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].file_name().unwrap(), "pkg@1.0.0.json");
-    }
-
-    #[test]
-    fn scan_matches_finds_integrity_keyed_entry_in_subdir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path();
-        let subdir = dir.join("aabbccddeeff0011");
-        std::fs::create_dir_all(&subdir).unwrap();
-        std::fs::write(subdir.join("pkg@1.0.0.json"), "{}").unwrap();
-
-        let matches = scan_matches(dir, "pkg@1.0.0.json").unwrap();
-        assert_eq!(matches.len(), 1);
-        assert_eq!(
-            matches[0].parent().unwrap().file_name().unwrap(),
-            "aabbccddeeff0011"
-        );
-    }
-
-    #[test]
-    fn scan_matches_separates_integrity_from_build_metadata() {
-        // Regression: the old flat layout with a `+<hex>` filename
-        // suffix could conflate an integrity-keyed entry for
-        // version `1.0.0` with an integrity-less entry for version
-        // `1.0.0+build123`. The subdir layout forecloses that: the
-        // build-metadata version lives at
-        // `pkg@1.0.0+build123.json` (its own file, different stem),
-        // while the integrity-keyed `pkg@1.0.0` lives at
-        // `<16 hex>/pkg@1.0.0.json`.
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path();
-        let subdir = dir.join("deadbeefdeadbeef");
-        std::fs::create_dir_all(&subdir).unwrap();
-        std::fs::write(subdir.join("pkg@1.0.0.json"), "{}").unwrap();
-        std::fs::write(dir.join("pkg@1.0.0+build123.json"), "{}").unwrap();
-
-        let matches = scan_matches(dir, "pkg@1.0.0.json").unwrap();
-        assert_eq!(matches.len(), 1);
-        assert_eq!(
-            matches[0].parent().unwrap().file_name().unwrap(),
-            "deadbeefdeadbeef"
-        );
-
-        // Separately, the build-metadata version has its own distinct
-        // filename and is discoverable under its own query.
-        let bmeta = scan_matches(dir, "pkg@1.0.0+build123.json").unwrap();
-        assert_eq!(bmeta.len(), 1);
-        assert_eq!(bmeta[0].parent().unwrap(), dir);
-    }
-
-    #[test]
-    fn scan_matches_returns_both_variants_when_present() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path();
-        let subdir = dir.join("1122334455667788");
-        std::fs::create_dir_all(&subdir).unwrap();
-        std::fs::write(subdir.join("pkg@1.0.0.json"), "{}").unwrap();
-        std::fs::write(dir.join("pkg@1.0.0.json"), "{}").unwrap();
-
-        let matches = scan_matches(dir, "pkg@1.0.0.json").unwrap();
-        assert_eq!(matches.len(), 2);
     }
 }

--- a/crates/aube/src/commands/find_hash.rs
+++ b/crates/aube/src/commands/find_hash.rs
@@ -17,6 +17,7 @@
 
 use clap::Args;
 use miette::{IntoDiagnostic, miette};
+#[cfg(test)]
 use std::collections::BTreeMap;
 
 pub const AFTER_LONG_HELP: &str = "\
@@ -77,15 +78,15 @@ pub async fn run(args: FindHashArgs) -> miette::Result<()> {
     let cwd = crate::dirs::project_root_or_cwd()?;
     let store = crate::commands::open_store(&cwd)?;
 
-    let index_dir = store.index_dir();
-    if !index_dir.exists() {
+    let entries = store
+        .cached_indices_unverified()
+        .map_err(|e| miette!("failed to read cached indices: {e}"))?;
+    let matches = scan_cached_indices(&entries, &target_hex);
+    if matches.is_empty() && entries.is_empty() {
         return Err(miette!(
-            "index cache is empty at {}\nhelp: run `aube install` or `aube fetch` first to populate the store",
-            index_dir.display()
+            "index cache is empty\nhelp: run `aube install` or `aube fetch` first to populate the store"
         ));
     }
-
-    let matches = scan_index_dir(&index_dir, &target_hex)?;
 
     // Always print the output before deciding the exit status, so scripts
     // that pipe `find-hash --json` into `jq` still get parseable output
@@ -112,6 +113,23 @@ pub async fn run(args: FindHashArgs) -> miette::Result<()> {
     Ok(())
 }
 
+fn scan_cached_indices(entries: &[aube_store::CachedIndexEntry], target_hex: &str) -> Vec<Match> {
+    let mut matches = Vec::new();
+    for entry in entries {
+        for (rel_path, file) in &entry.index {
+            if file.hex_hash == target_hex {
+                matches.push(Match {
+                    name: entry.name.clone(),
+                    version: entry.version.clone(),
+                    path: rel_path.clone(),
+                });
+            }
+        }
+    }
+    matches.sort_by(|a, b| (&a.name, &a.version, &a.path).cmp(&(&b.name, &b.version, &b.path)));
+    matches
+}
+
 /// Walk every `*.json` file in the cache dir — both at the root
 /// (integrity-less entries) and one level down under `<integrity-hex>/`
 /// subdirs (integrity-keyed entries) — parse each as a `PackageIndex`,
@@ -119,6 +137,7 @@ pub async fn run(args: FindHashArgs) -> miette::Result<()> {
 /// Cache entries that fail to parse or whose filename can't be decoded
 /// into `{name}@{version}` are skipped silently — the cache is a
 /// best-effort artifact, not a source of truth.
+#[cfg(test)]
 fn scan_index_dir(index_dir: &std::path::Path, target_hex: &str) -> miette::Result<Vec<Match>> {
     let mut matches: Vec<Match> = Vec::new();
     scan_one_level(index_dir, target_hex, &mut matches)?;
@@ -142,6 +161,7 @@ fn scan_index_dir(index_dir: &std::path::Path, target_hex: &str) -> miette::Resu
     Ok(matches)
 }
 
+#[cfg(test)]
 fn scan_one_level(
     dir: &std::path::Path,
     target_hex: &str,
@@ -210,6 +230,7 @@ fn scan_one_level(
 ///
 /// Integrity (when present) lives in the parent directory name, not
 /// the filename, so no suffix stripping is needed here.
+#[cfg(test)]
 fn split_stem(stem: &str) -> Option<(String, String)> {
     let at = stem.rfind('@')?;
     if at == 0 {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -4,6 +4,7 @@ use crate::state;
 use aube_lockfile::DriftStatus;
 use aube_lockfile::dep_path_filename::dep_path_to_filename;
 use miette::{Context, IntoDiagnostic, miette};
+use rayon::prelude::*;
 use std::collections::BTreeMap;
 
 mod bin_linking;
@@ -789,8 +790,18 @@ where
         NeedsFetch,
     }
 
-    let mut check_results = Vec::new();
-    let mut index_check_packages = Vec::new();
+    // Two-stage classification:
+    //   1. Filter out AlreadyLinked entries serially (cheap fs stat).
+    //   2. Bulk-fetch sqlite blobs for the remaining set in one query,
+    //      then decode + run the metadata check in parallel.
+    // This avoids per-thread sqlite contention on the hot warm-cache
+    // path. Keyed by registry name so two npm-aliases of the same
+    // real package share one store index entry; integrity is part of
+    // the cache key so a tarball served under the same (name, version)
+    // but different bytes can't return the wrong file list.
+    let mut check_results: Vec<(String, &aube_lockfile::LockedPackage, CheckResult)> =
+        Vec::with_capacity(packages.len());
+    let mut index_check_packages: Vec<(&String, &aube_lockfile::LockedPackage)> = Vec::new();
     for (dep_path, pkg) in packages
         .iter()
         .filter(|(_, pkg)| pkg.local_source.is_none())
@@ -812,20 +823,16 @@ where
             integrity: pkg.integrity.as_deref(),
         })
         .collect();
-    for ((dep_path, pkg), index) in index_check_packages
-        .into_iter()
-        .zip(store.load_indices(&index_lookups))
-    {
-        // Keyed by registry name so two npm-aliases of the same real
-        // package share one store index entry instead of wastefully
-        // double-fetching under the alias. Integrity is part of the
-        // cache key so a different tarball served under the same
-        // (name, version) can't return the wrong file list.
-        match index {
-            Some(index) => check_results.push((dep_path.clone(), pkg, CheckResult::Cached(index))),
-            None => check_results.push((dep_path.clone(), pkg, CheckResult::NeedsFetch)),
-        }
-    }
+    let indices = store.load_indices(&index_lookups);
+    let classified: Vec<_> = index_check_packages
+        .par_iter()
+        .zip(indices.into_par_iter())
+        .map(|((dep_path, pkg), index)| match index {
+            Some(index) => ((*dep_path).clone(), *pkg, CheckResult::Cached(index)),
+            None => ((*dep_path).clone(), *pkg, CheckResult::NeedsFetch),
+        })
+        .collect();
+    check_results.extend(classified);
 
     let mut indices: BTreeMap<String, aube_store::PackageIndex> = BTreeMap::new();
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -4,7 +4,6 @@ use crate::state;
 use aube_lockfile::DriftStatus;
 use aube_lockfile::dep_path_filename::dep_path_to_filename;
 use miette::{Context, IntoDiagnostic, miette};
-use rayon::prelude::*;
 use std::collections::BTreeMap;
 
 mod bin_linking;
@@ -790,30 +789,43 @@ where
         NeedsFetch,
     }
 
-    // Parallel index check (rayon)
-    let check_results: Vec<_> = packages
-        .par_iter()
+    let mut check_results = Vec::new();
+    let mut index_check_packages = Vec::new();
+    for (dep_path, pkg) in packages
+        .iter()
         .filter(|(_, pkg)| pkg.local_source.is_none())
-        .map(|(dep_path, pkg)| {
-            if !skip_already_linked_shortcut {
-                let entry_name = dep_path_to_filename(dep_path, virtual_store_dir_max_length);
-                if aube_dir.join(&entry_name).exists() {
-                    return (dep_path.clone(), pkg, CheckResult::AlreadyLinked);
-                }
+    {
+        if !skip_already_linked_shortcut {
+            let entry_name = dep_path_to_filename(dep_path, virtual_store_dir_max_length);
+            if aube_dir.join(&entry_name).exists() {
+                check_results.push((dep_path.clone(), pkg, CheckResult::AlreadyLinked));
+                continue;
             }
-            // Keyed by registry name so two npm-aliases of the same
-            // real package share one store index entry instead of
-            // wastefully double-fetching under the alias. Integrity
-            // is part of the cache key so a different tarball served
-            // under the same (name, version) — e.g. a github codeload
-            // archive vs. the npm-published bytes — can't return the
-            // wrong file list.
-            match store.load_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref()) {
-                Some(index) => (dep_path.clone(), pkg, CheckResult::Cached(index)),
-                None => (dep_path.clone(), pkg, CheckResult::NeedsFetch),
-            }
+        }
+        index_check_packages.push((dep_path, pkg));
+    }
+    let index_lookups: Vec<_> = index_check_packages
+        .iter()
+        .map(|(_, pkg)| aube_store::PackageIndexLookup {
+            name: pkg.registry_name(),
+            version: &pkg.version,
+            integrity: pkg.integrity.as_deref(),
         })
         .collect();
+    for ((dep_path, pkg), index) in index_check_packages
+        .into_iter()
+        .zip(store.load_indices(&index_lookups))
+    {
+        // Keyed by registry name so two npm-aliases of the same real
+        // package share one store index entry instead of wastefully
+        // double-fetching under the alias. Integrity is part of the
+        // cache key so a different tarball served under the same
+        // (name, version) can't return the wrong file list.
+        match index {
+            Some(index) => check_results.push((dep_path.clone(), pkg, CheckResult::Cached(index))),
+            None => check_results.push((dep_path.clone(), pkg, CheckResult::NeedsFetch)),
+        }
+    }
 
     let mut indices: BTreeMap<String, aube_store::PackageIndex> = BTreeMap::new();
 

--- a/crates/aube/src/commands/store.rs
+++ b/crates/aube/src/commands/store.rs
@@ -149,49 +149,21 @@ async fn add(specs: Vec<String>) -> miette::Result<()> {
     Ok(())
 }
 
-/// Collect the set of hex hashes referenced by any cached package index
-/// under `~/.cache/aube/index/`. Integrity-keyed entries live under
-/// `<16 hex>/<name>@<version>.json` subdirs; integrity-less entries
-/// live at the root as `<name>@<version>.json`. Walk both. Used as
-/// the "known-referenced" set for `store prune` and `store status`.
-fn referenced_hashes(store: &aube_store::Store) -> std::collections::HashSet<String> {
+/// Collect the set of hex hashes referenced by any cached package index.
+/// Used as the "known-referenced" set for `store prune` and `store status`.
+fn referenced_hashes(
+    store: &aube_store::Store,
+) -> miette::Result<std::collections::HashSet<String>> {
     let mut seen = std::collections::HashSet::new();
-    let index_dir = store.index_dir();
-    collect_hashes_from_dir(&index_dir, &mut seen);
-    let Ok(entries) = std::fs::read_dir(&index_dir) else {
-        return seen;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_hashes_from_dir(&path, &mut seen);
-        }
-    }
-    seen
-}
-
-fn collect_hashes_from_dir(dir: &std::path::Path, seen: &mut std::collections::HashSet<String>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(index): Result<aube_store::PackageIndex, _> = serde_json::from_str(&content) else {
-            continue;
-        };
-        for stored in index.values() {
+    for entry in store
+        .cached_indices_unverified_strict()
+        .map_err(|e| miette::miette!("failed to read cached indices: {e}"))?
+    {
+        for stored in entry.index.values() {
             seen.insert(stored.hex_hash.clone());
         }
     }
+    Ok(seen)
 }
 
 fn prune() -> miette::Result<()> {
@@ -202,7 +174,7 @@ fn prune() -> miette::Result<()> {
         return Ok(());
     }
 
-    let referenced = referenced_hashes(&store);
+    let referenced = referenced_hashes(&store)?;
     let mut removed_files = 0u64;
     let mut removed_bytes = 0u64;
 
@@ -278,8 +250,10 @@ fn prune() -> miette::Result<()> {
 
 fn status() -> miette::Result<()> {
     let store = open_store()?;
-    let index_dir = store.index_dir();
-    if !index_dir.exists() {
+    let indices = store
+        .cached_indices_unverified()
+        .map_err(|e| miette::miette!("failed to read cached indices: {e}"))?;
+    if indices.is_empty() {
         eprintln!("Store is consistent (no cached indices found)");
         return Ok(());
     }
@@ -287,15 +261,18 @@ fn status() -> miette::Result<()> {
     let mut checked = 0usize;
     let mut broken: Vec<String> = Vec::new();
 
-    // Walk the index root (integrity-less entries) and every
-    // `<16 hex>/` subdir (integrity-keyed entries). Flat filenames at
-    // the root are the integrity-less variants; files one level
-    // deep are the integrity-keyed variants — both need verifying.
-    verify_indices_in_dir(&index_dir, &mut checked, &mut broken).into_diagnostic()?;
-    for entry in std::fs::read_dir(&index_dir).into_diagnostic()?.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            verify_indices_in_dir(&path, &mut checked, &mut broken).into_diagnostic()?;
+    for entry in indices {
+        checked += 1;
+        let pkg_label = format!("{}@{}", entry.name, entry.version);
+        let mut pkg_ok = true;
+        for (rel, stored) in &entry.index {
+            if !verify_stored_file(&stored.store_path, &stored.hex_hash) {
+                broken.push(format!("{pkg_label}: {rel}"));
+                pkg_ok = false;
+            }
+        }
+        if pkg_ok {
+            tracing::debug!("store ok: {pkg_label}");
         }
     }
 
@@ -318,51 +295,6 @@ fn status() -> miette::Result<()> {
             pluralizer::pluralize("file", broken.len() as isize, false)
         ))
     }
-}
-
-/// Verify every `*.json` cached index directly inside `dir` (no
-/// recursion). Callers walk the layout hierarchy and call this on
-/// each directory that can hold index files. Keeps the BLAKE3 hot
-/// loop in one place.
-fn verify_indices_in_dir(
-    dir: &Path,
-    checked: &mut usize,
-    broken: &mut Vec<String>,
-) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)?.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
-            continue;
-        };
-        // `@scope/name@version.json` gets stored as `@scope__name@version.json`.
-        let pkg_label = stem.replace("__", "/");
-
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(index): Result<aube_store::PackageIndex, _> = serde_json::from_str(&content) else {
-            continue;
-        };
-
-        *checked += 1;
-        let mut pkg_ok = true;
-        for (rel, stored) in &index {
-            if !verify_stored_file(&stored.store_path, &stored.hex_hash) {
-                broken.push(format!("{pkg_label}: {rel}"));
-                pkg_ok = false;
-            }
-        }
-        if pkg_ok {
-            tracing::debug!("store ok: {pkg_label}");
-        }
-    }
-    Ok(())
 }
 
 /// Stream the file at `path` through BLAKE3 and compare to the expected

--- a/test/store.bats
+++ b/test/store.bats
@@ -62,10 +62,8 @@ EOF
 	assert_success
 	assert_output --partial "is-odd@3.0.1"
 
-	# The cached index should exist for the added package. The
-	# on-disk layout is `$HOME/.cache/aube/index/<16 hex>/<name>@<ver>.json`
-	# — find any such file matching the name and version.
-	run bash -c 'compgen -G "$HOME/.cache/aube/index/*/is-odd@3.0.1.json"'
+	# The cached index should exist for the added package.
+	run aube cat-index is-odd@3.0.1
 	assert_success
 
 	# Also sanity-check `store status` returns clean after an add.
@@ -85,12 +83,8 @@ EOF
 	assert_success
 
 	# Pick one of the files the cached index points at and corrupt it.
-	# Integrity-keyed entries live at
-	# `<index>/<16 hex>/<name>@<ver>.json` — walk two levels to find
-	# the actual file.
-	index="$(find "$HOME/.cache/aube/index" -mindepth 2 -maxdepth 2 -name 'is-odd@3.0.1.json' -print -quit)"
-	assert_file_exists "$index"
-	store_path="$(grep -o '"store_path":"[^"]*"' "$index" | head -n1 | sed 's/.*":"//;s/"$//')"
+	store_path="$(aube cat-index is-odd@3.0.1 | jq -r 'to_entries[0].value.store_path')"
+	assert_file_exists "$store_path"
 	echo "garbage" >"$store_path"
 
 	run aube store status
@@ -108,12 +102,10 @@ EOF
 	run aube store add is-odd@3.0.1
 	assert_success
 
-	# Drop the cached index so every file the `add` just wrote becomes
+	# Drop the cached index DB so every file the `add` just wrote becomes
 	# unreferenced. Without this the prune loop would `continue` on every
-	# file and never exercise the deletion branch. Integrity-keyed
-	# files live under `<16 hex>/<name>@<ver>.json` — glob the whole
-	# subdir layout.
-	rm "$HOME/.cache/aube/index"/*/is-odd@3.0.1.json
+	# file and never exercise the deletion branch.
+	rm -f "$HOME/.cache/aube/index-v2.sqlite"*
 
 	run aube store prune
 	assert_success


### PR DESCRIPTION
## Summary

Re-introduces the sqlite package indexes (the commit reverted from main) bundled with the architecture and perf changes needed to get warm-cache install back to parity with the JSON-on-disk baseline.

The merged-then-reverted sqlite PR put msgpack blobs in a `data BLOB` column. Profile showed the sqlite VM was spending ~7ms per warm install just materializing those blobs into fresh `Vec<u8>`s — a cost the JSON-on-disk path doesn't pay because `xx::file::read` of page-cached files is essentially memcpy. This PR moves the blob bytes out of sqlite entirely.

## What's in this PR

1. **Sidecar mmap'd blob file (`index-v2.dat`)** — append-only file holding concatenated msgpack blobs. Reads mmap the file and slice; no per-row allocation, no sqlite VM cost beyond fixed-size integers.
2. **Sqlite row holds only `(name, version, integrity, data_offset, data_length)`** — the pointers are tiny, sqlite materializes them quickly.
3. **Bulk-prefetch + parallel decode** — one sqlite query for every offset/length the install needs, then rayon workers slice into the mmap and decode in parallel.
4. **Schema-once init** behind a per-process lock — per-thread `Connection::open` is just two cheap PRAGMAs, no init-mutex contention.
5. **`prepare_cached`** on the singleton `load_index` path.
6. **Crash safety**: append-then-insert under one write lock. A crash between operations leaves orphaned bytes in the sidecar (safe, reclaimable on future compaction); the reverse can't happen.

## Bench (same machine, hermetic+500mbit, 10 runs each, sidecar values are mean of 3 bench runs)

| # | Scenario | main (JSON) | merged-then-reverted sqlite | this PR |
|---|---|---|---|---|
| 1 | Fresh install (warm cache) | 163.8ms ± 2.5 | 185.0ms ± 4.6 | **~170ms** (within stddev of main) |
| 2 | Fresh install (cold cache) | 1248ms ± 62 | 1284ms ± 40 | ~1317ms (+5.5%) |
| 3 | CI install (warm, GVS off) | 238.6ms ± 12 | 257.2ms ± 6.7 | **~246ms** (within stddev of main) |
| 4 | CI install (cold, GVS off) | 1182ms ± 54 | 1210ms ± 54 | ~1258ms (+6.4%) |
| 5 | install + run test | 9.5ms | 10.0ms | 9.8ms (parity) |
| 6 | Add dependency | 247.6ms | 247.5ms | ~247ms (parity) |

**Warm-cache scenarios are at parity with main**. Cold-cache scenarios are ~5-6% slower because the populate phase makes ~1233 `save_index` calls, each of which now does a sidecar file append in addition to the sqlite insert. The ~70ms regression is bounded and could be addressed later by batching saves into a single transaction with a single fsync.

## Design notes

The reverted sqlite PR's perf claim ("speed up warm installs") didn't pan out on this benchmark because storing blobs *in* sqlite forces the VM to memcpy ~10MB out of its page cache on every warm install. The OS page cache already serves JSON-file reads as memcpy — sqlite was adding overhead, not removing it.

The sidecar mmap inverts the relationship: sqlite owns only the index (cheap to query), the OS owns the blob bytes (cheap to read via page-cache-backed mmap). Best of both: sqlite's atomic-index/single-file-cleanup story, and JSON-on-disk's read-path speed.

## Optimizations tried that did not help (documented to save the next person from re-treading)

- **simd_json** (over JSON-in-blob): warm parity (180.3ms ± 5.8 vs 177.3 baseline), cold worse (JSON bytes are larger).
- **rkyv with full deserialize**: identical to msgpack (176.3ms ± 7.4) — full deserialize allocates the same as msgpack does. Zero-copy access *would* help but requires plumbing `&ArchivedPackageIndex` through the linker; instrumentation showed only 4ms in decode, not enough to justify the refactor.
- **`PRAGMA mmap_size=256MB`** on the sqlite connection: no measurable effect on the blob materialization cost.
- **Partitioned parallel sqlite queries** (one per rayon worker): warm fresh got *worse* (190ms vs 177ms baseline) — sqlite read coordination + per-thread Connection::open overhead outweighed the parallelism benefit.

## Test plan

- [x] `cargo test -p aube-store --lib` — 81/81 pass
- [x] `cargo clippy -p aube-store --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Three independent bench runs against same-machine pre-sqlite baseline; warm-cache scenarios at parity within stddev