### PR TITLE
ci: skip pr-bench comments on forked prs

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -67,8 +67,12 @@ jobs:
       - name: Summarize change
         run: node benchmarks/summarize-results-change.mjs /tmp/aube-bench-base.json /tmp/aube-bench-head.json > /tmp/aube-bench-summary.md
 
-      - name: Comment on PR
+      - name: Write benchmark summary
         if: github.event_name == 'pull_request'
+        run: cat /tmp/aube-bench-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- write pr-bench comparison output to the Actions step summary for pull_request runs
- only attempt to create or update the PR benchmark comment for same-repository PRs

## Why

Forked pull_request runs receive a read-only GITHUB_TOKEN even when the workflow requests issues/pull-requests write permissions. The benchmark job was succeeding, then failing only because the final comment write returned HTTP 403.

## Validation

- actionlint .github/workflows/bench-pr.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts PR benchmark reporting/output conditions; main risk is reduced visibility if the comment condition is mis-evaluated.
> 
> **Overview**
> Writes the PR benchmark comparison markdown to the GitHub Actions step summary (via `$GITHUB_STEP_SUMMARY`) for `pull_request` runs.
> 
> Restricts the PR comment create/update step to same-repository PRs (`head.repo.full_name == github.repository`) to avoid 403 failures on forked PRs with read-only tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1973104faa04c76aab2eb26bb592e13393944f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->