### PR TITLE
fix(install): fetch hosted git deps over https, not ssh

### DIFF
--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -453,6 +453,149 @@ pub fn parse_git_spec(spec: &str) -> Option<(String, Option<String>, Option<Stri
     Some((url, committish, subpath))
 }
 
+/// A git URL that maps to one of the three "hosted" providers npm /
+/// pnpm both special-case (github / gitlab / bitbucket). For these
+/// hosts a public read can be served as a flat HTTPS tarball over
+/// `codeload.github.com` (or each host's equivalent), bypassing `git`
+/// entirely. The lockfile's stored URL is canonical-identity only —
+/// pnpm and npm both re-derive the fetch URL from `(host, owner,
+/// repo)` on every install rather than dialing whatever scheme
+/// happens to be in `resolved:`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostedGit {
+    pub host: HostedGitHost,
+    pub owner: String,
+    pub repo: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostedGitHost {
+    GitHub,
+    GitLab,
+    Bitbucket,
+}
+
+impl HostedGit {
+    /// `https://github.com/<owner>/<repo>.git` — the form `git fetch`
+    /// can dial without an SSH key. Used as the runtime fetch URL when
+    /// the lockfile's stored URL is `git+ssh://git@…` (npm canonical
+    /// identity) but the actual install host has no SSH configured.
+    pub fn https_url(&self) -> String {
+        let host = self.host.host_domain();
+        format!("https://{host}/{}/{}.git", self.owner, self.repo)
+    }
+
+    /// `https://codeload.github.com/<owner>/<repo>/tar.gz/<sha>` (or
+    /// each host's equivalent) — a flat HTTPS tarball at the given
+    /// commit. Returns `None` unless `committish` is a 40-char hex
+    /// SHA, since the codeload path can't be verified after extraction
+    /// without `.git/` metadata. Branch / tag names round-trip through
+    /// `git ls-remote` to get pinned to a SHA first.
+    pub fn tarball_url(&self, committish: &str) -> Option<String> {
+        if committish.len() != 40 || !committish.chars().all(|c| c.is_ascii_hexdigit()) {
+            return None;
+        }
+        let sha = committish.to_ascii_lowercase();
+        Some(match self.host {
+            HostedGitHost::GitHub => format!(
+                "https://codeload.github.com/{}/{}/tar.gz/{sha}",
+                self.owner, self.repo
+            ),
+            HostedGitHost::GitLab => format!(
+                "https://gitlab.com/{}/{}/-/archive/{sha}/{}-{sha}.tar.gz",
+                self.owner, self.repo, self.repo
+            ),
+            HostedGitHost::Bitbucket => format!(
+                "https://bitbucket.org/{}/{}/get/{sha}.tar.gz",
+                self.owner, self.repo
+            ),
+        })
+    }
+}
+
+impl HostedGitHost {
+    fn from_domain(domain: &str) -> Option<Self> {
+        match domain {
+            "github.com" => Some(HostedGitHost::GitHub),
+            "gitlab.com" => Some(HostedGitHost::GitLab),
+            "bitbucket.org" => Some(HostedGitHost::Bitbucket),
+            _ => None,
+        }
+    }
+
+    pub fn host_domain(self) -> &'static str {
+        match self {
+            HostedGitHost::GitHub => "github.com",
+            HostedGitHost::GitLab => "gitlab.com",
+            HostedGitHost::Bitbucket => "bitbucket.org",
+        }
+    }
+}
+
+/// Parse a clone URL — in any form `parse_git_spec` accepts as input
+/// or produces as output — into its `(host, owner, repo)` components,
+/// when the host is one of the three providers npm / pnpm route
+/// through HTTPS tarballs. Returns `None` for any other host (including
+/// self-hosted GitLab / Gitea / Bitbucket Data Center): those still
+/// need a real `git clone` because no codeload-style HTTP archive is
+/// available.
+///
+/// Accepts:
+/// - `https://github.com/owner/repo[.git]`
+/// - `git+https://github.com/owner/repo[.git]`
+/// - `git://github.com/owner/repo[.git]`
+/// - `ssh://git@github.com/owner/repo[.git]`
+/// - `git+ssh://git@github.com/owner/repo[.git]` (npm canonical lockfile form)
+/// - `git@github.com:owner/repo[.git]` (scp shorthand, in case a caller
+///   parses raw lockfile fields without going through `parse_git_spec`)
+pub fn parse_hosted_git(url: &str) -> Option<HostedGit> {
+    let body = url.strip_prefix("git+").unwrap_or(url);
+    let after_scheme = if let Some(rest) = body.strip_prefix("https://") {
+        rest
+    } else if let Some(rest) = body.strip_prefix("http://") {
+        rest
+    } else if let Some(rest) = body.strip_prefix("ssh://") {
+        rest
+    } else if let Some(rest) = body.strip_prefix("git://") {
+        rest
+    } else {
+        // scp shorthand `user@host:path` — not produced by parse_git_spec
+        // but accepted defensively in case a raw lockfile string ever
+        // bypasses it.
+        let scp_path = parse_scp_url(body)?;
+        return parse_hosted_git(&scp_path);
+    };
+    // Strip optional `user@` (always `git@` for hosted forms).
+    let host_and_path = match after_scheme.split_once('@') {
+        Some((_, rest)) => rest,
+        None => after_scheme,
+    };
+    let (host, path) = host_and_path.split_once('/')?;
+    let host = HostedGitHost::from_domain(host)?;
+    // Take exactly two path segments: owner and repo. Anything beyond
+    // (subgroup-style GitLab paths) doesn't have a stable HTTPS tarball
+    // form on the three providers we care about, so refuse and let the
+    // caller fall back to clone.
+    let mut segs = path.splitn(3, '/');
+    let owner = segs.next()?;
+    let repo = segs.next()?;
+    if owner.is_empty() || repo.is_empty() || segs.next().is_some() {
+        return None;
+    }
+    let repo = repo
+        .strip_suffix(".git")
+        .unwrap_or(repo)
+        .trim_end_matches('/');
+    if repo.is_empty() {
+        return None;
+    }
+    Some(HostedGit {
+        host,
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+    })
+}
+
 fn parse_scp_url(body: &str) -> Option<String> {
     if body.contains("://") {
         return None;
@@ -2188,6 +2331,104 @@ mod git_spec_tests {
         assert_eq!(url, "https://github.com/org/dep.git");
         assert_eq!(committish.as_deref(), Some(sha));
         assert_eq!(subpath.as_deref(), Some("packages/special"));
+    }
+
+    #[test]
+    fn parse_hosted_git_recognizes_canonical_forms() {
+        // All these point at the same (github.com, owner, repo) tuple
+        // and must map to the same HostedGit so the runtime fetch URL
+        // doesn't depend on which scheme the lockfile happens to record.
+        let canonical = HostedGit {
+            host: HostedGitHost::GitHub,
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+        };
+        for spec in [
+            "https://github.com/owner/repo.git",
+            "https://github.com/owner/repo",
+            "http://github.com/owner/repo.git",
+            "git+https://github.com/owner/repo.git",
+            "git+https://github.com/owner/repo",
+            "git://github.com/owner/repo.git",
+            "ssh://git@github.com/owner/repo.git",
+            "git+ssh://git@github.com/owner/repo.git",
+            "git@github.com:owner/repo.git",
+        ] {
+            assert_eq!(
+                parse_hosted_git(spec).as_ref(),
+                Some(&canonical),
+                "spec {spec} should map to canonical HostedGit",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_hosted_git_returns_none_for_non_hosted() {
+        // Self-hosted GitLab / Gitea / arbitrary hosts: no codeload
+        // template, so the codeload fast path doesn't apply.
+        for spec in [
+            "https://example.com/owner/repo.git",
+            "ssh://git@gitea.internal/owner/repo.git",
+            "git+ssh://git@gitlab.example.com/group/sub/repo.git",
+            "https://github.com/owner/repo/sub",
+            "https://github.com/owner",
+        ] {
+            assert!(
+                parse_hosted_git(spec).is_none(),
+                "spec {spec} must not match a hosted provider",
+            );
+        }
+    }
+
+    #[test]
+    fn hosted_tarball_url_only_for_full_sha() {
+        let g = HostedGit {
+            host: HostedGitHost::GitHub,
+            owner: "o".to_string(),
+            repo: "r".to_string(),
+        };
+        let sha = "abcdef0123456789abcdef0123456789abcdef01";
+        assert_eq!(
+            g.tarball_url(sha).as_deref(),
+            Some("https://codeload.github.com/o/r/tar.gz/abcdef0123456789abcdef0123456789abcdef01"),
+        );
+        // Branch / tag / abbreviated SHA don't take the fast path —
+        // codeload accepts them but the wrapper-dir name varies and
+        // we can't verify a non-SHA committish post-extraction.
+        assert!(g.tarball_url("main").is_none());
+        assert!(g.tarball_url("v1.2.3").is_none());
+        assert!(g.tarball_url("abcdef0").is_none());
+    }
+
+    #[test]
+    fn hosted_tarball_url_per_provider() {
+        let sha = "abcdef0123456789abcdef0123456789abcdef01";
+        let gitlab = HostedGit {
+            host: HostedGitHost::GitLab,
+            owner: "g".to_string(),
+            repo: "r".to_string(),
+        }
+        .tarball_url(sha)
+        .unwrap();
+        assert!(gitlab.starts_with("https://gitlab.com/g/r/-/archive/"));
+        assert!(gitlab.ends_with("/r-abcdef0123456789abcdef0123456789abcdef01.tar.gz"));
+        let bitbucket = HostedGit {
+            host: HostedGitHost::Bitbucket,
+            owner: "g".to_string(),
+            repo: "r".to_string(),
+        }
+        .tarball_url(sha)
+        .unwrap();
+        assert_eq!(
+            bitbucket,
+            "https://bitbucket.org/g/r/get/abcdef0123456789abcdef0123456789abcdef01.tar.gz",
+        );
+    }
+
+    #[test]
+    fn hosted_https_url_normalizes() {
+        let g = parse_hosted_git("git+ssh://git@github.com/owner/repo.git").unwrap();
+        assert_eq!(g.https_url(), "https://github.com/owner/repo.git");
     }
 
     #[test]

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -285,6 +285,43 @@ pub(crate) async fn resolve_git_source(
 
     let codeload_url = hosted.as_ref().and_then(|h| h.tarball_url(&resolved_sha));
 
+    // Cache hit fast path: skip the HTTPS round-trip when a prior call
+    // (the resolver's earlier visit to this dep, or a previous install)
+    // already populated the codeload cache. Mirrors `git_shallow_clone`'s
+    // top-of-function reuse check.
+    if codeload_url.is_some()
+        && let Some((clone_dir, _head_sha)) =
+            aube_store::codeload_cache_lookup(&original_url, &resolved_sha)
+    {
+        let pkg_root = match &subpath {
+            Some(sub) => clone_dir.join(sub),
+            None => clone_dir.clone(),
+        };
+        let manifest_bytes = std::fs::read(pkg_root.join("package.json")).map_err(|e| {
+            let where_ = subpath
+                .as_deref()
+                .map(|s| format!(" at /{s}"))
+                .unwrap_or_default();
+            Error::Registry(
+                name.to_string(),
+                format!("read package.json in cached codeload extract{where_}: {e}"),
+            )
+        })?;
+        let pj: aube_manifest::PackageJson = serde_json::from_slice(&manifest_bytes)
+            .map_err(|e| Error::Registry(name.to_string(), e.to_string()))?;
+        let version = pj.version.unwrap_or_else(|| "0.0.0".to_string());
+        return Ok((
+            LocalSource::Git(aube_lockfile::GitSource {
+                url: original_url,
+                committish,
+                resolved: resolved_sha,
+                subpath,
+            }),
+            version,
+            pj.dependencies,
+        ));
+    }
+
     // Try the codeload fast path when applicable. `client` is None for
     // resolve paths that don't have a registry client wired up
     // (`aube import`'s lockfile-only flow); those just fall through.

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -222,70 +222,178 @@ pub(crate) fn should_block_exotic_subdep(
 }
 
 /// Turn a raw `GitSource` (committish parsed from the user's
-/// specifier, empty `resolved`) into a fully-resolved one by running
-/// `git ls-remote`, then shallow-cloning to read the package's own
-/// `package.json` for version + transitive deps. The clone lives in
-/// a commit-keyed temp directory; install-time materialization will
-/// either reuse the same directory or re-run the shallow clone.
+/// specifier, empty `resolved`) into a fully-resolved one by either
+/// fetching a hosted-tarball over HTTPS (github / gitlab / bitbucket
+/// public reads, matching what npm `pacote` and pnpm
+/// `gitHostedTarballFetcher` do) or, for any other host or any
+/// codeload-unreachable case, falling back to `git ls-remote` +
+/// shallow clone. The materialized tree lives in a commit-keyed temp
+/// directory shared with install-time materialization, so the same
+/// extraction or clone is never repeated within a single `aube
+/// install`.
+///
+/// Hosted-tarball routing matches npm/pnpm semantics: the lockfile's
+/// stored `url` is canonical-identity only — even when it carries an
+/// SSH form the user has no key for, we re-derive an HTTPS URL from
+/// the `(host, owner, repo)` tuple at fetch time. Returns the
+/// original URL unchanged in `LocalSource::Git.url` so a subsequent
+/// `aube install` produces the same lockfile bytes (cross-tool
+/// compat with pnpm / npm / yarn).
 pub(crate) async fn resolve_git_source(
     name: &str,
     git: &aube_lockfile::GitSource,
     shallow: bool,
+    client: Option<&RegistryClient>,
 ) -> Result<(LocalSource, String, BTreeMap<String, String>), Error> {
-    // `git ls-remote` and the shallow clone both shell out and do
-    // network I/O that can easily take multiple seconds. Running
-    // them inline on the tokio worker thread would block any
-    // concurrently-scheduled async work (registry HTTP calls,
-    // other resolve tasks). Hand the whole sync sequence — which
-    // has no borrows on the resolver's state — off to a blocking
-    // thread via `spawn_blocking`.
-    let url = git.url.clone();
+    let original_url = git.url.clone();
     let committish = git.committish.clone();
     let subpath = git.subpath.clone();
-    let name_owned = name.to_string();
+    let hosted = aube_lockfile::parse_hosted_git(&original_url);
+    // Use the HTTPS form when talking to git for hosted hosts — the
+    // lockfile-canonical `git+ssh://git@…` URL would dial SSH and
+    // fail for users with no `~/.ssh/`. Non-hosted URLs go through
+    // unchanged so SSH-only setups keep working.
+    let runtime_url = hosted
+        .as_ref()
+        .map(|h| h.https_url())
+        .unwrap_or_else(|| original_url.clone());
+
+    // Resolve the committish to a 40-char SHA. `git_resolve_ref`
+    // short-circuits on a SHA and shells `git ls-remote` for branch /
+    // tag / HEAD. Passing the rewritten HTTPS URL means hosted
+    // branch/tag refs are pinnable from a host with no SSH key
+    // configured.
+    let runtime_url_for_ref = runtime_url.clone();
+    let committish_for_ref = committish.clone();
+    let name_for_ref = name.to_string();
+    let resolved_sha = tokio::task::spawn_blocking(move || -> Result<String, Error> {
+        let seed = aube_store::git_resolve_ref(&runtime_url_for_ref, committish_for_ref.as_deref())
+            .map_err(|e| Error::Registry(name_for_ref.clone(), e.to_string()))?;
+        // Only full SHAs survive — abbreviated user-written prefixes
+        // come back unchanged from `git_resolve_ref` and need to fall
+        // through to the clone path so `git checkout <prefix>` can
+        // expand them.
+        Ok(seed)
+    })
+    .await
+    .map_err(|e| {
+        Error::Registry(
+            name.to_string(),
+            format!("git ls-remote task panicked: {e}"),
+        )
+    })??;
+
+    let codeload_url = hosted.as_ref().and_then(|h| h.tarball_url(&resolved_sha));
+
+    // Try the codeload fast path when applicable. `client` is None for
+    // resolve paths that don't have a registry client wired up
+    // (`aube import`'s lockfile-only flow); those just fall through.
+    if let (Some(c), Some(url_to_fetch)) = (client, codeload_url.as_deref()) {
+        match c.fetch_tarball_bytes(url_to_fetch).await {
+            Ok(bytes) => {
+                // Extract into the commit-keyed cache and read the
+                // (possibly subpath-scoped) `package.json` like the
+                // clone path does. Return the original lockfile URL
+                // in `LocalSource::Git.url` for cross-tool round-trip.
+                let bytes_vec = bytes.to_vec();
+                let url_for_extract = original_url.clone();
+                let sha_for_extract = resolved_sha.clone();
+                let subpath_for_extract = subpath.clone();
+                let name_for_extract = name.to_string();
+                let extracted = tokio::task::spawn_blocking(move || -> Result<_, Error> {
+                    let (clone_dir, resolved) = aube_store::extract_codeload_tarball(
+                        &bytes_vec,
+                        &url_for_extract,
+                        &sha_for_extract,
+                    )
+                    .map_err(|e| Error::Registry(name_for_extract.clone(), e.to_string()))?;
+                    let pkg_root = match &subpath_for_extract {
+                        Some(sub) => clone_dir.join(sub),
+                        None => clone_dir.clone(),
+                    };
+                    let manifest_bytes =
+                        std::fs::read(pkg_root.join("package.json")).map_err(|e| {
+                            let where_ = subpath_for_extract
+                                .as_deref()
+                                .map(|s| format!(" at /{s}"))
+                                .unwrap_or_default();
+                            Error::Registry(
+                                name_for_extract.clone(),
+                                format!("read package.json in codeload extract{where_}: {e}"),
+                            )
+                        })?;
+                    let pj: aube_manifest::PackageJson = serde_json::from_slice(&manifest_bytes)
+                        .map_err(|e| Error::Registry(name_for_extract.clone(), e.to_string()))?;
+                    let version = pj.version.unwrap_or_else(|| "0.0.0".to_string());
+                    Ok((resolved, version, pj.dependencies))
+                })
+                .await
+                .map_err(|e| {
+                    Error::Registry(name.to_string(), format!("codeload extract panicked: {e}"))
+                })??;
+                return Ok((
+                    LocalSource::Git(aube_lockfile::GitSource {
+                        url: original_url,
+                        committish,
+                        resolved: extracted.0,
+                        subpath,
+                    }),
+                    extracted.1,
+                    extracted.2,
+                ));
+            }
+            Err(e) => {
+                // Codeload 404s on private repos (it doesn't accept
+                // npm-registry auth) — fall through to `git
+                // clone`, which inherits the user's git credential
+                // helper / ssh keys for private access.
+                tracing::debug!(
+                    name,
+                    url = %aube_util::url::redact_url(url_to_fetch),
+                    "codeload fetch failed, falling back to git clone: {e}",
+                );
+            }
+        }
+    }
+
+    // Fallback: shallow git clone over the rewritten HTTPS URL (or the
+    // original URL for non-hosted hosts). Same `spawn_blocking` dance
+    // the original implementation used.
+    let runtime_url_for_clone = runtime_url;
+    let original_url_for_lockfile = original_url.clone();
+    let resolved_sha_for_clone = resolved_sha.clone();
+    let subpath_for_clone = subpath.clone();
+    let name_for_clone = name.to_string();
     let (local, version, deps) = tokio::task::spawn_blocking(move || -> Result<_, Error> {
-        // `git_resolve_ref` resolves branch / tag / HEAD names to a
-        // 40-char SHA via `ls-remote`, but passes hex prefixes (i.e.
-        // user-written abbreviated commit SHAs) through unchanged
-        // because abbreviated commits aren't advertised as refs. The
-        // canonical full SHA is recovered from `git_shallow_clone`'s
-        // post-checkout `rev-parse HEAD`, so the lockfile always
-        // pins the full form.
-        let resolve_seed = aube_store::git_resolve_ref(&url, committish.as_deref())
-            .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
-        let (clone_dir, resolved) = aube_store::git_shallow_clone(&url, &resolve_seed, shallow)
-            .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
-        // `&path:/<sub>` narrows the package root to a subdirectory
-        // of the cloned repo (pnpm-compatible). The manifest, version,
-        // and transitive deps all come from the subdir's
-        // `package.json`, not the repo root's.
-        let pkg_root = match &subpath {
+        let (clone_dir, resolved) =
+            aube_store::git_shallow_clone(&runtime_url_for_clone, &resolved_sha_for_clone, shallow)
+                .map_err(|e| Error::Registry(name_for_clone.clone(), e.to_string()))?;
+        let pkg_root = match &subpath_for_clone {
             Some(sub) => clone_dir.join(sub),
             None => clone_dir.clone(),
         };
         let manifest_bytes = std::fs::read(pkg_root.join("package.json")).map_err(|e| {
-            let where_ = subpath
+            let where_ = subpath_for_clone
                 .as_deref()
                 .map(|s| format!(" at /{s}"))
                 .unwrap_or_default();
             Error::Registry(
-                name_owned.clone(),
+                name_for_clone.clone(),
                 format!("read package.json in clone{where_}: {e}"),
             )
         })?;
         let pj: aube_manifest::PackageJson = serde_json::from_slice(&manifest_bytes)
-            .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
+            .map_err(|e| Error::Registry(name_for_clone.clone(), e.to_string()))?;
         let version = pj.version.unwrap_or_else(|| "0.0.0".to_string());
-        let deps = pj.dependencies;
         Ok((
             LocalSource::Git(aube_lockfile::GitSource {
-                url,
+                url: original_url_for_lockfile,
                 committish,
                 resolved,
-                subpath,
+                subpath: subpath_for_clone,
             }),
             version,
-            deps,
+            pj.dependencies,
         ))
     })
     .await

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -367,17 +367,33 @@ pub(crate) async fn resolve_git_source(
                 .await
                 .map_err(|e| {
                     Error::Registry(name.to_string(), format!("codeload extract panicked: {e}"))
-                })??;
-                return Ok((
-                    LocalSource::Git(aube_lockfile::GitSource {
-                        url: original_url,
-                        committish,
-                        resolved: extracted.0,
-                        subpath,
-                    }),
-                    extracted.1,
-                    extracted.2,
-                ));
+                })?;
+                match extracted {
+                    Ok((resolved, version, deps)) => {
+                        return Ok((
+                            LocalSource::Git(aube_lockfile::GitSource {
+                                url: original_url,
+                                committish,
+                                resolved,
+                                subpath,
+                            }),
+                            version,
+                            deps,
+                        ));
+                    }
+                    Err(e) => {
+                        // Mirror the installer: a corrupt or
+                        // unexpectedly-shaped tarball (CDN hiccup,
+                        // unsafe-path rejection, Windows symlink) falls
+                        // through to `git clone`, which inherits the
+                        // user's git credential helper and can write
+                        // symlinks via git's admin-aware path.
+                        tracing::debug!(
+                            name,
+                            "codeload extract failed, falling back to git clone: {e}",
+                        );
+                    }
+                }
             }
             Err(e) => {
                 // Codeload 404s on private repos (it doesn't accept

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -671,7 +671,7 @@ impl Resolver {
                     {
                         let shallow = aube_store::git_host_in_list(&g.url, &self.git_shallow_hosts);
                         let (resolved_local, version, deps) =
-                            resolve_git_source(&task.name, g, shallow)
+                            resolve_git_source(&task.name, g, shallow, Some(self.client.as_ref()))
                                 .await
                                 .map_err(|e| {
                                     Error::Registry(

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1690,6 +1690,24 @@ pub fn extract_codeload_tarball(
     url: &str,
     commit: &str,
 ) -> Result<(PathBuf, String), Error> {
+    let git_root = crate::dirs::cache_dir()
+        .map(|d| d.join("git"))
+        .unwrap_or_else(std::env::temp_dir);
+    extract_codeload_tarball_at(&git_root, bytes, url, commit)
+}
+
+/// Inner form of [`extract_codeload_tarball`] that takes the cache
+/// root explicitly. Public callers go through the wrapper above so
+/// the cache root resolution is uniform; tests pass an in-test
+/// `tempfile::tempdir()` directly to avoid mutating `XDG_CACHE_HOME`,
+/// which `cargo test`'s default parallel scheduling would race
+/// across multiple tests in the same binary.
+fn extract_codeload_tarball_at(
+    git_root: &Path,
+    bytes: &[u8],
+    url: &str,
+    commit: &str,
+) -> Result<(PathBuf, String), Error> {
     use std::io::Read;
     validate_git_positional(url, "git url")?;
     validate_git_positional(commit, "git commit")?;
@@ -1700,15 +1718,11 @@ pub fn extract_codeload_tarball(
     }
     let head_sha = commit.to_ascii_lowercase();
 
-    let git_root = crate::dirs::cache_dir()
-        .map(|d| d.join("git"))
-        .unwrap_or_else(std::env::temp_dir);
-    std::fs::create_dir_all(&git_root).map_err(|e| Error::Io(git_root.clone(), e))?;
+    std::fs::create_dir_all(git_root).map_err(|e| Error::Io(git_root.to_path_buf(), e))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        if let Err(e) = std::fs::set_permissions(&git_root, std::fs::Permissions::from_mode(0o700))
-        {
+        if let Err(e) = std::fs::set_permissions(git_root, std::fs::Permissions::from_mode(0o700)) {
             warn!(
                 "failed to chmod 0700 {}: {e}. Git scratch dir may be world-accessible, check filesystem permissions",
                 git_root.display()
@@ -1742,8 +1756,8 @@ pub fn extract_codeload_tarball(
     // `git_shallow_clone`'s scratch dance.
     let scratch = tempfile::Builder::new()
         .prefix(&format!("aube-codeload-{key}-{short}."))
-        .tempdir_in(&git_root)
-        .map_err(|e| Error::Io(git_root.clone(), e))?
+        .tempdir_in(git_root)
+        .map_err(|e| Error::Io(git_root.to_path_buf(), e))?
         .keep();
 
     let extract_into = |target: &Path| -> Result<(), Error> {
@@ -1868,11 +1882,24 @@ pub fn extract_codeload_tarball(
                         .map_err(|e| Error::Io(dest.clone(), e))?;
                     #[cfg(windows)]
                     {
-                        // Windows symlink creation requires elevated
-                        // privileges; a git tarball that smuggles
-                        // symlinks shouldn't break install on Windows.
-                        let _ = link_target;
-                        let _ = dest;
+                        // Windows symlink creation requires SeCreateSymbolicLink
+                        // (Developer Mode or admin), which most install hosts
+                        // lack. Silently dropping the entry would leave a
+                        // half-extracted tree that the linker would walk
+                        // straight into a "missing file" error several
+                        // layers down with no breadcrumbs back to the git
+                        // dep that's actually broken. Surface it now —
+                        // packages that genuinely need symlinks can fall
+                        // through to the `git clone` path on the next
+                        // install attempt by removing the cached extract,
+                        // since `git clone` materializes symlinks via
+                        // git's own (admin-aware) write path.
+                        return Err(Error::Tar(format!(
+                            "tarball symlink {} -> {} not supported on Windows; \
+                             remove the codeload cache entry and retry to fall back to `git clone`",
+                            raw_path.display(),
+                            link_target.display()
+                        )));
                     }
                 }
                 _ => {
@@ -2664,15 +2691,13 @@ mod tests {
 
     #[test]
     fn extract_codeload_tarball_strips_wrapper_and_caches() {
+        // Each test gets its own private cache root via `tempfile`,
+        // so the three new codeload tests don't race on a process-wide
+        // `XDG_CACHE_HOME` mutation under `cargo test`'s default
+        // parallel scheduling. Windows surfaces the race as a
+        // PermissionDenied on a sibling test's already-dropped temp
+        // dir; Linux happens to schedule us out of it.
         let tmp = tempfile::tempdir().unwrap();
-        // Sandbox `cache_dir()` so the test cannot pollute the user's
-        // real `$XDG_CACHE_HOME/aube/`.
-        // SAFETY: tests run serially within this binary; `set_var`
-        // here only races with parallel `cargo test --test-threads`,
-        // and a contended XDG_CACHE_HOME is the worst-case outcome
-        // (test reads from a sibling test's cache dir).
-        unsafe { std::env::set_var("XDG_CACHE_HOME", tmp.path()) };
-
         let sha = "abcdef0123456789abcdef0123456789abcdef01";
         let wrapper = format!("owner-repo-{}", &sha[..7]);
         let bytes = build_codeload_tarball(
@@ -2683,7 +2708,7 @@ mod tests {
             ],
         );
         let url = "https://github.com/owner/repo.git";
-        let (target, head) = extract_codeload_tarball(&bytes, url, sha).unwrap();
+        let (target, head) = extract_codeload_tarball_at(tmp.path(), &bytes, url, sha).unwrap();
         assert_eq!(head, sha);
         // Wrapper component is stripped — `package.json` lives at the
         // target root, not under `target/<wrapper>/package.json`.
@@ -2693,14 +2718,13 @@ mod tests {
 
         // Second call with the same (url, commit) reuses the cached
         // directory rather than re-extracting.
-        let (target2, _) = extract_codeload_tarball(&bytes, url, sha).unwrap();
+        let (target2, _) = extract_codeload_tarball_at(tmp.path(), &bytes, url, sha).unwrap();
         assert_eq!(target, target2);
     }
 
     #[test]
     fn extract_codeload_tarball_rejects_unsafe_paths() {
         let tmp = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("XDG_CACHE_HOME", tmp.path()) };
         let sha = "1111111111111111111111111111111111111111";
         // The tar crate's safe `set_path` rejects `..` paths up front,
         // so a crafted archive must be assembled with the header name
@@ -2722,7 +2746,8 @@ mod tests {
         let mut ar = tar::Builder::new(gz);
         ar.append(&h, &body[..]).unwrap();
         let bytes = ar.into_inner().unwrap().finish().unwrap();
-        let err = extract_codeload_tarball(&bytes, "https://example.com/r.git", sha).unwrap_err();
+        let err = extract_codeload_tarball_at(tmp.path(), &bytes, "https://example.com/r.git", sha)
+            .unwrap_err();
         assert!(
             matches!(err, Error::Tar(ref m) if m.contains("unsafe")),
             "expected Error::Tar with unsafe-path message, got {err:?}",
@@ -2736,10 +2761,10 @@ mod tests {
         // Branch / tag / abbreviated values must be pinned by an
         // upstream `git ls-remote` before reaching here.
         let tmp = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("XDG_CACHE_HOME", tmp.path()) };
         let bytes = build_codeload_tarball("wrapper", &[("ok", b"ok")]);
         let err =
-            extract_codeload_tarball(&bytes, "https://example.com/r.git", "abc1234").unwrap_err();
+            extract_codeload_tarball_at(tmp.path(), &bytes, "https://example.com/r.git", "abc1234")
+                .unwrap_err();
         assert!(matches!(err, Error::Git(ref m) if m.contains("40-char")));
     }
 

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1696,6 +1696,59 @@ pub fn extract_codeload_tarball(
     extract_codeload_tarball_at(&git_root, bytes, url, commit)
 }
 
+/// Return the cached codeload extract for `(url, commit)` without
+/// touching the network. Callers should consult this *before*
+/// downloading a codeload tarball — once the resolver has populated
+/// the cache during BFS, the install-time materialization should
+/// reuse it instead of paying a second HTTPS round-trip only to have
+/// `extract_codeload_tarball` short-circuit and discard the bytes.
+/// Mirrors `git_shallow_clone`'s top-of-function fast path.
+///
+/// Returns `None` for any input that couldn't possibly correspond to
+/// a cached entry — invalid URL/commit shapes, abbreviated SHAs, no
+/// resolvable cache root — so callers can chain straight into the
+/// fetch path on `None` without untangling an `Err`.
+pub fn codeload_cache_lookup(url: &str, commit: &str) -> Option<(PathBuf, String)> {
+    let git_root = crate::dirs::cache_dir()
+        .map(|d| d.join("git"))
+        .unwrap_or_else(std::env::temp_dir);
+    let (target, head_sha) = codeload_cache_paths(&git_root, url, commit)?;
+    target.is_dir().then_some((target, head_sha))
+}
+
+/// Compute the deterministic `(target, head_sha)` pair for a
+/// `(url, commit)` cache lookup, without touching the FS. Returns
+/// `None` for any input shape that `extract_codeload_tarball` would
+/// reject with `Err`, so the lookup and write paths agree on which
+/// inputs even *can* have a cache entry.
+fn codeload_cache_paths(cache_root: &Path, url: &str, commit: &str) -> Option<(PathBuf, String)> {
+    if validate_git_positional(url, "git url").is_err()
+        || validate_git_positional(commit, "git commit").is_err()
+    {
+        return None;
+    }
+    if commit.len() != 40 || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let head_sha = commit.to_ascii_lowercase();
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(url.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(head_sha.as_bytes());
+    let digest = hasher.finalize();
+    let key: String = digest
+        .as_bytes()
+        .iter()
+        .take(8)
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    let short = head_sha[..12].to_string();
+    Some((
+        cache_root.join(format!("aube-codeload-{key}-{short}")),
+        head_sha,
+    ))
+}
+
 /// Inner form of [`extract_codeload_tarball`] that takes the cache
 /// root explicitly. Public callers go through the wrapper above so
 /// the cache root resolution is uniform; tests pass an in-test
@@ -1709,14 +1762,16 @@ fn extract_codeload_tarball_at(
     commit: &str,
 ) -> Result<(PathBuf, String), Error> {
     use std::io::Read;
-    validate_git_positional(url, "git url")?;
-    validate_git_positional(commit, "git commit")?;
-    if commit.len() != 40 || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(Error::Git(format!(
-            "extract_codeload_tarball: commit must be a full 40-char SHA, got {commit}"
-        )));
-    }
-    let head_sha = commit.to_ascii_lowercase();
+    let (target, head_sha) = codeload_cache_paths(git_root, url, commit).ok_or_else(|| {
+        Error::Git(format!(
+            "extract_codeload_tarball: invalid (url, commit) — commit must be a full 40-char SHA, got {commit}"
+        ))
+    })?;
+    let key_short = target
+        .file_name()
+        .and_then(|s| s.to_str())
+        .and_then(|s| s.strip_prefix("aube-codeload-"))
+        .unwrap_or("");
 
     std::fs::create_dir_all(git_root).map_err(|e| Error::Io(git_root.to_path_buf(), e))?;
     #[cfg(unix)]
@@ -1730,20 +1785,6 @@ fn extract_codeload_tarball_at(
         }
     }
 
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(url.as_bytes());
-    hasher.update(b"\0");
-    hasher.update(head_sha.as_bytes());
-    let digest = hasher.finalize();
-    let key: String = digest
-        .as_bytes()
-        .iter()
-        .take(8)
-        .map(|b| format!("{b:02x}"))
-        .collect();
-    let short = head_sha[..12].to_string();
-    let target = git_root.join(format!("aube-codeload-{key}-{short}"));
-
     // Reuse a prior successful extraction for this exact (url, commit).
     // The atomic-rename pattern below makes a populated `target` always
     // a complete tree — no half-extracted state to worry about.
@@ -1755,7 +1796,7 @@ fn extract_codeload_tarball_at(
     // failure-recovery and concurrent-install reasoning as
     // `git_shallow_clone`'s scratch dance.
     let scratch = tempfile::Builder::new()
-        .prefix(&format!("aube-codeload-{key}-{short}."))
+        .prefix(&format!("aube-codeload-{key_short}."))
         .tempdir_in(git_root)
         .map_err(|e| Error::Io(git_root.to_path_buf(), e))?
         .keep();
@@ -2720,6 +2761,59 @@ mod tests {
         // directory rather than re-extracting.
         let (target2, _) = extract_codeload_tarball_at(tmp.path(), &bytes, url, sha).unwrap();
         assert_eq!(target, target2);
+    }
+
+    #[test]
+    fn codeload_cache_lookup_returns_target_only_after_extract() {
+        // Lookup must only report `Some` once the cache directory
+        // exists, so callers can use it to skip the HTTPS round-trip
+        // on resolver→installer reuse without falsely short-circuiting
+        // before the bytes have ever been fetched.
+        let tmp = tempfile::tempdir().unwrap();
+        let sha = "fedcba9876543210fedcba9876543210fedcba98";
+        let wrapper = format!("owner-repo-{}", &sha[..7]);
+        let url = "https://github.com/owner/repo.git";
+        let bytes = build_codeload_tarball(
+            &wrapper,
+            &[("package.json", br#"{"name":"x","version":"0.0.1"}"#)],
+        );
+
+        // Pre-extract miss.
+        let (expected_target, expected_sha) = codeload_cache_paths(tmp.path(), url, sha).unwrap();
+        assert!(!expected_target.exists());
+        // The public lookup uses the real `dirs::cache_dir()` so the
+        // test path can't drive it directly. Instead, drive the inner
+        // helper through the cache_paths function and verify the
+        // exists check parallels the `is_dir` filter `codeload_cache_lookup`
+        // applies. After extract, the lookup-equivalent must succeed.
+        let (target, head) = extract_codeload_tarball_at(tmp.path(), &bytes, url, sha).unwrap();
+        assert_eq!(target, expected_target);
+        assert_eq!(head, expected_sha);
+        assert!(target.is_dir(), "extract must populate the cache target");
+        // A second `extract_codeload_tarball_at` (the equivalent of a
+        // post-resolver install-time call) reuses the same dir without
+        // re-extracting — same cache path comes back.
+        let (target2, _) = extract_codeload_tarball_at(tmp.path(), &bytes, url, sha).unwrap();
+        assert_eq!(target, target2);
+    }
+
+    #[test]
+    fn codeload_cache_paths_rejects_invalid_inputs() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Abbreviated SHA — codeload extracts can't be verified for
+        // non-full-SHA committishes, so the cache key would be ambiguous.
+        assert!(codeload_cache_paths(tmp.path(), "https://example.com/r.git", "abc1234").is_none());
+        // Dash-prefixed URL — `validate_git_positional` rejects.
+        assert!(
+            codeload_cache_paths(
+                tmp.path(),
+                "--upload-pack=/tmp/evil",
+                "abcdef0123456789abcdef0123456789abcdef01"
+            )
+            .is_none()
+        );
+        // Branch name — not a SHA.
+        assert!(codeload_cache_paths(tmp.path(), "https://example.com/r.git", "main").is_none());
     }
 
     #[test]

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1666,6 +1666,250 @@ fn canonicalize_clone_dir(
     }
 }
 
+/// Extract a codeload-style HTTPS tarball (e.g. the bytes of a GET to
+/// `https://codeload.github.com/<owner>/<repo>/tar.gz/<sha>`) into a
+/// deterministic per-(url, commit) cache directory and return a path
+/// shaped like `git_shallow_clone`'s output: the extracted tree at
+/// the top level, with the `<owner>-<repo>-<sha>/` wrapper component
+/// codeload adds stripped off so callers can join `subpath` and read
+/// `package.json` exactly the same way they do for a clone.
+///
+/// `commit` must be a 40-char SHA — codeload tarballs do not embed
+/// `.git/`, so there is no post-extraction `rev-parse HEAD` to verify
+/// the extracted tree is the requested commit. The lockfile resolver
+/// (or an upstream `git ls-remote`) is responsible for pinning a SHA
+/// before this is called. The returned `head_sha` is `commit`
+/// lowercased.
+///
+/// Cache layout uses a separate `aube-codeload-` prefix from the
+/// `aube-git-` prefix `git_shallow_clone` writes, so a per-dep
+/// fallback from one path to the other doesn't trip on the other
+/// caller's marker files.
+pub fn extract_codeload_tarball(
+    bytes: &[u8],
+    url: &str,
+    commit: &str,
+) -> Result<(PathBuf, String), Error> {
+    use std::io::Read;
+    validate_git_positional(url, "git url")?;
+    validate_git_positional(commit, "git commit")?;
+    if commit.len() != 40 || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(Error::Git(format!(
+            "extract_codeload_tarball: commit must be a full 40-char SHA, got {commit}"
+        )));
+    }
+    let head_sha = commit.to_ascii_lowercase();
+
+    let git_root = crate::dirs::cache_dir()
+        .map(|d| d.join("git"))
+        .unwrap_or_else(std::env::temp_dir);
+    std::fs::create_dir_all(&git_root).map_err(|e| Error::Io(git_root.clone(), e))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) = std::fs::set_permissions(&git_root, std::fs::Permissions::from_mode(0o700))
+        {
+            warn!(
+                "failed to chmod 0700 {}: {e}. Git scratch dir may be world-accessible, check filesystem permissions",
+                git_root.display()
+            );
+        }
+    }
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(url.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(head_sha.as_bytes());
+    let digest = hasher.finalize();
+    let key: String = digest
+        .as_bytes()
+        .iter()
+        .take(8)
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    let short = head_sha[..12].to_string();
+    let target = git_root.join(format!("aube-codeload-{key}-{short}"));
+
+    // Reuse a prior successful extraction for this exact (url, commit).
+    // The atomic-rename pattern below makes a populated `target` always
+    // a complete tree — no half-extracted state to worry about.
+    if target.is_dir() {
+        return Ok((target, head_sha));
+    }
+
+    // Extract into a scratch dir and atomic-rename into place. Same
+    // failure-recovery and concurrent-install reasoning as
+    // `git_shallow_clone`'s scratch dance.
+    let scratch = tempfile::Builder::new()
+        .prefix(&format!("aube-codeload-{key}-{short}."))
+        .tempdir_in(&git_root)
+        .map_err(|e| Error::Io(git_root.clone(), e))?
+        .keep();
+
+    let extract_into = |target: &Path| -> Result<(), Error> {
+        let gz = flate2::read::GzDecoder::new(bytes);
+        let capped = CappedReader::new(gz, MAX_TARBALL_DECOMPRESSED_BYTES);
+        let buffered = std::io::BufReader::with_capacity(256 * 1024, capped);
+        let mut archive = tar::Archive::new(buffered);
+        let mut entries_seen: usize = 0;
+        for entry in archive.entries().map_err(|e| Error::Tar(e.to_string()))? {
+            entries_seen += 1;
+            if entries_seen > MAX_TARBALL_ENTRIES {
+                return Err(Error::Tar(format!(
+                    "tarball exceeds entry cap of {MAX_TARBALL_ENTRIES}"
+                )));
+            }
+            let mut entry = entry.map_err(|e| Error::Tar(e.to_string()))?;
+            let entry_type = entry.header().entry_type();
+            // Codeload archives carry directories, regular files, and
+            // (rarely) symlinks. Reject everything else for the same
+            // reason `import_tarball` does — the linker imports this
+            // tree into the store and we don't want the same node-tar
+            // CVE class biting us through the git path.
+            if matches!(
+                entry_type,
+                tar::EntryType::XGlobalHeader | tar::EntryType::XHeader
+            ) {
+                continue;
+            }
+            let raw_path = entry
+                .path()
+                .map_err(|e| Error::Tar(e.to_string()))?
+                .to_path_buf();
+            // Strip the leading `<owner>-<repo>-<sha>/` wrapper
+            // codeload prepends. If an entry is at depth 0 (the
+            // wrapper directory itself) just create the target dir;
+            // if at depth >= 1 lop off the first component.
+            let mut comps = raw_path.components();
+            let _wrapper = comps.next();
+            let rel: PathBuf = comps.collect();
+            if rel.as_os_str().is_empty() {
+                continue;
+            }
+            // Reject any path that would escape the target (`..`,
+            // absolute) — `tar::Entry::unpack` does this internally
+            // but we're materializing manually so it's our job.
+            for c in rel.components() {
+                use std::path::Component;
+                if !matches!(c, Component::Normal(_)) {
+                    return Err(Error::Tar(format!(
+                        "tarball entry has unsafe path component: {}",
+                        raw_path.display()
+                    )));
+                }
+            }
+            let dest = target.join(&rel);
+            if entry_type.is_dir() {
+                std::fs::create_dir_all(&dest).map_err(|e| Error::Io(dest.clone(), e))?;
+                continue;
+            }
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.to_path_buf(), e))?;
+            }
+            match entry_type {
+                tar::EntryType::Regular | tar::EntryType::Continuous => {
+                    let declared = entry
+                        .header()
+                        .size()
+                        .map_err(|e| Error::Tar(e.to_string()))?;
+                    if declared > MAX_TARBALL_ENTRY_BYTES {
+                        return Err(Error::Tar(format!(
+                            "tarball entry exceeds per-entry cap: {declared} bytes > {MAX_TARBALL_ENTRY_BYTES}"
+                        )));
+                    }
+                    let mut out =
+                        std::fs::File::create(&dest).map_err(|e| Error::Io(dest.clone(), e))?;
+                    let mut limited = entry.by_ref().take(MAX_TARBALL_ENTRY_BYTES);
+                    std::io::copy(&mut limited, &mut out)
+                        .map_err(|e| Error::Io(dest.clone(), e))?;
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        if let Ok(mode) = entry.header().mode() {
+                            // Mask to 0o755 / 0o644 — codeload archives
+                            // sometimes carry executable bits; preserve
+                            // them so build scripts work, but never
+                            // honor setuid/setgid/sticky.
+                            let safe = if mode & 0o111 != 0 { 0o755 } else { 0o644 };
+                            let _ = std::fs::set_permissions(
+                                &dest,
+                                std::fs::Permissions::from_mode(safe),
+                            );
+                        }
+                    }
+                }
+                tar::EntryType::Symlink => {
+                    let link_target = entry
+                        .link_name()
+                        .map_err(|e| Error::Tar(e.to_string()))?
+                        .ok_or_else(|| Error::Tar("symlink without target".into()))?
+                        .into_owned();
+                    // Reject absolute or `..`-laden symlink targets so
+                    // a hostile archive can't plant a link out of the
+                    // extraction tree. The store-import pass would
+                    // then resolve the link inside the prepared dir
+                    // and read whatever the attacker pointed at.
+                    if link_target.is_absolute()
+                        || link_target.components().any(|c| {
+                            matches!(
+                                c,
+                                std::path::Component::ParentDir | std::path::Component::RootDir
+                            )
+                        })
+                    {
+                        return Err(Error::Tar(format!(
+                            "tarball symlink {} -> {} escapes target",
+                            raw_path.display(),
+                            link_target.display()
+                        )));
+                    }
+                    #[cfg(unix)]
+                    std::os::unix::fs::symlink(&link_target, &dest)
+                        .map_err(|e| Error::Io(dest.clone(), e))?;
+                    #[cfg(windows)]
+                    {
+                        // Windows symlink creation requires elevated
+                        // privileges; a git tarball that smuggles
+                        // symlinks shouldn't break install on Windows.
+                        let _ = link_target;
+                        let _ = dest;
+                    }
+                }
+                _ => {
+                    return Err(Error::Tar(format!(
+                        "tarball entry type {entry_type:?} is not allowed"
+                    )));
+                }
+            }
+        }
+        Ok(())
+    };
+
+    if let Err(e) = extract_into(&scratch) {
+        let _ = std::fs::remove_dir_all(&scratch);
+        return Err(e);
+    }
+
+    match aube_util::fs_atomic::rename_with_retry(&scratch, &target) {
+        Ok(()) => Ok((target, head_sha)),
+        Err(_) => {
+            // Two concurrent extracts of the same (url, commit) — the
+            // loser sees `target` already populated. Drop the loser's
+            // scratch and reuse the winner's directory.
+            if target.is_dir() {
+                let _ = std::fs::remove_dir_all(&scratch);
+                return Ok((target, head_sha));
+            }
+            let _ = std::fs::remove_dir_all(&target);
+            aube_util::fs_atomic::rename_with_retry(&scratch, &target).map_err(|e| {
+                let _ = std::fs::remove_dir_all(&scratch);
+                Error::Git(format!("rename codeload extract into place: {e}"))
+            })?;
+            Ok((target, head_sha))
+        }
+    }
+}
+
 fn git_commit_matches(actual: &str, requested: &str) -> bool {
     actual == requested
         || (requested.len() >= 7
@@ -2390,6 +2634,113 @@ mod tests {
         assert!(!git_commit_matches(full, "0b6ea5"));
         assert!(!git_commit_matches(full, "abc1234"));
         assert!(!git_commit_matches(full, "main"));
+    }
+
+    /// Build a minimal codeload-style `.tar.gz`: a wrapper directory
+    /// `<wrapper>/` followed by a few file entries inside it. Mirrors
+    /// the layout `https://codeload.github.com/<owner>/<repo>/tar.gz/<sha>`
+    /// produces in the wild.
+    fn build_codeload_tarball(wrapper: &str, files: &[(&str, &[u8])]) -> Vec<u8> {
+        let gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut ar = tar::Builder::new(gz);
+        let mut dh = tar::Header::new_gnu();
+        dh.set_path(format!("{wrapper}/")).unwrap();
+        dh.set_size(0);
+        dh.set_mode(0o755);
+        dh.set_entry_type(tar::EntryType::Directory);
+        dh.set_cksum();
+        ar.append(&dh, std::io::empty()).unwrap();
+        for (path, content) in files {
+            let mut h = tar::Header::new_gnu();
+            h.set_path(format!("{wrapper}/{path}")).unwrap();
+            h.set_size(content.len() as u64);
+            h.set_mode(0o644);
+            h.set_cksum();
+            ar.append(&h, *content).unwrap();
+        }
+        let gz = ar.into_inner().unwrap();
+        gz.finish().unwrap()
+    }
+
+    #[test]
+    fn extract_codeload_tarball_strips_wrapper_and_caches() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Sandbox `cache_dir()` so the test cannot pollute the user's
+        // real `$XDG_CACHE_HOME/aube/`.
+        // SAFETY: tests run serially within this binary; `set_var`
+        // here only races with parallel `cargo test --test-threads`,
+        // and a contended XDG_CACHE_HOME is the worst-case outcome
+        // (test reads from a sibling test's cache dir).
+        unsafe { std::env::set_var("XDG_CACHE_HOME", tmp.path()) };
+
+        let sha = "abcdef0123456789abcdef0123456789abcdef01";
+        let wrapper = format!("owner-repo-{}", &sha[..7]);
+        let bytes = build_codeload_tarball(
+            &wrapper,
+            &[
+                ("package.json", br#"{"name":"x","version":"0.0.1"}"#),
+                ("src/index.js", b"module.exports = 1;\n"),
+            ],
+        );
+        let url = "https://github.com/owner/repo.git";
+        let (target, head) = extract_codeload_tarball(&bytes, url, sha).unwrap();
+        assert_eq!(head, sha);
+        // Wrapper component is stripped — `package.json` lives at the
+        // target root, not under `target/<wrapper>/package.json`.
+        assert!(target.join("package.json").is_file());
+        assert!(target.join("src/index.js").is_file());
+        assert!(!target.join(&wrapper).exists());
+
+        // Second call with the same (url, commit) reuses the cached
+        // directory rather than re-extracting.
+        let (target2, _) = extract_codeload_tarball(&bytes, url, sha).unwrap();
+        assert_eq!(target, target2);
+    }
+
+    #[test]
+    fn extract_codeload_tarball_rejects_unsafe_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("XDG_CACHE_HOME", tmp.path()) };
+        let sha = "1111111111111111111111111111111111111111";
+        // The tar crate's safe `set_path` rejects `..` paths up front,
+        // so a crafted archive must be assembled with the header name
+        // field written directly. This mirrors what a hostile
+        // codeload mirror could serve, and verifies our component
+        // check catches it before any byte lands on disk.
+        let body = b"pwn";
+        let mut h = tar::Header::new_gnu();
+        h.set_size(body.len() as u64);
+        h.set_mode(0o644);
+        h.set_entry_type(tar::EntryType::Regular);
+        // GNU header `name[100]` — write directly to skip set_path's
+        // safety filter.
+        let raw = b"wrapper/../escape.txt";
+        let name = &mut h.as_gnu_mut().unwrap().name;
+        name[..raw.len()].copy_from_slice(raw);
+        h.set_cksum();
+        let gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut ar = tar::Builder::new(gz);
+        ar.append(&h, &body[..]).unwrap();
+        let bytes = ar.into_inner().unwrap().finish().unwrap();
+        let err = extract_codeload_tarball(&bytes, "https://example.com/r.git", sha).unwrap_err();
+        assert!(
+            matches!(err, Error::Tar(ref m) if m.contains("unsafe")),
+            "expected Error::Tar with unsafe-path message, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn extract_codeload_tarball_rejects_short_commit() {
+        // The cache layout assumes `commit` is the canonical 40-hex
+        // SHA, both for the cache key and as the returned head_sha.
+        // Branch / tag / abbreviated values must be pinned by an
+        // upstream `git ls-remote` before reaching here.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("XDG_CACHE_HOME", tmp.path()) };
+        let bytes = build_codeload_tarball("wrapper", &[("ok", b"ok")]);
+        let err =
+            extract_codeload_tarball(&bytes, "https://example.com/r.git", "abc1234").unwrap_err();
+        assert!(matches!(err, Error::Git(ref m) if m.contains("40-char")));
     }
 
     #[test]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -483,8 +483,18 @@ pub(super) async fn import_local_source(
                 .unwrap_or_else(|| url.clone());
             let codeload_url = hosted.as_ref().and_then(|h| h.tarball_url(&resolved));
 
-            let mut clone_dir: Option<std::path::PathBuf> = None;
-            if let (Some(c), Some(url_to_fetch)) = (client, codeload_url.as_deref()) {
+            // Cache hit fast path: skip the HTTPS round-trip when the
+            // resolver already populated the codeload cache for this
+            // (url, commit) pair earlier in the install. Mirrors
+            // `git_shallow_clone`'s top-of-function reuse check.
+            let mut clone_dir: Option<std::path::PathBuf> = if codeload_url.is_some() {
+                aube_store::codeload_cache_lookup(&url, &resolved).map(|(dir, _)| dir)
+            } else {
+                None
+            };
+            if clone_dir.is_none()
+                && let (Some(c), Some(url_to_fetch)) = (client, codeload_url.as_deref())
+            {
                 match c.fetch_tarball_bytes(url_to_fetch).await {
                     Ok(bytes) => {
                         let bytes_vec = bytes.to_vec();

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -451,28 +451,88 @@ pub(super) async fn import_local_source(
             Ok(Some(index))
         }
         LocalSource::Git(g) => {
-            // Shallow-clone into a temp directory and hardlink-import
-            // into the store exactly like a `file:` directory. The
-            // resolver already pinned `g.resolved` to a full commit
-            // SHA, and `git_shallow_clone` is keyed by url+commit —
-            // if the resolver already cloned this (url, sha) pair
-            // during BFS, the call short-circuits and we reuse the
-            // existing checkout instead of cloning twice.
+            // Materialize the git dep into a commit-keyed cache
+            // directory and hardlink-import into the store exactly
+            // like a `file:` directory. The resolver already pinned
+            // `g.resolved` to a full commit SHA, so we route through
+            // the same hosted-tarball-then-clone fallback npm and
+            // pnpm use:
             //
-            // The clone shells out to `git` and does network I/O
-            // that can take multiple seconds, so hand it off to
-            // `spawn_blocking` instead of stalling whatever async
-            // task the install loop is driving.
+            //   1. github / gitlab / bitbucket public reads → a flat
+            //      HTTPS tarball over codeload (no `git` binary, no
+            //      SSH key required).
+            //   2. Anything else, plus codeload errors → shallow
+            //      `git clone` over HTTPS (rewritten from the stored
+            //      lockfile URL when the host is hosted, so an
+            //      `git+ssh://git@github.com/…` lockfile still works
+            //      on a host with no SSH key).
+            //   3. Non-hosted hosts → unchanged: clone whatever URL
+            //      the lockfile recorded, preserving SSH-only setups.
+            //
+            // Both the codeload extract and the clone share the
+            // `(url, commit)` cache so the resolver's earlier call
+            // for the same dep doesn't pay the network round-trip
+            // twice.
             let url = g.url.clone();
             let resolved = g.resolved.clone();
             let spec = local.specifier();
-            let shallow = aube_store::git_host_in_list(&url, git_shallow_hosts);
-            let (clone_dir, _head_sha) = tokio::task::spawn_blocking(move || {
-                aube_store::git_shallow_clone(&url, &resolved, shallow)
-            })
-            .await
-            .map_err(|e| miette!("git clone task panicked: {e}"))?
-            .map_err(|e| miette!("failed to clone {spec}: {e}"))?;
+            let hosted = aube_lockfile::parse_hosted_git(&url);
+            let runtime_url = hosted
+                .as_ref()
+                .map(|h| h.https_url())
+                .unwrap_or_else(|| url.clone());
+            let codeload_url = hosted.as_ref().and_then(|h| h.tarball_url(&resolved));
+
+            let mut clone_dir: Option<std::path::PathBuf> = None;
+            if let (Some(c), Some(url_to_fetch)) = (client, codeload_url.as_deref()) {
+                match c.fetch_tarball_bytes(url_to_fetch).await {
+                    Ok(bytes) => {
+                        let bytes_vec = bytes.to_vec();
+                        let url_for_extract = url.clone();
+                        let resolved_for_extract = resolved.clone();
+                        match tokio::task::spawn_blocking(move || {
+                            aube_store::extract_codeload_tarball(
+                                &bytes_vec,
+                                &url_for_extract,
+                                &resolved_for_extract,
+                            )
+                        })
+                        .await
+                        .map_err(|e| miette!("codeload extract task panicked: {e}"))?
+                        {
+                            Ok((dir, _sha)) => clone_dir = Some(dir),
+                            Err(e) => {
+                                tracing::debug!(
+                                    %spec,
+                                    "codeload extract failed, falling back to git clone: {e}",
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            %spec,
+                            url = %aube_util::url::redact_url(url_to_fetch),
+                            "codeload fetch failed, falling back to git clone: {e}",
+                        );
+                    }
+                }
+            }
+
+            let clone_dir = if let Some(dir) = clone_dir {
+                dir
+            } else {
+                let shallow = aube_store::git_host_in_list(&runtime_url, git_shallow_hosts);
+                let url_for_clone = runtime_url.clone();
+                let resolved_for_clone = resolved.clone();
+                let (dir, _head_sha) = tokio::task::spawn_blocking(move || {
+                    aube_store::git_shallow_clone(&url_for_clone, &resolved_for_clone, shallow)
+                })
+                .await
+                .map_err(|e| miette!("git clone task panicked: {e}"))?
+                .map_err(|e| miette!("failed to clone {spec}: {e}"))?;
+                dir
+            };
 
             // `&path:/<sub>` narrows the package root to a
             // subdirectory of the cloned repo (pnpm-compatible).


### PR DESCRIPTION
## Summary

- For github / gitlab / bitbucket deps, re-derive an HTTPS URL from `(host, owner, repo, sha)` at fetch time instead of dialing whatever scheme the lockfile recorded. Matches npm `pacote` and pnpm `gitHostedTarballFetcher`.
- SHA-pinned hosted reads go through `https://codeload.github.com/<owner>/<repo>/tar.gz/<sha>` (no `git` binary, no SSH key); on any HTTP error, fall back to a shallow `git clone` over the rewritten HTTPS URL so a system git credential helper (gh CLI etc.) keeps private repos working.
- Branch / tag committishes are pinned via `git ls-remote` on the same rewritten HTTPS URL before reaching the codeload path. Non-hosted hosts (self-hosted GitLab / Gitea / arbitrary) still use the URL as written, preserving SSH-only setups.

## Why

Reported in [discussion #335](https://github.com/endevco/aube/discussions/335) as a follow-up to #338. After #338 made `package-lock.json` git deps parse correctly, aube was dialing the lockfile-canonical `git+ssh://git@github.com/…#<sha>` directly, which fails for users with HTTPS-only git auth (e.g. `gh` CLI's git credential helper, no `~/.ssh/`). npm/pnpm never dial that SSH URL — it's an identity form, not a fetch URL.

`LocalSource::Git.url` in the lockfile is preserved verbatim so cross-tool round-trip with pnpm / npm / yarn is unaffected.

## Test plan

- [x] `cargo test -p aube-lockfile -p aube-store -p aube-resolver --lib` (459 unit tests, all green)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `mise run test:bats test/git_deps.bats test/install.bats test/package_lock_write.bats` (87 / 87 pass — clone fallback path unchanged)
- [x] 5 new unit tests covering: `parse_hosted_git` across all clone-URL forms (https / ssh / git+ / scp / `github:`), per-provider codeload URL synthesis, `extract_codeload_tarball` wrapper-strip + caching, defense against `..`/absolute symlink targets in tarball entries, short-commit rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git dependency fetching/materialization and introduces new tarball extraction logic, which can affect install reliability and security if edge cases slip through. Mitigated by strict SHA gating, cache reuse, and explicit unsafe-path/symlink defenses with clone fallback.
> 
> **Overview**
> Git dependencies on GitHub/GitLab/Bitbucket are now resolved/installed using npm/pnpm-like *hosted routing*: derive a canonical `(host, owner, repo)` identity from the lockfile URL, pin refs via `git ls-remote` over derived HTTPS, then prefer fetching a provider-specific codeload-style tarball for full-SHA commits (with fallback to shallow `git clone`).
> 
> This adds a new codeload extraction cache and hardened tarball extraction path in `aube-store` (wrapper-dir stripping, atomic cache population, entry/path/symlink validation, and Windows symlink handling), and wires the new flow through both the resolver (`resolve_git_source` now takes an optional `RegistryClient`) and installer while keeping the original lockfile `url` bytes unchanged for cross-tool round-tripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bd9198fbf3d33bbf43ac0dcabd1a3f96f929df5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->