### PR TITLE
fix(resolver): bound resolved package stream

### DIFF
--- a/crates/aube-resolver/src/builder.rs
+++ b/crates/aube-resolver/src/builder.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 impl Resolver {
+    const DEFAULT_STREAM_CAPACITY: usize = 64;
+
     pub fn new(client: Arc<RegistryClient>) -> Self {
         Self {
             client,
@@ -43,10 +45,16 @@ impl Resolver {
     /// Create a resolver that streams resolved packages through a channel.
     /// Returns `(resolver, receiver)`. The receiver yields packages as they're
     /// discovered, allowing tarball fetches to start during resolution.
-    pub fn with_stream(
+    pub fn with_stream(client: Arc<RegistryClient>) -> (Self, mpsc::Receiver<ResolvedPackage>) {
+        Self::with_stream_capacity(client, Self::DEFAULT_STREAM_CAPACITY)
+    }
+
+    /// Create a streaming resolver with a bounded resolved-package buffer.
+    pub fn with_stream_capacity(
         client: Arc<RegistryClient>,
-    ) -> (Self, mpsc::UnboundedReceiver<ResolvedPackage>) {
-        let (tx, rx) = mpsc::unbounded_channel();
+        capacity: usize,
+    ) -> (Self, mpsc::Receiver<ResolvedPackage>) {
+        let (tx, rx) = mpsc::channel(capacity.max(1));
         (
             Self {
                 client,

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -64,7 +64,7 @@ pub struct Resolver {
     client: Arc<RegistryClient>,
     cache: FxHashMap<String, Packument>,
     /// Optional channel to stream resolved packages as they're discovered.
-    resolved_tx: Option<mpsc::UnboundedSender<ResolvedPackage>>,
+    resolved_tx: Option<mpsc::Sender<ResolvedPackage>>,
     /// Optional disk cache directory for packuments (with ETag revalidation).
     packument_cache_dir: Option<std::path::PathBuf>,
     /// Separate disk cache for full (non-corgi) packuments; only used

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -765,28 +765,30 @@ impl Resolver {
                             },
                         );
                         if let Some(ref tx) = self.resolved_tx {
-                            let _ = tx.send(ResolvedPackage {
-                                dep_path: dep_path.clone(),
-                                name: linked_name.clone(),
-                                version: real_version.clone(),
-                                integrity: None,
-                                tarball_url: None,
-                                // local_source deps aren't aliased —
-                                // `file:`/`link:` specifiers go
-                                // through the local-source branch,
-                                // not the `npm:` rewrite.
-                                alias_of: None,
-                                local_source: Some(local.clone()),
-                                // Local `file:`/`link:` packages never
-                                // carry npm-style platform constraints
-                                // — they're whatever the user points
-                                // at, so the fetch coordinator treats
-                                // them as unconstrained (always fetch).
-                                os: aube_lockfile::PlatformList::new(),
-                                cpu: aube_lockfile::PlatformList::new(),
-                                libc: aube_lockfile::PlatformList::new(),
-                                deprecated: None,
-                            });
+                            let _ = tx
+                                .send(ResolvedPackage {
+                                    dep_path: dep_path.clone(),
+                                    name: linked_name.clone(),
+                                    version: real_version.clone(),
+                                    integrity: None,
+                                    tarball_url: None,
+                                    // local_source deps aren't aliased —
+                                    // `file:`/`link:` specifiers go
+                                    // through the local-source branch,
+                                    // not the `npm:` rewrite.
+                                    alias_of: None,
+                                    local_source: Some(local.clone()),
+                                    // Local `file:`/`link:` packages never
+                                    // carry npm-style platform constraints
+                                    // — they're whatever the user points
+                                    // at, so the fetch coordinator treats
+                                    // them as unconstrained (always fetch).
+                                    os: aube_lockfile::PlatformList::new(),
+                                    cpu: aube_lockfile::PlatformList::new(),
+                                    libc: aube_lockfile::PlatformList::new(),
+                                    deprecated: None,
+                                })
+                                .await;
                         }
                         // Enqueue transitive deps of the local package
                         // (directories + tarballs only — `link:` deps
@@ -1028,32 +1030,34 @@ impl Resolver {
                             }
 
                             if let Some(ref tx) = self.resolved_tx {
-                                let _ = tx.send(ResolvedPackage {
-                                    dep_path: dep_path.clone(),
-                                    name: task.name.clone(),
-                                    version: version.clone(),
-                                    integrity: locked_pkg.integrity.clone(),
-                                    tarball_url: locked_pkg.tarball_url.clone(),
-                                    // Carry the alias identity
-                                    // through the reuse path — the
-                                    // existing `locked_pkg` already
-                                    // records it if the lockfile held
-                                    // an aliased entry, so the
-                                    // streaming fetch still hits the
-                                    // real registry name.
-                                    alias_of: locked_pkg.alias_of.clone(),
-                                    local_source: locked_pkg.local_source.clone(),
-                                    os: locked_pkg.os.clone(),
-                                    cpu: locked_pkg.cpu.clone(),
-                                    libc: locked_pkg.libc.clone(),
-                                    // Lockfile reuse skips the packument
-                                    // fetch, so we have no deprecation
-                                    // message to forward here. The
-                                    // `aube deprecations` command re-queries
-                                    // packuments live for the
-                                    // after-the-fact view.
-                                    deprecated: None,
-                                });
+                                let _ = tx
+                                    .send(ResolvedPackage {
+                                        dep_path: dep_path.clone(),
+                                        name: task.name.clone(),
+                                        version: version.clone(),
+                                        integrity: locked_pkg.integrity.clone(),
+                                        tarball_url: locked_pkg.tarball_url.clone(),
+                                        // Carry the alias identity
+                                        // through the reuse path — the
+                                        // existing `locked_pkg` already
+                                        // records it if the lockfile held
+                                        // an aliased entry, so the
+                                        // streaming fetch still hits the
+                                        // real registry name.
+                                        alias_of: locked_pkg.alias_of.clone(),
+                                        local_source: locked_pkg.local_source.clone(),
+                                        os: locked_pkg.os.clone(),
+                                        cpu: locked_pkg.cpu.clone(),
+                                        libc: locked_pkg.libc.clone(),
+                                        // Lockfile reuse skips the packument
+                                        // fetch, so we have no deprecation
+                                        // message to forward here. The
+                                        // `aube deprecations` command re-queries
+                                        // packuments live for the
+                                        // after-the-fact view.
+                                        deprecated: None,
+                                    })
+                                    .await;
                             }
 
                             // Carry declared peer deps forward from the
@@ -1530,19 +1534,21 @@ impl Resolver {
                 // for aliased packages where `name` alone (`h3-v2`)
                 // would 404.
                 if let Some(ref tx) = self.resolved_tx {
-                    let _ = tx.send(ResolvedPackage {
-                        dep_path: dep_path.clone(),
-                        name: task.name.clone(),
-                        version: version.clone(),
-                        integrity: integrity.clone(),
-                        tarball_url: tarball_url.clone(),
-                        alias_of: task.real_name.clone(),
-                        local_source: None,
-                        os: version_meta.os.iter().cloned().collect(),
-                        cpu: version_meta.cpu.iter().cloned().collect(),
-                        libc: version_meta.libc.iter().cloned().collect(),
-                        deprecated: deprecated_msg.clone(),
-                    });
+                    let _ = tx
+                        .send(ResolvedPackage {
+                            dep_path: dep_path.clone(),
+                            name: task.name.clone(),
+                            version: version.clone(),
+                            integrity: integrity.clone(),
+                            tarball_url: tarball_url.clone(),
+                            alias_of: task.real_name.clone(),
+                            local_source: None,
+                            os: version_meta.os.iter().cloned().collect(),
+                            cpu: version_meta.cpu.iter().cloned().collect(),
+                            libc: version_meta.libc.iter().cloned().collect(),
+                            deprecated: deprecated_msg.clone(),
+                        })
+                        .await;
                 }
 
                 // Capture the declared peer deps now so the post-pass can

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2144,7 +2144,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // Set up streaming resolver with disk-backed packument cache.
             // Resolver options are applied via `configure_resolver` so the
             // `--lockfile-only` short-circuit produces an identical lockfile.
-            let (resolver, mut resolved_rx) = aube_resolver::Resolver::with_stream(client);
+            let fetch_network_concurrency =
+                network_concurrency_setting.unwrap_or_else(default_streaming_network_concurrency);
+            let (resolver, mut resolved_rx) =
+                aube_resolver::Resolver::with_stream_capacity(client, fetch_network_concurrency);
             let pnpmfile_path = (!opts.ignore_pnpmfile)
                 .then(|| crate::pnpmfile::detect(&cwd, ws_config_shared.pnpmfile_path.as_deref()))
                 .flatten();
@@ -2189,8 +2192,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let fetch_local_client = tarball_client.clone();
             let fetch_ignore_scripts = opts.ignore_scripts;
             let fetch_git_prepare_depth = opts.git_prepare_depth;
-            let fetch_network_concurrency =
-                network_concurrency_setting.unwrap_or_else(default_streaming_network_concurrency);
             let fetch_verify_integrity = verify_store_integrity_setting;
             let fetch_strict_integrity = strict_store_integrity_setting;
             let fetch_strict_pkg_content_check = strict_store_pkg_content_check_setting;
@@ -3682,23 +3683,6 @@ fn package_name_from_spec_key(spec: &str) -> String {
         .unwrap_or_else(|| spec.to_string())
 }
 
-#[cfg(test)]
-mod allow_build_review_tests {
-    use super::package_name_from_spec_key;
-
-    #[test]
-    fn package_name_from_spec_key_handles_scoped_names() {
-        assert_eq!(package_name_from_spec_key("@scope/pkg@1.2.3"), "@scope/pkg");
-        assert_eq!(package_name_from_spec_key("@scope/pkg"), "@scope/pkg");
-    }
-
-    #[test]
-    fn package_name_from_spec_key_handles_unscoped_names() {
-        assert_eq!(package_name_from_spec_key("esbuild@1.2.3"), "esbuild");
-        assert_eq!(package_name_from_spec_key("esbuild"), "esbuild");
-    }
-}
-
 fn print_already_up_to_date() {
     if clx::progress::output() == clx::progress::ProgressOutput::Text {
         return;
@@ -3921,4 +3905,21 @@ fn filter_graph_to_importers<const N: usize>(
         ..graph.clone()
     };
     filtered.filter_deps(|_| true)
+}
+
+#[cfg(test)]
+mod allow_build_review_tests {
+    use super::package_name_from_spec_key;
+
+    #[test]
+    fn package_name_from_spec_key_handles_scoped_names() {
+        assert_eq!(package_name_from_spec_key("@scope/pkg@1.2.3"), "@scope/pkg");
+        assert_eq!(package_name_from_spec_key("@scope/pkg"), "@scope/pkg");
+    }
+
+    #[test]
+    fn package_name_from_spec_key_handles_unscoped_names() {
+        assert_eq!(package_name_from_spec_key("esbuild@1.2.3"), "esbuild");
+        assert_eq!(package_name_from_spec_key("esbuild"), "esbuild");
+    }
 }


### PR DESCRIPTION
## Summary
- replace the resolver resolved-package stream with a bounded Tokio channel
- size the install streaming buffer from the same network concurrency used by fetch workers
- await stream sends so resolver/fetch overlap applies backpressure instead of growing an unbounded queue
- move an existing install test module below helper items so current all-targets clippy stays green

## Validation
- cargo check -p aube-resolver -p aube
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test -p aube-resolver

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async streaming semantics (`send().await`) between resolver and installer, which can affect throughput and introduce stalls if the receiver isn’t drained as expected. Scope is contained to the streaming resolution/fetch overlap path.
> 
> **Overview**
> The resolver’s resolved-package stream is now **bounded**: `Resolver::with_stream` uses a fixed default capacity and a new `with_stream_capacity` constructor, and `resolved_tx` switches from `mpsc::UnboundedSender` to `mpsc::Sender`.
> 
> All resolver streaming `send` call sites now `await` to apply **backpressure** instead of accumulating an unbounded queue, and `install` sizes the stream buffer from the same network concurrency used by tarball fetch workers. A small test-module move keeps `--all-targets` clippy passing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b20f7bce9f5dde627a1871217136c8f36bae795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->