### PR TITLE
fix(lockfile): hoist npm workspace links to root importer deps

### DIFF
--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -523,6 +523,55 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         push_direct(dep_name, DepType::Optional, &mut direct);
     }
 
+    // npm symlinks every workspace member (and any other top-level
+    // `npm install ../local-pkg` link) into the root `node_modules/`
+    // regardless of what the root manifest declares. Each one shows
+    // up in the lockfile as `node_modules/<name>: { link: true,
+    // resolved: "<rel>" }`. Surface those as direct deps of the
+    // root importer so the linker recreates the same symlinks on
+    // `aube install`. Without this, builds that resolve workspace
+    // packages from the repo root (Angular CLI / Nx / many monorepo
+    // build tools) silently break when migrating npm-managed
+    // workspaces over to aube — the root `node_modules/<ws-pkg>`
+    // entry simply isn't created. Sorted by name for deterministic
+    // ordering.
+    let already_added: BTreeSet<&str> = direct.iter().map(|d| d.name.as_str()).collect();
+    let mut workspace_links: Vec<DirectDep> = Vec::new();
+    for (install_path, raw_entry) in &raw.packages {
+        if !raw_entry.link {
+            continue;
+        }
+        let Some(rest) = install_path.strip_prefix("node_modules/") else {
+            continue;
+        };
+        // Only consider top-level entries: `node_modules/<name>` or
+        // `node_modules/@scope/<name>`. A nested `node_modules/`
+        // segment means this is a non-hoisted nested link, not a
+        // root symlink.
+        if rest.contains("/node_modules/") {
+            continue;
+        }
+        let segments = rest.split('/').count();
+        let expected = if rest.starts_with('@') { 2 } else { 1 };
+        if segments != expected {
+            continue;
+        }
+        let Some(info) = install_path_info.get(install_path) else {
+            continue;
+        };
+        if already_added.contains(info.name.as_str()) {
+            continue;
+        }
+        workspace_links.push(DirectDep {
+            name: info.name.clone(),
+            dep_path: info.dep_path.clone(),
+            dep_type: DepType::Production,
+            specifier: None,
+        });
+    }
+    workspace_links.sort_by(|a, b| a.name.cmp(&b.name));
+    direct.extend(workspace_links);
+
     graph.importers.insert(".".to_string(), direct);
     Ok(graph)
 }
@@ -2543,6 +2592,82 @@ mod tests {
             Some("5.4.1")
         );
         assert!(!graph.packages.contains_key("@scope/app@0.68.1"));
+    }
+
+    /// npm workspaces that aren't listed in the root manifest's
+    /// `dependencies`/`devDependencies` still get a `node_modules/<name>`
+    /// link entry in the lockfile — npm symlinks every workspace member
+    /// at the workspace root regardless. The siemens/element repo
+    /// (https://github.com/siemens/element) hits this: its 11 workspace
+    /// projects under `projects/*` aren't declared as deps of the root
+    /// `package.json`, so the linker had nothing to link at the root and
+    /// `node_modules/@siemens/element-ng` (and friends) silently went
+    /// missing — breaking Angular CLI builds that resolve workspace
+    /// libraries from the repo root.
+    #[test]
+    fn test_parse_workspace_links_undeclared_in_root_deps() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+            "name": "workspace-root",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "workspace-root",
+                    "version": "1.0.0",
+                    "workspaces": ["projects/element-ng", "projects/charts-ng"],
+                    "dependencies": { "chalk": "^5.4.1" }
+                },
+                "node_modules/@siemens/element-ng": {
+                    "resolved": "projects/element-ng",
+                    "link": true
+                },
+                "node_modules/@siemens/charts-ng": {
+                    "resolved": "projects/charts-ng",
+                    "link": true
+                },
+                "node_modules/chalk": {
+                    "version": "5.4.1",
+                    "integrity": "sha512-chalk"
+                },
+                "projects/element-ng": {
+                    "name": "@siemens/element-ng",
+                    "version": "21.0.0"
+                },
+                "projects/charts-ng": {
+                    "name": "@siemens/charts-ng",
+                    "version": "21.0.0"
+                }
+            }
+        }"#;
+        std::fs::write(tmp.path(), content).unwrap();
+
+        let graph = parse(tmp.path()).unwrap();
+        let importer = &graph.importers["."];
+
+        let names: Vec<&str> = importer.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&"chalk"));
+        assert!(
+            names.contains(&"@siemens/element-ng"),
+            "workspace package `@siemens/element-ng` should be a direct dep of root \
+             so the linker creates `node_modules/@siemens/element-ng`, even though \
+             the root manifest doesn't list it; got importer deps {names:?}"
+        );
+        assert!(
+            names.contains(&"@siemens/charts-ng"),
+            "workspace package `@siemens/charts-ng` should be a direct dep of root; \
+             got importer deps {names:?}"
+        );
+
+        // Each workspace dep_path round-trips through LocalSource::Link.
+        let element_ng = importer
+            .iter()
+            .find(|d| d.name == "@siemens/element-ng")
+            .unwrap();
+        assert_eq!(
+            graph.packages[&element_ng.dep_path].local_source,
+            Some(LocalSource::Link(PathBuf::from("projects/element-ng")))
+        );
     }
 
     /// npm copies `funding:` verbatim from each package's


### PR DESCRIPTION
## Summary

- npm symlinks every workspace member into the root `node_modules/` regardless of whether the root `package.json` declares it as a dep — recorded in `package-lock.json` as `node_modules/<name>: { link: true, resolved: "<rel>" }`. Aube was seeding the root importer only from `dependencies`/`devDependencies`/`optionalDependencies`, so undeclared workspace projects never got a top-level `node_modules/<ws-pkg>` symlink and Angular CLI / Nx / similar tooling that resolves workspace libraries from the repo root broke when migrating npm-managed monorepos to aube.
- Surface every top-level link entry (plain or scoped, no nested `/node_modules/` segment) as a direct dep of the root importer in the npm-lockfile parser. Existing `already_added` dedupe preserves explicit `dependencies: { "@scope/x": "file:packages/x" }` declarations; entries are appended sorted by name for deterministic output.

Reported in https://github.com/endevco/aube/discussions/345#discussioncomment-16754288 (siemens/element).

## Test plan

- [x] `cargo test -p aube-lockfile` (new test `test_parse_workspace_links_undeclared_in_root_deps` + existing `test_parse_workspace_links` to confirm no double-add when the workspace IS in root deps)
- [x] `cargo test` workspace-wide
- [x] Manual smoke: minimal repro repo with `workspaces: ["projects/foo", "projects/bar"]`, neither declared in root `dependencies`, package-lock.json with `node_modules/@scope/foo` + `node_modules/@scope/bar` link entries → `aube install` produces `node_modules/@scope/foo` and `node_modules/@scope/bar` symlinks pointing at `../../projects/<name>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how npm lockfiles are interpreted to seed root direct dependencies, which can affect install layout and hoisting behavior for workspace/linked packages.
> 
> **Overview**
> Ensures npm-managed workspaces that are **not declared in the root `package.json` deps** still get their top-level `node_modules/<workspace>` symlinks recreated by `aube install`.
> 
> The npm lockfile parser now scans `package-lock.json` `packages` for top-level `node_modules/*` entries with `link: true`, de-dupes against already-declared direct deps, sorts them deterministically, and appends them to the root importer’s direct deps. Adds a regression test covering undeclared workspace members being surfaced as root direct deps and round-tripping as `LocalSource::Link`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c98805f70d41477f04da00d2ba83ddb45e60c22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->