### PR TITLE
test: port hook tests from pnpm install/hooks.ts

### DIFF
--- a/test/PNPM_TEST_IMPORT.md
+++ b/test/PNPM_TEST_IMPORT.md
@@ -39,8 +39,10 @@ Goal: highest install-path parity coverage for lowest cost. Each row is a pnpm s
 
 - [ ] `pnpm/test/install/misc.ts` (37 tests, 645 LOC) → [test/pnpm_install_misc.bats](pnpm_install_misc.bats) (1/37 ported as worked example)
   - Highest-value targets: `--lockfile-only`, `--no-lockfile`, `--prefix`, case-sensitive FS, `STORE_VERSION` migrations
-- [ ] `pnpm/test/install/hooks.ts` (22 tests, 698 LOC) → fold into [test/pnpmfile.bats](pnpmfile.bats)
-  - `readPackage` sync/async, hook removes a dep, hook overrides version, hook fails install, hook on workspace packages
+- [ ] `pnpm/test/install/hooks.ts` (22 tests, 698 LOC) → [test/pnpm_install_hooks.bats](pnpm_install_hooks.bats) (5/22 ported, 2 skipped divergences)
+  - Done: async readPackage on transitive (43), async afterAllResolved (498), syntax error in pnpmfile (292), require() of missing module (303), readPackage normalizes optional/peer/dev fields on transitive (528).
+  - Skipped (need fixtures): sync readPackage (18), custom pnpmfile location (85), global pnpmfile (110, 135, 176), workspace pnpmfile (217), readPackage during update (263), --ignore-pnpmfile cases (314, 338), context.log via ndjson reporter (366, 404), preResolution hook (624 — aube doesn't support), shared workspace lockfile (661).
+  - Documented divergences (don't port without aube-side fix): readPackage returning undefined fails install (68), readPackage on root project's manifest applies (551).
 - [ ] `pnpm/test/install/lifecycleScripts.ts` (21 tests, 356 LOC) → fold into [test/lifecycle_scripts.bats](lifecycle_scripts.bats)
   - pre/postinstall ordering, exit-code propagation, env-var inheritance, script-not-found handling
 - [ ] `pnpm/test/saveCatalog.ts` (8 tests, 224 LOC) → fold into [test/catalogs.bats](catalogs.bats)

--- a/test/pnpm_install_hooks.bats
+++ b/test/pnpm_install_hooks.bats
@@ -1,0 +1,232 @@
+#!/usr/bin/env bats
+#
+# Ported from pnpm/test/install/hooks.ts.
+# See test/PNPM_TEST_IMPORT.md for translation conventions.
+#
+# Coverage focus: .pnpmfile.cjs hook behavior — readPackage (sync/async),
+# afterAllResolved (async), and pnpmfile load-time error paths.
+# @pnpm.e2e/* fixtures aren't mirrored yet, so tests that require them
+# (most of hooks.ts uses `@pnpm.e2e/pkg-with-1-dep` + addDistTag) are
+# substituted with packages already in test/registry/storage/ where the
+# behavior is package-agnostic, or deferred until Phase 0 fixtures land.
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "pnpmfile: async readPackage hook mutates transitive dependencies" {
+	# Ported from pnpm/test/install/hooks.ts:43 ('readPackage async hook').
+	# Substitution: pnpm's @pnpm.e2e/pkg-with-1-dep + addDistTag → is-even
+	# (pulls in is-odd transitively). The hook strips is-odd's deps.
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-hooks-readpackage-async",
+  "version": "0.0.0",
+  "dependencies": { "is-even": "1.0.0" }
+}
+JSON
+
+	cat >.pnpmfile.cjs <<'EOF'
+'use strict'
+module.exports = {
+  hooks: {
+    async readPackage (pkg) {
+      if (pkg.name === 'is-odd') {
+        pkg.dependencies = {}
+      }
+      return pkg
+    }
+  }
+}
+EOF
+
+	run aube install
+	assert_success
+	# The hook cleared is-odd's dependencies; the snapshot entry should
+	# be empty rather than pulling in is-number / kind-of.
+	run bash -c "awk '/^snapshots:/,0' aube-lock.yaml | grep '^  is-odd@'"
+	assert_output --partial 'is-odd@0.1.2: {}'
+}
+
+@test "pnpmfile: async afterAllResolved hook runs and is awaited" {
+	# Ported from pnpm/test/install/hooks.ts:498 ('pnpmfile: run async
+	# afterAllResolved hook'). pnpm asserts on ndjson reporter logs;
+	# aube's reporter pipeline doesn't surface context.log to stdout the
+	# same way, so we assert the install completes (i.e. the async hook
+	# is awaited and its return value reused) and that the lockfile got
+	# written.
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-hooks-afterallresolved-async",
+  "version": "0.0.0",
+  "dependencies": { "is-odd": "3.0.1" }
+}
+JSON
+
+	cat >.pnpmfile.cjs <<'EOF'
+'use strict'
+module.exports = {
+  hooks: {
+    async afterAllResolved (lockfile, context) {
+      // No mutation; just exercise the async path. Return a promise
+      // that resolves on the next tick so we know aube actually
+      // awaited it rather than dropping it on the floor.
+      await new Promise((resolve) => setImmediate(resolve))
+      return lockfile
+    }
+  }
+}
+EOF
+
+	run aube install
+	assert_success
+	assert_file_exists aube-lock.yaml
+	assert_file_exists node_modules/is-odd/index.js
+}
+
+@test "pnpmfile: syntax error in .pnpmfile.cjs fails the install" {
+	# Ported from pnpm/test/install/hooks.ts:292 ('prints meaningful error
+	# when there is syntax error in .pnpmfile.cjs').
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-hooks-syntax-error",
+  "version": "0.0.0",
+  "dependencies": { "is-odd": "3.0.1" }
+}
+JSON
+	# `/boom` parses as the start of a regex literal with no closing /.
+	echo '/boom' >.pnpmfile.cjs
+
+	run aube install
+	assert_failure
+	# The exact wording may differ from pnpm; just assert aube surfaces
+	# *some* signal that the pnpmfile is the culprit.
+	assert_output --partial 'pnpmfile'
+}
+
+@test "pnpmfile: require() of a missing module fails the install" {
+	# Ported from pnpm/test/install/hooks.ts:303 ('fails when .pnpmfile.cjs
+	# requires a non-existed module').
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-hooks-require-missing",
+  "version": "0.0.0",
+  "dependencies": { "is-odd": "3.0.1" }
+}
+JSON
+	echo 'module.exports = require("./this-does-not-exist")' >.pnpmfile.cjs
+
+	run aube install
+	assert_failure
+	assert_output --partial 'pnpmfile'
+}
+
+@test "pnpmfile: readPackage hook can set optionalDependencies / peerDependencies / devDependencies on a transitive" {
+	# Ported from pnpm/test/install/hooks.ts:528 ('readPackage hook
+	# normalizes the package manifest'). Substitution: pnpm's
+	# @pnpm.e2e/dep-of-pkg-with-1-dep → is-odd; is-positive / is-negative
+	# → is-number (already in test/registry/storage/). Verifies the
+	# resolver doesn't choke when the hook sets optional/peer/dev fields
+	# on a transitive that doesn't originally declare them.
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-hooks-normalize",
+  "version": "0.0.0",
+  "dependencies": { "is-even": "1.0.0" }
+}
+JSON
+
+	cat >.pnpmfile.cjs <<'EOF'
+'use strict'
+module.exports = {
+  hooks: {
+    readPackage (pkg) {
+      if (pkg.name === 'is-odd') {
+        pkg.optionalDependencies = pkg.optionalDependencies || {}
+        pkg.optionalDependencies['is-number'] = '*'
+        pkg.peerDependencies = pkg.peerDependencies || {}
+        pkg.peerDependencies['is-number'] = '*'
+        pkg.devDependencies = pkg.devDependencies || {}
+        pkg.devDependencies['is-number'] = '*'
+      }
+      return pkg
+    }
+  }
+}
+EOF
+
+	run aube install
+	assert_success
+	assert_file_exists node_modules/is-even/index.js
+	# is-odd is transitive (via is-even), so it lands in the virtual
+	# store rather than at node_modules root. The peer-context suffix
+	# (`_is-number@3.0.0`) is what tells us aube actually applied the
+	# hook's peerDependencies edit before resolving.
+	assert_dir_exists node_modules/.aube/is-odd@0.1.2_is-number@3.0.0/node_modules/is-odd
+}
+
+@test "pnpmfile: readPackage that returns undefined fails the install" {
+	skip "aube divergence: aube continues with the original manifest when readPackage returns undefined; pnpm fails the install. File a Discussion before un-skipping."
+	# Ported from pnpm/test/install/hooks.ts:68 ('readPackage hook makes
+	# installation fail if it does not return the modified package
+	# manifests'). Skipped pending https://github.com/endevco/aube/discussions
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-hooks-undef-return",
+  "version": "0.0.0",
+  "dependencies": { "is-even": "1.0.0" }
+}
+JSON
+
+	cat >.pnpmfile.cjs <<'EOF'
+'use strict'
+module.exports = {
+  hooks: {
+    readPackage (pkg) {}
+  }
+}
+EOF
+
+	run aube install
+	assert_failure
+}
+
+@test "pnpmfile: readPackage hook can mutate the root project's dependencies" {
+	skip "aube divergence: aube does not run readPackage on the root project's manifest, so deps added by the hook are not installed. pnpm does. File a Discussion before un-skipping."
+	# Ported from pnpm/test/install/hooks.ts:551 ('readPackage hook
+	# overrides project package'). Skipped pending
+	# https://github.com/endevco/aube/discussions
+	cat >package.json <<'JSON'
+{
+  "name": "test-read-package-hook",
+  "version": "0.0.0"
+}
+JSON
+
+	cat >.pnpmfile.cjs <<'EOF'
+'use strict'
+module.exports = {
+  hooks: {
+    readPackage (pkg) {
+      if (pkg.name === 'test-read-package-hook') {
+        pkg.dependencies = { 'is-odd': '3.0.1' }
+      }
+      return pkg
+    }
+  }
+}
+EOF
+
+	run aube install
+	assert_success
+	assert_file_exists node_modules/is-odd/index.js
+	# package.json on disk should NOT have been written — the hook only
+	# mutates the in-memory manifest.
+	run cat package.json
+	refute_output --partial '"dependencies"'
+}

--- a/test/pnpm_install_hooks.bats
+++ b/test/pnpm_install_hooks.bats
@@ -51,6 +51,14 @@ EOF
 	# be empty rather than pulling in is-number / kind-of.
 	run bash -c "awk '/^snapshots:/,0' aube-lock.yaml | grep '^  is-odd@'"
 	assert_output --partial 'is-odd@0.1.2: {}'
+	# Belt-and-braces: confirm the transitive chain is-odd → is-number
+	# → kind-of was actually short-circuited, not just hidden in the
+	# snapshot. A regression that empties the snapshot entry while still
+	# resolving the deps would otherwise sneak through.
+	run grep 'is-number' aube-lock.yaml
+	assert_failure
+	run grep 'kind-of' aube-lock.yaml
+	assert_failure
 }
 
 @test "pnpmfile: async afterAllResolved hook runs and is awaited" {


### PR DESCRIPTION
## Summary

Ports 5 active hook tests + 2 skipped divergences from [`pnpm/test/install/hooks.ts`](https://github.com/pnpm/pnpm/blob/main/pnpm/test/install/hooks.ts) into the new [test/pnpm_install_hooks.bats](https://github.com/endevco/aube/blob/claude/pnpm-import-hooks/test/pnpm_install_hooks.bats), following the pattern established by [#416](https://github.com/endevco/aube/pull/416) (tracked in `test/PNPM_TEST_IMPORT.md`).

**Active tests (all passing):**
- async `readPackage` mutates a transitive's deps — pnpm hooks.ts:43
- async `afterAllResolved` runs and is awaited — hooks.ts:498
- syntax error in `.pnpmfile.cjs` fails the install — hooks.ts:292
- `require()` of a missing module fails the install — hooks.ts:303
- `readPackage` setting optional/peer/dev fields on a transitive — hooks.ts:528

**Skipped — surfaced aube divergences (worth filing as Discussions before un-skipping):**
- `readPackage` returning `undefined` should fail the install (hooks.ts:68); aube continues with the original manifest
- `readPackage` mutating the root project's `.dependencies` should install those deps (hooks.ts:551); aube does not run the hook on the root manifest

The remaining 15 tests in hooks.ts depend on `@pnpm.e2e/*` fixtures (Phase 0) or `addDistTag` helper (Phase 2) and are tracked in the TODO doc.

## Test plan

- [x] `mise run test:bats test/pnpm_install_hooks.bats` — 5 ok, 2 skip, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test suite additions and a tracking doc update, with no production code impact. Main risk is potential test flakiness due to lockfile/path assertions and pnpmfile error-message matching.
> 
> **Overview**
> Ports a first batch of `pnpm/test/install/hooks.ts` coverage into aube’s bats suite by adding `test/pnpm_install_hooks.bats`.
> 
> The new tests exercise `.pnpmfile.cjs` hook behavior (async `readPackage` mutation of transitives, async `afterAllResolved` being awaited) and failure paths when the pnpmfile has a syntax error or `require()`s a missing module; two additional cases are added but marked `skip` to document current aube divergences.
> 
> Updates `test/PNPM_TEST_IMPORT.md` to track the hooks port progress, list completed/skipped cases, and note divergences/fixture-dependent tests still pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10406fa5dcf64e1cee1ed6ca1bb579052a2afa21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->