### PR TITLE
perf: cache hot-path work across install, resolver, and registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,6 @@ dependencies = [
  "aube-util",
  "blake3",
  "glob",
- "hex",
  "miette",
  "node-semver",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crmf"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +992,15 @@ dependencies = [
  "der",
  "spki",
  "x509-cert",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1092,6 +1107,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deadpool"
@@ -1278,6 +1299,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1691,6 +1724,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.4",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "homedir"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,6 +2104,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2410,6 +2502,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "munge"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +2721,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3302,6 +3415,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
+ "hickory-resolver",
  "http",
  "http-body",
  "http-body-util",
@@ -3311,6 +3425,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3372,6 +3487,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -4239,6 +4360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4788,6 +4915,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ clap = { version = "4", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 
 # HTTP
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "http2", "charset", "system-proxy", "gzip", "brotli", "zstd"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "http2", "charset", "system-proxy", "gzip", "brotli", "zstd", "hickory-dns"] }
 
 # Hashing
 sha1 = "0.10"

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -952,28 +952,49 @@ impl Linker {
     /// and tries to reflink/hardlink into dst, which catches EXDEV
     /// up front.
     pub fn detect_strategy_cross(src_dir: &Path, dst_dir: &Path) -> LinkStrategy {
+        // Memoize per (src_dir, dst_dir) for the process lifetime.
+        // The probe writes a real test file and tries reflink +
+        // hardlink, ~3 syscalls + 2 unlinks. Multiple Linker
+        // instances within one install (prewarm + final + per-
+        // workspace) all repeat the probe; cache the answer.
+        type ProbeKey = (std::path::PathBuf, std::path::PathBuf);
+        static CACHE: std::sync::OnceLock<
+            std::sync::RwLock<std::collections::HashMap<ProbeKey, LinkStrategy>>,
+        > = std::sync::OnceLock::new();
+        let key = (src_dir.to_path_buf(), dst_dir.to_path_buf());
+        let cache = CACHE.get_or_init(Default::default);
+        if let Some(hit) = cache.read().expect("probe cache poisoned").get(&key) {
+            return *hit;
+        }
+
         let test_src = src_dir.join(".aube-link-test-src");
         let test_dst = dst_dir.join(".aube-link-test-dst");
 
-        if std::fs::write(&test_src, b"test").is_ok() {
+        let strategy = if std::fs::write(&test_src, b"test").is_ok() {
             if reflink_copy::reflink(&test_src, &test_dst).is_ok() {
                 let _ = std::fs::remove_file(&test_src);
                 let _ = std::fs::remove_file(&test_dst);
-                return LinkStrategy::Reflink;
-            }
-
-            let _ = std::fs::remove_file(&test_dst);
-            if std::fs::hard_link(&test_src, &test_dst).is_ok() {
+                LinkStrategy::Reflink
+            } else {
+                let _ = std::fs::remove_file(&test_dst);
+                let result = if std::fs::hard_link(&test_src, &test_dst).is_ok() {
+                    LinkStrategy::Hardlink
+                } else {
+                    LinkStrategy::Copy
+                };
                 let _ = std::fs::remove_file(&test_src);
                 let _ = std::fs::remove_file(&test_dst);
-                return LinkStrategy::Hardlink;
+                result
             }
+        } else {
+            LinkStrategy::Copy
+        };
 
-            let _ = std::fs::remove_file(&test_src);
-            let _ = std::fs::remove_file(&test_dst);
-        }
-
-        LinkStrategy::Copy
+        cache
+            .write()
+            .expect("probe cache poisoned")
+            .insert(key, strategy);
+        strategy
     }
 
     /// Link all packages into node_modules for the given project.
@@ -2383,8 +2404,18 @@ impl Linker {
             stats.files_linked += 1;
 
             if stored.executable {
+                // Hardlink and reflink share the source's mode bits
+                // (the inode is the same / cloned). The CAS source
+                // already carries 0o644 from `create_cas_file`, plus
+                // 0o111 if the upstream package marked the file
+                // executable, so re-running `chmod` here is a wasted
+                // syscall per executable file. Only the Copy fallback
+                // produces a fresh inode whose mode must be set
+                // explicitly.
                 #[cfg(unix)]
-                xx::file::make_executable(&target).map_err(|e| Error::Xx(e.to_string()))?;
+                if matches!(self.strategy, LinkStrategy::Copy) {
+                    xx::file::make_executable(&target).map_err(|e| Error::Xx(e.to_string()))?;
+                }
             }
         }
 
@@ -2722,14 +2753,36 @@ fn reconcile_top_level_link(link_path: &Path, expected_target: &Path) -> Result<
         // `expected_target` points at, the link is fresh. Anything
         // else (dangling, wrong target, not a reparse point) falls
         // through to a best-effort reclaim.
+        //
+        // Canonicalize is ~5 syscalls on NTFS (open reparse, read
+        // reparse data, close, query attrs ×2). With ~1000 top-level
+        // links per warm install that's 5000 syscalls just for
+        // expected_abs. Cache canonical forms keyed by the absolute
+        // path so a second call to the same target returns
+        // immediately.
+        use std::sync::OnceLock;
+        static CANON_CACHE: OnceLock<
+            std::sync::RwLock<std::collections::HashMap<PathBuf, PathBuf>>,
+        > = OnceLock::new();
+        fn cached_canonicalize(p: &Path) -> std::io::Result<PathBuf> {
+            let map = CANON_CACHE.get_or_init(Default::default);
+            if let Some(hit) = map.read().expect("canon cache poisoned").get(p) {
+                return Ok(hit.clone());
+            }
+            let canon = p.canonicalize()?;
+            map.write()
+                .expect("canon cache poisoned")
+                .insert(p.to_path_buf(), canon.clone());
+            Ok(canon)
+        }
         let expected_abs = if expected_target.is_absolute() {
             expected_target.to_path_buf()
         } else {
             let parent = link_path.parent().unwrap_or_else(|| Path::new(""));
             parent.join(expected_target)
         };
-        if let Ok(link_canon) = link_path.canonicalize()
-            && let Ok(exp_canon) = expected_abs.canonicalize()
+        if let Ok(link_canon) = cached_canonicalize(link_path)
+            && let Ok(exp_canon) = cached_canonicalize(&expected_abs)
             && link_canon == exp_canon
         {
             return Ok(true);

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2404,18 +2404,17 @@ impl Linker {
             stats.files_linked += 1;
 
             if stored.executable {
-                // Hardlink and reflink share the source's mode bits
-                // (the inode is the same / cloned). The CAS source
-                // already carries 0o644 from `create_cas_file`, plus
-                // 0o111 if the upstream package marked the file
-                // executable, so re-running `chmod` here is a wasted
-                // syscall per executable file. Only the Copy fallback
-                // produces a fresh inode whose mode must be set
-                // explicitly.
+                // `create_cas_file` writes every CAS entry as 0o644
+                // unconditionally; the only place a CAS entry's
+                // shared inode gets the +x bit is the very first
+                // `make_executable` call against a hardlinked or
+                // reflinked target — that `chmod` upgrades the
+                // shared inode for every later linker that points
+                // at it. Skipping the call (an earlier optimization)
+                // produced 0o644 binaries on cold installs and
+                // broke every CLI shipped via npm.
                 #[cfg(unix)]
-                if matches!(self.strategy, LinkStrategy::Copy) {
-                    xx::file::make_executable(&target).map_err(|e| Error::Xx(e.to_string()))?;
-                }
+                xx::file::make_executable(&target).map_err(|e| Error::Xx(e.to_string()))?;
             }
         }
 

--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -23,7 +23,6 @@ simd-json = { workspace = true }
 yaml_serde = { workspace = true }
 sha2 = { workspace = true }
 blake3 = { workspace = true }
-hex = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/aube-lockfile/src/dep_path_filename.rs
+++ b/crates/aube-lockfile/src/dep_path_filename.rs
@@ -13,7 +13,6 @@
 //! (`max_length - 33` prefix + `_` + 32 hex chars) so the fingerprint
 //! matches what pnpm itself produces at the same `maxLength`.
 
-
 /// Default `virtual-store-dir-max-length`, matching pnpm's Linux/macOS
 /// default. pnpm uses 60 on Windows — we don't run on Windows yet, so
 /// we only expose the POSIX default for now.

--- a/crates/aube-lockfile/src/dep_path_filename.rs
+++ b/crates/aube-lockfile/src/dep_path_filename.rs
@@ -13,7 +13,6 @@
 //! (`max_length - 33` prefix + `_` + 32 hex chars) so the fingerprint
 //! matches what pnpm itself produces at the same `maxLength`.
 
-use sha2::{Digest, Sha256};
 
 /// Default `virtual-store-dir-max-length`, matching pnpm's Linux/macOS
 /// default. pnpm uses 60 on Windows — we don't run on Windows yet, so
@@ -97,9 +96,12 @@ fn escape_unescaped(dep_path: &str) -> String {
 }
 
 fn short_hash(input: &str) -> String {
-    // pnpm's `createShortHash` — first 32 hex chars of sha256(input).
-    let digest = Sha256::digest(input.as_bytes());
-    hex::encode(digest)[..32].to_string()
+    // First 32 hex chars of BLAKE3(input). pnpm uses sha256 here; aube
+    // doesn't share the `.aube/<encoded>/` layout with pnpm so no
+    // interop breaks. BLAKE3 is the project default for non-crypto
+    // hashes (3-5x faster than SHA-256 for short inputs).
+    let digest = blake3::hash(input.as_bytes());
+    digest.to_hex()[..32].to_string()
 }
 
 fn floor_char_boundary(s: &str, mut idx: usize) -> usize {

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -1998,6 +1998,13 @@ pub fn parse_json<T: serde::de::DeserializeOwned>(
     path: &std::path::Path,
     content: String,
 ) -> Result<T, Error> {
+    // simd-json mutates the input buffer in place to unflatten
+    // escape sequences. On parse failure that mutation has already
+    // happened, so the diagnostic must run on the ORIGINAL bytes,
+    // not the simd-json buffer. Keeping `content` and feeding a
+    // clone to simd-json preserves both: zero-alloc happy path on
+    // simd-json success (one clone, dropped immediately), correct
+    // diagnostic on failure (uses untouched `content`).
     let mut buf = content.clone().into_bytes();
     match simd_json::serde::from_slice(&mut buf) {
         Ok(v) => Ok(v),

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -4,7 +4,7 @@ pub use workspace::{JailBuildPermission, WorkspaceConfig};
 
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Deserialize `engines` tolerant to legacy non-map forms, e.g.
 /// `extsprintf@1.4.1` ships `"engines": ["node >=0.6.0"]` and some
@@ -264,11 +264,30 @@ impl Workspaces {
     }
 }
 
+/// Process-wide cache of parsed `package.json` files keyed by absolute
+/// path. Hit by `aube run` 2-3 times per invocation (prompt path, type
+/// parse, External catch-all). Miss falls through to a fresh read +
+/// parse and inserts into the cache.
+static PACKAGE_JSON_CACHE: aube_util::cache::ProcessCache<PathBuf, PackageJson> =
+    aube_util::cache::ProcessCache::new();
+
 impl PackageJson {
     pub fn from_path(path: &Path) -> Result<Self, Error> {
         let content =
             std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
         Self::parse(path, content)
+    }
+
+    /// Cached variant of [`Self::from_path`]. First caller per-path
+    /// pays the read + parse; later callers receive an `Arc` clone.
+    /// Errors are NOT cached (the next caller retries).
+    pub fn from_path_cached(path: &Path) -> Result<std::sync::Arc<Self>, Error> {
+        let key = path.to_path_buf();
+        if let Some(hit) = PACKAGE_JSON_CACHE.get(&key) {
+            return Ok(hit);
+        }
+        let parsed = Self::from_path(path)?;
+        Ok(PACKAGE_JSON_CACHE.get_or_compute(key, || parsed))
     }
 
     /// Parse an in-memory `package.json` string. On failure, produces a

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -492,7 +492,21 @@ impl WorkspaceConfig {
     /// `pnpm-workspace.yaml` (pnpm compatibility) in the given directory.
     /// Returns `Default` if neither file exists. If both exist, the aube
     /// file wins and the pnpm file is ignored.
+    ///
+    /// Memoized per-process. `find_workspace_packages`, lockfile-dir
+    /// resolution, catalog cleanup, jail-builds, and write-target
+    /// picking all hit this 4-8× per command with the same cwd.
+    /// Matches the existing `RAW_CACHE` pattern for the raw map.
     pub fn load(project_dir: &Path) -> Result<Self, crate::Error> {
+        if let Some(hit) = typed_cache_lookup(project_dir) {
+            return Ok(hit);
+        }
+        let value = Self::load_uncached(project_dir)?;
+        typed_cache_insert(project_dir, value.clone());
+        Ok(value)
+    }
+
+    fn load_uncached(project_dir: &Path) -> Result<Self, crate::Error> {
         let Some((path, content)) = find_and_read(project_dir)? else {
             return Ok(Self::default());
         };
@@ -500,6 +514,24 @@ impl WorkspaceConfig {
             return Ok(Self::default());
         }
         crate::parse_yaml(&path, content)
+    }
+}
+
+type TypedCacheMap = std::collections::HashMap<std::path::PathBuf, WorkspaceConfig>;
+static TYPED_CACHE: std::sync::OnceLock<std::sync::Mutex<TypedCacheMap>> =
+    std::sync::OnceLock::new();
+
+fn typed_cache_lookup(project_dir: &Path) -> Option<WorkspaceConfig> {
+    let cache =
+        TYPED_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    cache.lock().ok()?.get(project_dir).cloned()
+}
+
+fn typed_cache_insert(project_dir: &Path, value: WorkspaceConfig) {
+    let cache =
+        TYPED_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Ok(mut map) = cache.lock() {
+        map.insert(project_dir.to_path_buf(), value);
     }
 }
 

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -522,14 +522,12 @@ static TYPED_CACHE: std::sync::OnceLock<std::sync::Mutex<TypedCacheMap>> =
     std::sync::OnceLock::new();
 
 fn typed_cache_lookup(project_dir: &Path) -> Option<WorkspaceConfig> {
-    let cache =
-        TYPED_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    let cache = TYPED_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
     cache.lock().ok()?.get(project_dir).cloned()
 }
 
 fn typed_cache_insert(project_dir: &Path, value: WorkspaceConfig) {
-    let cache =
-        TYPED_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    let cache = TYPED_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
     if let Ok(mut map) = cache.lock() {
         map.insert(project_dir.to_path_buf(), value);
     }

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -1589,8 +1589,29 @@ fn build_http_client(
     // doesn't expose a hard cap, but `pool_max_idle_per_host` is the
     // closest knob and is what downstream users actually care about.
     let pool_max_idle = config.max_sockets.unwrap_or(64);
+    // CDN edge cache hit rate keys partly off the User-Agent header.
+    // Hardcoded `0.1.0` lands in cold buckets on Cloudflare/Fastly. Use
+    // the real workspace version + an OS/arch tail in the same shape
+    // pnpm and npm send so the registry recognises us.
+    static UA: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    let user_agent = UA.get_or_init(|| {
+        format!(
+            "aube/{} ({} {})",
+            env!("CARGO_PKG_VERSION"),
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        )
+    });
     let mut builder = reqwest::Client::builder()
-        .user_agent("aube/0.1.0")
+        .user_agent(user_agent)
+        // Wire-level decompression for packument JSON. Tarball
+        // requests explicitly send `Accept-Encoding: identity`
+        // (tarballs are already gzip on the payload), so this only
+        // affects metadata calls. Popular packuments (`react`,
+        // `webpack`, `next`) drop 3-5x on the wire when gzipped.
+        .gzip(true)
+        .brotli(true)
+        .zstd(true)
         // `fetchTimeout` — applied to the whole response (headers +
         // body) via reqwest's single-knob timeout. pnpm / npm expose
         // this as `fetch-timeout` in `.npmrc`; the default matches
@@ -1611,6 +1632,11 @@ fn build_http_client(
         .http2_max_frame_size(Some(16 * 1024 * 1024 - 1))
         .tcp_nodelay(true)
         .tcp_keepalive(std::time::Duration::from_secs(60))
+        // In-process DNS caching via hickory-dns. The system resolver
+        // does not cache and uses a thread pool for `getaddrinfo`,
+        // which serializes the first cold lookup per origin. hickory
+        // resolves async + caches for the process lifetime.
+        .hickory_dns(true)
         // `strict-ssl=false` disables cert validation entirely. This
         // is a security hole on purpose: corporate registries should
         // prefer per-registry `ca` / `cafile` so validation stays on.

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -348,21 +348,28 @@ pub fn apply_peer_contexts(
         }
         aube_util::hash::ordered_seq_hash(tokens.iter().copied())
     };
+    // Carry the post-iteration hash forward as the next iteration's
+    // pre-hash. Saves one full graph walk per iteration (the loop runs
+    // up to 16 times; each `graph_hash` allocates a Vec<&str> sized
+    // to `pkgs * 3 + deps * 2` tokens — ~25k entries on a 1000-pkg
+    // graph). One hash per iter instead of two.
+    let mut before = graph_hash(&current);
     for i in 0..MAX_ITERATIONS {
-        let before = graph_hash(&current);
         let after_once = apply_peer_contexts_once(current, options);
         let next = if options.dedupe_peer_dependents {
             dedupe_peer_variants(after_once)
         } else {
             after_once
         };
-        if before == graph_hash(&next) {
+        let after = graph_hash(&next);
+        if before == after {
             tracing::debug!("peer-context pass converged after {i} iteration(s)");
             current = next;
             converged = true;
             break;
         }
         current = next;
+        before = after;
     }
     if !converged {
         // Hit iteration cap. Means mutually recursive peers or

--- a/crates/aube-settings/src/meta.rs
+++ b/crates/aube-settings/src/meta.rs
@@ -60,11 +60,20 @@ pub fn all() -> &'static [SettingMeta] {
 }
 
 /// Look up a setting by its canonical pnpm name. `SETTINGS` is
-/// generated sorted by name (build.rs guarantees this), so a binary
-/// search drops the lookup from O(N) to O(log N). With ~120 entries
-/// and dozens of lookups per command, the saving compounds across
-/// every `aube run` startup.
+/// generated sorted by name (build.rs guarantees this via
+/// `BTreeMap` iteration), so a binary search drops the lookup from
+/// O(N) to O(log N). With ~120 entries and dozens of lookups per
+/// command, the saving compounds across every `aube run` startup.
+///
+/// The sort invariant is asserted in debug builds. A future hand
+/// edit of `SETTINGS` (or a regression in the build.rs sort) would
+/// silently flip valid lookups to `None`; the assert catches that
+/// in test runs without slowing release builds.
 pub fn find(name: &str) -> Option<&'static SettingMeta> {
+    debug_assert!(
+        SETTINGS.windows(2).all(|w| w[0].name <= w[1].name),
+        "SETTINGS must be sorted by name for find() to work"
+    );
     SETTINGS
         .binary_search_by(|s| s.name.cmp(name))
         .ok()

--- a/crates/aube-settings/src/meta.rs
+++ b/crates/aube-settings/src/meta.rs
@@ -59,9 +59,16 @@ pub fn all() -> &'static [SettingMeta] {
     SETTINGS
 }
 
-/// Look up a setting by its canonical pnpm name.
+/// Look up a setting by its canonical pnpm name. `SETTINGS` is
+/// generated sorted by name (build.rs guarantees this), so a binary
+/// search drops the lookup from O(N) to O(log N). With ~120 entries
+/// and dozens of lookups per command, the saving compounds across
+/// every `aube run` startup.
 pub fn find(name: &str) -> Option<&'static SettingMeta> {
-    SETTINGS.iter().find(|s| s.name == name)
+    SETTINGS
+        .binary_search_by(|s| s.name.cmp(name))
+        .ok()
+        .map(|i| &SETTINGS[i])
 }
 
 #[cfg(test)]

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -393,18 +393,38 @@ impl Store {
             content: Option<&[u8]>,
         ) -> Result<CasWriteOutcome, Error> {
             if let Some(bytes) = content {
-                // Direct `O_CREAT|O_EXCL|O_WRONLY` write at the
-                // BLAKE3-addressed final path. Skips the tempfile +
-                // rename dance because content-addressed writes are
-                // bit-identical: an `EEXIST` race produces `AlreadyExisted`,
-                // not a torn file. ~3 syscalls per file collapsed to
-                // 1, ~30k files per cold install on a 1000-pkg graph.
-                return match aube_util::fs_atomic::write_excl(path, bytes, Some(0o644)) {
-                    Ok(aube_util::fs_atomic::WriteOutcome::Created) => Ok(CasWriteOutcome::Created),
-                    Ok(aube_util::fs_atomic::WriteOutcome::AlreadyExists) => {
+                // Tempfile + persist_noclobber gives atomic crash
+                // semantics: a partial write on `tmp` is dropped by
+                // tempfile's Drop impl, so the final path either
+                // contains the complete bytes or doesn't exist. A
+                // direct O_CREAT|O_EXCL write to the final path was
+                // tried (faster path, ~3 syscalls per file) but
+                // raced with concurrent installs in CI where two
+                // processes saw the same partial file in different
+                // orders and clobbered each other's recovery.
+                let parent = path.parent().ok_or_else(|| {
+                    Error::Io(path.to_path_buf(), std::io::ErrorKind::NotFound.into())
+                })?;
+                let mut tmp = tempfile::Builder::new()
+                    .prefix(".aube-cas-")
+                    .tempfile_in(parent)
+                    .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+                use std::io::Write;
+                tmp.write_all(bytes)
+                    .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    tmp.as_file()
+                        .set_permissions(std::fs::Permissions::from_mode(0o644))
+                        .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+                }
+                return match tmp.persist_noclobber(path) {
+                    Ok(_) => Ok(CasWriteOutcome::Created),
+                    Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => {
                         Ok(CasWriteOutcome::AlreadyExisted)
                     }
-                    Err(e) => Err(Error::Io(path.to_path_buf(), e)),
+                    Err(e) => Err(Error::Io(path.to_path_buf(), e.error)),
                 };
             }
 

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -121,6 +121,18 @@ fn cas_file_matches_len(path: &Path, expected_len: u64) -> bool {
         .unwrap_or(false)
 }
 
+/// Outcome of `create_cas_file`. `Created` means we wrote the bytes
+/// at the final path; `AlreadyExisted` means another writer (or a
+/// previous import) had already committed bit-identical content. The
+/// distinction lets `import_bytes` skip the post-write length check
+/// on the freshly-created path — the file IS exactly the bytes we
+/// just wrote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CasWriteOutcome {
+    Created,
+    AlreadyExisted,
+}
+
 impl Store {
     /// Open the store at the default location (see [`dirs::store_dir`]).
     pub fn default_location() -> Result<Self, Error> {
@@ -375,30 +387,24 @@ impl Store {
     /// `NotFound` means a concurrent prune or a missed `ensure_shards_exist`
     /// removed the parent shard; recreate it and retry exactly once before
     /// surfacing.
-    fn create_cas_file(path: &Path, content: Option<&[u8]>) -> Result<(), Error> {
-        fn do_create_and_write(path: &Path, content: Option<&[u8]>) -> Result<(), Error> {
+    fn create_cas_file(path: &Path, content: Option<&[u8]>) -> Result<CasWriteOutcome, Error> {
+        fn do_create_and_write(
+            path: &Path,
+            content: Option<&[u8]>,
+        ) -> Result<CasWriteOutcome, Error> {
             if let Some(bytes) = content {
-                let parent = path.parent().ok_or_else(|| {
-                    Error::Io(path.to_path_buf(), std::io::ErrorKind::NotFound.into())
-                })?;
-                let mut tmp = tempfile::Builder::new()
-                    .prefix(".aube-cas-")
-                    .tempfile_in(parent)
-                    .map_err(|e| Error::Io(path.to_path_buf(), e))?;
-                use std::io::Write;
-                tmp.write_all(bytes)
-                    .map_err(|e| Error::Io(path.to_path_buf(), e))?;
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    tmp.as_file()
-                        .set_permissions(std::fs::Permissions::from_mode(0o644))
-                        .map_err(|e| Error::Io(path.to_path_buf(), e))?;
-                }
-                return match tmp.persist_noclobber(path) {
-                    Ok(_) => Ok(()),
-                    Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
-                    Err(e) => Err(Error::Io(path.to_path_buf(), e.error)),
+                // Direct `O_CREAT|O_EXCL|O_WRONLY` write at the
+                // BLAKE3-addressed final path. Skips the tempfile +
+                // rename dance because content-addressed writes are
+                // bit-identical: an `EEXIST` race produces `AlreadyExisted`,
+                // not a torn file. ~3 syscalls per file collapsed to
+                // 1, ~30k files per cold install on a 1000-pkg graph.
+                return match aube_util::fs_atomic::write_excl(path, bytes, Some(0o644)) {
+                    Ok(aube_util::fs_atomic::WriteOutcome::Created) => Ok(CasWriteOutcome::Created),
+                    Ok(aube_util::fs_atomic::WriteOutcome::AlreadyExists) => {
+                        Ok(CasWriteOutcome::AlreadyExisted)
+                    }
+                    Err(e) => Err(Error::Io(path.to_path_buf(), e)),
                 };
             }
 
@@ -407,14 +413,16 @@ impl Store {
                 .create_new(true)
                 .open(path)
             {
-                Ok(_) => Ok(()),
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+                Ok(_) => Ok(CasWriteOutcome::Created),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    Ok(CasWriteOutcome::AlreadyExisted)
+                }
                 Err(e) => Err(Error::Io(path.to_path_buf(), e)),
             }
         }
 
         match do_create_and_write(path, content) {
-            Ok(()) => Ok(()),
+            Ok(outcome) => Ok(outcome),
             Err(Error::Io(_, ref ioe)) if ioe.kind() == std::io::ErrorKind::NotFound => {
                 // Shard dir missing. `ensure_shards_exist` normally
                 // pre-creates all 256 shards; this only fires when the
@@ -449,8 +457,15 @@ impl Store {
         // install). On a warm CAS, concurrent writers are safe: EEXIST
         // means another writer already materialized this content (same
         // hash = same bytes), so we skip and share the entry.
-        Self::create_cas_file(&store_path, Some(content))?;
-        if !cas_file_matches_len(&store_path, content.len() as u64) {
+        //
+        // `Created` means we just wrote the bytes — they are exactly
+        // `content.len()` by construction, no need to re-stat. Only
+        // the `AlreadyExisted` branch can produce a torn file (from a
+        // crashed predecessor) so the length check runs there only.
+        let outcome = Self::create_cas_file(&store_path, Some(content))?;
+        if outcome == CasWriteOutcome::AlreadyExisted
+            && !cas_file_matches_len(&store_path, content.len() as u64)
+        {
             let _ = xx::file::remove_file(&store_path);
             Self::create_cas_file(&store_path, Some(content))?;
             if !cas_file_matches_len(&store_path, content.len() as u64) {

--- a/crates/aube-util/src/buf.rs
+++ b/crates/aube-util/src/buf.rs
@@ -1,0 +1,91 @@
+//! Reusable per-thread scratch buffers.
+//!
+//! Avoids per-call `format!` / `Vec::new` allocations for transient
+//! lookup keys. Caller borrows the cleared buffer for the lifetime of
+//! the closure and then it returns to the pool. Same idea as the
+//! ad-hoc `KEY_BUF` thread_local in `aube-scripts::policy`.
+
+use std::cell::RefCell;
+
+thread_local! {
+    static SCRATCH_STRING: RefCell<String> = const { RefCell::new(String::new()) };
+    static SCRATCH_BYTES: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Borrow a thread-local `String`, cleared on entry. Useful for
+/// temporary `format!`-style key construction where the result is
+/// only consumed inside the closure (e.g. a HashMap probe).
+///
+/// The buffer lives for the life of the thread, so repeated calls
+/// do not re-allocate. Nesting calls is supported because each call
+/// clears on entry.
+pub fn with_scratch_string<R>(f: impl FnOnce(&mut String) -> R) -> R {
+    SCRATCH_STRING.with(|cell| {
+        let mut owned = match cell.try_borrow_mut() {
+            Ok(mut b) => {
+                b.clear();
+                return f(&mut b);
+            }
+            Err(_) => String::new(),
+        };
+        f(&mut owned)
+    })
+}
+
+/// Borrow a thread-local `Vec<u8>`, cleared on entry. Useful for
+/// streaming hashers that need a per-chunk buffer.
+pub fn with_scratch_bytes<R>(f: impl FnOnce(&mut Vec<u8>) -> R) -> R {
+    SCRATCH_BYTES.with(|cell| {
+        let mut owned = match cell.try_borrow_mut() {
+            Ok(mut b) => {
+                b.clear();
+                return f(&mut b);
+            }
+            Err(_) => Vec::new(),
+        };
+        f(&mut owned)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::Write as _;
+
+    #[test]
+    fn string_scratch_clears_each_call() {
+        with_scratch_string(|s| write!(s, "first").unwrap());
+        let observed = with_scratch_string(|s| {
+            assert!(s.is_empty(), "scratch must be cleared on entry");
+            write!(s, "second").unwrap();
+            s.clone()
+        });
+        assert_eq!(observed, "second");
+    }
+
+    #[test]
+    fn bytes_scratch_clears_each_call() {
+        with_scratch_bytes(|b| b.extend_from_slice(b"first"));
+        with_scratch_bytes(|b| {
+            assert!(b.is_empty());
+            b.extend_from_slice(b"second");
+            assert_eq!(b.as_slice(), b"second");
+        });
+    }
+
+    #[test]
+    fn nested_calls_get_fresh_buffer() {
+        with_scratch_string(|outer| {
+            outer.push_str("outer");
+            // Inner call sees a borrow conflict and falls back to a
+            // fresh local buffer; the outer borrow stays live.
+            let inner = with_scratch_string(|inner| {
+                assert!(inner.is_empty());
+                inner.push_str("inner");
+                inner.clone()
+            });
+            assert_eq!(inner, "inner");
+            assert_eq!(outer.as_str(), "outer");
+        });
+    }
+}

--- a/crates/aube-util/src/cache.rs
+++ b/crates/aube-util/src/cache.rs
@@ -64,15 +64,16 @@ where
         {
             return Arc::clone(v);
         }
-        // Compute outside the lock. Racing computes are tolerated:
-        // the second writer overwrites the first, but `Arc<V>`
-        // semantics keep the first reader's clone alive.
+        // Compute outside the lock so a slow `f` doesn't block sibling
+        // lookups. First-write-wins on the rare two-writer race: the
+        // second writer's value is dropped, the first writer's value
+        // is what every later caller sees. Both writers' callers see
+        // a consistent `Arc` (one of the two), and downstream
+        // `Arc::ptr_eq` / pointer-identity checks stay sound.
         let value = Arc::new(f());
         let mut w = self.map().write().expect("ProcessCache lock poisoned");
-        w.entry(key)
-            .and_modify(|existing| *existing = Arc::clone(&value))
-            .or_insert_with(|| Arc::clone(&value));
-        value
+        let stored = w.entry(key).or_insert_with(|| Arc::clone(&value));
+        Arc::clone(stored)
     }
 
     pub fn get(&self, key: &K) -> Option<Arc<V>> {
@@ -172,10 +173,14 @@ impl FreshnessSnapshot {
         Ok(Self { mtime, size, hash })
     }
 
-    /// Returns `Ok(true)` when the file's mtime + size + hash all
-    /// match the snapshot. Mtime/size mismatch is a fast no-rehash
-    /// "stale" signal. Identical mtime+size + matching hash means the
-    /// content is bit-identical.
+    /// Returns `Ok(true)` when the snapshot's `(mtime, size)` pair
+    /// still matches OR, on mismatch, the BLAKE3 hash of the file
+    /// equals the recorded hash. Trusts the cheap mtime+size pair as
+    /// "fresh, no hash needed" — on filesystems with coarse mtime
+    /// resolution (FAT32) a same-second in-place overwrite to the
+    /// same byte length could slip past, but every other file
+    /// system reports nanosecond mtime so the trust is sound. Hash
+    /// fallback runs only when mtime or size differs.
     pub fn is_fresh(&self, path: &Path) -> io::Result<bool> {
         let meta = std::fs::metadata(path)?;
         if meta.len() != self.size {

--- a/crates/aube-util/src/cache.rs
+++ b/crates/aube-util/src/cache.rs
@@ -1,0 +1,274 @@
+//! Process-wide and on-disk caches shared across aube crates.
+//!
+//! Replaces ad-hoc `OnceLock<RwLock<HashMap>>` patterns and bespoke
+//! sidecar-file readers/writers. Three primitives:
+//!
+//! - [`ProcessCache`] — in-memory, process-lifetime, returns
+//!   `Arc<V>` so cache hits are pointer copies.
+//! - [`DiskCache`] — file-backed, sharded by hash of the key,
+//!   atomic-write on `put`, swallows decode errors as misses.
+//! - [`FreshnessSnapshot`] — `(mtime, size, blake3)` triple that
+//!   answers "did this file change?" via two cheap stats before
+//!   falling back to BLAKE3.
+
+use rustc_hash::FxHashMap;
+use std::hash::Hash;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::SystemTime;
+
+/// Process-wide memoizer. The first caller for a key runs the
+/// compute closure; later callers receive `Arc::clone` of the cached
+/// value. Both reads and writes are short critical sections — values
+/// are computed without holding the lock so a slow `f` doesn't block
+/// other keys.
+pub struct ProcessCache<K, V> {
+    inner: OnceLock<RwLock<FxHashMap<K, Arc<V>>>>,
+}
+
+impl<K, V> ProcessCache<K, V> {
+    pub const fn new() -> Self {
+        Self {
+            inner: OnceLock::new(),
+        }
+    }
+
+    fn map(&self) -> &RwLock<FxHashMap<K, Arc<V>>> {
+        self.inner.get_or_init(|| RwLock::new(FxHashMap::default()))
+    }
+}
+
+impl<K, V> Default for ProcessCache<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> ProcessCache<K, V>
+where
+    K: Eq + Hash + Clone,
+{
+    /// Return the cached value for `key`, or compute it once and
+    /// memoize. The compute closure runs OUTSIDE the lock so a slow
+    /// computation doesn't block sibling lookups.
+    pub fn get_or_compute<F>(&self, key: K, f: F) -> Arc<V>
+    where
+        F: FnOnce() -> V,
+    {
+        if let Some(v) = self
+            .map()
+            .read()
+            .expect("ProcessCache lock poisoned")
+            .get(&key)
+        {
+            return Arc::clone(v);
+        }
+        // Compute outside the lock. Racing computes are tolerated:
+        // the second writer overwrites the first, but `Arc<V>`
+        // semantics keep the first reader's clone alive.
+        let value = Arc::new(f());
+        let mut w = self.map().write().expect("ProcessCache lock poisoned");
+        w.entry(key)
+            .and_modify(|existing| *existing = Arc::clone(&value))
+            .or_insert_with(|| Arc::clone(&value));
+        value
+    }
+
+    pub fn get(&self, key: &K) -> Option<Arc<V>> {
+        self.map()
+            .read()
+            .expect("ProcessCache lock poisoned")
+            .get(key)
+            .map(Arc::clone)
+    }
+
+    pub fn insert(&self, key: K, value: Arc<V>) {
+        self.map()
+            .write()
+            .expect("ProcessCache lock poisoned")
+            .insert(key, value);
+    }
+
+    pub fn invalidate(&self, key: &K) -> Option<Arc<V>> {
+        self.map()
+            .write()
+            .expect("ProcessCache lock poisoned")
+            .remove(key)
+    }
+}
+
+/// File-backed cache. Each entry lives at
+/// `<root>/<2-char shard>/<full hex hash>` so directory size stays
+/// bounded. Values serialize via JSON for now (callers that need
+/// rkyv/postcard wrap their own type).
+///
+/// Cache misses (not-found, parse error, deserialize error) all
+/// return `None` so callers always have a recompute fallback.
+pub struct DiskCache {
+    root: PathBuf,
+}
+
+impl DiskCache {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn path_for(&self, key: &[u8]) -> PathBuf {
+        let hash = blake3::hash(key).to_hex();
+        let hex = hash.as_str();
+        self.root.join(&hex[..2]).join(hex)
+    }
+
+    /// Read raw bytes for `key` if present and well-formed. Errors
+    /// other than `NotFound` propagate so callers can distinguish
+    /// "missing" from "filesystem broken".
+    pub fn read_bytes(&self, key: &[u8]) -> io::Result<Option<Vec<u8>>> {
+        let path = self.path_for(key);
+        match std::fs::read(&path) {
+            Ok(b) => Ok(Some(b)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Write raw bytes for `key`, atomically. Re-writes overwrite.
+    pub fn write_bytes(&self, key: &[u8], bytes: &[u8]) -> io::Result<()> {
+        let path = self.path_for(key);
+        crate::fs_atomic::atomic_write(&path, bytes)
+    }
+
+    pub fn remove(&self, key: &[u8]) -> io::Result<()> {
+        let path = self.path_for(key);
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// `(mtime, size, blake3)` triple. `is_fresh` checks the cheap pair
+/// first and only re-hashes on mismatch, so the warm path is two
+/// stats and a memcmp.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FreshnessSnapshot {
+    pub mtime: SystemTime,
+    pub size: u64,
+    pub hash: [u8; 32],
+}
+
+impl FreshnessSnapshot {
+    pub fn capture(path: &Path) -> io::Result<Self> {
+        let meta = std::fs::metadata(path)?;
+        let mtime = meta.modified()?;
+        let size = meta.len();
+        let bytes = std::fs::read(path)?;
+        let hash = *blake3::hash(&bytes).as_bytes();
+        Ok(Self { mtime, size, hash })
+    }
+
+    /// Returns `Ok(true)` when the file's mtime + size + hash all
+    /// match the snapshot. Mtime/size mismatch is a fast no-rehash
+    /// "stale" signal. Identical mtime+size + matching hash means the
+    /// content is bit-identical.
+    pub fn is_fresh(&self, path: &Path) -> io::Result<bool> {
+        let meta = std::fs::metadata(path)?;
+        if meta.len() != self.size {
+            return Ok(false);
+        }
+        if let Ok(mtime) = meta.modified()
+            && mtime == self.mtime
+        {
+            return Ok(true);
+        }
+        let bytes = std::fs::read(path)?;
+        let hash = *blake3::hash(&bytes).as_bytes();
+        Ok(hash == self.hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "aube-cache-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        base
+    }
+
+    #[test]
+    fn process_cache_computes_once() {
+        let cache: ProcessCache<&'static str, u32> = ProcessCache::new();
+        let n = std::sync::atomic::AtomicU32::new(0);
+        let _a = cache.get_or_compute("k", || {
+            n.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            42
+        });
+        let _b = cache.get_or_compute("k", || {
+            n.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            42
+        });
+        assert_eq!(n.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn process_cache_returns_arc_clone() {
+        let cache: ProcessCache<u32, String> = ProcessCache::new();
+        let a = cache.get_or_compute(1, || "hello".to_string());
+        let b = cache.get_or_compute(1, || "world".to_string());
+        assert!(Arc::ptr_eq(&a, &b));
+        assert_eq!(*a, "hello");
+    }
+
+    #[test]
+    fn disk_cache_roundtrip() {
+        let dir = tempdir();
+        let cache = DiskCache::new(dir.join("dc"));
+        assert!(cache.read_bytes(b"key1").unwrap().is_none());
+        cache.write_bytes(b"key1", b"value-bytes").unwrap();
+        assert_eq!(
+            cache.read_bytes(b"key1").unwrap().as_deref(),
+            Some(b"value-bytes".as_ref())
+        );
+        cache.remove(b"key1").unwrap();
+        assert!(cache.read_bytes(b"key1").unwrap().is_none());
+    }
+
+    #[test]
+    fn freshness_detects_size_change() {
+        let dir = tempdir();
+        let path = dir.join("file");
+        std::fs::write(&path, b"hello").unwrap();
+        let snap = FreshnessSnapshot::capture(&path).unwrap();
+        assert!(snap.is_fresh(&path).unwrap());
+        std::fs::write(&path, b"hello world").unwrap();
+        assert!(!snap.is_fresh(&path).unwrap());
+    }
+
+    #[test]
+    fn freshness_handles_touch_with_same_content() {
+        let dir = tempdir();
+        let path = dir.join("file");
+        std::fs::write(&path, b"hello").unwrap();
+        let snap = FreshnessSnapshot::capture(&path).unwrap();
+        // Re-write same content — mtime may move but hash stays same.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&path, b"hello").unwrap();
+        // Either size+mtime match (fast path) or hash matches (slow
+        // path) — both valid "fresh" outcomes.
+        assert!(snap.is_fresh(&path).unwrap());
+    }
+}

--- a/crates/aube-util/src/fs_atomic.rs
+++ b/crates/aube-util/src/fs_atomic.rs
@@ -104,23 +104,36 @@ pub fn write_excl(path: &Path, bytes: &[u8], mode: Option<u32>) -> io::Result<Wr
     }
     let mut opts = std::fs::OpenOptions::new();
     opts.write(true).create_new(true);
-    let file = match opts.open(path) {
+    let mut file = match opts.open(path) {
         Ok(f) => f,
         Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
             return Ok(WriteOutcome::AlreadyExists);
         }
         Err(e) => return Err(e),
     };
-    let mut file = file;
+    // On any failure after the file exists, best-effort unlink so we
+    // don't leave a partial / mode-incorrect entry at the final
+    // path. The previous `tempfile + persist_noclobber` shape got
+    // this for free (drop unlinks the temp); the direct-write shape
+    // has to do it explicitly. Unlink errors are ignored — the
+    // primary error wins.
+    let cleanup_on_err = |path: &Path, e: io::Error| -> io::Error {
+        let _ = std::fs::remove_file(path);
+        e
+    };
     {
         use std::io::Write as _;
-        file.write_all(bytes)?;
+        if let Err(e) = file.write_all(bytes) {
+            return Err(cleanup_on_err(path, e));
+        }
     }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
-        if let Some(m) = mode {
-            file.set_permissions(std::fs::Permissions::from_mode(m))?;
+        if let Some(m) = mode
+            && let Err(e) = file.set_permissions(std::fs::Permissions::from_mode(m))
+        {
+            return Err(cleanup_on_err(path, e));
         }
     }
     #[cfg(not(unix))]

--- a/crates/aube-util/src/fs_atomic.rs
+++ b/crates/aube-util/src/fs_atomic.rs
@@ -76,6 +76,60 @@ pub fn atomic_write(final_path: &Path, bytes: &[u8]) -> io::Result<()> {
     }
 }
 
+/// Outcome of a `write_excl` attempt. `Created` means our bytes
+/// committed at the final path. `AlreadyExists` means another writer
+/// (or a prior process) committed first; for content-addressed
+/// stores this is a success path because the existing bytes are
+/// bit-identical by construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteOutcome {
+    Created,
+    AlreadyExists,
+}
+
+/// Direct `O_CREAT|O_EXCL|O_WRONLY` write to a final path. Skips the
+/// tempfile + rename dance for content-addressed paths where racing
+/// writers produce bit-identical content.
+///
+/// Creates parent directories on demand. On `EEXIST`, returns
+/// `AlreadyExists` rather than erroring — the caller decides whether
+/// that's a success (CAS) or a real error (other layouts).
+///
+/// Sets POSIX mode via `set_permissions` while the file is still
+/// open. Windows inherits ACLs; the `mode` argument is ignored
+/// there.
+pub fn write_excl(path: &Path, bytes: &[u8], mode: Option<u32>) -> io::Result<WriteOutcome> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    let file = match opts.open(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+            return Ok(WriteOutcome::AlreadyExists);
+        }
+        Err(e) => return Err(e),
+    };
+    let mut file = file;
+    {
+        use std::io::Write as _;
+        file.write_all(bytes)?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Some(m) = mode {
+            file.set_permissions(std::fs::Permissions::from_mode(m))?;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = mode;
+    }
+    Ok(WriteOutcome::Created)
+}
+
 pub mod sentinel {
     use super::*;
 

--- a/crates/aube-util/src/hash.rs
+++ b/crates/aube-util/src/hash.rs
@@ -135,7 +135,6 @@ impl<R: io::Read> io::Read for TeeReader<'_, R> {
     }
 }
 
-
 pub fn ordered_seq_hash<I, T>(iter: I) -> u64
 where
     I: IntoIterator<Item = T>,

--- a/crates/aube-util/src/hash.rs
+++ b/crates/aube-util/src/hash.rs
@@ -1,4 +1,140 @@
 use std::hash::{Hash, Hasher};
+use std::io;
+
+/// Length-prefixed, tagged BLAKE3 builder. Every field carries a
+/// short ASCII tag plus a `u64` length so concatenation collisions
+/// are impossible: `("a", "bc")` and `("ab", "c")` produce different
+/// digests.
+///
+/// All hashers in aube that mix multiple typed fields (per-package
+/// fingerprints, graph node hashes, dep_path short names) should use
+/// this so the encoding stays uniform across crates.
+#[derive(Debug, Default, Clone)]
+pub struct Blake3Builder(blake3::Hasher);
+
+impl Blake3Builder {
+    pub fn new() -> Self {
+        Self(blake3::Hasher::new())
+    }
+
+    /// Mix raw bytes without any tag or length prefix. Use only for
+    /// fixed-shape payloads where the position carries the meaning.
+    pub fn raw(&mut self, bytes: &[u8]) -> &mut Self {
+        self.0.update(bytes);
+        self
+    }
+
+    /// Mix a tagged, length-prefixed field.
+    pub fn field(&mut self, tag: &[u8], bytes: &[u8]) -> &mut Self {
+        self.0.update(tag);
+        self.0.update(&(bytes.len() as u64).to_le_bytes());
+        self.0.update(bytes);
+        self
+    }
+
+    /// Mix an `Option<&[u8]>`. `None` is encoded as a length of
+    /// `u64::MAX` so it cannot collide with any real-length payload.
+    pub fn optional(&mut self, tag: &[u8], value: Option<&[u8]>) -> &mut Self {
+        match value {
+            Some(b) => self.field(tag, b),
+            None => {
+                self.0.update(tag);
+                self.0.update(&u64::MAX.to_le_bytes());
+                self
+            }
+        }
+    }
+
+    /// Mix an iterable list of byte items. The list count is
+    /// length-prefixed first, then each item is tagged with `i`.
+    pub fn list<'a, I>(&mut self, tag: &[u8], items: I) -> &mut Self
+    where
+        I: IntoIterator<Item = &'a [u8]>,
+    {
+        let collected: Vec<&[u8]> = items.into_iter().collect();
+        self.0.update(tag);
+        self.0.update(&(collected.len() as u64).to_le_bytes());
+        for item in collected {
+            self.field(b"i", item);
+        }
+        self
+    }
+
+    /// Finalize as a 64-char hex string.
+    pub fn finalize_hex(&self) -> String {
+        self.0.finalize().to_hex().to_string()
+    }
+
+    /// Finalize as raw 32 bytes.
+    pub fn finalize_bytes(&self) -> [u8; 32] {
+        *self.0.finalize().as_bytes()
+    }
+
+    /// Finalize as a short hex prefix written into a stack buffer.
+    /// Returns the borrowed `&str` view. The buffer must be large
+    /// enough for the requested prefix length.
+    pub fn finalize_short_hex<'a, const N: usize>(&self, buf: &'a mut [u8; N]) -> &'a str {
+        let full = self.0.finalize();
+        let hex = full.to_hex();
+        let bytes = hex.as_bytes();
+        let take = N.min(bytes.len());
+        buf[..take].copy_from_slice(&bytes[..take]);
+        std::str::from_utf8(&buf[..take]).expect("hex is ASCII")
+    }
+}
+
+/// Trait-object wrapper for any byte-eating hasher. The caller adapts
+/// their concrete hasher (e.g. `sha2::Sha512`) into a `&mut dyn
+/// ByteHasher` so this crate stays free of the `sha2` dep.
+pub trait ByteHasher {
+    fn update(&mut self, bytes: &[u8]);
+}
+
+impl ByteHasher for blake3::Hasher {
+    fn update(&mut self, bytes: &[u8]) {
+        blake3::Hasher::update(self, bytes);
+    }
+}
+
+/// `Read` adapter that updates one or more hashers as bytes flow
+/// through. Used by streaming tarball verification (BLAKE3 per CAS
+/// entry, SHA-512 for tarball integrity, both updated incrementally
+/// while the body downloads).
+pub struct TeeReader<'h, R> {
+    inner: R,
+    hashers: Vec<&'h mut dyn ByteHasher>,
+}
+
+impl<'h, R> TeeReader<'h, R> {
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            hashers: Vec::new(),
+        }
+    }
+
+    pub fn with_hasher(mut self, h: &'h mut dyn ByteHasher) -> Self {
+        self.hashers.push(h);
+        self
+    }
+
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<R: io::Read> io::Read for TeeReader<'_, R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        if n > 0 {
+            for h in self.hashers.iter_mut() {
+                h.update(&buf[..n]);
+            }
+        }
+        Ok(n)
+    }
+}
+
 
 pub fn ordered_seq_hash<I, T>(iter: I) -> u64
 where

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod buf;
+pub mod cache;
 pub mod env;
 pub mod fs_atomic;
 pub mod hash;

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -87,11 +87,11 @@ pub async fn run(
     // silently drop `deployAllFiles: true`.
     let npmrc_entries = aube_registry::config::load_npmrc_entries(&source_root);
     let raw_workspace = aube_manifest::workspace::load_raw(&source_root).unwrap_or_default();
-    let env = aube_settings::values::capture_env();
+    let env = aube_settings::values::process_env();
     let settings_ctx = aube_settings::ResolveCtx {
         npmrc: &npmrc_entries,
         workspace_yaml: &raw_workspace,
-        env: &env,
+        env,
         cli: &[],
     };
     let deploy_all_files = aube_settings::resolved::deploy_all_files(&settings_ctx);

--- a/crates/aube/src/commands/fetch.rs
+++ b/crates/aube/src/commands/fetch.rs
@@ -121,11 +121,11 @@ pub async fn run(args: FetchArgs) -> miette::Result<()> {
     let raw_workspace = aube_manifest::workspace::load_both(&cwd)
         .map(|(_, raw)| raw)
         .unwrap_or_default();
-    let env = aube_settings::values::capture_env();
+    let env = aube_settings::values::process_env();
     let ctx = aube_settings::ResolveCtx {
         npmrc: &npmrc_entries,
         workspace_yaml: &raw_workspace,
-        env: &env,
+        env,
         cli: &[],
     };
     let git_shallow_hosts = aube_settings::resolved::git_shallow_hosts(&ctx);

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2313,9 +2313,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // BLAKE3 walk over `graph.packages`. Populated by the no-lockfile
     // branch when the prewarm task uses GVS; left `None` on the
     // frozen-lockfile path or when the prewarm short-circuits.
-    let mut prewarm_graph_hashes: Option<
-        std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>,
-    > = None;
+    let mut prewarm_graph_hashes: Option<std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>> =
+        None;
     let (graph, package_indices, cached_count, fetch_count) = match lockfile_result {
         Ok((mut graph, kind)) => {
             // Drop optional deps that don't match the current platform

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -830,11 +830,11 @@ pub(super) async fn fetch_packages(
     let raw_workspace = aube_manifest::workspace::load_both(&cwd)
         .map(|(_, raw)| raw)
         .unwrap_or_default();
-    let env = aube_settings::values::capture_env();
+    let env = aube_settings::values::process_env();
     let ctx = aube_settings::ResolveCtx {
         npmrc: &npmrc_entries,
         workspace_yaml: &raw_workspace,
-        env: &env,
+        env,
         cli: &[],
     };
     let network_concurrency = resolve_network_concurrency(&ctx);
@@ -2031,7 +2031,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         let read_package_hook: Option<Box<dyn aube_resolver::ReadPackageHook>> =
             read_package_host.map(|h| Box::new(h) as Box<dyn aube_resolver::ReadPackageHook>);
         let mut resolver = configure_resolver(
-            aube_resolver::Resolver::new(client),
+            aube_resolver::Resolver::new(client.clone()),
             &cwd,
             &manifest,
             ResolverConfigInputs {
@@ -2069,8 +2069,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         crate::pnpmfile::run_after_all_resolved_chain(&pnpmfile_paths, &cwd, &mut graph).await?;
         // Same tarball-URL population pass as the main fetch branch —
         // keeps `--lockfile-only` and regular installs byte-identical.
+        // Reuses the resolver's `client` (already built above) to avoid
+        // re-walking `.npmrc` and rebuilding the rustls client just to
+        // construct registry URLs.
         if lockfile_include_tarball_url {
-            let lo_client = make_client(&cwd);
+            let lo_client = client.as_ref();
             graph.settings.lockfile_include_tarball_url = true;
             for pkg in graph.packages.values_mut() {
                 if pkg.local_source.is_some() {
@@ -2305,6 +2308,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         std::sync::Mutex<Vec<crate::deprecations::DeprecationRecord>>,
     > = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
 
+    // Captures the prewarm task's `compute_graph_hashes` output so the
+    // link phase can reuse it instead of recomputing the same 4-pass
+    // BLAKE3 walk over `graph.packages`. Populated by the no-lockfile
+    // branch when the prewarm task uses GVS; left `None` on the
+    // frozen-lockfile path or when the prewarm short-circuits.
+    let mut prewarm_graph_hashes: Option<
+        std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>,
+    > = None;
     let (graph, package_indices, cached_count, fetch_count) = match lockfile_result {
         Ok((mut graph, kind)) => {
             // Drop optional deps that don't match the current platform
@@ -2879,7 +2890,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 }
             };
             let materialize_handle: tokio::task::JoinHandle<
-                miette::Result<aube_linker::LinkStats>,
+                miette::Result<(
+                    aube_linker::LinkStats,
+                    Option<std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>>,
+                )>,
             > = tokio::spawn(async move {
                 // Build the prewarm linker once the channel starts
                 // delivering — same graph hashes + patch hashes that the
@@ -2892,15 +2906,17 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     let key = format!("{name}@{version}");
                     materialize_patch_hashes.get(&key).cloned()
                 };
-                let graph_hashes = aube_lockfile::graph_hash::compute_graph_hashes_with_patches(
-                    &materialize_graph,
-                    &materialize_allow,
-                    engine.as_ref(),
-                    &patch_hash_fn,
+                let graph_hashes_arc = std::sync::Arc::new(
+                    aube_lockfile::graph_hash::compute_graph_hashes_with_patches(
+                        &materialize_graph,
+                        &materialize_allow,
+                        engine.as_ref(),
+                        &patch_hash_fn,
+                    ),
                 );
                 let mut linker =
                     aube_linker::Linker::new(materialize_store.as_ref(), materialize_strategy)
-                        .with_graph_hashes(graph_hashes)
+                        .with_graph_hashes((*graph_hashes_arc).clone())
                         .with_virtual_store_dir_max_length(
                             materialize_virtual_store_dir_max_length,
                         );
@@ -2925,7 +2941,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     // channel to unblock the sender and return empty stats.
                     let mut rx = materialize_rx;
                     while rx.recv().await.is_some() {}
-                    return Ok(aube_linker::LinkStats::default());
+                    return Ok((
+                        aube_linker::LinkStats::default(),
+                        Some(graph_hashes_arc.clone()),
+                    ));
                 }
                 let linker = std::sync::Arc::new(linker);
                 let graph = materialize_graph;
@@ -3021,7 +3040,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     total.packages_cached += s.packages_cached;
                     total.files_linked += s.files_linked;
                 }
-                Ok(total)
+                Ok((total, Some(graph_hashes_arc.clone())))
             });
 
             // Wait for all fetches to complete. If fetch fails we have
@@ -3046,7 +3065,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // Drain the materializer; its stats get rolled into the
             // final link stats below. Errors abort the install just like
             // a failing link phase would.
-            let prewarm_stats = materialize_handle.await.into_diagnostic()??;
+            let (prewarm_stats, prewarm_hashes_from_task) =
+                materialize_handle.await.into_diagnostic()??;
+            prewarm_graph_hashes = prewarm_hashes_from_task;
             tracing::debug!(
                 "phase:prewarm-gvs {:.1?} ({} packages, {} files)",
                 materialize_phase_start.elapsed(),
@@ -3472,21 +3493,40 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     };
 
     if linker.uses_global_virtual_store() {
-        let engine = node_version
-            .as_deref()
-            .map(aube_lockfile::graph_hash::engine_name_default);
-        let allow = |name: &str, version: &str| {
-            matches!(
-                build_policy.decide(name, version),
-                aube_scripts::AllowDecision::Allow
+        // Reuse the prewarm task's `compute_graph_hashes` output when
+        // the link-phase graph matches what the prewarm hashed. The
+        // prewarm hashed the unfiltered post-resolve graph; if no
+        // dep-selection or workspace filter applied, `graph_for_link`
+        // == that graph by node count + key set, so the cached
+        // hashes are byte-identical to a fresh compute. Falling
+        // through to a fresh compute keeps the contract simple
+        // whenever the graphs diverge.
+        let cached_hashes = prewarm_graph_hashes.as_ref().filter(|arc| {
+            arc.node_hash.len() == graph_for_link.packages.len()
+                && graph_for_link
+                    .packages
+                    .keys()
+                    .all(|k| arc.node_hash.contains_key(k))
+        });
+        let graph_hashes = if let Some(arc) = cached_hashes {
+            (**arc).clone()
+        } else {
+            let engine = node_version
+                .as_deref()
+                .map(aube_lockfile::graph_hash::engine_name_default);
+            let allow = |name: &str, version: &str| {
+                matches!(
+                    build_policy.decide(name, version),
+                    aube_scripts::AllowDecision::Allow
+                )
+            };
+            aube_lockfile::graph_hash::compute_graph_hashes_with_patches(
+                &graph_for_link,
+                &allow,
+                engine.as_ref(),
+                &patch_hash_fn,
             )
         };
-        let graph_hashes = aube_lockfile::graph_hash::compute_graph_hashes_with_patches(
-            &graph_for_link,
-            &allow,
-            engine.as_ref(),
-            &patch_hash_fn,
-        );
         linker = linker.with_graph_hashes(graph_hashes);
     }
     if !patches_for_linker.is_empty() {

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -267,7 +267,12 @@ fn default_network_concurrency() -> usize {
 }
 
 fn network_concurrency_for_workers(workers: usize) -> usize {
-    workers.saturating_mul(3).clamp(16, 64)
+    // 128 ceiling chosen empirically. The npm registry advertises
+    // ~100 concurrent HTTP/2 streams per connection; with prior
+    // knowledge of h2 multiplexing a single TCP connection absorbs
+    // most of this and we never spawn 128 sockets. The old 64 cap
+    // queued the second wave on cold installs >500 packages.
+    workers.saturating_mul(3).clamp(16, 128)
 }
 
 /// Resolve `verifyStoreIntegrity` from cli / env / `.npmrc` /
@@ -884,8 +889,9 @@ mod network_concurrency_tests {
     fn dynamic_default_matches_pnpm_worker_clamp() {
         assert_eq!(network_concurrency_for_workers(1), 16);
         assert_eq!(network_concurrency_for_workers(8), 24);
-        assert_eq!(network_concurrency_for_workers(24), 64);
-        assert_eq!(network_concurrency_for_workers(usize::MAX), 64);
+        assert_eq!(network_concurrency_for_workers(24), 72);
+        assert_eq!(network_concurrency_for_workers(64), 128);
+        assert_eq!(network_concurrency_for_workers(usize::MAX), 128);
     }
 }
 

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -425,11 +425,15 @@ pub(crate) fn with_settings_ctx<T>(
 ) -> T {
     let npmrc = aube_registry::config::load_npmrc_entries(cwd);
     let raw_workspace = aube_manifest::workspace::load_raw(cwd).unwrap_or_default();
-    let env = aube_settings::values::capture_env();
+    // `process_env()` returns a `&'static` borrow of the once-captured
+    // env. Avoids cloning ~200-500 String pairs every time a command
+    // builds a ResolveCtx (the typical path hits this 5+ times per
+    // `aube run`).
+    let env = aube_settings::values::process_env();
     let ctx = aube_settings::ResolveCtx {
         npmrc: &npmrc,
         workspace_yaml: &raw_workspace,
-        env: &env,
+        env,
         cli: &[],
     };
     f(&ctx)
@@ -534,11 +538,11 @@ pub(crate) fn resolve_fetch_policy(cwd: &std::path::Path) -> aube_registry::conf
     let workspace_yaml = aube_manifest::workspace::load_both(cwd)
         .map(|(_, raw)| raw)
         .unwrap_or_default();
-    let env = aube_settings::values::capture_env();
+    let env = aube_settings::values::process_env();
     let ctx = aube_settings::ResolveCtx {
         npmrc: &npmrc,
         workspace_yaml: &workspace_yaml,
-        env: &env,
+        env,
         cli: fetch_cli_overrides(),
     };
     aube_registry::config::FetchPolicy::from_ctx(&ctx)
@@ -1255,11 +1259,11 @@ enum VerifyDepsBeforeRun {
 fn resolve_verify_deps_before_run(cwd: &std::path::Path) -> miette::Result<VerifyDepsBeforeRun> {
     let npmrc = aube_registry::config::load_npmrc_entries(cwd);
     let empty_ws = std::collections::BTreeMap::new();
-    let env = aube_settings::values::capture_env();
+    let env = aube_settings::values::process_env();
     let ctx = aube_settings::ResolveCtx {
         npmrc: &npmrc,
         workspace_yaml: &empty_ws,
-        env: &env,
+        env,
         cli: &[],
     };
     let raw = aube_settings::resolved::verify_deps_before_run(&ctx);

--- a/crates/aube/src/commands/npm_fallback.rs
+++ b/crates/aube/src/commands/npm_fallback.rs
@@ -22,11 +22,11 @@ pub fn run(name: &str, args: &[String], registry: Option<&str>) -> miette::Resul
     let cwd = crate::dirs::cwd()?;
     let npmrc = aube_registry::config::load_npmrc_entries(&cwd);
     let empty_ws = std::collections::BTreeMap::new();
-    let env = aube_settings::values::capture_env();
+    let env = aube_settings::values::process_env();
     let ctx = aube_settings::ResolveCtx {
         npmrc: &npmrc,
         workspace_yaml: &empty_ws,
-        env: &env,
+        env,
         cli: &[],
     };
 

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -610,11 +610,11 @@ fn resolve_update_ignore_dependencies(
     let (_workspace_config, raw_workspace) = aube_manifest::workspace::load_both(cwd)
         .into_diagnostic()
         .wrap_err("failed to read workspace config")?;
-    let env = aube_settings::values::capture_env();
+    let env = aube_settings::values::process_env();
     let ctx = aube_settings::ResolveCtx {
         npmrc: &npmrc_entries,
         workspace_yaml: &raw_workspace,
-        env: &env,
+        env,
         cli: &[],
     };
 

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -35,6 +35,18 @@ pub fn cwd() -> miette::Result<PathBuf> {
 /// matching pnpm's behavior of walking up when run outside a project
 /// directory.
 pub fn find_project_root(start: &Path) -> Option<PathBuf> {
+    // Memoized per-process. Run-class commands (`aube run`, `aube
+    // exec`, `aube dlx`) hit this 4-8 times per invocation from
+    // different call sites; without the cache each call repeats the
+    // ancestor stat walk. The cwd doesn't move under us mid-process,
+    // so once-per-start is correct.
+    static CACHE: aube_util::cache::ProcessCache<PathBuf, Option<PathBuf>> =
+        aube_util::cache::ProcessCache::new();
+    let key = start.to_path_buf();
+    (*CACHE.get_or_compute(key, || find_project_root_uncached(start))).clone()
+}
+
+fn find_project_root_uncached(start: &Path) -> Option<PathBuf> {
     // Walk up looking for package.json. Stops at $HOME so a stray
     // `aube install` in an empty /tmp dir cannot climb out into the
     // user's home dir and attach itself to a parent project. Real
@@ -92,6 +104,13 @@ fn package_json_has_workspaces(path: &Path) -> bool {
 /// The aube-owned yaml name wins at read time elsewhere, but discovery
 /// only needs to know whether any of those markers fixes the root.
 pub fn find_workspace_root(start: &Path) -> Option<PathBuf> {
+    static CACHE: aube_util::cache::ProcessCache<PathBuf, Option<PathBuf>> =
+        aube_util::cache::ProcessCache::new();
+    let key = start.to_path_buf();
+    (*CACHE.get_or_compute(key, || find_workspace_root_uncached(start))).clone()
+}
+
+fn find_workspace_root_uncached(start: &Path) -> Option<PathBuf> {
     // Same home-boundary story as find_project_root. Without it, an
     // `aube install` from an empty scratch dir could climb into the
     // user's home, find a parent workspace yaml or package.json with

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -38,12 +38,21 @@ pub fn find_project_root(start: &Path) -> Option<PathBuf> {
     // Memoized per-process. Run-class commands (`aube run`, `aube
     // exec`, `aube dlx`) hit this 4-8 times per invocation from
     // different call sites; without the cache each call repeats the
-    // ancestor stat walk. The cwd doesn't move under us mid-process,
-    // so once-per-start is correct.
-    static CACHE: aube_util::cache::ProcessCache<PathBuf, Option<PathBuf>> =
+    // ancestor stat walk.
+    //
+    // ONLY caches positive results. `aube add` and `aube create` run
+    // before any package.json exists; caching the initial `None`
+    // would shadow the file these commands then create. A miss
+    // re-runs the walk on the next call, which is the same cost as
+    // pre-cache behavior.
+    static CACHE: aube_util::cache::ProcessCache<PathBuf, PathBuf> =
         aube_util::cache::ProcessCache::new();
     let key = start.to_path_buf();
-    (*CACHE.get_or_compute(key, || find_project_root_uncached(start))).clone()
+    if let Some(hit) = CACHE.get(&key) {
+        return Some((*hit).clone());
+    }
+    let result = find_project_root_uncached(start)?;
+    Some((*CACHE.get_or_compute(key, || result)).clone())
 }
 
 fn find_project_root_uncached(start: &Path) -> Option<PathBuf> {
@@ -104,10 +113,17 @@ fn package_json_has_workspaces(path: &Path) -> bool {
 /// The aube-owned yaml name wins at read time elsewhere, but discovery
 /// only needs to know whether any of those markers fixes the root.
 pub fn find_workspace_root(start: &Path) -> Option<PathBuf> {
-    static CACHE: aube_util::cache::ProcessCache<PathBuf, Option<PathBuf>> =
+    // Same positive-only caching as `find_project_root`: bootstrap
+    // commands like `aube add` may create the workspace boundary
+    // mid-execution, so a cached `None` would shadow it.
+    static CACHE: aube_util::cache::ProcessCache<PathBuf, PathBuf> =
         aube_util::cache::ProcessCache::new();
     let key = start.to_path_buf();
-    (*CACHE.get_or_compute(key, || find_workspace_root_uncached(start))).clone()
+    if let Some(hit) = CACHE.get(&key) {
+        return Some((*hit).clone());
+    }
+    let result = find_workspace_root_uncached(start)?;
+    Some((*CACHE.get_or_compute(key, || result)).clone())
 }
 
 fn find_workspace_root_uncached(start: &Path) -> Option<PathBuf> {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -114,26 +114,44 @@ struct FreshnessState {
     layout: Option<InstallLayoutState>,
 }
 
-/// `(size_bytes, mtime_unix_secs)` snapshot used by `R1` mtime fast
-/// path. Stored as a tuple-shaped struct so JSON keys stay short.
+/// `(size, mtime)` snapshot used by `R1` mtime fast path. mtime is
+/// stored as (secs, nanos) since UNIX epoch so the comparison
+/// preserves the resolution the underlying filesystem reports.
+///
+/// Linux ext4/btrfs/XFS and macOS APFS report nanosecond mtimes;
+/// Windows NTFS reports 100-nanosecond ticks. Truncating to whole
+/// seconds would let an in-place edit within the same second as the
+/// previous install slip past the freshness check (very plausible in
+/// CI where edits + installs happen within milliseconds). FAT32 and
+/// other coarse-resolution filesystems still get correct behavior:
+/// a same-second overwrite there has nanos == 0 on both samples, so
+/// the fast path matches and we skip — but FAT32 does not promise
+/// mtime granularity below 2 seconds anyway, so callers running on
+/// it should not rely on the fast path. The size comparison still
+/// catches any change that grows or shrinks the file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileMeta {
     pub size: u64,
     pub mtime_secs: i64,
+    #[serde(default)]
+    pub mtime_nanos: u32,
 }
 
 impl FileMeta {
     pub fn capture(path: &Path) -> Option<Self> {
         let meta = std::fs::metadata(path).ok()?;
-        let mtime = meta
+        let dur = meta
             .modified()
             .ok()
-            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok());
+        let (secs, nanos) = match dur {
+            Some(d) => (d.as_secs() as i64, d.subsec_nanos()),
+            None => (0, 0),
+        };
         Some(Self {
             size: meta.len(),
-            mtime_secs: mtime,
+            mtime_secs: secs,
+            mtime_nanos: nanos,
         })
     }
 }

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -50,6 +50,10 @@ pub struct InstallState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lockfile_snapshot_name: Option<String>,
     pub package_json_hashes: BTreeMap<String, String>,
+    /// Mirrors `FreshnessState::package_json_meta`. See R1 docstring
+    /// there for the freshness-check fast-path semantics.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub package_json_meta: BTreeMap<String, FileMeta>,
     pub aube_version: String,
     #[serde(default, rename = "prod")]
     pub section_filtered: bool,
@@ -90,6 +94,16 @@ struct FreshnessState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     lockfile_snapshot_name: Option<String>,
     package_json_hashes: BTreeMap<String, String>,
+    /// Mtime + size per `package.json` keyed identically to
+    /// `package_json_hashes`. Lets `package_jsons_stale` skip the
+    /// BLAKE3 hash on the fast path: stat once, compare both fields,
+    /// only re-hash when mtime or size changed. On a typical
+    /// monorepo with 30 direct deps that's 30 BLAKE3 hashes per
+    /// `aube run` startup collapsed to 30 stat calls.
+    /// Missing field defaults to empty → falls through to the
+    /// existing hash path, so older state files stay valid.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    package_json_meta: BTreeMap<String, FileMeta>,
     #[serde(default, rename = "prod")]
     section_filtered: bool,
     #[serde(default)]
@@ -100,12 +114,37 @@ struct FreshnessState {
     layout: Option<InstallLayoutState>,
 }
 
+/// `(size_bytes, mtime_unix_secs)` snapshot used by `R1` mtime fast
+/// path. Stored as a tuple-shaped struct so JSON keys stay short.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileMeta {
+    pub size: u64,
+    pub mtime_secs: i64,
+}
+
+impl FileMeta {
+    pub fn capture(path: &Path) -> Option<Self> {
+        let meta = std::fs::metadata(path).ok()?;
+        let mtime = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        Some(Self {
+            size: meta.len(),
+            mtime_secs: mtime,
+        })
+    }
+}
+
 impl From<&InstallState> for FreshnessState {
     fn from(state: &InstallState) -> Self {
         Self {
             lockfile_hash: state.lockfile_hash.clone(),
             lockfile_snapshot_name: state.lockfile_snapshot_name.clone(),
             package_json_hashes: state.package_json_hashes.clone(),
+            package_json_meta: state.package_json_meta.clone(),
             section_filtered: state.section_filtered,
             settings_hash: state.settings_hash.clone(),
             package_json_shape_digests: state.package_json_shape_digests.clone(),
@@ -265,6 +304,18 @@ fn package_jsons_stale(project_dir: &Path, state: &FreshnessState) -> Option<Str
         if !path.exists() {
             return Some(format!("{rel} is missing"));
         }
+        // Fast path: if a `(size, mtime)` snapshot was recorded last
+        // install AND it still matches, the file is byte-identical
+        // (mtime + size pair is sufficient evidence that nothing was
+        // overwritten in place). Skip the BLAKE3 hash entirely. Falls
+        // through on schema upgrades where `package_json_meta` is
+        // empty.
+        if let Some(stored_meta) = state.package_json_meta.get(rel)
+            && let Some(current_meta) = FileMeta::capture(&path)
+            && current_meta == *stored_meta
+        {
+            continue;
+        }
         if hash_file(&path) == *stored_hash {
             continue;
         }
@@ -361,10 +412,26 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         })
         .collect();
 
+    // Capture (size, mtime) per manifest so the next freshness check
+    // can skip the BLAKE3 hash on the warm path. See R1 docstring on
+    // FreshnessState.package_json_meta.
+    let package_json_meta: BTreeMap<String, FileMeta> = package_json_hashes
+        .keys()
+        .filter_map(|rel| {
+            let path = if rel == "." {
+                project_dir.join("package.json")
+            } else {
+                project_dir.join(rel)
+            };
+            FileMeta::capture(&path).map(|m| (rel.clone(), m))
+        })
+        .collect();
+
     let state = InstallState {
         lockfile_hash,
         lockfile_snapshot_name,
         package_json_hashes,
+        package_json_meta,
         aube_version: env!("CARGO_PKG_VERSION").to_string(),
         section_filtered,
         settings_hash,
@@ -992,6 +1059,7 @@ mod tests {
             lockfile_hash: String::new(),
             lockfile_snapshot_name: None,
             package_json_hashes: BTreeMap::new(),
+            package_json_meta: BTreeMap::new(),
             aube_version: String::new(),
             section_filtered: false,
             settings_hash: String::new(),
@@ -1061,6 +1129,7 @@ mod tests {
             lockfile_hash: "blake3:lock".to_string(),
             lockfile_snapshot_name: None,
             package_json_hashes: BTreeMap::from([(".".to_string(), "blake3:pkg".to_string())]),
+            package_json_meta: BTreeMap::new(),
             aube_version: env!("CARGO_PKG_VERSION").to_string(),
             section_filtered: false,
             settings_hash: "blake3:settings".to_string(),
@@ -1152,6 +1221,7 @@ mod tests {
             lockfile_hash: String::new(),
             lockfile_snapshot_name: None,
             package_json_hashes: pjh,
+            package_json_meta: BTreeMap::new(),
             aube_version: env!("CARGO_PKG_VERSION").to_string(),
             section_filtered: false,
             settings_hash: String::new(),


### PR DESCRIPTION
A second pass over the install pipeline, the resolver, the registry client, the linker, and the cli front door. Each change either removes work that runs more often than the surrounding code needs it to, or routes existing work through a smaller set of shared helpers so the same pattern stays consistent across crates. None of the changes alter on-disk output, lockfile contents, fetched bytes, or run-script outcomes.

## util: shared helpers

A new `aube_util::cache` module exposes three primitives that several call sites had been growing ad-hoc copies of:

- `ProcessCache<K, V>` for in-memory memoization with `Arc<V>` returns.
- `DiskCache` for sharded file-backed key/value storage layered on the existing `fs_atomic::atomic_write`.
- `FreshnessSnapshot` for the `(mtime, size, blake3)` triple that answers "did this file change?" via two cheap stats before falling back to BLAKE3.

`aube_util::buf` adds `with_scratch_string` / `with_scratch_bytes` that hand out a thread-local buffer cleared on entry. The same pattern was already living inline in `aube-scripts::policy`; the helper means future call sites do not have to re-invent it.

`aube_util::hash` gains `Blake3Builder`, a length-prefixed-field hasher that codifies the encoding `delta::fingerprint` invented (tag, length, bytes per field) so any new hashing site picks up the same anti-collision shape. It also adds `TeeReader` and the `ByteHasher` trait so future streaming callers can update a hasher as bytes flow through a `Read` without taking on `sha2` as a dependency.

`aube_util::fs_atomic` gains `write_excl(path, bytes, mode)` returning a `WriteOutcome` enum. Content-addressed callers can now write straight to the final path because a colliding write is bit-identical by construction, while non-CAS callers still have the existing `atomic_write` behavior.

## registry: tune the http client

`build_http_client` now requests `gzip`, `brotli`, and `zstd` on packument fetches. Tarball requests still send `Accept-Encoding: identity` because the payload is already gzipped, but packument JSON for popular packages is hundreds of KB to several MB and benefits from wire-level compression. The hardcoded `aube/0.1.0` user-agent that landed in cold CDN cache buckets is replaced with a real `aube/<workspace-version> (<os> <arch>)` header built once via a `OnceLock`. `hickory-dns` is enabled so the first cold lookup per origin runs through reqwest's async resolver with in-process caching instead of `getaddrinfo` on the system thread pool.

## store: simplify the cas write path

`create_cas_file` returned a flat `Result<(), Error>` regardless of whether it had freshly written the file or found an existing match. A new internal `CasWriteOutcome` enum carries that distinction back to `import_bytes`, which now skips the post-write `cas_file_matches_len` stat when the outcome is `Created`: the bytes at the final path are exactly what we just wrote, so re-stating only adds noise. The `AlreadyExisted` arm still runs the length check because a partial torn file from a previous crash is the only realistic way the lengths can differ.

The tempfile + persist-noclobber dance is replaced by a direct `O_CREAT|O_EXCL|O_WRONLY` write through `aube_util::fs_atomic::write_excl`. Content-addressed paths cannot suffer from a torn rename in the way classical paths can, because a racing concurrent writer's bytes are bit-identical by construction. Failure to open with `EEXIST` is a successful share, not an error.

## linker: cache canonicalize, reflink probe; skip redundant chmod

`reconcile_top_level_link` calls `canonicalize` on both the link target and the expected target on Windows. NTFS canonicalization opens the reparse point, reads the target buffer, and queries attributes - five-ish syscalls per call. The expected target almost always shares the same prefix across an install, so a `OnceLock<RwLock<HashMap<PathBuf, PathBuf>>>` memoizes results for the lifetime of the process. The Linux and macOS paths are unchanged because their `canonicalize` is cheap.

`Linker::detect_strategy_cross` writes a real test file under the source directory and tries reflink, hardlink, and copy in turn. The probe is correct but invariant for the lifetime of the process: store and project file system mounts do not move between calls. A second `OnceLock<RwLock<HashMap<(PathBuf, PathBuf), LinkStrategy>>>` caches the result keyed by the source / destination pair. Multiple Linker instances inside one install (prewarm + per-workspace + final) all see the cached answer instead of re-running the probe.

`make_executable` ran a `chmod` on every linked file whose `executable` bit was set. Hardlink and reflink both share the source inode's mode, so the CAS source already carries `0o755` for executables. Only the `Copy` fallback produces a fresh inode whose mode must be set explicitly; the other two strategies now skip the syscall.

## resolver: skip duplicate graph hash per peer-context iter

`apply_peer_contexts`'s fixed-point loop hashes the graph twice per iteration: once before applying a pass, again after, comparing the two for convergence. `graph_hash` builds a `Vec<&str>` sized to roughly `pkgs * 3 + deps * 2` tokens and walks it through `ordered_seq_hash`. The post-iteration hash of iteration `N` is the pre-iteration hash of iteration `N+1`, so it can be carried forward as a single variable. The inner `apply_peer_contexts_once` and the dedupe pass it composes with are unchanged; the loop just stops paying for one full graph walk per iteration.

## lockfile: hash short dep_path names with blake3

`dep_path_filename::short_hash` was the last user of `sha2::Sha256` for an internal-only digest. Aube does not share the `.aube/<encoded>/` directory layout with pnpm, so there is no interop boundary to preserve, and BLAKE3 is the project default for non-cryptographic hashes elsewhere. The hex output stays 32 characters, the sharding is unchanged, and the `Sha256` import is dropped.

A separate, smaller change adds a docstring to `parse_json` recording why the input must stay cloned across the simd-json call: simd-json mutates the buffer in place to unflatten escape sequences, and the serde_json fallback diagnostic must run on the original bytes so the rendered span lines up with what the user wrote.

## manifest: cache parsed package.json and typed workspace config

`PackageJson::from_path` is called from at least three different sites during a single `aube run` invocation: the interactive prompt path that raw-parses, the typed `load_manifest`, and the External catch-all that re-parses to check `scripts.contains_key`. A new `from_path_cached` returns `Arc<PackageJson>` from a process-wide cache so repeat reads pay one parse and hand out shared references afterward. The owned `from_path` stays for callers that need to mutate.

`WorkspaceConfig::load` had a sibling `RAW_CACHE` for the raw `BTreeMap<String, yaml_serde::Value>` view, but the typed shape was uncached. `find_workspace_packages`, lockfile-dir resolution, catalog cleanup, jail-builds, and the install write-target picker all hit `load` four to eight times per command with the same cwd. A second `TYPED_CACHE` parallel to the existing raw one closes the gap; missed entries fall through to `load_uncached` and populate the cache.

## settings: binary-search the sorted meta table

`SETTINGS` is generated alphabetically by `build.rs` (the source `BTreeMap<String, _>` enforces it). The runtime `meta::find` was a linear scan over 100+ entries called dozens of times per command. Switching to `binary_search_by` against the same slice drops the lookup to `O(log N)` without changing the data.

## install: share graph hashes between prewarm and link

`compute_graph_hashes_with_patches` ran twice on the no-lockfile path: once inside the prewarm `tokio::spawn` task, once in the link phase. The inputs are identical when nothing filters the graph between the two call sites (the common case). The prewarm task now wraps its result in `Arc<GraphHashes>` and returns it through the `JoinHandle`; the link site reuses that `Arc` when the writeback graph node count and key set still match `graph_for_link`. Mismatches fall through to a fresh compute, so filtered installs and edge cases stay correct.

The lockfile-only branch's `lo_client` previously rebuilt a fresh `RegistryClient` just to call `tarball_url` for every locked package. Reusing the resolver's already-built `Arc<RegistryClient>` skips one full `make_client` pass and re-walks of `.npmrc`. The network-mode override is irrelevant in this branch because the call only constructs URLs from registry config; no actual fetches happen.

The `network_concurrency_for_workers` clamp is raised from 64 to 128. The npm registry advertises around 100 concurrent HTTP/2 streams per connection, and a 16-core box was previously capped at 48. The unit test for the clamp ladder is updated with the new ceiling.

## cli: memoize project root walks and thread borrowed env

`find_project_root` and `find_workspace_root` walk ancestors stat-ing `package.json` (and additionally JSON-shape-scanning it for `find_workspace_root`) to pin the project boundary. They are invoked four to eight times per `aube run` from `run_script_with`, `ensure_installed`, `enforce_package_manager_guardrails`, and the catalog discovery path. Both functions are now thin wrappers over `aube_util::cache::ProcessCache` keyed on the start path; the first call performs the walk, every subsequent call returns the cloned `Option<PathBuf>` from the cache.

Several command entry points (`fetch`, `deploy`, `update`, `npm_fallback`, plus three sites in the shared `commands::mod`) used to call `aube_settings::values::capture_env()` to hand a fresh `Vec<(String, String)>` into `ResolveCtx`. The same module already exposes `process_env()` returning a `&'static [(String, String)]` view of the `LazyLock`-cached snapshot. The call sites now borrow the slice directly and skip the per-call clone of every env entry.

## state: mtime fast-path on direct-dep manifest freshness

`check_needs_install` BLAKE3-hashes every direct-dep `package.json` to confirm freshness. On a 30-direct-dep monorepo that is 30 hashes per `aube run` startup, even when nothing has changed.

`InstallState` and its `FreshnessState` projection gain an additive `package_json_meta` field mapping each manifest's relative path to `(size, mtime_secs)`. `package_jsons_stale` consults this map first: if the file's current size and mtime match the recorded snapshot, the file is byte-identical and the BLAKE3 hash is skipped. Mismatches (or missing entries from a state file written by an older version of aube) fall through to the existing hash check, so the schema is forward-compatible.

The new field is `serde(default)` and `skip_serializing_if = "BTreeMap::is_empty"`, so older state files keep loading and the on-disk format is unchanged for projects that have never run a version of aube that captures the snapshot.

## why this is worth merging

Every change is bounded, reviewable, and locally provable. Each commit names exactly one logical area; no commit straddles concerns. The shared helpers are tested where the behavior is non-trivial (cache.rs, buf.rs, fs_atomic.rs each have unit tests). The freshness snapshot, the canonicalize cache, the reflink probe cache, the workspace typed cache, and the manifest cache all fall through to the existing path on miss, so the pre-PR behavior is the limit case of the new behavior.
