### PR TITLE
fix(lockfile): accept scalar os/cpu/libc in npm package-lock.json

### DIFF
--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -70,11 +70,11 @@ struct RawNpmPackage {
     peer_dependencies: BTreeMap<String, String>,
     #[serde(default)]
     peer_dependencies_meta: BTreeMap<String, RawNpmPeerDepMeta>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
     os: Vec<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
     cpu: Vec<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
     libc: Vec<String>,
     /// Captured verbatim for round-trip. npm writes these on every
     /// package entry; dropping them on re-emit is one of the
@@ -1875,6 +1875,52 @@ mod tests {
         );
         assert_eq!(
             native.libc.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["glibc"]
+        );
+    }
+
+    /// npm sometimes emits `os` / `cpu` / `libc` as scalar strings instead
+    /// of arrays (e.g. `sass-embedded-linux-arm@1.99.0` ships
+    /// `"libc": "glibc"`). Verbatim-roundtripped into package-lock.json,
+    /// the field stays scalar — accept both shapes the same way the
+    /// pnpm + bun parsers already do.
+    #[test]
+    fn parse_npm_package_platform_fields_accept_scalar_strings() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+            "name": "scalar-platform-root",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "scalar-platform-root",
+                    "version": "1.0.0",
+                    "dependencies": { "sass-embedded-linux-arm": "1.99.0" }
+                },
+                "node_modules/sass-embedded-linux-arm": {
+                    "version": "1.99.0",
+                    "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.99.0.tgz",
+                    "integrity": "sha512-native",
+                    "cpu": "arm",
+                    "os": "linux",
+                    "libc": "glibc"
+                }
+            }
+        }"#;
+        std::fs::write(tmp.path(), content).unwrap();
+
+        let graph = parse(tmp.path()).unwrap();
+        let pkg = &graph.packages["sass-embedded-linux-arm@1.99.0"];
+        assert_eq!(
+            pkg.os.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["linux"]
+        );
+        assert_eq!(
+            pkg.cpu.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["arm"]
+        );
+        assert_eq!(
+            pkg.libc.iter().map(String::as_str).collect::<Vec<_>>(),
             vec!["glibc"]
         );
     }


### PR DESCRIPTION
## Summary

- Extends [#337](https://github.com/endevco/aube/pull/337) to the npm `package-lock.json` parser. The pnpm parser learned to accept scalar `libc` / `os` / `cpu` (e.g. `"libc": "glibc"`) but the npm parser still required arrays, so verbatim-roundtripped lockfiles containing `sass-embedded-linux-*` and friends fail to parse.
- Switches `RawNpmPackage::{os,cpu,libc}` to `aube_util::string_or_seq`, the same helper bun and pnpm already use.
- Adds a regression test with the exact shape reported in [discussion #336](https://github.com/endevco/aube/discussions/336#discussioncomment-16772185).

## Test plan

- [x] `cargo test -p aube-lockfile --lib npm::`
- [x] `cargo clippy -p aube-lockfile --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to npm lockfile deserialization to accept an additional JSON shape, with a focused regression test covering the new behavior.
> 
> **Overview**
> Fixes npm `package-lock.json` parsing to accept platform fields `os`, `cpu`, and `libc` when npm emits them as **scalar strings** instead of arrays, by deserializing them via `aube_util::string_or_seq`.
> 
> Adds a regression test that parses a minimal v3 lockfile containing scalar `os`/`cpu`/`libc` (e.g. `sass-embedded-linux-arm`) and asserts the values are captured correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d164b37bf20e2d98c7095d0e181eafbc7fdbe2ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->