### PR TITLE
chore: release v1.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "aube-util",
  "miette",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "aube-manifest",
  "landlock",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "aube-util",
  "base64",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "blake3",
  "rustc-hash",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.5.1"
+version = "1.5.2"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -122,14 +122,14 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.5.1" }
-aube-settings = { path = "crates/aube-settings", version = "1.5.1" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.5.1" }
-aube-registry = { path = "crates/aube-registry", version = "1.5.1" }
-aube-store = { path = "crates/aube-store", version = "1.5.1" }
-aube-linker = { path = "crates/aube-linker", version = "1.5.1" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.5.1" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.5.1" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.5.1" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.5.1" }
-aube-util = { path = "crates/aube-util", version = "1.5.1" }
+aube = { path = "crates/aube", version = "1.5.2" }
+aube-settings = { path = "crates/aube-settings", version = "1.5.2" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.5.2" }
+aube-registry = { path = "crates/aube-registry", version = "1.5.2" }
+aube-store = { path = "crates/aube-store", version = "1.5.2" }
+aube-linker = { path = "crates/aube-linker", version = "1.5.2" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.5.2" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.5.2" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.5.2" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.5.2" }
+aube-util = { path = "crates/aube-util", version = "1.5.2" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.5.1"
+version "1.5.2"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/aube-linker-v1.5.1...aube-linker-v1.5.2) - 2026-04-30
+
+### Fixed
+
+- *(linker)* retry transient Windows junction errors ([#406](https://github.com/endevco/aube/pull/406))
+- *(linker,store)* self-heal install on missing CAS shard ([#395](https://github.com/endevco/aube/pull/395))
+
+### Other
+
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.1](https://github.com/endevco/aube/compare/aube-linker-v1.5.0...aube-linker-v1.5.1) - 2026-04-29
 
 ### Fixed

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/aube-lockfile-v1.5.1...aube-lockfile-v1.5.2) - 2026-04-30
+
+### Fixed
+
+- *(lockfile)* accept scalar os/cpu/libc in npm package-lock.json ([#405](https://github.com/endevco/aube/pull/405))
+- *(lockfile)* synthesize npm-alias entries for transitive deps in pnpm lockfiles ([#403](https://github.com/endevco/aube/pull/403))
+- *(install)* fetch hosted git deps over https, not ssh ([#394](https://github.com/endevco/aube/pull/394))
+
+### Other
+
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.4.0...aube-lockfile-v1.5.0) - 2026-04-29
 
 ### Fixed

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/aube-manifest-v1.5.1...aube-manifest-v1.5.2) - 2026-04-30
+
+### Other
+
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.0](https://github.com/endevco/aube/compare/aube-manifest-v1.4.0...aube-manifest-v1.5.0) - 2026-04-29
 
 ### Fixed

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/aube-registry-v1.5.1...aube-registry-v1.5.2) - 2026-04-30
+
+### Other
+
+- *(resolver)* add bundled metadata primer ([#397](https://github.com/endevco/aube/pull/397))
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.0](https://github.com/endevco/aube/compare/aube-registry-v1.4.0...aube-registry-v1.5.0) - 2026-04-29
 
 ### Fixed

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/aube-resolver-v1.5.1...aube-resolver-v1.5.2) - 2026-04-30
+
+### Fixed
+
+- *(resolver)* detect host libc via /proc/self/maps ([#398](https://github.com/endevco/aube/pull/398))
+- *(install)* fetch hosted git deps over https, not ssh ([#394](https://github.com/endevco/aube/pull/394))
+
+### Other
+
+- *(resolver)* add bundled metadata primer ([#397](https://github.com/endevco/aube/pull/397))
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- *(resolver)* fetch full metadata for age-gated resolves ([#391](https://github.com/endevco/aube/pull/391))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.0](https://github.com/endevco/aube/compare/aube-resolver-v1.4.0...aube-resolver-v1.5.0) - 2026-04-29
 
 ### Fixed

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/aube-scripts-v1.5.1...aube-scripts-v1.5.2) - 2026-04-30
+
+### Other
+
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.0](https://github.com/endevco/aube/compare/aube-scripts-v1.4.0...aube-scripts-v1.5.0) - 2026-04-29
 
 ### Fixed

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/aube-settings-v1.5.1...aube-settings-v1.5.2) - 2026-04-30
+
+### Other
+
+- *(resolver)* add bundled metadata primer ([#397](https://github.com/endevco/aube/pull/397))
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.0](https://github.com/endevco/aube/compare/aube-settings-v1.4.0...aube-settings-v1.5.0) - 2026-04-29
 
 ### Fixed

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/aube-store-v1.5.1...aube-store-v1.5.2) - 2026-04-30
+
+### Fixed
+
+- *(install)* fetch hosted git deps over https, not ssh ([#394](https://github.com/endevco/aube/pull/394))
+- *(linker,store)* self-heal install on missing CAS shard ([#395](https://github.com/endevco/aube/pull/395))
+
+### Other
+
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.1](https://github.com/endevco/aube/compare/aube-store-v1.5.0...aube-store-v1.5.1) - 2026-04-29
 
 ### Fixed

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/aube-util-v1.5.1...aube-util-v1.5.2) - 2026-04-30
+
+### Other
+
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.0](https://github.com/endevco/aube/compare/aube-util-v1.4.0...aube-util-v1.5.0) - 2026-04-29
 
 ### Fixed

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/aube-workspace-v1.5.1...aube-workspace-v1.5.2) - 2026-04-30
+
+### Other
+
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.4.0](https://github.com/endevco/aube/compare/aube-workspace-v1.3.0...aube-workspace-v1.4.0) - 2026-04-28
 
 ### Fixed

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2](https://github.com/endevco/aube/compare/v1.5.1...v1.5.2) - 2026-04-30
+
+### Fixed
+
+- *(cli)* honor full gitignore semantics in pack/publish ([#411](https://github.com/endevco/aube/pull/411))
+- *(dlx)* pick .cmd shim on Windows so bin runs without --shell-mode ([#401](https://github.com/endevco/aube/pull/401))
+- *(install)* fetch hosted git deps over https, not ssh ([#394](https://github.com/endevco/aube/pull/394))
+
+### Other
+
+- *(resolver)* add bundled metadata primer ([#397](https://github.com/endevco/aube/pull/397))
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.0](https://github.com/endevco/aube/compare/v1.4.0...v1.5.0) - 2026-04-29
 
 ### Added

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6088,7 +6088,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.5.1",
+  "version": "1.5.2",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.5.1
+**Version**: 1.5.2
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.5.1",
-  "releasedAt": "2026-04-29T21:38:17Z"
+  "version": "1.5.2",
+  "releasedAt": "2026-04-30T20:52:19Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.5.2`

This PR bumps the workspace to `v1.5.2` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
