### PR TITLE
test(cli): port pnpm monorepo filter tests + wire --fail-if-no-match

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -527,7 +527,7 @@ cmd la hide=#true help="Alias for `list --long` (hidden; prefer `list --long`)" 
     flag "-g --global" help="List globally-installed packages instead of the project's dependency tree"
     flag "-P --prod --production" help="Show only production dependencies (skip devDependencies)"
     flag --depth help="How deep to render the transitive tree" default="0" {
-        long_help "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat."
+        long_help "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat. `--depth=-1` (pnpm spelling) lists project headers only — no direct or transitive deps."
         arg <DEPTH>
     }
     flag --format help="Output format: one of `default`, `json`, or `parseable`" default=default {
@@ -568,7 +568,7 @@ cmd list help="Print the installed dependency tree" {
     flag "-g --global" help="List globally-installed packages instead of the project's dependency tree"
     flag "-P --prod --production" help="Show only production dependencies (skip devDependencies)"
     flag --depth help="How deep to render the transitive tree" default="0" {
-        long_help "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat."
+        long_help "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat. `--depth=-1` (pnpm spelling) lists project headers only — no direct or transitive deps."
         arg <DEPTH>
     }
     flag --format help="Output format: one of `default`, `json`, or `parseable`" default=default {
@@ -590,7 +590,7 @@ cmd ll hide=#true help="Alias for `list --long` (hidden; prefer `list --long`)" 
     flag "-g --global" help="List globally-installed packages instead of the project's dependency tree"
     flag "-P --prod --production" help="Show only production dependencies (skip devDependencies)"
     flag --depth help="How deep to render the transitive tree" default="0" {
-        long_help "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat."
+        long_help "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat. `--depth=-1` (pnpm spelling) lists project headers only — no direct or transitive deps."
         arg <DEPTH>
     }
     flag --format help="Output format: one of `default`, `json`, or `parseable`" default=default {

--- a/crates/aube-workspace/src/selector.rs
+++ b/crates/aube-workspace/src/selector.rs
@@ -33,6 +33,10 @@ pub struct EffectiveFilter {
     /// Raw `--filter-prod` values. These apply the same selector forms as
     /// `filters` but restrict graph walks to production edges.
     pub filter_prods: Vec<String>,
+    /// `--fail-if-no-match` — promote "no projects matched" from a warning
+    /// to a hard error. pnpm's default is to warn and exit 0; this flag
+    /// (mirrored) opts into the strict behavior for CI use.
+    pub fail_if_no_match: bool,
 }
 
 impl EffectiveFilter {
@@ -50,6 +54,7 @@ impl EffectiveFilter {
         Self {
             filters: filters.into_iter().map(Into::into).collect(),
             filter_prods: Vec::new(),
+            fail_if_no_match: false,
         }
     }
 }
@@ -127,13 +132,19 @@ impl Selector {
         let base = if raw.starts_with('[') && raw.ends_with(']') && raw.len() > 2 {
             BaseSelector::ChangedSince(raw[1..raw.len() - 1].to_string())
         }
-        // Path-style selectors: leading `./`, `../`, `/`, or a trailing `/`.
+        // Path-style selectors: leading `./`, `../`, `/`, a trailing
+        // `/`, or a trailing `/**` (the pnpm-style "directory and all
+        // descendants" form). `./packages/**` is treated as a synonym
+        // for `./packages` because aube's path selector is already
+        // "at or under" — pnpm v9 introduced an exact-vs-recursive
+        // split via `legacyDirFiltering`, which aube does not implement.
         else if raw.starts_with("./")
             || raw.starts_with("../")
             || raw.starts_with('/')
             || raw.ends_with('/')
+            || raw.ends_with("/**")
         {
-            let trimmed = raw.trim_end_matches('/');
+            let trimmed = raw.strip_suffix("/**").unwrap_or(raw).trim_end_matches('/');
             // Strip a leading `./` so the stored PathBuf has no CurDir
             // component. `Path::components` normalizes mid-path `CurDir`
             // already, but keeping the stored form canonical makes the

--- a/crates/aube-workspace/src/selector.rs
+++ b/crates/aube-workspace/src/selector.rs
@@ -132,17 +132,17 @@ impl Selector {
         let base = if raw.starts_with('[') && raw.ends_with(']') && raw.len() > 2 {
             BaseSelector::ChangedSince(raw[1..raw.len() - 1].to_string())
         }
-        // Path-style selectors: leading `./`, `../`, `/`, a trailing
-        // `/`, or a trailing `/**` (the pnpm-style "directory and all
-        // descendants" form). `./packages/**` is treated as a synonym
-        // for `./packages` because aube's path selector is already
-        // "at or under" — pnpm v9 introduced an exact-vs-recursive
-        // split via `legacyDirFiltering`, which aube does not implement.
+        // Path-style selectors: leading `./`, `../`, `/`, or a trailing `/`.
+        // The pnpm-style `./packages/**` "directory and all descendants"
+        // form already enters this branch via the `./` prefix; we then
+        // strip the `/**` suffix so it collapses to the same `./packages`
+        // path. We deliberately do NOT also accept a bare `/**` suffix
+        // here — `@scope/**` and `name/**` are name globs and must keep
+        // routing through the `NameGlob` branch below.
         else if raw.starts_with("./")
             || raw.starts_with("../")
             || raw.starts_with('/')
             || raw.ends_with('/')
-            || raw.ends_with("/**")
         {
             let trimmed = raw.strip_suffix("/**").unwrap_or(raw).trim_end_matches('/');
             // Strip a leading `./` so the stored PathBuf has no CurDir
@@ -574,6 +574,34 @@ mod tests {
             Selector::parse("./packages/a").unwrap(),
             Selector {
                 base: BaseSelector::Path(PathBuf::from("packages/a")),
+                include_dependencies: false,
+                include_dependents: false,
+                exclude_self: false,
+                exclude: false,
+                prod_only: false,
+            }
+        );
+        // `./packages/**` is the pnpm "directory and all descendants"
+        // form; aube collapses it to the same path because the matcher
+        // is already "at or under".
+        assert_eq!(
+            Selector::parse("./packages/**").unwrap(),
+            Selector {
+                base: BaseSelector::Path(PathBuf::from("packages")),
+                include_dependencies: false,
+                include_dependents: false,
+                exclude_self: false,
+                exclude: false,
+                prod_only: false,
+            }
+        );
+        // A bare `<name>/**` (no path-y prefix) must keep routing
+        // through `NameGlob` — `@scope/**` is a scoped name glob, not
+        // a path.
+        assert_eq!(
+            Selector::parse("@scope/**").unwrap(),
+            Selector {
+                base: BaseSelector::NameGlob("@scope/**".into()),
                 include_dependencies: false,
                 include_dependents: false,
                 exclude_self: false,

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -155,6 +155,20 @@ pub async fn run(
     // stdout when nothing matches. The result is threaded into
     // `run_filtered` so we don't re-walk the workspace on the match
     // path.
+    // Resolve the effective output format up front so the no-match
+    // suppression below honors `--format parseable` / `--format json`
+    // as well as the `--parseable` / `--json` shortcut flags. Without
+    // this, `--format parseable --filter=nonexistent` would print the
+    // human "No projects matched…" message and corrupt machine-parseable
+    // stdout.
+    let format = if args.json {
+        ListFormat::Json
+    } else if args.parseable {
+        ListFormat::Parseable
+    } else {
+        args.format
+    };
+
     let selected = if !filter.is_empty() {
         let workspace_pkgs = aube_workspace::find_workspace_packages(&read_from)
             .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
@@ -182,7 +196,7 @@ pub async fn run(
                     "aube list: filter {shown:?} did not match any workspace package"
                 ));
             }
-            if !args.parseable {
+            if format == ListFormat::Default {
                 println!("No projects matched the filters in {}", read_from.display());
             }
             return Ok(());
@@ -207,15 +221,6 @@ pub async fn run(
         Err(e) => {
             return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile");
         }
-    };
-
-    // Resolve format from the flag combination.
-    let format = if args.json {
-        ListFormat::Json
-    } else if args.parseable {
-        ListFormat::Parseable
-    } else {
-        args.format
     };
 
     let dep_filter = DepFilter::from_flags(args.prod, args.dev);

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -78,8 +78,10 @@ pub struct ListArgs {
     /// `0` (default) shows only the top-level direct deps. Pass
     /// `9999` (or any large number) for the full graph;
     /// `--depth=Infinity` is accepted for pnpm/npm compat.
+    /// `--depth=-1` (pnpm spelling) lists project headers only —
+    /// no direct or transitive deps.
     #[arg(long, default_value = "0", value_parser = parse_depth)]
-    pub depth: usize,
+    pub depth: Depth,
 
     /// Output format: one of `default`, `json`, or `parseable`
     #[arg(long, value_enum, default_value_t = ListFormat::Default)]
@@ -103,19 +105,48 @@ pub struct ListArgs {
     pub parseable: bool,
 }
 
+/// Parsed `--depth` value. `include_direct=false` is the pnpm
+/// `--depth=-1` shape: list project headers only, no deps. The `max`
+/// field caps transitive expansion (0 = direct only, `usize::MAX` for
+/// `--depth=Infinity`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Depth {
+    pub include_direct: bool,
+    pub max: usize,
+}
+
+impl Depth {
+    /// Whether to recurse past the direct-deps layer.
+    fn includes_transitive(self) -> bool {
+        self.include_direct && self.max >= 1
+    }
+}
+
 /// `--depth=Infinity` is what pnpm/npm accept for "all the way down".
 /// Map it to a very large number so we never actually stop walking.
-/// `-1` is pnpm's spelling for "no transitive deps" and collapses to
-/// the same `0` we already use for top-level only.
-fn parse_depth(s: &str) -> Result<usize, String> {
+/// `-1` is pnpm's spelling for "no deps at all" and disables even the
+/// direct-deps layer (project header only) — distinct from `0`, which
+/// shows direct deps and stops there.
+fn parse_depth(s: &str) -> Result<Depth, String> {
     if s.eq_ignore_ascii_case("infinity") || s == "inf" {
-        return Ok(usize::MAX);
+        return Ok(Depth {
+            include_direct: true,
+            max: usize::MAX,
+        });
     }
     if s == "-1" {
-        return Ok(0);
+        return Ok(Depth {
+            include_direct: false,
+            max: 0,
+        });
     }
-    s.parse::<usize>()
-        .map_err(|e| format!("invalid depth {s:?}: {e}"))
+    let max = s
+        .parse::<usize>()
+        .map_err(|e| format!("invalid depth {s:?}: {e}"))?;
+    Ok(Depth {
+        include_direct: true,
+        max,
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -503,6 +534,13 @@ fn render_default_for_importer(
     println!("{project_name}@{project_version} {project_path}");
     println!();
 
+    // `--depth=-1` lists project headers only — skip dep enumeration
+    // entirely. Pnpm's spelling for this case is to suppress everything
+    // beyond the project line.
+    if !args.depth.include_direct {
+        return Ok(());
+    }
+
     let grouped = group_roots(graph, importer, filter, args.pattern.as_deref());
     if grouped.prod.is_empty() && grouped.dev.is_empty() && grouped.optional.is_empty() {
         println!("(no dependencies)");
@@ -608,7 +646,7 @@ fn render_section(
         };
         println!("{connector}{} {version}{extra}", dep.name);
 
-        if args.depth >= 1
+        if args.depth.includes_transitive()
             && let Some(pkg) = pkg
         {
             let child_prefix = if is_last { "    " } else { "│   " };
@@ -642,7 +680,7 @@ fn render_subtree(
     vstore_max_len: usize,
     vstore_prefix: &str,
 ) {
-    if current_depth > args.depth {
+    if current_depth > args.depth.max {
         return;
     }
     let children: Vec<(&String, &String)> = pkg.dependencies.iter().collect();
@@ -739,6 +777,12 @@ fn json_importer_value(
         serde_json::Value::String(cwd.display().to_string()),
     );
 
+    // `--depth=-1` lists project headers only — emit just name/version/path
+    // and skip the dep maps. Pnpm's JSON output mirrors this shape.
+    if !args.depth.include_direct {
+        return serde_json::Value::Object(importer);
+    }
+
     if !grouped.prod.is_empty() {
         importer.insert(
             "dependencies".to_string(),
@@ -776,7 +820,7 @@ fn build_json_deps(
                 serde_json::Value::String(pkg.version.clone()),
             );
         }
-        if args.depth >= 1
+        if args.depth.includes_transitive()
             && let Some(pkg) = pkg
         {
             let mut visited: BTreeSet<String> = BTreeSet::new();
@@ -802,7 +846,7 @@ fn build_json_subtree(
     visited: &mut BTreeSet<String>,
 ) -> serde_json::Map<String, serde_json::Value> {
     let mut out = serde_json::Map::new();
-    if current_depth > args.depth {
+    if current_depth > args.depth.max {
         return out;
     }
     for (name, version) in &pkg.dependencies {
@@ -851,6 +895,14 @@ fn render_parseable_for_importer(
     filter: DepFilter,
     importer: &str,
 ) -> miette::Result<()> {
+    // `--depth=-1` lists project headers only — skip dep enumeration
+    // entirely so the only thing on stdout is the importer dir line
+    // emitted by the caller. Without this guard, projects with deps
+    // would still print dep records that pnpm suppresses.
+    if !args.depth.include_direct {
+        return Ok(());
+    }
+
     let grouped = group_roots(graph, importer, filter, args.pattern.as_deref());
 
     // Collect roots + transitives (respecting --depth) into a BTreeMap so
@@ -867,8 +919,8 @@ fn render_parseable_for_importer(
                 dep.dep_path.clone(),
                 (pkg.name.clone(), pkg.version.clone()),
             );
-            if args.depth >= 1 {
-                collect_transitive(graph, pkg, args.depth, 1, &mut out);
+            if args.depth.includes_transitive() {
+                collect_transitive(graph, pkg, args.depth.max, 1, &mut out);
             }
         }
     }
@@ -946,7 +998,10 @@ mod tests {
             dev: false,
             prod: false,
             global: false,
-            depth: usize::MAX,
+            depth: Depth {
+                include_direct: true,
+                max: usize::MAX,
+            },
             format: ListFormat::Json,
             json: true,
             long: false,

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -146,27 +146,31 @@ pub async fn run(
         cwd.clone()
     };
 
-    // When a workspace filter is set, evaluate it first so a no-match
-    // case takes the warn-and-exit-0 path before we try to read the
-    // lockfile. pnpm prints "No projects matched the filters in <root>"
-    // on stdout and exits 0 by default; `--fail-if-no-match` promotes
-    // it to an error. In `--parseable` mode no message is printed —
-    // machine consumers expect empty stdout when nothing matches.
-    if !filter.is_empty() {
+    // When a workspace filter is set, resolve workspace + selectors
+    // first so a no-match case takes the warn-and-exit-0 path before
+    // we try to read the lockfile. pnpm prints "No projects matched
+    // the filters in <root>" on stdout and exits 0 by default;
+    // `--fail-if-no-match` promotes it to an error. In `--parseable`
+    // mode no message is printed — machine consumers expect empty
+    // stdout when nothing matches. The result is threaded into
+    // `run_filtered` so we don't re-walk the workspace on the match
+    // path.
+    let selected = if !filter.is_empty() {
         let workspace_pkgs = aube_workspace::find_workspace_packages(&read_from)
             .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
-        let no_match = if workspace_pkgs.is_empty() {
-            true
-        } else {
-            let selected = aube_workspace::selector::select_workspace_packages(
-                &read_from,
-                &workspace_pkgs,
-                &filter,
-            )
-            .map_err(|e| miette!("invalid --filter selector: {e}"))?;
-            selected.is_empty()
-        };
-        if no_match {
+        if workspace_pkgs.is_empty() {
+            return Err(miette!(
+                "aube list: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
+                read_from.display()
+            ));
+        }
+        let selected = aube_workspace::selector::select_workspace_packages(
+            &read_from,
+            &workspace_pkgs,
+            &filter,
+        )
+        .map_err(|e| miette!("invalid --filter selector: {e}"))?;
+        if selected.is_empty() {
             if filter.fail_if_no_match {
                 return Err(miette!(
                     "aube list: filter {:?} did not match any workspace package",
@@ -178,7 +182,10 @@ pub async fn run(
             }
             return Ok(());
         }
-    }
+        Some(selected)
+    } else {
+        None
+    };
 
     // Read manifest (needed even for `list` — we print the project name/version
     // at the top, and the lockfile parser needs it for non-pnpm formats).
@@ -226,14 +233,14 @@ pub async fn run(
         &read_from,
     );
 
-    if !filter.is_empty() {
+    if let Some(selected) = selected {
         return run_filtered(
             &read_from,
             &manifest,
             &graph,
             &args,
             dep_filter,
-            &filter,
+            &selected,
             vstore_max_len,
             &vstore_prefix,
         );
@@ -265,36 +272,10 @@ fn run_filtered(
     graph: &LockfileGraph,
     args: &ListArgs,
     dep_filter: DepFilter,
-    workspace_filter: &aube_workspace::selector::EffectiveFilter,
+    selected: &[aube_workspace::selector::SelectedPackage],
     vstore_max_len: usize,
     vstore_prefix: &str,
 ) -> miette::Result<()> {
-    let workspace_pkgs = aube_workspace::find_workspace_packages(root)
-        .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
-    if workspace_pkgs.is_empty() {
-        return Err(miette!(
-            "aube list: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
-            root.display()
-        ));
-    }
-    let selected = aube_workspace::selector::select_workspace_packages(
-        root,
-        &workspace_pkgs,
-        workspace_filter,
-    )
-    .map_err(|e| miette!("invalid --filter selector: {e}"))?;
-    if selected.is_empty() {
-        if workspace_filter.fail_if_no_match {
-            return Err(miette!(
-                "aube list: filter {workspace_filter:?} did not match any workspace package"
-            ));
-        }
-        if !args.parseable {
-            println!("No projects matched the filters in {}", root.display());
-        }
-        return Ok(());
-    }
-
     let format = if args.json {
         ListFormat::Json
     } else if args.parseable {
@@ -306,7 +287,7 @@ fn run_filtered(
     match format {
         ListFormat::Json => {
             let mut values = Vec::new();
-            for pkg in &selected {
+            for pkg in selected {
                 let importer = super::workspace_importer_path(root, &pkg.dir)?;
                 values.push(json_importer_value(
                     &pkg.dir,
@@ -343,7 +324,7 @@ fn run_filtered(
             }
         }
         ListFormat::Parseable => {
-            for pkg in &selected {
+            for pkg in selected {
                 // Lead with the package's directory so consumers can
                 // find each filtered project on its own line — this is
                 // the pnpm `list --filter … --parseable` shape, and

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -172,9 +172,14 @@ pub async fn run(
         .map_err(|e| miette!("invalid --filter selector: {e}"))?;
         if selected.is_empty() {
             if filter.fail_if_no_match {
+                let shown: Vec<&str> = filter
+                    .filters
+                    .iter()
+                    .chain(filter.filter_prods.iter())
+                    .map(String::as_str)
+                    .collect();
                 return Err(miette!(
-                    "aube list: filter {:?} did not match any workspace package",
-                    filter.filters
+                    "aube list: filter {shown:?} did not match any workspace package"
                 ));
             }
             if !args.parseable {

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -105,9 +105,14 @@ pub struct ListArgs {
 
 /// `--depth=Infinity` is what pnpm/npm accept for "all the way down".
 /// Map it to a very large number so we never actually stop walking.
+/// `-1` is pnpm's spelling for "no transitive deps" and collapses to
+/// the same `0` we already use for top-level only.
 fn parse_depth(s: &str) -> Result<usize, String> {
     if s.eq_ignore_ascii_case("infinity") || s == "inf" {
         return Ok(usize::MAX);
+    }
+    if s == "-1" {
+        return Ok(0);
     }
     s.parse::<usize>()
         .map_err(|e| format!("invalid depth {s:?}: {e}"))
@@ -140,6 +145,40 @@ pub async fn run(
     } else {
         cwd.clone()
     };
+
+    // When a workspace filter is set, evaluate it first so a no-match
+    // case takes the warn-and-exit-0 path before we try to read the
+    // lockfile. pnpm prints "No projects matched the filters in <root>"
+    // on stdout and exits 0 by default; `--fail-if-no-match` promotes
+    // it to an error. In `--parseable` mode no message is printed —
+    // machine consumers expect empty stdout when nothing matches.
+    if !filter.is_empty() {
+        let workspace_pkgs = aube_workspace::find_workspace_packages(&read_from)
+            .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
+        let no_match = if workspace_pkgs.is_empty() {
+            true
+        } else {
+            let selected = aube_workspace::selector::select_workspace_packages(
+                &read_from,
+                &workspace_pkgs,
+                &filter,
+            )
+            .map_err(|e| miette!("invalid --filter selector: {e}"))?;
+            selected.is_empty()
+        };
+        if no_match {
+            if filter.fail_if_no_match {
+                return Err(miette!(
+                    "aube list: filter {:?} did not match any workspace package",
+                    filter.filters
+                ));
+            }
+            if !args.parseable {
+                println!("No projects matched the filters in {}", read_from.display());
+            }
+            return Ok(());
+        }
+    }
 
     // Read manifest (needed even for `list` — we print the project name/version
     // at the top, and the lockfile parser needs it for non-pnpm formats).
@@ -245,9 +284,15 @@ fn run_filtered(
     )
     .map_err(|e| miette!("invalid --filter selector: {e}"))?;
     if selected.is_empty() {
-        return Err(miette!(
-            "aube list: filter {workspace_filter:?} did not match any workspace package"
-        ));
+        if workspace_filter.fail_if_no_match {
+            return Err(miette!(
+                "aube list: filter {workspace_filter:?} did not match any workspace package"
+            ));
+        }
+        if !args.parseable {
+            println!("No projects matched the filters in {}", root.display());
+        }
+        return Ok(());
     }
 
     let format = if args.json {
@@ -299,6 +344,15 @@ fn run_filtered(
         }
         ListFormat::Parseable => {
             for pkg in &selected {
+                // Lead with the package's directory so consumers can
+                // find each filtered project on its own line — this is
+                // the pnpm `list --filter … --parseable` shape, and
+                // works correctly with `--depth=-1` when no deps are
+                // listed. The unfiltered `render_parseable` path keeps
+                // the legacy deps-only format that other tools depend
+                // on (test/list.bats asserts 3-field tab-separated
+                // lines).
+                println!("{}", pkg.dir.display());
                 let importer = super::workspace_importer_path(root, &pkg.dir)?;
                 render_parseable_for_importer(graph, args, dep_filter, &importer)?;
             }

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -1634,6 +1634,7 @@ fn compute_effective_filter(cli: &Cli) -> aube_workspace::selector::EffectiveFil
     aube_workspace::selector::EffectiveFilter {
         filters,
         filter_prods: cli.filter_prod.clone(),
+        fail_if_no_match: cli.fail_if_no_match,
     }
 }
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2864,7 +2864,7 @@
             "name": "depth",
             "usage": "--depth <DEPTH>",
             "help": "How deep to render the transitive tree",
-            "help_long": "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat.",
+            "help_long": "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat. `--depth=-1` (pnpm spelling) lists project headers only — no direct or transitive deps.",
             "help_first_line": "How deep to render the transitive tree",
             "short": [],
             "long": [
@@ -3155,7 +3155,7 @@
             "name": "depth",
             "usage": "--depth <DEPTH>",
             "help": "How deep to render the transitive tree",
-            "help_long": "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat.",
+            "help_long": "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat. `--depth=-1` (pnpm spelling) lists project headers only — no direct or transitive deps.",
             "help_first_line": "How deep to render the transitive tree",
             "short": [],
             "long": [
@@ -3318,7 +3318,7 @@
             "name": "depth",
             "usage": "--depth <DEPTH>",
             "help": "How deep to render the transitive tree",
-            "help_long": "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat.",
+            "help_long": "How deep to render the transitive tree.\n\n`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat. `--depth=-1` (pnpm spelling) lists project headers only — no direct or transitive deps.",
             "help_first_line": "How deep to render the transitive tree",
             "short": [],
             "long": [

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -30,7 +30,7 @@ Show only production dependencies (skip devDependencies)
 
 How deep to render the transitive tree.
 
-`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat.
+`0` (default) shows only the top-level direct deps. Pass `9999` (or any large number) for the full graph; `--depth=Infinity` is accepted for pnpm/npm compat. `--depth=-1` (pnpm spelling) lists project headers only — no direct or transitive deps.
 
 **Default:** `0`
 

--- a/test/PNPM_TEST_IMPORT.md
+++ b/test/PNPM_TEST_IMPORT.md
@@ -42,8 +42,11 @@ Goal: highest install-path parity coverage for lowest cost. Each row is a pnpm s
 
 ## Phase 3 — Tier 2 (workspace + extras, batched)
 
-- [ ] `pnpm/test/monorepo/index.ts` (41 tests, 2026 LOC) — workspace-wide install behavior. Bite off in batches of 10-15:
-  - [ ] batch 1: filter + `--filter` semantics
+- [ ] `pnpm/test/monorepo/index.ts` (41 tests, 2026 LOC) → [test/pnpm_monorepo_index.bats](pnpm_monorepo_index.bats) — workspace-wide install behavior. Bite off in batches of 10-15:
+  - [ ] batch 1: filter + `--filter` semantics (5/~7 ported)
+    - Done: no-projects-matched warn-and-exit-0 (31 — 3 sub-cases: default, `--fail-if-no-match`, `--parseable`-silent), `--filter=...<pkg>` topological run order with intervening unrelated workspace packages (512), `--filter=./packages/**` directory glob (1662 sub-case 2 only).
+    - Aube-side fixes that landed alongside the ports: (1) wired the parsed-but-unread `--fail-if-no-match` global into `EffectiveFilter` and softened `aube list`'s no-match path from hard-error to "No projects matched the filters in <root>" + exit 0 (suppressed under `--parseable`), (2) `--depth=-1` accepted as an alias for `--depth=0` to match pnpm's "no transitives" spelling, (3) `./packages/**` parses as a synonym for `./packages` since aube's path selector is already "at or under" (no separate `legacyDirFiltering` gate), (4) filtered `list --parseable` now leads each importer block with the package directory path so consumers can find each filtered project on its own line — non-filtered `--parseable` keeps the legacy 3-field tab-separated dep records.
+    - Documented divergences (don't port without aube-side fix): no-projects-found on empty workspace (56 — `prepareEmpty()` + `list -r` expects "No projects found in <dir>"; aube errors at `project_root()` because it requires a `package.json` walk-up. A workspace-yaml-only-root case is on the same fault line — touch list, run, install, query, why all together when this lands.), `--filter=./packages` exact-directory match (1662 sub-case 1 — pnpm v9 default treats `./packages` as exact-match-no-descendants gated on `legacyDirFiltering=false`. aube's path selector is "at or under" by design so `./packages` matches descendants. **Not implementing `legacyDirFiltering`** — aube's behavior is the more useful default.).
   - [ ] batch 2: workspace: protocol edge cases
   - [ ] batch 3: shared-workspace-lockfile behavior
   - [ ] batch 4: dedupePeers across workspace
@@ -67,6 +70,7 @@ These test pnpm-specific behavior aube doesn't replicate:
 - `pnpm/test/install/nodeRuntime.ts` — pnpm `node` runtime feature
 - `pnpm/test/install/runtimeOnFail.ts` — pnpm `node` runtime feature
 - `pnpm/test/syncInjectedDepsAfterScripts*.ts` — `injected: true` (aube doesn't ship this)
+- `pnpm/test/monorepo/index.ts:1633` ('legacy directory filtering') and the `legacyDirFiltering: true` workspace setting — aube's path selector is already "at or under" by design (`./packages` matches descendants), so the pnpm v9 split between exact-match (default) and recursive-match (`legacyDirFiltering=true`) doesn't apply. We are not implementing `legacyDirFiltering`.
 
 ## Conventions for translations
 

--- a/test/pnpm_monorepo_index.bats
+++ b/test/pnpm_monorepo_index.bats
@@ -167,8 +167,11 @@ _setup_no_match_workspace() {
 # `./packages/**` sub-case ports cleanly.
 @test "aube list --filter=./packages/**: matches every package under the directory" {
 	# Ported from pnpm/test/monorepo/index.ts:1662 (sub-case 2).
-	# `--depth=-1` is pnpm's spelling for "no transitive deps"; aube
-	# accepts it as an alias for `--depth=0`.
+	# `--depth=-1` is pnpm's spelling for "list project headers only,
+	# no deps". project-1 has a real dep (is-odd) so this also locks
+	# the contract that `--depth=-1` skips dep enumeration even when
+	# the importer has deps to enumerate — the no-deps semantics is
+	# distinct from `--depth=0` (which prints direct deps).
 	cat >package.json <<-'EOF'
 		{"name": "root", "version": "0.0.0", "private": true}
 	EOF
@@ -179,7 +182,11 @@ _setup_no_match_workspace() {
 	EOF
 	mkdir -p packages/project-1 packages/project-2
 	cat >packages/project-1/package.json <<-'EOF'
-		{"name": "project-1", "version": "1.0.0"}
+		{
+		  "name": "project-1",
+		  "version": "1.0.0",
+		  "dependencies": {"is-odd": "^3.0.1"}
+		}
 	EOF
 	cat >packages/project-2/package.json <<-'EOF'
 		{"name": "project-2", "version": "1.0.0"}
@@ -197,4 +204,14 @@ _setup_no_match_workspace() {
 	# its own line ending with the package directory.
 	assert_line --regexp '/packages/project-1$'
 	assert_line --regexp '/packages/project-2$'
+	# `--depth=-1` must NOT emit any dep records (project-1 owns
+	# is-odd as a direct dep — make sure it doesn't leak).
+	refute_output --partial "is-odd"
+
+	# Sanity: with `--depth=0` (direct deps only) the same fixture
+	# does emit project-1's direct dep, so the suppression above is
+	# specific to `-1`, not a side effect of the filter.
+	run aube list --filter='./packages/**' --parseable --depth=0
+	assert_success
+	assert_output --partial "is-odd"
 }

--- a/test/pnpm_monorepo_index.bats
+++ b/test/pnpm_monorepo_index.bats
@@ -1,0 +1,175 @@
+#!/usr/bin/env bats
+#
+# Ported from pnpm/test/monorepo/index.ts.
+# See test/PNPM_TEST_IMPORT.md for translation conventions.
+#
+# This file covers Phase 3 batch 1 — filter + `--filter` semantics for
+# workspace commands. pnpm's monorepo suite is large (41 tests, 2026
+# LOC); the batches in PNPM_TEST_IMPORT.md slice it by topic.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+# pnpm's `preparePackages` creates each package as a sibling subdir
+# without writing a root package.json. aube requires a root manifest at
+# the workspace root, so all of these fixtures add a private root
+# package.json — matching the conventional aube workspace shape and
+# keeping the tests focused on filter behavior, not manifest discovery.
+
+_setup_no_match_workspace() {
+	cat >package.json <<-'EOF'
+		{"name": "root", "version": "0.0.0", "private": true}
+	EOF
+	cat >pnpm-workspace.yaml <<-EOF
+		packages:
+		  - "**"
+		  - "!store/**"
+	EOF
+	mkdir project
+	cat >project/package.json <<-'EOF'
+		{"name": "project", "version": "1.0.0"}
+	EOF
+}
+
+@test "aube list --filter=<no-match>: warns to stdout and exits 0" {
+	# Ported from pnpm/test/monorepo/index.ts:31 ('no projects matched the filters').
+	_setup_no_match_workspace
+
+	run aube list --filter=not-exists
+	assert_success
+	assert_output --partial "No projects matched the filters in"
+}
+
+@test "aube list --filter=<no-match> --fail-if-no-match: exits 1" {
+	# Ported from pnpm/test/monorepo/index.ts:31 (sub-case 2).
+	_setup_no_match_workspace
+
+	run aube list --filter=not-exists --fail-if-no-match
+	assert_failure
+	assert_output --partial "did not match"
+}
+
+@test "aube list --filter=<no-match> --parseable: silent stdout, exits 0" {
+	# Ported from pnpm/test/monorepo/index.ts:31 (sub-case 3). Machine
+	# consumers expect empty stdout on no-match — the warning is
+	# suppressed when --parseable is requested.
+	_setup_no_match_workspace
+
+	run aube list --filter=not-exists --parseable
+	assert_success
+	assert_output ""
+}
+
+@test "aube --filter=...<pkg> run: dependents run after the seed (topological order)" {
+	# Ported from pnpm/test/monorepo/index.ts:512
+	# ('do not get confused by filtered dependencies when searching for
+	# dependents in monorepo'). The scenario: project-2 is filtered with
+	# `...project-2` so dependents (project-3, project-4) join the run,
+	# but two unrelated workspace packages (unused-project-{1,2}) sit in
+	# project-2's dep list and shouldn't perturb the dependent search.
+	# Topological order requires project-2 to run BEFORE project-3 and
+	# project-4 — they depend on it.
+	cat >package.json <<-'EOF'
+		{"name": "root", "version": "0.0.0", "private": true}
+	EOF
+	cat >pnpm-workspace.yaml <<-EOF
+		packages:
+		  - "**"
+		  - "!store/**"
+		linkWorkspacePackages: true
+	EOF
+	mkdir unused-project-1 unused-project-2 project-2 project-3 project-4
+	cat >unused-project-1/package.json <<-'EOF'
+		{"name": "unused-project-1", "version": "1.0.0"}
+	EOF
+	cat >unused-project-2/package.json <<-'EOF'
+		{"name": "unused-project-2", "version": "1.0.0"}
+	EOF
+	cat >project-2/package.json <<-'EOF'
+		{
+		  "name": "project-2",
+		  "version": "1.0.0",
+		  "dependencies": {"unused-project-1": "1.0.0", "unused-project-2": "1.0.0"},
+		  "scripts": {"test": "node -e \"process.stdout.write('printed by project-2')\""}
+		}
+	EOF
+	cat >project-3/package.json <<-'EOF'
+		{
+		  "name": "project-3",
+		  "version": "1.0.0",
+		  "dependencies": {"project-2": "1.0.0"},
+		  "scripts": {"test": "node -e \"process.stdout.write('printed by project-3')\""}
+		}
+	EOF
+	cat >project-4/package.json <<-'EOF'
+		{
+		  "name": "project-4",
+		  "version": "1.0.0",
+		  "dependencies": {"project-2": "1.0.0", "unused-project-1": "1.0.0", "unused-project-2": "1.0.0"},
+		  "scripts": {"test": "node -e \"process.stdout.write('printed by project-4')\""}
+		}
+	EOF
+
+	cd project-2
+	run aube --filter='...project-2' run test
+	assert_success
+	assert_output --partial "printed by project-2"
+	assert_output --partial "printed by project-3"
+	assert_output --partial "printed by project-4"
+
+	# Topological order: project-2 (the seed) before its dependents.
+	# Flatten the captured output so newlines in install banners don't
+	# break the substring search.
+	local flat="${output//$'\n'/ }"
+	local p2_idx="${flat%%printed by project-2*}"
+	local p3_idx="${flat%%printed by project-3*}"
+	local p4_idx="${flat%%printed by project-4*}"
+	[ "${#p2_idx}" -lt "${#p3_idx}" ]
+	[ "${#p2_idx}" -lt "${#p4_idx}" ]
+}
+
+# pnpm's "directory filtering" test (monorepo/index.ts:1662) covers two
+# sub-cases. Sub-case 1 (`--filter=./packages` matches nothing) is an
+# aube divergence: aube's path selector is "at or under", so
+# `./packages` already matches packages nested below it. pnpm v9
+# changed this to require the explicit `/**` recursive glob, gated on a
+# `legacyDirFiltering` workspace setting. aube does not implement that
+# setting (see test/PNPM_TEST_IMPORT.md "Explicitly skipped"). Only the
+# `./packages/**` sub-case ports cleanly.
+@test "aube list --filter=./packages/**: matches every package under the directory" {
+	# Ported from pnpm/test/monorepo/index.ts:1662 (sub-case 2).
+	# `--depth=-1` is pnpm's spelling for "no transitive deps"; aube
+	# accepts it as an alias for `--depth=0`.
+	cat >package.json <<-'EOF'
+		{"name": "root", "version": "0.0.0", "private": true}
+	EOF
+	cat >pnpm-workspace.yaml <<-EOF
+		packages:
+		  - "**"
+		  - "!store/**"
+	EOF
+	mkdir -p packages/project-1 packages/project-2
+	cat >packages/project-1/package.json <<-'EOF'
+		{"name": "project-1", "version": "1.0.0"}
+	EOF
+	cat >packages/project-2/package.json <<-'EOF'
+		{"name": "project-2", "version": "1.0.0"}
+	EOF
+
+	# Populate the lockfile so `list --parseable` has something to walk.
+	run aube install
+	assert_success
+
+	run aube list --filter='./packages/**' --parseable --depth=-1
+	assert_success
+	assert_output --partial "project-1"
+	assert_output --partial "project-2"
+}

--- a/test/pnpm_monorepo_index.bats
+++ b/test/pnpm_monorepo_index.bats
@@ -68,6 +68,27 @@ _setup_no_match_workspace() {
 	assert_output ""
 }
 
+@test "aube list --filter=<no-match>: --format parseable / --format json suppress the warning" {
+	# Regression: the no-match suppression must check the resolved
+	# output format, not just the `--parseable` / `--json` shortcuts.
+	# `--format parseable` and `--format json` carry the same
+	# machine-readable contract — printing the human "No projects
+	# matched..." message would corrupt downstream parsers.
+	_setup_no_match_workspace
+
+	run aube list --filter=not-exists --format parseable
+	assert_success
+	assert_output ""
+
+	run aube list --filter=not-exists --format json
+	assert_success
+	assert_output ""
+
+	run aube list --filter=not-exists --json
+	assert_success
+	assert_output ""
+}
+
 @test "aube --filter=...<pkg> run: dependents run after the seed (topological order)" {
 	# Ported from pnpm/test/monorepo/index.ts:512
 	# ('do not get confused by filtered dependencies when searching for
@@ -170,6 +191,10 @@ _setup_no_match_workspace() {
 
 	run aube list --filter='./packages/**' --parseable --depth=-1
 	assert_success
-	assert_output --partial "project-1"
-	assert_output --partial "project-2"
+	# Filtered `--parseable` leads each importer with its absolute
+	# directory path (matches the help-text contract in list.rs and
+	# pnpm's `list --filter=… --parseable` shape). Each project gets
+	# its own line ending with the package directory.
+	assert_line --regexp '/packages/project-1$'
+	assert_line --regexp '/packages/project-2$'
 }


### PR DESCRIPTION
## Summary

Phase 3 batch 1 of the pnpm test import — the first 5 filter-semantics
tests from [`pnpm/test/monorepo/index.ts`](https://github.com/pnpm/pnpm/blob/main/pnpm/test/monorepo/index.ts) translated into a new
[`test/pnpm_monorepo_index.bats`](https://github.com/endevco/aube/blob/main/test/pnpm_monorepo_index.bats), plus the small aube-side fixes the ports surfaced.

**Tests ported**

| pnpm source | aube target |
|---|---|
| `monorepo/index.ts:31` (3 sub-cases — default, `--fail-if-no-match`, `--parseable`) | "no projects matched the filters" warn-and-exit-0 |
| `monorepo/index.ts:512` | `--filter=...<pkg>` topological run order with intervening unrelated workspace pkgs |
| `monorepo/index.ts:1662` (sub-case 2) | `--filter=./packages/**` directory glob |

## Aube-side fixes

- **Wire `--fail-if-no-match`** — the global flag was parsed at [`crates/aube/src/main.rs:217`](https://github.com/endevco/aube/blob/main/crates/aube/src/main.rs#L217) but never read. Added `fail_if_no_match: bool` to `EffectiveFilter` and softened `aube list`'s no-match path from a hard error to `"No projects matched the filters in <root>"` + exit 0 (suppressed under `--parseable`; hard-errors only with `--fail-if-no-match`).
- **`--depth=-1` accepted** as an alias for `--depth=0` to match pnpm's "no transitives" spelling.
- **`./packages/**` parses as a synonym for `./packages`** — aube's path selector is "at or under" by design, so the pnpm v9 exact-vs-recursive split (gated on `legacyDirFiltering`) doesn't apply. Explicitly skipped per [`PNPM_TEST_IMPORT.md`](https://github.com/endevco/aube/blob/main/test/PNPM_TEST_IMPORT.md) — aube's default is the more useful one.
- **Filtered `list --parseable`** now leads each importer block with the package directory path so consumers can find each filtered project on its own line. Non-filtered `--parseable` keeps the legacy 3-field tab-separated dep records (asserted by `test/list.bats:171`).

## Documented divergences (not fixed here)

- `monorepo/index.ts:56` ("no projects found" on `prepareEmpty()` + `list -r`) — needs broader `project_root()` tolerance (workspace-yaml-only or no-manifest root). On the same fault line as `list`/`run`/`install`/`query`/`why` — touch them together when this lands.
- `monorepo/index.ts:1662` sub-case 1 (`./packages` matches nothing) — pnpm v9 default is exact-directory match gated on `legacyDirFiltering=false`; aube doesn't implement `legacyDirFiltering` and treats `./packages` as "at or under".

## Test plan

- [x] `cargo build`, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` — all green
- [x] `mise run test:bats test/pnpm_monorepo_index.bats` — 5/5 pass
- [x] `mise run test:bats test/filter.bats test/list.bats` — 43/43 pass (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace selector parsing and `aube list` output/exit-code behavior under filtering, which can affect CI scripts and machine parsers relying on prior semantics.
> 
> **Overview**
> Aligns workspace filtering behavior with pnpm for parity and CI use by threading the global `--fail-if-no-match` flag through `EffectiveFilter` and updating `aube list --filter` to **warn+exit 0 on no matches** by default (optionally hard-failing with `--fail-if-no-match`) while suppressing the warning for machine formats.
> 
> Updates `aube list`’s `--depth` handling by introducing a `Depth` type so `--depth=-1` can list project headers only (no deps) across default/JSON/parseable outputs, and adjusts filtered `--parseable` output to print each selected project directory before any dep records.
> 
> Extends selector parsing so pnpm’s `./packages/**` directory form is accepted as a path selector synonym (without reinterpreting name globs like `@scope/**`), and adds new bats coverage via `test/pnpm_monorepo_index.bats` plus updates to `test/PNPM_TEST_IMPORT.md` to track the ported pnpm monorepo filter tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c65964ca1bfe56491ed21981d03815c61349fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->