### PR TITLE
docs: add setup-aube GitHub Action to installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,11 +154,6 @@ against the workspace, so any of `mise.toml`, `.tool-versions`,
 honored — no separate `actions/setup-node` step required.
 :::
 
-Supported runners: `ubuntu-latest`, `ubuntu-*-arm`, `macos-latest`,
-`windows-latest`. macOS x86_64 (`macos-13`) is not covered by the
-prebuilt binaries — fall back to `cargo install aube --locked` or use
-`macos-latest` (arm64).
-
 See the [`setup-aube` README](https://github.com/endevco/setup-aube#readme)
 for the full input/output reference.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -122,6 +122,46 @@ cargo install --path crates/aube
 
 This installs the `aube` binary into `~/.cargo/bin`.
 
+## GitHub Actions
+
+For CI workflows, use the
+[`endevco/setup-aube`](https://github.com/endevco/setup-aube) Action.
+It downloads the prebuilt aube binary that matches the runner's OS and
+architecture, adds it to `PATH`, and (optionally) installs Node.js
+inline via [mise](https://mise.jdx.dev) so a single step covers both
+the package manager and the runtime:
+
+```yaml
+- uses: endevco/setup-aube@v1
+- run: aube install
+```
+
+Pin a specific aube version, install Node, and run `aube install` in
+one go:
+
+```yaml
+- uses: endevco/setup-aube@v1
+  with:
+    version: 1.5.1         # or "latest"
+    node-version: "22"     # or "auto" to read mise.toml / .tool-versions / .nvmrc
+    run-install: true
+```
+
+::: tip
+With `node-version: auto`, the action runs `mise ls --current node`
+against the workspace, so any of `mise.toml`, `.tool-versions`,
+`.nvmrc`, `.node-version`, or `package.json` `devEngines.runtime` is
+honored — no separate `actions/setup-node` step required.
+:::
+
+Supported runners: `ubuntu-latest`, `ubuntu-*-arm`, `macos-latest`,
+`windows-latest`. macOS x86_64 (`macos-13`) is not covered by the
+prebuilt binaries — fall back to `cargo install aube --locked` or use
+`macos-latest` (arm64).
+
+See the [`setup-aube` README](https://github.com/endevco/setup-aube#readme)
+for the full input/output reference.
+
 ## Verify
 
 ```sh


### PR DESCRIPTION
## Summary

Adds a `## GitHub Actions` section to [docs/installation.md](docs/installation.md)
covering [`endevco/setup-aube`](https://github.com/endevco/setup-aube),
the new composite action that:

- downloads the prebuilt aube binary matching the runner's OS / arch
- adds it to `PATH`
- optionally installs Node.js inline via mise (no `actions/setup-node`
  prerequisite), reading `mise.toml` / `.tool-versions` / `.nvmrc` /
  `.node-version` / `package.json` `devEngines.runtime` when invoked
  with `node-version: auto`
- optionally runs `aube install` after setup

The page covers the minimal usage, the pinned + node + run-install form,
the auto-discovery mode, supported runners (incl. the macOS x86_64
caveat), and links to the action's README for the full input/output
reference.

## Test plan

- [ ] `mise run docs:dev` (or however docs are previewed locally) renders the new section without layout regressions
- [ ] Links in the new section resolve (setup-aube repo, README, mise docs)

## Sequencing

This PR depends on `endevco/setup-aube@v1` being published. PR #2 on
that repo (release-please-opened "chore(main): release 1.0.0") needs
to merge first; that creates the `v1.0.0` tag and the moving `v1` tag
the docs reference.

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime, build, or security-sensitive code paths are modified.
> 
> **Overview**
> Adds a new **GitHub Actions** section to `docs/installation.md` documenting how to install and run `aube` in CI via the `endevco/setup-aube@v1` action, including examples for pinning `aube` versions, optionally installing Node via mise (with `node-version: auto`), and a link to the action’s README for full reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2cd89d5299caab1533a15b3a590b828435cf70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->