### PR TITLE
fix(linker,store): self-heal install on missing CAS shard

### DIFF
--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -401,7 +401,20 @@ pub(crate) fn link_hoisted_importer(
             // Key already validated in the parent-collection loop
             // above. The index is immutable between the two loops.
             let target = pkg_dir.join(rel_path);
-            linker.link_file_fresh(stored, &target)?;
+            if let Err(e) = linker.link_file_fresh(stored, rel_path, &target) {
+                if let Error::MissingStoreFile { .. } = &e {
+                    // Cached index references a vanished CAS shard —
+                    // drop the index JSON so the next install re-imports
+                    // the tarball. See materialize_into for the same
+                    // recovery hatch on the isolated path.
+                    let _ = linker.store.invalidate_cached_index(
+                        pkg.registry_name(),
+                        &pkg.version,
+                        pkg.integrity.as_deref(),
+                    );
+                }
+                return Err(e);
+            }
             stats.files_linked += 1;
             if stored.executable {
                 #[cfg(unix)]

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -403,15 +403,7 @@ pub(crate) fn link_hoisted_importer(
             let target = pkg_dir.join(rel_path);
             if let Err(e) = linker.link_file_fresh(stored, rel_path, &target) {
                 if let Error::MissingStoreFile { .. } = &e {
-                    // Cached index references a vanished CAS shard —
-                    // drop the index JSON so the next install re-imports
-                    // the tarball. See materialize_into for the same
-                    // recovery hatch on the isolated path.
-                    let _ = linker.store.invalidate_cached_index(
-                        pkg.registry_name(),
-                        &pkg.version,
-                        pkg.integrity.as_deref(),
-                    );
+                    crate::invalidate_stale_index_for_package(&linker.store, pkg);
                 }
                 return Err(e);
             }

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2374,7 +2374,22 @@ impl Linker {
             // above. The index is immutable between the two loops.
             let target = pkg_nm_dir.join(rel_path);
 
-            self.link_file_fresh(stored, &target)?;
+            if let Err(e) = self.link_file_fresh(stored, rel_path, &target) {
+                if let Error::MissingStoreFile { .. } = &e {
+                    // The cached index for this package points at a
+                    // CAS shard that no longer exists. Drop the
+                    // index-cache JSON so the next install re-imports
+                    // the tarball cleanly. Best-effort: if the
+                    // invalidation itself fails, surface the original
+                    // (more useful) materialize error.
+                    let _ = self.store.invalidate_cached_index(
+                        pkg.registry_name(),
+                        &pkg.version,
+                        pkg.integrity.as_deref(),
+                    );
+                }
+                return Err(e);
+            }
             stats.files_linked += 1;
 
             if stored.executable {
@@ -2493,40 +2508,63 @@ impl Linker {
     /// `remove_file(dst)` an idempotent variant would need is skipped.
     /// Eliminates one syscall per linked file (~45k on the medium
     /// benchmark fixture).
-    pub(crate) fn link_file_fresh(&self, stored: &StoredFile, dst: &Path) -> Result<(), Error> {
+    pub(crate) fn link_file_fresh(
+        &self,
+        stored: &StoredFile,
+        rel_path: &str,
+        dst: &Path,
+    ) -> Result<(), Error> {
         #[cfg(target_os = "macos")]
         const SMALL_FILE_COPY_MAX: u64 = 16 * 1024;
+        let map_io = |e: std::io::Error| classify_link_error(stored, rel_path, dst, e);
         match self.strategy {
             LinkStrategy::Reflink => {
                 #[cfg(target_os = "macos")]
                 if matches!(stored.size, Some(size) if size <= SMALL_FILE_COPY_MAX) {
-                    std::fs::copy(&stored.store_path, dst)
-                        .map_err(|e| Error::Io(dst.to_path_buf(), e))?;
+                    std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
                     return Ok(());
                 }
                 if let Err(e) = reflink_copy::reflink(&stored.store_path, dst) {
                     // Fall back to copy on cross-filesystem errors
                     trace!("reflink failed, falling back to copy: {e}");
-                    std::fs::copy(&stored.store_path, dst)
-                        .map_err(|e| Error::Io(dst.to_path_buf(), e))?;
+                    std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
                 }
             }
             LinkStrategy::Hardlink => {
                 if let Err(e) = std::fs::hard_link(&stored.store_path, dst) {
                     // Fall back to copy on cross-filesystem errors (EXDEV)
                     trace!("hardlink failed, falling back to copy: {e}");
-                    std::fs::copy(&stored.store_path, dst)
-                        .map_err(|e| Error::Io(dst.to_path_buf(), e))?;
+                    std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
                 }
             }
             LinkStrategy::Copy => {
-                std::fs::copy(&stored.store_path, dst)
-                    .map_err(|e| Error::Io(dst.to_path_buf(), e))?;
+                std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
             }
         }
 
         Ok(())
     }
+}
+
+/// Translate a copy/hardlink/reflink failure into the most informative
+/// linker error. ENOENT can mean either side of the link is missing —
+/// stat the source CAS shard to attribute it. A missing shard means the
+/// cached package index is out of sync with the on-disk store, which
+/// the caller can recover from by invalidating the cached index and
+/// re-importing the tarball.
+fn classify_link_error(
+    stored: &StoredFile,
+    rel_path: &str,
+    dst: &Path,
+    err: std::io::Error,
+) -> Error {
+    if err.kind() == std::io::ErrorKind::NotFound && !stored.store_path.exists() {
+        return Error::MissingStoreFile {
+            store_path: stored.store_path.clone(),
+            rel_path: rel_path.to_string(),
+        };
+    }
+    Error::Io(dst.to_path_buf(), err)
 }
 
 #[derive(Debug, Default)]
@@ -2562,6 +2600,13 @@ pub enum Error {
     MissingPackageIndex(String),
     #[error("refusing to materialize unsafe index key: {0:?}")]
     UnsafeIndexKey(String),
+    #[error(
+        "cached package index references a missing CAS shard at {store_path} (file: {rel_path:?}). The store and its index cache are out of sync — the cached index has been invalidated; rerun the install to re-fetch the tarball."
+    )]
+    MissingStoreFile {
+        store_path: PathBuf,
+        rel_path: String,
+    },
 }
 
 /// Defence in depth for the tarball path-traversal class. The
@@ -3601,6 +3646,53 @@ mod tests {
 
         assert_eq!(stats.packages_linked, 2);
         assert!(stats.files_linked >= 3); // foo has 2 files, bar has 1
+    }
+
+    #[test]
+    fn test_link_file_fresh_reports_missing_cas_shard_and_invalidates_cache() {
+        // Reproduces endevco/aube#393: a partially corrupt CAS leaves the
+        // cached package index pointing at a missing shard. Materialize
+        // must distinguish "source CAS file missing" from a generic ENOENT
+        // and drop the stale index JSON so the next install re-imports
+        // the tarball.
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = dir.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let (store, indices) = setup_store_with_files(dir.path());
+        // Persist foo's index so invalidate_cached_index has something
+        // to remove. Real installs save indices via the fetch path.
+        let foo_index = indices.get("foo@1.0.0").unwrap();
+        store.save_index("foo", "1.0.0", None, foo_index).unwrap();
+        let cached_path = store.index_dir().join("foo@1.0.0.json");
+        assert!(
+            cached_path.exists(),
+            "test setup: index cache must be written"
+        );
+
+        // Delete the CAS shard for foo's package.json (matches the
+        // failure mode in #393 where one shard is missing while others
+        // remain).
+        let pkgjson_store_path = foo_index.get("package.json").unwrap().store_path.clone();
+        std::fs::remove_file(&pkgjson_store_path).unwrap();
+
+        let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true);
+        let graph = make_graph();
+        let err = linker
+            .link_all(&project_dir, &graph, &indices)
+            .expect_err("link must fail when a referenced CAS shard is gone");
+        assert!(
+            matches!(&err, Error::MissingStoreFile { rel_path, .. } if rel_path == "package.json"),
+            "expected MissingStoreFile {{ rel_path: \"package.json\" }}, got {err:?}"
+        );
+
+        // Side effect: cached index dropped, so the next install will
+        // miss load_index and re-fetch instead of looping on the same
+        // dead shard reference.
+        assert!(
+            !cached_path.exists(),
+            "stale index cache must be invalidated on MissingStoreFile"
+        );
     }
 
     #[test]

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2376,17 +2376,7 @@ impl Linker {
 
             if let Err(e) = self.link_file_fresh(stored, rel_path, &target) {
                 if let Error::MissingStoreFile { .. } = &e {
-                    // The cached index for this package points at a
-                    // CAS shard that no longer exists. Drop the
-                    // index-cache JSON so the next install re-imports
-                    // the tarball cleanly. Best-effort: if the
-                    // invalidation itself fails, surface the original
-                    // (more useful) materialize error.
-                    let _ = self.store.invalidate_cached_index(
-                        pkg.registry_name(),
-                        &pkg.version,
-                        pkg.integrity.as_deref(),
-                    );
+                    invalidate_stale_index_for_package(&self.store, pkg);
                 }
                 return Err(e);
             }
@@ -2517,6 +2507,10 @@ impl Linker {
         #[cfg(target_os = "macos")]
         const SMALL_FILE_COPY_MAX: u64 = 16 * 1024;
         let map_io = |e: std::io::Error| classify_link_error(stored, rel_path, dst, e);
+        let missing_source = || Error::MissingStoreFile {
+            store_path: stored.store_path.clone(),
+            rel_path: rel_path.to_string(),
+        };
         match self.strategy {
             LinkStrategy::Reflink => {
                 #[cfg(target_os = "macos")]
@@ -2525,6 +2519,12 @@ impl Linker {
                     return Ok(());
                 }
                 if let Err(e) = reflink_copy::reflink(&stored.store_path, dst) {
+                    // Source-missing short-circuit avoids the misleading
+                    // "fell back to copy" trace and the redundant copy
+                    // attempt that would just ENOENT for the same reason.
+                    if !stored.store_path.exists() {
+                        return Err(missing_source());
+                    }
                     // Fall back to copy on cross-filesystem errors
                     trace!("reflink failed, falling back to copy: {e}");
                     std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
@@ -2532,6 +2532,9 @@ impl Linker {
             }
             LinkStrategy::Hardlink => {
                 if let Err(e) = std::fs::hard_link(&stored.store_path, dst) {
+                    if !stored.store_path.exists() {
+                        return Err(missing_source());
+                    }
                     // Fall back to copy on cross-filesystem errors (EXDEV)
                     trace!("hardlink failed, falling back to copy: {e}");
                     std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
@@ -2546,11 +2549,11 @@ impl Linker {
     }
 }
 
-/// Translate a copy/hardlink/reflink failure into the most informative
-/// linker error. ENOENT can mean either side of the link is missing —
-/// stat the source CAS shard to attribute it. A missing shard means the
-/// cached package index is out of sync with the on-disk store, which
-/// the caller can recover from by invalidating the cached index and
+/// Translate a copy failure into the most informative linker error.
+/// ENOENT can mean either side of the operation is missing — stat the
+/// source CAS shard to attribute it. A missing shard means the cached
+/// package index is out of sync with the on-disk store, which the
+/// caller can recover from by invalidating the cached index and
 /// re-importing the tarball.
 fn classify_link_error(
     stored: &StoredFile,
@@ -2565,6 +2568,25 @@ fn classify_link_error(
         };
     }
     Error::Io(dst.to_path_buf(), err)
+}
+
+/// Best-effort drop the cached package index when materialize discovers
+/// its referenced CAS shard is gone. Callers always surface the original
+/// `MissingStoreFile` error first; this side effect just makes sure the
+/// next install miss `load_index` instead of looping on the same dead
+/// reference. If the cache write fails (e.g. permission error), warn
+/// loudly so the user knows the auto-recovery didn't take and they need
+/// to wipe `~/.cache/aube/index/` by hand.
+pub(crate) fn invalidate_stale_index_for_package(store: &aube_store::Store, pkg: &LockedPackage) {
+    match store.invalidate_cached_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref())
+    {
+        Ok(true) => debug!("invalidated stale index for {}", pkg.spec_key()),
+        Ok(false) => {}
+        Err(e) => warn!(
+            "failed to invalidate stale index for {}: {e}; manual recovery: rm -rf ~/.cache/aube/index",
+            pkg.spec_key()
+        ),
+    }
 }
 
 #[derive(Debug, Default)]
@@ -2601,7 +2623,7 @@ pub enum Error {
     #[error("refusing to materialize unsafe index key: {0:?}")]
     UnsafeIndexKey(String),
     #[error(
-        "cached package index references a missing CAS shard at {store_path} (file: {rel_path:?}). The store and its index cache are out of sync — the cached index has been invalidated; rerun the install to re-fetch the tarball."
+        "cached package index references a missing CAS shard at {store_path} (file: {rel_path:?}). The store and its index cache are out of sync — rerun the install to re-fetch the tarball."
     )]
     MissingStoreFile {
         store_path: PathBuf,
@@ -3692,6 +3714,38 @@ mod tests {
         assert!(
             !cached_path.exists(),
             "stale index cache must be invalidated on MissingStoreFile"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
+        // Hardlink path used to silently fall through to `std::fs::copy`
+        // on ENOENT and emit a misleading "hardlink failed, falling back
+        // to copy" trace, even though the real cause was the source
+        // shard going missing. Short-circuit returns MissingStoreFile
+        // directly so traces stay accurate.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("store/files"));
+        let stored = store.import_bytes(b"hello", false).unwrap();
+        // Capture the path before we move `stored` into link_file_fresh.
+        let store_path = stored.store_path.clone();
+        std::fs::remove_file(&store_path).unwrap();
+
+        let dst_dir = dir.path().join("dst");
+        std::fs::create_dir_all(&dst_dir).unwrap();
+        let dst = dst_dir.join("hello.txt");
+
+        let linker = Linker::new_with_gvs(&store, LinkStrategy::Hardlink, true);
+        let err = linker
+            .link_file_fresh(&stored, "hello.txt", &dst)
+            .expect_err("source missing must fail");
+        assert!(
+            matches!(
+                &err,
+                Error::MissingStoreFile { store_path: p, rel_path } if p == &store_path && rel_path == "hello.txt"
+            ),
+            "expected MissingStoreFile from Hardlink branch, got {err:?}"
         );
     }
 

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -248,6 +248,31 @@ impl Store {
         Some(index)
     }
 
+    /// Delete the cached package index for `(name, version, integrity)` if
+    /// it exists. Used as a recovery hatch when the linker discovers a
+    /// CAS shard referenced by the index has gone missing — the cached
+    /// JSON points at a dead `store_path`, so the next install must
+    /// re-derive the index by re-importing the tarball.
+    ///
+    /// `Ok(true)` when an entry was removed; `Ok(false)` when there
+    /// was nothing to remove (or the coordinate was invalid). Errors
+    /// surface only on real I/O failure, not on the missing-file case.
+    pub fn invalidate_cached_index(
+        &self,
+        name: &str,
+        version: &str,
+        integrity: Option<&str>,
+    ) -> Result<bool, Error> {
+        let Some(index_path) = self.index_path(name, version, integrity) else {
+            return Ok(false);
+        };
+        match std::fs::remove_file(&index_path) {
+            Ok(()) => Ok(true),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(Error::Io(index_path, e)),
+        }
+    }
+
     /// Save a package index to the cache.
     ///
     /// See [`load_index`](Self::load_index) for the semantics of
@@ -1971,6 +1996,49 @@ mod tests {
             store
                 .load_index_verified("pkg", "1.0.0", Some(TEST_INTEGRITY))
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn test_invalidate_cached_index_removes_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+
+        let stored = store.import_bytes(b"content", false).unwrap();
+        let mut index = BTreeMap::new();
+        index.insert("index.js".to_string(), stored);
+
+        store
+            .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
+            .unwrap();
+        // First call removes the entry; second call sees it gone.
+        assert!(
+            store
+                .invalidate_cached_index("pkg", "1.0.0", Some(TEST_INTEGRITY))
+                .unwrap()
+        );
+        assert!(
+            !store
+                .invalidate_cached_index("pkg", "1.0.0", Some(TEST_INTEGRITY))
+                .unwrap()
+        );
+        // load_index now misses, forcing a re-import on the next install.
+        assert!(
+            store
+                .load_index("pkg", "1.0.0", Some(TEST_INTEGRITY))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_invalidate_cached_index_returns_false_for_invalid_coordinate() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        // Empty name doesn't yield a valid index path; must not error.
+        assert!(
+            !store
+                .invalidate_cached_index("", "1.0.0", Some(TEST_INTEGRITY))
+                .unwrap()
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes [#393](https://github.com/endevco/aube/discussions/393). When a cached package index references a CAS shard that's no longer on disk, `link_file_fresh` ENOENTs — but `std::fs::copy` / `hard_link` / `reflink` wrap the **destination** path on error, so the user sees a misleading "No such file or directory" against `node_modules/<pkg>/<file>` and concludes (reasonably) that the linker is computing the wrong destination. In #393 it looked like aube was confusing alias names with real names; the actual cause is a missing source.

The stale index also slips past `load_index`'s fast-path validation (which only stats the first entry alphabetically — `README.md` for the repro package, which still existed), so every retry hits the same dead shard reference and the install loops without progress.

## Fix

- New `Error::MissingStoreFile { store_path, rel_path }` variant in `aube-linker`. `link_file_fresh` distinguishes ENOENT-source from ENOENT-dest via a single `stored.store_path.exists()` check on the error path. Error message tells the user exactly what's wrong and what to do.
- New `Store::invalidate_cached_index(name, version, integrity)` in `aube-store`. Best-effort delete of the stale `~/.cache/aube/index/<…>.json`; returns `Ok(false)` for missing entries / invalid coordinates so callers can fire-and-forget.
- Both materialize paths (`materialize_into` for isolated mode, `link_hoisted_importer` for hoisted mode) invalidate the cached index when they see `MissingStoreFile`. The next `aube install` then misses `load_index`, falls through to `NeedsFetch`, and re-imports the tarball with a fresh shard. **The failed install self-heals on retry** — verified end-to-end against the #393 repro.

## Why not just fix `load_index` to verify all files

Considered. Two reasons against:

1. The fast-path comment notes the cost was deliberately kept to "one metadata check" specifically to avoid making every warm install pay for an N-syscall walk per package. Going thorough would add ~60k stats on a 2k-package install (avg 30 files/pkg). Not catastrophic but it's a real warm-install regression.
2. Even with thorough validation, the user's first failed install would still surface the misleading destination-path error. Detecting at materialize time gives both a clearer message *and* the auto-recovery, without paying the cost on every install.

The fast-path stays; the materialize path now has an escape hatch when the fast-path lies.

## Test plan

- [x] `cargo test -p aube-linker -p aube-store` — 75 + 75 pass, including 3 new tests
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] End-to-end: deleted one CAS shard, ran `aube install` against the #393 repro:
  - First run: clear `MissingStoreFile` error, cached index invalidated
  - Second run: re-fetches the tarball and installs successfully

Pre-existing test failure noted: `aube-resolver platform::tests::linux_glibc_host_rejects_musl_only_package` fails on `08f0594` (clean main) on this host. Unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core linking/materialization error paths and introduces automatic cache invalidation, which could affect install reliability if mis-triggered, but the changes are narrow and covered by new tests.
> 
> **Overview**
> Improves install failure handling when a cached `PackageIndex` points at a missing CAS shard by introducing a dedicated `Error::MissingStoreFile { store_path, rel_path }` and teaching `link_file_fresh` to distinguish missing-source ENOENT from destination errors (including short-circuiting hardlink/reflink fallbacks when the source is gone).
> 
> On `MissingStoreFile`, both isolated and hoisted materialization paths now best-effort invalidate the cached index so the next install re-imports the tarball instead of repeatedly failing on the same stale reference. `aube-store` adds `Store::invalidate_cached_index(...)` plus tests, and `aube-linker` adds regression tests covering the new error classification and cache invalidation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b15b0879c9c53c904fc2b8e0c75728c12eef4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->