### PR TITLE
ci: share rust cache across base + -large namespace profiles

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,10 @@ self-hosted-runner:
     - namespace-profile-endev-linux-amd64-large
     - namespace-profile-endev-linux-arm64
     - namespace-profile-endev-macos-arm64
+    # Namespace lets you append `;overrides.cache-tag=NAME` to a profile
+    # to share a cache volume across multiple profiles. Both the base
+    # and `-large` Linux profiles point at the same `aube-rust-linux`
+    # tag so the rust cache is shared between regular CI and the bench
+    # jobs that run on `-large`.
+    - namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    - namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,7 +25,7 @@ jobs:
       github.actor != 'renovate[bot]'
       && github.actor != 'mend[bot]'
       && !startsWith(github.head_ref, 'release-plz-')
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
   MISE_EXPERIMENTAL: true
 
 jobs:

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -14,10 +14,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   bench:
     name: Compare PR performance
-    runs-on: namespace-profile-endev-linux-amd64-large
+    runs-on: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -23,6 +23,9 @@ concurrency:
   group: bench-refresh
   cancel-in-progress: true
 
+env:
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   # Gate: only run bench if `benchmarks/results.json` is pinned to an older
   # `aube` version than the workspace. A pure chore/docs push to main
@@ -67,7 +70,7 @@ jobs:
     name: Refresh benchmarks
     needs: check
     if: needs.check.outputs.drift == 'true'
-    runs-on: namespace-profile-endev-linux-amd64-large
+    runs-on: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
           - os: macos-latest
             runner: namespace-profile-endev-macos-arm64
     runs-on: ${{ matrix.runner }}
@@ -58,7 +58,7 @@ jobs:
   # lint failures don't block the BATS jobs from starting against a
   # known-good binary.
   test-linux:
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     timeout-minutes: 30
     env:
       RUSTFLAGS: "-D warnings"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,9 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   build:
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,7 @@ jobs:
   # dependency order. Otherwise it's a no-op.
   release-plz-release:
     name: release-plz release
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     # Two commits landing on main in quick succession must not double-publish.
     concurrency:
       group: release-plz-release-${{ github.ref }}
@@ -196,7 +196,7 @@ jobs:
   # an out-of-date `aube.usage.kdl`.
   release-plz-pr:
     name: release-plz PR
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   # On every push to main: run `release-plz release`. If the current
   # workspace version has no tag yet (because the release PR was just

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   upload-assets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,19 +44,19 @@ jobs:
             build-tool: cargo
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
             build-tool: cross
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
             build-tool: cross
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
             build-tool: cross
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
             build-tool: cross
           - target: x86_64-pc-windows-msvc
             os: windows-latest

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -15,7 +15,13 @@ set -euo pipefail
 #
 # Environment variables:
 #   WARMUP       — warmup runs before timing (default: 1)
-#   RUNS         — timed runs per benchmark (default: 10)
+#   RUNS         — timed runs per benchmark (default: 10). Applies to
+#                  the fast tools (aube, bun). Slower tools default to
+#                  fewer runs so the matrix doesn't take forever:
+#                  pnpm = ceil(RUNS/2), npm = yarn = ceil(RUNS/3).
+#   RUNS_PNPM, RUNS_NPM, RUNS_YARN, RUNS_BUN, RUNS_AUBE — override the
+#                  per-tool run count individually. Falls back to the
+#                  defaults above when unset.
 #   RESULTS_JSON — override the structured JSON output path
 #   BENCH_TOOLS  — comma-separated tools to include
 #                  (default: aube,bun,pnpm,npm,yarn)
@@ -48,6 +54,13 @@ BUN_BIN="$(command -v bun || true)"
 BENCH_DIR="$(mktemp -d "${TMPDIR:-/tmp}/aube-bench.XXXXXX")"
 WARMUP="${WARMUP:-1}"
 RUNS="${RUNS:-10}"
+# Slower tools take a real chunk of wall time per iteration; default
+# pnpm to half the run count and npm/yarn to a third. Each is overridable.
+RUNS_AUBE="${RUNS_AUBE:-$RUNS}"
+RUNS_BUN="${RUNS_BUN:-$RUNS}"
+RUNS_PNPM="${RUNS_PNPM:-$(((RUNS + 1) / 2))}"
+RUNS_NPM="${RUNS_NPM:-$(((RUNS + 2) / 3))}"
+RUNS_YARN="${RUNS_YARN:-$(((RUNS + 2) / 3))}"
 BENCH_TOOLS="${BENCH_TOOLS:-aube,bun,pnpm,npm,yarn}"
 BENCH_SCENARIOS="${BENCH_SCENARIOS:-gvs-warm,gvs-cold,ci-warm,ci-cold,install-test,add}"
 BENCH_PHASES="${BENCH_PHASES:-1}"
@@ -155,6 +168,17 @@ if [ -n "$node_version" ]; then
 fi
 export BENCH_VERSIONS_FILE="$versions_file"
 echo ""
+
+runs_for_tool() {
+	case "$1" in
+	aube) echo "$RUNS_AUBE" ;;
+	bun) echo "$RUNS_BUN" ;;
+	pnpm) echo "$RUNS_PNPM" ;;
+	npm) echo "$RUNS_NPM" ;;
+	yarn) echo "$RUNS_YARN" ;;
+	*) echo "$RUNS" ;;
+	esac
+}
 
 # Per-tool lockfile filename (the name the pm writes into the project
 # directory after `install`). Used to decide what to save after the
@@ -418,11 +442,13 @@ run_bench() {
 		local cmd
 		cmd=$(expand_template "$cmd_tpl" "$project" "$bin" "$home" "$store" "$cache" "$lockfile" "$lockfile_dest")
 
+		local tool_runs
+		tool_runs=$(runs_for_tool "$tool")
 		echo ""
 		echo "  $tool:"
 		hyperfine \
 			--warmup "$WARMUP" \
-			--runs "$RUNS" \
+			--runs "$tool_runs" \
 			--ignore-failure \
 			--prepare "$prepare" \
 			--command-name "$tool" \
@@ -475,11 +501,13 @@ run_bench_preinstall() {
 		# state — the developer-loop "run my tests again" case.
 		local prepare="$warm_prep && $cmd"
 
+		local tool_runs
+		tool_runs=$(runs_for_tool "$tool")
 		echo ""
 		echo "  $tool:"
 		hyperfine \
 			--warmup "$WARMUP" \
-			--runs "$RUNS" \
+			--runs "$tool_runs" \
 			--ignore-failure \
 			--prepare "$prepare" \
 			--command-name "$tool" \


### PR DESCRIPTION
## Summary
- Append `;overrides.cache-tag=aube-rust-linux` to every Linux profile that mounts `cache: rust` so the regular `*-amd64` CI runners and the `*-amd64-large` bench runners share one cache volume. Per Namespace docs ([custom cache identity](https://namespace.so/docs/reference/github-actions/runner-configuration#custom-cache-identity)), cache volumes are scoped per profile by default, so `bench-pr` / `bench-refresh` were starting cold every run.
- Add `CARGO_INCREMENTAL=0` to bench-pr.yml + bench-refresh.yml (matches ci.yml) so incremental artifacts don't accumulate forever in the persistent volume — they never help across distinct PRs.
- Register the suffixed labels in `.github/actionlint.yaml` so actionlint recognises them.

macOS is unchanged — only one mac profile in use, so there is nothing to share.

## Test plan
- [ ] `actionlint .github/workflows/*.yml` passes locally (verified)
- [ ] Watch the next bench-pr run on this PR — first run on each profile pays a one-time cold-cache cost while the new `aube-rust-linux` volume warms up; subsequent runs across CI + bench should share artifacts
- [ ] Confirm the `final` aggregator job in ci.yml still passes (it doesn't mount the rust cache, so the tag doesn't apply there)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multiple GitHub Actions workflows’ runner labels and Rust build settings, which could impact CI reliability/performance if the cache-tag override behaves unexpectedly. No production/runtime code paths are affected.
> 
> **Overview**
> **Unifies Rust cache volumes across Linux CI and bench runners** by appending `;overrides.cache-tag=aube-rust-linux` to Namespace Linux `runs-on` labels in workflows (CI, benches, docs, release, autofix), so `cache: rust` is shared between base and `-large` profiles.
> 
> **Reduces persistent cache growth** by setting `CARGO_INCREMENTAL=0` in additional workflows (bench, docs, release, autofix) to avoid accumulating incremental artifacts on shared cache volumes.
> 
> **Bench script update:** `benchmarks/bench.sh` now supports per-tool run counts (defaults fewer runs for slower tools like `pnpm`/`npm`/`yarn`) via `RUNS_*` env vars, and uses the per-tool value when invoking `hyperfine`.
> 
> Registers the new suffixed Namespace runner labels in `.github/actionlint.yaml` so `actionlint` recognizes them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c12a11f7bfb3753113351c61fb94e814533e78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->