### PR TITLE
fix(resolver): ship empty primer when generator script unavailable

### DIFF
--- a/crates/aube-resolver/build.rs
+++ b/crates/aube-resolver/build.rs
@@ -39,7 +39,20 @@ fn main() {
                 source.display()
             );
         }
-        generate(&manifest_dir, &source, primer_top());
+        let script = manifest_dir
+            .parent()
+            .and_then(Path::parent)
+            .map(|w| w.join("scripts/generate-primer.mjs"));
+        match script {
+            Some(s) if s.is_file() => generate(&manifest_dir, &source, primer_top()),
+            _ => {
+                // Published crate (or downstream consumer without the workspace
+                // generator script) and no primer data file: ship an empty
+                // primer. Runtime falls back to network packument fetches.
+                write_package_blob(&out_dir, &[]);
+                return;
+            }
+        }
     }
 
     let generated_at = std::fs::metadata(&source)


### PR DESCRIPTION
## Summary
- Fix [run 25189018599](https://github.com/endevco/aube/actions/runs/25189018599/job/73853888933): release-plz failed publishing `aube-resolver@1.5.2` because `cargo publish --verify` runs the build script from `target/package/aube-resolver-1.5.2/`, where the workspace-level `scripts/generate-primer.mjs` is unreachable.
- When the bundled primer data file is missing AND the generator script can't be located, fall back to an empty primer instead of panicking. Runtime already tolerates an empty `PRIMER_INDEX` and falls through to network packument fetches.

## Repro
Locally `cargo package -p aube-resolver` (the verify pass) failed the same way before this fix and now succeeds.

## Test plan
- [x] `cargo build -p aube-resolver`
- [x] `cargo clippy -p aube-resolver --all-targets -- -D warnings`
- [x] `cargo test -p aube-resolver --lib primer`
- [x] `cargo package -p aube-resolver` (verify step compiles cleanly)

After merge, re-run release-plz to finish the partially-published v1.5.2 (aube-util/manifest/settings/lockfile/store/linker/registry already shipped; resolver/scripts/workspace/aube still pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-script change that only affects the fallback path when primer data is missing; main risk is unintentionally shipping without bundled primer data, which should degrade performance but not correctness.
> 
> **Overview**
> Makes `aube-resolver`’s `build.rs` resilient when packaging/publishing: if the primer data file is missing and the workspace `scripts/generate-primer.mjs` can’t be found, it now **writes an empty primer blob/index and exits** instead of attempting generation.
> 
> If `AUBE_PRIMER_PATH` is explicitly set to a non-file, it still panics; otherwise generation proceeds as before when the script is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3dcca97e63042d210f3fae3b7abc212ec116019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->