### PR TITLE
fix(cli,linker,lockfile): patch-commit destination, CRLF patches, npm-alias catalog

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2908,7 +2908,10 @@ fn apply_multi_file_patch(pkg_dir: &Path, patch_text: &str) -> Result<(), String
         let patched_lf = diffy::apply(&normalized, &parsed)
             .map_err(|e| format!("failed to apply patch for {rel}: {e}"))?;
         let patched = if was_crlf {
-            patched_lf.replace('\n', "\r\n")
+            // Promote bare `\n` to `\r\n`, then collapse any `\r\r\n`
+            // back so a patch line containing a literal `\r` byte (rare
+            // but legal for binary-ish text) doesn't gain a second CR.
+            patched_lf.replace('\n', "\r\n").replace("\r\r\n", "\r\n")
         } else {
             patched_lf
         };
@@ -3354,6 +3357,28 @@ mod patch_tests {
         apply_multi_file_patch(&pkg, patch).unwrap();
         let bytes = std::fs::read(pkg.join("a.txt")).unwrap();
         assert_eq!(bytes, b"one\r\nTWO\r\nthree\r\n");
+    }
+
+    #[test]
+    fn crlf_restore_preserves_embedded_cr_byte() {
+        // A patch line that adds a literal `\r` byte mid-line must not
+        // gain a second `\r` when we re-CRLF the output. Naive
+        // `replace('\n', "\r\n")` would turn `\r\n` into `\r\r\n`; the
+        // `\r\r\n` collapse undoes that.
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("a.txt"), b"one\r\ntwo\r\n").unwrap();
+        let patch = "diff --git a/a.txt b/a.txt\n\
+                     --- a/a.txt\n\
+                     +++ b/a.txt\n\
+                     @@ -1,2 +1,2 @@\n\
+                     -one\n\
+                     +has\rcr\n\
+                     \x20two\n";
+        apply_multi_file_patch(&pkg, patch).unwrap();
+        let bytes = std::fs::read(pkg.join("a.txt")).unwrap();
+        assert_eq!(bytes, b"has\rcr\r\ntwo\r\n");
     }
 
     #[test]

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2891,10 +2891,27 @@ fn apply_multi_file_patch(pkg_dir: &Path, patch_text: &str) -> Result<(), String
             }
             continue;
         }
+        // git-style patches always use LF line endings, but published
+        // tarballs frequently ship files with CRLF (Windows editors,
+        // `core.autocrlf=true` checkouts). Diffy is byte-exact and
+        // refuses to match CRLF context against LF hunk lines, so we
+        // normalize the original to LF before applying and restore the
+        // CRLF on write. pnpm's patch applier does the same thing.
+        let was_crlf = original.contains("\r\n");
+        let normalized = if was_crlf {
+            original.replace("\r\n", "\n")
+        } else {
+            original
+        };
         let parsed = diffy::Patch::from_str(&section.body)
             .map_err(|e| format!("failed to parse patch for {rel}: {e}"))?;
-        let patched = diffy::apply(&original, &parsed)
+        let patched_lf = diffy::apply(&normalized, &parsed)
             .map_err(|e| format!("failed to apply patch for {rel}: {e}"))?;
+        let patched = if was_crlf {
+            patched_lf.replace('\n', "\r\n")
+        } else {
+            patched_lf
+        };
         // Break any reflink/hardlink to the global store before
         // writing the patched bytes — otherwise we'd silently mutate
         // every other project sharing this CAS file. Stage the write
@@ -3313,6 +3330,30 @@ mod patch_tests {
         let sections = split_patch_sections(patch);
         assert_eq!(sections.len(), 1);
         assert_eq!(sections[0].rel_path.as_deref(), Some("path with spaces.js"));
+    }
+
+    #[test]
+    fn applies_lf_patch_against_crlf_file() {
+        // Tarballs published from Windows editors ship CRLF text. pnpm
+        // / git emit LF-only patches even against those files. Diffy is
+        // byte-exact, so the apply path normalizes CRLF -> LF before
+        // matching and restores CRLF on write.
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("a.txt"), b"one\r\ntwo\r\nthree\r\n").unwrap();
+
+        let patch = "diff --git a/a.txt b/a.txt\n\
+                     --- a/a.txt\n\
+                     +++ b/a.txt\n\
+                     @@ -1,3 +1,3 @@\n\
+                     \x20one\n\
+                     -two\n\
+                     +TWO\n\
+                     \x20three\n";
+        apply_multi_file_patch(&pkg, patch).unwrap();
+        let bytes = std::fs::read(pkg.join("a.txt")).unwrap();
+        assert_eq!(bytes, b"one\r\nTWO\r\nthree\r\n");
     }
 
     #[test]

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -99,16 +99,26 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                     ..Default::default()
                 });
         } else {
-            let dep_path = if info.specifier.starts_with("npm:")
-                && let Some((real_name, resolved)) = parse_dep_path(&info.version)
+            // Detect npm-aliased deps purely from the shape of
+            // `version:`. pnpm encodes aliases as
+            // `<real_name>@<resolved>(peers…)` regardless of how the
+            // alias was declared:
+            //   - direct:  `specifier: npm:beamcoder-prebuild@0.7.1`
+            //   - catalog: `specifier: 'catalog:'` (the alias lives
+            //              in `pnpm-workspace.yaml#catalog`)
+            // The earlier `specifier.starts_with("npm:")` gate missed
+            // the catalog flavor and silently dropped those deps.
+            // Strip any peer suffix before parsing so `version:
+            // 18.2.0(react@18.2.0)` (a regular dep with peers) does
+            // not parse as `name="18.2.0(react"`.
+            let bare_version = info
+                .version
+                .split('(')
+                .next()
+                .unwrap_or(info.version.as_str());
+            let dep_path = if let Some((real_name, resolved)) = parse_dep_path(bare_version)
                 && real_name != name
             {
-                // npm-alias: importer key is the alias, `version:`
-                // is `<real>@<resolved>`. Re-key the dep_path under
-                // the alias so it lines up with the resolver-fresh
-                // shape; record the remap so the canonical-packages
-                // loop can synthesize a matching LockedPackage with
-                // `alias_of: Some(real_name)`.
                 let peer_suffix = info
                     .version
                     .find('(')
@@ -3417,6 +3427,68 @@ snapshots:
         let real = graph.packages.get("express@4.22.1").expect("real entry");
         assert_eq!(real.name, "express");
         assert!(real.alias_of.is_none());
+    }
+
+    #[test]
+    fn parse_synthesizes_npm_alias_from_pnpm_lockfile_catalog_specifier() {
+        // pnpm-resolved catalog aliases keep `specifier: 'catalog:'`
+        // in the importer block while the `version:` field already
+        // carries the resolved alias (`<real>@<resolved>`). The
+        // reader must detect the alias from the version shape alone
+        // — gating on `specifier.starts_with("npm:")` would silently
+        // drop the dep and leave node_modules empty.
+        // Repro:
+        //   https://github.com/endevco/aube/discussions/383#discussioncomment-16759640
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &path,
+            r#"
+lockfileVersion: '9.0'
+
+catalogs:
+  default:
+    beamcoder:
+      specifier: npm:beamcoder-prebuild@0.7.1-rc.18
+      version: 0.7.1-rc.18
+
+importers:
+  packages/app:
+    dependencies:
+      beamcoder:
+        specifier: 'catalog:'
+        version: beamcoder-prebuild@0.7.1-rc.18
+
+packages:
+  beamcoder-prebuild@0.7.1-rc.18:
+    resolution: {integrity: sha512-fake}
+
+snapshots:
+  beamcoder-prebuild@0.7.1-rc.18: {}
+"#,
+        )
+        .unwrap();
+
+        let graph = parse(&path).unwrap();
+        let app = graph
+            .importers
+            .get("packages/app")
+            .expect("packages/app importer");
+        assert_eq!(app.len(), 1, "alias-resolved catalog dep must be parsed");
+        let dep = &app[0];
+        assert_eq!(dep.name, "beamcoder", "DirectDep keeps the alias name");
+        assert_eq!(
+            dep.dep_path, "beamcoder@0.7.1-rc.18",
+            "DirectDep dep_path is alias-keyed"
+        );
+        assert_eq!(dep.specifier.as_deref(), Some("catalog:"));
+
+        let pkg = graph
+            .packages
+            .get("beamcoder@0.7.1-rc.18")
+            .expect("synthesized alias-keyed package");
+        assert_eq!(pkg.name, "beamcoder");
+        assert_eq!(pkg.alias_of.as_deref(), Some("beamcoder-prebuild"));
     }
 
     #[test]

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -682,20 +682,25 @@ pub fn remove_setting_entry(cwd: &Path, key: &str, entry_key: &str) -> Result<bo
 }
 
 /// Mutate a namespaced map setting (e.g. `patchedDependencies`,
-/// `allowBuilds`) inside `package.json` and write back. Picks the
-/// namespace by looking at the existing manifest:
+/// `allowBuilds`) inside `package.json` and write back.
 ///
-/// - If `pnpm` is already declared in `package.json`, write under
-///   `pnpm.<key>` so we don't fragment the user's chosen namespace.
-/// - Otherwise write under `aube.<key>` — aube's native namespace.
-///   The read side already gives `aube.*` precedence over `pnpm.*`,
-///   so a fresh project doesn't have to inherit pnpm-branded keys.
+/// The closure receives a **merged** view of `pnpm.<key>` and
+/// `aube.<key>`, with `aube.*` winning on key conflict — the same
+/// precedence the read side already uses. After the closure runs,
+/// the merged result is written to a single namespace and the other
+/// is cleared, so a future read sees exactly one source of truth and
+/// can never silently shadow a stale entry. This matters because
+/// pnpm-aware tools (and pnpm itself) can introduce a `pnpm` key into
+/// a manifest after aube has already populated `aube.<key>`; without
+/// the merge-and-collapse, a re-record would leave the new value in
+/// `pnpm.<key>` while the stale `aube.<key>` entry kept winning on
+/// read.
 ///
-/// Creates the namespace and the inner `<key>` map as needed, drops
-/// them again when they end up empty (so a remove-last-entry call
-/// doesn't leave a `"<ns>": { "<key>": {} }` stub behind), and skips
-/// the rewrite entirely when the closure produced no structural
-/// change. Mirrors the no-op-skip guarantee of [`edit_workspace_yaml`].
+/// The chosen namespace follows [`config_write_target`]'s rule:
+/// `pnpm` if a `pnpm` namespace is already declared in the manifest,
+/// `aube` otherwise. Empty namespaces and inner maps are scrubbed,
+/// and the rewrite is skipped entirely when nothing structural
+/// changes — mirrors the no-op-skip guarantee of [`edit_workspace_yaml`].
 pub fn edit_setting_map<F>(cwd: &Path, key: &str, f: F) -> Result<(), crate::Error>
 where
     F: FnOnce(&mut serde_json::Map<String, serde_json::Value>),
@@ -709,32 +714,61 @@ where
     })?;
     let before = obj.clone();
 
-    let ns = if obj.contains_key("pnpm") {
+    // Build the merged view (pnpm first, aube overrides on conflict)
+    // before mutating, so the closure sees the same map the install
+    // path would.
+    let mut merged: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+    for ns in ["pnpm", "aube"] {
+        if let Some(inner) = obj
+            .get(ns)
+            .and_then(serde_json::Value::as_object)
+            .and_then(|m| m.get(key))
+            .and_then(serde_json::Value::as_object)
+        {
+            for (k, v) in inner {
+                merged.insert(k.clone(), v.clone());
+            }
+        }
+    }
+
+    f(&mut merged);
+
+    let chosen_ns = if obj.contains_key("pnpm") {
         "pnpm"
     } else {
         "aube"
     };
+    let other_ns = if chosen_ns == "pnpm" { "aube" } else { "pnpm" };
 
-    let ns_value = obj
-        .entry(ns.to_string())
-        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-    let ns_obj = ns_value
-        .as_object_mut()
-        .ok_or_else(|| crate::Error::YamlParse(path.clone(), format!("`{ns}` is not an object")))?;
-    let inner = ns_obj
-        .entry(key.to_string())
-        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-    let inner_obj = inner.as_object_mut().ok_or_else(|| {
-        crate::Error::YamlParse(path.clone(), format!("`{ns}.{key}` is not an object"))
-    })?;
-
-    f(inner_obj);
-
-    if inner_obj.is_empty() {
-        ns_obj.remove(key);
+    // Drop `<key>` from the other namespace so the post-write state
+    // has one source of truth.
+    let mut other_ns_empty_after = false;
+    if let Some(other_obj) = obj.get_mut(other_ns).and_then(|v| v.as_object_mut()) {
+        other_obj.remove(key);
+        other_ns_empty_after = other_obj.is_empty();
     }
-    if ns_obj.is_empty() {
-        obj.remove(ns);
+    if other_ns_empty_after {
+        obj.remove(other_ns);
+    }
+
+    // Write merged into the chosen namespace, or scrub it if empty.
+    if merged.is_empty() {
+        let mut chosen_ns_empty_after = false;
+        if let Some(chosen_obj) = obj.get_mut(chosen_ns).and_then(|v| v.as_object_mut()) {
+            chosen_obj.remove(key);
+            chosen_ns_empty_after = chosen_obj.is_empty();
+        }
+        if chosen_ns_empty_after {
+            obj.remove(chosen_ns);
+        }
+    } else {
+        let chosen_value = obj
+            .entry(chosen_ns.to_string())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        let chosen_obj = chosen_value.as_object_mut().ok_or_else(|| {
+            crate::Error::YamlParse(path.clone(), format!("`{chosen_ns}` is not an object"))
+        })?;
+        chosen_obj.insert(key.to_string(), serde_json::Value::Object(merged));
     }
 
     if *obj == before {

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -576,7 +576,7 @@ pub fn workspace_yaml_existing(project_dir: &Path) -> Option<PathBuf> {
 
 /// Resolve which workspace-yaml path a writer should mutate in
 /// `project_dir`. Existing `aube-workspace.yaml` wins over
-/// `pnpm-workspace.yaml`; when neither exists, create
+/// `pnpm-workspace.yaml`; when neither exists, falls back to
 /// `aube-workspace.yaml` — aube's own filename, parallel to the
 /// `aube-lock.yaml` shape we use for the lockfile.
 ///
@@ -588,31 +588,196 @@ pub fn workspace_yaml_existing(project_dir: &Path) -> Option<PathBuf> {
 /// (`aube-lock.yaml`, `aube-workspace.yaml`) rather than mixing
 /// vendor namespaces.
 ///
-/// Use this for write-with-create call sites (allowBuilds,
-/// patchedDependencies). For read-or-skip callers, prefer
-/// [`workspace_yaml_existing`].
+/// Most writers should go through [`config_write_target`] instead,
+/// which only resolves to the workspace yaml when one already exists
+/// on disk. This raw helper is for the rare caller that genuinely
+/// needs a workspace yaml path even on a fresh project (e.g. the
+/// node-gyp bootstrap dummy file).
 pub fn workspace_yaml_target(project_dir: &Path) -> PathBuf {
     workspace_yaml_existing(project_dir).unwrap_or_else(|| project_dir.join("aube-workspace.yaml"))
 }
 
-/// Merge `names` into the workspace's `allowBuilds` map.
+/// Where the next mutation of a workspace-level setting should land.
+/// `pnpm.<key>` in `package.json` and the workspace yaml hold the same
+/// shape for almost every aube-mutated setting (`patchedDependencies`,
+/// `allowBuilds`, future settings) so there is one rule that applies
+/// to all of them — see [`config_write_target`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigWriteTarget {
+    /// Mutate `pnpm.<key>` in `package.json` via [`edit_setting_map`].
+    PackageJson,
+    /// Mutate the existing workspace yaml at this path via
+    /// [`edit_workspace_yaml`].
+    WorkspaceYaml(PathBuf),
+}
+
+/// Pick which file a workspace-level config write should mutate. Pure
+/// file-existence rule: when the workspace yaml exists, write there
+/// (the pnpm v10+ canonical home, where YAML comments can document
+/// each entry); otherwise write to `package.json`. We deliberately do
+/// not introspect contents — a project with a workspace yaml gets all
+/// its workspace-level config there even when prior entries lived in
+/// `package.json`.
 ///
-/// Write-target precedence:
-/// 1. `aube-workspace.yaml` if it exists — top-level `allowBuilds`.
-/// 2. `pnpm-workspace.yaml` if it exists — top-level `allowBuilds`.
-/// 3. Otherwise — create `aube-workspace.yaml` with top-level
-///    `allowBuilds` (matches aube's `aube-lock.yaml` naming).
+/// Used by every aube command that mutates a setting which can live in
+/// either file (`aube patch-commit`, `aube patch-remove`,
+/// `aube approve-builds`, install-time auto-deny seeding, …).
+pub fn config_write_target(project_dir: &Path) -> ConfigWriteTarget {
+    match workspace_yaml_existing(project_dir) {
+        Some(path) => ConfigWriteTarget::WorkspaceYaml(path),
+        None => ConfigWriteTarget::PackageJson,
+    }
+}
+
+/// Drop `entry_key` from `pnpm.<key>` and `aube.<key>` in
+/// `package.json`. Returns `Ok(true)` when at least one namespace held
+/// it. Empty inner maps and empty namespaces are scrubbed too. The
+/// rewrite is skipped entirely when nothing structural changes —
+/// mirrors the no-op-skip guarantee of [`edit_workspace_yaml`].
+///
+/// Walking both namespaces matters because the read side merges them
+/// (`aube.*` wins on conflict), so an entry recorded in either
+/// location is live; a one-namespace removal would leave a stale
+/// duplicate behind.
+pub fn remove_setting_entry(cwd: &Path, key: &str, entry_key: &str) -> Result<bool, crate::Error> {
+    let path = cwd.join("package.json");
+    if !path.exists() {
+        return Ok(false);
+    }
+    let raw = std::fs::read_to_string(&path).map_err(|e| crate::Error::Io(path.clone(), e))?;
+    let mut value = crate::parse_json::<serde_json::Value>(&path, raw)?;
+    let obj = value.as_object_mut().ok_or_else(|| {
+        crate::Error::YamlParse(path.clone(), "package.json is not an object".to_string())
+    })?;
+    let before = obj.clone();
+
+    let mut existed = false;
+    for ns in ["pnpm", "aube"] {
+        let mut ns_empty = false;
+        if let Some(ns_obj) = obj.get_mut(ns).and_then(|v| v.as_object_mut()) {
+            if let Some(inner) = ns_obj.get_mut(key).and_then(|v| v.as_object_mut()) {
+                if inner.remove(entry_key).is_some() {
+                    existed = true;
+                }
+                if inner.is_empty() {
+                    ns_obj.remove(key);
+                }
+            }
+            ns_empty = ns_obj.is_empty();
+        }
+        if ns_empty {
+            obj.remove(ns);
+        }
+    }
+
+    if *obj == before {
+        return Ok(existed);
+    }
+
+    let mut out = serde_json::to_string_pretty(&value)
+        .map_err(|e| crate::Error::YamlParse(path.clone(), format!("failed to serialize: {e}")))?;
+    out.push('\n');
+    std::fs::write(&path, out).map_err(|e| crate::Error::Io(path, e))?;
+    Ok(existed)
+}
+
+/// Mutate a namespaced map setting (e.g. `patchedDependencies`,
+/// `allowBuilds`) inside `package.json` and write back. Picks the
+/// namespace by looking at the existing manifest:
+///
+/// - If `pnpm` is already declared in `package.json`, write under
+///   `pnpm.<key>` so we don't fragment the user's chosen namespace.
+/// - Otherwise write under `aube.<key>` — aube's native namespace.
+///   The read side already gives `aube.*` precedence over `pnpm.*`,
+///   so a fresh project doesn't have to inherit pnpm-branded keys.
+///
+/// Creates the namespace and the inner `<key>` map as needed, drops
+/// them again when they end up empty (so a remove-last-entry call
+/// doesn't leave a `"<ns>": { "<key>": {} }` stub behind), and skips
+/// the rewrite entirely when the closure produced no structural
+/// change. Mirrors the no-op-skip guarantee of [`edit_workspace_yaml`].
+pub fn edit_setting_map<F>(cwd: &Path, key: &str, f: F) -> Result<(), crate::Error>
+where
+    F: FnOnce(&mut serde_json::Map<String, serde_json::Value>),
+{
+    let path = cwd.join("package.json");
+    let raw = std::fs::read_to_string(&path).map_err(|e| crate::Error::Io(path.clone(), e))?;
+    let mut value = crate::parse_json::<serde_json::Value>(&path, raw)?;
+
+    let obj = value.as_object_mut().ok_or_else(|| {
+        crate::Error::YamlParse(path.clone(), "package.json is not an object".to_string())
+    })?;
+    let before = obj.clone();
+
+    let ns = if obj.contains_key("pnpm") {
+        "pnpm"
+    } else {
+        "aube"
+    };
+
+    let ns_value = obj
+        .entry(ns.to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    let ns_obj = ns_value
+        .as_object_mut()
+        .ok_or_else(|| crate::Error::YamlParse(path.clone(), format!("`{ns}` is not an object")))?;
+    let inner = ns_obj
+        .entry(key.to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    let inner_obj = inner.as_object_mut().ok_or_else(|| {
+        crate::Error::YamlParse(path.clone(), format!("`{ns}.{key}` is not an object"))
+    })?;
+
+    f(inner_obj);
+
+    if inner_obj.is_empty() {
+        ns_obj.remove(key);
+    }
+    if ns_obj.is_empty() {
+        obj.remove(ns);
+    }
+
+    if *obj == before {
+        return Ok(());
+    }
+
+    let mut out = serde_json::to_string_pretty(&value)
+        .map_err(|e| crate::Error::YamlParse(path.clone(), format!("failed to serialize: {e}")))?;
+    out.push('\n');
+    std::fs::write(&path, out).map_err(|e| crate::Error::Io(path, e))?;
+    Ok(())
+}
+
+/// Merge `names` into the project's `allowBuilds` map. Routes through
+/// [`config_write_target`]: workspace yaml when one exists, otherwise
+/// `package.json#pnpm.allowBuilds`. Returns the file that was written.
 ///
 /// `allowed=true` is used by `aube approve-builds`; `allowed=false` is
-/// used by install to seed unreviewed packages for later review. Returns
-/// the file that was written.
+/// used by install to seed unreviewed packages for later review. The
+/// install-time seed is idempotent — names already on the list are
+/// left at their existing value, and the underlying writers skip the
+/// rewrite when nothing structural changed.
 pub fn add_to_allow_builds(
     project_dir: &Path,
     names: &[String],
     allowed: bool,
-) -> Result<std::path::PathBuf, crate::Error> {
-    let path = workspace_yaml_target(project_dir);
-    write_to_yaml(&path, names, allowed)
+) -> Result<PathBuf, crate::Error> {
+    match config_write_target(project_dir) {
+        ConfigWriteTarget::WorkspaceYaml(path) => write_allow_builds_yaml(&path, names, allowed),
+        ConfigWriteTarget::PackageJson => {
+            edit_setting_map(project_dir, "allowBuilds", |map| {
+                for name in names {
+                    if allowed {
+                        map.insert(name.clone(), serde_json::Value::Bool(true));
+                    } else {
+                        map.entry(name.clone())
+                            .or_insert(serde_json::Value::Bool(false));
+                    }
+                }
+            })?;
+            Ok(project_dir.join("package.json"))
+        }
+    }
 }
 
 /// Insert or replace a single `patchedDependencies` entry in the
@@ -732,7 +897,11 @@ where
     Ok(path.to_path_buf())
 }
 
-fn write_to_yaml(path: &Path, names: &[String], allowed: bool) -> Result<PathBuf, crate::Error> {
+fn write_allow_builds_yaml(
+    path: &Path,
+    names: &[String],
+    allowed: bool,
+) -> Result<PathBuf, crate::Error> {
     edit_workspace_yaml(path, |map| {
         let allow_builds = workspace_yaml_submap(map, "allowBuilds", path)?;
         for name in names {
@@ -942,13 +1111,12 @@ patchedDependencies:
     }
 
     #[test]
-    fn add_to_allow_builds_creates_aube_workspace_when_no_yaml() {
-        // When no workspace yaml exists yet, aube creates
-        // `aube-workspace.yaml` (parallels `aube-lock.yaml`).
-        // Existing `pnpm-workspace.yaml` files are still read +
-        // mutated in place — see
-        // `add_to_allow_builds_writes_to_existing_pnpm_workspace`
-        // for that branch.
+    fn add_to_allow_builds_writes_to_package_json_when_no_yaml() {
+        // No yaml on disk, no `pnpm` namespace in package.json: the
+        // setting lands under `aube.allowBuilds` per the shared
+        // `config_write_target` rule. Tests for the existing-yaml
+        // branch live in `add_to_allow_builds_writes_to_existing_pnpm_workspace`
+        // and `add_to_allow_builds_writes_to_aube_file_when_present`.
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("package.json"),
@@ -961,16 +1129,16 @@ patchedDependencies:
             true,
         )
         .unwrap();
-        assert_eq!(path, dir.path().join("aube-workspace.yaml"));
-        let config = WorkspaceConfig::load(dir.path()).unwrap();
-        assert!(matches!(
-            config.allow_builds.get("esbuild"),
-            Some(yaml_serde::Value::Bool(true))
-        ));
-        assert!(matches!(
-            config.allow_builds.get("sharp"),
-            Some(yaml_serde::Value::Bool(true))
-        ));
+        assert_eq!(path, dir.path().join("package.json"));
+        let raw = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["aube"]["allowBuilds"]["esbuild"], true);
+        assert_eq!(parsed["aube"]["allowBuilds"]["sharp"], true);
+        // Existing manifest keys are preserved.
+        assert_eq!(parsed["name"], "solo");
+        // No yaml file should have been created.
+        assert!(!dir.path().join("aube-workspace.yaml").exists());
+        assert!(!dir.path().join("pnpm-workspace.yaml").exists());
     }
 
     #[test]
@@ -1025,7 +1193,28 @@ patchedDependencies:
 
     #[test]
     fn add_to_allow_builds_writes_false_for_review() {
+        // Install-time auto-deny seed. Without a yaml on disk it lands
+        // in package.json under the `aube` namespace; the install
+        // codepath always operates on a project that has package.json.
         let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
+        add_to_allow_builds(dir.path(), &["esbuild".to_string()], false).unwrap();
+        let raw = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["aube"]["allowBuilds"]["esbuild"], false);
+    }
+
+    #[test]
+    fn add_to_allow_builds_writes_false_for_review_yaml() {
+        // Same scenario as `add_to_allow_builds_writes_false_for_review`
+        // but with a yaml on disk — the seed lands in the yaml, and
+        // the typed view picks it up via WorkspaceConfig.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'p/*'\n",
+        )
+        .unwrap();
         add_to_allow_builds(dir.path(), &["esbuild".to_string()], false).unwrap();
         let config = WorkspaceConfig::load(dir.path()).unwrap();
         assert!(matches!(

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -617,13 +617,22 @@ pub fn add_to_allow_builds(
 
 /// Insert or replace a single `patchedDependencies` entry in the
 /// workspace yaml at `path`. Creates the file (and the
-/// `patchedDependencies` mapping) if needed. Returns the file that
-/// was written.
+/// `patchedDependencies` mapping) if needed. No-ops (and returns the
+/// path untouched) when `key` already maps to `rel_patch_path` —
+/// yaml_serde's round-trip drops comments, so we must avoid rewriting
+/// the file when nothing actually changes.
 pub fn upsert_workspace_patched_dependency(
     path: &Path,
     key: &str,
     rel_patch_path: &str,
 ) -> Result<std::path::PathBuf, crate::Error> {
+    if read_workspace_patched_dependencies(path)?
+        .get(key)
+        .and_then(yaml_serde::Value::as_str)
+        == Some(rel_patch_path)
+    {
+        return Ok(path.to_path_buf());
+    }
     edit_patched_dependencies_yaml(path, |map| {
         map.insert(
             yaml_serde::Value::String(key.to_string()),
@@ -635,18 +644,44 @@ pub fn upsert_workspace_patched_dependency(
 /// Drop a `patchedDependencies` entry from the workspace yaml at
 /// `path`. Returns `Ok(true)` when the entry existed (and the file was
 /// rewritten), `Ok(false)` when the file was missing or had no such
-/// entry. When the removal empties `patchedDependencies`, the key is
-/// dropped from the document so we don't leave a `patchedDependencies: {}`
-/// stub behind.
+/// entry. The presence check happens *before* opening the file for a
+/// rewrite — yaml_serde's round-trip strips user comments, and
+/// `aube patch-remove` is called with both yaml and json destinations
+/// regardless of where the patch actually lives, so we must skip the
+/// write when there's nothing to remove. When the removal empties
+/// `patchedDependencies`, the key is dropped from the document so we
+/// don't leave a `patchedDependencies: {}` stub behind.
 pub fn remove_workspace_patched_dependency(path: &Path, key: &str) -> Result<bool, crate::Error> {
-    if !path.exists() {
+    if !read_workspace_patched_dependencies(path)?.contains_key(key) {
         return Ok(false);
     }
-    let mut existed = false;
     edit_patched_dependencies_yaml(path, |map| {
-        existed = map.shift_remove(key).is_some();
+        map.shift_remove(key);
     })?;
-    Ok(existed)
+    Ok(true)
+}
+
+/// Read the `patchedDependencies` map directly from a workspace yaml
+/// file. Returns an empty map when the file is missing, empty, or has
+/// no `patchedDependencies` key. Used as a peek before write so the
+/// upsert/remove paths can avoid a yaml_serde round-trip (and the
+/// comment loss it implies) when nothing would actually change.
+fn read_workspace_patched_dependencies(path: &Path) -> Result<yaml_serde::Mapping, crate::Error> {
+    if !path.exists() {
+        return Ok(yaml_serde::Mapping::new());
+    }
+    let content =
+        std::fs::read_to_string(path).map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
+    if content.trim().is_empty() {
+        return Ok(yaml_serde::Mapping::new());
+    }
+    let value: yaml_serde::Value = crate::parse_yaml(path, content)?;
+    Ok(value
+        .as_mapping()
+        .and_then(|m| m.get("patchedDependencies"))
+        .and_then(yaml_serde::Value::as_mapping)
+        .cloned()
+        .unwrap_or_default())
 }
 
 fn edit_patched_dependencies_yaml<F>(path: &Path, f: F) -> Result<std::path::PathBuf, crate::Error>
@@ -1212,5 +1247,33 @@ updateConfig:
         .unwrap();
         let removed = remove_workspace_patched_dependency(&path, "missing@9.9.9").unwrap();
         assert!(!removed);
+    }
+
+    #[test]
+    fn remove_workspace_patched_dependency_does_not_rewrite_when_key_absent() {
+        // yaml_serde's round-trip drops comments. `aube patch-remove`
+        // calls remove on both the workspace yaml and package.json
+        // regardless of where the patch lives, so a no-op remove must
+        // not touch the file (and lose the user's comments).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        let original = "# top-level comment\npatchedDependencies:\n  # patch annotation\n  \"a@1.0.0\": patches/a@1.0.0.patch\n";
+        std::fs::write(&path, original).unwrap();
+        let removed = remove_workspace_patched_dependency(&path, "missing@9.9.9").unwrap();
+        assert!(!removed);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn upsert_workspace_patched_dependency_does_not_rewrite_when_value_unchanged() {
+        // Same comment-preservation argument as the remove case: an
+        // idempotent re-record after editing the patch file should not
+        // strip yaml comments.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        let original = "# top-level comment\npatchedDependencies:\n  # patch annotation\n  \"a@1.0.0\": patches/a@1.0.0.patch\n";
+        std::fs::write(&path, original).unwrap();
+        upsert_workspace_patched_dependency(&path, "a@1.0.0", "patches/a@1.0.0.patch").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
     }
 }

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -558,9 +558,25 @@ pub fn load_both(
     Ok((typed, raw))
 }
 
-/// Resolve which workspace-yaml path `add_to_allow_builds` should
-/// mutate in `project_dir`. Existing `aube-workspace.yaml` wins
-/// over `pnpm-workspace.yaml`; when neither exists, create
+/// Path to the existing workspace yaml in `project_dir`, if any.
+/// `aube-workspace.yaml` wins over `pnpm-workspace.yaml` so an
+/// aube-native project's preferences override a co-existing pnpm
+/// fallback. Returns `None` when neither file exists — read-or-skip
+/// callers (catalog cleanup, ancestor walks) treat that as "nothing
+/// to read or rewrite".
+pub fn workspace_yaml_existing(project_dir: &Path) -> Option<PathBuf> {
+    for name in WORKSPACE_YAML_NAMES {
+        let path = project_dir.join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Resolve which workspace-yaml path a writer should mutate in
+/// `project_dir`. Existing `aube-workspace.yaml` wins over
+/// `pnpm-workspace.yaml`; when neither exists, create
 /// `aube-workspace.yaml` — aube's own filename, parallel to the
 /// `aube-lock.yaml` shape we use for the lockfile.
 ///
@@ -571,14 +587,12 @@ pub fn load_both(
 /// project's filesystem layout matches aube's overall naming
 /// (`aube-lock.yaml`, `aube-workspace.yaml`) rather than mixing
 /// vendor namespaces.
-pub fn workspace_yaml_target(project_dir: &Path) -> std::path::PathBuf {
-    for name in WORKSPACE_YAML_NAMES {
-        let path = project_dir.join(name);
-        if path.exists() {
-            return path;
-        }
-    }
-    project_dir.join("aube-workspace.yaml")
+///
+/// Use this for write-with-create call sites (allowBuilds,
+/// patchedDependencies). For read-or-skip callers, prefer
+/// [`workspace_yaml_existing`].
+pub fn workspace_yaml_target(project_dir: &Path) -> PathBuf {
+    workspace_yaml_existing(project_dir).unwrap_or_else(|| project_dir.join("aube-workspace.yaml"))
 }
 
 /// Merge `names` into the workspace's `allowBuilds` map.

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -617,76 +617,80 @@ pub fn add_to_allow_builds(
 
 /// Insert or replace a single `patchedDependencies` entry in the
 /// workspace yaml at `path`. Creates the file (and the
-/// `patchedDependencies` mapping) if needed. No-ops (and returns the
-/// path untouched) when `key` already maps to `rel_patch_path` —
-/// yaml_serde's round-trip drops comments, so we must avoid rewriting
-/// the file when nothing actually changes.
+/// `patchedDependencies` mapping) if needed. The shared
+/// [`edit_workspace_yaml`] helper skips the rewrite when the closure
+/// produces no structural change, so an idempotent re-record after
+/// editing the patch file leaves yaml comments intact.
 pub fn upsert_workspace_patched_dependency(
     path: &Path,
     key: &str,
     rel_patch_path: &str,
-) -> Result<std::path::PathBuf, crate::Error> {
-    if read_workspace_patched_dependencies(path)?
-        .get(key)
-        .and_then(yaml_serde::Value::as_str)
-        == Some(rel_patch_path)
-    {
-        return Ok(path.to_path_buf());
-    }
-    edit_patched_dependencies_yaml(path, |map| {
-        map.insert(
+) -> Result<PathBuf, crate::Error> {
+    edit_workspace_yaml(path, |map| {
+        let pd_map = workspace_yaml_submap(map, "patchedDependencies", path)?;
+        pd_map.insert(
             yaml_serde::Value::String(key.to_string()),
             yaml_serde::Value::String(rel_patch_path.to_string()),
         );
+        Ok(())
     })
 }
 
 /// Drop a `patchedDependencies` entry from the workspace yaml at
-/// `path`. Returns `Ok(true)` when the entry existed (and the file was
-/// rewritten), `Ok(false)` when the file was missing or had no such
-/// entry. The presence check happens *before* opening the file for a
-/// rewrite — yaml_serde's round-trip strips user comments, and
-/// `aube patch-remove` is called with both yaml and json destinations
-/// regardless of where the patch actually lives, so we must skip the
-/// write when there's nothing to remove. When the removal empties
-/// `patchedDependencies`, the key is dropped from the document so we
+/// `path`. Returns `Ok(true)` when the entry was removed (and the
+/// file was rewritten). When the removal empties
+/// `patchedDependencies` we drop the key from the document so we
 /// don't leave a `patchedDependencies: {}` stub behind.
 pub fn remove_workspace_patched_dependency(path: &Path, key: &str) -> Result<bool, crate::Error> {
-    if !read_workspace_patched_dependencies(path)?.contains_key(key) {
-        return Ok(false);
-    }
-    edit_patched_dependencies_yaml(path, |map| {
-        map.shift_remove(key);
+    let mut existed = false;
+    edit_workspace_yaml(path, |map| {
+        let pd_map = workspace_yaml_submap(map, "patchedDependencies", path)?;
+        existed = pd_map.shift_remove(key).is_some();
+        if pd_map.is_empty() {
+            map.shift_remove("patchedDependencies");
+        }
+        Ok(())
     })?;
-    Ok(true)
+    Ok(existed)
 }
 
-/// Read the `patchedDependencies` map directly from a workspace yaml
-/// file. Returns an empty map when the file is missing, empty, or has
-/// no `patchedDependencies` key. Used as a peek before write so the
-/// upsert/remove paths can avoid a yaml_serde round-trip (and the
-/// comment loss it implies) when nothing would actually change.
-fn read_workspace_patched_dependencies(path: &Path) -> Result<yaml_serde::Mapping, crate::Error> {
-    if !path.exists() {
-        return Ok(yaml_serde::Mapping::new());
-    }
-    let content =
-        std::fs::read_to_string(path).map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
-    if content.trim().is_empty() {
-        return Ok(yaml_serde::Mapping::new());
-    }
-    let value: yaml_serde::Value = crate::parse_yaml(path, content)?;
-    Ok(value
-        .as_mapping()
-        .and_then(|m| m.get("patchedDependencies"))
-        .and_then(yaml_serde::Value::as_mapping)
-        .cloned()
-        .unwrap_or_default())
+/// Get the inner mapping for a top-level workspace-yaml key, creating
+/// it if absent. Errors when the key exists but isn't a mapping (a
+/// hand-edited file shape we shouldn't silently replace).
+fn workspace_yaml_submap<'a>(
+    map: &'a mut yaml_serde::Mapping,
+    key: &str,
+    path: &Path,
+) -> Result<&'a mut yaml_serde::Mapping, crate::Error> {
+    let entry = map
+        .entry(yaml_serde::Value::String(key.to_string()))
+        .or_insert_with(|| yaml_serde::Value::Mapping(yaml_serde::Mapping::new()));
+    entry.as_mapping_mut().ok_or_else(|| {
+        crate::Error::YamlParse(path.to_path_buf(), format!("`{key}` must be a mapping"))
+    })
 }
 
-fn edit_patched_dependencies_yaml<F>(path: &Path, f: F) -> Result<std::path::PathBuf, crate::Error>
+/// Apply `f` to the parsed top-level mapping of the workspace yaml at
+/// `path` and write it back. The helper exists so every workspace-yaml
+/// writer (allowBuilds, patchedDependencies, catalog cleanup, future
+/// settings) shares one comment-preserving rule: **the file is left
+/// untouched whenever `f` produces no structural change**.
+///
+/// `yaml_serde` is not a comment-preserving parser — every round trip
+/// strips user-authored comments and reflows the layout. That means a
+/// "no-op" edit (inserting an entry that already exists, removing one
+/// that isn't there, re-recording an unchanged value) would still
+/// rewrite the file and silently destroy the comments the workspace
+/// yaml was chosen to host.
+///
+/// Comparing the parsed `Value` before and after the closure catches
+/// all of those cases without needing per-call peeks. When `f` does
+/// produce a structural change, the user has explicitly asked for a
+/// rewrite and the comment loss is unavoidable until aube migrates to
+/// a comment-preserving YAML library.
+pub fn edit_workspace_yaml<F>(path: &Path, f: F) -> Result<PathBuf, crate::Error>
 where
-    F: FnOnce(&mut yaml_serde::Mapping),
+    F: FnOnce(&mut yaml_serde::Mapping) -> Result<(), crate::Error>,
 {
     use yaml_serde::{Mapping, Value};
 
@@ -709,75 +713,10 @@ where
         )
     })?;
 
-    let pd_key = Value::String("patchedDependencies".to_string());
-    let entry = map
-        .entry(pd_key.clone())
-        .or_insert_with(|| Value::Mapping(Mapping::new()));
-    let pd_map = entry.as_mapping_mut().ok_or_else(|| {
-        crate::Error::YamlParse(
-            path.to_path_buf(),
-            "`patchedDependencies` must be a mapping".to_string(),
-        )
-    })?;
-
-    f(pd_map);
-
-    if pd_map.is_empty() {
-        map.shift_remove("patchedDependencies");
-    }
-
-    let raw = yaml_serde::to_string(&doc)
-        .map_err(|e| crate::Error::YamlParse(path.to_path_buf(), e.to_string()))?;
-    let indented = indent_block_sequences(&raw);
-    aube_util::fs_atomic::atomic_write(path, indented.as_bytes())
-        .map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
-    Ok(path.to_path_buf())
-}
-
-fn write_to_yaml(
-    path: &Path,
-    names: &[String],
-    allowed: bool,
-) -> Result<std::path::PathBuf, crate::Error> {
-    use yaml_serde::{Mapping, Value};
-
-    let mut doc: Value = if path.exists() {
-        let content =
-            std::fs::read_to_string(path).map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
-        if content.trim().is_empty() {
-            Value::Mapping(Mapping::new())
-        } else {
-            crate::parse_yaml(path, content)?
-        }
-    } else {
-        Value::Mapping(Mapping::new())
-    };
-
-    let map = doc.as_mapping_mut().ok_or_else(|| {
-        crate::Error::YamlParse(
-            path.to_path_buf(),
-            "top-level yaml must be a mapping".to_string(),
-        )
-    })?;
-
-    let key = Value::String("allowBuilds".to_string());
-    let existing = map
-        .entry(key.clone())
-        .or_insert_with(|| Value::Mapping(Mapping::new()));
-    let allow_builds = existing.as_mapping_mut().ok_or_else(|| {
-        crate::Error::YamlParse(
-            path.to_path_buf(),
-            "`allowBuilds` must be a mapping".to_string(),
-        )
-    })?;
-
-    for name in names {
-        let key = Value::String(name.clone());
-        if allowed {
-            allow_builds.insert(key, Value::Bool(true));
-        } else {
-            allow_builds.entry(key).or_insert(Value::Bool(false));
-        }
+    let before = map.clone();
+    f(map)?;
+    if *map == before {
+        return Ok(path.to_path_buf());
     }
 
     let raw = yaml_serde::to_string(&doc)
@@ -791,6 +730,23 @@ fn write_to_yaml(
     aube_util::fs_atomic::atomic_write(path, indented.as_bytes())
         .map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
     Ok(path.to_path_buf())
+}
+
+fn write_to_yaml(path: &Path, names: &[String], allowed: bool) -> Result<PathBuf, crate::Error> {
+    edit_workspace_yaml(path, |map| {
+        let allow_builds = workspace_yaml_submap(map, "allowBuilds", path)?;
+        for name in names {
+            let key = yaml_serde::Value::String(name.clone());
+            if allowed {
+                allow_builds.insert(key, yaml_serde::Value::Bool(true));
+            } else {
+                allow_builds
+                    .entry(key)
+                    .or_insert(yaml_serde::Value::Bool(false));
+            }
+        }
+        Ok(())
+    })
 }
 
 /// Bump every block-sequence item line (`- ...`) by two spaces. Leaves
@@ -1275,5 +1231,64 @@ updateConfig:
         std::fs::write(&path, original).unwrap();
         upsert_workspace_patched_dependency(&path, "a@1.0.0", "patches/a@1.0.0.patch").unwrap();
         assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn add_to_allow_builds_does_not_rewrite_when_already_approved() {
+        // Re-approving an already-approved name must leave the file
+        // (and its yaml comments) untouched. `aube approve-builds` and
+        // the install-time auto-deny seed both call into this path on
+        // every invocation, so steady-state runs must not strip
+        // comments.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        let original = "# why we trust this build\nallowBuilds:\n  # esbuild ships native bindings\n  esbuild: true\n";
+        std::fs::write(&path, original).unwrap();
+        let written = add_to_allow_builds(dir.path(), &["esbuild".to_string()], true).unwrap();
+        assert_eq!(written, path);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn add_to_allow_builds_does_not_rewrite_when_seeding_existing_review_entry() {
+        // The install-time review seed (`allowed=false`) should not
+        // overwrite a name that is already on the allow list — but
+        // also must not rewrite the file just to confirm that.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        let original = "allowBuilds:\n  # already approved\n  esbuild: true\n";
+        std::fs::write(&path, original).unwrap();
+        add_to_allow_builds(dir.path(), &["esbuild".to_string()], false).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn edit_workspace_yaml_preserves_comments_on_no_op() {
+        // Direct test of the shared helper: a closure that doesn't
+        // mutate the parsed structure must leave the file byte-equal,
+        // including comments yaml_serde would otherwise strip.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        let original = "# header comment\npackages:\n  # workspace globs\n  - 'pkgs/*'\n";
+        std::fs::write(&path, original).unwrap();
+        edit_workspace_yaml(&path, |_map| Ok(())).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn edit_workspace_yaml_writes_when_structure_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        std::fs::write(&path, "packages:\n  - 'pkgs/*'\n").unwrap();
+        edit_workspace_yaml(&path, |map| {
+            map.insert(
+                yaml_serde::Value::String("foo".to_string()),
+                yaml_serde::Value::String("bar".to_string()),
+            );
+            Ok(())
+        })
+        .unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("foo: bar"));
     }
 }

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -601,6 +601,90 @@ pub fn add_to_allow_builds(
     write_to_yaml(&path, names, allowed)
 }
 
+/// Insert or replace a single `patchedDependencies` entry in the
+/// workspace yaml at `path`. Creates the file (and the
+/// `patchedDependencies` mapping) if needed. Returns the file that
+/// was written.
+pub fn upsert_workspace_patched_dependency(
+    path: &Path,
+    key: &str,
+    rel_patch_path: &str,
+) -> Result<std::path::PathBuf, crate::Error> {
+    edit_patched_dependencies_yaml(path, |map| {
+        map.insert(
+            yaml_serde::Value::String(key.to_string()),
+            yaml_serde::Value::String(rel_patch_path.to_string()),
+        );
+    })
+}
+
+/// Drop a `patchedDependencies` entry from the workspace yaml at
+/// `path`. Returns `Ok(true)` when the entry existed (and the file was
+/// rewritten), `Ok(false)` when the file was missing or had no such
+/// entry. When the removal empties `patchedDependencies`, the key is
+/// dropped from the document so we don't leave a `patchedDependencies: {}`
+/// stub behind.
+pub fn remove_workspace_patched_dependency(path: &Path, key: &str) -> Result<bool, crate::Error> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let mut existed = false;
+    edit_patched_dependencies_yaml(path, |map| {
+        existed = map.shift_remove(key).is_some();
+    })?;
+    Ok(existed)
+}
+
+fn edit_patched_dependencies_yaml<F>(path: &Path, f: F) -> Result<std::path::PathBuf, crate::Error>
+where
+    F: FnOnce(&mut yaml_serde::Mapping),
+{
+    use yaml_serde::{Mapping, Value};
+
+    let mut doc: Value = if path.exists() {
+        let content =
+            std::fs::read_to_string(path).map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
+        if content.trim().is_empty() {
+            Value::Mapping(Mapping::new())
+        } else {
+            crate::parse_yaml(path, content)?
+        }
+    } else {
+        Value::Mapping(Mapping::new())
+    };
+
+    let map = doc.as_mapping_mut().ok_or_else(|| {
+        crate::Error::YamlParse(
+            path.to_path_buf(),
+            "top-level yaml must be a mapping".to_string(),
+        )
+    })?;
+
+    let pd_key = Value::String("patchedDependencies".to_string());
+    let entry = map
+        .entry(pd_key.clone())
+        .or_insert_with(|| Value::Mapping(Mapping::new()));
+    let pd_map = entry.as_mapping_mut().ok_or_else(|| {
+        crate::Error::YamlParse(
+            path.to_path_buf(),
+            "`patchedDependencies` must be a mapping".to_string(),
+        )
+    })?;
+
+    f(pd_map);
+
+    if pd_map.is_empty() {
+        map.shift_remove("patchedDependencies");
+    }
+
+    let raw = yaml_serde::to_string(&doc)
+        .map_err(|e| crate::Error::YamlParse(path.to_path_buf(), e.to_string()))?;
+    let indented = indent_block_sequences(&raw);
+    aube_util::fs_atomic::atomic_write(path, indented.as_bytes())
+        .map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
+    Ok(path.to_path_buf())
+}
+
 fn write_to_yaml(
     path: &Path,
     names: &[String],
@@ -1055,5 +1139,64 @@ updateConfig:
                 .map(|u| u.ignore_dependencies.as_slice()),
             Some(["is-odd".to_string()].as_slice())
         );
+    }
+
+    #[test]
+    fn upsert_workspace_patched_dependency_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        upsert_workspace_patched_dependency(
+            &path,
+            "is-positive@3.1.0",
+            "patches/is-positive@3.1.0.patch",
+        )
+        .unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("patchedDependencies:"));
+        assert!(written.contains("is-positive@3.1.0"));
+        assert!(written.contains("patches/is-positive@3.1.0.patch"));
+    }
+
+    #[test]
+    fn upsert_workspace_patched_dependency_preserves_other_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        std::fs::write(&path, "packages:\n  - 'pkgs/*'\noverrides:\n  foo: 1.0.0\n").unwrap();
+        upsert_workspace_patched_dependency(&path, "bar@2.0.0", "patches/bar@2.0.0.patch").unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("packages:"));
+        assert!(written.contains("- 'pkgs/*'") || written.contains("- pkgs/*"));
+        assert!(written.contains("overrides:"));
+        assert!(written.contains("foo:"));
+        assert!(written.contains("patchedDependencies:"));
+        assert!(written.contains("bar@2.0.0"));
+    }
+
+    #[test]
+    fn remove_workspace_patched_dependency_drops_empty_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        std::fs::write(
+            &path,
+            "patchedDependencies:\n  \"a@1.0.0\": patches/a@1.0.0.patch\n",
+        )
+        .unwrap();
+        let removed = remove_workspace_patched_dependency(&path, "a@1.0.0").unwrap();
+        assert!(removed);
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(!written.contains("patchedDependencies"));
+    }
+
+    #[test]
+    fn remove_workspace_patched_dependency_missing_returns_false() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-workspace.yaml");
+        std::fs::write(
+            &path,
+            "patchedDependencies:\n  \"a@1.0.0\": patches/a@1.0.0.patch\n",
+        )
+        .unwrap();
+        let removed = remove_workspace_patched_dependency(&path, "missing@9.9.9").unwrap();
+        assert!(!removed);
     }
 }

--- a/crates/aube-util/src/hash.rs
+++ b/crates/aube-util/src/hash.rs
@@ -39,6 +39,7 @@ where
 }
 
 pub const INSTALL_SHAPE_FIELDS: &[&str] = &[
+    "aube",
     "bundleDependencies",
     "bundledDependencies",
     "catalog",

--- a/crates/aube/src/commands/catalogs.rs
+++ b/crates/aube/src/commands/catalogs.rs
@@ -11,6 +11,7 @@
 //! rather than in either command module.
 
 use aube_settings::resolved::CatalogMode;
+use miette::WrapErr;
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -122,16 +123,16 @@ fn range_compatible(
 /// package)` pairs that were dropped so the caller can surface a
 /// one-line summary.
 ///
-/// The rewrite is a plain `yaml_serde` round trip: comments and custom
-/// layout are not preserved. Callers gate this on `cleanupUnusedCatalogs`
-/// so the destructive rewrite only happens when the user opted in.
+/// Goes through `aube_manifest::workspace::edit_workspace_yaml`, which
+/// no-ops the rewrite when the closure produces no structural change —
+/// catalog cleanup runs on every install under `cleanupUnusedCatalogs`
+/// and we don't want to strip user comments on the steady-state pass
+/// where every declared entry is still referenced.
 pub(crate) fn prune_unused_catalog_entries(
     workspace_path: &Path,
     declared: &BTreeMap<String, BTreeMap<String, String>>,
     used: &BTreeMap<String, BTreeMap<String, aube_lockfile::CatalogEntry>>,
 ) -> miette::Result<Vec<(String, String)>> {
-    use miette::{Context, IntoDiagnostic};
-
     let mut unused: Vec<(String, String)> = Vec::new();
     for (cat_name, entries) in declared {
         for pkg in entries.keys() {
@@ -148,88 +149,68 @@ pub(crate) fn prune_unused_catalog_entries(
         return Ok(unused);
     }
 
-    let text = std::fs::read_to_string(workspace_path)
-        .into_diagnostic()
-        .wrap_err_with(|| {
-            format!(
-                "failed to read {} for cleanupUnusedCatalogs",
-                workspace_path.display()
-            )
-        })?;
-    let mut value: yaml_serde::Value = yaml_serde::from_str(&text)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("failed to parse {}", workspace_path.display()))?;
-
-    // An empty file deserializes to `null`; nothing to strip.
-    if value.is_null() {
-        return Ok(Vec::new());
-    }
-    let Some(root) = value.as_mapping_mut() else {
-        return Ok(Vec::new());
-    };
-
-    for (cat_name, pkg_name) in &unused {
-        if cat_name == "default" {
-            if let Some(map) = root
-                .get_mut(yaml_serde::Value::String("catalog".to_string()))
+    aube_manifest::workspace::edit_workspace_yaml(workspace_path, |root| {
+        for (cat_name, pkg_name) in &unused {
+            if cat_name == "default" {
+                if let Some(map) = root
+                    .get_mut("catalog")
+                    .and_then(yaml_serde::Value::as_mapping_mut)
+                {
+                    map.shift_remove(pkg_name.as_str());
+                }
+            } else if let Some(catalogs) = root
+                .get_mut("catalogs")
                 .and_then(yaml_serde::Value::as_mapping_mut)
+                && let Some(map) = catalogs
+                    .get_mut(cat_name.as_str())
+                    .and_then(yaml_serde::Value::as_mapping_mut)
             {
-                map.remove(yaml_serde::Value::String(pkg_name.clone()));
+                map.shift_remove(pkg_name.as_str());
             }
-        } else if let Some(catalogs) = root
-            .get_mut(yaml_serde::Value::String("catalogs".to_string()))
-            .and_then(yaml_serde::Value::as_mapping_mut)
-            && let Some(map) = catalogs
-                .get_mut(yaml_serde::Value::String(cat_name.clone()))
-                .and_then(yaml_serde::Value::as_mapping_mut)
+        }
+        // Drop now-empty containers so the file doesn't grow meaningless
+        // `catalog: {}` / `catalogs:` headers.
+        if root
+            .get("catalog")
+            .and_then(yaml_serde::Value::as_mapping)
+            .is_some_and(yaml_serde::Mapping::is_empty)
         {
-            map.remove(yaml_serde::Value::String(pkg_name.clone()));
+            root.shift_remove("catalog");
         }
-    }
-
-    // Drop now-empty catalog containers so the file doesn't grow
-    // meaningless `catalog: {}` / `catalogs:` headers.
-    let empty_default = root
-        .get(yaml_serde::Value::String("catalog".to_string()))
-        .and_then(yaml_serde::Value::as_mapping)
-        .is_some_and(yaml_serde::Mapping::is_empty);
-    if empty_default {
-        root.remove(yaml_serde::Value::String("catalog".to_string()));
-    }
-    if let Some(catalogs) = root
-        .get_mut(yaml_serde::Value::String("catalogs".to_string()))
-        .and_then(yaml_serde::Value::as_mapping_mut)
-    {
-        let to_drop: Vec<yaml_serde::Value> = catalogs
-            .iter()
-            .filter_map(|(k, v)| match v.as_mapping() {
-                Some(m) if m.is_empty() => Some(k.clone()),
-                _ => None,
-            })
-            .collect();
-        for key in to_drop {
-            catalogs.remove(key);
+        if let Some(catalogs) = root
+            .get_mut("catalogs")
+            .and_then(yaml_serde::Value::as_mapping_mut)
+        {
+            let to_drop: Vec<String> = catalogs
+                .iter()
+                .filter_map(|(k, v)| {
+                    let key = k.as_str()?;
+                    match v.as_mapping() {
+                        Some(m) if m.is_empty() => Some(key.to_string()),
+                        _ => None,
+                    }
+                })
+                .collect();
+            for key in to_drop {
+                catalogs.shift_remove(key.as_str());
+            }
         }
-    }
-    let empty_named = root
-        .get(yaml_serde::Value::String("catalogs".to_string()))
-        .and_then(yaml_serde::Value::as_mapping)
-        .is_some_and(yaml_serde::Mapping::is_empty);
-    if empty_named {
-        root.remove(yaml_serde::Value::String("catalogs".to_string()));
-    }
-
-    let new_text = yaml_serde::to_string(&value)
-        .into_diagnostic()
-        .wrap_err("failed to serialize workspace yaml after cleanupUnusedCatalogs")?;
-    aube_util::fs_atomic::atomic_write(workspace_path, new_text.as_bytes())
-        .into_diagnostic()
-        .wrap_err_with(|| {
-            format!(
-                "failed to write {} after cleanupUnusedCatalogs",
-                workspace_path.display()
-            )
-        })?;
+        if root
+            .get("catalogs")
+            .and_then(yaml_serde::Value::as_mapping)
+            .is_some_and(yaml_serde::Mapping::is_empty)
+        {
+            root.shift_remove("catalogs");
+        }
+        Ok(())
+    })
+    .map_err(miette::Report::new)
+    .wrap_err_with(|| {
+        format!(
+            "failed to write {} after cleanupUnusedCatalogs",
+            workspace_path.display()
+        )
+    })?;
     Ok(unused)
 }
 

--- a/crates/aube/src/commands/catalogs.rs
+++ b/crates/aube/src/commands/catalogs.rs
@@ -12,7 +12,7 @@
 
 use aube_settings::resolved::CatalogMode;
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// Outcome of matching an `aube add` spec against the default catalog.
 #[derive(Debug)]
@@ -115,20 +115,6 @@ fn range_compatible(
         return false;
     };
     version.satisfies(&catalog_parsed)
-}
-
-/// Locate the workspace yaml file (`aube-workspace.yaml` preferred,
-/// `pnpm-workspace.yaml` as fallback) inside `project_dir`. Returns
-/// `None` when neither file exists — callers treat that as "no catalogs
-/// declared, nothing to clean up".
-pub(crate) fn workspace_yaml_path(project_dir: &Path) -> Option<PathBuf> {
-    for name in ["aube-workspace.yaml", "pnpm-workspace.yaml"] {
-        let path = project_dir.join(name);
-        if path.exists() {
-            return Some(path);
-        }
-    }
-    None
 }
 
 /// Remove catalog entries from the workspace yaml that the freshly

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -208,7 +208,7 @@ pub(super) fn maybe_cleanup_unused_catalogs(
     if declared.is_empty() {
         return Ok(());
     }
-    let Some(ws_path) = super::super::catalogs::workspace_yaml_path(cwd) else {
+    let Some(ws_path) = aube_manifest::workspace::workspace_yaml_existing(cwd) else {
         return Ok(());
     };
     let dropped = super::super::catalogs::prune_unused_catalog_entries(&ws_path, declared, used)?;

--- a/crates/aube/src/commands/patch_commit.rs
+++ b/crates/aube/src/commands/patch_commit.rs
@@ -80,20 +80,27 @@ pub async fn run(args: PatchCommitArgs) -> Result<()> {
     // Manifest write failure means the patch on disk is not
     // referenced anywhere. Restore the prior patch if there was one
     // (re-patch path), else remove the orphan.
-    if let Err(e) = upsert_patched_dependency(&cwd, &key, &rel_path) {
-        match prior_patch {
-            Some(bytes) => {
-                let _ = aube_util::fs_atomic::atomic_write(&abs_path, &bytes);
+    let manifest_path = match upsert_patched_dependency(&cwd, &key, &rel_path) {
+        Ok(p) => p,
+        Err(e) => {
+            match prior_patch {
+                Some(bytes) => {
+                    let _ = aube_util::fs_atomic::atomic_write(&abs_path, &bytes);
+                }
+                None => {
+                    let _ = std::fs::remove_file(&abs_path);
+                }
             }
-            None => {
-                let _ = std::fs::remove_file(&abs_path);
-            }
+            return Err(e);
         }
-        return Err(e);
-    }
+    };
 
+    let manifest_label = manifest_path
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_else(|| manifest_path.display().to_string());
     eprintln!("Wrote {}", abs_path.display());
-    eprintln!("Recorded {key} -> {rel_path} in package.json");
+    eprintln!("Recorded {key} -> {rel_path} in {manifest_label}");
 
     // Drop the snapshot tempdir now that we've captured the diff —
     // matches pnpm's behavior of cleaning up after a successful commit.

--- a/crates/aube/src/commands/patch_remove.rs
+++ b/crates/aube/src/commands/patch_remove.rs
@@ -23,7 +23,7 @@ pub async fn run(args: PatchRemoveArgs) -> Result<()> {
     let cwd = crate::dirs::project_root()?;
     let declared = read_patched_dependencies(&cwd)?;
     if declared.is_empty() {
-        return Err(miette!("no patches declared in package.json"));
+        return Err(miette!("no patches declared"));
     }
 
     let to_remove: Vec<String> = if args.packages.is_empty() {
@@ -46,8 +46,13 @@ pub async fn run(args: PatchRemoveArgs) -> Result<()> {
                 .map_err(|e| miette!("failed to remove {}: {e}", abs.display()))?;
             eprintln!("Removed {}", abs.display());
         }
-        remove_patched_dependency(&cwd, key)?;
-        eprintln!("Removed {key} from package.json");
+        for rewritten in remove_patched_dependency(&cwd, key)? {
+            let label = rewritten
+                .file_name()
+                .map(|f| f.to_string_lossy().into_owned())
+                .unwrap_or_else(|| rewritten.display().to_string());
+            eprintln!("Removed {key} from {label}");
+        }
     }
 
     let opts = crate::commands::install::InstallOptions::with_mode(

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -79,7 +79,7 @@ pub fn find_workspace_root(start: &Path) -> Option<PathBuf> {
     // at $HOME so that never happens.
     let stop = home_stop_boundary();
     for dir in start.ancestors() {
-        if dir.join("aube-workspace.yaml").exists() || dir.join("pnpm-workspace.yaml").exists() {
+        if aube_manifest::workspace::workspace_yaml_existing(dir).is_some() {
             return Some(dir.to_path_buf());
         }
         let pkg = dir.join("package.json");
@@ -105,7 +105,7 @@ pub fn find_workspace_yaml_root(start: &Path) -> Option<PathBuf> {
     // Cap the walk at $HOME for the same reason as find_project_root.
     let stop = home_stop_boundary();
     for dir in start.ancestors() {
-        if dir.join("aube-workspace.yaml").exists() || dir.join("pnpm-workspace.yaml").exists() {
+        if aube_manifest::workspace::workspace_yaml_existing(dir).is_some() {
             return Some(dir.to_path_buf());
         }
         if stop.as_deref() == Some(dir) {

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -219,22 +219,28 @@ pub fn upsert_patched_dependency(cwd: &Path, key: &str, rel_patch_path: &str) ->
 }
 
 /// Drop an entry from `patchedDependencies` in whichever file declares
-/// it. Returns `true` if the entry existed.
+/// it. Returns `true` if the entry existed. Each side peeks before
+/// rewriting so a remove that targets only one location doesn't churn
+/// the other (the workspace yaml in particular can hold user-authored
+/// comments that yaml_serde's round-trip would discard).
 pub fn remove_patched_dependency(cwd: &Path, key: &str) -> Result<bool> {
-    let mut removed_from_ws = false;
     let ws_target = aube_manifest::workspace::workspace_yaml_target(cwd);
-    if ws_target.exists() {
-        removed_from_ws =
-            aube_manifest::workspace::remove_workspace_patched_dependency(&ws_target, key)
-                .map_err(miette::Report::new)
-                .wrap_err_with(|| format!("failed to write {}", ws_target.display()))?;
-    }
-    let mut removed_from_pkg = false;
-    if cwd.join("package.json").exists() {
+    let removed_from_ws = if ws_target.exists() {
+        aube_manifest::workspace::remove_workspace_patched_dependency(&ws_target, key)
+            .map_err(miette::Report::new)
+            .wrap_err_with(|| format!("failed to write {}", ws_target.display()))?
+    } else {
+        false
+    };
+    let removed_from_pkg = if read_package_json_patched_dependencies(cwd)?.contains_key(key) {
+        let mut existed = false;
         edit_patched_dependencies(cwd, |map| {
-            removed_from_pkg = map.remove(key).is_some();
+            existed = map.remove(key).is_some();
         })?;
-    }
+        existed
+    } else {
+        false
+    };
     Ok(removed_from_ws || removed_from_pkg)
 }
 

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -150,31 +150,107 @@ pub fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
     Ok(out)
 }
 
-/// Add or replace an entry in `pnpm.patchedDependencies`, preserving
-/// the rest of `package.json`. Writes the file back with a trailing
-/// newline.
-pub fn upsert_patched_dependency(cwd: &Path, key: &str, rel_patch_path: &str) -> Result<()> {
-    edit_patched_dependencies(cwd, |map| {
-        map.insert(
-            key.to_string(),
-            serde_json::Value::String(rel_patch_path.to_string()),
-        );
-    })
+/// Where the next `aube patch-commit` write should land. pnpm v10
+/// moved `patchedDependencies` out of `package.json` into the workspace
+/// yaml so users can document patches with YAML comments — when a
+/// project is already using the new home, append there. Otherwise fall
+/// back to `package.json` for projects that predate the move.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PatchDestination {
+    PackageJson,
+    WorkspaceYaml(PathBuf),
 }
 
-/// Drop an entry from `pnpm.patchedDependencies`. Returns `true` if
-/// the entry existed.
+/// Pick which file `aube patch-commit` should mutate. Precedence:
+/// 1. Whichever file already declares any `patchedDependencies` wins.
+///    A workspace-yaml entry wins on a tie because aube's
+///    `load_patches` already gives the workspace yaml precedence on
+///    key conflict, so writing there keeps the live entry in sync.
+/// 2. Otherwise, prefer the workspace yaml when one exists on disk —
+///    matches pnpm v10+ convention.
+/// 3. Otherwise, default to `package.json`.
+fn patch_destination(cwd: &Path) -> PatchDestination {
+    let ws_target = aube_manifest::workspace::workspace_yaml_target(cwd);
+    let ws_has_patches = aube_manifest::workspace::WorkspaceConfig::load(cwd)
+        .map(|c| !c.patched_dependencies.is_empty())
+        .unwrap_or(false);
+    if ws_has_patches {
+        return PatchDestination::WorkspaceYaml(ws_target);
+    }
+    let pkg_has_patches = read_package_json_patched_dependencies(cwd)
+        .map(|m| !m.is_empty())
+        .unwrap_or(false);
+    if pkg_has_patches {
+        return PatchDestination::PackageJson;
+    }
+    if ws_target.exists() {
+        return PatchDestination::WorkspaceYaml(ws_target);
+    }
+    PatchDestination::PackageJson
+}
+
+/// Add or replace an entry in `patchedDependencies`. The destination is
+/// resolved by `patch_destination` — workspace yaml when the project is
+/// already using pnpm v10+ conventions, `package.json` otherwise.
+/// Returns the path that was rewritten so the caller can report it to
+/// the user.
+pub fn upsert_patched_dependency(cwd: &Path, key: &str, rel_patch_path: &str) -> Result<PathBuf> {
+    match patch_destination(cwd) {
+        PatchDestination::PackageJson => {
+            edit_patched_dependencies(cwd, |map| {
+                map.insert(
+                    key.to_string(),
+                    serde_json::Value::String(rel_patch_path.to_string()),
+                );
+            })?;
+            Ok(cwd.join("package.json"))
+        }
+        PatchDestination::WorkspaceYaml(path) => {
+            aube_manifest::workspace::upsert_workspace_patched_dependency(
+                &path,
+                key,
+                rel_patch_path,
+            )
+            .map_err(miette::Report::new)
+            .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+            Ok(path)
+        }
+    }
+}
+
+/// Drop an entry from `patchedDependencies` in whichever file declares
+/// it. Returns `true` if the entry existed.
 pub fn remove_patched_dependency(cwd: &Path, key: &str) -> Result<bool> {
-    let mut existed = false;
-    edit_patched_dependencies(cwd, |map| {
-        existed = map.remove(key).is_some();
-    })?;
-    Ok(existed)
+    let mut removed_from_ws = false;
+    let ws_target = aube_manifest::workspace::workspace_yaml_target(cwd);
+    if ws_target.exists() {
+        removed_from_ws =
+            aube_manifest::workspace::remove_workspace_patched_dependency(&ws_target, key)
+                .map_err(miette::Report::new)
+                .wrap_err_with(|| format!("failed to write {}", ws_target.display()))?;
+    }
+    let mut removed_from_pkg = false;
+    if cwd.join("package.json").exists() {
+        edit_patched_dependencies(cwd, |map| {
+            removed_from_pkg = map.remove(key).is_some();
+        })?;
+    }
+    Ok(removed_from_ws || removed_from_pkg)
 }
 
-/// Read the current `pnpm.patchedDependencies` map from
-/// `package.json`. Returns an empty map if the field is absent.
+/// Read every declared `patchedDependencies` entry across both the
+/// workspace yaml and `package.json`, with workspace-yaml entries
+/// winning on key conflict (same precedence used by `load_patches`).
 pub fn read_patched_dependencies(cwd: &Path) -> Result<BTreeMap<String, String>> {
+    let mut out = read_package_json_patched_dependencies(cwd)?;
+    let ws_config = aube_manifest::workspace::WorkspaceConfig::load(cwd)
+        .map_err(miette::Report::new)
+        .wrap_err("failed to read workspace yaml")?;
+    out.extend(ws_config.patched_dependencies);
+    Ok(out)
+}
+
+fn read_package_json_patched_dependencies(cwd: &Path) -> Result<BTreeMap<String, String>> {
     let manifest_path = cwd.join("package.json");
     if !manifest_path.exists() {
         return Ok(BTreeMap::new());
@@ -300,5 +376,62 @@ mod tests {
     fn split_missing_version_errors() {
         assert!(split_patch_key("is-positive").is_err());
         assert!(split_patch_key("@babel/core").is_err());
+    }
+
+    #[test]
+    fn destination_prefers_workspace_yaml_when_it_already_holds_patches() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "patchedDependencies:\n  \"a@1.0.0\": patches/a@1.0.0.patch\n",
+        )
+        .unwrap();
+        match patch_destination(dir.path()) {
+            PatchDestination::WorkspaceYaml(p) => {
+                assert_eq!(p, dir.path().join("pnpm-workspace.yaml"));
+            }
+            d => panic!("expected workspace yaml destination, got {d:?}"),
+        }
+    }
+
+    #[test]
+    fn destination_prefers_package_json_when_it_already_holds_patches() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            "{\"pnpm\":{\"patchedDependencies\":{\"a@1.0.0\":\"patches/a@1.0.0.patch\"}}}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'pkgs/*'\n",
+        )
+        .unwrap();
+        assert_eq!(patch_destination(dir.path()), PatchDestination::PackageJson);
+    }
+
+    #[test]
+    fn destination_prefers_workspace_yaml_when_present_and_neither_holds_patches() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'pkgs/*'\n",
+        )
+        .unwrap();
+        match patch_destination(dir.path()) {
+            PatchDestination::WorkspaceYaml(p) => {
+                assert_eq!(p, dir.path().join("pnpm-workspace.yaml"));
+            }
+            d => panic!("expected workspace yaml destination, got {d:?}"),
+        }
+    }
+
+    #[test]
+    fn destination_falls_back_to_package_json_when_no_workspace_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
+        assert_eq!(patch_destination(dir.path()), PatchDestination::PackageJson);
     }
 }

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -332,6 +332,35 @@ mod tests {
     }
 
     #[test]
+    fn upsert_collapses_shadow_when_other_namespace_holds_stale_entry() {
+        // A pnpm-aware tool can add a `pnpm` namespace after aube has
+        // already populated `aube.patchedDependencies`. Without the
+        // merge-and-collapse below, the next `aube patch-commit` would
+        // write to `pnpm.patchedDependencies` while the stale
+        // `aube.patchedDependencies.<key>` entry shadowed it on read
+        // (aube.* wins on conflict). Pin the post-write invariant:
+        // exactly one namespace holds the entry.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            "{\"aube\":{\"patchedDependencies\":{\"a@1.0.0\":\"patches/old.patch\"}},\"pnpm\":{\"someKey\":1}}\n",
+        )
+        .unwrap();
+        upsert_patched_dependency(dir.path(), "a@1.0.0", "patches/new.patch").unwrap();
+        let raw = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        // Entry migrated to pnpm.patchedDependencies, with the new value.
+        assert_eq!(
+            parsed["pnpm"]["patchedDependencies"]["a@1.0.0"],
+            "patches/new.patch"
+        );
+        // Stale aube.patchedDependencies entry is gone — no shadow.
+        assert!(parsed["aube"]["patchedDependencies"].is_null());
+        // The user's other pnpm config is preserved.
+        assert_eq!(parsed["pnpm"]["someKey"], 1);
+    }
+
+    #[test]
     fn upsert_writes_to_pnpm_namespace_when_pnpm_already_present() {
         let dir = tempfile::tempdir().unwrap();
         // User already has a pnpm-namespaced setting (allowBuilds);

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -150,62 +150,26 @@ pub fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
     Ok(out)
 }
 
-/// Where the next `aube patch-commit` write should land. pnpm v10
-/// moved `patchedDependencies` out of `package.json` into the workspace
-/// yaml so users can document patches with YAML comments — when a
-/// project is already using the new home, append there. Otherwise fall
-/// back to `package.json` for projects that predate the move.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum PatchDestination {
-    PackageJson,
-    WorkspaceYaml(PathBuf),
-}
-
-/// Pick which file `aube patch-commit` should mutate. Precedence:
-/// 1. Whichever file already declares any `patchedDependencies` wins.
-///    A workspace-yaml entry wins on a tie because aube's
-///    `load_patches` already gives the workspace yaml precedence on
-///    key conflict, so writing there keeps the live entry in sync.
-/// 2. Otherwise, prefer the workspace yaml when one exists on disk —
-///    matches pnpm v10+ convention.
-/// 3. Otherwise, default to `package.json`.
-fn patch_destination(cwd: &Path) -> PatchDestination {
-    let ws_target = aube_manifest::workspace::workspace_yaml_target(cwd);
-    let ws_has_patches = aube_manifest::workspace::WorkspaceConfig::load(cwd)
-        .map(|c| !c.patched_dependencies.is_empty())
-        .unwrap_or(false);
-    if ws_has_patches {
-        return PatchDestination::WorkspaceYaml(ws_target);
-    }
-    let pkg_has_patches = read_package_json_patched_dependencies(cwd)
-        .map(|m| !m.is_empty())
-        .unwrap_or(false);
-    if pkg_has_patches {
-        return PatchDestination::PackageJson;
-    }
-    if ws_target.exists() {
-        return PatchDestination::WorkspaceYaml(ws_target);
-    }
-    PatchDestination::PackageJson
-}
-
-/// Add or replace an entry in `patchedDependencies`. The destination is
-/// resolved by `patch_destination` — workspace yaml when the project is
-/// already using pnpm v10+ conventions, `package.json` otherwise.
+/// Add or replace an entry in `patchedDependencies`. Routes through
+/// the shared [`aube_manifest::workspace::config_write_target`] rule:
+/// workspace yaml when one is present, otherwise `package.json`.
 /// Returns the path that was rewritten so the caller can report it to
 /// the user.
 pub fn upsert_patched_dependency(cwd: &Path, key: &str, rel_patch_path: &str) -> Result<PathBuf> {
-    match patch_destination(cwd) {
-        PatchDestination::PackageJson => {
-            edit_patched_dependencies(cwd, |map| {
+    use aube_manifest::workspace::ConfigWriteTarget;
+    match aube_manifest::workspace::config_write_target(cwd) {
+        ConfigWriteTarget::PackageJson => {
+            aube_manifest::workspace::edit_setting_map(cwd, "patchedDependencies", |map| {
                 map.insert(
                     key.to_string(),
                     serde_json::Value::String(rel_patch_path.to_string()),
                 );
-            })?;
+            })
+            .map_err(miette::Report::new)
+            .wrap_err("failed to write package.json")?;
             Ok(cwd.join("package.json"))
         }
-        PatchDestination::WorkspaceYaml(path) => {
+        ConfigWriteTarget::WorkspaceYaml(path) => {
             aube_manifest::workspace::upsert_workspace_patched_dependency(
                 &path,
                 key,
@@ -219,29 +183,25 @@ pub fn upsert_patched_dependency(cwd: &Path, key: &str, rel_patch_path: &str) ->
 }
 
 /// Drop an entry from `patchedDependencies` in whichever file declares
-/// it. Returns the files that were rewritten — empty when neither
-/// location held the entry. Each side peeks before rewriting so a
-/// remove that targets only one location doesn't churn the other (the
-/// workspace yaml in particular can hold user-authored comments that
-/// yaml_serde's round-trip would discard).
+/// it (workspace yaml, `package.json#pnpm.patchedDependencies`,
+/// `package.json#aube.patchedDependencies`, or any combination).
+/// Returns the files that were rewritten — empty when no location held
+/// the entry. Each side peeks before rewriting so the no-op case
+/// leaves the file (and any user yaml comments) intact.
 pub fn remove_patched_dependency(cwd: &Path, key: &str) -> Result<Vec<PathBuf>> {
     let mut rewritten = Vec::new();
-    let ws_target = aube_manifest::workspace::workspace_yaml_target(cwd);
-    if ws_target.exists()
-        && aube_manifest::workspace::remove_workspace_patched_dependency(&ws_target, key)
+    if let Some(ws_path) = aube_manifest::workspace::workspace_yaml_existing(cwd)
+        && aube_manifest::workspace::remove_workspace_patched_dependency(&ws_path, key)
             .map_err(miette::Report::new)
-            .wrap_err_with(|| format!("failed to write {}", ws_target.display()))?
+            .wrap_err_with(|| format!("failed to write {}", ws_path.display()))?
     {
-        rewritten.push(ws_target);
+        rewritten.push(ws_path);
     }
-    if read_package_json_patched_dependencies(cwd)?.contains_key(key) {
-        let mut existed = false;
-        edit_patched_dependencies(cwd, |map| {
-            existed = map.remove(key).is_some();
-        })?;
-        if existed {
-            rewritten.push(cwd.join("package.json"));
-        }
+    if aube_manifest::workspace::remove_setting_entry(cwd, "patchedDependencies", key)
+        .map_err(miette::Report::new)
+        .wrap_err("failed to write package.json")?
+    {
+        rewritten.push(cwd.join("package.json"));
     }
     Ok(rewritten)
 }
@@ -267,61 +227,6 @@ fn read_package_json_patched_dependencies(cwd: &Path) -> Result<BTreeMap<String,
         .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
     Ok(manifest.pnpm_patched_dependencies())
-}
-
-/// Read `package.json` as a generic `Value`, run `f` on the
-/// `pnpm.patchedDependencies` object (creating it if needed), and
-/// write the file back. Using a raw `Value` round-trip rather than
-/// the typed `PackageJson` keeps unrelated keys, ordering, and
-/// serialization details intact.
-fn edit_patched_dependencies<F>(cwd: &Path, f: F) -> Result<()>
-where
-    F: FnOnce(&mut serde_json::Map<String, serde_json::Value>),
-{
-    let manifest_path = cwd.join("package.json");
-    let raw = std::fs::read_to_string(&manifest_path)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to read package.json: {e}"))?;
-    let mut value = aube_manifest::parse_json::<serde_json::Value>(&manifest_path, raw)
-        .map_err(miette::Report::new)
-        .wrap_err("failed to parse package.json")?;
-
-    let obj = value
-        .as_object_mut()
-        .ok_or_else(|| miette!("package.json is not an object"))?;
-    let pnpm = obj
-        .entry("pnpm".to_string())
-        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-    let pnpm_obj = pnpm
-        .as_object_mut()
-        .ok_or_else(|| miette!("`pnpm` field in package.json is not an object"))?;
-    let patched = pnpm_obj
-        .entry("patchedDependencies".to_string())
-        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-    let patched_obj = patched
-        .as_object_mut()
-        .ok_or_else(|| miette!("`pnpm.patchedDependencies` is not an object"))?;
-
-    f(patched_obj);
-
-    // If the user removed the last patch, drop the now-empty
-    // `patchedDependencies` (and `pnpm` itself when it's empty too)
-    // so we don't leave noise in the manifest.
-    if patched_obj.is_empty() {
-        pnpm_obj.remove("patchedDependencies");
-    }
-    if pnpm_obj.is_empty() {
-        obj.remove("pnpm");
-    }
-
-    let mut out = serde_json::to_string_pretty(&value)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to serialize package.json: {e}"))?;
-    out.push('\n');
-    std::fs::write(&manifest_path, out)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to write package.json: {e}"))?;
-    Ok(())
 }
 
 /// Recursively copy `src` into `dst`, following file content but
@@ -387,60 +292,66 @@ mod tests {
     }
 
     #[test]
-    fn destination_prefers_workspace_yaml_when_it_already_holds_patches() {
+    fn upsert_writes_to_yaml_when_one_exists() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
         std::fs::write(
             dir.path().join("pnpm-workspace.yaml"),
-            "patchedDependencies:\n  \"a@1.0.0\": patches/a@1.0.0.patch\n",
+            "packages:\n  - 'pkgs/*'\n",
         )
         .unwrap();
-        match patch_destination(dir.path()) {
-            PatchDestination::WorkspaceYaml(p) => {
-                assert_eq!(p, dir.path().join("pnpm-workspace.yaml"));
-            }
-            d => panic!("expected workspace yaml destination, got {d:?}"),
-        }
+        let written =
+            upsert_patched_dependency(dir.path(), "a@1.0.0", "patches/a@1.0.0.patch").unwrap();
+        assert_eq!(written, dir.path().join("pnpm-workspace.yaml"));
     }
 
     #[test]
-    fn destination_prefers_package_json_when_it_already_holds_patches() {
+    fn upsert_writes_to_package_json_when_no_yaml() {
         let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
+        let written =
+            upsert_patched_dependency(dir.path(), "a@1.0.0", "patches/a@1.0.0.patch").unwrap();
+        assert_eq!(written, dir.path().join("package.json"));
+    }
+
+    #[test]
+    fn upsert_writes_to_aube_namespace_when_no_pnpm_in_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
+        upsert_patched_dependency(dir.path(), "a@1.0.0", "patches/a@1.0.0.patch").unwrap();
+        let manifest = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
+        assert!(
+            manifest.contains("\"aube\""),
+            "expected aube namespace, got:\n{manifest}"
+        );
+        assert!(
+            !manifest.contains("\"pnpm\""),
+            "should not introduce pnpm namespace, got:\n{manifest}"
+        );
+        assert!(manifest.contains("\"patchedDependencies\""));
+    }
+
+    #[test]
+    fn upsert_writes_to_pnpm_namespace_when_pnpm_already_present() {
+        let dir = tempfile::tempdir().unwrap();
+        // User already has a pnpm-namespaced setting (allowBuilds);
+        // a new patch should land in the same pnpm bucket so we don't
+        // fragment their config across two namespaces.
         std::fs::write(
             dir.path().join("package.json"),
-            "{\"pnpm\":{\"patchedDependencies\":{\"a@1.0.0\":\"patches/a@1.0.0.patch\"}}}\n",
+            "{\"pnpm\":{\"allowBuilds\":{\"esbuild\":true}}}\n",
         )
         .unwrap();
-        std::fs::write(
-            dir.path().join("pnpm-workspace.yaml"),
-            "packages:\n  - 'pkgs/*'\n",
-        )
-        .unwrap();
-        assert_eq!(patch_destination(dir.path()), PatchDestination::PackageJson);
-    }
-
-    #[test]
-    fn destination_prefers_workspace_yaml_when_present_and_neither_holds_patches() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
-        std::fs::write(
-            dir.path().join("pnpm-workspace.yaml"),
-            "packages:\n  - 'pkgs/*'\n",
-        )
-        .unwrap();
-        match patch_destination(dir.path()) {
-            PatchDestination::WorkspaceYaml(p) => {
-                assert_eq!(p, dir.path().join("pnpm-workspace.yaml"));
-            }
-            d => panic!("expected workspace yaml destination, got {d:?}"),
-        }
-    }
-
-    #[test]
-    fn destination_falls_back_to_package_json_when_no_workspace_yaml() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
-        assert_eq!(patch_destination(dir.path()), PatchDestination::PackageJson);
+        upsert_patched_dependency(dir.path(), "a@1.0.0", "patches/a@1.0.0.patch").unwrap();
+        let manifest = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
+        assert!(manifest.contains("\"pnpm\""));
+        assert!(
+            !manifest.contains("\"aube\""),
+            "should not introduce aube namespace alongside pnpm: {manifest}"
+        );
+        // The patch entry must be inside pnpm.
+        let parsed: serde_json::Value = serde_json::from_str(&manifest).unwrap();
+        assert!(parsed["pnpm"]["patchedDependencies"]["a@1.0.0"].is_string());
     }
 
     #[test]

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -219,29 +219,31 @@ pub fn upsert_patched_dependency(cwd: &Path, key: &str, rel_patch_path: &str) ->
 }
 
 /// Drop an entry from `patchedDependencies` in whichever file declares
-/// it. Returns `true` if the entry existed. Each side peeks before
-/// rewriting so a remove that targets only one location doesn't churn
-/// the other (the workspace yaml in particular can hold user-authored
-/// comments that yaml_serde's round-trip would discard).
-pub fn remove_patched_dependency(cwd: &Path, key: &str) -> Result<bool> {
+/// it. Returns the files that were rewritten — empty when neither
+/// location held the entry. Each side peeks before rewriting so a
+/// remove that targets only one location doesn't churn the other (the
+/// workspace yaml in particular can hold user-authored comments that
+/// yaml_serde's round-trip would discard).
+pub fn remove_patched_dependency(cwd: &Path, key: &str) -> Result<Vec<PathBuf>> {
+    let mut rewritten = Vec::new();
     let ws_target = aube_manifest::workspace::workspace_yaml_target(cwd);
-    let removed_from_ws = if ws_target.exists() {
-        aube_manifest::workspace::remove_workspace_patched_dependency(&ws_target, key)
+    if ws_target.exists()
+        && aube_manifest::workspace::remove_workspace_patched_dependency(&ws_target, key)
             .map_err(miette::Report::new)
             .wrap_err_with(|| format!("failed to write {}", ws_target.display()))?
-    } else {
-        false
-    };
-    let removed_from_pkg = if read_package_json_patched_dependencies(cwd)?.contains_key(key) {
+    {
+        rewritten.push(ws_target);
+    }
+    if read_package_json_patched_dependencies(cwd)?.contains_key(key) {
         let mut existed = false;
         edit_patched_dependencies(cwd, |map| {
             existed = map.remove(key).is_some();
         })?;
-        existed
-    } else {
-        false
-    };
-    Ok(removed_from_ws || removed_from_pkg)
+        if existed {
+            rewritten.push(cwd.join("package.json"));
+        }
+    }
+    Ok(rewritten)
 }
 
 /// Read every declared `patchedDependencies` entry across both the
@@ -439,5 +441,39 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
         assert_eq!(patch_destination(dir.path()), PatchDestination::PackageJson);
+    }
+
+    #[test]
+    fn remove_returns_each_rewritten_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            "{\"pnpm\":{\"patchedDependencies\":{\"a@1.0.0\":\"patches/a@1.0.0.patch\"}}}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "patchedDependencies:\n  \"a@1.0.0\": patches/a@1.0.0.patch\n",
+        )
+        .unwrap();
+        let rewritten = remove_patched_dependency(dir.path(), "a@1.0.0").unwrap();
+        let names: Vec<String> = rewritten
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        assert_eq!(names, vec!["pnpm-workspace.yaml", "package.json"]);
+    }
+
+    #[test]
+    fn remove_returns_empty_when_neither_file_holds_key() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}\n").unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'pkgs/*'\n",
+        )
+        .unwrap();
+        let rewritten = remove_patched_dependency(dir.path(), "missing@9.9.9").unwrap();
+        assert!(rewritten.is_empty());
     }
 }

--- a/test/approve_builds.bats
+++ b/test/approve_builds.bats
@@ -121,18 +121,20 @@ JSON
 	run aube install
 	assert_success
 	assert_file_not_exists aube-builds-marker.txt
-	assert_file_exists aube-workspace.yaml
-	run grep -q 'allowBuilds:' aube-workspace.yaml
+	# No yaml on disk and no `pnpm` namespace in package.json, so the
+	# install-time auto-deny seed writes to package.json#aube.allowBuilds.
+	assert_file_not_exists aube-workspace.yaml
+	run grep -q '"allowBuilds"' package.json
 	assert_success
-	run grep -q 'aube-test-builds-marker: false' aube-workspace.yaml
+	run grep -q '"aube-test-builds-marker": false' package.json
 	assert_success
 
 	run aube approve-builds --all
 	assert_success
 	assert_output --partial "aube-test-builds-marker"
-	assert_output --partial "aube-workspace.yaml"
+	assert_output --partial "package.json"
 
-	run grep -q 'aube-test-builds-marker: true' aube-workspace.yaml
+	run grep -q '"aube-test-builds-marker": true' package.json
 	assert_success
 	run grep -q 'onlyBuiltDependencies' package.json
 	assert_failure
@@ -143,10 +145,12 @@ JSON
 	assert_file_exists aube-builds-marker.txt
 }
 
-@test "approve-builds --all in npm-style monorepo writes aube-workspace allowBuilds" {
+@test "approve-builds --all in npm-style monorepo writes package.json allowBuilds" {
 	# An npm/yarn-style monorepo carries `workspaces` directly in
-	# package.json. aube creates `aube-workspace.yaml` from scratch
-	# to hold the allowBuilds review map (parallels `aube-lock.yaml`).
+	# package.json. With no workspace yaml and no `pnpm` namespace,
+	# the unified writer rule lands the review map in
+	# package.json#aube.allowBuilds rather than spawning a fresh
+	# aube-workspace.yaml.
 	mkdir -p packages/app
 	cat >package.json <<'JSON'
 {
@@ -172,16 +176,16 @@ JSON
 	assert_success
 	assert_output --partial "aube-test-builds-marker"
 
-	assert_file_exists aube-workspace.yaml
+	assert_file_not_exists aube-workspace.yaml
 	assert_file_not_exists pnpm-workspace.yaml
 
-	run grep -q 'allowBuilds:' aube-workspace.yaml
+	run grep -q '"allowBuilds"' package.json
 	assert_success
-	run grep -q 'aube-test-builds-marker: true' aube-workspace.yaml
+	run grep -q '"aube-test-builds-marker": true' package.json
 	assert_success
 
-	# Round-trip: a re-install must honor the policy stored under
-	# allowBuilds and run the previously-skipped postinstall.
+	# Round-trip: a re-install must honor the policy and run the
+	# previously-skipped postinstall.
 	run aube install
 	assert_success
 	assert_file_exists aube-builds-marker.txt

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -162,12 +162,16 @@ teardown() {
 	assert_output --partial "aube-test-builds-marker"
 	assert_output --partial "global install"
 
-	# Global installs use the same pnpm v11 review map as projects,
-	# written to aube-workspace.yaml (parallels aube-lock.yaml).
-	assert_file_exists "$install_dir/aube-workspace.yaml"
-	run grep -q 'allowBuilds:' "$install_dir/aube-workspace.yaml"
+	# Global installs use the same pnpm v11 review map as projects.
+	# When no workspace yaml exists, the entry lands in package.json
+	# under the `aube` namespace (the writer prefers `aube.*` until a
+	# `pnpm` namespace is already present).
+	assert_file_not_exists "$install_dir/aube-workspace.yaml"
+	run grep -q '"aube"' "$install_dir/package.json"
 	assert_success
-	run grep -q 'aube-test-builds-marker: true' "$install_dir/aube-workspace.yaml"
+	run grep -q '"allowBuilds"' "$install_dir/package.json"
+	assert_success
+	run grep -q '"aube-test-builds-marker": true' "$install_dir/package.json"
 	assert_success
 
 	run aube -C "$install_dir" rebuild

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -117,8 +117,10 @@ JSON
 	assert_failure
 	assert_output --partial "dependencies with build scripts must be reviewed"
 	assert_output --partial "dep-with-build@1.0.0"
-	assert_file_exists aube-workspace.yaml
-	run grep -q 'dep-with-build: false' aube-workspace.yaml
+	# No yaml + no pnpm namespace in package.json → seed lands in
+	# package.json#aube.allowBuilds.
+	assert_file_not_exists aube-workspace.yaml
+	run grep -q '"dep-with-build": false' package.json
 	assert_success
 }
 

--- a/test/patch.bats
+++ b/test/patch.bats
@@ -44,8 +44,9 @@ EOF
 	run aube patch-commit "$edit_dir"
 	assert_success
 	assert [ -f patches/is-odd@3.0.1.patch ]
-	# The recorded entry should land in pnpm.patchedDependencies.
-	run node -e 'console.log(require("./package.json").pnpm.patchedDependencies["is-odd@3.0.1"])'
+	# No `pnpm` namespace in the test's package.json, so the
+	# unified writer rule lands the entry under `aube.patchedDependencies`.
+	run node -e 'console.log(require("./package.json").aube.patchedDependencies["is-odd@3.0.1"])'
 	assert_output "patches/is-odd@3.0.1.patch"
 
 	# The linked package should now contain the sentinel.
@@ -57,7 +58,7 @@ EOF
 	run aube patch-remove is-odd@3.0.1
 	assert_success
 	assert [ ! -f patches/is-odd@3.0.1.patch ]
-	run node -e 'const p = require("./package.json"); console.log(p.pnpm ? Object.keys(p.pnpm.patchedDependencies||{}).length : 0)'
+	run node -e 'const p = require("./package.json"); console.log(p.aube ? Object.keys(p.aube.patchedDependencies||{}).length : 0)'
 	assert_output "0"
 	run grep -q "patched-by-aube-test" node_modules/is-odd/index.js
 	assert_failure


### PR DESCRIPTION
## Summary

Three bug fixes for [endevco/aube#383](https://github.com/endevco/aube/discussions/383) plus the supporting refactors that fell out of code review.

### Bug fixes

- **Patches against CRLF text files** — tarballs published from Windows editors ship CRLF (e.g. `gifuct-js@2.1.2/index.d.ts`), but git/pnpm-style patches always emit LF. Diffy is byte-exact and refused to match CRLF context against LF hunks, so a clean patch failed with `error applying hunk #1`. Normalize the original to LF before apply and restore CRLF on write — same approach pnpm uses. The CRLF restore also collapses any `\r\r\n` so a patch line containing a literal `\r` byte mid-line doesn't gain a second carriage return.

- **`aube patch-commit` destination** — previously wrote unconditionally to `pnpm.patchedDependencies` in `package.json`, even on projects already using the pnpm v10+ workspace-yaml home. Now follows the unified rule below. `aube patch-remove` now strips entries from every place they could live (both yaml and both `pnpm.*` / `aube.*` namespaces) and reports the actual files rewritten in its status output.

- **npm-aliased catalog deps from pnpm-generated lockfiles** ([discussioncomment](https://github.com/endevco/aube/discussions/383#discussioncomment-16759640)) — `aube install --frozen-lockfile` accepted a pnpm lockfile with `beamcoder: npm:beamcoder-prebuild@…` (declared via `pnpm-workspace.yaml#catalog`) and silently produced an empty `node_modules`. The importer's `specifier:` was `'catalog:'`, but the alias detection only fired on `specifier.starts_with("npm:")`. Now detects aliases purely from the `version:` shape (the canonical `<real>@<resolved>` form pnpm always uses), with a peer-suffix strip so `version: 18.2.0(react@18.2.0)` doesn't get misclassified.

### Refactor: unified workspace-config writer

One rule applies to every command that mutates a setting which can live in either the workspace yaml or `package.json#{pnpm,aube}.<key>` (`aube patch-commit`, `aube patch-remove`, `aube approve-builds`, install-time auto-deny seeding, future settings):

1. If a workspace yaml exists on disk → write there.
2. Otherwise, if `package.json#pnpm` is already declared → write `pnpm.<key>` (preserve the user's chosen namespace).
3. Otherwise → write `aube.<key>` (aube's native namespace; the read side already gives `aube.*` precedence over `pnpm.*`).

New helpers in `aube_manifest::workspace`:
- `ConfigWriteTarget` + `config_write_target(dir)` — picks step 1 vs steps 2/3.
- `edit_workspace_yaml(path, f)` — yaml writer; **skips the rewrite when the closure produces no structural change**, so user comments survive every no-op write. Used by allowBuilds, patchedDependencies, and catalog cleanup.
- `edit_setting_map(cwd, key, f)` — `package.json` writer; picks namespace per steps 2/3, also skips no-op rewrites.
- `remove_setting_entry(cwd, key, entry_key)` — strips an entry from both `pnpm.<key>` and `aube.<key>` so a one-namespace removal doesn't leave a stale duplicate behind on the read merge.

Migrated callers: `aube approve-builds` (and the install-time auto-deny seed), `aube patch-commit`, `aube patch-remove`, catalog cleanup. The `PatchDestination` enum and `edit_patched_dependencies` helper that lived in `aube/src/patches.rs` are gone.

### Refactor: workspace-yaml file selection

Centralized the `aube-workspace.yaml` → `pnpm-workspace.yaml` precedence walk into `aube_manifest::workspace::workspace_yaml_existing`. `workspace_yaml_target` is now a one-liner over it. Removed three duplicates of the same loop (`catalogs.rs`, `find_workspace_root`, `find_workspace_yaml_root`).

## Test plan

- [x] `cargo test` (1185 passing — new coverage spans CRLF apply + embedded-`\r` restore in `aube-linker`; helper-level + per-writer no-op-skip tests for allowBuilds, patchedDependencies, and catalog cleanup; `ConfigWriteTarget` + namespace-picking cases; pnpm-lockfile catalog alias)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] End-to-end repros from the discussion: `aube install` against `patch-application-failure` succeeds with CRLF preserved; `aube install --frozen-lockfile` against `catalog-npm-alias` installs `beamcoder` (resolved to `beamcoder-prebuild`) into `packages/app/node_modules/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install/patch/config persistence paths and changes where settings are written (`workspace` YAML vs `package.json`), which can affect real projects’ config layout; mitigated by extensive new tests and largely additive helpers.
> 
> **Overview**
> Fixes patch application on CRLF-backed files by normalizing input to LF for diff matching and restoring CRLF on write (with protection for embedded literal `\r`), plus adds regression tests.
> 
> Unifies how workspace-level settings are written: if a workspace yaml exists, write there; otherwise write to `package.json` under `aube.*` unless `pnpm` already exists. This refactor is applied to `allowBuilds` seeding/approval, `patch-commit`/`patch-remove` (including removing entries from all possible locations and reporting the actual files changed), and catalog cleanup (now skips no-op YAML rewrites to avoid stripping comments).
> 
> Fixes pnpm lockfile parsing to detect npm-aliased dependencies based on the `version:` field shape (including catalog-declared aliases and peer suffix handling), with new tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74cbd4dd52a577e4cdde9b1c4c69fb83c40bf30c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->