### PR TITLE
test(lockfile): add property roundtrip coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,7 @@ dependencies = [
  "hex",
  "miette",
  "node-semver",
+ "proptest",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -504,6 +505,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -2840,6 +2856,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +3032,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "ratatui"
@@ -3372,6 +3422,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4490,6 +4552,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -29,4 +29,5 @@ rustc-hash = { workspace = true }
 smallvec = { workspace = true }
 
 [dev-dependencies]
+proptest = "1"
 tempfile = "3"

--- a/crates/aube-lockfile/tests/proptest.rs
+++ b/crates/aube-lockfile/tests/proptest.rs
@@ -1,0 +1,242 @@
+use aube_lockfile::{
+    DepType, DirectDep, LockedPackage, LockfileGraph, LockfileKind, LockfileSettings,
+};
+use proptest::prelude::*;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone)]
+struct GraphShape {
+    package_count: usize,
+    edge_bits: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedGraph {
+    importers: BTreeMap<String, Vec<NormalizedDirectDep>>,
+    packages: BTreeMap<String, NormalizedPackage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedDirectDep {
+    name: String,
+    dep_path: String,
+    dep_type: DepType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedPackage {
+    name: String,
+    version: String,
+    dependencies: BTreeMap<String, String>,
+    optional_dependencies: BTreeMap<String, String>,
+}
+
+fn graph_shapes() -> impl Strategy<Value = GraphShape> {
+    (1usize..=8).prop_flat_map(|package_count| {
+        let edge_count = package_count * (package_count - 1) / 2;
+        let edge_space = 1u32 << edge_count;
+        (Just(package_count), 0..edge_space).prop_map(|(package_count, edge_bits)| GraphShape {
+            package_count,
+            edge_bits,
+        })
+    })
+}
+
+fn graph_from_shape(shape: GraphShape) -> (LockfileGraph, aube_manifest::PackageJson) {
+    let mut manifest = aube_manifest::PackageJson {
+        name: Some("roundtrip-root".to_string()),
+        version: Some("1.0.0".to_string()),
+        ..Default::default()
+    };
+    let mut graph = LockfileGraph {
+        settings: LockfileSettings::default(),
+        ..Default::default()
+    };
+
+    for idx in 0..shape.package_count {
+        let name = package_name(idx);
+        let version = package_version(idx);
+        let dep_path = dep_path(&name, &version);
+        let dep_type = dep_type(idx);
+
+        match dep_type {
+            DepType::Production => {
+                manifest.dependencies.insert(name.clone(), version.clone());
+            }
+            DepType::Dev => {
+                manifest
+                    .dev_dependencies
+                    .insert(name.clone(), version.clone());
+            }
+            DepType::Optional => {
+                manifest
+                    .optional_dependencies
+                    .insert(name.clone(), version.clone());
+            }
+        }
+
+        graph
+            .importers
+            .entry(".".to_string())
+            .or_default()
+            .push(DirectDep {
+                name: name.clone(),
+                dep_path: dep_path.clone(),
+                dep_type,
+                specifier: Some(version.clone()),
+            });
+
+        let mut pkg = LockedPackage {
+            name: name.clone(),
+            version: version.clone(),
+            integrity: Some(format!("sha512-{idx:02x}")),
+            dep_path: dep_path.clone(),
+            ..Default::default()
+        };
+
+        for prior_idx in 0..idx {
+            let bit_idx = idx * (idx - 1) / 2 + prior_idx;
+            if shape.edge_bits & (1 << bit_idx) == 0 {
+                continue;
+            }
+            let child_name = package_name(prior_idx);
+            let child_version = package_version(prior_idx);
+            pkg.dependencies
+                .insert(child_name.clone(), child_version.clone());
+            pkg.declared_dependencies.insert(child_name, child_version);
+        }
+
+        graph.packages.insert(dep_path, pkg);
+    }
+
+    (graph, manifest)
+}
+
+fn package_name(idx: usize) -> String {
+    format!("pkg-{idx}")
+}
+
+fn package_version(idx: usize) -> String {
+    format!("1.0.{idx}")
+}
+
+fn dep_path(name: &str, version: &str) -> String {
+    format!("{name}@{version}")
+}
+
+fn dep_type(idx: usize) -> DepType {
+    match idx % 3 {
+        1 => DepType::Dev,
+        2 => DepType::Optional,
+        _ => DepType::Production,
+    }
+}
+
+fn normalize(graph: &LockfileGraph) -> NormalizedGraph {
+    let importers = graph
+        .importers
+        .iter()
+        .map(|(path, deps)| {
+            let mut deps: Vec<_> = deps
+                .iter()
+                .map(|dep| NormalizedDirectDep {
+                    name: dep.name.clone(),
+                    dep_path: dep.dep_path.clone(),
+                    dep_type: dep.dep_type,
+                })
+                .collect();
+            deps.sort_by(|a, b| {
+                (&a.name, &a.dep_path, dep_type_rank(a.dep_type)).cmp(&(
+                    &b.name,
+                    &b.dep_path,
+                    dep_type_rank(b.dep_type),
+                ))
+            });
+            (path.clone(), deps)
+        })
+        .collect();
+    let packages = graph
+        .packages
+        .iter()
+        .map(|(dep_path, pkg)| {
+            (
+                dep_path.clone(),
+                NormalizedPackage {
+                    name: pkg.name.clone(),
+                    version: pkg.version.clone(),
+                    dependencies: normalize_dep_edges(&pkg.dependencies),
+                    optional_dependencies: normalize_dep_edges(&pkg.optional_dependencies),
+                },
+            )
+        })
+        .collect();
+
+    NormalizedGraph {
+        importers,
+        packages,
+    }
+}
+
+fn normalize_dep_edges(deps: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    deps.iter()
+        .map(|(name, value)| {
+            let full_key = if value.starts_with(&format!("{name}@")) {
+                value.clone()
+            } else {
+                dep_path(name, value)
+            };
+            (name.clone(), full_key)
+        })
+        .collect()
+}
+
+fn dep_type_rank(dep_type: DepType) -> u8 {
+    match dep_type {
+        DepType::Production => 0,
+        DepType::Dev => 1,
+        DepType::Optional => 2,
+    }
+}
+
+fn roundtrip(
+    graph: &LockfileGraph,
+    manifest: &aube_manifest::PackageJson,
+    kind: LockfileKind,
+) -> NormalizedGraph {
+    let dir = tempfile::tempdir().expect("tempdir");
+    aube_lockfile::write_lockfile_as(dir.path(), graph, manifest, kind).expect("write lockfile");
+    let reparsed = aube_lockfile::parse_lockfile(dir.path(), manifest).expect("parse lockfile");
+    normalize(&reparsed)
+}
+
+proptest! {
+    #[test]
+    fn pnpm_lockfile_roundtrips_generated_registry_graph(shape in graph_shapes()) {
+        let (graph, manifest) = graph_from_shape(shape);
+        prop_assert_eq!(roundtrip(&graph, &manifest, LockfileKind::Pnpm), normalize(&graph));
+    }
+
+    #[test]
+    fn npm_lockfile_roundtrips_generated_registry_graph(shape in graph_shapes()) {
+        let (graph, manifest) = graph_from_shape(shape);
+        prop_assert_eq!(roundtrip(&graph, &manifest, LockfileKind::Npm), normalize(&graph));
+    }
+
+    #[test]
+    fn bun_lockfile_roundtrips_generated_registry_graph(shape in graph_shapes()) {
+        let (graph, manifest) = graph_from_shape(shape);
+        prop_assert_eq!(roundtrip(&graph, &manifest, LockfileKind::Bun), normalize(&graph));
+    }
+
+    #[test]
+    fn yarn_classic_lockfile_roundtrips_generated_registry_graph(shape in graph_shapes()) {
+        let (graph, manifest) = graph_from_shape(shape);
+        prop_assert_eq!(roundtrip(&graph, &manifest, LockfileKind::Yarn), normalize(&graph));
+    }
+
+    #[test]
+    fn yarn_berry_lockfile_roundtrips_generated_registry_graph(shape in graph_shapes()) {
+        let (graph, manifest) = graph_from_shape(shape);
+        prop_assert_eq!(roundtrip(&graph, &manifest, LockfileKind::YarnBerry), normalize(&graph));
+    }
+}


### PR DESCRIPTION
## Summary

Adds property-based lockfile roundtrip coverage for generated registry-only graphs across pnpm, npm, Bun, Yarn classic, and Yarn Berry lockfile writers/parsers. The tests normalize dependency edges before comparing so they focus on structural graph preservation across each format.

## Validation

- cargo fmt --check
- cargo test -p aube-lockfile --test proptest
- cargo test -p aube-lockfile
- cargo clippy -p aube-lockfile --all-targets -- -D warnings

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus a new dev-dependency; no production code paths are modified.
> 
> **Overview**
> Adds property-based roundtrip tests in `aube-lockfile` that generate small registry-only dependency graphs, write them as each supported lockfile format (pnpm/npm/bun/yarn classic/yarn berry), re-parse them, and compare a normalized representation to ensure structural preservation.
> 
> Introduces `proptest` as a dev-dependency (and updates `Cargo.lock`) to support this new randomized/parametric test coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 499374fb20c188d7c0cc1faf23f5555b38acad2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->