### PR TITLE
perf: dedupe and cache hot-path work in install and resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "aube-manifest",
  "aube-settings",
  "aube-util",
+ "blake3",
  "glob",
  "hex",
  "miette",

--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = { workspace = true }
 simd-json = { workspace = true }
 yaml_serde = { workspace = true }
 sha2 = { workspace = true }
+blake3 = { workspace = true }
 hex = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/aube-lockfile/src/graph_hash.rs
+++ b/crates/aube-lockfile/src/graph_hash.rs
@@ -18,17 +18,17 @@
 //!    that builds) has a hash of `engine=null` — stable across
 //!    architectures, so pure-JS trees are still shared globally.
 //!
-//! Unlike pnpm, we use SHA-256 over a canonical JSON serialization —
+//! Unlike pnpm, we use BLAKE3 over a canonical JSON serialization —
 //! aube's virtual store is internal to aube (the CAS under
 //! `$XDG_DATA_HOME/aube/store/v1/files` is ours alone), so we don't
 //! need bit-for-bit compatibility with pnpm's `object-hash`.
 //! Determinism is all that matters, and `serde_json` plus `BTreeMap`
-//! gives us alphabetized keys for free.
+//! gives us alphabetized keys for free. BLAKE3 is the project default
+//! for non-crypto-verifying hashes (3-5x faster than SHA-256).
 
 use crate::{LockedPackage, LockfileGraph};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
 /// A callback the caller provides to tell the hasher which
@@ -301,14 +301,13 @@ fn full_pkg_id(pkg: &LockedPackage, patch_hash: PatchHashFn<'_>) -> String {
     }
 }
 
-/// SHA-256 over a canonical JSON serialization. `serde_json` plus
+/// BLAKE3 over a canonical JSON serialization. `serde_json` plus
 /// `BTreeMap` gives alphabetized keys; primitives serialize
 /// deterministically. Return the full hex digest so callers can pick
 /// whatever prefix length they want.
 fn hash_canonical<T: Serialize>(value: &T) -> String {
     let json = serde_json::to_vec(value).expect("graph hash input must serialize");
-    let digest = Sha256::digest(&json);
-    hex::encode(digest)
+    blake3::hash(&json).to_hex().to_string()
 }
 
 #[derive(Serialize)]

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -150,6 +150,13 @@ pub struct RegistryClient {
     http: reqwest::Client,
     http_by_uri: BTreeMap<String, reqwest::Client>,
     token_helper_cache: Mutex<BTreeMap<String, Option<String>>>,
+    /// Memoized result of `registry_auth_token_for(url)`. Without this,
+    /// every authed request walks `auth_by_uri` for a longest-prefix
+    /// match against `registry_url`. On a 2000-package install that's
+    /// 2000 × O(N_uris × strcmp) wasted lookups. The token is fixed
+    /// for the lifetime of the process (helpers are already memoized
+    /// in `token_helper_cache`), so per-URL caching is safe.
+    auth_token_by_url: Mutex<BTreeMap<String, Option<String>>>,
     config: NpmConfig,
     network_mode: NetworkMode,
     fetch_policy: FetchPolicy,
@@ -206,6 +213,7 @@ impl RegistryClient {
             http,
             http_by_uri,
             token_helper_cache: Mutex::new(BTreeMap::new()),
+            auth_token_by_url: Mutex::new(BTreeMap::new()),
             config,
             network_mode: NetworkMode::Online,
             fetch_policy,
@@ -407,15 +415,28 @@ impl RegistryClient {
     }
 
     fn registry_auth_token_for(&self, registry_url: &str) -> Option<String> {
-        if let Some(auth) = self.config.registry_config_for(registry_url) {
-            if let Some(token) = auth.auth_token.as_ref() {
-                return Some(token.to_string());
-            }
-            if let Some(helper) = auth.token_helper.as_deref() {
-                return self.cached_token_helper_result(helper);
-            }
+        // Fast path: memoized result. Hit on the second-and-later
+        // request to the same registry URL within one process.
+        if let Ok(cache) = self.auth_token_by_url.lock()
+            && let Some(cached) = cache.get(registry_url)
+        {
+            return cached.clone();
         }
-        None
+        let resolved = if let Some(auth) = self.config.registry_config_for(registry_url) {
+            if let Some(token) = auth.auth_token.as_ref() {
+                Some(token.to_string())
+            } else if let Some(helper) = auth.token_helper.as_deref() {
+                self.cached_token_helper_result(helper)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        if let Ok(mut cache) = self.auth_token_by_url.lock() {
+            cache.insert(registry_url.to_string(), resolved.clone());
+        }
+        resolved
     }
 
     /// Cache key is the helper command itself, not the registry URL:

--- a/crates/aube-scripts/src/policy.rs
+++ b/crates/aube-scripts/src/policy.rs
@@ -188,17 +188,42 @@ impl BuildPolicy {
     /// Decide whether `(name, version)` may run lifecycle scripts.
     /// Explicit denies always win over allows (mirrors pnpm).
     pub fn decide(&self, name: &str, version: &str) -> AllowDecision {
-        let with_version = format!("{name}@{version}");
-        if self.denied.contains(name) || self.denied.contains(&with_version) {
+        // Reusable thread-local buffer for the `name@version` probe key.
+        // Avoids a `format!` allocation on every call — ~2k throwaway
+        // Strings on a typical install otherwise.
+        thread_local! {
+            static KEY_BUF: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
+        }
+        if self.denied.contains(name) {
             return AllowDecision::Deny;
         }
         if matches_any_wildcard(name, &self.denied_wildcards) {
             return AllowDecision::Deny;
         }
+        let denied_versioned = KEY_BUF.with(|buf| {
+            let mut b = buf.borrow_mut();
+            b.clear();
+            use std::fmt::Write as _;
+            let _ = write!(b, "{name}@{version}");
+            self.denied.contains(b.as_str())
+        });
+        if denied_versioned {
+            return AllowDecision::Deny;
+        }
         if self.allow_all {
             return AllowDecision::Allow;
         }
-        if self.allowed.contains(name) || self.allowed.contains(&with_version) {
+        if self.allowed.contains(name) {
+            return AllowDecision::Allow;
+        }
+        let allowed_versioned = KEY_BUF.with(|buf| {
+            let mut b = buf.borrow_mut();
+            b.clear();
+            use std::fmt::Write as _;
+            let _ = write!(b, "{name}@{version}");
+            self.allowed.contains(b.as_str())
+        });
+        if allowed_versioned {
             return AllowDecision::Allow;
         }
         if matches_any_wildcard(name, &self.allowed_wildcards) {

--- a/crates/aube-scripts/src/policy.rs
+++ b/crates/aube-scripts/src/policy.rs
@@ -200,12 +200,15 @@ impl BuildPolicy {
         if matches_any_wildcard(name, &self.denied_wildcards) {
             return AllowDecision::Deny;
         }
-        let denied_versioned = KEY_BUF.with(|buf| {
+        // Build the `name@version` probe key once and answer both the
+        // deny and the allow lookups from a single buffer borrow.
+        let (denied_versioned, allowed_versioned) = KEY_BUF.with(|buf| {
             let mut b = buf.borrow_mut();
             b.clear();
             use std::fmt::Write as _;
             let _ = write!(b, "{name}@{version}");
-            self.denied.contains(b.as_str())
+            let key = b.as_str();
+            (self.denied.contains(key), self.allowed.contains(key))
         });
         if denied_versioned {
             return AllowDecision::Deny;
@@ -213,17 +216,7 @@ impl BuildPolicy {
         if self.allow_all {
             return AllowDecision::Allow;
         }
-        if self.allowed.contains(name) {
-            return AllowDecision::Allow;
-        }
-        let allowed_versioned = KEY_BUF.with(|buf| {
-            let mut b = buf.borrow_mut();
-            b.clear();
-            use std::fmt::Write as _;
-            let _ = write!(b, "{name}@{version}");
-            self.allowed.contains(b.as_str())
-        });
-        if allowed_versioned {
+        if self.allowed.contains(name) || allowed_versioned {
             return AllowDecision::Allow;
         }
         if matches_any_wildcard(name, &self.allowed_wildcards) {

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -88,18 +88,33 @@ impl<'a> ResolveCtx<'a> {
     }
 }
 
+/// Process-wide env snapshot. Captured once on first read so every
+/// `ResolveCtx` walks the same list without repeating the
+/// `std::env::vars()` syscall storm. Subprocesses can't mutate the
+/// parent env, so a single capture is correct for the lifetime of the
+/// CLI process.
+static PROCESS_ENV: std::sync::LazyLock<Vec<(String, String)>> =
+    std::sync::LazyLock::new(|| std::env::vars().collect());
+
 /// Snapshot the process environment into a `(name, value)` list the
 /// resolver can walk. Filtering happens at lookup time against the
 /// setting's declared `env_vars` aliases, so this captures everything
 /// upfront and lets the metadata decide what's relevant.
 ///
-/// Call this once at program start and share the resulting `Vec` with
-/// every `ResolveCtx`. Cheaper than re-reading `std::env` for each
-/// setting, and makes behavior deterministic across a single command
-/// invocation even if subprocesses mutate the parent env (they can't,
-/// but the invariant is still easier to reason about).
+/// First caller in the process triggers the underlying `std::env::vars()`
+/// walk; subsequent callers get a cheap `Vec` clone of the cached
+/// snapshot. The clone keeps the existing `Vec<(String, String)>` API
+/// surface; callers that want zero-alloc access can read [`process_env`]
+/// directly.
 pub fn capture_env() -> Vec<(String, String)> {
-    std::env::vars().collect()
+    PROCESS_ENV.clone()
+}
+
+/// Borrowed view of the process-wide env snapshot. Callers that only
+/// need to read should prefer this over [`capture_env`] — no Vec
+/// clone, no per-entry String clone.
+pub fn process_env() -> &'static [(String, String)] {
+    PROCESS_ENV.as_slice()
 }
 
 /// Typed per-setting accessors generated at build time from

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -698,21 +698,23 @@ async fn update_manifest_for_add(
         // range — the display version should match what will actually
         // get installed, not what the user's original range resolved
         // to, so we call this twice when the rewrite fires.
+        //
+        // Parse every candidate version once (skipping invalid ones
+        // entirely) and sort the parsed pairs. Comparator-only parsing
+        // burned ~2N parses per add; pre-parse turns it into N + log N
+        // and lets the satisfies-scan reuse the parsed `Version`.
+        let mut parsed_versions: Vec<(&String, node_semver::Version)> = packument
+            .versions
+            .keys()
+            .filter_map(|v| node_semver::Version::parse(v).ok().map(|p| (v, p)))
+            .collect();
+        parsed_versions.sort_by(|a, b| b.1.cmp(&a.1));
         let highest_satisfying = |range_str: &str| -> Option<String> {
             let range = node_semver::Range::parse(range_str).ok()?;
-            let mut versions: Vec<&String> = packument.versions.keys().collect();
-            versions.sort_by(|a, b| {
-                let va = node_semver::Version::parse(a);
-                let vb = node_semver::Version::parse(b);
-                match (va, vb) {
-                    (Ok(va), Ok(vb)) => vb.cmp(&va),
-                    _ => std::cmp::Ordering::Equal,
-                }
-            });
-            versions
-                .into_iter()
-                .find(|v| node_semver::Version::parse(v).is_ok_and(|p| p.satisfies(&range)))
-                .cloned()
+            parsed_versions
+                .iter()
+                .find(|(_, parsed)| parsed.satisfies(&range))
+                .map(|(raw, _)| (*raw).clone())
         };
         let resolved_version = highest_satisfying(&effective_range)
             .ok_or_else(|| miette!("no version of {} matches {effective_range}", spec.name))?;

--- a/crates/aube/src/commands/install/delta.rs
+++ b/crates/aube/src/commands/install/delta.rs
@@ -132,6 +132,11 @@ pub struct DeltaPlan {
     pub added: Vec<String>,
     pub removed: Vec<String>,
     pub changed: Vec<String>,
+    /// Pre-built `added ∪ changed` lookup. Built once at construction
+    /// so `should_touch` stays O(log N) per probe. The linker walks
+    /// the graph 4-5 times; without this cache each probe was a
+    /// linear scan over both `Vec`s.
+    touched: BTreeSet<String>,
 }
 
 impl DeltaPlan {
@@ -148,29 +153,38 @@ impl DeltaPlan {
     /// Membership test for `added ∪ changed`. Only these need fetch
     /// or re-link. `removed` runs through a separate unlink pass.
     pub fn should_touch(&self, dep_path: &str) -> bool {
-        self.added.iter().any(|d| d == dep_path) || self.changed.iter().any(|d| d == dep_path)
+        self.touched.contains(dep_path)
     }
 
-    /// O(log N) lookup view for callers that probe many times per
-    /// install. The linker walks the graph 4-5 times. Scanning two
-    /// `Vec`s each time would be O(N) per probe.
-    pub fn touched_set(&self) -> BTreeSet<&str> {
-        let mut s = BTreeSet::new();
-        s.extend(self.added.iter().map(String::as_str));
-        s.extend(self.changed.iter().map(String::as_str));
-        s
+    /// Borrowed view of the cached `added ∪ changed` set. Stable for
+    /// the lifetime of the plan; cheaper than rebuilding per probe.
+    pub fn touched_set(&self) -> &BTreeSet<String> {
+        &self.touched
     }
 }
 
 /// blake3 fingerprint for every package in `graph`. Keys mirror
 /// `graph.packages` so callers can join directly.
-pub fn compute_package_hashes(graph: &LockfileGraph) -> BTreeMap<String, String> {
+///
+/// `patch_hashes` keys are `name@version`. Folding the patch content
+/// hash into the fingerprint makes a re-patched package land in the
+/// `changed` bucket on the next install. Without this, two installs
+/// whose lockfile is identical but whose `pnpm.patchedDependencies`
+/// changed would silently skip rebuild of the affected entries.
+pub fn compute_package_hashes(
+    graph: &LockfileGraph,
+    patch_hashes: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
     // Pure, per-package, CPU-bound. Perfect rayon target. 500-pkg
     // graph drops from ~25 ms serial to ~6 ms on 4 cores.
     graph
         .packages
         .par_iter()
-        .map(|(dep_path, pkg)| (dep_path.clone(), fingerprint(pkg)))
+        .map(|(dep_path, pkg)| {
+            let patch_key = format!("{}@{}", pkg.name, pkg.version);
+            let patch = patch_hashes.get(&patch_key).map(String::as_str);
+            (dep_path.clone(), fingerprint(pkg, patch))
+        })
         .collect()
 }
 
@@ -185,8 +199,26 @@ pub fn compute_package_hashes(graph: &LockfileGraph) -> BTreeMap<String, String>
 /// an acyclic node. Peer-dep cycles happen in aube-resolver's
 /// peer_context. Rare but real, so SCC handling is correctness
 /// not just robustness.
-pub fn compute_subtree_hashes(graph: &LockfileGraph) -> BTreeMap<String, String> {
-    let leaf = compute_package_hashes(graph);
+/// Compute leaf and subtree hashes in one pass. Callers that need
+/// both should prefer this over calling each function separately so
+/// the BLAKE3 leaf pass runs once. Returns `(leaf, subtree)`.
+pub fn compute_leaf_and_subtree_hashes(
+    graph: &LockfileGraph,
+    patch_hashes: &BTreeMap<String, String>,
+) -> (BTreeMap<String, String>, BTreeMap<String, String>) {
+    let leaf = compute_package_hashes(graph, patch_hashes);
+    let subtree = compute_subtree_hashes_from_leaf(graph, &leaf);
+    (leaf, subtree)
+}
+
+/// Variant of [`compute_subtree_hashes`] that reuses an already-built
+/// leaf-fingerprint map. The caller wires this when it has both
+/// fingerprints and subtree hashes to compute, so the BLAKE3 leaf
+/// pass runs once instead of twice.
+pub fn compute_subtree_hashes_from_leaf(
+    graph: &LockfileGraph,
+    leaf: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
     let sccs = tarjan_scc(graph);
     // dep_path to scc index.
     let mut scc_index: BTreeMap<String, usize> = BTreeMap::new();
@@ -363,10 +395,17 @@ fn dfs_post(start: usize, edges: &[BTreeSet<usize>], seen: &mut [bool], order: &
 /// falls through to the regular full-install flow.
 pub fn diff(stored: &BTreeMap<String, String>, current: &BTreeMap<String, String>) -> DeltaPlan {
     let mut plan = DeltaPlan::default();
+    let mut touched = BTreeSet::new();
     for (dep_path, new_hash) in current {
         match stored.get(dep_path) {
-            None => plan.added.push(dep_path.clone()),
-            Some(old_hash) if old_hash != new_hash => plan.changed.push(dep_path.clone()),
+            None => {
+                touched.insert(dep_path.clone());
+                plan.added.push(dep_path.clone());
+            }
+            Some(old_hash) if old_hash != new_hash => {
+                touched.insert(dep_path.clone());
+                plan.changed.push(dep_path.clone());
+            }
             Some(_) => {}
         }
     }
@@ -375,6 +414,7 @@ pub fn diff(stored: &BTreeMap<String, String>, current: &BTreeMap<String, String
             plan.removed.push(dep_path.clone());
         }
     }
+    plan.touched = touched;
     plan
 }
 
@@ -382,7 +422,7 @@ pub fn diff(stored: &BTreeMap<String, String>, current: &BTreeMap<String, String
 /// Field order matters. Changing it invalidates every stored
 /// fingerprint on the next install. That still cascades to a full
 /// install, just costs one "already up to date" miss.
-fn fingerprint(pkg: &LockedPackage) -> String {
+fn fingerprint(pkg: &LockedPackage, patch_hash: Option<&str>) -> String {
     let mut h = Hasher::new();
     update_field(&mut h, b"name", pkg.name.as_bytes());
     update_field(&mut h, b"version", pkg.version.as_bytes());
@@ -390,6 +430,7 @@ fn fingerprint(pkg: &LockedPackage) -> String {
     update_optional(&mut h, b"integrity", pkg.integrity.as_deref());
     update_optional(&mut h, b"tarball_url", pkg.tarball_url.as_deref());
     update_optional(&mut h, b"alias_of", pkg.alias_of.as_deref());
+    update_optional(&mut h, b"patch", patch_hash);
     // BTreeMap iteration is canonical. Length-prefix every entry so
     // "a" -> "bc" cannot collide with "ab" -> "c".
     h.update(b"deps");
@@ -494,18 +535,27 @@ mod tests {
         graph
     }
 
+    fn fp(p: &LockedPackage) -> String {
+        fingerprint(p, None)
+    }
+
+    fn cph(g: &LockfileGraph) -> BTreeMap<String, String> {
+        compute_package_hashes(g, &BTreeMap::new())
+    }
+
+    fn csh(g: &LockfileGraph) -> BTreeMap<String, String> {
+        compute_leaf_and_subtree_hashes(g, &BTreeMap::new()).1
+    }
+
     #[test]
     fn fingerprint_is_deterministic() {
         let p = pkg("react", "18.2.0");
-        assert_eq!(fingerprint(&p), fingerprint(&p.clone()));
+        assert_eq!(fp(&p), fp(&p.clone()));
     }
 
     #[test]
     fn fingerprint_changes_on_version_bump() {
-        assert_ne!(
-            fingerprint(&pkg("react", "18.2.0")),
-            fingerprint(&pkg("react", "18.3.0"))
-        );
+        assert_ne!(fp(&pkg("react", "18.2.0")), fp(&pkg("react", "18.3.0")));
     }
 
     #[test]
@@ -514,7 +564,7 @@ mod tests {
         let mut b = a.clone();
         a.integrity = Some("sha512-AAAA".into());
         b.integrity = Some("sha512-BBBB".into());
-        assert_ne!(fingerprint(&a), fingerprint(&b));
+        assert_ne!(fp(&a), fp(&b));
     }
 
     #[test]
@@ -525,7 +575,7 @@ mod tests {
             .insert("loose-envify".into(), "loose-envify@1.4.0".into());
         b.dependencies
             .insert("loose-envify".into(), "loose-envify@1.5.0".into());
-        assert_ne!(fingerprint(&a), fingerprint(&b));
+        assert_ne!(fp(&a), fp(&b));
     }
 
     #[test]
@@ -536,7 +586,7 @@ mod tests {
         let mut b = pkg("react", "18.2.0");
         b.dependencies.insert("b".into(), "2".into());
         b.dependencies.insert("a".into(), "1".into());
-        assert_eq!(fingerprint(&a), fingerprint(&b));
+        assert_eq!(fp(&a), fp(&b));
     }
 
     #[test]
@@ -546,7 +596,7 @@ mod tests {
         let mut a = pkg("react", "18.2.0");
         let b = a.clone();
         a.peer_dependencies.insert("something".into(), "*".into());
-        assert_eq!(fingerprint(&a), fingerprint(&b));
+        assert_eq!(fp(&a), fp(&b));
     }
 
     #[test]
@@ -555,13 +605,13 @@ mod tests {
         let mut b = pkg("a", "b1");
         a.integrity = None;
         b.integrity = None;
-        assert_ne!(fingerprint(&a), fingerprint(&b));
+        assert_ne!(fp(&a), fp(&b));
     }
 
     #[test]
     fn diff_empty_stored_marks_everything_added() {
         let graph = graph_of(&[pkg("a", "1"), pkg("b", "2")]);
-        let current = compute_package_hashes(&graph);
+        let current = cph(&graph);
         let plan = diff(&BTreeMap::new(), &current);
         assert_eq!(plan.added.len(), 2);
         assert_eq!(plan.removed.len(), 0);
@@ -571,7 +621,7 @@ mod tests {
     #[test]
     fn diff_identical_maps_is_empty() {
         let graph = graph_of(&[pkg("a", "1"), pkg("b", "2")]);
-        let current = compute_package_hashes(&graph);
+        let current = cph(&graph);
         let plan = diff(&current, &current);
         assert!(plan.is_empty());
     }
@@ -584,13 +634,12 @@ mod tests {
         // update that rewrote the dependencies map.
         let mut republished = pkg("keep", "1");
         republished.integrity = Some("sha512-after-republish".into());
-        let before = compute_package_hashes(&graph_of(&[
+        let before = cph(&graph_of(&[
             pkg("keep", "1"),
             pkg("gone", "1"),
             pkg("bump", "1"),
         ]));
-        let after =
-            compute_package_hashes(&graph_of(&[republished, pkg("new", "1"), pkg("bump", "2")]));
+        let after = cph(&graph_of(&[republished, pkg("new", "1"), pkg("bump", "2")]));
         let plan = diff(&before, &after);
         // Version bumps show up as distinct dep_paths: bump@1 gone,
         // bump@2 added. Only the stable-path republish lands in
@@ -611,18 +660,18 @@ mod tests {
         let mut g2 = LockfileGraph::default();
         g2.packages.insert("b@1".into(), pkg("b", "1"));
         g2.packages.insert("a@1".into(), pkg("a", "1"));
-        let plan = diff(&compute_package_hashes(&g1), &compute_package_hashes(&g2));
+        let plan = diff(&cph(&g1), &cph(&g2));
         assert!(plan.is_empty());
     }
 
     #[test]
     fn changed_subtree_roots_includes_changed_ancestors() {
-        let before = compute_subtree_hashes(&graph_of(&[
+        let before = csh(&graph_of(&[
             pkg_with_deps("app", "1", &[("dep", "1")]),
             pkg("dep", "1"),
             pkg("peer", "1"),
         ]));
-        let after = compute_subtree_hashes(&graph_of(&[
+        let after = csh(&graph_of(&[
             pkg_with_deps("app", "1", &[("dep", "2")]),
             pkg("dep", "2"),
             pkg("peer", "1"),
@@ -634,12 +683,48 @@ mod tests {
     }
 
     #[test]
+    fn patch_hash_change_lands_in_changed_bucket() {
+        // Same lockfile, same integrity. Only `pnpm.patchedDependencies`
+        // moved. Without folding patch hash into the fingerprint this
+        // would silently match prior state and the side-effects cache
+        // would skip the rebuild.
+        let graph = graph_of(&[pkg("react", "18.2.0")]);
+        let mut before_patches = BTreeMap::new();
+        before_patches.insert("react@18.2.0".to_string(), "patch-old".to_string());
+        let mut after_patches = BTreeMap::new();
+        after_patches.insert("react@18.2.0".to_string(), "patch-new".to_string());
+        let before = compute_package_hashes(&graph, &before_patches);
+        let after = compute_package_hashes(&graph, &after_patches);
+        let plan = diff(&before, &after);
+        assert_eq!(plan.changed, vec!["react@18.2.0".to_string()]);
+        assert!(plan.added.is_empty());
+        assert!(plan.removed.is_empty());
+    }
+
+    #[test]
+    fn no_patch_matches_empty_patch_map() {
+        // Stable across the rollout: a package with no patch entry
+        // hashes the same regardless of whether the patch map exists
+        // at all.
+        let graph = graph_of(&[pkg("react", "18.2.0")]);
+        let empty = BTreeMap::new();
+        let unrelated_patch: BTreeMap<String, String> =
+            [("other@1".to_string(), "patch-x".to_string())]
+                .into_iter()
+                .collect();
+        assert_eq!(
+            compute_package_hashes(&graph, &empty),
+            compute_package_hashes(&graph, &unrelated_patch)
+        );
+    }
+
+    #[test]
     fn platform_list_edit_changes_fingerprint() {
         let mut a = pkg("native", "1");
         let mut b = a.clone();
         a.os.push("linux".into());
         b.os.push("darwin".into());
-        assert_ne!(fingerprint(&a), fingerprint(&b));
+        assert_ne!(fp(&a), fp(&b));
     }
 
     #[test]
@@ -648,7 +733,7 @@ mod tests {
         let mut b = a.clone();
         a.tarball_url = Some("https://a.example/a-1.tgz".into());
         b.tarball_url = Some("https://b.example/a-1.tgz".into());
-        assert_ne!(fingerprint(&a), fingerprint(&b));
+        assert_ne!(fp(&a), fp(&b));
     }
 
     #[test]
@@ -657,7 +742,7 @@ mod tests {
         let mut b = a.clone();
         a.alias_of = Some("h3".into());
         b.alias_of = Some("h3-beta".into());
-        assert_ne!(fingerprint(&a), fingerprint(&b));
+        assert_ne!(fp(&a), fp(&b));
     }
 
     #[test]
@@ -733,7 +818,7 @@ mod tests {
     fn subtree_hash_stable_for_identical_graph() {
         let g1 = graph_of(&[pkg("a", "1"), pkg("b", "1")]);
         let g2 = graph_of(&[pkg("b", "1"), pkg("a", "1")]);
-        assert_eq!(compute_subtree_hashes(&g1), compute_subtree_hashes(&g2));
+        assert_eq!(csh(&g1), csh(&g2));
     }
 
     #[test]
@@ -746,8 +831,8 @@ mod tests {
         let g_before = graph_of(&[parent.clone(), child.clone()]);
         child.integrity = Some("sha512-tampered".into());
         let g_after = graph_of(&[parent, child]);
-        let h_before = compute_subtree_hashes(&g_before);
-        let h_after = compute_subtree_hashes(&g_after);
+        let h_before = csh(&g_before);
+        let h_after = csh(&g_after);
         assert_ne!(h_before["root@1"], h_after["root@1"]);
         assert_ne!(h_before["leaf@1"], h_after["leaf@1"]);
     }
@@ -767,8 +852,8 @@ mod tests {
         let mut la2 = la.clone();
         la2.integrity = Some("sha512-changed".into());
         let g2 = graph_of(&[pa, pb, la2, lb]);
-        let h1 = compute_subtree_hashes(&g1);
-        let h2 = compute_subtree_hashes(&g2);
+        let h1 = csh(&g1);
+        let h2 = csh(&g2);
         assert_ne!(h1["pa@1"], h2["pa@1"]);
         assert_eq!(h1["pb@1"], h2["pb@1"]);
         assert_eq!(h1["leaf-b@1"], h2["leaf-b@1"]);
@@ -784,7 +869,7 @@ mod tests {
         a.dependencies.insert("b".into(), "b@1".into());
         b.dependencies.insert("a".into(), "a@1".into());
         let g = graph_of(&[a, b]);
-        let hashes = compute_subtree_hashes(&g);
+        let hashes = csh(&g);
         assert_eq!(hashes.len(), 2);
         assert_eq!(hashes["a@1"], hashes["b@1"]);
     }

--- a/crates/aube/src/commands/install/delta.rs
+++ b/crates/aube/src/commands/install/delta.rs
@@ -136,7 +136,11 @@ pub struct DeltaPlan {
     /// so `should_touch` stays O(log N) per probe. The linker walks
     /// the graph 4-5 times; without this cache each probe was a
     /// linear scan over both `Vec`s.
-    touched: BTreeSet<String>,
+    ///
+    /// Named `touch_set` (not `touched`) because `touched()` is the
+    /// counter method on the same type and the field/method collision
+    /// trips up future readers reaching for `plan.touched`.
+    touch_set: BTreeSet<String>,
 }
 
 impl DeltaPlan {
@@ -153,13 +157,13 @@ impl DeltaPlan {
     /// Membership test for `added ∪ changed`. Only these need fetch
     /// or re-link. `removed` runs through a separate unlink pass.
     pub fn should_touch(&self, dep_path: &str) -> bool {
-        self.touched.contains(dep_path)
+        self.touch_set.contains(dep_path)
     }
 
     /// Borrowed view of the cached `added ∪ changed` set. Stable for
     /// the lifetime of the plan; cheaper than rebuilding per probe.
     pub fn touched_set(&self) -> &BTreeSet<String> {
-        &self.touched
+        &self.touch_set
     }
 }
 
@@ -414,7 +418,7 @@ pub fn diff(stored: &BTreeMap<String, String>, current: &BTreeMap<String, String
             plan.removed.push(dep_path.clone());
         }
     }
-    plan.touched = touched;
+    plan.touch_set = touched;
     plan
 }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2813,7 +2813,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // on every re-resolve even though the resolved versions
             // didn't change, which churns the lockfile diff against
             // formats (npm, bun) that preserve them.
-            if let Ok(prior) =
+            // Reuse the pre-parsed lockfile when the resolver already
+            // loaded it for seeding (Fix/Prefer modes). Skips a second
+            // YAML parse pass over the same 5-50 KB file.
+            if let Some((prior, _)) = lockfile_pre_parse.as_ref() {
+                graph.overlay_metadata_from(prior);
+            } else if let Ok(prior) =
                 parse_lockfile_dir_remapped(&lockfile_dir, &lockfile_importer_key, &manifest)
             {
                 graph.overlay_metadata_from(&prior);
@@ -3408,11 +3413,33 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         linker = linker.with_use_global_virtual_store(enabled);
     }
 
-    let current_subtree_hashes = (!virtual_store_only
+    // Load `pnpm.patchedDependencies` and pre-compute per-package
+    // patch hashes. Hoisted ahead of subtree-hash computation so the
+    // patch content gets folded into delta fingerprints — without
+    // this, a re-patched package would not land in the `changed`
+    // bucket and the side-effects skip path could wrongly trust a
+    // stale marker.
+    let resolved_patches = crate::patches::load_patches(&cwd)?;
+    let patch_hashes: std::collections::BTreeMap<String, String> = resolved_patches
+        .values()
+        .map(|p| (p.key.clone(), p.content_hash()))
+        .collect();
+
+    // Compute leaf + subtree hashes together when both are needed.
+    // Linker invalidation reads `current_subtree_hashes`; the late
+    // state writeback reads the leaf map. Sharing the BLAKE3 leaf
+    // pass cuts a duplicate `compute_package_hashes` traversal.
+    let (current_leaf_hashes, current_subtree_hashes) = if !virtual_store_only
         && matches!(node_linker, aube_linker::NodeLinker::Isolated)
         && !opts.dep_selection.is_filtered()
-        && opts.workspace_filter.is_empty())
-    .then(|| delta::compute_subtree_hashes(&graph_for_link));
+        && opts.workspace_filter.is_empty()
+    {
+        let (leaf, subtree) =
+            delta::compute_leaf_and_subtree_hashes(&graph_for_link, &patch_hashes);
+        (Some(leaf), Some(subtree))
+    } else {
+        (None, None)
+    };
     if !linker.uses_global_virtual_store()
         && let Some(current_subtree_hashes) = current_subtree_hashes.as_ref()
         && let Some(prior_subtrees) = state::read_state_subtree_hashes(&cwd)
@@ -3435,14 +3462,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     //     deps)` under different node / arch combos from stomping on
     //     each other; pure-JS packages with no build-allowed
     //     descendants get engine-agnostic hashes and stay shared.
-    // Load `pnpm.patchedDependencies` and pre-compute per-package
-    // patch hashes. We always load these, even when `use_global_virtual_store`
-    // is off, so the linker can apply patches at materialize time.
-    let resolved_patches = crate::patches::load_patches(&cwd)?;
-    let patch_hashes: std::collections::BTreeMap<String, String> = resolved_patches
-        .values()
-        .map(|p| (p.key.clone(), p.content_hash()))
-        .collect();
     let patches_for_linker: aube_linker::Patches = resolved_patches
         .values()
         .map(|p| (p.key.clone(), p.content.clone()))
@@ -3789,9 +3808,18 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         // install can diff and skip unchanged entries. Missing or
         // stale fingerprints fall back to a full install on the
         // read side. Safe for older readers that ignore the field.
-        let package_content_hashes = delta::compute_package_hashes(&graph);
-        let package_subtree_hashes =
-            current_subtree_hashes.unwrap_or_else(|| delta::compute_subtree_hashes(&graph));
+        // When the early pass already produced the leaf map for
+        // `graph_for_link`, reuse it here as long as the writeback
+        // graph matches by node count (filtered installs short-
+        // circuit before this branch). Falling through to a fresh
+        // compute keeps the contract simple and is exact whenever
+        // the graphs diverge.
+        let package_content_hashes = current_leaf_hashes
+            .filter(|leaf| leaf.len() == graph.packages.len())
+            .unwrap_or_else(|| delta::compute_package_hashes(&graph, &patch_hashes));
+        let package_subtree_hashes = current_subtree_hashes.unwrap_or_else(|| {
+            delta::compute_subtree_hashes_from_leaf(&graph, &package_content_hashes)
+        });
         let graph_lthash = hex::encode(delta::lthash_of(&package_content_hashes).digest());
         let package_json_hashes =
             state::collect_package_json_hashes_from_manifests(&cwd, &manifests);

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3809,13 +3809,17 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         // stale fingerprints fall back to a full install on the
         // read side. Safe for older readers that ignore the field.
         // When the early pass already produced the leaf map for
-        // `graph_for_link`, reuse it here as long as the writeback
-        // graph matches by node count (filtered installs short-
-        // circuit before this branch). Falling through to a fresh
-        // compute keeps the contract simple and is exact whenever
-        // the graphs diverge.
+        // `graph_for_link`, reuse it here as long as it covers every
+        // dep_path in the writeback `graph`. Filtered installs short-
+        // circuit before this branch so the two graphs are normally
+        // identical, but verifying every key keeps the reuse safe
+        // against any future code path that diverges them. Any miss
+        // falls back to a fresh compute over `graph`.
         let package_content_hashes = current_leaf_hashes
-            .filter(|leaf| leaf.len() == graph.packages.len())
+            .filter(|leaf| {
+                leaf.len() == graph.packages.len()
+                    && graph.packages.keys().all(|k| leaf.contains_key(k))
+            })
             .unwrap_or_else(|| delta::compute_package_hashes(&graph, &patch_hashes));
         let package_subtree_hashes = current_subtree_hashes.unwrap_or_else(|| {
             delta::compute_subtree_hashes_from_leaf(&graph, &package_content_hashes)

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -63,6 +63,26 @@ fn home_stop_boundary() -> Option<PathBuf> {
     aube_util::env::home_dir()
 }
 
+/// Shape-only check for a `package.json`'s `workspaces` field. Parses
+/// just enough JSON to know if the field is present and non-null,
+/// skipping the full `PackageJson` parse (which allocates IndexMaps,
+/// deps maps, scripts, the whole thing) for every ancestor in the
+/// walk. Callers up the chain run this 5-20 times per `aube run` /
+/// `aube exec` / `aube dlx`.
+fn package_json_has_workspaces(path: &Path) -> bool {
+    #[derive(serde::Deserialize)]
+    struct ShapeOnly {
+        #[serde(default)]
+        workspaces: Option<serde::de::IgnoredAny>,
+    }
+    let Ok(bytes) = std::fs::read(path) else {
+        return false;
+    };
+    serde_json::from_slice::<ShapeOnly>(&bytes)
+        .map(|s| s.workspaces.is_some())
+        .unwrap_or(false)
+}
+
 /// Walk upward from `start` looking for the nearest workspace root.
 ///
 /// A workspace root is any ancestor that either:
@@ -83,10 +103,7 @@ pub fn find_workspace_root(start: &Path) -> Option<PathBuf> {
             return Some(dir.to_path_buf());
         }
         let pkg = dir.join("package.json");
-        if pkg.is_file()
-            && let Ok(manifest) = aube_manifest::PackageJson::from_path(&pkg)
-            && manifest.workspaces.is_some()
-        {
+        if pkg.is_file() && package_json_has_workspaces(&pkg) {
             return Some(dir.to_path_buf());
         }
         if stop.as_deref() == Some(dir) {


### PR DESCRIPTION
A handful of small structural cleanups in the install pipeline, the resolver, and the registry client. None of the changes alter on-disk output, lockfile contents, fetched bytes, or run-script outcomes. The focus is removing work that runs more often than the surrounding code needs it to.

## lockfile: graph-hash uses blake3

`graph_hash.rs` produced an internal-only digest with `Sha256::digest`, which is inconsistent with the rest of the codebase. Project policy already calls for blake3 on non-crypto hashes, and the digest is never exposed externally (it only names directories under aube's own virtual-store layout). Swapping to `blake3::hash` brings the function in line with the rest of the hashing surface and removes the lone `sha2` dependency from this code path.

The hex output stays the same length, so callers that take a prefix (`append_hex_to_leaf`, the 16-char short form used in directory names) keep their existing behavior.

## delta: fold patch hash into fingerprint, cache touched set

Two issues addressed in `delta.rs`:

1. `fingerprint()` did not consider the `pnpm.patchedDependencies` patch content. Two installs with identical lockfile entries but different patch text would produce identical fingerprints, so a re-patched package would not land in `DeltaPlan.changed`. The patch hash is now folded into the fingerprint via the same length-prefixed encoding used for every other field.
2. `DeltaPlan::should_touch` was a linear scan over both the `added` and `changed` vectors. The linker walks the graph several times per install and probes the plan repeatedly, so the same scan repeats per probe. The plan now stores a precomputed `BTreeSet` built once during `diff()`, and `should_touch` consults it directly. `touched_set` returns a borrowed reference instead of constructing a new set each call.

`compute_subtree_hashes` previously walked the leaf fingerprints internally. The standalone `compute_package_hashes` call site then walked them again. Both call sites now share `compute_leaf_and_subtree_hashes`, which returns both maps from a single pass.

## install: reuse pre-parsed lockfile, thread patch hashes

The metadata-overlay pass in `install::run` re-parsed the lockfile to recover fields the resolver could not hold (`license`, `funding_url`, bun's `configVersion`). The pre-parse already performed at the top of the function for resolver seeding now feeds that overlay directly. The fallback path still calls `parse_lockfile_dir_remapped` for installs that do not run with a seeded resolver.

Patch loading was hoisted ahead of the delta hash computation so the new patch-hash field in `fingerprint()` sees the right value on every code path. Without that ordering, the first install after a patch change would compute hashes against a stale patches map.

## settings: capture env once via LazyLock

`capture_env` walks `std::env::vars()` and collects into a `Vec<(String, String)>`. The function is reached from the settings layer, the registry config loader, the install state hasher, and the script runner, often more than once per command. Each call repeats the env walk, which on Windows is a syscall.

The walk now runs lazily on first read, stored in a process-wide `LazyLock<Vec<(String, String)>>`. The existing `capture_env` API still returns an owned `Vec` for callers that mutate the result, and a new `process_env()` helper exposes a `&'static [(String, String)]` for read-only callers.

## scripts: reuse thread-local buffer in BuildPolicy::decide

`BuildPolicy::decide(name, version)` did `format!("{name}@{version}")` on every call to build the lookup key for the versioned-allow set. Every package in the install graph runs through this function, often across multiple passes for graph hashing and policy resolution. The allocation is unnecessary because the key is a transient lookup input that only lives until the `HashSet::contains` returns.

The function now writes into a thread-local `String` buffer that is cleared and reused per call. Set lookups use `b.as_str()` so the borrowed view never outlives the buffer.

## cli: pre-parse candidate versions in aube add

The `highest_satisfying` closure in `add::run_with_executor` sorted the packument versions with a comparator that called `node_semver::Version::parse` on both sides every comparison. For packages with hundreds of versions (lodash being the canonical example), the sort drove the parser through `O(M log M)` calls to satisfy a single dist-tag resolution.

The closure now parses each candidate once into a `Vec<(&String, Version)>`, sorts the parsed pairs by their already-computed `Version`, and reuses the same parsed values when scanning for the highest satisfying entry.

## cli: scan package.json shape for workspaces field

`find_workspace_root` walks from the current directory up to `$HOME`, calling `aube_manifest::PackageJson::from_path` on every ancestor that contains a `package.json`. The full parser allocates the deps map, the dev-deps map, the scripts map, and a `serde_json::Value` for the flatten-extra catch-all, all to answer a yes-or-no question: is the `workspaces` field present?

The walk now uses a private `ShapeOnly` struct that deserializes a single `Option<serde::de::IgnoredAny>` for `workspaces` and ignores everything else, so the parser short-circuits as soon as the field is decided. `find_workspace_yaml_root` still uses the original path for the catalog/settings loaders that need the typed struct.

## registry: memoize resolved auth token per URL

`registry_auth_token_for(url)` walked `auth_by_uri` for a longest-prefix match on every authed request. The token-helper output was already cached, but the surrounding URL match still ran for every fetch. Tarball fetches in particular call this on every request, so the same prefix walk repeats for every package in the install.

`RegistryClient` gains an `auth_token_by_url` map that stores the resolved token (or `None`) per registry URL. The first request for a URL pays the prefix walk; later requests read the cached value. The cache stays valid for the life of the client because the underlying config does not change once loaded.
