### PR TITLE
fix(install): match pnpm network concurrency default

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -428,7 +428,7 @@ cmd install help="Install all dependencies" {
         long_help "Merge every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yaml` and delete the branch files.\n\nCompanion to `gitBranchLockfile`. When `mergeGitBranchLockfilesBranchPattern` is set in `pnpm-workspace.yaml`, this happens automatically on matching branches; the flag forces it regardless."
     }
     flag --network-concurrency help="Cap concurrent tarball downloads" {
-        long_help "Cap concurrent tarball downloads.\n\nOverrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to the built-in defaults otherwise (128 for the lockfile path, 64 for the streaming path)."
+        long_help "Cap concurrent tarball downloads.\n\nOverrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to an auto-scaled default of worker count x3, clamped to 16-64."
         arg <N>
     }
     flag --no-optional help="Skip optionalDependencies; don't install optional native modules"

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -291,9 +291,9 @@ pub struct WorkspaceConfig {
     #[serde(default, rename = "childConcurrency")]
     pub child_concurrency: Option<u64>,
 
-    /// Cap concurrent tarball downloads. When unset, aube uses its
-    /// built-in defaults (128 for the lockfile path, 64 for the
-    /// streaming path). Same typed/raw duality as `child_concurrency`.
+    /// Cap concurrent tarball downloads. When unset, aube uses an
+    /// auto-scaled worker count x3 default, clamped to 16-64. Same
+    /// typed/raw duality as `child_concurrency`.
     #[serde(default, rename = "networkConcurrency")]
     pub network_concurrency: Option<u64>,
 

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1172,15 +1172,14 @@ examples = []
 [networkConcurrency]
 description = "Maximum concurrent HTTP(S) requests."
 type = "int"
-default = "128 (tarballs), 64 (packuments)"
+default = "auto (workers x3 clamped to 16-64)"
 docs = """
 Caps the tokio semaphores that gate concurrent tarball downloads
-inside `crates/aube/src/commands/install.rs`. When set, both the
-lockfile-driven and streaming fetch paths use the configured value
-instead of the built-in defaults (128 for tarballs, 64 for the
-streaming path). The resolver's packument fetcher still uses its own
-internal cap for now; plumbing that cap through is tracked as a
-follow-up.
+inside `crates/aube/src/commands/install.rs`. When unset, aube
+matches pnpm's dynamic default: worker count x3, clamped to 16-64.
+Set this value explicitly to override the automatic scaling. The
+resolver's packument fetcher still uses its own internal cap for now;
+plumbing that cap through is tracked as a follow-up.
 """
 sources.cli = ["network-concurrency"]
 sources.env = ["npm_config_network_concurrency", "NPM_CONFIG_NETWORK_CONCURRENCY", "AUBE_NETWORK_CONCURRENCY"]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -95,9 +95,8 @@ pub struct InstallArgs {
     /// Cap concurrent tarball downloads.
     ///
     /// Overrides `network-concurrency` from `.npmrc` /
-    /// `aube-workspace.yaml` when set. Falls back to the built-in
-    /// defaults otherwise (128 for the lockfile path, 64 for the
-    /// streaming path).
+    /// `aube-workspace.yaml` when set. Falls back to an auto-scaled
+    /// default of worker count x3, clamped to 16-64.
     #[arg(long, value_name = "N")]
     pub network_concurrency: Option<u64>,
     /// Skip optionalDependencies; don't install optional native modules
@@ -1404,10 +1403,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // front so every downstream fetch site (the lockfile path, the
     // streaming-resolver path, and the forthcoming `aube fetch`
     // bridge) reads the same values. `network_concurrency_setting`
-    // stays `Option<usize>` so each site can apply its own sensible
-    // fallback when the setting is absent (128 for the lockfile
-    // path's HTTP/2-friendly burst, 64 for the streaming path that
-    // overlaps with resolver packument fetches).
+    // stays `Option<usize>` so each site can apply the dynamic
+    // built-in fallback when the setting is absent.
     //
     // `sideEffectsCache` controls whether allowlisted dependency
     // lifecycle scripts can reuse a previously-cached post-build

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -252,11 +252,22 @@ pub(super) fn resolve_link_concurrency(ctx: &aube_settings::ResolveCtx<'_>) -> O
 }
 
 pub(super) fn default_lockfile_network_concurrency() -> usize {
-    if cfg!(target_os = "macos") { 24 } else { 128 }
+    default_network_concurrency()
 }
 
 pub(super) fn default_streaming_network_concurrency() -> usize {
-    if cfg!(target_os = "macos") { 24 } else { 64 }
+    default_network_concurrency()
+}
+
+fn default_network_concurrency() -> usize {
+    let workers = std::thread::available_parallelism()
+        .map(std::num::NonZero::get)
+        .unwrap_or(4);
+    network_concurrency_for_workers(workers)
+}
+
+fn network_concurrency_for_workers(workers: usize) -> usize {
+    workers.saturating_mul(3).clamp(16, 64)
 }
 
 /// Resolve `verifyStoreIntegrity` from cli / env / `.npmrc` /
@@ -857,6 +868,19 @@ fn compile_peer_patterns(field: &str, raw: &[String]) -> Vec<glob::Pattern> {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod network_concurrency_tests {
+    use super::*;
+
+    #[test]
+    fn dynamic_default_matches_pnpm_worker_clamp() {
+        assert_eq!(network_concurrency_for_workers(1), 16);
+        assert_eq!(network_concurrency_for_workers(8), 24);
+        assert_eq!(network_concurrency_for_workers(24), 64);
+        assert_eq!(network_concurrency_for_workers(usize::MAX), 64);
+    }
 }
 
 #[cfg(test)]

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2370,7 +2370,7 @@
             "name": "network-concurrency",
             "usage": "--network-concurrency <N>",
             "help": "Cap concurrent tarball downloads",
-            "help_long": "Cap concurrent tarball downloads.\n\nOverrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to the built-in defaults otherwise (128 for the lockfile path, 64 for the streaming path).",
+            "help_long": "Cap concurrent tarball downloads.\n\nOverrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to an auto-scaled default of worker count x3, clamped to 16-64.",
             "help_first_line": "Cap concurrent tarball downloads",
             "short": [],
             "long": [

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -57,7 +57,7 @@ Companion to `gitBranchLockfile`. When `mergeGitBranchLockfilesBranchPattern` is
 
 Cap concurrent tarball downloads.
 
-Overrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to the built-in defaults otherwise (128 for the lockfile path, 64 for the streaming path).
+Overrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to an auto-scaled default of worker count x3, clamped to 16-64.
 
 ### `--no-optional`
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1212,19 +1212,18 @@ regardless of which strategy produced it.
 Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
-- Default: `128 (tarballs), 64 (packuments)`
+- Default: `auto (workers x3 clamped to 16-64)`
 - CLI flags: `network-concurrency`
 - Environment: `npm_config_network_concurrency`, `NPM_CONFIG_NETWORK_CONCURRENCY`, `AUBE_NETWORK_CONCURRENCY`
 - .npmrc keys: `network-concurrency`, `networkConcurrency`
 - Workspace YAML keys: `networkConcurrency`
 
 Caps the tokio semaphores that gate concurrent tarball downloads
-inside `crates/aube/src/commands/install.rs`. When set, both the
-lockfile-driven and streaming fetch paths use the configured value
-instead of the built-in defaults (128 for tarballs, 64 for the
-streaming path). The resolver's packument fetcher still uses its own
-internal cap for now; plumbing that cap through is tracked as a
-follow-up.
+inside `crates/aube/src/commands/install.rs`. When unset, aube
+matches pnpm's dynamic default: worker count x3, clamped to 16-64.
+Set this value explicitly to override the automatic scaling. The
+resolver's packument fetcher still uses its own internal cap for now;
+plumbing that cap through is tracked as a follow-up.
 
 Examples:
 


### PR DESCRIPTION
## Summary

- Match pnpm's dynamic `networkConcurrency` default by using available worker count x3, clamped to 16-64.
- Apply the same dynamic default to both lockfile and streaming tarball fetch paths while preserving explicit config overrides.
- Update CLI/settings docs and add a unit test for the clamp behavior.

## Why

The previous Linux lockfile fetch default was a fixed 128 concurrent tarball downloads, which can be much more aggressive than pnpm's current auto-scaled 16-64 range and can trigger registry response body read failures under load.

## Validation

- `cargo fmt --check`
- `cargo test -p aube commands::install::settings::network_concurrency_tests::dynamic_default_matches_pnpm_worker_clamp`
- `cargo test -p aube-settings meta::tests::workspace_yaml_keys_deserialize_onto_workspace_config`
- `mise run docs:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default level of concurrent network requests during installs, which can impact performance and failure modes under load across different machines.
> 
> **Overview**
> Aligns `networkConcurrency`’s *unset* behavior with pnpm by switching from fixed per-path defaults to a dynamic default of `available_parallelism * 3`, clamped to **16–64**, and using it for both lockfile-driven and streaming tarball fetch paths while keeping explicit config/CLI overrides.
> 
> Updates the setting metadata and generated docs/CLI help to reflect the new default, and adds a focused unit test for the clamp/scaling logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca7a982b6bd1f527f1869858651bccf5578c415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->