### PR TITLE
ci: drop shared aube-rust-linux cache-tag, point -large at base cache

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,10 +4,10 @@ self-hosted-runner:
     - namespace-profile-endev-linux-amd64-large
     - namespace-profile-endev-linux-arm64
     - namespace-profile-endev-macos-arm64
-    # Namespace lets you append `;overrides.cache-tag=NAME` to a profile
-    # to share a cache volume across multiple profiles. Both the base
-    # and `-large` Linux profiles point at the same `aube-rust-linux`
-    # tag so the rust cache is shared between regular CI and the bench
-    # jobs that run on `-large`.
-    - namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
-    - namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
+    # The `-large` profile (used by bench-pr / bench-refresh) overrides
+    # its cache-tag to match the base `*-amd64` profile's default cache
+    # identity, so the bench runners share the warm Rust cache that the
+    # regular CI jobs build up. The base profile keeps its default (no
+    # override) — empirically a custom cache-tag fragments into per-job
+    # forks that never consolidate, while the default volume reuses fine.
+    - namespace-profile-endev-linux-amd64-large;overrides.cache-tag=github-namespace-profile-endev-linux-amd64-endevco-aube

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -26,7 +26,7 @@ jobs:
       github.actor != 'renovate[bot]'
       && github.actor != 'mend[bot]'
       && !startsWith(github.head_ref, 'release-plz-')
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   bench:
     name: Compare PR performance
-    runs-on: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
+    runs-on: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=github-namespace-profile-endev-linux-amd64-endevco-aube
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -70,7 +70,7 @@ jobs:
     name: Refresh benchmarks
     needs: check
     if: needs.check.outputs.drift == 'true'
-    runs-on: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
+    runs-on: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=github-namespace-profile-endev-linux-amd64-endevco-aube
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+            runner: namespace-profile-endev-linux-amd64
           - os: macos-latest
             runner: namespace-profile-endev-macos-arm64
     runs-on: ${{ matrix.runner }}
@@ -58,7 +58,7 @@ jobs:
   # lint failures don't block the BATS jobs from starting against a
   # known-good binary.
   test-linux:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 30
     env:
       RUSTFLAGS: "-D warnings"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   build:
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    runs-on: namespace-profile-endev-linux-amd64
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -20,7 +20,7 @@ jobs:
   # dependency order. Otherwise it's a no-op.
   release-plz-release:
     name: release-plz release
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    runs-on: namespace-profile-endev-linux-amd64
     # Two commits landing on main in quick succession must not double-publish.
     concurrency:
       group: release-plz-release-${{ github.ref }}
@@ -199,7 +199,7 @@ jobs:
   # an out-of-date `aube.usage.kdl`.
   release-plz-pr:
     name: release-plz PR
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,19 +45,19 @@ jobs:
             build-tool: cargo
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+            runner: namespace-profile-endev-linux-amd64
             build-tool: cross
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+            runner: namespace-profile-endev-linux-amd64
             build-tool: cross
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+            runner: namespace-profile-endev-linux-amd64
             build-tool: cross
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+            runner: namespace-profile-endev-linux-amd64
             build-tool: cross
           - target: x86_64-pc-windows-msvc
             os: windows-latest


### PR DESCRIPTION
## Summary

[#415](https://github.com/endevco/aube/pull/415) introduced `;overrides.cache-tag=aube-rust-linux` on every Linux Namespace `runs-on` to share the Rust cache across base + `-large` profiles. Empirically the override creates a separate cache volume that fragments into per-job forks and never reconciles — four consecutive main runs (commits `135fe797`, `92af0bdf`, `113eb8be`, plus the in-progress run) all started cold:

```
Some cache paths missing: /home/runner/.cargo/registry, ./target, ...
Total available cache space is 49G, and 5.0M have been used.
```

…despite each post-step writing 4–5 GiB. The Namespace dashboard shows 9 separate forks of `aube-rust-linux`, none consolidating.

The pre-#415 default volume `github-namespace-profile-endev-linux-amd64-endevco-aube` is still warm at 7.5 GiB and was hitting `All cache paths found and restored. 13G used` before #415.

## Changes

- **Strip** `;overrides.cache-tag=aube-rust-linux` from every base `*-amd64` runs-on (ci, autofix, docs, release, release-plz). Falls back to the working default volume.
- **Re-point** `bench-pr` / `bench-refresh` (`*-amd64-large`) at the base profile's default cache identity via `;overrides.cache-tag=github-namespace-profile-endev-linux-amd64-endevco-aube`. Bench runners join the warm cache instead of cold-starting.
- **Update** `.github/actionlint.yaml` to register the new `-large` override label and drop the `aube-rust-linux` ones.

`CARGO_INCREMENTAL=0` additions from #415 stay (orthogonal cleanup that's still wanted).

## Test plan

- [ ] Watch this PR's CI build/test-linux jobs report `All cache paths found and restored. NN G used` (instead of `5.0M`).
- [ ] Watch the next bench-pr run (this PR will trigger one) report a warm cache hit pulling from the base profile's volume.
- [ ] `actionlint` passes locally — verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions runner labels and cache-tag overrides across core CI, release, and bench workflows; misconfiguration could lead to slower builds or unexpected cache misses/failures but does not affect product runtime behavior.
> 
> **Overview**
> Removes the custom Namespace `;overrides.cache-tag=aube-rust-linux` from the standard Linux `*-amd64` runners across CI, docs, autofix, and release workflows, reverting them to the default cache identity.
> 
> Updates the `*-amd64-large` bench workflows to explicitly override their `cache-tag` to the base runner’s default cache volume so bench jobs share the same warmed Rust cache, and adjusts `.github/actionlint.yaml` labels accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f707ab4c3172249f96660f39106973f0c955614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->