### PR TITLE
fix(install): allow POSIX colon tarball filenames

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2591,10 +2591,17 @@ fn validate_index_key(key: &str) -> Result<(), Error> {
                 return Err(Error::UnsafeIndexKey(key.to_string()));
             }
             std::path::Component::Normal(os) => {
-                if let Some(s) = os.to_str()
-                    && s.contains(':')
+                #[cfg(windows)]
                 {
-                    return Err(Error::UnsafeIndexKey(key.to_string()));
+                    if let Some(s) = os.to_str()
+                        && s.contains(':')
+                    {
+                        return Err(Error::UnsafeIndexKey(key.to_string()));
+                    }
+                }
+                #[cfg(not(windows))]
+                {
+                    let _ = os;
                 }
             }
             std::path::Component::CurDir => {}
@@ -4031,6 +4038,12 @@ mod tests {
         validate_index_key("a/b/c/d/e/f.js").unwrap();
     }
 
+    #[cfg(not(windows))]
+    #[test]
+    fn validate_index_key_accepts_posix_colon_filename() {
+        validate_index_key("dist/__mocks__/package-json:version.d.ts").unwrap();
+    }
+
     #[test]
     fn validate_index_key_rejects_empty() {
         assert!(matches!(
@@ -4075,6 +4088,7 @@ mod tests {
         ));
     }
 
+    #[cfg(windows)]
     #[test]
     fn validate_index_key_rejects_windows_drive() {
         assert!(matches!(

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -658,10 +658,8 @@ impl Store {
 /// eventual `pkg_dir.join(key)` file outside the package root:
 /// `..` anywhere in the remaining path, absolute paths, Windows
 /// drive prefixes, backslash separators smuggled inside a single
-/// component, NUL bytes, and `:` (which `Path::components` surfaces
-/// as `Normal("C:evil")` on unix where it wouldn't parse as a
-/// drive prefix). Non-UTF-8 paths are also rejected because the
-/// stored index is a JSON map keyed by string.
+/// component, and NUL bytes. Non-UTF-8 paths are also rejected because
+/// the stored index is a JSON map keyed by string.
 ///
 /// `Ok(None)` means the entry stripped down to the wrapper itself
 /// and should be skipped by the caller.
@@ -719,12 +717,7 @@ fn normalize_tar_entry_path(raw: &Path) -> Result<Option<String>, Error> {
                         "tarball entry path contains non-UTF-8 bytes: {raw:?}"
                     ))
                 })?;
-                if s.is_empty()
-                    || s.contains('\0')
-                    || s.contains('\\')
-                    || s.contains('/')
-                    || s.contains(':')
-                {
+                if s.is_empty() || s.contains('\0') || s.contains('\\') || s.contains('/') {
                     return Err(Error::Tar(format!(
                         "tarball entry path contains a malformed component: {raw:?}"
                     )));
@@ -739,6 +732,13 @@ fn normalize_tar_entry_path(raw: &Path) -> Result<Option<String>, Error> {
                 // publisher's problem to validate.
                 #[cfg(windows)]
                 {
+                    // `:` is an alternate data stream separator on
+                    // NTFS and is rejected by Windows path creation.
+                    if s.contains(':') {
+                        return Err(Error::Tar(format!(
+                            "tarball entry path contains a malformed component: {raw:?}"
+                        )));
+                    }
                     // NTFS reserved device names. `CON`, `con.txt`,
                     // `CON.tar.gz` all resolve to the console
                     // device. Writing one either fails with
@@ -2474,6 +2474,20 @@ mod tests {
         assert!(index.contains_key("index.js"));
     }
 
+    #[cfg(not(windows))]
+    #[test]
+    fn test_import_tarball_accepts_posix_colon_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+        let tarball = build_tarball(
+            "package/dist/__mocks__/package-json:version.d.ts",
+            b"export {};",
+        );
+        let index = store.import_tarball(&tarball).unwrap();
+        assert!(index.contains_key("dist/__mocks__/package-json:version.d.ts"));
+    }
+
     #[test]
     fn test_import_tarball_rejects_per_entry_cap_exceeded() {
         // A single entry with a declared size past the per-entry cap
@@ -2668,10 +2682,9 @@ mod tests {
         assert!(matches!(err, Error::Tar(_)));
     }
 
+    #[cfg(windows)]
     #[test]
-    fn normalize_tar_entry_path_rejects_colon_smuggle() {
-        // On unix `C:evil` parses as `Normal("C:evil")`, not a
-        // Prefix. Reject defensively.
+    fn normalize_tar_entry_path_rejects_colon_on_windows() {
         let err = normalize_tar_entry_path(Path::new("package/C:evil")).unwrap_err();
         assert!(matches!(err, Error::Tar(_)));
     }


### PR DESCRIPTION
## Summary

- Allow `:` inside tarball entry filenames on POSIX platforms while continuing to reject it on Windows.
- Keep the linker materialization guard in sync with the store-side tarball validator.
- Add regression tests for the reported `package-json:version.d.ts` path.

## Root Cause

The store tarball validator treated `:` as malformed on every platform to defend against Windows drive-prefix and NTFS alternate-data-stream ambiguity. That was too broad for POSIX, where colon is a valid filename character. After relaxing the store-side validator, the linker still rejected cached package index keys containing `:`, so both guards needed the same platform split.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-store`
- `cargo test -p aube-linker`
- `cargo clippy -p aube-store --all-targets -- -D warnings`
- `cargo clippy -p aube-linker --all-targets -- -D warnings`
- Smoke-tested the reported `redos-detector@6.1.4` install with the debug binary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted validation change gated by OS cfg; main risk is unintended path-safety regression, mitigated by keeping Windows restrictions and adding tests.
> 
> **Overview**
> Allows `:` in package tarball entry filenames and cached `PackageIndex` keys on **non-Windows** platforms while continuing to reject `:` on Windows (drive/ADS safety).
> 
> Updates `aube-store` tarball path normalization and the linker's `validate_index_key` to apply colon checks only under `cfg(windows)`, and adds platform-gated regression tests covering `dist/__mocks__/package-json:version.d.ts` plus the Windows-only rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6e5d81d66ba33101899e9a6b3fb21d0bac15932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->