### PR TITLE
chore: release v1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aube-util",
  "miette",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aube-manifest",
  "landlock",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "blake3",
  "rustc-hash",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -3711,9 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15ee875bc02244694d5b380ba437349d269cf168bbd84e896437c579317ac6e4"
+checksum = "0e7dc53c8a941858d01479622dbb7650aaa2ee0ca1fb58fb6cdddbfc3064abbb"
 dependencies = [
  "base64",
  "hex",
@@ -3729,9 +3729,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38e3886caf4e1a5a20806c0dc0f5acf33a0bd9c720415ece9e44ddc7a7bf1c1"
+checksum = "da90c3d9af638898a5fdc347479b18f950bb0dde11ecf2244f94cd28135da53b"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -3751,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c813a3bb8997ebd2ed01564bf23318960dc1ca88104c72bd5719c629522c5"
+checksum = "c60b95ecc87b2e279705e4a617cfb2d668bb9dfb15b3a99322524b6f44a4201b"
 dependencies = [
  "base64",
  "reqwest 0.13.3",
@@ -3768,9 +3768,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa2a84ceb4b2a7bd42cff428555b7ac8897ce22b8c74a56558b53ac6ff10af9"
+checksum = "7c0d53558825c77716855c13794306fff766854c1bf92948e77d7890da3f2455"
 dependencies = [
  "base64",
  "hex",
@@ -3781,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd4ae883c74bfb7c7d85d5a21bd054c9589d4109a28ab6db55e43ab94f417b7"
+checksum = "3cff865c405b9bcc2d8f684245307880c282c87edcd34b0039babfde9ae301ba"
 dependencies = [
  "ambient-id",
  "base64",
@@ -3801,9 +3801,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c012c1a119e2533d236d5d4244fec16e3be1243ce3fa0e0e9130cb6fc5f830c9"
+checksum = "641fdaaa40d0cd6e249cf1671c2240beff1a3ece578062cf43e750779e8db2b3"
 dependencies = [
  "base64",
  "hex",
@@ -3819,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecc951910318de1475041aa6a749f0a0671cfc82c14ae458df25cf93944cacf"
+checksum = "67ae2a8b1e76abe552de2ba89c85013d09753beeebc76b5c50bfdff4abc689a1"
 dependencies = [
  "base64",
  "serde_json",
@@ -3839,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa1be3a70fdefac1156561f70b44263601dce6ca8ce7022c0c51b142ec0138f"
+checksum = "a6b0d2550f05c096400066e858db13d91f9de3b750a7541fb1291c1dc80ca290"
 dependencies = [
  "base64",
  "chrono",
@@ -3857,9 +3857,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d48313c1591c98f6233882786809069ff8f047271d3ffac48fb34966f61ba4e"
+checksum = "0bc86c8abc1ece6832236e7e34e9baebb5d4d40490c0332b814a0d8624ca7255"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -3883,9 +3883,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb6793ac7a0960807ed731055763f0cdf3ae356c5eccfdb21a44b9671e96d6c"
+checksum = "f8d870c9bcfdf83396ac2bd2d6a23c5d09ec02cc9fda50fa1cbb3dd71a9bee53"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -115,14 +115,14 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.4.0" }
-aube-settings = { path = "crates/aube-settings", version = "1.4.0" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.4.0" }
-aube-registry = { path = "crates/aube-registry", version = "1.4.0" }
-aube-store = { path = "crates/aube-store", version = "1.4.0" }
-aube-linker = { path = "crates/aube-linker", version = "1.4.0" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.4.0" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.4.0" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.4.0" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.4.0" }
-aube-util = { path = "crates/aube-util", version = "1.4.0" }
+aube = { path = "crates/aube", version = "1.5.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.5.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.5.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.5.0" }
+aube-store = { path = "crates/aube-store", version = "1.5.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.5.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.5.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.5.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.5.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.5.0" }
+aube-util = { path = "crates/aube-util", version = "1.5.0" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.4.0"
+version "1.5.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/endevco/aube/compare/aube-linker-v1.4.0...aube-linker-v1.5.0) - 2026-04-29
+
+### Fixed
+
+- *(cli,linker,lockfile)* patch-commit destination, CRLF patches, npm-alias catalog ([#384](https://github.com/endevco/aube/pull/384))
+
 ## [1.4.0](https://github.com/endevco/aube/compare/aube-linker-v1.3.0...aube-linker-v1.4.0) - 2026-04-28
 
 ### Fixed

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.4.0...aube-lockfile-v1.5.0) - 2026-04-29
+
+### Fixed
+
+- *(cli,linker,lockfile)* patch-commit destination, CRLF patches, npm-alias catalog ([#384](https://github.com/endevco/aube/pull/384))
+- *(lockfile)* preserve pnpm registry tarball urls ([#378](https://github.com/endevco/aube/pull/378))
+- *(lockfile)* hoist npm workspace links to root importer deps ([#374](https://github.com/endevco/aube/pull/374))
+
+### Other
+
+- *(lockfile)* add property roundtrip coverage ([#376](https://github.com/endevco/aube/pull/376))
+
 ## [1.4.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.3.0...aube-lockfile-v1.4.0) - 2026-04-28
 
 ### Fixed

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/endevco/aube/compare/aube-manifest-v1.4.0...aube-manifest-v1.5.0) - 2026-04-29
+
+### Fixed
+
+- *(cli,linker,lockfile)* patch-commit destination, CRLF patches, npm-alias catalog ([#384](https://github.com/endevco/aube/pull/384))
+- *(workspace)* default-write aube-workspace.yaml instead of pnpm-workspace.yaml ([#382](https://github.com/endevco/aube/pull/382))
+
 ## [1.4.0](https://github.com/endevco/aube/compare/aube-manifest-v1.3.0...aube-manifest-v1.4.0) - 2026-04-28
 
 ### Added

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/endevco/aube/compare/aube-registry-v1.4.0...aube-registry-v1.5.0) - 2026-04-29
+
+### Fixed
+
+- *(resolver)* require structured trust evidence ([#379](https://github.com/endevco/aube/pull/379))
+
 ## [1.4.0](https://github.com/endevco/aube/compare/aube-registry-v1.3.0...aube-registry-v1.4.0) - 2026-04-28
 
 ### Fixed

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/endevco/aube/compare/aube-resolver-v1.4.0...aube-resolver-v1.5.0) - 2026-04-29
+
+### Fixed
+
+- *(resolver)* require structured trust evidence ([#379](https://github.com/endevco/aube/pull/379))
+- *(resolver)* bound resolved package stream ([#377](https://github.com/endevco/aube/pull/377))
+
 ## [1.4.0](https://github.com/endevco/aube/compare/aube-resolver-v1.3.0...aube-resolver-v1.4.0) - 2026-04-28
 
 ### Added

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/endevco/aube/compare/aube-scripts-v1.4.0...aube-scripts-v1.5.0) - 2026-04-29
+
+### Fixed
+
+- *(workspace)* default-write aube-workspace.yaml instead of pnpm-workspace.yaml ([#382](https://github.com/endevco/aube/pull/382))
+
 ## [1.4.0](https://github.com/endevco/aube/compare/aube-scripts-v1.3.0...aube-scripts-v1.4.0) - 2026-04-28
 
 ### Added

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/endevco/aube/compare/aube-settings-v1.4.0...aube-settings-v1.5.0) - 2026-04-29
+
+### Fixed
+
+- *(resolver)* require structured trust evidence ([#379](https://github.com/endevco/aube/pull/379))
+
 ## [1.4.0](https://github.com/endevco/aube/compare/aube-settings-v1.3.0...aube-settings-v1.4.0) - 2026-04-28
 
 ### Added

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/endevco/aube/compare/aube-util-v1.4.0...aube-util-v1.5.0) - 2026-04-29
+
+### Fixed
+
+- *(cli,linker,lockfile)* patch-commit destination, CRLF patches, npm-alias catalog ([#384](https://github.com/endevco/aube/pull/384))
+
 ## [1.4.0](https://github.com/endevco/aube/compare/aube-util-v1.3.0...aube-util-v1.4.0) - 2026-04-28
 
 ### Fixed

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/endevco/aube/compare/v1.4.0...v1.5.0) - 2026-04-29
+
+### Added
+
+- *(cli)* add dependency graph query command ([#380](https://github.com/endevco/aube/pull/380))
+
+### Fixed
+
+- *(cli,linker,lockfile)* patch-commit destination, CRLF patches, npm-alias catalog ([#384](https://github.com/endevco/aube/pull/384))
+- *(workspace)* default-write aube-workspace.yaml instead of pnpm-workspace.yaml ([#382](https://github.com/endevco/aube/pull/382))
+- *(resolver)* bound resolved package stream ([#377](https://github.com/endevco/aube/pull/377))
+
+### Other
+
+- *(bench)* add install phase timings ([#381](https://github.com/endevco/aube/pull/381))
+
 ## [1.4.0](https://github.com/endevco/aube/compare/v1.3.0...v1.4.0) - 2026-04-28
 
 ### Added

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6036,7 +6036,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.4.0",
+  "version": "1.5.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.4.0
+**Version**: 1.5.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.4.0",
-  "releasedAt": "2026-04-28T23:09:06Z"
+  "version": "1.5.0",
+  "releasedAt": "2026-04-29T19:49:21Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.5.0`

This PR bumps the workspace to `v1.5.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
