### PR TITLE
docs: rename setup-aube references to aube-action

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -125,14 +125,14 @@ This installs the `aube` binary into `~/.cargo/bin`.
 ## GitHub Actions
 
 For CI workflows, use the
-[`endevco/setup-aube`](https://github.com/endevco/setup-aube) Action.
+[`endevco/aube-action`](https://github.com/endevco/aube-action) Action.
 It downloads the prebuilt aube binary that matches the runner's OS and
 architecture, adds it to `PATH`, and (optionally) installs Node.js
 inline via [mise](https://mise.jdx.dev) so a single step covers both
 the package manager and the runtime:
 
 ```yaml
-- uses: endevco/setup-aube@v1
+- uses: endevco/aube-action@v1
 - run: aube install
 ```
 
@@ -140,7 +140,7 @@ Pin a specific aube version, install Node, and run `aube install` in
 one go:
 
 ```yaml
-- uses: endevco/setup-aube@v1
+- uses: endevco/aube-action@v1
   with:
     version: 1.5.1         # or "latest"
     node-version: "22"     # or "auto" to read mise.toml / .tool-versions / .nvmrc
@@ -154,7 +154,7 @@ against the workspace, so any of `mise.toml`, `.tool-versions`,
 honored — no separate `actions/setup-node` step required.
 :::
 
-See the [`setup-aube` README](https://github.com/endevco/setup-aube#readme)
+See the [`aube-action` README](https://github.com/endevco/aube-action#readme)
 for the full input/output reference.
 
 ## Verify


### PR DESCRIPTION
## Summary

The CI installation Action moved from \`endevco/setup-aube\` to [\`endevco/aube-action\`](https://github.com/endevco/aube-action). The old slug collided with [\`verzly/setup-aube\`](https://github.com/verzly/setup-aube) on the GitHub Marketplace, so a fresh clean repo + slug avoids the long-term confusion. The new repo:

- ships a single \`feat:\` commit with a \`Release-As: 1.0.0\` footer so release-please opens a v1.0.0 PR on first run
- has the same composite-action behavior (download prebuilt binary, optional Node via mise, optional \`aube install\`)
- keeps the same usage shape -- only the repo path in \`uses:\` changes

This PR updates the four references in [docs/installation.md](docs/installation.md) accordingly.

## Test plan

- [ ] \`mise run docs:dev\` (or however docs are previewed locally) renders the section with the new links
- [ ] \`endevco/aube-action#readme\` resolves once the new repo's release-please PR merges and the README is on main (it already is)

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating GitHub Action references; no runtime or build logic is modified.
> 
> **Overview**
> Updates the installation guide’s GitHub Actions section to reference the renamed action repo `endevco/aube-action` instead of `endevco/setup-aube`, including the link, `uses:` examples, and README reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e67ef989016202691584c78a82b6aa1dc96305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->