### PR TITLE
fix(workspace): default-write aube-workspace.yaml instead of pnpm-workspace.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+- `aube approve-builds` (and the install-time auto-seed of unreviewed
+  build scripts) now creates `aube-workspace.yaml` when no workspace
+  yaml exists in the project, parallel to the `aube-lock.yaml` shape
+  already used for the lockfile. Existing `pnpm-workspace.yaml` files
+  are still read and mutated in place — backward-compat with
+  pnpm-style projects is unchanged. Closes the asymmetry where the
+  lockfile got the `aube-` prefix but the workspace yaml didn't.
+
 ## [v1.0.0-beta.2](https://github.com/endevco/aube/releases/tag/v1.0.0-beta.2) - 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 ## [Unreleased]
 
-### Changed
-- `aube approve-builds` (and the install-time auto-seed of unreviewed
-  build scripts) now creates `aube-workspace.yaml` when no workspace
-  yaml exists in the project, parallel to the `aube-lock.yaml` shape
-  already used for the lockfile. Existing `pnpm-workspace.yaml` files
-  are still read and mutated in place — backward-compat with
-  pnpm-style projects is unchanged. Closes the asymmetry where the
-  lockfile got the `aube-` prefix but the workspace yaml didn't.
-
 ## [v1.0.0-beta.2](https://github.com/endevco/aube/releases/tag/v1.0.0-beta.2) - 2026-04-18
 
 ### Added

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -106,7 +106,7 @@ cmd add help="Add a dependency" {
     }
     arg "[PACKAGES]…" help="Package(s) to add" required=#false var=#true
 }
-cmd approve-builds help="Approve ignored dependency build scripts in `pnpm-workspace.yaml`'s `allowBuilds`" {
+cmd approve-builds help="Approve ignored dependency build scripts in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present) under `allowBuilds`" {
     flag --all help="Approve every pending ignored build without prompting"
     flag "-g --global" help="Operate on globally-installed packages instead of the current project"
     arg "[PKG]…" help="Packages to approve directly, skipping the picker. Each name must match a currently-ignored build. Unknown names are rejected so a typo cannot silently no-op" required=#false var=#true

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -559,9 +559,18 @@ pub fn load_both(
 }
 
 /// Resolve which workspace-yaml path `add_to_allow_builds` should
-/// mutate in `project_dir`. Existing `aube-workspace.yaml` wins over
-/// `pnpm-workspace.yaml`; when neither exists, create
-/// `pnpm-workspace.yaml` to match pnpm's build-review behavior.
+/// mutate in `project_dir`. Existing `aube-workspace.yaml` wins
+/// over `pnpm-workspace.yaml`; when neither exists, create
+/// `aube-workspace.yaml` — aube's own filename, parallel to the
+/// `aube-lock.yaml` shape we use for the lockfile.
+///
+/// Background: aube reads both `aube-workspace.yaml` (preferred)
+/// and `pnpm-workspace.yaml` (fallback) for backward compatibility
+/// with pnpm-style repos that already ship the latter. The
+/// generated default flips to the aube-prefixed name so a fresh
+/// project's filesystem layout matches aube's overall naming
+/// (`aube-lock.yaml`, `aube-workspace.yaml`) rather than mixing
+/// vendor namespaces.
 pub fn workspace_yaml_target(project_dir: &Path) -> std::path::PathBuf {
     for name in WORKSPACE_YAML_NAMES {
         let path = project_dir.join(name);
@@ -569,7 +578,7 @@ pub fn workspace_yaml_target(project_dir: &Path) -> std::path::PathBuf {
             return path;
         }
     }
-    project_dir.join("pnpm-workspace.yaml")
+    project_dir.join("aube-workspace.yaml")
 }
 
 /// Merge `names` into the workspace's `allowBuilds` map.
@@ -577,7 +586,8 @@ pub fn workspace_yaml_target(project_dir: &Path) -> std::path::PathBuf {
 /// Write-target precedence:
 /// 1. `aube-workspace.yaml` if it exists — top-level `allowBuilds`.
 /// 2. `pnpm-workspace.yaml` if it exists — top-level `allowBuilds`.
-/// 3. Otherwise — create `pnpm-workspace.yaml` with top-level `allowBuilds`.
+/// 3. Otherwise — create `aube-workspace.yaml` with top-level
+///    `allowBuilds` (matches aube's `aube-lock.yaml` naming).
 ///
 /// `allowed=true` is used by `aube approve-builds`; `allowed=false` is
 /// used by install to seed unreviewed packages for later review. Returns
@@ -843,7 +853,13 @@ patchedDependencies:
     }
 
     #[test]
-    fn add_to_allow_builds_creates_pnpm_workspace_when_no_yaml() {
+    fn add_to_allow_builds_creates_aube_workspace_when_no_yaml() {
+        // When no workspace yaml exists yet, aube creates
+        // `aube-workspace.yaml` (parallels `aube-lock.yaml`).
+        // Existing `pnpm-workspace.yaml` files are still read +
+        // mutated in place — see
+        // `add_to_allow_builds_writes_to_existing_pnpm_workspace`
+        // for that branch.
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("package.json"),
@@ -856,7 +872,7 @@ patchedDependencies:
             true,
         )
         .unwrap();
-        assert_eq!(path, dir.path().join("pnpm-workspace.yaml"));
+        assert_eq!(path, dir.path().join("aube-workspace.yaml"));
         let config = WorkspaceConfig::load(dir.path()).unwrap();
         assert!(matches!(
             config.allow_builds.get("esbuild"),
@@ -866,6 +882,31 @@ patchedDependencies:
             config.allow_builds.get("sharp"),
             Some(yaml_serde::Value::Bool(true))
         ));
+    }
+
+    #[test]
+    fn add_to_allow_builds_writes_to_existing_pnpm_workspace() {
+        // Pin the backward-compat behavior: a project that
+        // already ships `pnpm-workspace.yaml` (e.g. migrated
+        // from pnpm) keeps mutating the existing file in
+        // place rather than spawning a parallel
+        // `aube-workspace.yaml`. Without this, an `aube
+        // approve-builds` run would silently fork the config
+        // into two files.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"solo","version":"0.0.0"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'pnpm/*'\n",
+        )
+        .unwrap();
+        let path = add_to_allow_builds(dir.path(), &["esbuild".to_string()], true).unwrap();
+        assert_eq!(path, dir.path().join("pnpm-workspace.yaml"));
+        assert!(!dir.path().join("aube-workspace.yaml").exists());
     }
 
     #[test]

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -8,8 +8,8 @@
 //!   from a native module) are SKIPPED by default. A package runs its
 //!   lifecycle scripts only if the active [`BuildPolicy`] allows it —
 //!   configured via `pnpm.allowBuilds` in `package.json`, `allowBuilds`
-//!   in `pnpm-workspace.yaml`, or the escape-hatch
-//!   `--dangerously-allow-all-builds` flag.
+//!   in `aube-workspace.yaml` (or `pnpm-workspace.yaml`), or the
+//!   escape-hatch `--dangerously-allow-all-builds` flag.
 //! - `--ignore-scripts` forces everything off, matching pnpm/npm.
 
 pub mod policy;

--- a/crates/aube/src/commands/approve_builds.rs
+++ b/crates/aube/src/commands/approve_builds.rs
@@ -1,6 +1,7 @@
-//! `aube approve-builds` — flip packages to `true` in
-//! `pnpm-workspace.yaml`'s `allowBuilds` map so their install scripts
-//! run on the next `aube install`.
+//! `aube approve-builds` — flip packages to `true` in the workspace
+//! yaml's `allowBuilds` map so their install scripts run on the next
+//! `aube install`. Writes to `aube-workspace.yaml` by default, or
+//! mutates an existing `pnpm-workspace.yaml` in place.
 //!
 //! Walks the lockfile via `ignored_builds::collect_ignored`, presents an
 //! interactive multi-select picker (or approves everything under

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -374,7 +374,7 @@ enum Commands {
     /// Add a dependency
     #[command(visible_alias = "a")]
     Add(commands::add::AddArgs),
-    /// Approve ignored dependency build scripts in `pnpm-workspace.yaml`'s `allowBuilds`
+    /// Approve ignored dependency build scripts in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present) under `allowBuilds`
     ApproveBuilds(commands::approve_builds::ApproveBuildsArgs),
     /// Check installed packages against the registry advisory DB
     #[command(after_long_help = commands::audit::AFTER_LONG_HELP)]

--- a/docs/bun-users.md
+++ b/docs/bun-users.md
@@ -50,9 +50,9 @@ future installs keep writing `aube-lock.yaml`.
   `trustedDependencies` array in addition to pnpm's
   `pnpm.allowBuilds` / `pnpm.onlyBuiltDependencies`, so an existing
   Bun manifest keeps running its install scripts without edits.
-  Install writes unreviewed packages into `pnpm-workspace.yaml`'s
-  `allowBuilds` with `false`; `aube approve-builds` flips reviewed entries
-  to `true`. Approved dependency builds can also run in a
+  Install writes unreviewed packages into `aube-workspace.yaml`'s
+  `allowBuilds` with `false` (or `pnpm-workspace.yaml` if one already
+  exists); `aube approve-builds` flips reviewed entries to `true`. Approved dependency builds can also run in a
   [jail](/package-manager/jailed-builds) with package-specific env, path,
   and network permissions.
 

--- a/docs/cli/approve-builds.md
+++ b/docs/cli/approve-builds.md
@@ -3,7 +3,7 @@
 
 - **Usage**: `aube approve-builds [--all] [-g --global] [PKG]…`
 
-Approve ignored dependency build scripts in `pnpm-workspace.yaml`'s `allowBuilds`
+Approve ignored dependency build scripts in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present) under `allowBuilds`
 
 ## Arguments
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -208,7 +208,7 @@
         ],
         "mounts": [],
         "hide": false,
-        "help": "Approve ignored dependency build scripts in `pnpm-workspace.yaml`'s `allowBuilds`",
+        "help": "Approve ignored dependency build scripts in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present) under `allowBuilds`",
         "name": "approve-builds",
         "aliases": [],
         "hidden_aliases": [],

--- a/docs/package-manager/lifecycle-scripts.md
+++ b/docs/package-manager/lifecycle-scripts.md
@@ -25,8 +25,9 @@ aube rebuild
 
 Supported policy fields — aube reads all of these at install time:
 
-In `pnpm-workspace.yaml` (pnpm v11's build-review map, and what aube writes
-to):
+In `aube-workspace.yaml` or `pnpm-workspace.yaml` (pnpm v11's build-review
+map, and what aube writes to — aube creates `aube-workspace.yaml` from
+scratch, but mutates an existing `pnpm-workspace.yaml` in place):
 
 ```yaml
 allowBuilds:

--- a/docs/pnpm-users.md
+++ b/docs/pnpm-users.md
@@ -57,9 +57,10 @@ contract and may diverge over time.
 aube never touches pnpm's `node_modules/.pnpm/` or `~/.pnpm-store/`. The two
 virtual stores can coexist under `node_modules`. For the lockfile and
 workspace YAML, aube reads and writes whichever file already exists on disk
-— `pnpm-lock.yaml` keeps getting updates in place, and `pnpm-workspace.yaml`
-is read in place (aube does not emit an `aube-workspace.yaml` for existing
-projects).
+— `pnpm-lock.yaml` keeps getting updates in place, and an existing
+`pnpm-workspace.yaml` is mutated in place (aube does not spawn a parallel
+`aube-workspace.yaml` alongside it). When neither workspace yaml exists,
+aube creates `aube-workspace.yaml`.
 
 ## What's different
 
@@ -72,12 +73,11 @@ projects).
   yet gets `aube-lock.yaml`. If it already has `pnpm-lock.yaml` (or any
   other supported lockfile — `package-lock.json`, `npm-shrinkwrap.json`,
   `yarn.lock`, `bun.lock`), aube reads and writes that file in place.
-  Install auto-adds unreviewed dependency builds to
-  `pnpm-workspace.yaml`'s `allowBuilds` with `false`; `aube approve-builds`
-  flips reviewed entries to `true` (matching pnpm v11), creating the file
-  if missing. aube does not generate an
-  `aube-workspace.yaml` for you — create it yourself if you want the
-  aube-named variant.
+  Install auto-adds unreviewed dependency builds to the workspace yaml's
+  `allowBuilds` map with `false`; `aube approve-builds` flips reviewed
+  entries to `true` (matching pnpm v11). When no workspace yaml exists,
+  aube creates `aube-workspace.yaml`; an existing `pnpm-workspace.yaml`
+  is mutated in place.
 - **Build approvals.** Dependency lifecycle script approval follows pnpm
   v11's allowlist model. Use explicit policy fields in `package.json` or
   `aube-workspace.yaml` to opt in. aube can also run approved dependency

--- a/docs/security.md
+++ b/docs/security.md
@@ -35,7 +35,7 @@ supply-chain edge in a JavaScript install. aube does not run dependency
 lifecycle scripts unless you've approved them explicitly:
 
 ```yaml
-# pnpm-workspace.yaml
+# aube-workspace.yaml
 allowBuilds:
   esbuild: true
   sharp: true
@@ -51,8 +51,8 @@ Root-package lifecycle scripts (your own project's) still run normally — the
 boundary is dependency code.
 
 Settings: [`allowBuilds`](/settings/#setting-allowbuilds). Install adds
-unreviewed build packages to `pnpm-workspace.yaml` as `false`; approving them
-flips the entry to `true`.
+unreviewed build packages to `aube-workspace.yaml` (or `pnpm-workspace.yaml`
+if one already exists) as `false`; approving them flips the entry to `true`.
 
 ## Jailed lifecycle scripts
 
@@ -191,7 +191,7 @@ schema.
 For most projects, the following is a good starting point:
 
 ```yaml
-# pnpm-workspace.yaml
+# aube-workspace.yaml
 paranoid: true             # bundles jailBuilds, no-downgrade, strict gates
 allowBuilds:
   esbuild: true

--- a/test/approve_builds.bats
+++ b/test/approve_builds.bats
@@ -121,18 +121,18 @@ JSON
 	run aube install
 	assert_success
 	assert_file_not_exists aube-builds-marker.txt
-	assert_file_exists pnpm-workspace.yaml
-	run grep -q 'allowBuilds:' pnpm-workspace.yaml
+	assert_file_exists aube-workspace.yaml
+	run grep -q 'allowBuilds:' aube-workspace.yaml
 	assert_success
-	run grep -q 'aube-test-builds-marker: false' pnpm-workspace.yaml
+	run grep -q 'aube-test-builds-marker: false' aube-workspace.yaml
 	assert_success
 
 	run aube approve-builds --all
 	assert_success
 	assert_output --partial "aube-test-builds-marker"
-	assert_output --partial "pnpm-workspace.yaml"
+	assert_output --partial "aube-workspace.yaml"
 
-	run grep -q 'aube-test-builds-marker: true' pnpm-workspace.yaml
+	run grep -q 'aube-test-builds-marker: true' aube-workspace.yaml
 	assert_success
 	run grep -q 'onlyBuiltDependencies' package.json
 	assert_failure
@@ -143,10 +143,10 @@ JSON
 	assert_file_exists aube-builds-marker.txt
 }
 
-@test "approve-builds --all in npm-style monorepo writes pnpm-workspace allowBuilds" {
+@test "approve-builds --all in npm-style monorepo writes aube-workspace allowBuilds" {
 	# An npm/yarn-style monorepo carries `workspaces` directly in
-	# package.json. Under pnpm v11 semantics aube creates
-	# pnpm-workspace.yaml to hold the allowBuilds review map.
+	# package.json. aube creates `aube-workspace.yaml` from scratch
+	# to hold the allowBuilds review map (parallels `aube-lock.yaml`).
 	mkdir -p packages/app
 	cat >package.json <<'JSON'
 {
@@ -172,12 +172,12 @@ JSON
 	assert_success
 	assert_output --partial "aube-test-builds-marker"
 
-	assert_file_exists pnpm-workspace.yaml
-	assert_file_not_exists aube-workspace.yaml
+	assert_file_exists aube-workspace.yaml
+	assert_file_not_exists pnpm-workspace.yaml
 
-	run grep -q 'allowBuilds:' pnpm-workspace.yaml
+	run grep -q 'allowBuilds:' aube-workspace.yaml
 	assert_success
-	run grep -q 'aube-test-builds-marker: true' pnpm-workspace.yaml
+	run grep -q 'aube-test-builds-marker: true' aube-workspace.yaml
 	assert_success
 
 	# Round-trip: a re-install must honor the policy stored under

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -162,11 +162,12 @@ teardown() {
 	assert_output --partial "aube-test-builds-marker"
 	assert_output --partial "global install"
 
-	# Global installs use the same pnpm v11 review map as projects.
-	assert_file_exists "$install_dir/pnpm-workspace.yaml"
-	run grep -q 'allowBuilds:' "$install_dir/pnpm-workspace.yaml"
+	# Global installs use the same pnpm v11 review map as projects,
+	# written to aube-workspace.yaml (parallels aube-lock.yaml).
+	assert_file_exists "$install_dir/aube-workspace.yaml"
+	run grep -q 'allowBuilds:' "$install_dir/aube-workspace.yaml"
 	assert_success
-	run grep -q 'aube-test-builds-marker: true' "$install_dir/pnpm-workspace.yaml"
+	run grep -q 'aube-test-builds-marker: true' "$install_dir/aube-workspace.yaml"
 	assert_success
 
 	run aube -C "$install_dir" rebuild

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -117,8 +117,8 @@ JSON
 	assert_failure
 	assert_output --partial "dependencies with build scripts must be reviewed"
 	assert_output --partial "dep-with-build@1.0.0"
-	assert_file_exists pnpm-workspace.yaml
-	run grep -q 'dep-with-build: false' pnpm-workspace.yaml
+	assert_file_exists aube-workspace.yaml
+	run grep -q 'dep-with-build: false' aube-workspace.yaml
 	assert_success
 }
 


### PR DESCRIPTION
## Summary

When `aube approve-builds` (or the install-time auto-seed of unreviewed build scripts) needs to create a workspace yaml from scratch, aube was writing `pnpm-workspace.yaml`. The lockfile companion is `aube-lock.yaml` — having the workspace yaml stay pnpm-prefixed is an asymmetry: a fresh `aube install` on a solo project produces a filesystem layout with both names sitting next to each other, mixing vendor namespaces.

Switches the **default write** filename to `aube-workspace.yaml` so the two aube-generated files share a naming scheme.

## Backward compat

Unchanged. The read path already prefers `aube-workspace.yaml` and falls back to `pnpm-workspace.yaml` (constant `WORKSPACE_YAML_NAMES = ["aube-workspace.yaml", "pnpm-workspace.yaml"]` in `crates/aube-manifest/src/workspace.rs:6`). The write path's existing-file precedence is unchanged too: a project that already ships `pnpm-workspace.yaml` keeps mutating that file in place. The only behavior change is the **fallback** when neither file exists — that branch now creates the aube-prefixed name.

| State | Before this PR | After this PR |
|---|---|---|
| `aube-workspace.yaml` present | mutate it | mutate it (unchanged) |
| `pnpm-workspace.yaml` present | mutate it | mutate it (unchanged) |
| Both present | mutate `aube-workspace.yaml` | mutate `aube-workspace.yaml` (unchanged) |
| Neither present | **create `pnpm-workspace.yaml`** | **create `aube-workspace.yaml`** ← change |

## Test coverage

- Renames the existing `add_to_allow_builds_creates_pnpm_workspace_when_no_yaml` test to its new behavior (`add_to_allow_builds_creates_aube_workspace_when_no_yaml`).
- Adds a companion `add_to_allow_builds_writes_to_existing_pnpm_workspace` that pins the backward-compat branch — a project with an existing `pnpm-workspace.yaml` keeps using it; no `aube-workspace.yaml` is created alongside.

## Test plan

- [x] `cargo test -p aube-manifest workspace` — 24 pass (including the 2 covered above)
- [x] `cargo test --workspace --all-targets` — all green (~1500 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to the fallback filename used when creating a new workspace YAML; existing files and build-policy logic remain unchanged.
> 
> **Overview**
> Changes the default workspace YAML write target for `allowBuilds` updates: when neither `aube-workspace.yaml` nor `pnpm-workspace.yaml` exists, aube now creates `aube-workspace.yaml` instead of `pnpm-workspace.yaml` (while still mutating an existing `pnpm-workspace.yaml` in place for backward compatibility).
> 
> Updates `approve-builds`/lifecycle-script documentation, CLI help text, and bats/unit tests to reflect the new filename and to add coverage that existing `pnpm-workspace.yaml` files are not “forked” into a new `aube-workspace.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3532589a694fcabe149dfa720bae8c918e3f671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->