### PR TITLE
ci(bench): run pr bench on amd64-large runner

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   bench:
     name: Compare PR performance
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64-large
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary
- Bumps `Compare PR performance` from `namespace-profile-endev-linux-amd64` to `namespace-profile-endev-linux-amd64-large` so per-PR bench comparisons get the same headroom as the daily `bench-refresh` job (#413).

## Test plan
- [ ] On next PR push, confirm the `Compare PR performance` job picks up the `-large` runner cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; the main impact is increased runner resource usage and potentially different benchmark timing characteristics due to the larger machine.
> 
> **Overview**
> Updates the `pr-bench` GitHub Actions workflow so the **Compare PR performance** job runs on `namespace-profile-endev-linux-amd64-large` instead of the smaller `...-amd64` runner, aligning PR benchmark comparisons with the daily `bench-refresh` job’s runner sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6285a3bf2ee6ab348f17040f0bef53a50e5b8584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->