### PR TITLE
ci: bump upload-pages-artifact v3->v5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,6 +59,10 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs/.vitepress/dist
+          # v5 excludes dotfiles by default; .nojekyll is created above
+          # to disable GitHub Pages' Jekyll processing for the VitePress
+          # build, so it must ship inside the artifact.
+          include-hidden-files: true
 
   deploy:
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
           ../target/debug/aube run docs:build
           touch .vitepress/dist/.nojekyll
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs/.vitepress/dist
 


### PR DESCRIPTION
## Summary
- Follow-up to [aube#408](https://github.com/endevco/aube/pull/408): the `docs build` job is still rejected because `actions/upload-pages-artifact@v3` internally references `actions/upload-artifact@v4` with no SHA pin, and the org's pinning policy validates the full action graph. Bumping to v5 fixes it — v5 pins its internal `upload-artifact` reference to a SHA.
- Failing run: https://github.com/endevco/aube/actions/runs/25182879873/job/73832414104 — `The action actions/upload-artifact@v4 is not allowed in endevco/aube because all actions must be pinned to a full-length commit SHA.`

## Test plan
- [ ] `docs` workflow `build` job reaches its actual steps instead of being rejected at setup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change to the GitHub Pages docs workflow; main impact is artifact packaging, which could affect deployment if misconfigured.
> 
> **Overview**
> Updates the `docs` GitHub Pages workflow to use `actions/upload-pages-artifact` **v5** (pinned SHA) instead of v3.
> 
> Adds `include-hidden-files: true` so the generated `.nojekyll` file is included in the uploaded Pages artifact, preventing GitHub Pages from applying Jekyll processing to the VitePress output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2484a68f9d0d24915beabdd8d9acf35ed9e46e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->