### PR TITLE
ci: pin remaining actions to commit SHAs

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -30,7 +30,7 @@ jobs:
       workspace: ${{ steps.drift.outputs.workspace }}
       bench: ${{ steps.drift.outputs.bench }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Compare workspace vs bench version
         id: drift
         run: |
@@ -60,7 +60,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUBE_GH_TOKEN }}

--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -35,7 +35,7 @@ jobs:
           rpmdev-setuptree
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event_name == 'release' && github.ref || inputs.tag }}
           fetch-depth: 0
@@ -78,7 +78,7 @@ jobs:
           COPR_API_TOKEN: ${{ secrets.COPR_API_TOKEN }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: copr-${{ env.VERSION }}
           path: artifacts/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: namespace-profile-endev-linux-amd64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
@@ -36,7 +36,7 @@ jobs:
       - name: Build aube
         run: cargo build
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Render CLI docs from usage spec
         run: |
           ./target/debug/aube usage > aube.usage.kdl
@@ -56,7 +56,7 @@ jobs:
           ../target/debug/aube run docs:build
           touch .vitepress/dist/.nojekyll
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs/.vitepress/dist
 
@@ -70,4 +70,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event_name == 'release' && github.ref || inputs.tag }}
           fetch-depth: 0
@@ -95,7 +95,7 @@ jobs:
             jq
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
 
@@ -125,7 +125,7 @@ jobs:
           git config --global user.email "${{ env.MAINTAINER_EMAIL }}"
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         with:
           gpg_private_key: ${{ secrets.AUBE_GPG_KEY }}
           git_user_signingkey: true

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -41,7 +41,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: refs/tags/${{ steps.tag.outputs.tag }}
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -53,10 +53,10 @@ jobs:
             exit 1
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: refs/tags/${{ steps.tag.outputs.tag }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUBE_GH_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
           cache: rust
       - name: Run release-plz
         id: release-plz
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
         with:
           command: release
         env:
@@ -149,7 +149,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: refs/tags/${{ needs.release-plz-release.outputs.tag }}
           submodules: recursive
@@ -204,7 +204,7 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.AUBE_GH_TOKEN }}
@@ -220,7 +220,7 @@ jobs:
       - uses: jdx/mise-action@b287efda3dc5f4f3c328507653b6617da783ff84 # v4
         env:
           MISE_LOCKED: "1"
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2
         with:
           tool: release-plz
       - name: Configure git identity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
             runner: windows-latest
             build-tool: cargo
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: refs/tags/${{ inputs.tag }}
           submodules: recursive
@@ -77,7 +77,7 @@ jobs:
           cache: rust
       - name: Import codesign certs
         if: startsWith(matrix.os, 'macos')
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         with:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
@@ -91,7 +91,7 @@ jobs:
       - name: Upload binary (macOS signed)
         id: upload-macos
         if: startsWith(matrix.os, 'macos')
-        uses: taiki-e/upload-rust-binary-action@v1
+        uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
         with:
           bin: aube,aubr,aubx
           archive: aube-$tag-$target
@@ -104,7 +104,7 @@ jobs:
       - name: Upload binary (non-macOS)
         id: upload-non-macos
         if: ${{ !startsWith(matrix.os, 'macos') }}
-        uses: taiki-e/upload-rust-binary-action@v1
+        uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
         with:
           bin: aube,aubr,aubx
           archive: aube-$tag-$target
@@ -127,6 +127,6 @@ jobs:
           fi
           echo "path=$archive" >> "$GITHUB_OUTPUT"
       - name: Attest release archive
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: ${{ steps.archive.outputs.path }}


### PR DESCRIPTION
## Summary
- Org policy now requires every action to be pinned to a full-length commit SHA. On 51b80add the `release-plz release`, `release-plz PR`, and `docs build` jobs failed at job start with: _The actions actions/checkout@v4 ... are not allowed in endevco/aube because all actions must be pinned to a full-length commit SHA._
- This pins every still-floating action across `release-plz`, `docs`, `release`, `publish-homebrew`, `publish-npm`, `ppa-publish`, `copr-publish`, and `bench-refresh` to the SHA its current tag points at, with the `# vN` comment kept for readability (matching the convention already used in `ci.yml` / `autofix.yml`).
- No version bumps — each `@vN` was resolved to that tag's tip.

## Test plan
- [ ] `release-plz release` and `release-plz PR` jobs reach their actual steps instead of being rejected at setup
- [ ] `docs` workflow's `build` job reaches checkout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow metadata, pinning existing actions to immutable SHAs without altering job logic or permissions.
> 
> **Overview**
> Updates multiple GitHub Actions workflows to satisfy org policy by **pinning previously tag-referenced actions** (e.g. `actions/checkout@v4`, `actions/setup-node@v4`, `actions/deploy-pages@v4`) to their **full commit SHAs** while keeping the `# vN` tag comments for readability.
> 
> No functional workflow logic changes are introduced; this is a supply-chain hardening/CI compatibility update to prevent jobs from being blocked at startup due to unpinned actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9032398709e12f7603548fdb39d35dc8fe986489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->