### PR TITLE
chore: release v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "aube-util",
  "miette",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "aube-manifest",
  "landlock",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "blake3",
  "rustc-hash",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -1109,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.5.2"
+version = "1.6.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -122,14 +122,14 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.5.2" }
-aube-settings = { path = "crates/aube-settings", version = "1.5.2" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.5.2" }
-aube-registry = { path = "crates/aube-registry", version = "1.5.2" }
-aube-store = { path = "crates/aube-store", version = "1.5.2" }
-aube-linker = { path = "crates/aube-linker", version = "1.5.2" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.5.2" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.5.2" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.5.2" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.5.2" }
-aube-util = { path = "crates/aube-util", version = "1.5.2" }
+aube = { path = "crates/aube", version = "1.6.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.6.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.6.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.6.0" }
+aube-store = { path = "crates/aube-store", version = "1.6.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.6.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.6.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.6.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.6.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.6.0" }
+aube-util = { path = "crates/aube-util", version = "1.6.0" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.5.2"
+version "1.6.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/aube-linker-v1.5.2...aube-linker-v1.6.0) - 2026-05-01
+
+### Other
+
+- cache hot-path work across install, resolver, and registry ([#453](https://github.com/endevco/aube/pull/453))
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+- refresh benchmarks for v1.5.1 ([#426](https://github.com/endevco/aube/pull/426))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/aube-linker-v1.5.1...aube-linker-v1.5.2) - 2026-04-30
 
 ### Fixed

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.5.2...aube-lockfile-v1.6.0) - 2026-05-01
+
+### Fixed
+
+- Preserve npm workspace importers ([#443](https://github.com/endevco/aube/pull/443))
+
+### Other
+
+- cache hot-path work across install, resolver, and registry ([#453](https://github.com/endevco/aube/pull/453))
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- dedupe and cache hot-path work in install and resolver ([#449](https://github.com/endevco/aube/pull/449))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+- refresh benchmarks for v1.5.1 ([#426](https://github.com/endevco/aube/pull/426))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/aube-lockfile-v1.5.1...aube-lockfile-v1.5.2) - 2026-04-30
 
 ### Fixed

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/aube-manifest-v1.5.2...aube-manifest-v1.6.0) - 2026-05-01
+
+### Added
+
+- *(cli)* add --lockfile-dir / lockfileDir setting ([#431](https://github.com/endevco/aube/pull/431))
+- --save-catalog, workspace:* parsing, and sharedWorkspaceLockfile=false ([#418](https://github.com/endevco/aube/pull/418))
+
+### Other
+
+- cache hot-path work across install, resolver, and registry ([#453](https://github.com/endevco/aube/pull/453))
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+- *(install)* port four allowBuilds review tests from pnpm lifecycleScripts.ts ([#441](https://github.com/endevco/aube/pull/441))
+- refresh benchmarks for v1.5.1 ([#426](https://github.com/endevco/aube/pull/426))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/aube-manifest-v1.5.1...aube-manifest-v1.5.2) - 2026-04-30
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/aube-registry-v1.5.2...aube-registry-v1.6.0) - 2026-05-01
+
+### Other
+
+- cache hot-path work across install, resolver, and registry ([#453](https://github.com/endevco/aube/pull/453))
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- dedupe and cache hot-path work in install and resolver ([#449](https://github.com/endevco/aube/pull/449))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+- refresh benchmarks for v1.5.1 ([#426](https://github.com/endevco/aube/pull/426))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/aube-registry-v1.5.1...aube-registry-v1.5.2) - 2026-04-30
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/aube-resolver-v1.5.2...aube-resolver-v1.6.0) - 2026-05-01
+
+### Other
+
+- cache hot-path work across install, resolver, and registry ([#453](https://github.com/endevco/aube/pull/453))
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/aube-resolver-v1.5.1...aube-resolver-v1.5.2) - 2026-04-30
 
 ### Fixed

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/aube-scripts-v1.5.2...aube-scripts-v1.6.0) - 2026-05-01
+
+### Other
+
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- dedupe and cache hot-path work in install and resolver ([#449](https://github.com/endevco/aube/pull/449))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+- *(install)* port four allowBuilds review tests from pnpm lifecycleScripts.ts ([#441](https://github.com/endevco/aube/pull/441))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/aube-scripts-v1.5.1...aube-scripts-v1.5.2) - 2026-04-30
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/aube-settings-v1.5.2...aube-settings-v1.6.0) - 2026-05-01
+
+### Added
+
+- *(cli)* add generic --config.<key>=<value> flags ([#447](https://github.com/endevco/aube/pull/447))
+- *(cli)* add --pnpmfile and --global-pnpmfile flags ([#439](https://github.com/endevco/aube/pull/439))
+- *(cli)* add --lockfile-dir / lockfileDir setting ([#431](https://github.com/endevco/aube/pull/431))
+- *(cli)* add --fetch-timeout / --fetch-retries / retry backoff flags ([#436](https://github.com/endevco/aube/pull/436))
+- --save-catalog, workspace:* parsing, and sharedWorkspaceLockfile=false ([#418](https://github.com/endevco/aube/pull/418))
+
+### Fixed
+
+- *(cli)* reject `.` as a foreign --lockfile-dir importer; correct docs ([#442](https://github.com/endevco/aube/pull/442))
+
+### Other
+
+- cache hot-path work across install, resolver, and registry ([#453](https://github.com/endevco/aube/pull/453))
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- dedupe and cache hot-path work in install and resolver ([#449](https://github.com/endevco/aube/pull/449))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+- refresh benchmarks for v1.5.1 ([#426](https://github.com/endevco/aube/pull/426))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/aube-settings-v1.5.1...aube-settings-v1.5.2) - 2026-04-30
 
 ### Other

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/aube-store-v1.5.2...aube-store-v1.6.0) - 2026-05-01
+
+### Other
+
+- cache hot-path work across install, resolver, and registry ([#453](https://github.com/endevco/aube/pull/453))
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+- refresh benchmarks for v1.5.1 ([#426](https://github.com/endevco/aube/pull/426))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/aube-store-v1.5.1...aube-store-v1.5.2) - 2026-04-30
 
 ### Fixed

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/aube-util-v1.5.2...aube-util-v1.6.0) - 2026-05-01
+
+### Other
+
+- cache hot-path work across install, resolver, and registry ([#453](https://github.com/endevco/aube/pull/453))
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+- refresh benchmarks for v1.5.1 ([#426](https://github.com/endevco/aube/pull/426))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/aube-util-v1.5.1...aube-util-v1.5.2) - 2026-04-30
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/aube-workspace-v1.5.2...aube-workspace-v1.6.0) - 2026-05-01
+
+### Other
+
+- *(cli)* port pnpm monorepo filter tests + wire --fail-if-no-match ([#457](https://github.com/endevco/aube/pull/457))
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/aube-workspace-v1.5.1...aube-workspace-v1.5.2) - 2026-04-30
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0](https://github.com/endevco/aube/compare/v1.5.1...v1.6.0) - 2026-05-01
+
+### Added
+
+- *(cli)* aube update parses <pkg>@<spec> args + accepts indirect deps ([#446](https://github.com/endevco/aube/pull/446))
+- *(cli)* add generic --config.<key>=<value> flags ([#447](https://github.com/endevco/aube/pull/447))
+- *(cli)* emit pnpm's verbatim error for empty --allow-build values ([#444](https://github.com/endevco/aube/pull/444))
+- *(pnpmfile)* emit ctx.log records as pnpm:hook ndjson on stdout ([#440](https://github.com/endevco/aube/pull/440))
+- *(cli)* add --pnpmfile and --global-pnpmfile flags ([#439](https://github.com/endevco/aube/pull/439))
+- *(cli)* add --lockfile-dir / lockfileDir setting ([#431](https://github.com/endevco/aube/pull/431))
+- *(cli)* add --fetch-timeout / --fetch-retries / retry backoff flags ([#436](https://github.com/endevco/aube/pull/436))
+- *(pnpmfile)* wire hooks into update; add preResolution hook ([#423](https://github.com/endevco/aube/pull/423))
+- --save-catalog, workspace:* parsing, and sharedWorkspaceLockfile=false ([#418](https://github.com/endevco/aube/pull/418))
+- *(cli)* aube add bootstraps package.json + 10 misc.ts ports ([#417](https://github.com/endevco/aube/pull/417))
+
+### Fixed
+
+- *(cli)* honor AUBE_VIRTUAL_STORE_DIR env var + port 5 more pnpm/misc tests ([#456](https://github.com/endevco/aube/pull/456))
+- *(cli)* aube update --latest preserves higher-than-latest prerelease pins ([#445](https://github.com/endevco/aube/pull/445))
+- *(cli)* reject `.` as a foreign --lockfile-dir importer; correct docs ([#442](https://github.com/endevco/aube/pull/442))
+- *(scripts)* close 3 lifecycle parity gaps with pnpm ([#421](https://github.com/endevco/aube/pull/421))
+- *(cli)* honor full gitignore semantics in pack/publish ([#411](https://github.com/endevco/aube/pull/411))
+- *(dlx)* pick .cmd shim on Windows so bin runs without --shell-mode ([#401](https://github.com/endevco/aube/pull/401))
+- *(install)* fetch hosted git deps over https, not ssh ([#394](https://github.com/endevco/aube/pull/394))
+
+### Other
+
+- *(cli)* port pnpm monorepo filter tests + wire --fail-if-no-match ([#457](https://github.com/endevco/aube/pull/457))
+- cache hot-path work across install, resolver, and registry ([#453](https://github.com/endevco/aube/pull/453))
+- refresh benchmarks for v1.5.2 ([#452](https://github.com/endevco/aube/pull/452))
+- dedupe and cache hot-path work in install and resolver ([#449](https://github.com/endevco/aube/pull/449))
+- refresh benchmarks for v1.5.2 ([#448](https://github.com/endevco/aube/pull/448))
+- *(install)* port four allowBuilds review tests from pnpm lifecycleScripts.ts ([#441](https://github.com/endevco/aube/pull/441))
+- *(install)* port pnpm/test/update.ts (13/22) ([#438](https://github.com/endevco/aube/pull/438))
+- refresh benchmarks for v1.5.1 ([#426](https://github.com/endevco/aube/pull/426))
+- release v1.5.2 ([#389](https://github.com/endevco/aube/pull/389))
+- *(resolver)* add bundled metadata primer ([#397](https://github.com/endevco/aube/pull/397))
+- thank Namespace for GitHub Actions runner support ([#412](https://github.com/endevco/aube/pull/412))
+- refresh benchmarks for v1.5.1 ([#392](https://github.com/endevco/aube/pull/392))
+
 ## [1.5.2](https://github.com/endevco/aube/compare/v1.5.1...v1.5.2) - 2026-04-30
 
 ### Fixed

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6368,7 +6368,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.5.2",
+  "version": "1.6.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.5.2
+**Version**: 1.6.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.5.2",
-  "releasedAt": "2026-04-30T20:52:19Z"
+  "version": "1.6.0",
+  "releasedAt": "2026-05-01T17:59:34Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.6.0`

This PR bumps the workspace to `v1.6.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
