### PR TITLE
fix(linker): retry transient Windows junction errors

### DIFF
--- a/crates/aube-linker/src/sys.rs
+++ b/crates/aube-linker/src/sys.rs
@@ -79,7 +79,7 @@ pub fn create_dir_link(target: &Path, link: &Path) -> io::Result<()> {
             })?;
             normalize_path(&parent.join(target))
         };
-        junction::create(abs_target, link)
+        create_junction_with_retry(&abs_target, link)
     }
     #[cfg(not(any(unix, windows)))]
     {
@@ -89,6 +89,28 @@ pub fn create_dir_link(target: &Path, link: &Path) -> io::Result<()> {
             "directory links are not supported on this platform",
         ))
     }
+}
+
+#[cfg(windows)]
+fn create_junction_with_retry(target: &Path, link: &Path) -> io::Result<()> {
+    let mut attempt = 0;
+    let mut delay_ms = 50u64;
+    loop {
+        match junction::create(target, link) {
+            Ok(()) => return Ok(()),
+            Err(e) if is_retriable_link_error(&e) && attempt < 9 => {
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                delay_ms = (delay_ms * 2).min(2000);
+                attempt += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn is_retriable_link_error(error: &io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(5 | 32))
 }
 
 /// Options controlling the shape of a generated bin entry.


### PR DESCRIPTION
## Summary
- retry Windows junction creation when transient access or sharing errors occur
- keep Unix directory link behavior unchanged

## Tests
- cargo fmt --check
- cargo test -p aube-linker
- cargo clippy -p aube-linker --all-targets -- -D warnings

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk and Windows-only: adds bounded retries around `junction::create` for specific transient OS errors, leaving Unix behavior unchanged. Main concern is slightly longer link creation delays or inadvertently retrying some legitimate failures on Windows.
> 
> **Overview**
> Improves Windows robustness of `create_dir_link` by wrapping NTFS junction creation in a bounded retry loop with exponential backoff.
> 
> Retries only on transient `Access is denied` / `Sharing violation` (`raw_os_error` 5/32) and otherwise preserves existing behavior, including unchanged Unix symlink handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c08024234a533012e2fef8f41323e618ed4846e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->