### PR TITLE
fix(lockfile): synthesize npm-alias entries for transitive deps in pnpm lockfiles

### DIFF
--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -237,13 +237,15 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 })
             });
             if let Some(snap) = snap
-                && let Some(deps) = snap.dependencies.clone()
+                && let Some(mut deps) = snap.dependencies.clone()
             {
+                rewrite_snapshot_alias_deps(&mut deps, &mut alias_remaps);
                 local_pkg.dependencies = deps;
             }
             if let Some(snap) = snap
-                && let Some(opt_deps) = snap.optional_dependencies.clone()
+                && let Some(mut opt_deps) = snap.optional_dependencies.clone()
             {
+                rewrite_snapshot_alias_deps(&mut opt_deps, &mut alias_remaps);
                 local_pkg.dependencies.extend(opt_deps.clone());
                 local_pkg.optional_dependencies = opt_deps;
             }
@@ -379,38 +381,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         let mut dependencies = snapshot
             .and_then(|s| s.dependencies.clone())
             .unwrap_or_default();
-        // Detect npm-aliased transitive deps. pnpm encodes them as
-        // `<alias>: <real>@<resolved>(peers…)` inside a snapshot's
-        // dependency map (e.g. `string-width-cjs: string-width@4.2.3`
-        // for the `"string-width-cjs": "npm:string-width@^4.2.0"` dep
-        // declared by `@isaacs/cliui@8.0.2`). Aube stores transitive
-        // tails as bare resolved versions and synthesizes an alias-
-        // keyed package entry under `<alias>@<resolved>` with
-        // `alias_of=Some(real)`. Rewriting here keeps a single shape
-        // downstream: the linker computes `<dep_name>@<dep_tail>` and
-        // hits the synthetic alias entry, and the resolver's lockfile-
-        // reuse path enqueues transitives with `range = <resolved>`
-        // (not the malformed `string-width@4.2.3`) so a re-resolve
-        // doesn't try to find `string-width-cjs` versions matching a
-        // synthetic `<real>@<version>` range.
-        let mut rewrite_alias_values = |deps: &mut BTreeMap<String, String>| {
-            for (dep_name, dep_value) in deps.iter_mut() {
-                let bare = dep_value.split('(').next().unwrap_or(dep_value);
-                let Some((real_name, resolved)) = parse_dep_path(bare) else {
-                    continue;
-                };
-                if real_name == *dep_name {
-                    continue;
-                }
-                let peer_suffix = dep_value.find('(').map(|i| &dep_value[i..]).unwrap_or("");
-                let alias_dep_path = format!("{dep_name}@{resolved}{peer_suffix}");
-                let real_dep_path = dep_value.clone();
-                alias_remaps.push((alias_dep_path, real_dep_path, dep_name.clone(), real_name));
-                *dep_value = format!("{resolved}{peer_suffix}");
-            }
-        };
-        rewrite_alias_values(&mut dependencies);
-        rewrite_alias_values(&mut optional_dependencies);
+        rewrite_snapshot_alias_deps(&mut dependencies, &mut alias_remaps);
+        rewrite_snapshot_alias_deps(&mut optional_dependencies, &mut alias_remaps);
         dependencies.extend(optional_dependencies.clone());
         let bundled_dependencies = snapshot
             .and_then(|s| s.bundled_dependencies.clone())
@@ -533,7 +505,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             return Err(Error::parse(
                 path,
                 format!(
-                    "npm-alias importer references missing package {real_dep_path} (alias dep_path: {alias_dep_path})"
+                    "npm-alias references missing package {real_dep_path} (alias dep_path: {alias_dep_path})"
                 ),
             ));
         };
@@ -1181,6 +1153,41 @@ fn parse_dep_path(dep_path: &str) -> Option<(String, String)> {
         .to_string();
 
     Some((name, version))
+}
+
+/// Detect npm-aliased entries inside a snapshot's `dependencies` /
+/// `optionalDependencies` map and rewrite them to aube's internal shape.
+///
+/// pnpm encodes a transitive npm alias as `<alias>: <real>@<resolved>(peers…)`
+/// (e.g. `@isaacs/cliui@8.0.2` records `string-width-cjs: string-width@4.2.3`
+/// for its `"string-width-cjs": "npm:string-width@^4.2.0"` dep). Aube's
+/// linker keys sibling symlinks against `<dep_name>@<dep_value>`, so a raw
+/// pnpm value yields a broken `string-width-cjs@string-width@4.2.3` virtual
+/// store path. This helper rewrites the value to the bare resolved version
+/// (preserving any peer-context suffix) and pushes onto `alias_remaps` so
+/// the synthesis loop creates a `<alias>@<resolved>` `LockedPackage` with
+/// `alias_of=Some(real)`. After that the linker resolves the alias symlink
+/// to the synthetic dir and the resolver's lockfile-reuse path enqueues
+/// transitives with `range = <resolved>` (not the malformed
+/// `<real>@<resolved>` that no `<alias>` packument can satisfy).
+fn rewrite_snapshot_alias_deps(
+    deps: &mut BTreeMap<String, String>,
+    alias_remaps: &mut Vec<(String, String, String, String)>,
+) {
+    for (dep_name, dep_value) in deps.iter_mut() {
+        let bare = dep_value.split('(').next().unwrap_or(dep_value);
+        let Some((real_name, resolved)) = parse_dep_path(bare) else {
+            continue;
+        };
+        if real_name == *dep_name {
+            continue;
+        }
+        let peer_suffix = dep_value.find('(').map(|i| &dep_value[i..]).unwrap_or("");
+        let alias_dep_path = format!("{dep_name}@{resolved}{peer_suffix}");
+        let real_dep_path = dep_value.clone();
+        alias_remaps.push((alias_dep_path, real_dep_path, dep_name.clone(), real_name));
+        *dep_value = format!("{resolved}{peer_suffix}");
+    }
 }
 
 // -- Writable serde types for pnpm-lock.yaml v9 --
@@ -3707,5 +3714,63 @@ snapshots:
             .expect("synthesized alias entry with peer suffix");
         assert_eq!(alias.name, "alias-pkg");
         assert_eq!(alias.alias_of.as_deref(), Some("real-pkg"));
+    }
+
+    #[test]
+    fn parse_synthesizes_npm_alias_for_transitive_deps_of_local_packages() {
+        // The local-packages absorption loop runs before the main
+        // snapshot loop and pulls a `file:` workspace package's
+        // transitive deps directly out of `raw.snapshots`. Those
+        // values must go through the same alias rewrite as the main
+        // path, or a workspace package depending on
+        // `"string-width-cjs": "npm:string-width@^4.2.0"` would still
+        // produce the broken `string-width-cjs@string-width@4.2.3`
+        // virtual store path on install.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &path,
+            r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      local-pkg:
+        specifier: file:./local-pkg
+        version: file:./local-pkg
+
+packages:
+  local-pkg@file:./local-pkg:
+    resolution: {directory: ./local-pkg, type: directory}
+  string-width@4.2.3:
+    resolution: {integrity: sha512-fake}
+
+snapshots:
+  local-pkg@file:./local-pkg:
+    dependencies:
+      string-width-cjs: string-width@4.2.3
+  string-width@4.2.3: {}
+"#,
+        )
+        .unwrap();
+
+        let graph = parse(&path).unwrap();
+        let local = graph
+            .packages
+            .values()
+            .find(|p| p.name == "local-pkg")
+            .expect("local-pkg entry");
+        assert_eq!(
+            local.dependencies.get("string-width-cjs").unwrap(),
+            "4.2.3",
+            "transitive alias on a local package gets rewritten too"
+        );
+        let alias = graph
+            .packages
+            .get("string-width-cjs@4.2.3")
+            .expect("synthesized alias entry from local package's transitive");
+        assert_eq!(alias.name, "string-width-cjs");
+        assert_eq!(alias.alias_of.as_deref(), Some("string-width"));
     }
 }

--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -373,12 +373,44 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         };
 
         let snapshot = raw.snapshots.get(&dep_path);
-        let optional_dependencies = snapshot
+        let mut optional_dependencies = snapshot
             .and_then(|s| s.optional_dependencies.clone())
             .unwrap_or_default();
         let mut dependencies = snapshot
             .and_then(|s| s.dependencies.clone())
             .unwrap_or_default();
+        // Detect npm-aliased transitive deps. pnpm encodes them as
+        // `<alias>: <real>@<resolved>(peers…)` inside a snapshot's
+        // dependency map (e.g. `string-width-cjs: string-width@4.2.3`
+        // for the `"string-width-cjs": "npm:string-width@^4.2.0"` dep
+        // declared by `@isaacs/cliui@8.0.2`). Aube stores transitive
+        // tails as bare resolved versions and synthesizes an alias-
+        // keyed package entry under `<alias>@<resolved>` with
+        // `alias_of=Some(real)`. Rewriting here keeps a single shape
+        // downstream: the linker computes `<dep_name>@<dep_tail>` and
+        // hits the synthetic alias entry, and the resolver's lockfile-
+        // reuse path enqueues transitives with `range = <resolved>`
+        // (not the malformed `string-width@4.2.3`) so a re-resolve
+        // doesn't try to find `string-width-cjs` versions matching a
+        // synthetic `<real>@<version>` range.
+        let mut rewrite_alias_values = |deps: &mut BTreeMap<String, String>| {
+            for (dep_name, dep_value) in deps.iter_mut() {
+                let bare = dep_value.split('(').next().unwrap_or(dep_value);
+                let Some((real_name, resolved)) = parse_dep_path(bare) else {
+                    continue;
+                };
+                if real_name == *dep_name {
+                    continue;
+                }
+                let peer_suffix = dep_value.find('(').map(|i| &dep_value[i..]).unwrap_or("");
+                let alias_dep_path = format!("{dep_name}@{resolved}{peer_suffix}");
+                let real_dep_path = dep_value.clone();
+                alias_remaps.push((alias_dep_path, real_dep_path, dep_name.clone(), real_name));
+                *dep_value = format!("{resolved}{peer_suffix}");
+            }
+        };
+        rewrite_alias_values(&mut dependencies);
+        rewrite_alias_values(&mut optional_dependencies);
         dependencies.extend(optional_dependencies.clone());
         let bundled_dependencies = snapshot
             .and_then(|s| s.bundled_dependencies.clone())
@@ -3538,5 +3570,142 @@ snapshots:
             .expect("real entry");
         assert_eq!(real.name, "@types/node");
         assert!(real.alias_of.is_none());
+    }
+
+    #[test]
+    fn parse_synthesizes_npm_alias_for_transitive_deps() {
+        // pnpm encodes npm-aliased *transitive* deps as
+        // `<alias>: <real>@<resolved>` inside a snapshot's
+        // dependencies map (e.g. `@isaacs/cliui@8.0.2` declares
+        // `"string-width-cjs": "npm:string-width@^4.2.0"` and
+        // pnpm resolves it as `string-width-cjs: string-width@4.2.3`).
+        // The reader must rewrite the dep value to the resolved
+        // version and synthesize the alias-keyed package entry, or
+        // the linker creates a broken symlink to a non-existent
+        // `string-width-cjs@string-width@4.2.3` virtual store dir
+        // and the resolver's lockfile-reuse path enqueues a
+        // transitive task with a malformed `string-width@4.2.3`
+        // range that no string-width-cjs version can satisfy.
+        // Repro: https://github.com/stevelandeydescript/aube-bug-repros/tree/main/npm-alias-resolution-failure
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &path,
+            r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      jackspeak:
+        specifier: 4.1.1
+        version: 4.1.1
+
+packages:
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-fake}
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-fake}
+  string-width@4.2.3:
+    resolution: {integrity: sha512-fake}
+  string-width@5.1.2:
+    resolution: {integrity: sha512-fake}
+
+snapshots:
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+  jackspeak@4.1.1:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+  string-width@4.2.3: {}
+  string-width@5.1.2: {}
+"#,
+        )
+        .unwrap();
+
+        let graph = parse(&path).unwrap();
+
+        let cliui = graph
+            .packages
+            .get("@isaacs/cliui@8.0.2")
+            .expect("cliui entry");
+        assert_eq!(
+            cliui.dependencies.get("string-width-cjs").unwrap(),
+            "4.2.3",
+            "transitive alias dep value rewritten from `string-width@4.2.3` to bare `4.2.3`"
+        );
+        assert_eq!(cliui.dependencies.get("string-width").unwrap(), "5.1.2");
+
+        let alias = graph
+            .packages
+            .get("string-width-cjs@4.2.3")
+            .expect("synthesized alias-keyed package for transitive");
+        assert_eq!(alias.name, "string-width-cjs");
+        assert_eq!(alias.alias_of.as_deref(), Some("string-width"));
+        assert_eq!(alias.dep_path, "string-width-cjs@4.2.3");
+
+        let real = graph
+            .packages
+            .get("string-width@4.2.3")
+            .expect("real entry stays put");
+        assert_eq!(real.name, "string-width");
+        assert!(real.alias_of.is_none());
+    }
+
+    #[test]
+    fn parse_handles_npm_alias_for_transitive_deps_with_peer_suffix() {
+        // Aliased transitive whose alias target carries a peer
+        // suffix: `<alias>: <real>@<resolved>(peer@ver)`. The
+        // peer-context tail must follow through to the synthetic
+        // alias dep_path so the linker keys the same context.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &path,
+            r#"
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      parent-pkg:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+  parent-pkg@1.0.0:
+    resolution: {integrity: sha512-fake}
+  real-pkg@2.0.0:
+    resolution: {integrity: sha512-fake}
+  peer-pkg@3.0.0:
+    resolution: {integrity: sha512-fake}
+
+snapshots:
+  parent-pkg@1.0.0:
+    dependencies:
+      alias-pkg: real-pkg@2.0.0(peer-pkg@3.0.0)
+  real-pkg@2.0.0(peer-pkg@3.0.0):
+    dependencies:
+      peer-pkg: 3.0.0
+  peer-pkg@3.0.0: {}
+"#,
+        )
+        .unwrap();
+
+        let graph = parse(&path).unwrap();
+        let parent = graph.packages.get("parent-pkg@1.0.0").expect("parent");
+        assert_eq!(
+            parent.dependencies.get("alias-pkg").unwrap(),
+            "2.0.0(peer-pkg@3.0.0)",
+            "peer-context suffix preserved on the rewritten alias dep value"
+        );
+        let alias = graph
+            .packages
+            .get("alias-pkg@2.0.0(peer-pkg@3.0.0)")
+            .expect("synthesized alias entry with peer suffix");
+        assert_eq!(alias.name, "alias-pkg");
+        assert_eq!(alias.alias_of.as_deref(), Some("real-pkg"));
     }
 }


### PR DESCRIPTION
## Summary
- pnpm encodes aliased transitive deps as `<alias>: <real>@<resolved>` inside a snapshot's dependency map (e.g. `string-width-cjs: string-width@4.2.3` for the `"string-width-cjs": "npm:string-width@^4.2.0"` declared by `@isaacs/cliui@8.0.2`). The reader passed the value through unchanged, so the linker keyed the symlink against `<dep_name>@<dep_value>` and produced a broken `string-width-cjs@string-width@4.2.3` virtual store path. On a re-resolve, the resolver's lockfile-reuse path enqueued a transitive task with the literal `string-width@4.2.3` range that no `string-width-cjs` version could satisfy, surfacing as `no version of string-width-cjs matches range \`string-width@4.2.3\``.
- Detect the alias shape at parse, rewrite the dep value to the bare resolved version (preserving any peer-context suffix), and feed the existing `alias_remaps` channel that the importer path already uses to synthesize an alias-keyed `LockedPackage` with `alias_of=Some(real)`. The linker then resolves the alias symlink against the synthetic dir, and the resolver's reuse path matches the synthetic entry by name+version with no malformed range.
- Reported in [endevco/aube#345](https://github.com/endevco/aube/discussions/345#discussioncomment-16771341), repro at [stevelandeydescript/aube-bug-repros/npm-alias-resolution-failure](https://github.com/stevelandeydescript/aube-bug-repros/tree/main/npm-alias-resolution-failure). The earlier #384 fix covered the importer-level alias case from a pnpm-generated lockfile; this is the matching fix for the snapshot dependency map.

## Test plan
- [x] `cargo test -p aube-lockfile parse_synthesizes_npm_alias_for_transitive_deps` (new)
- [x] `cargo test -p aube-lockfile parse_handles_npm_alias_for_transitive_deps_with_peer_suffix` (new)
- [x] `cargo test -p aube-lockfile -p aube-resolver -p aube-linker` — full lockfile/resolver/linker suites
- [x] `cargo clippy -p aube-lockfile --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] End-to-end against the repro: `pnpm install` → `rm pnpm-lock.yaml node_modules` → `aube install --frozen-lockfile` (or fresh resolve) → `node -e "require('jackspeak')"` succeeds. Before the fix, `string-width-cjs` symlink dangled; after, it resolves through the synthetic `string-width-cjs@4.2.3` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pnpm lockfile dependency rewriting and package synthesis logic, which can affect install graph correctness if alias detection is too broad or misses edge cases; coverage is improved with targeted tests.
> 
> **Overview**
> Fixes pnpm v9 lockfile parsing for **npm-aliased transitive dependencies** encoded in `snapshots` as `<alias>: <real>@<resolved>(peers…)`. The parser now rewrites those snapshot dependency values to the bare resolved version (preserving any peer-context suffix) and feeds the existing `alias_remaps` path so alias-keyed `LockedPackage` entries are synthesized consistently.
> 
> This logic is applied both in the main snapshot loop and when absorbing snapshot deps for local (`file:`) workspace packages, and includes new unit tests covering plain transitive aliases, peer-suffixed aliases, and local-package transitives; also slightly clarifies the missing-package error message for alias synthesis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2fe158150261a9179f2764bef5fdcd50ddcfe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->