### PR TITLE
feat(pnpmfile): wire hooks into update; add preResolution hook

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -836,6 +836,7 @@ cmd update help="Update dependencies" {
         long_help "Dependency traversal depth.\n\nParsed for pnpm compatibility."
         arg <DEPTH>
     }
+    flag --ignore-pnpmfile help="Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this update"
     flag --ignore-scripts help="Skip lifecycle scripts" {
         long_help "Skip lifecycle scripts.\n\nAccepted for pnpm parity — dep scripts are already gated by `allowBuilds`, so the flag is currently a no-op, but scripts that wrap `pnpm update --ignore-scripts` keep working without complaint."
     }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1879,6 +1879,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         let pnpmfile_path = (!opts.ignore_pnpmfile)
             .then(|| crate::pnpmfile::detect(&cwd, ws_config_shared.pnpmfile_path.as_deref()))
             .flatten();
+        if let Some(p) = pnpmfile_path.as_deref() {
+            super::run_pnpmfile_pre_resolution(p, &cwd, existing_for_resolver).await?;
+        }
         let read_package_host = match pnpmfile_path.as_deref() {
             Some(p) => crate::pnpmfile::ReadPackageHost::spawn(p)
                 .await
@@ -2319,6 +2322,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let pnpmfile_path = (!opts.ignore_pnpmfile)
                 .then(|| crate::pnpmfile::detect(&cwd, ws_config_shared.pnpmfile_path.as_deref()))
                 .flatten();
+            if let Some(p) = pnpmfile_path.as_deref() {
+                super::run_pnpmfile_pre_resolution(p, &cwd, existing_for_resolver).await?;
+            }
             let read_package_host = match pnpmfile_path.as_deref() {
                 Some(p) => crate::pnpmfile::ReadPackageHost::spawn(p)
                     .await

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -435,6 +435,44 @@ pub(crate) fn make_client(cwd: &std::path::Path) -> aube_registry::client::Regis
     aube_registry::client::RegistryClient::from_config_with_policy(config, policy)
 }
 
+/// Run the pnpmfile `preResolution` hook before the resolver walks
+/// the graph. Builds a context snapshot (lockfile dir, store dir,
+/// existing lockfile, registry map) from the same sources the rest
+/// of the install pipeline consumes, so install and update see an
+/// identical hook contract.
+pub(crate) async fn run_pnpmfile_pre_resolution(
+    pnpmfile: &std::path::Path,
+    cwd: &std::path::Path,
+    existing: Option<&aube_lockfile::LockfileGraph>,
+) -> miette::Result<()> {
+    let config = load_npm_config(cwd);
+    let mut registries = std::collections::BTreeMap::new();
+    registries.insert("default".to_string(), config.registry);
+    for (scope, url) in config.scoped_registries {
+        registries.insert(scope, url);
+    }
+    // Honor `storeDir` from `.npmrc` / `pnpm-workspace.yaml` so the
+    // hook's `storeDir` field matches the path `open_store` operates
+    // on. Both branches return the user-facing root (without the
+    // `v1/files` CAS schema suffix) so a hook reading `storeDir`
+    // doesn't see different depths depending on whether the user set
+    // an override; the platform default's CAS path lives at
+    // `<root>/v1/files`, so we strip those two segments.
+    let store_dir = resolved_store_dir(cwd).or_else(|| {
+        aube_store::dirs::store_dir()
+            .and_then(|p| p.parent()?.parent().map(std::path::Path::to_path_buf))
+    });
+    let ctx = crate::pnpmfile::PreResolutionContext::from_existing(
+        cwd,
+        store_dir.as_deref(),
+        existing,
+        registries,
+    );
+    crate::pnpmfile::run_pre_resolution(pnpmfile, &ctx)
+        .await
+        .wrap_err("pnpmfile preResolution hook failed")
+}
+
 /// Build the standard resolver used by add/remove/update/dedupe: a
 /// shared `RegistryClient` wrapped in `Arc`, the shared packument
 /// cache directory, the given catalog map, and the dependency policy

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -42,6 +42,9 @@ pub struct UpdateArgs {
     /// Parsed for pnpm compatibility.
     #[arg(long)]
     pub depth: Option<String>,
+    /// Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this update.
+    #[arg(long)]
+    pub ignore_pnpmfile: bool,
     /// Skip lifecycle scripts.
     ///
     /// Accepted for pnpm parity — dep scripts are already gated by
@@ -214,14 +217,44 @@ pub async fn run(
         filtered
     });
 
-    // Re-resolve the full dependency tree
+    // Re-resolve the full dependency tree. Wire the pnpmfile in so
+    // `readPackage` mutations apply during update (not just first
+    // install) and `afterAllResolved` gets a chance to rewrite the
+    // graph before we hand it to the lockfile writer; without this,
+    // `aube install` runs in frozen-prefer mode below and never
+    // re-evaluates the hook.
+    let pnpmfile_path = (!args.ignore_pnpmfile)
+        .then(|| {
+            let (ws, _) = aube_manifest::workspace::load_both(&cwd).unwrap_or_default();
+            crate::pnpmfile::detect(&cwd, ws.pnpmfile_path.as_deref())
+        })
+        .flatten();
+    if let Some(p) = pnpmfile_path.as_deref() {
+        super::run_pnpmfile_pre_resolution(p, &cwd, existing.as_ref()).await?;
+    }
+    let read_package_host = match pnpmfile_path.as_deref() {
+        Some(p) => crate::pnpmfile::ReadPackageHost::spawn(p)
+            .await
+            .wrap_err("failed to start pnpmfile readPackage host")?,
+        None => None,
+    };
     let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
     let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
-    let graph = resolver
+    if let Some(host) = read_package_host {
+        resolver = resolver
+            .with_read_package_hook(Box::new(host) as Box<dyn aube_resolver::ReadPackageHook>);
+    }
+    let mut graph = resolver
         .resolve(&resolver_manifest, filtered_existing.as_ref())
         .await
         .map_err(miette::Report::new)
         .wrap_err("failed to resolve dependencies")?;
+    drop(resolver);
+    if let Some(p) = pnpmfile_path.as_deref() {
+        crate::pnpmfile::run_after_all_resolved(p, &mut graph)
+            .await
+            .wrap_err("pnpmfile afterAllResolved hook failed")?;
+    }
 
     // Report what changed
     for manifest_key in &manifest_keys_to_update {
@@ -311,10 +344,16 @@ pub async fn run(
 
     super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
 
-    install::run(install::InstallOptions::with_mode(
-        super::chained_frozen_mode(install::FrozenMode::Prefer),
-    ))
-    .await?;
+    // Propagate `--ignore-pnpmfile` into the chained install. Frozen-prefer
+    // normally short-circuits to a no-op fetch/link, but if the lockfile
+    // we just wrote falls out of sync (drift, manual edits, future
+    // chained calls) the install would re-resolve and re-attach the
+    // pnpmfile hook — silently overriding the flag the user passed to
+    // `aube update`.
+    let mut chained =
+        install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Prefer));
+    chained.ignore_pnpmfile = args.ignore_pnpmfile;
+    install::run(chained).await?;
 
     Ok(())
 }

--- a/crates/aube/src/pnpmfile.rs
+++ b/crates/aube/src/pnpmfile.rs
@@ -71,8 +71,8 @@ pub fn detect(cwd: &Path, workspace_pnpmfile_path: Option<&str>) -> Option<PathB
     None
 }
 
-#[derive(Serialize, Deserialize, Default)]
-struct LockfileWire {
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct LockfileWire {
     importers: BTreeMap<String, Vec<DirectDepWire>>,
     packages: BTreeMap<String, PackageWire>,
 }
@@ -224,39 +224,34 @@ process.stdin.on('end', async () => {
 });
 "#;
 
-fn after_all_resolved_shim() -> String {
+/// Generic shim used for any one-shot hook (`afterAllResolved`,
+/// `preResolution`, …). Dispatches on `process.env.AUBE_HOOK` so a new
+/// one-shot hook only needs a `run_one_shot_hook(.., name, ..)` call —
+/// don't add a parallel shim.
+fn one_shot_hook_shim() -> String {
     format!("{LOAD_PNPMFILE_JS}{SHIM}")
 }
 
-/// Run the `afterAllResolved` hook against a resolved lockfile graph.
-/// Mutations to `packages[].dependencies` and `packages[].peerDependencies`
-/// are applied in place. All other fields are round-tripped but
-/// ignored on the way back.
-pub async fn run_after_all_resolved(pnpmfile: &Path, graph: &mut LockfileGraph) -> Result<()> {
-    let input = to_wire(graph);
-    let input_json = serde_json::to_vec(&input)
-        .into_diagnostic()
-        .wrap_err("failed to serialize lockfile for pnpmfile hook")?;
-
-    tracing::debug!(
-        "running pnpmfile hook afterAllResolved ({})",
-        pnpmfile.display()
-    );
+/// Spawn a one-shot `node` child running the shared shim for `hook_name`,
+/// pipe `input_json` in on stdin, and return the captured stdout. Shared
+/// scaffolding for `afterAllResolved` (which round-trips a lockfile) and
+/// `preResolution` (which fires-and-forgets a context object).
+async fn run_one_shot_hook(pnpmfile: &Path, hook_name: &str, input_json: &[u8]) -> Result<Vec<u8>> {
+    tracing::debug!("running pnpmfile hook {hook_name} ({})", pnpmfile.display());
 
     let mut cmd = tokio::process::Command::new("node");
     cmd.arg("-e")
-        .arg(after_all_resolved_shim())
+        .arg(one_shot_hook_shim())
         .env("AUBE_PNPMFILE", pnpmfile)
-        .env("AUBE_HOOK", "afterAllResolved")
+        .env("AUBE_HOOK", hook_name)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::inherit())
-        // Match ReadPackageHost::spawn below. Without kill_on_drop
-        // the Node child keeps running when the parent future is
-        // cancelled. Install task panics or gets aborted, user
-        // Ctrl-C's aube, Node process stays alive running the
-        // afterAllResolved hook body until stdin closes on its own.
-        // Unlikely to bite in practice but zero-cost to guard.
+        // Match ReadPackageHost::spawn below. Without kill_on_drop the
+        // Node child keeps running when the parent future is cancelled
+        // (install panics, user Ctrl-C's, etc) and the hook body races
+        // on past stdin close. Unlikely to bite in practice but
+        // zero-cost to guard.
         .kill_on_drop(true);
 
     let mut child = cmd
@@ -270,10 +265,10 @@ pub async fn run_after_all_resolved(pnpmfile: &Path, graph: &mut LockfileGraph) 
             .as_mut()
             .ok_or_else(|| miette!("failed to open stdin for pnpmfile node child"))?;
         stdin
-            .write_all(&input_json)
+            .write_all(input_json)
             .await
             .into_diagnostic()
-            .wrap_err("failed to write lockfile JSON to pnpmfile hook")?;
+            .wrap_err_with(|| format!("failed to write JSON to pnpmfile {hook_name} hook"))?;
         stdin
             .shutdown()
             .await
@@ -288,15 +283,87 @@ pub async fn run_after_all_resolved(pnpmfile: &Path, graph: &mut LockfileGraph) 
         .wrap_err("pnpmfile hook child process failed")?;
     if !output.status.success() {
         return Err(miette!(
-            "pnpmfile hook `afterAllResolved` exited with status {}",
+            "pnpmfile hook `{hook_name}` exited with status {}",
             output.status
         ));
     }
+    Ok(output.stdout)
+}
 
-    let wire: LockfileWire = serde_json::from_slice(&output.stdout)
+/// Run the `afterAllResolved` hook against a resolved lockfile graph.
+/// Mutations to `packages[].dependencies` and `packages[].peerDependencies`
+/// are applied in place. All other fields are round-tripped but
+/// ignored on the way back.
+pub async fn run_after_all_resolved(pnpmfile: &Path, graph: &mut LockfileGraph) -> Result<()> {
+    let input = to_wire(graph);
+    let input_json = serde_json::to_vec(&input)
+        .into_diagnostic()
+        .wrap_err("failed to serialize lockfile for pnpmfile hook")?;
+    let stdout = run_one_shot_hook(pnpmfile, "afterAllResolved", &input_json).await?;
+    let wire: LockfileWire = serde_json::from_slice(&stdout)
         .into_diagnostic()
         .wrap_err("pnpmfile hook returned invalid JSON from afterAllResolved")?;
     apply(wire, graph);
+    Ok(())
+}
+
+/// Snapshot passed to the `preResolution` hook before resolve starts.
+/// Mirrors pnpm's context shape (camelCase on the wire) so existing
+/// pnpmfiles can read the fields they expect.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreResolutionContext<'a> {
+    pub lockfile_dir: &'a Path,
+    pub store_dir: Option<&'a Path>,
+    pub current_lockfile: Option<LockfileWire>,
+    pub wanted_lockfile: Option<LockfileWire>,
+    pub exists_current_lockfile: bool,
+    pub exists_non_empty_wanted_lockfile: bool,
+    pub registries: BTreeMap<String, String>,
+}
+
+impl<'a> PreResolutionContext<'a> {
+    /// Build the snapshot for `lockfile_dir`. `existing` is the on-disk
+    /// lockfile graph (or `None` when there isn't one); both
+    /// `currentLockfile` and `wantedLockfile` are derived from it
+    /// because at preResolution time they're identical — pnpm only
+    /// diverges them after resolve has produced the wanted graph.
+    pub fn from_existing(
+        lockfile_dir: &'a Path,
+        store_dir: Option<&'a Path>,
+        existing: Option<&LockfileGraph>,
+        registries: BTreeMap<String, String>,
+    ) -> Self {
+        let wire = existing.map(to_wire);
+        let exists_current_lockfile = existing.is_some();
+        let exists_non_empty_wanted_lockfile = wire
+            .as_ref()
+            .is_some_and(|w| !w.importers.is_empty() || !w.packages.is_empty());
+        Self {
+            lockfile_dir,
+            store_dir,
+            current_lockfile: wire.clone(),
+            wanted_lockfile: wire,
+            exists_current_lockfile,
+            exists_non_empty_wanted_lockfile,
+            registries,
+        }
+    }
+}
+
+/// Run the `preResolution` hook before the resolver walks the graph.
+/// Fire-and-forget — the hook's return value is discarded by pnpm and
+/// by aube. Skips spawning `node` when the pnpmfile doesn't reference
+/// `preResolution` so a hook-less pnpmfile doesn't pay the per-install
+/// node-startup cost on every command.
+pub async fn run_pre_resolution(pnpmfile: &Path, ctx: &PreResolutionContext<'_>) -> Result<()> {
+    if !has_hook(pnpmfile, "preResolution").await? {
+        return Ok(());
+    }
+    let input_json = serde_json::to_vec(ctx)
+        .into_diagnostic()
+        .wrap_err("failed to serialize preResolution context")?;
+    run_one_shot_hook(pnpmfile, "preResolution", &input_json).await?;
     Ok(())
 }
 
@@ -392,7 +459,7 @@ impl ReadPackageHost {
     /// skip attaching a hook entirely in that case and save the
     /// per-call JSON round-trip), otherwise the live host.
     pub async fn spawn(pnpmfile: &Path) -> Result<Option<Self>> {
-        if !has_read_package_hook(pnpmfile).await? {
+        if !has_hook(pnpmfile, "readPackage").await? {
             return Ok(None);
         }
         tracing::debug!(
@@ -488,20 +555,19 @@ impl ReadPackageHook for ReadPackageHost {
     }
 }
 
-/// Quick scan of the pnpmfile source for a `readPackage` identifier.
-/// Avoids the cost of spawning a node child when the hook doesn't
-/// exist — the vast majority of pnpmfiles in the wild use only
-/// `afterAllResolved`. False positives are fine: if a pnpmfile
-/// references `readPackage` in a comment but doesn't export it, the
-/// child spawns, the hook is absent, and `readPackage` calls short-
-/// circuit through the `typeof ... === 'function'` check in the
-/// shim.
-async fn has_read_package_hook(pnpmfile: &Path) -> Result<bool> {
+/// Quick scan of the pnpmfile source for a hook identifier. Avoids
+/// the cost of spawning a node child when the hook doesn't exist —
+/// the vast majority of pnpmfiles use only `afterAllResolved`. False
+/// positives are fine: if a pnpmfile references the hook name in a
+/// comment but doesn't export it, the child spawns, the hook is
+/// absent, and the call short-circuits through the
+/// `typeof ... === 'function'` check in the shim.
+async fn has_hook(pnpmfile: &Path, name: &str) -> Result<bool> {
     let contents = tokio::fs::read_to_string(pnpmfile)
         .await
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to read pnpmfile at {}", pnpmfile.display()))?;
-    Ok(contents.contains("readPackage"))
+    Ok(contents.contains(name))
 }
 
 #[cfg(test)]

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5310,6 +5310,18 @@
             }
           },
           {
+            "name": "ignore-pnpmfile",
+            "usage": "--ignore-pnpmfile",
+            "help": "Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this update",
+            "help_first_line": "Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this update",
+            "short": [],
+            "long": [
+              "ignore-pnpmfile"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "ignore-scripts",
             "usage": "--ignore-scripts",
             "help": "Skip lifecycle scripts",

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -47,6 +47,10 @@ Dependency traversal depth.
 
 Parsed for pnpm compatibility.
 
+### `--ignore-pnpmfile`
+
+Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this update
+
 ### `--ignore-scripts`
 
 Skip lifecycle scripts.

--- a/test/PNPM_TEST_IMPORT.md
+++ b/test/PNPM_TEST_IMPORT.md
@@ -4,7 +4,7 @@ Tracking the import of pnpm's test suite into aube's bats suite for parity cover
 
 Source: [pnpm/pnpm](https://github.com/pnpm/pnpm) checkout. Translation pattern: `prepare(manifest)` → write `package.json` + `cd`; `execPnpm([...])` → `aube ...`; `project.has(name)` → `assert_link_exists node_modules/$name`; `project.readLockfile()` → parse `aube-lock.yaml`.
 
-## Phase 0 — infrastructure
+## Phase 0 — infrastructure (done)
 
 - [x] Mirror the ~25 `@pnpm.e2e/*` fixture packages used by Tier 1 tests into [test/registry/storage/@pnpm.e2e/](registry/storage/@pnpm.e2e/) ([#424](https://github.com/endevco/aube/pull/424)). Procedure documented at the top of [test/registry/config.yaml](registry/config.yaml). All 24 packages mirrored.
 - [x] Add an `add_dist_tag` bash helper in [test/test_helper/common_setup.bash:84](test_helper/common_setup.bash) ([#422](https://github.com/endevco/aube/pull/422)).
@@ -18,10 +18,10 @@ Goal: highest install-path parity coverage for lowest cost. Each row is a pnpm s
   - Remaining high-value: strict-store-pkg-content-check (516 — pnpm tampers with the cached manifest in the store and expects the next install to fail; aube parity depends on whether aube has an equivalent integrity check), install timeout, top-level-plugins (190 — needs `standard` package, not in registry).
   - Skipped (still need fixtures): peer-deps-warning (541 — needs `@udecode/plate-*`), circular-peer-deps (556), trust-policy (578-643 — pnpm-specific feature).
   - Documented divergences (don't port without aube-side fix): `--lockfile-dir` (112 — aube has no flag for placing the lockfile outside the project root).
-- [ ] `pnpm/test/install/hooks.ts` (22 tests, 698 LOC) → [test/pnpm_install_hooks.bats](pnpm_install_hooks.bats) (5/22 ported, 2 skipped divergences)
-  - Done: async readPackage on transitive (43), async afterAllResolved (498), syntax error in pnpmfile (292), require() of missing module (303), readPackage normalizes optional/peer/dev fields on transitive (528).
-  - Skipped (need fixtures): sync readPackage (18), custom pnpmfile location (85), global pnpmfile (110, 135, 176), workspace pnpmfile (217), readPackage during update (263), --ignore-pnpmfile cases (314, 338), context.log via ndjson reporter (366, 404), preResolution hook (624 — aube doesn't support), shared workspace lockfile (661).
-  - Documented divergences (don't port without aube-side fix): readPackage returning undefined fails install (68), readPackage on root project's manifest applies (551).
+- [ ] `pnpm/test/install/hooks.ts` (22 tests, 698 LOC) → [test/pnpm_install_hooks.bats](pnpm_install_hooks.bats) (8/22 ported, 2 skipped divergences)
+  - Done: async readPackage on transitive (43), async afterAllResolved (498), syntax error in pnpmfile (292), require() of missing module (303), readPackage normalizes optional/peer/dev fields on transitive (528), readPackage during `aube update` (263), `--ignore-pnpmfile` on `aube update` (338), `preResolution` hook fires before resolve (624).
+  - Not yet ported (Phase 0 unblocked): sync readPackage (18), custom pnpmfile location (85 — needs `--pnpmfile` CLI flag), global pnpmfile (110, 135, 176 — needs `--global-pnpmfile`), workspace pnpmfile (217), context.log via ndjson reporter (366, 404 — needs ndjson `pnpm:hook` log surface), shared workspace lockfile (661).
+  - Documented divergences (don't port without aube-side fix): readPackage returning undefined fails install (68), readPackage on root project's manifest applies (551). The 314 install-side --ignore-pnpmfile case is already covered by [test/pnpmfile.bats](pnpmfile.bats:215).
 - [ ] `pnpm/test/install/lifecycleScripts.ts` (21 tests, 356 LOC) → folded into [test/lifecycle_scripts.bats](lifecycle_scripts.bats) (8/21 ported, [#421](https://github.com/endevco/aube/pull/421))
   - Done: preinstall/postinstall/prepare stdout reaches the user (43, 56, 95), `npm_config_user_agent` set on lifecycle scripts (29), root postinstall NOT triggered by `aube add` / root prepare NOT triggered by `aube add` (69, 82), root postinstall NOT triggered by `aube remove` / `aube update`.
   - Remaining: exit-code propagation, env-var inheritance specifics, script-not-found handling, ordering edge cases.

--- a/test/pnpm_install_hooks.bats
+++ b/test/pnpm_install_hooks.bats
@@ -178,6 +178,133 @@ EOF
 	assert_dir_exists node_modules/.aube/is-odd@0.1.2_is-number@3.0.0/node_modules/is-odd
 }
 
+@test "pnpmfile: readPackage hook fires during aube update" {
+	# Ported from pnpm/test/install/hooks.ts:263 ('readPackage hook during
+	# update'). pnpm relies on addDistTag to publish a newer version
+	# that `update` then resolves through the hook; aube's offline
+	# registry fixtures don't have an addDistTag analogue, so we instead
+	# run `update` from scratch with the hook already wired in. The
+	# hook's mutation must land in the lockfile that update writes —
+	# which it can only do if update's resolver attaches the readPackage
+	# host (the gap this test was added to close).
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-hooks-readpackage-during-update",
+  "version": "0.0.0",
+  "dependencies": { "is-even": "1.0.0" }
+}
+JSON
+
+	cat >.pnpmfile.cjs <<'EOF'
+'use strict'
+module.exports = {
+  hooks: {
+    readPackage (pkg) {
+      if (pkg.name === 'is-odd') {
+        pkg.dependencies = {}
+      }
+      return pkg
+    }
+  }
+}
+EOF
+
+	run aube update
+	assert_success
+	# Guard against the false-pass where `aube update` leaves no
+	# lockfile and the negative greps below trip on grep's
+	# exit-2-for-file-not-found rather than on the hook actually
+	# stripping the chain.
+	assert_file_exists aube-lock.yaml
+	run bash -c "awk '/^snapshots:/,0' aube-lock.yaml | grep '^  is-odd@'"
+	assert_output --partial 'is-odd@0.1.2: {}'
+	# The transitive chain (is-odd → is-number → kind-of) is gone
+	# because the hook stripped is-odd's deps before the resolver
+	# walked them. Without the readPackage host wired into update,
+	# is-number and kind-of would still appear.
+	run grep 'is-number' aube-lock.yaml
+	assert_failure
+	run grep 'kind-of' aube-lock.yaml
+	assert_failure
+}
+
+@test "pnpmfile: --ignore-pnpmfile during aube update" {
+	# Ported from pnpm/test/install/hooks.ts:338 ('ignore .pnpmfile.cjs
+	# during update when --ignore-pnpmfile is used').
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-hooks-ignore-pnpmfile-update",
+  "version": "0.0.0",
+  "dependencies": { "is-even": "1.0.0" }
+}
+JSON
+
+	# Step 1: install with NO pnpmfile — full transitive chain in the lockfile.
+	run aube install
+	assert_success
+
+	# Step 2: drop in a hook that would strip is-odd's deps.
+	cat >.pnpmfile.cjs <<'EOF'
+'use strict'
+module.exports = {
+  hooks: {
+    readPackage (pkg) {
+      if (pkg.name === 'is-odd') {
+        pkg.dependencies = {}
+      }
+      return pkg
+    }
+  }
+}
+EOF
+
+	# With --ignore-pnpmfile the hook should NOT fire, so is-odd's
+	# transitive deps stay intact in the lockfile after update.
+	run aube update --ignore-pnpmfile
+	assert_success
+	run grep 'is-number' aube-lock.yaml
+	assert_success
+	run grep 'kind-of' aube-lock.yaml
+	assert_success
+}
+
+@test "pnpmfile: preResolution hook fires before resolve" {
+	# Ported from pnpm/test/install/hooks.ts:624 ('preResolution hook').
+	# The pnpm test asserts the hook receives a resolution context with
+	# currentLockfile / wantedLockfile / registries / lockfileDir /
+	# storeDir. We assert on a subset that's stable across aube's
+	# context shape — the existence of the file proves the hook fired,
+	# and the lockfileDir + registries fields prove we're passing the
+	# pnpm-shaped ctx, not just an empty object.
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-hooks-preresolution",
+  "version": "0.0.0",
+  "dependencies": { "is-odd": "3.0.1" }
+}
+JSON
+
+	cat >.pnpmfile.cjs <<'EOF'
+'use strict'
+const fs = require('fs')
+module.exports = {
+  hooks: {
+    preResolution (ctx) {
+      fs.writeFileSync('preresolution-fired.json', JSON.stringify(ctx))
+    }
+  }
+}
+EOF
+
+	run aube install
+	assert_success
+	assert_file_exists preresolution-fired.json
+	run cat preresolution-fired.json
+	assert_output --partial '"lockfileDir"'
+	assert_output --partial '"registries"'
+	assert_output --partial '"existsCurrentLockfile":false'
+}
+
 @test "pnpmfile: readPackage that returns undefined fails the install" {
 	skip "aube divergence: aube continues with the original manifest when readPackage returns undefined; pnpm fails the install. File a Discussion before un-skipping."
 	# Ported from pnpm/test/install/hooks.ts:68 ('readPackage hook makes


### PR DESCRIPTION
## Summary

Closes three pnpmfile gaps surfaced while porting more cases from [`pnpm/test/install/hooks.ts`](https://github.com/pnpm/pnpm/blob/main/pnpm/test/install/hooks.ts) (follow-up to [#419](https://github.com/endevco/aube/pull/419)):

- **`aube update` now runs the full pnpmfile cycle.** Previously update built its resolver via `commands::build_resolver` without attaching the readPackage host, then handed off to `install::run` in frozen-prefer mode — which consumes the lockfile as-is, so the hook never fired on update. Now update wires `preResolution` + `readPackage` + `afterAllResolved` the same way install does.
- **`aube update --ignore-pnpmfile`** is now accepted and honored, matching the install-side flag and pnpm.
- **`preResolution` hook** is now supported. The hook receives a context object with `lockfileDir`, `storeDir`, `currentLockfile`, `wantedLockfile`, `existsCurrentLockfile`, `existsNonEmptyWantedLockfile`, and a `registries` map (default + scoped), matching pnpm's wire shape (camelCase). It fires before resolve in install (lockfile-only and streaming paths) and update; the spawn is skipped when the pnpmfile doesn't reference `preResolution`, so hook-less files don't pay the per-install node-startup cost.

Implementation factors out a `run_one_shot_hook` helper in [`crates/aube/src/pnpmfile.rs`](https://github.com/endevco/aube/blob/claude/pnpm-import-hooks-followup/crates/aube/src/pnpmfile.rs) so `afterAllResolved` and `preResolution` share the same node-spawn / pipe / wait scaffolding, and a `commands::run_pnpmfile_pre_resolution` helper in [`crates/aube/src/commands/mod.rs`](https://github.com/endevco/aube/blob/claude/pnpm-import-hooks-followup/crates/aube/src/commands/mod.rs) so install and update build the context from the same sources.

Also adds three more ports from `hooks.ts` ([`test/pnpm_install_hooks.bats`](https://github.com/endevco/aube/blob/claude/pnpm-import-hooks-followup/test/pnpm_install_hooks.bats)) — these are the originals that surfaced the divergences during the port and pass once the gaps above are closed:

- `readPackage` during `aube update` (hooks.ts:263)
- `--ignore-pnpmfile` on `aube update` (hooks.ts:338)
- `preResolution` hook fires before resolve (hooks.ts:624)

## Test plan

- [x] `mise run test:bats test/pnpm_install_hooks.bats` — 8 ok, 2 skip (the two pre-existing divergences from #419), 0 fail.
- [x] `mise run test:bats test/pnpmfile.bats` — 9 ok.
- [x] `mise run test:bats test/update.bats` — 10 ok.
- [x] `mise run test:bats test/install.bats` — 61 ok.
- [x] `cargo test -p aube` — 330 unit tests + 4 e2e, 0 failures.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how `.pnpmfile.*` hooks execute (including spawning `node`) during `update` and early install resolution, which can affect dependency graphs and lockfile output.
> 
> **Overview**
> `aube update` now runs the pnpmfile hook lifecycle (runs `preResolution`, attaches `readPackage`, then runs `afterAllResolved`) so hook-driven dependency mutations are reflected in the updated lockfile.
> 
> Adds support for the pnpmfile `preResolution` hook with a pnpm-shaped context snapshot, and factors one-shot hook execution into a shared `run_one_shot_hook` helper. Introduces `update --ignore-pnpmfile` and propagates it through the chained frozen-prefer install.
> 
> Updates CLI usage/docs and adds new Bats coverage for `readPackage` during update, `--ignore-pnpmfile` on update, and `preResolution` firing before resolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad36a52097fb824e937ef117ac19238e17105e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->