### PR TITLE
fix(cli): reject `.` as a foreign --lockfile-dir importer; correct docs

### DIFF
--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1000,9 +1000,11 @@ docs = """
 By default the lockfile lives at `<project_root>/aube-lock.yaml`. Set
 this to relocate it. When the resolved path differs from the project
 root, the project becomes an importer keyed by its relative path
-(e.g. `project` if the lockfile is one directory above), so several
-unrelated projects can share a single committed lockfile without
-declaring a `pnpm-workspace.yaml`.
+(e.g. `project` if the lockfile is one directory above).
+
+Single-project relocation only — multi-project shared lockfiles
+require a `pnpm-workspace.yaml` workspace. Pointing two unrelated
+projects at the same `lockfileDir` is rejected at install time.
 
 Mirrors pnpm's `--lockfile-dir` / `lockfile-dir`. A relative path is
 resolved against the project root, not the current working directory.

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -4049,11 +4049,15 @@ fn guard_against_foreign_importers(
     importer_key: &str,
     graph: &aube_lockfile::LockfileGraph,
 ) -> Result<(), aube_lockfile::Error> {
+    // Caller gates on `importer_key != "."`, so any `"."` entry on
+    // disk is itself a project that ran `aube install` directly in
+    // `lockfile_dir` without `--lockfile-dir`. That entry would be
+    // dropped on write, so it counts as foreign.
     let foreign: Vec<&str> = graph
         .importers
         .keys()
         .map(String::as_str)
-        .filter(|k| *k != "." && *k != importer_key)
+        .filter(|k| *k != importer_key)
         .collect();
     if foreign.is_empty() {
         return Ok(());

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1047,9 +1047,11 @@ Directory the lockfile is written to and read from.
 By default the lockfile lives at `<project_root>/aube-lock.yaml`. Set
 this to relocate it. When the resolved path differs from the project
 root, the project becomes an importer keyed by its relative path
-(e.g. `project` if the lockfile is one directory above), so several
-unrelated projects can share a single committed lockfile without
-declaring a `pnpm-workspace.yaml`.
+(e.g. `project` if the lockfile is one directory above).
+
+Single-project relocation only — multi-project shared lockfiles
+require a `pnpm-workspace.yaml` workspace. Pointing two unrelated
+projects at the same `lockfileDir` is rejected at install time.
 
 Mirrors pnpm's `--lockfile-dir` / `lockfile-dir`. A relative path is
 resolved against the project root, not the current working directory.

--- a/test/lockfile_dir.bats
+++ b/test/lockfile_dir.bats
@@ -114,6 +114,38 @@ JSON
 	assert_output --partial "alpha"
 }
 
+@test "aube install --lockfile-dir: refuses to clobber a parent dir that is itself a project" {
+	# `lockfile_dir` is itself someone's project root (importer `.`).
+	# Pointing a subdir there with `--lockfile-dir ..` would silently
+	# drop the parent's `.` entry on write — same data-loss class as
+	# two unrelated peers. The foreign-importer guard must reject `.`
+	# too, since by the time it runs the caller has already
+	# established that the current project's importer key is non-`.`.
+	cat >package.json <<'JSON'
+{
+  "name": "lfd-parent",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "3.0.1" }
+}
+JSON
+	mkdir child
+	cat >child/package.json <<'JSON'
+{
+  "name": "lfd-child",
+  "version": "1.0.0",
+  "dependencies": { "is-even": "1.0.0" }
+}
+JSON
+
+	aube install --no-frozen-lockfile
+	assert_file_exists aube-lock.yaml
+
+	cd child || return
+	run aube install --lockfile-dir .. --no-frozen-lockfile
+	assert_failure
+	assert_output --partial "records importers from other projects"
+}
+
 @test "aube install --lockfile-dir: warm install reads the relocated lockfile" {
 	# Round-trip: write once, wipe node_modules, install again. The
 	# second install must read the relocated lockfile (not regenerate)


### PR DESCRIPTION
Follow-up to [#431](https://github.com/endevco/aube/pull/431) addressing two greptile P1s left over after merge.

## Summary

- **Foreign-importer guard previously exempted `"."`.** When the current project's importer key is non-`.`, a `"."` entry on disk is itself an unrelated project that ran `aube install` in the lockfile dir directly. Dropping it on write is the same data-loss class the guard exists to prevent. Drop the `"."` exemption from the filter; the caller already gates on `importer_key != "."` so the default install path stays untouched.
- **Replace stale `lockfileDir` docs.** [crates/aube-settings/settings.toml](crates/aube-settings/settings.toml) and the generated [docs/settings/index.md](docs/settings/index.md) still claimed "several unrelated projects can share a single committed lockfile", which is the exact configuration the guard rejects. Replaced with the correct scope: single-project relocation only, multi-project sharing requires a workspace.

## Test plan

- [x] New: `refuses to clobber a parent dir that is itself a project` in [test/lockfile_dir.bats](test/lockfile_dir.bats) — covers the `.` foreign-importer case the previous filter missed.
- [x] `mise run test:bats test/lockfile_dir.bats` (6/6).
- [x] `mise run test:bats test/install.bats test/workspace.bats` (79/79) — no regressions; workspace installs with multiple importers stay healthy because the guard is gated on a non-`.` importer key.
- [x] `cargo clippy -p aube --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `aube install --lockfile-dir` to fail in an additional scenario (when the target lockfile already contains a `.` importer), which could break previously-working but unsafe setups. Scope is small and covered by a new bats test, but it affects install-time behavior and lockfile safety checks.
> 
> **Overview**
> Tightens the `--lockfile-dir` foreign-importer guard so a lockfile containing a `.` importer is treated as *foreign* when installing from a subproject, preventing silent loss of the parent project’s lockfile entries.
> 
> Updates `lockfileDir` documentation (settings registry + generated docs) to remove the claim that unrelated projects can share a lockfile, clarifying that multi-project sharing requires a `pnpm-workspace.yaml` workspace. Adds a bats regression test to ensure installs refuse to target a parent directory that is itself a project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa91acb32afe9213a7753a475f20976972f5316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->