### PR TITLE
fix(resolver): require structured trust evidence

### DIFF
--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -194,10 +194,9 @@ pub struct PeerDepMeta {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct NpmUser {
-    /// Truthy when the publish came from an npm "trusted publisher"
-    /// (e.g. GitHub Actions OIDC). Pnpm's trust-policy check treats
-    /// presence of any non-null value here as the strongest evidence
-    /// (rank 2, above provenance attestations).
+    /// Structured npm trusted-publisher evidence for publishes that came
+    /// through OIDC-backed automation (e.g. GitHub Actions). aube's
+    /// trust-policy check requires an object with a non-empty `id`.
     #[serde(default, rename = "trustedPublisher")]
     pub trusted_publisher: Option<serde_json::Value>,
 }
@@ -208,9 +207,8 @@ pub struct Dist {
     pub integrity: Option<String>,
     pub shasum: Option<String>,
     /// Sigstore attestations block. The trust-policy check reads
-    /// `dist.attestations.provenance` as a rank-1 trust-evidence
-    /// signal (`npm publish --provenance`). Existence is the only
-    /// signal we read — neither pnpm nor aube validates the bundle.
+    /// `dist.attestations.provenance` as rank-1 trust evidence when
+    /// it is an object with an SLSA provenance `predicateType`.
     #[serde(default)]
     pub attestations: Option<Attestations>,
 }

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -208,7 +208,9 @@ pub struct Dist {
     pub shasum: Option<String>,
     /// Sigstore attestations block. The trust-policy check reads
     /// `dist.attestations.provenance` as rank-1 trust evidence when
-    /// it is an object with an SLSA provenance `predicateType`.
+    /// it is an object with an SLSA provenance `predicateType`. aube
+    /// validates this metadata shape during install; it does not
+    /// cryptographically verify the attached attestation bundle.
     #[serde(default)]
     pub attestations: Option<Attestations>,
 }

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -954,7 +954,9 @@ async fn trust_policy_no_downgrade_blocks_downgraded_install() {
         .insert("3.0.0".to_string(), "2025-03-01T00:00:00.000Z".to_string());
     let v2 = packument.versions.get_mut("2.0.0").unwrap();
     v2.dist.as_mut().unwrap().attestations = Some(Attestations {
-        provenance: Some(serde_json::json!({"predicateType": "slsa"})),
+        provenance: Some(serde_json::json!({
+            "predicateType": "https://slsa.dev/provenance/v1"
+        })),
     });
     let body = serde_json::to_vec(&packument).unwrap();
 

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -4,14 +4,15 @@
 //! (resolving/npm-resolver/src/trustChecks.ts), verified against pnpm's
 //! own test suite. Two trust-evidence sources, ranked
 //! `TrustedPublisher (2) > Provenance (1)`. aube only accepts the
-//! structured metadata shapes npm emits after server-side verification:
+//! structured metadata shapes npm emits after server-side checks:
 //! `_npmUser.trustedPublisher` must name a publisher id, and
 //! `dist.attestations.provenance` must name an SLSA provenance predicate.
-//! The check runs immediately after a version is picked from a packument:
-//! if any strictly older version of the same package had stronger trust
-//! evidence, the install fails. Pre-2010 packuments without per-version
-//! `time` entries error when the picked version isn't excluded — same as
-//! pnpm.
+//! This is metadata-shape validation, not install-time cryptographic
+//! verification of the attestation bundle. The check runs immediately
+//! after a version is picked from a packument: if any strictly older
+//! version of the same package had stronger trust evidence, the install
+//! fails. Pre-2010 packuments without per-version `time` entries error
+//! when the picked version isn't excluded — same as pnpm.
 
 use aube_registry::{Packument, VersionMetadata};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -75,7 +76,12 @@ fn is_provenance(v: &serde_json::Value) -> bool {
     v.as_object()
         .and_then(|o| o.get("predicateType"))
         .and_then(|predicate| predicate.as_str())
-        .is_some_and(|predicate| predicate.starts_with("https://slsa.dev/provenance/"))
+        .is_some_and(|predicate| {
+            predicate
+                .strip_prefix("https://slsa.dev/provenance/v")
+                .and_then(|suffix| suffix.chars().next())
+                .is_some_and(|c| c.is_ascii_digit())
+        })
 }
 
 #[derive(Debug)]
@@ -596,6 +602,9 @@ mod tests {
             serde_json::json!([]),
             serde_json::json!({}),
             serde_json::json!({"predicateType": ""}),
+            serde_json::json!({"predicateType": "https://slsa.dev/provenance/"}),
+            serde_json::json!({"predicateType": "https://slsa.dev/provenance/v"}),
+            serde_json::json!({"predicateType": "https://slsa.dev/provenance/latest"}),
             serde_json::json!({"predicateType": "https://example.com/provenance/v1"}),
         ] {
             v.dist.as_mut().unwrap().attestations = Some(Attestations {

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -3,11 +3,15 @@
 //! Mirrors pnpm's `failIfTrustDowngraded`
 //! (resolving/npm-resolver/src/trustChecks.ts), verified against pnpm's
 //! own test suite. Two trust-evidence sources, ranked
-//! `TrustedPublisher (2) > Provenance (1)`. The check runs immediately
-//! after a version is picked from a packument: if any strictly older
-//! version of the same package had stronger trust evidence, the install
-//! fails. Pre-2010 packuments without per-version `time` entries error
-//! when the picked version isn't excluded — same as pnpm.
+//! `TrustedPublisher (2) > Provenance (1)`. aube only accepts the
+//! structured metadata shapes npm emits after server-side verification:
+//! `_npmUser.trustedPublisher` must name a publisher id, and
+//! `dist.attestations.provenance` must name an SLSA provenance predicate.
+//! The check runs immediately after a version is picked from a packument:
+//! if any strictly older version of the same package had stronger trust
+//! evidence, the install fails. Pre-2010 packuments without per-version
+//! `time` entries error when the picked version isn't excluded — same as
+//! pnpm.
 
 use aube_registry::{Packument, VersionMetadata};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -38,15 +42,13 @@ impl TrustEvidence {
 }
 
 /// Strongest trust evidence carried by a single version's metadata.
-/// Mirrors pnpm's `getTrustEvidence`: `_npmUser.trustedPublisher`
-/// outranks `dist.attestations.provenance`. JS-style truthiness on the
-/// trustedPublisher value: any non-null, non-`false` value counts.
+/// `_npmUser.trustedPublisher` outranks `dist.attestations.provenance`.
 pub fn evidence_for(meta: &VersionMetadata) -> Option<TrustEvidence> {
     if meta
         .npm_user
         .as_ref()
         .and_then(|u| u.trusted_publisher.as_ref())
-        .is_some_and(is_truthy)
+        .is_some_and(is_trusted_publisher)
     {
         return Some(TrustEvidence::TrustedPublisher);
     }
@@ -55,30 +57,25 @@ pub fn evidence_for(meta: &VersionMetadata) -> Option<TrustEvidence> {
         .as_ref()
         .and_then(|d| d.attestations.as_ref())
         .and_then(|a| a.provenance.as_ref())
-        .is_some_and(is_truthy)
+        .is_some_and(is_provenance)
     {
         return Some(TrustEvidence::Provenance);
     }
     None
 }
 
-/// JS-style truthiness for `_npmUser.trustedPublisher`. Pnpm's check
-/// is `manifest._npmUser?.trustedPublisher`, which evaluates the value
-/// in a boolean context — so we have to reject every JS falsy value,
-/// not just `null`/`false`. Falsy: `null`, `false`, `0`, `""`, `NaN`.
-/// Truthy: every object (including `{}`), every array (including `[]`),
-/// every non-zero number, every non-empty string. In practice the
-/// field is always either an object or absent, but matching JS
-/// semantics keeps a hostile registry from sneaking trust evidence
-/// past us via `0` or an empty string.
-fn is_truthy(v: &serde_json::Value) -> bool {
-    match v {
-        serde_json::Value::Null => false,
-        serde_json::Value::Bool(b) => *b,
-        serde_json::Value::Number(n) => n.as_f64().is_none_or(|f| f != 0.0 && !f.is_nan()),
-        serde_json::Value::String(s) => !s.is_empty(),
-        serde_json::Value::Array(_) | serde_json::Value::Object(_) => true,
-    }
+fn is_trusted_publisher(v: &serde_json::Value) -> bool {
+    v.as_object()
+        .and_then(|o| o.get("id"))
+        .and_then(|id| id.as_str())
+        .is_some_and(|id| !id.is_empty())
+}
+
+fn is_provenance(v: &serde_json::Value) -> bool {
+    v.as_object()
+        .and_then(|o| o.get("predicateType"))
+        .and_then(|predicate| predicate.as_str())
+        .is_some_and(|predicate| predicate.starts_with("https://slsa.dev/provenance/"))
 }
 
 #[derive(Debug)]
@@ -514,7 +511,9 @@ mod tests {
     fn with_provenance(mut v: VersionMetadata) -> VersionMetadata {
         let dist = v.dist.as_mut().unwrap();
         dist.attestations = Some(Attestations {
-            provenance: Some(serde_json::json!({"predicateType": "slsa"})),
+            provenance: Some(serde_json::json!({
+                "predicateType": "https://slsa.dev/provenance/v1"
+            })),
         });
         v
     }
@@ -563,67 +562,63 @@ mod tests {
     }
 
     #[test]
-    fn evidence_falsy_trusted_publisher_is_none() {
+    fn evidence_malformed_trusted_publisher_is_none() {
         let mut v = version("foo", "1.0.0");
-        for falsy in [
+        for malformed in [
             serde_json::Value::Bool(false),
             serde_json::Value::Null,
             serde_json::json!(0),
             serde_json::json!(0.0),
             serde_json::json!(""),
+            serde_json::json!([]),
+            serde_json::json!({}),
+            serde_json::json!({"id": ""}),
         ] {
             v.npm_user = Some(NpmUser {
-                trusted_publisher: Some(falsy.clone()),
+                trusted_publisher: Some(malformed.clone()),
             });
-            assert_eq!(evidence_for(&v), None, "{falsy:?} should be falsy");
+            assert_eq!(
+                evidence_for(&v),
+                None,
+                "{malformed:?} should not count as trusted-publisher evidence"
+            );
         }
     }
 
     #[test]
-    fn evidence_falsy_provenance_is_none() {
-        // Symmetric with the trustedPublisher truthiness check —
-        // `dist.attestations.provenance` is also evaluated in JS
-        // boolean context in pnpm, so falsy values must not count
-        // as evidence. Real registries always emit an object here,
-        // but this guards against a hostile registry shipping
-        // `provenance: false` to bypass the no-downgrade check.
+    fn evidence_malformed_provenance_is_none() {
         let mut v = version("foo", "1.0.0");
-        for falsy in [
+        for malformed in [
             serde_json::Value::Bool(false),
             serde_json::Value::Null,
             serde_json::json!(0),
             serde_json::json!(""),
+            serde_json::json!([]),
+            serde_json::json!({}),
+            serde_json::json!({"predicateType": ""}),
+            serde_json::json!({"predicateType": "https://example.com/provenance/v1"}),
         ] {
             v.dist.as_mut().unwrap().attestations = Some(Attestations {
-                provenance: Some(falsy.clone()),
+                provenance: Some(malformed.clone()),
             });
-            assert_eq!(evidence_for(&v), None, "{falsy:?} should be falsy");
+            assert_eq!(
+                evidence_for(&v),
+                None,
+                "{malformed:?} should not count as provenance evidence"
+            );
         }
     }
 
     #[test]
-    fn evidence_truthy_non_object_trusted_publisher_counts() {
-        // JS truthy values that aren't objects: non-zero numbers,
-        // non-empty strings, empty arrays/objects. Real registries only
-        // ever emit an object here, but match JS semantics for
-        // defense-in-depth against a hostile/buggy registry.
+    fn evidence_structured_trusted_publisher_counts() {
         let mut v = version("foo", "1.0.0");
-        for truthy in [
-            serde_json::json!(true),
-            serde_json::json!(1),
-            serde_json::json!("oidc:gh"),
-            serde_json::json!([]),
-            serde_json::json!({}),
-        ] {
-            v.npm_user = Some(NpmUser {
-                trusted_publisher: Some(truthy.clone()),
-            });
-            assert_eq!(
-                evidence_for(&v),
-                Some(TrustEvidence::TrustedPublisher),
-                "{truthy:?} should be truthy"
-            );
-        }
+        v.npm_user = Some(NpmUser {
+            trusted_publisher: Some(serde_json::json!({
+                "id": "github",
+                "oidcConfigId": "oidc:example"
+            })),
+        });
+        assert_eq!(evidence_for(&v), Some(TrustEvidence::TrustedPublisher));
     }
 
     #[test]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -257,10 +257,10 @@ default = "\"no-downgrade\""
 docs = """
 When `no-downgrade` (the default), aube rejects a version that carries weaker
 trust evidence than any earlier-published version of the same package.
-Recognized evidence: npm trusted-publisher (`_npmUser.trustedPublisher`)
-outranks sigstore provenance (`dist.attestations.provenance`). Set to `off`
-to disable, or use `trustPolicyExclude` to whitelist specific packages or
-versions.
+Recognized evidence: structured npm trusted-publisher metadata
+(`_npmUser.trustedPublisher.id`) outranks structured SLSA provenance metadata
+(`dist.attestations.provenance.predicateType`). Set to `off` to disable, or
+use `trustPolicyExclude` to whitelist specific packages or versions.
 """
 sources.cli = []
 sources.env = ["npm_config_trust_policy", "NPM_CONFIG_TRUST_POLICY", "AUBE_TRUST_POLICY"]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -260,7 +260,9 @@ trust evidence than any earlier-published version of the same package.
 Recognized evidence: structured npm trusted-publisher metadata
 (`_npmUser.trustedPublisher.id`) outranks structured SLSA provenance metadata
 (`dist.attestations.provenance.predicateType`). Set to `off` to disable, or
-use `trustPolicyExclude` to whitelist specific packages or versions.
+use `trustPolicyExclude` to whitelist specific packages or versions. This
+policy validates registry metadata shape; it does not cryptographically verify
+the attached attestation bundle.
 """
 sources.cli = []
 sources.env = ["npm_config_trust_policy", "NPM_CONFIG_TRUST_POLICY", "AUBE_TRUST_POLICY"]

--- a/docs/security.md
+++ b/docs/security.md
@@ -85,13 +85,14 @@ Full reference: [Jailed builds](/package-manager/jailed-builds).
 ## Trust policy
 
 `trustPolicy = no-downgrade` blocks installs of a version that carries weaker
-trust evidence than any earlier-published version of the same package. Two
-evidence sources, ranked:
+trust evidence than any earlier-published version of the same package. aube
+only counts the structured metadata shape npm emits after registry-side checks:
 
 1. **npm trusted-publisher** — package was published via OIDC from a trusted
-   CI provider (`_npmUser.trustedPublisher`).
+   CI provider (`_npmUser.trustedPublisher.id`).
 2. **Sigstore provenance** — package was published with `npm publish
-   --provenance` (`dist.attestations.provenance`).
+   --provenance` (`dist.attestations.provenance.predicateType` with an SLSA
+   provenance URI).
 
 A trust downgrade may indicate a supply-chain incident: publisher account
 takeover, repository tampering, or a malicious co-maintainer publishing

--- a/docs/security.md
+++ b/docs/security.md
@@ -94,6 +94,9 @@ only counts the structured metadata shape npm emits after registry-side checks:
    --provenance` (`dist.attestations.provenance.predicateType` with an SLSA
    provenance URI).
 
+This install-time policy validates the registry metadata shape; it does not
+cryptographically verify the attached attestation bundle.
+
 A trust downgrade may indicate a supply-chain incident: publisher account
 takeover, repository tampering, or a malicious co-maintainer publishing
 without the original CI flow.

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -336,7 +336,9 @@ trust evidence than any earlier-published version of the same package.
 Recognized evidence: structured npm trusted-publisher metadata
 (`_npmUser.trustedPublisher.id`) outranks structured SLSA provenance metadata
 (`dist.attestations.provenance.predicateType`). Set to `off` to disable, or
-use `trustPolicyExclude` to whitelist specific packages or versions.
+use `trustPolicyExclude` to whitelist specific packages or versions. This
+policy validates registry metadata shape; it does not cryptographically verify
+the attached attestation bundle.
 
 ### `trustPolicyExclude` {#setting-trustpolicyexclude}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -333,10 +333,10 @@ Fail install when a package's trust evidence weakens between releases.
 
 When `no-downgrade` (the default), aube rejects a version that carries weaker
 trust evidence than any earlier-published version of the same package.
-Recognized evidence: npm trusted-publisher (`_npmUser.trustedPublisher`)
-outranks sigstore provenance (`dist.attestations.provenance`). Set to `off`
-to disable, or use `trustPolicyExclude` to whitelist specific packages or
-versions.
+Recognized evidence: structured npm trusted-publisher metadata
+(`_npmUser.trustedPublisher.id`) outranks structured SLSA provenance metadata
+(`dist.attestations.provenance.predicateType`). Set to `off` to disable, or
+use `trustPolicyExclude` to whitelist specific packages or versions.
 
 ### `trustPolicyExclude` {#setting-trustpolicyexclude}
 


### PR DESCRIPTION
## Summary

- require npm trusted-publisher evidence to include a structured non-empty `id`
- require provenance evidence to include an SLSA `predicateType`
- update trust policy docs and regenerated settings docs

## Why

The trust downgrade policy previously treated arbitrary truthy registry values as trust evidence. That matched pnpm-style boolean checks, but it meant malformed or hostile packument metadata such as `{}` or `"oidc"` could satisfy aube's trust policy. This keeps the existing metadata-based policy but narrows the accepted shapes to the structured metadata npm emits after registry-side checks.

## Validation

- `cargo run -p aube-settings --bin generate-settings-docs`
- `cargo fmt --check`
- `cargo test -p aube-resolver trust::tests`
- `cargo test -p aube-registry provenance`
- `cargo clippy -p aube-resolver -p aube-registry --all-targets -- -D warnings`

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security enforcement logic for installs, which could newly reject packages with malformed/nonstandard registry metadata or alter downgrade decisions; behavior is well-covered by updated tests and docs.
> 
> **Overview**
> Tightens trust-policy evidence detection so `_npmUser.trustedPublisher` only counts when it is an object with a non-empty `id`, and `dist.attestations.provenance` only counts when it is an object whose `predicateType` matches an SLSA provenance URI (e.g. `https://slsa.dev/provenance/v1`).
> 
> Updates resolver/unit tests and documentation/settings text to reflect the new structured-shape requirements and clarify that this is *metadata validation* (not cryptographic attestation verification).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a5bb03e42808c1b830f06be2fc69e480921674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->