### PR TITLE
fix(scripts): close 3 lifecycle parity gaps with pnpm

### DIFF
--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -436,10 +436,19 @@ fn node_platform() -> &'static str {
 }
 
 fn node_arch() -> &'static str {
+    // Mappings from Rust's `std::env::consts::ARCH` to Node's
+    // `process.arch`. Common arches first; the rare ones at the bottom
+    // exist so the test below stays a real guarantee on every host
+    // Rust ships, not just x64/arm64. Pass-through covers `arm`,
+    // `mips`, `riscv64`, `s390x` — those tokens match between the two
+    // vocabularies.
     match std::env::consts::ARCH {
         "x86_64" => "x64",
         "aarch64" => "arm64",
         "x86" => "ia32",
+        "powerpc" => "ppc",
+        "powerpc64" => "ppc64",
+        "loongarch64" => "loong64",
         other => other,
     }
 }
@@ -944,11 +953,22 @@ mod user_agent_tests {
             "platform `{platform}` should follow Node's `process.platform` vocabulary"
         );
         // Arch must be a Node-style token, not Rust's `x86_64`/`aarch64`.
+        // Allowlist is the union of mapped outputs (`node_arch`) and the
+        // pass-through tokens that already match Node's vocabulary.
         let arch = parts[2];
         assert!(
             matches!(
                 arch,
-                "x64" | "arm64" | "ia32" | "arm" | "ppc64" | "s390x" | "mips" | "mipsel"
+                "x64"
+                    | "arm64"
+                    | "ia32"
+                    | "arm"
+                    | "ppc"
+                    | "ppc64"
+                    | "loong64"
+                    | "mips"
+                    | "riscv64"
+                    | "s390x"
             ),
             "arch `{arch}` should follow Node's `process.arch` vocabulary"
         );

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -409,6 +409,20 @@ pub fn exit_code_from_status(status: std::process::ExitStatus) -> i32 {
     1
 }
 
+/// User agent string exported to lifecycle scripts as
+/// `npm_config_user_agent`. Mirrors pnpm's format
+/// (`<name>/<version> <os> <arch>`) so dep build scripts that sniff
+/// the env var to detect the running PM (e.g. `husky`,
+/// `unrs-resolver`) recognize aube without falling back to npm-mode.
+pub fn aube_user_agent() -> String {
+    format!(
+        "aube/{} {} {}",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+    )
+}
+
 fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &ScriptSettings) {
     // Strip credentials that aube itself owns before we spawn any
     // lifecycle script. AUBE_AUTH_TOKEN is aube's own registry login
@@ -417,6 +431,11 @@ fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &Scrip
     // flows ("npm publish" in a postpublish script) genuinely need
     // them. Matches what pnpm does today.
     cmd.env_remove("AUBE_AUTH_TOKEN");
+    // pnpm parity: every lifecycle script gets `npm_config_user_agent`
+    // so dep postinstalls can detect the running PM. Set here (not at
+    // spawn time) so it flows through both the jailed and the
+    // non-jailed paths.
+    cmd.env("npm_config_user_agent", aube_user_agent());
     if let Some(node_options) = settings.node_options.as_deref() {
         cmd.env("NODE_OPTIONS", node_options);
     }

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -414,13 +414,34 @@ pub fn exit_code_from_status(status: std::process::ExitStatus) -> i32 {
 /// (`<name>/<version> <os> <arch>`) so dep build scripts that sniff
 /// the env var to detect the running PM (e.g. `husky`,
 /// `unrs-resolver`) recognize aube without falling back to npm-mode.
+/// OS/arch use Node's `process.platform` / `process.arch` vocabulary
+/// (`darwin`/`linux`/`win32`, `x64`/`arm64`), not Rust's native
+/// `std::env::consts::{OS,ARCH}` values, so tools that parse the full
+/// UA string identify the platform the same way npm/yarn/pnpm do.
 pub fn aube_user_agent() -> String {
     format!(
         "aube/{} {} {}",
         env!("CARGO_PKG_VERSION"),
-        std::env::consts::OS,
-        std::env::consts::ARCH,
+        node_platform(),
+        node_arch(),
     )
+}
+
+fn node_platform() -> &'static str {
+    match std::env::consts::OS {
+        "macos" => "darwin",
+        "windows" => "win32",
+        other => other,
+    }
+}
+
+fn node_arch() -> &'static str {
+    match std::env::consts::ARCH {
+        "x86_64" => "x64",
+        "aarch64" => "arm64",
+        "x86" => "ia32",
+        other => other,
+    }
 }
 
 fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &ScriptSettings) {
@@ -900,6 +921,38 @@ pub enum Error {
     Spawn(String, String),
     #[error("script `{script}` exited with code {code:?}")]
     NonZeroExit { script: String, code: Option<i32> },
+}
+
+#[cfg(test)]
+mod user_agent_tests {
+    use super::*;
+
+    #[test]
+    fn user_agent_uses_node_style_platform_and_arch() {
+        let ua = aube_user_agent();
+        // Format: "aube/<version> <platform> <arch>"
+        assert!(ua.starts_with("aube/"), "unexpected prefix: {ua}");
+        let parts: Vec<&str> = ua.split(' ').collect();
+        assert_eq!(parts.len(), 3, "expected 3 space-separated fields: {ua}");
+        // Platform must be a Node-style token, not Rust's `macos`/`windows`.
+        let platform = parts[1];
+        assert!(
+            matches!(
+                platform,
+                "darwin" | "linux" | "win32" | "freebsd" | "openbsd" | "netbsd" | "dragonfly"
+            ),
+            "platform `{platform}` should follow Node's `process.platform` vocabulary"
+        );
+        // Arch must be a Node-style token, not Rust's `x86_64`/`aarch64`.
+        let arch = parts[2];
+        assert!(
+            matches!(
+                arch,
+                "x64" | "arm64" | "ia32" | "arm" | "ppc64" | "s390x" | "mips" | "mipsel"
+            ),
+            "arch `{arch}` should follow Node's `process.arch` vocabulary"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -361,13 +361,13 @@ pub async fn run(
     // new dep. Wrapping in a `Result` so the restore step below runs
     // even on failure — a network error mid-resolve would otherwise
     // leave the mutated `package.json` on disk, breaking `--no-save`.
-    // pnpm parity: `pnpm install <pkg>` (≈ `aube add`) does NOT run root
-    // lifecycle hooks. Skip them so adding a single dep doesn't re-run an
-    // expensive root postinstall / prepare on every `aube add`.
-    let mut install_opts =
-        install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Fix));
-    install_opts.skip_root_lifecycle = true;
-    let pipeline_result: miette::Result<()> = install::run(install_opts).await;
+    // `with_mode()` already skips root lifecycle hooks (chained-call
+    // contract) so `aube add` doesn't re-run the root postinstall /
+    // prepare on every invocation.
+    let pipeline_result: miette::Result<()> = install::run(install::InstallOptions::with_mode(
+        super::chained_frozen_mode(install::FrozenMode::Fix),
+    ))
+    .await;
 
     // 5. Under `--no-save`, restore the snapshotted `package.json` and
     // lockfile so neither shows up in `git status`. The user's
@@ -798,9 +798,6 @@ async fn run_filtered(
             install::FrozenMode::Fix,
         ));
         install_opts.workspace_filter = filter.clone();
-        // pnpm parity: skip root lifecycle hooks on `aube add` (see the
-        // single-project path above for the contract).
-        install_opts.skip_root_lifecycle = true;
         install::run(install_opts).await?;
         Ok(())
     }

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -361,10 +361,13 @@ pub async fn run(
     // new dep. Wrapping in a `Result` so the restore step below runs
     // even on failure — a network error mid-resolve would otherwise
     // leave the mutated `package.json` on disk, breaking `--no-save`.
-    let pipeline_result: miette::Result<()> = install::run(install::InstallOptions::with_mode(
-        super::chained_frozen_mode(install::FrozenMode::Fix),
-    ))
-    .await;
+    // pnpm parity: `pnpm install <pkg>` (≈ `aube add`) does NOT run root
+    // lifecycle hooks. Skip them so adding a single dep doesn't re-run an
+    // expensive root postinstall / prepare on every `aube add`.
+    let mut install_opts =
+        install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Fix));
+    install_opts.skip_root_lifecycle = true;
+    let pipeline_result: miette::Result<()> = install::run(install_opts).await;
 
     // 5. Under `--no-save`, restore the snapshotted `package.json` and
     // lockfile so neither shows up in `git status`. The user's
@@ -795,6 +798,9 @@ async fn run_filtered(
             install::FrozenMode::Fix,
         ));
         install_opts.workspace_filter = filter.clone();
+        // pnpm parity: skip root lifecycle hooks on `aube add` (see the
+        // single-project path above for the contract).
+        install_opts.skip_root_lifecycle = true;
         install::run(install_opts).await?;
         Ok(())
     }

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -67,6 +67,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         env_snapshot: aube_settings::values::capture_env(),
         git_prepare_depth: 0,
         workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
+        skip_root_lifecycle: false,
     };
     install::run(opts).await
 }

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -246,6 +246,7 @@ pub async fn run(
             env_snapshot: aube_settings::values::capture_env(),
             git_prepare_depth: 0,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
+            skip_root_lifecycle: false,
         };
         install::run(opts).await?;
 

--- a/crates/aube/src/commands/install/git_prepare.rs
+++ b/crates/aube/src/commands/install/git_prepare.rs
@@ -106,6 +106,12 @@ pub(super) async fn run_git_dep_prepare(
     opts.project_dir = Some(clone_dir.to_path_buf());
     opts.ignore_scripts = ignore_scripts;
     opts.git_prepare_depth = depth + 1;
+    // Override the chained-call default: this nested install's "root" IS
+    // the git dep itself, and running its `prepare` (plus
+    // pre/post-install) is the entire point of git-dep preparation.
+    // Treat this as if it were an argumentless `aube install` against the
+    // dep's clone directory.
+    opts.skip_root_lifecycle = false;
     let spec = spec.to_string();
     tokio::task::spawn_blocking(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -379,17 +379,17 @@ pub struct InstallOptions {
     pub workspace_filter: aube_workspace::selector::EffectiveFilter,
     /// Skip the root package's `preinstall` / `install` / `postinstall` /
     /// `prepare` lifecycle hooks. pnpm parity: those hooks fire only on
-    /// argumentless `pnpm install`. Every other entry point — `add`,
-    /// `remove`, `update`, `dedupe`, `dlx`, patch tooling, the
-    /// `ensure_installed` auto-install before `run`/`test`, nested git
-    /// prepare installs — must skip them so a chained `aube add foo`
-    /// doesn't re-run an expensive root postinstall on every invocation.
-    /// Independent of `ignore_scripts`, which also skips dep scripts.
-    /// `with_mode()` defaults to `true` (chained-call constructor); the
-    /// argumentless `aube install` path threaded through
-    /// `InstallArgs::into_options` is the only construction site that
-    /// flips this back to `false`. `aube ci` and `aube deploy` build
-    /// `InstallOptions` literally and explicitly opt back in.
+    /// argumentless `pnpm install`. Every other user-facing entry point —
+    /// `add`, `remove`, `update`, `dedupe`, `dlx`, patch tooling, the
+    /// `ensure_installed` auto-install before `run`/`test` — must skip
+    /// them so a chained `aube add foo` doesn't re-run an expensive root
+    /// postinstall on every invocation. Independent of `ignore_scripts`,
+    /// which also skips dep scripts. `with_mode()` defaults to `true`
+    /// (chained-call constructor). The exceptions are argumentless
+    /// `aube install` (`InstallArgs::into_options`), `aube ci` /
+    /// `aube deploy` (literal struct constructions), and the nested
+    /// git-prepare install — that one's "root" IS the git dep itself and
+    /// running its `prepare` is the whole point.
     pub skip_root_lifecycle: bool,
 }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -290,6 +290,10 @@ impl InstallArgs {
             env_snapshot,
             git_prepare_depth: 0,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
+            // Argumentless `aube install` runs root lifecycle hooks; the
+            // chained-call constructor (`with_mode`) is where commands
+            // with package args opt into skipping them.
+            skip_root_lifecycle: false,
         }
     }
 }
@@ -373,6 +377,14 @@ pub struct InstallOptions {
     /// selectors additionally skip `devDependencies` edges during
     /// graph traversal — see `aube_workspace::selector::EffectiveFilter`.
     pub workspace_filter: aube_workspace::selector::EffectiveFilter,
+    /// Skip the root package's `preinstall` / `install` / `postinstall` /
+    /// `prepare` lifecycle hooks. pnpm parity: those hooks fire only on
+    /// argumentless `pnpm install`, never on `pnpm install <pkg>` (≈
+    /// `aube add`), `pnpm update`, `pnpm remove`, etc. Set by chained
+    /// commands that pass package arguments so a fresh `aube add foo`
+    /// doesn't re-run an expensive root postinstall on every invocation.
+    /// Independent of `ignore_scripts`, which also skips dep scripts.
+    pub skip_root_lifecycle: bool,
 }
 
 #[derive(Default)]
@@ -454,6 +466,7 @@ impl InstallOptions {
             env_snapshot: aube_settings::values::capture_env(),
             git_prepare_depth: 0,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
+            skip_root_lifecycle: false,
         }
     }
 }
@@ -1557,7 +1570,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     //     (both imply "no node_modules touched, so lifecycle scripts
     //     have nothing to gate"). Dependency scripts are always
     //     skipped.
-    if !opts.ignore_scripts && !lockfile_only_effective {
+    if !opts.ignore_scripts && !lockfile_only_effective && !opts.skip_root_lifecycle {
         let phase_start = std::time::Instant::now();
         run_root_lifecycle(
             &cwd,
@@ -3531,7 +3544,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     //     that mode.
     //     A hook that's not defined in package.json is a silent no-op.
     //     A hook that exits non-zero fails the install (fail-fast, matching pnpm).
-    if !opts.ignore_scripts && !virtual_store_only {
+    if !opts.ignore_scripts && !virtual_store_only && !opts.skip_root_lifecycle {
         let phase_start = std::time::Instant::now();
         for hook in [
             aube_scripts::LifecycleHook::Install,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -379,11 +379,17 @@ pub struct InstallOptions {
     pub workspace_filter: aube_workspace::selector::EffectiveFilter,
     /// Skip the root package's `preinstall` / `install` / `postinstall` /
     /// `prepare` lifecycle hooks. pnpm parity: those hooks fire only on
-    /// argumentless `pnpm install`, never on `pnpm install <pkg>` (≈
-    /// `aube add`), `pnpm update`, `pnpm remove`, etc. Set by chained
-    /// commands that pass package arguments so a fresh `aube add foo`
+    /// argumentless `pnpm install`. Every other entry point — `add`,
+    /// `remove`, `update`, `dedupe`, `dlx`, patch tooling, the
+    /// `ensure_installed` auto-install before `run`/`test`, nested git
+    /// prepare installs — must skip them so a chained `aube add foo`
     /// doesn't re-run an expensive root postinstall on every invocation.
     /// Independent of `ignore_scripts`, which also skips dep scripts.
+    /// `with_mode()` defaults to `true` (chained-call constructor); the
+    /// argumentless `aube install` path threaded through
+    /// `InstallArgs::into_options` is the only construction site that
+    /// flips this back to `false`. `aube ci` and `aube deploy` build
+    /// `InstallOptions` literally and explicitly opt back in.
     pub skip_root_lifecycle: bool,
 }
 
@@ -466,7 +472,12 @@ impl InstallOptions {
             env_snapshot: aube_settings::values::capture_env(),
             git_prepare_depth: 0,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
-            skip_root_lifecycle: false,
+            // pnpm parity: every chained-call site (add / remove / update
+            // / dedupe / dlx / patch / ensure_installed / git prepare)
+            // skips root lifecycle hooks. Argumentless `aube install` is
+            // the only construction path that runs them and it goes
+            // through `InstallArgs::into_options`, not here.
+            skip_root_lifecycle: true,
         }
     }
 }

--- a/crates/aube/src/commands/install_test.rs
+++ b/crates/aube/src/commands/install_test.rs
@@ -38,7 +38,13 @@ pub async fn run(script_args: ScriptArgs) -> miette::Result<()> {
             None,
             aube_settings::resolved::prefer_frozen_lockfile(&ctx),
         );
-        install::run(install::InstallOptions::with_mode(mode)).await?;
+        // `install-test` is a pnpm-compat alias for `install && test`,
+        // so the install phase needs to behave like argumentless `aube
+        // install` — including running root lifecycle hooks. Override
+        // the chained-call default that `with_mode()` sets.
+        let mut opts = install::InstallOptions::with_mode(mode);
+        opts.skip_root_lifecycle = false;
+        install::run(opts).await?;
     }
 
     run_script(

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -310,3 +310,137 @@ JSON
 	assert_success
 	assert_file_exists aube-transitive-bin-probe.txt
 }
+
+# -- Ported from pnpm/test/install/lifecycleScripts.ts ------------------------
+#
+# Existing aube tests above cover most of pnpm's filesystem-marker assertions
+# (preinstall ran / postinstall ran / prepare ran / exit-non-zero fails install
+# / --ignore-scripts skips hooks / npm_package_* env vars). The block below
+# adds the orthogonal stdout-visibility assertions from pnpm's suite — proving
+# the script's stdout reaches the user — plus three known-divergence skip
+# tests that document parity gaps surfaced by porting the suite.
+
+@test "aube install: preinstall script stdout reaches the user" {
+	# Ported from pnpm/test/install/lifecycleScripts.ts:43
+	# ('preinstall is executed before general installation').
+	# Complements the existing filesystem-marker test by also asserting
+	# that the script's echoed output makes it through aube's progress UI.
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-lifecycle-preinstall-stdout",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "echo HELLO_FROM_PREINSTALL"
+  }
+}
+JSON
+	run aube install
+	assert_success
+	assert_output --partial "HELLO_FROM_PREINSTALL"
+}
+
+@test "aube install: postinstall script stdout reaches the user" {
+	# Ported from pnpm/test/install/lifecycleScripts.ts:56
+	# ('postinstall is executed after general installation').
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-lifecycle-postinstall-stdout",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "echo HELLO_FROM_POSTINSTALL"
+  }
+}
+JSON
+	run aube install
+	assert_success
+	assert_output --partial "HELLO_FROM_POSTINSTALL"
+}
+
+@test "aube install: prepare script stdout reaches the user (argumentless install)" {
+	# Ported from pnpm/test/install/lifecycleScripts.ts:95
+	# ('prepare is executed after argumentless installation').
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-lifecycle-prepare-stdout",
+  "version": "1.0.0",
+  "scripts": {
+    "prepare": "echo HELLO_FROM_PREPARE"
+  }
+}
+JSON
+	run aube install
+	assert_success
+	assert_output --partial "HELLO_FROM_PREPARE"
+}
+
+@test "aube: lifecycle scripts receive npm_config_user_agent (PARITY GAP)" {
+	# Ported from pnpm/test/install/lifecycleScripts.ts:29
+	# ('lifecycle script runs with the correct user agent').
+	# pnpm exports `npm_config_user_agent="pnpm/<version> ..."` to every
+	# lifecycle script so dep build scripts can detect the running PM.
+	# aube does not currently set this env var — see
+	# crates/aube-scripts/src/lib.rs (only npm_package_* + a small
+	# npm_config_* allowlist are exported). This is a documented
+	# divergence; remove the skip when aube adds the export.
+	skip "aube divergence: npm_config_user_agent not exported to lifecycle scripts"
+
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-lifecycle-user-agent",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "node -e 'console.log(\"UA=\" + (process.env.npm_config_user_agent || \"\"))'"
+  }
+}
+JSON
+	run aube install
+	assert_success
+	# pnpm asserts the user agent starts with `${pkgName}/${pkgVersion}`.
+	assert_output --regexp "UA=aube/[0-9]+\.[0-9]+\.[0-9]+"
+}
+
+@test "aube add: root postinstall is NOT triggered when adding a named dep (PARITY GAP)" {
+	# Ported from pnpm/test/install/lifecycleScripts.ts:69
+	# ('postinstall is not executed after named installation').
+	# pnpm's contract: lifecycle hooks (preinstall/install/postinstall/
+	# prepare) only run during a "full install" — `pnpm install` with no
+	# package args. `pnpm install <pkg>` (i.e. `aube add <pkg>`) skips
+	# them so adding a single dep doesn't re-run codegen / build steps.
+	# aube currently fires root postinstall on every `aube add`. Remove
+	# the skip when aube gates root hooks on argumentless install.
+	skip "aube divergence: root postinstall fires on aube add <pkg>"
+
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-lifecycle-named-postinstall",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node -e 'require(\"fs\").writeFileSync(\"postinstall.marker\", \"ran\")'"
+  }
+}
+JSON
+	run aube add is-odd@3.0.1
+	assert_success
+	assert [ ! -e postinstall.marker ]
+}
+
+@test "aube add: root prepare is NOT triggered when adding a named dep (PARITY GAP)" {
+	# Ported from pnpm/test/install/lifecycleScripts.ts:82
+	# ('prepare is not executed after installation with arguments').
+	# Same divergence as the postinstall case above — see that skip for
+	# the underlying contract.
+	skip "aube divergence: root prepare fires on aube add <pkg>"
+
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-lifecycle-named-prepare",
+  "version": "1.0.0",
+  "scripts": {
+    "prepare": "node -e 'require(\"fs\").writeFileSync(\"prepare.marker\", \"ran\")'"
+  }
+}
+JSON
+	run aube add is-odd@3.0.1
+	assert_success
+	assert [ ! -e prepare.marker ]
+}

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -432,3 +432,53 @@ JSON
 	assert_success
 	assert [ ! -e prepare.marker ]
 }
+
+@test "aube remove: root postinstall is NOT triggered" {
+	# Same pnpm contract as the `aube add` cases — root hooks fire only
+	# on argumentless `aube install`. `pnpm remove <pkg>` is a chained
+	# operation that must not re-run them.
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-lifecycle-remove",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node -e 'require(\"fs\").writeFileSync(\"postinstall.marker\", \"ran\")'"
+  },
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}
+JSON
+	# Seed node_modules with --ignore-scripts so the marker isn't written
+	# during setup, then exercise `aube remove` under regular settings.
+	run aube install --ignore-scripts
+	assert_success
+	rm -f postinstall.marker
+
+	run aube remove is-odd
+	assert_success
+	assert [ ! -e postinstall.marker ]
+}
+
+@test "aube update: root postinstall is NOT triggered" {
+	# Same pnpm contract — `aube update` is a chained operation.
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-lifecycle-update",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node -e 'require(\"fs\").writeFileSync(\"postinstall.marker\", \"ran\")'"
+  },
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}
+JSON
+	run aube install --ignore-scripts
+	assert_success
+	rm -f postinstall.marker
+
+	run aube update
+	assert_success
+	assert [ ! -e postinstall.marker ]
+}

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -316,9 +316,11 @@ JSON
 # Existing aube tests above cover most of pnpm's filesystem-marker assertions
 # (preinstall ran / postinstall ran / prepare ran / exit-non-zero fails install
 # / --ignore-scripts skips hooks / npm_package_* env vars). The block below
-# adds the orthogonal stdout-visibility assertions from pnpm's suite — proving
-# the script's stdout reaches the user — plus three known-divergence skip
-# tests that document parity gaps surfaced by porting the suite.
+# adds the orthogonal stdout-visibility assertions from pnpm's suite (the
+# script's echo reaches the user), plus three parity tests that previously
+# documented divergences and now ride the corresponding fixes:
+# `npm_config_user_agent` is exported, and root postinstall/prepare no longer
+# fire on `aube add <pkg>`.
 
 @test "aube install: preinstall script stdout reaches the user" {
 	# Ported from pnpm/test/install/lifecycleScripts.ts:43
@@ -373,17 +375,11 @@ JSON
 	assert_output --partial "HELLO_FROM_PREPARE"
 }
 
-@test "aube: lifecycle scripts receive npm_config_user_agent (PARITY GAP)" {
+@test "aube: lifecycle scripts receive npm_config_user_agent" {
 	# Ported from pnpm/test/install/lifecycleScripts.ts:29
 	# ('lifecycle script runs with the correct user agent').
-	# pnpm exports `npm_config_user_agent="pnpm/<version> ..."` to every
-	# lifecycle script so dep build scripts can detect the running PM.
-	# aube does not currently set this env var — see
-	# crates/aube-scripts/src/lib.rs (only npm_package_* + a small
-	# npm_config_* allowlist are exported). This is a documented
-	# divergence; remove the skip when aube adds the export.
-	skip "aube divergence: npm_config_user_agent not exported to lifecycle scripts"
-
+	# aube exports the same env var so dep build scripts (husky,
+	# unrs-resolver, node-pre-gyp, etc.) can detect the running PM.
 	cat >package.json <<'JSON'
 {
   "name": "pnpm-lifecycle-user-agent",
@@ -399,17 +395,12 @@ JSON
 	assert_output --regexp "UA=aube/[0-9]+\.[0-9]+\.[0-9]+"
 }
 
-@test "aube add: root postinstall is NOT triggered when adding a named dep (PARITY GAP)" {
+@test "aube add: root postinstall is NOT triggered when adding a named dep" {
 	# Ported from pnpm/test/install/lifecycleScripts.ts:69
 	# ('postinstall is not executed after named installation').
-	# pnpm's contract: lifecycle hooks (preinstall/install/postinstall/
-	# prepare) only run during a "full install" — `pnpm install` with no
-	# package args. `pnpm install <pkg>` (i.e. `aube add <pkg>`) skips
+	# pnpm's contract: lifecycle hooks only run during an argumentless
+	# `install` — `pnpm install <pkg>` (i.e. `aube add <pkg>`) skips
 	# them so adding a single dep doesn't re-run codegen / build steps.
-	# aube currently fires root postinstall on every `aube add`. Remove
-	# the skip when aube gates root hooks on argumentless install.
-	skip "aube divergence: root postinstall fires on aube add <pkg>"
-
 	cat >package.json <<'JSON'
 {
   "name": "pnpm-lifecycle-named-postinstall",
@@ -424,13 +415,10 @@ JSON
 	assert [ ! -e postinstall.marker ]
 }
 
-@test "aube add: root prepare is NOT triggered when adding a named dep (PARITY GAP)" {
+@test "aube add: root prepare is NOT triggered when adding a named dep" {
 	# Ported from pnpm/test/install/lifecycleScripts.ts:82
 	# ('prepare is not executed after installation with arguments').
-	# Same divergence as the postinstall case above — see that skip for
-	# the underlying contract.
-	skip "aube divergence: root prepare fires on aube add <pkg>"
-
+	# Same contract as the postinstall case above.
 	cat >package.json <<'JSON'
 {
   "name": "pnpm-lifecycle-named-prepare",


### PR DESCRIPTION
## Summary

Ports the relevant tests from [pnpm/test/install/lifecycleScripts.ts](https://github.com/pnpm/pnpm/blob/main/pnpm/test/install/lifecycleScripts.ts) into [test/lifecycle_scripts.bats](https://github.com/endevco/aube/blob/claude/lifecycle-scripts-port/test/lifecycle_scripts.bats), per the plan in [test/PNPM_TEST_IMPORT.md](https://github.com/endevco/aube/blob/claude/elated-tharp-beb760/test/PNPM_TEST_IMPORT.md) (#416), and closes the parity gaps surfaced by the port.

## Test ports

**3 green ports** — orthogonal stdout-visibility checks that complement aube's existing filesystem-marker tests by proving the script's echoed output reaches the user through aube's progress UI:
- preinstall echo (pnpm L43)
- postinstall echo (pnpm L56)
- prepare echo on argumentless install (pnpm L95)

**3 ports that previously documented parity gaps**, now green:
- `npm_config_user_agent` exported to lifecycle scripts (pnpm L29)
- root `postinstall` is NOT triggered when adding a named dep (pnpm L69)
- root `prepare` is NOT triggered when adding a named dep (pnpm L82)

**2 extra coverage tests for `aube remove` / `aube update`** — the same pnpm contract extended to all chained-call commands (added in response to PR review).

## Gap fixes

### 1. `npm_config_user_agent` exported

`crates/aube-scripts/src/lib.rs` — adds `aube_user_agent()` returning `"aube/<version> <os> <arch>"` (mirrors pnpm's format) and sets it via `apply_script_settings_env`, which covers root + dep, jailed + non-jailed paths. Dep build scripts that sniff this env var to detect the running PM (husky, unrs-resolver, node-pre-gyp) now recognize aube instead of falling back to npm-mode.

### 2. Root hooks gated to argumentless `aube install` only

pnpm's contract: root lifecycle hooks fire only on the literal `pnpm install` invocation (no package args). Every other entry point — `add`, `remove`, `update`, `dedupe`, `dlx`, patch tooling, the `ensure_installed` auto-install before `run`/`test`, nested git-prepare installs — must skip them.

- `crates/aube/src/commands/install/mod.rs` — adds `InstallOptions.skip_root_lifecycle: bool` and gates both `run_root_lifecycle` blocks on it. The chained-call constructor `with_mode()` defaults to `true` so every chained site (every command except argumentless `install`) inherits the correct behavior automatically. Argumentless `aube install` (via `InstallArgs::into_options`) and `ci.rs` / `deploy.rs` (literal struct) keep `false`.

## Test plan

- [x] `mise run test:bats test/lifecycle_scripts.bats` — 21 ok, no skips
- [x] `cargo test -p aube-scripts` — 29 ok
- [x] Combined run across install, add, remove, update, lifecycle_scripts, dedupe, patch, ci suites — 141 ok, 0 failures
- [x] Pre-commit hooks (cargo-fmt, cargo-clippy, shfmt, shellcheck) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when root lifecycle hooks run across multiple commands and adds a new env var for all lifecycle scripts, which may affect projects relying on prior hook behavior or script environment.
> 
> **Overview**
> Improves pnpm parity for lifecycle scripts by exporting `npm_config_user_agent` (Node-style platform/arch) to all spawned scripts so dependency postinstalls can correctly detect aube.
> 
> Updates the install pipeline to *skip root* `preinstall`/`install`/`postinstall`/`prepare` hooks for chained installs (e.g. `add`/`remove`/`update`), while keeping them enabled for argumentless `aube install`, `ci`, `deploy`, and nested git-dep `prepare` installs.
> 
> Ports/extends pnpm lifecycle tests in `test/lifecycle_scripts.bats` and adds a unit test for the new user-agent formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a16e909bd846d5e966293009a634a7269d6c0f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->