### PR TITLE
feat(cli): add generic --config.<key>=<value> flags

### DIFF
--- a/crates/aube-settings/src/lib.rs
+++ b/crates/aube-settings/src/lib.rs
@@ -23,4 +23,6 @@ pub mod meta;
 pub mod values;
 
 pub use meta::{SettingMeta, all, find};
-pub use values::{ResolveCtx, parse_bool, resolved, workspace_yaml_value};
+pub use values::{
+    ResolveCtx, parse_bool, resolved, set_global_cli_overrides, workspace_yaml_value,
+};

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -421,11 +421,18 @@ fn cli_key_matches(key: &str, meta: &meta::SettingMeta) -> bool {
 }
 
 /// Lower-case kebab form of a setting / flag identifier. Splits on
-/// `-`, `_`, camelCase boundaries, and dotted-path segments so callers
-/// can compare `strict-dep-builds`, `strictDepBuilds`, `STRICT_DEP_BUILDS`,
-/// and `strict_dep_builds` interchangeably. Dots are preserved so
-/// nested settings like `peerDependencyRules.ignoreMissing` keep their
-/// path structure.
+/// `-`, `_`, dotted-path segments, and lowercase→UPPER transitions so
+/// callers can compare `strict-dep-builds`, `strictDepBuilds`,
+/// `STRICT_DEP_BUILDS`, and `strict_dep_builds` interchangeably. Dots
+/// are preserved so nested settings like
+/// `peerDependencyRules.ignoreMissing` keep their path structure.
+///
+/// Consecutive uppercase runs (e.g. `XMLConfig`) are collapsed to a
+/// single lowercase token (`xmlconfig`), matching the auto-alias
+/// generator in `aube-settings/build.rs`. No pnpm setting today contains
+/// an internal acronym, so the imperfection is invisible in practice; if
+/// one is ever added, the synthesized npmrc alias and this matcher have
+/// to evolve together.
 fn to_kebab_case(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 4);
     let mut prev_lower = false;
@@ -452,20 +459,25 @@ fn to_kebab_case(s: &str) -> String {
     out
 }
 
-/// Walk the per-callsite `cli` slice (newest entry first) and then the
-/// process-global `--config.<key>` overrides. First match wins, mirroring
-/// the existing reverse-scan semantics for `cli`. Returning the borrowed
-/// raw value lets each caller pick its own parsing path; the global
-/// overrides have `'static` storage so the merged lifetime is whichever
-/// `cli` borrow the caller passed in.
-fn cli_raw_for<'a>(meta: &meta::SettingMeta, cli: &'a [(String, String)]) -> Option<&'a str> {
+/// Walk the per-callsite `cli` slice (newest entry first), then the
+/// process-global `--config.<key>` overrides. The `accept` predicate
+/// lets typed callers (`bool`, `int`) keep scanning past an unparseable
+/// value so a later valid duplicate still wins — matching the original
+/// per-source loops. String / string-list callers pass `|_| true`; the
+/// global overrides have `'static` storage so the merged lifetime is
+/// whichever `cli` borrow the caller passed in.
+fn cli_raw_for<'a>(
+    meta: &meta::SettingMeta,
+    cli: &'a [(String, String)],
+    accept: impl Fn(&str) -> bool,
+) -> Option<&'a str> {
     for (key, raw) in cli.iter().rev() {
-        if cli_key_matches(key, meta) {
+        if cli_key_matches(key, meta) && accept(raw.as_str()) {
             return Some(raw.as_str());
         }
     }
     for (key, raw) in global_cli_overrides().iter().rev() {
-        if cli_key_matches(key, meta) {
+        if cli_key_matches(key, meta) && accept(raw.as_str()) {
             return Some(raw.as_str());
         }
     }
@@ -477,13 +489,16 @@ fn cli_raw_for<'a>(meta: &meta::SettingMeta, cli: &'a [(String, String)]) -> Opt
 /// before building the `ResolveCtx`. Keys may be either an alias
 /// declared in `sources.cli` or the canonical setting name (in any
 /// reasonable case form), so generic `--config.<key>` overrides reach
-/// every setting without per-flag wiring.
+/// every setting without per-flag wiring. An unparseable value (e.g.
+/// `--config.strictDepBuilds=notabool`) is skipped rather than masking
+/// an earlier valid entry — caller still gets `None` if every match is
+/// invalid, matching how `bool_from_npmrc` handles the same case.
 pub(crate) fn bool_from_cli(setting: &str, cli: &[(String, String)]) -> Option<bool> {
     let meta = meta::find(setting)?;
     if meta.type_ != "bool" {
         return None;
     }
-    cli_raw_for(meta, cli).and_then(parse_bool)
+    cli_raw_for(meta, cli, |raw| parse_bool(raw).is_some()).and_then(parse_bool)
 }
 
 /// Resolve a `string` setting from a parsed CLI flag bag.
@@ -492,7 +507,7 @@ pub fn string_from_cli(setting: &str, cli: &[(String, String)]) -> Option<String
     if !is_stringish(meta.type_) {
         return None;
     }
-    cli_raw_for(meta, cli).map(ToOwned::to_owned)
+    cli_raw_for(meta, cli, |_| true).map(ToOwned::to_owned)
 }
 
 /// Resolve an `int` setting from a parsed CLI flag bag.
@@ -501,7 +516,8 @@ pub(crate) fn u64_from_cli(setting: &str, cli: &[(String, String)]) -> Option<u6
     if meta.type_ != "int" {
         return None;
     }
-    cli_raw_for(meta, cli).and_then(|raw| raw.trim().parse::<u64>().ok())
+    cli_raw_for(meta, cli, |raw| raw.trim().parse::<u64>().is_ok())
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
 }
 
 /// Resolve a `list<string>` setting from a parsed CLI flag bag.
@@ -510,7 +526,7 @@ pub(crate) fn string_list_from_cli(setting: &str, cli: &[(String, String)]) -> O
     if meta.type_ != "list<string>" {
         return None;
     }
-    cli_raw_for(meta, cli).map(parse_string_list)
+    cli_raw_for(meta, cli, |_| true).map(parse_string_list)
 }
 
 /// Parse a pnpm/npm-style stringified list. Accepts a JSON-ish array
@@ -831,6 +847,25 @@ mod tests {
         // The exact alias must keep working unchanged.
         let cli = vec![("verify-store-integrity".to_string(), "true".to_string())];
         assert_eq!(bool_from_cli("verifyStoreIntegrity", &cli), Some(true));
+    }
+
+    #[test]
+    fn cli_bag_falls_through_unparseable_values_to_earlier_valid_entry() {
+        // Regression: an unparseable `--config.<key>=garbage` must not
+        // mask an earlier valid entry for the same setting. Iteration
+        // is reverse, so the later (garbage) entry is visited first;
+        // the helper has to keep scanning rather than commit to it.
+        let cli = vec![
+            ("strictDepBuilds".to_string(), "true".to_string()),
+            ("strictDepBuilds".to_string(), "notabool".to_string()),
+        ];
+        assert_eq!(bool_from_cli("strictDepBuilds", &cli), Some(true));
+
+        let cli = vec![
+            ("network-concurrency".to_string(), "8".to_string()),
+            ("network-concurrency".to_string(), "garbage".to_string()),
+        ];
+        assert_eq!(u64_from_cli("networkConcurrency", &cli), Some(8));
     }
 
     #[test]

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -24,7 +24,27 @@
 //! Supported sources are `.npmrc` entries, a raw `pnpm-workspace.yaml`
 //! map, captured environment variables, and parsed CLI flags.
 
+use std::sync::OnceLock;
+
 use crate::meta;
+
+/// Process-wide CLI overrides registered from generic `--config.<key>`
+/// flags. Walked by every `*_from_cli` helper *after* the per-callsite
+/// `cli` slice, so command-specific flags keep first-match priority and
+/// the generic form acts as a fallback that still wins over env / file
+/// sources.
+static GLOBAL_CLI_OVERRIDES: OnceLock<Vec<(String, String)>> = OnceLock::new();
+
+/// Register the parsed `--config.<key>[=<value>]` pairs once per
+/// process. Idempotent — second calls are silently ignored, matching
+/// the other `set_global_*` helpers in the binary crate.
+pub fn set_global_cli_overrides(overrides: Vec<(String, String)>) {
+    let _ = GLOBAL_CLI_OVERRIDES.set(overrides);
+}
+
+fn global_cli_overrides() -> &'static [(String, String)] {
+    GLOBAL_CLI_OVERRIDES.get().map(Vec::as_slice).unwrap_or(&[])
+}
 
 /// Bundle of source inputs consumed by the per-setting typed
 /// accessors in [`resolved`]. Each field is a borrowed view so
@@ -380,23 +400,90 @@ pub(crate) fn string_list_from_env(setting: &str, env: &[(String, String)]) -> O
     raw_from_env(meta, env).map(parse_string_list)
 }
 
+/// True if the user-supplied CLI key targets `meta`. Matches against
+/// the declared `sources.cli` aliases first (preserving exact behavior
+/// for command-specific flags) and then falls back to the canonical
+/// pnpm name in either kebab- or camelCase form so generic
+/// `--config.<key>` overrides resolve regardless of which spelling the
+/// user typed.
+fn cli_key_matches(key: &str, meta: &meta::SettingMeta) -> bool {
+    if meta.cli_flags.contains(&key) {
+        return true;
+    }
+    if key == meta.name {
+        return true;
+    }
+    let key_kebab = to_kebab_case(key);
+    if key_kebab == to_kebab_case(meta.name) {
+        return true;
+    }
+    false
+}
+
+/// Lower-case kebab form of a setting / flag identifier. Splits on
+/// `-`, `_`, camelCase boundaries, and dotted-path segments so callers
+/// can compare `strict-dep-builds`, `strictDepBuilds`, `STRICT_DEP_BUILDS`,
+/// and `strict_dep_builds` interchangeably. Dots are preserved so
+/// nested settings like `peerDependencyRules.ignoreMissing` keep their
+/// path structure.
+fn to_kebab_case(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    let mut prev_lower = false;
+    for c in s.chars() {
+        if c == '_' || c == '-' {
+            if !out.ends_with('-') && !out.is_empty() {
+                out.push('-');
+            }
+            prev_lower = false;
+        } else if c == '.' {
+            out.push('.');
+            prev_lower = false;
+        } else if c.is_ascii_uppercase() {
+            if prev_lower {
+                out.push('-');
+            }
+            out.push(c.to_ascii_lowercase());
+            prev_lower = false;
+        } else {
+            out.push(c);
+            prev_lower = c.is_ascii_lowercase() || c.is_ascii_digit();
+        }
+    }
+    out
+}
+
+/// Walk the per-callsite `cli` slice (newest entry first) and then the
+/// process-global `--config.<key>` overrides. First match wins, mirroring
+/// the existing reverse-scan semantics for `cli`. Returning the borrowed
+/// raw value lets each caller pick its own parsing path; the global
+/// overrides have `'static` storage so the merged lifetime is whichever
+/// `cli` borrow the caller passed in.
+fn cli_raw_for<'a>(meta: &meta::SettingMeta, cli: &'a [(String, String)]) -> Option<&'a str> {
+    for (key, raw) in cli.iter().rev() {
+        if cli_key_matches(key, meta) {
+            return Some(raw.as_str());
+        }
+    }
+    for (key, raw) in global_cli_overrides().iter().rev() {
+        if cli_key_matches(key, meta) {
+            return Some(raw.as_str());
+        }
+    }
+    None
+}
+
 /// Resolve a `bool` setting from a parsed CLI flag bag. The bag
 /// entries are whatever each command extracts from its clap struct
-/// before building the `ResolveCtx`. Keys must match the
-/// `sources.cli` aliases declared in `settings.toml`.
+/// before building the `ResolveCtx`. Keys may be either an alias
+/// declared in `sources.cli` or the canonical setting name (in any
+/// reasonable case form), so generic `--config.<key>` overrides reach
+/// every setting without per-flag wiring.
 pub(crate) fn bool_from_cli(setting: &str, cli: &[(String, String)]) -> Option<bool> {
     let meta = meta::find(setting)?;
     if meta.type_ != "bool" {
         return None;
     }
-    for (key, raw) in cli.iter().rev() {
-        if meta.cli_flags.contains(&key.as_str())
-            && let Some(v) = parse_bool(raw)
-        {
-            return Some(v);
-        }
-    }
-    None
+    cli_raw_for(meta, cli).and_then(parse_bool)
 }
 
 /// Resolve a `string` setting from a parsed CLI flag bag.
@@ -405,12 +492,7 @@ pub fn string_from_cli(setting: &str, cli: &[(String, String)]) -> Option<String
     if !is_stringish(meta.type_) {
         return None;
     }
-    for (key, raw) in cli.iter().rev() {
-        if meta.cli_flags.contains(&key.as_str()) {
-            return Some(raw.clone());
-        }
-    }
-    None
+    cli_raw_for(meta, cli).map(ToOwned::to_owned)
 }
 
 /// Resolve an `int` setting from a parsed CLI flag bag.
@@ -419,14 +501,7 @@ pub(crate) fn u64_from_cli(setting: &str, cli: &[(String, String)]) -> Option<u6
     if meta.type_ != "int" {
         return None;
     }
-    for (key, raw) in cli.iter().rev() {
-        if meta.cli_flags.contains(&key.as_str())
-            && let Ok(v) = raw.trim().parse::<u64>()
-        {
-            return Some(v);
-        }
-    }
-    None
+    cli_raw_for(meta, cli).and_then(|raw| raw.trim().parse::<u64>().ok())
 }
 
 /// Resolve a `list<string>` setting from a parsed CLI flag bag.
@@ -435,12 +510,7 @@ pub(crate) fn string_list_from_cli(setting: &str, cli: &[(String, String)]) -> O
     if meta.type_ != "list<string>" {
         return None;
     }
-    for (key, raw) in cli.iter().rev() {
-        if meta.cli_flags.contains(&key.as_str()) {
-            return Some(parse_string_list(raw));
-        }
-    }
-    None
+    cli_raw_for(meta, cli).map(parse_string_list)
 }
 
 /// Parse a pnpm/npm-style stringified list. Accepts a JSON-ish array
@@ -738,6 +808,29 @@ mod tests {
             string_from_cli("resolutionMode", &cli),
             Some("time-based".to_string())
         );
+    }
+
+    #[test]
+    fn cli_bag_matches_canonical_name_for_settings_without_declared_cli_alias() {
+        // `strictDepBuilds` declares `sources.cli = []`, but generic
+        // `--config.<key>` overrides should still reach it via the
+        // canonical name in any reasonable case form.
+        let kebab = vec![("strict-dep-builds".to_string(), "true".to_string())];
+        assert_eq!(bool_from_cli("strictDepBuilds", &kebab), Some(true));
+
+        let camel = vec![("strictDepBuilds".to_string(), "true".to_string())];
+        assert_eq!(bool_from_cli("strictDepBuilds", &camel), Some(true));
+
+        let screaming = vec![("STRICT_DEP_BUILDS".to_string(), "false".to_string())];
+        assert_eq!(bool_from_cli("strictDepBuilds", &screaming), Some(false));
+    }
+
+    #[test]
+    fn cli_bag_keeps_existing_alias_match_for_declared_settings() {
+        // `verifyStoreIntegrity` declares `sources.cli = ["verify-store-integrity"]`.
+        // The exact alias must keep working unchanged.
+        let cli = vec![("verify-store-integrity".to_string(), "true".to_string())];
+        assert_eq!(bool_from_cli("verifyStoreIntegrity", &cli), Some(true));
     }
 
     #[test]

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -26,6 +26,47 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use tracing_subscriber::prelude::*;
 
+/// Strip pnpm-style generic `--config.<key>[=<value>]` flags out of the
+/// argv before clap sees them. Returns the parsed `(key, value)` pairs
+/// in the order they appeared so the last one wins on duplicates. The
+/// supported forms are:
+///
+///   --config.<key>            → ("<key>", "true")
+///   --config.<key>=<value>    → ("<key>", "<value>")
+///
+/// `--config.<key> <value>` (space-separated) is NOT consumed: a stray
+/// positional after a bool-form switch could shadow a real argument
+/// (e.g. `aube add --config.foo lodash`), and the `=` form is what
+/// pnpm's docs use anyway. Anything after a bare `--` separator is
+/// left untouched so user-supplied positional args containing the
+/// literal `--config.` prefix still pass through.
+fn extract_config_overrides(args: &mut Vec<OsString>) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut i = 1;
+    while i < args.len() {
+        let Some(s) = args[i].to_str() else {
+            i += 1;
+            continue;
+        };
+        if s == "--" {
+            break;
+        }
+        if let Some(rest) = s.strip_prefix("--config.") {
+            let (key, value) = match rest.split_once('=') {
+                Some((k, v)) => (k.to_string(), v.to_string()),
+                None => (rest.to_string(), "true".to_string()),
+            };
+            if !key.is_empty() {
+                out.push((key, value));
+                args.remove(i);
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
 /// Inspect `argv[0]` and, when invoked as a multicall shim (`aubr`, `aubx`),
 /// rewrite the argv so clap sees the equivalent `aube run …` / `aube dlx …`.
 /// Shims are installed as hardlinks (or copies on Windows) that point at the
@@ -611,7 +652,14 @@ enum Commands {
 }
 
 fn main() -> miette::Result<()> {
-    let cli = Cli::parse_from(rewrite_multicall_argv(std::env::args_os().collect()));
+    let mut argv: Vec<OsString> = std::env::args_os().collect();
+    // pnpm-compat: pull `--config.<key>[=<value>]` out of argv before
+    // clap parses it. Stripping here means the rest of the binary sees
+    // a clean argv, and the parsed pairs feed every `ResolveCtx::cli`
+    // through the process-global slot in `aube_settings`.
+    let config_overrides = extract_config_overrides(&mut argv);
+    aube_settings::set_global_cli_overrides(config_overrides);
+    let cli = Cli::parse_from(rewrite_multicall_argv(argv));
 
     // `--color` / `--no-color` take effect before anything else touches
     // color state: we translate the flags into the env vars that miette,
@@ -1840,6 +1888,68 @@ mod multicall_tests {
             ]),
             os(&["aube", "run", "build"])
         );
+    }
+
+    #[test]
+    fn extract_config_overrides_strips_equals_form() {
+        let mut argv = os(&["aube", "install", "--config.strict-dep-builds=true"]);
+        let parsed = extract_config_overrides(&mut argv);
+        assert_eq!(argv, os(&["aube", "install"]));
+        assert_eq!(
+            parsed,
+            vec![("strict-dep-builds".to_string(), "true".to_string())]
+        );
+    }
+
+    #[test]
+    fn extract_config_overrides_strips_bool_form() {
+        let mut argv = os(&["aube", "--config.strictDepBuilds", "install"]);
+        let parsed = extract_config_overrides(&mut argv);
+        assert_eq!(argv, os(&["aube", "install"]));
+        assert_eq!(
+            parsed,
+            vec![("strictDepBuilds".to_string(), "true".to_string())]
+        );
+    }
+
+    #[test]
+    fn extract_config_overrides_handles_multiple_and_preserves_order() {
+        let mut argv = os(&[
+            "aube",
+            "--config.foo=1",
+            "install",
+            "--config.bar=two",
+            "--config.foo=3",
+        ]);
+        let parsed = extract_config_overrides(&mut argv);
+        assert_eq!(argv, os(&["aube", "install"]));
+        assert_eq!(
+            parsed,
+            vec![
+                ("foo".to_string(), "1".to_string()),
+                ("bar".to_string(), "two".to_string()),
+                ("foo".to_string(), "3".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_config_overrides_stops_at_double_dash() {
+        let mut argv = os(&["aube", "exec", "--", "node", "--config.foo=should-stay"]);
+        let parsed = extract_config_overrides(&mut argv);
+        assert!(parsed.is_empty());
+        assert_eq!(
+            argv,
+            os(&["aube", "exec", "--", "node", "--config.foo=should-stay"])
+        );
+    }
+
+    #[test]
+    fn extract_config_overrides_preserves_argv_when_absent() {
+        let mut argv = os(&["aube", "install", "--frozen-lockfile"]);
+        let parsed = extract_config_overrides(&mut argv);
+        assert!(parsed.is_empty());
+        assert_eq!(argv, os(&["aube", "install", "--frozen-lockfile"]));
     }
 }
 

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -124,6 +124,35 @@ JSON
 	assert_success
 }
 
+@test "--config.strict-dep-builds=true forces strictDepBuilds for one invocation" {
+	# pnpm-style generic `--config.<key>=<value>` flag should set
+	# `strictDepBuilds` even though the setting declares no
+	# command-specific CLI alias.
+	mkdir -p dep-with-build
+	cat >dep-with-build/package.json <<'JSON'
+{
+  "name": "dep-with-build",
+  "version": "1.0.0",
+  "scripts": {
+    "install": "node -e 'require(\"fs\").writeFileSync(\"built.marker\", \"ran\")'"
+  }
+}
+JSON
+	cat >package.json <<'JSON'
+{
+  "name": "config-flag-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "dep-with-build": "file:./dep-with-build"
+  }
+}
+JSON
+	run aube install --config.strict-dep-builds=true
+	assert_failure
+	assert_output --partial "dependencies with build scripts must be reviewed"
+	assert_output --partial "dep-with-build@1.0.0"
+}
+
 @test "strictDepBuilds=false keeps unreviewed dependency build scripts skipped" {
 	cat >.npmrc <<'EOF'
 strictDepBuilds=false


### PR DESCRIPTION
## Summary

- Adds pnpm-style `--config.<key>` and `--config.<key>=<value>` flags so any setting in `settings.toml` is reachable from the CLI, even ones without a declared `sources.cli` alias (e.g. `strictDepBuilds`).
- Argv is pre-parsed before clap; parsed pairs feed a new process-global slot in `aube-settings` that every `*_from_cli` helper consults after the per-callsite `cli` slice.
- The matcher accepts the canonical setting name in kebab / camel / snake form, so `--config.strict-dep-builds=true`, `--config.strictDepBuilds=true`, and `--config.STRICT_DEP_BUILDS=true` all resolve.

## Behavior notes

- Per-callsite CLI args still beat `--config.<key>` (first-match-wins), so existing flags like `--frozen-lockfile` keep priority.
- `--config.<key>` still beats env / `.npmrc` / workspace yaml — same precedence as any other CLI source.
- Anything after a bare `--` separator is left untouched, so `aube exec -- node --config.foo=bar` passes `--config.foo=bar` through to the child.
- Bare `--config.<key>` with no `=` defaults to `"true"` (matches pnpm/commander). The `--config.<key> <value>` space form is intentionally NOT consumed to avoid eating positional args.

## Test plan

- [x] `cargo test -p aube-settings` — covers canonical-name matching across kebab/camel/screaming-snake.
- [x] `cargo test -p aube --bin aube` — covers `extract_config_overrides` (=, bool, multiple, `--`, no-op).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `mise run test:bats test/lifecycle_scripts.bats` — new `--config.strict-dep-builds=true` test plus existing 21 pass.
- [x] Manual smoke: `aube install --config.strict-dep-builds=true` triggers the gate; `--config.strict-dep-builds=false` overrides `.npmrc strictDepBuilds=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies top-level argv handling and settings CLI resolution precedence, which could change how flags are parsed/overridden across commands if edge cases are missed.
> 
> **Overview**
> Adds pnpm-compatible generic `--config.<key>` / `--config.<key>=<value>` support by stripping these flags from argv before clap parsing and registering them as process-wide setting overrides.
> 
> Updates `aube-settings` CLI resolvers to consult these global overrides (after command-specific CLI flags), including matching keys by canonical setting name across kebab/camel/snake forms and skipping unparseable values so earlier valid duplicates still win. Adds unit tests plus a bats regression test proving `--config.strict-dep-builds=true` can flip `strictDepBuilds` for a single `aube install` run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d23eb91ef76be670e7061fedea936e5d73d841b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->