### PR TITLE
docs: reorder home chart and label yarn v1

### DIFF
--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -10,7 +10,14 @@ type BenchmarkRow = {
   values: Record<string, number>;
 };
 
-const chartTools = ["aube", "bun", "pnpm", "yarn", "npm"] as const;
+const chartTools = ["aube", "bun", "pnpm", "npm", "yarn"] as const;
+const chartLabels: Record<(typeof chartTools)[number], string> = {
+  aube: "aube",
+  bun: "bun",
+  pnpm: "pnpm",
+  npm: "npm",
+  yarn: "yarn v1",
+};
 const warmInstallBenchmark = (benchmarkResults.rows as BenchmarkRow[]).find(
   (row) => row.key === "gvs-warm",
 );
@@ -25,6 +32,7 @@ const chartRows = chartTools.map((tool) => {
 
   return {
     tool,
+    label: chartLabels[tool],
     style: { "--bar-width": `${width}%` },
   };
 });
@@ -321,7 +329,7 @@ watch(progressBarEl, (el, previousEl) => {
             :class="`aube-chart-row-${row.tool}`"
             :style="row.style"
           >
-            <span>{{ row.tool }}</span>
+            <span>{{ row.label }}</span>
             <span><i></i></span>
           </span>
         </span>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -929,7 +929,7 @@ body {
   align-items: center;
   display: grid;
   gap: 10px;
-  grid-template-columns: 44px minmax(0, 1fr);
+  grid-template-columns: 56px minmax(0, 1fr);
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary
- Move yarn after npm in the homepage warm-install chart so the row order matches `benchmarks/results.json` (aube, bun, pnpm, npm, yarn).
- Label the yarn row as "yarn v1" since the benchmark uses yarn 1.22.22.

## Test plan
- [ ] `mise run docs:dev` (or equivalent) and confirm the chart on the landing page renders aube → bun → pnpm → npm → yarn v1, with bar widths still keyed off `gvs-warm` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only UI tweak that reorders and relabels a homepage benchmark chart; no runtime/business logic changes beyond display mapping.
> 
> **Overview**
> Updates the docs homepage warm-install benchmark chart to match the ordering in `benchmarks/results.json` by moving `yarn` after `npm`.
> 
> Adds a label mapping so the `yarn` row renders as **"yarn v1"** (instead of the raw tool key), and slightly widens the chart’s label column in CSS to fit the new text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d4912ae0074f4627279711d34b64831fe4ed44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->