### PR TITLE
ci(bench): run bench-refresh on amd64-large runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
   labels:
     - namespace-profile-endev-linux-amd64
+    - namespace-profile-endev-linux-amd64-large
     - namespace-profile-endev-linux-arm64
     - namespace-profile-endev-macos-arm64

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -67,7 +67,7 @@ jobs:
     name: Refresh benchmarks
     needs: check
     if: needs.check.outputs.drift == 'true'
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64-large
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- Bumps the `Refresh benchmarks` job from `namespace-profile-endev-linux-amd64` to `namespace-profile-endev-linux-amd64-large` so the daily hermetic bench has more headroom on the heavy `mise run bench:bump` step.
- Leaves the cheap `Check version drift` job on the standard `amd64` runner — it's just `cargo metadata` + `jq`.

## Test plan

- [ ] Trigger via `workflow_dispatch` once merged and confirm the `Refresh benchmarks` job picks up the `-large` runner cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but workflows may fail if the new `namespace-profile-endev-linux-amd64-large` runner label is unavailable or misconfigured.
> 
> **Overview**
> Switches the `bench-refresh` workflow’s **Refresh benchmarks** job to run on the larger self-hosted runner label `namespace-profile-endev-linux-amd64-large` for more compute headroom.
> 
> Updates `.github/actionlint.yaml` to allow the new `-large` runner label so actionlint validation continues to pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3623764417814ca5179431d68495a7db73b262a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->