### PR TITLE
fix(resolver): detect host libc via /proc/self/maps

### DIFF
--- a/crates/aube-resolver/src/platform.rs
+++ b/crates/aube-resolver/src/platform.rs
@@ -166,43 +166,54 @@ pub fn host_triple() -> (&'static str, &'static str, &'static str) {
 }
 
 /// Probe the active dynamic linker to tell musl from glibc at runtime.
-/// Alpine and other musl distros ship `/lib/ld-musl-<arch>.so.1`.
-/// glibc distros ship `/lib64/ld-linux-x86-64.so.2`, `/lib/ld-linux-aarch64.so.1`,
-/// etc. Cache once via OnceLock so repeated calls in the resolver
-/// BFS do not re-stat. If neither matches (unusual container, stripped
-/// rootfs), fall back to glibc which is the common case.
+/// Authoritative signal is `/proc/self/maps`: the dynamic linker that
+/// loaded the running aube binary is always mmap'd into the process,
+/// so whichever of `ld-musl-*` or `ld-linux-*` shows up there is the
+/// libc the host actually runs. Cached once via OnceLock.
+///
+/// The previous /lib-scan heuristic broke on Ubuntu glibc hosts that
+/// `apt install musl` for cross-compile tooling: the musl package
+/// drops `/lib/ld-musl-<arch>.so.1` alongside the system glibc loader,
+/// and a first-match scan returned "musl", causing aube to install
+/// `*-linux-x64-musl` native bindings that node (linked against
+/// glibc) cannot load. /proc/self/maps cuts straight to which loader
+/// actually runs and ignores the partial-install noise. The /lib
+/// fallback is kept for non-Linux containers / stripped rootfs that
+/// expose no procfs, but checks glibc *first* so a dual-loader system
+/// still resolves correctly there.
 fn detect_linux_libc() -> &'static str {
     use std::sync::OnceLock;
     static CACHE: OnceLock<&'static str> = OnceLock::new();
     CACHE.get_or_init(|| {
-        let lib_dir = std::path::Path::new("/lib");
-        if let Ok(entries) = std::fs::read_dir(lib_dir) {
-            for entry in entries.flatten() {
-                let name = entry.file_name();
-                let name = name.to_string_lossy();
-                if name.starts_with("ld-musl-") {
-                    return "musl";
-                }
+        if let Ok(maps) = std::fs::read_to_string("/proc/self/maps") {
+            if maps.contains("/ld-musl-") {
+                return "musl";
+            }
+            if maps.contains("/ld-linux") {
+                return "glibc";
             }
         }
-        // Look for glibc explicitly before defaulting. Covers cases
-        // where /lib has no ld-musl-* but also no ld-linux-* (sparse
-        // containers), in which case we still pick glibc as the
-        // safer default since more prebuilts ship for glibc.
-        for dir in [
+        let glibc_dirs = [
             "/lib",
             "/lib64",
             "/lib/x86_64-linux-gnu",
             "/lib/aarch64-linux-gnu",
-        ] {
-            let p = std::path::Path::new(dir);
-            if let Ok(entries) = std::fs::read_dir(p) {
+        ];
+        for dir in glibc_dirs {
+            if let Ok(entries) = std::fs::read_dir(dir) {
                 for entry in entries.flatten() {
                     let name = entry.file_name();
-                    let name = name.to_string_lossy();
-                    if name.starts_with("ld-linux") {
+                    if name.to_string_lossy().starts_with("ld-linux") {
                         return "glibc";
                     }
+                }
+            }
+        }
+        if let Ok(entries) = std::fs::read_dir("/lib") {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                if name.to_string_lossy().starts_with("ld-musl-") {
+                    return "musl";
                 }
             }
         }


### PR DESCRIPTION
## Summary

- `detect_linux_libc()` walked `/lib` and returned `"musl"` on the first `ld-musl-*` it saw, so any glibc Ubuntu host with `apt install musl` (the [`musl`](https://packages.ubuntu.com/jammy/musl) package, common for cross-compile dev) was misidentified as musl.
- Aube then installed the `*-linux-x64-musl` native bindings on a glibc system; node (linked against glibc) refused to load them with `Cannot find module ../foo-linux-x64-gnu.node`.
- Fix reads `/proc/self/maps` and looks for whichever of `/ld-musl-` or `/ld-linux` is mmap'd into the running aube process — that's the loader that actually loaded us, which is the host's libc by definition. The `/lib` scan stays as a fallback for non-procfs environments but checks glibc first there too, so a dual-loader rootfs resolves correctly even when procfs is unavailable.

## Repro

On an Ubuntu glibc host with the `musl` package installed:

```
$ ls /lib/ld-musl-* /lib/ld-linux-* 2>/dev/null
/lib/ld-linux-x86-64.so.2   /lib/ld-musl-x86_64.so.1

$ aube install   # against any project that depends on rolldown / esbuild / swc / sharp / …
$ ls node_modules/.aube/ | grep binding-linux
@rolldown+binding-linux-x64-musl@1.0.0-rc.17    # wrong — should be -gnu

$ vitest
Error: Cannot find module '../rolldown-binding.linux-x64-gnu.node'
```

After the fix:

```
$ aube install
$ ls node_modules/.aube/ | grep binding-linux
@rolldown+binding-linux-x64-gnu@1.0.0-rc.17     # correct
$ vitest
✓ src/google.test.ts (1 test) 112ms
Test Files  1 passed (1)
```

## Test plan

- [x] `cargo test -p aube-resolver --release platform::` — 11/11 pass
- [x] `cargo clippy -p aube-resolver --all-targets -- -D warnings` — clean
- [x] Verified end-to-end on a dual-loader Ubuntu host (bamboo): correct binding installed, vitest passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the platform-resolution signal used to pick native binaries on Linux; while small and localized, mistakes here can break installs at runtime on certain container/host setups.
> 
> **Overview**
> Fixes Linux `libc` detection in `detect_linux_libc()` by preferring `/proc/self/maps` to identify whether the running process is using `ld-musl` or `ld-linux`, rather than scanning `/lib` for the first matching loader.
> 
> Keeps a directory-scan fallback for procfs-less/stripped environments, but reorders it to check known glibc loader locations *before* musl, preventing dual-loader systems from incorrectly selecting musl and installing incompatible `*-linux-*-musl` native bindings on glibc hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c7385c1e44c9009a478369583692a2361252665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->