### PR TITLE
test: add add_dist_tag bats helper for verdaccio storage

### DIFF
--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -70,3 +70,22 @@ _setup_basic_fixture() {
 	cp "$PROJECT_ROOT/fixtures/basic/package.json" .
 	cp "$PROJECT_ROOT/fixtures/basic/aube-lock.yaml" .
 }
+
+# Set a dist-tag on a package in the committed Verdaccio storage.
+# Verdaccio re-reads package.json from disk per request, so the new
+# tag takes effect on the next resolve without a registry restart.
+#
+# Mutates test/registry/storage/<pkg>/package.json — callers MUST
+# restore the file via `git checkout` in teardown (see deprecate.bats
+# for the canonical pattern) so the fixture stays clean across runs.
+# Tests using this helper are not parallel-safe and should set
+# `# bats file_tags=serial` + `BATS_NO_PARALLELIZE_WITHIN_FILE=1`.
+#
+# Usage: add_dist_tag <pkg> <tag> <version>
+add_dist_tag() {
+	local pkg="$1" tag="$2" version="$3"
+	local file="$PROJECT_ROOT/test/registry/storage/${pkg}/package.json"
+	local tmp="${file}.tmp"
+	jq --arg t "$tag" --arg v "$version" '.["dist-tags"][$t] = $v' "$file" >"$tmp"
+	mv "$tmp" "$file"
+}

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -86,6 +86,9 @@ add_dist_tag() {
 	local pkg="$1" tag="$2" version="$3"
 	local file="$PROJECT_ROOT/test/registry/storage/${pkg}/package.json"
 	local tmp="${file}.tmp"
-	jq --arg t "$tag" --arg v "$version" '.["dist-tags"][$t] = $v' "$file" >"$tmp"
+	jq --arg t "$tag" --arg v "$version" '.["dist-tags"][$t] = $v' "$file" >"$tmp" || {
+		rm -f "$tmp"
+		return 1
+	}
 	mv "$tmp" "$file"
 }


### PR DESCRIPTION
## Summary

- Adds `add_dist_tag <pkg> <tag> <version>` to `test/test_helper/common_setup.bash`. It splices a dist-tag into `test/registry/storage/<pkg>/package.json` via `jq` — Verdaccio re-reads from disk per request, so the new tag takes effect on the next resolve without a registry restart.
- Needed by ~10 test files (heaviest in `update.bats`); factoring it out avoids reinventing the same `jq` splice in each caller.

## Notes for reviewers

- The helper mutates the **committed** Verdaccio fixture. Callers must restore via `git checkout` in teardown — same pattern `deprecate.bats` already uses. The doc comment spells this out and points at that file.
- Tests using this helper aren't parallel-safe (they share the on-disk fixture across tests). Doc comment recommends `# bats file_tags=serial` + `BATS_NO_PARALLELIZE_WITHIN_FILE=1`, matching the existing convention in `deprecate.bats`.
- No existing call sites are migrated in this PR — landing the helper first lets the follow-up file conversions stay narrow.

## Test plan

- [x] Sanity-checked the helper against `is-odd`: adds `next: 0.1.2` alongside `latest: 3.0.1`, then `git checkout` cleanly restores.
- [ ] Confirm shfmt/shellcheck pass on `test/test_helper/common_setup.bash` (pre-commit ran clean locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since it only adds a test helper, but it mutates committed Verdaccio fixtures so incorrect cleanup could cause flaky or non-parallel-safe test runs.
> 
> **Overview**
> Adds `add_dist_tag <pkg> <tag> <version>` to `test/test_helper/common_setup.bash` to let BATS tests update a package’s `dist-tags` directly in the committed Verdaccio storage via `jq` (taking effect on the next registry resolve).
> 
> The helper writes via a temp file and documents required `git checkout` teardown cleanup plus serial/within-file non-parallel execution to avoid cross-test fixture races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b0262f96e72127da12d700d03d34049d2d8d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->