### PR TITLE
perf(install): reuse imported manifest validation bytes

### DIFF
--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -98,6 +98,13 @@ pub struct StoredFile {
 /// Index of all files in a package, keyed by relative path within the package.
 pub type PackageIndex = BTreeMap<String, StoredFile>;
 
+/// Result of importing a package tarball into the CAS.
+#[derive(Debug)]
+pub struct ImportedTarball {
+    pub index: PackageIndex,
+    pub package_json: Option<Vec<u8>>,
+}
+
 fn index_files_match_metadata(index: &PackageIndex, verify_all: bool) -> bool {
     let mut files = index.values();
     if verify_all {
@@ -539,6 +546,15 @@ impl Store {
     /// Import a tarball (.tgz) into the store.
     /// Returns a PackageIndex mapping relative paths to stored files.
     pub fn import_tarball(&self, tarball_bytes: &[u8]) -> Result<PackageIndex, Error> {
+        Ok(self.import_tarball_with_manifest(tarball_bytes)?.index)
+    }
+
+    /// Import a tarball (.tgz) into the store, also returning the
+    /// decompressed `package.json` bytes when present.
+    pub fn import_tarball_with_manifest(
+        &self,
+        tarball_bytes: &[u8],
+    ) -> Result<ImportedTarball, Error> {
         use std::io::Read;
 
         // Caps defend against gzip bombs and lying tar headers. The
@@ -557,6 +573,7 @@ impl Store {
         let buffered = std::io::BufReader::with_capacity(256 * 1024, capped);
         let mut archive = tar::Archive::new(buffered);
         let mut index = BTreeMap::new();
+        let mut package_json = None;
         let mut entries_seen: usize = 0;
 
         // Serial walk — each tarball is decoded by one spawn_blocking
@@ -642,12 +659,17 @@ impl Store {
 
             let mode = entry.header().mode().unwrap_or(0o644);
             let executable = mode & 0o111 != 0;
-
             let stored = self.import_bytes(&content, executable)?;
+            if rel_path == "package.json" {
+                package_json = Some(content);
+            }
             index.insert(rel_path, stored);
         }
 
-        Ok(index)
+        Ok(ImportedTarball {
+            index,
+            package_json,
+        })
     }
 }
 
@@ -1106,12 +1128,38 @@ pub fn validate_pkg_content(
         .ok_or_else(|| Error::Tar("package.json missing from tarball".to_string()))?;
     let bytes =
         std::fs::read(&stored.store_path).map_err(|e| Error::Io(stored.store_path.clone(), e))?;
-    let v: serde_json::Value = {
-        let mut buf = bytes.clone();
-        simd_json::serde::from_slice(&mut buf)
-            .or_else(|_| serde_json::from_slice(&bytes))
-            .map_err(|e| Error::Tar(format!("invalid package.json: {e}")))?
-    };
+    validate_pkg_content_bytes(&bytes, expected_name, expected_version)
+}
+
+/// Cross-check package metadata using manifest bytes already read from a tarball.
+pub fn validate_pkg_content_bytes(
+    bytes: &[u8],
+    expected_name: &str,
+    expected_version: &str,
+) -> Result<(), Error> {
+    let v: serde_json::Value = serde_json::from_slice(bytes)
+        .map_err(|e| Error::Tar(format!("invalid package.json: {e}")))?;
+    validate_pkg_content_manifest(v, expected_name, expected_version)
+}
+
+/// Cross-check package metadata using owned manifest bytes.
+pub fn validate_pkg_content_bytes_owned(
+    mut bytes: Vec<u8>,
+    expected_name: &str,
+    expected_version: &str,
+) -> Result<(), Error> {
+    let fallback = bytes.clone();
+    let v: serde_json::Value = simd_json::serde::from_slice(&mut bytes)
+        .or_else(|_| serde_json::from_slice(&fallback))
+        .map_err(|e| Error::Tar(format!("invalid package.json: {e}")))?;
+    validate_pkg_content_manifest(v, expected_name, expected_version)
+}
+
+fn validate_pkg_content_manifest(
+    v: serde_json::Value,
+    expected_name: &str,
+    expected_version: &str,
+) -> Result<(), Error> {
     let actual_name = v.get("name").and_then(|n| n.as_str()).unwrap_or("");
     let actual_version = v.get("version").and_then(|v| v.as_str()).unwrap_or("");
     // Tolerate a leading `v` on the tarball's version (e.g. "v2.0.8").

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -571,8 +571,8 @@ pub(super) fn import_verified_tarball(
             );
         }
     }
-    let index = store
-        .import_tarball(bytes)
+    let imported = store
+        .import_tarball_with_manifest(bytes)
         .map_err(|e| miette!("failed to import {display_name}@{version}: {e}"))?;
     // strictStorePkgContentCheck: cross-check the freshly stored
     // package.json against the resolver-asserted (name, version)
@@ -581,7 +581,10 @@ pub(super) fn import_verified_tarball(
     // in the tarball's own `package.json` — not the alias, or this
     // would fail every npm-aliased entry.
     if strict_pkg_content_check {
-        aube_store::validate_pkg_content(&index, registry_name, version)
+        let package_json = imported.package_json.ok_or_else(|| {
+            miette!("{display_name}@{version}: tarball extraction error: package.json missing from tarball")
+        })?;
+        aube_store::validate_pkg_content_bytes_owned(package_json, registry_name, version)
             .map_err(|e| miette!("{display_name}@{version}: {e}"))?;
     }
     // Cache under `registry_name` so two aliases of the same real
@@ -591,10 +594,10 @@ pub(super) fn import_verified_tarball(
     // tarballs from different sources; when `None` falls back to the
     // plain name@version key so warm installs still find the cache
     // on integrity-stripping proxies.
-    if let Err(e) = store.save_index(registry_name, version, integrity, &index) {
+    if let Err(e) = store.save_index(registry_name, version, integrity, &imported.index) {
         tracing::warn!("Failed to cache index for {display_name}@{version}: {e}");
     }
-    Ok(index)
+    Ok(imported.index)
 }
 
 pub(super) fn validate_required_scripts(


### PR DESCRIPTION
## Summary

- Capture `package.json` bytes while importing tarballs into the store.
- Reuse those bytes for strict package-content validation instead of reading the manifest back from CAS.
- Parse the hot-path owned manifest buffer with the same `simd-json` then `serde_json` fallback behavior used by the original validation code.
- Move the captured manifest buffer instead of cloning it after CAS import.
- Keep the existing `import_tarball` API behavior for other callers.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-store import_tarball`
- `cargo test -p aube-store validate_pkg_content`
- `cargo check -p aube`
- pre-commit `cargo clippy` / `cargo fmt` on touched Rust files
- `cargo build --release -p aube`

## Benchmark

Using the vlt benchmark wrapper with `CI=1`, `warmup=1`, `large/lockfile`.

PR command:

```text
PATH=/home/jdx/src/aube/target/release:$PATH CI=1 ./bench run --fixtures=large --variation=lockfile --pms=aube --runs=7 --warmup=1
```

`origin/main` command:

```text
PATH=/tmp/aube-origin-main-bench/target/release:$PATH CI=1 ./bench run --fixtures=large --variation=lockfile --pms=aube --runs=7 --warmup=1
```

| build | mean | median | trimmed mean | stddev | range | times |
| --- | ---: | ---: | ---: | ---: | --- | --- |
| PR `690d687` | `1.437s` | `1.395s` | `1.411s` | `0.172s` | `1.277s .. 1.723s` | `1.395, 1.723, 1.615, 1.287, 1.318, 1.442, 1.277` |
| `origin/main` `08f0594` | `1.747s` | `1.365s` | `1.371s` | `1.042s` | `1.270s .. 4.104s` | `1.316, 1.297, 1.270, 1.466, 1.365, 4.104, 1.411` |

Raw mean favors the PR only because `origin/main` hit a large outlier. Median and trimmed mean are more representative here and show the PR slower by `+0.030s` median (`+2.23%`) and `+0.041s` trimmed mean (`+2.96%`). Treat this benchmark result as no demonstrated performance win.

Note: the benchmark table above was run before commit `1b0ada0`, which removes the extra manifest clone. That follow-up is smaller than the benchmark noise seen here, so the comparison is still best read as no demonstrated win.