### PR TITLE
fix(ci): unblock v1.6.0 release publishing path

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -30,7 +30,10 @@ env:
 
 jobs:
   publish-ppa:
-    runs-on: namespace-profile-endev-linux-amd64
+    # github-hosted runner: namespace runners block outbound FTP (port 21)
+    # to ppa.launchpad.net, which is what dput needs to upload the source
+    # package. Ubuntu-hosted runners allow it.
+    runs-on: ubuntu-latest
     environment: ppa-publishing
     timeout-minutes: 45
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,7 +30,11 @@ concurrency:
 jobs:
   publish:
     name: Publish to npm
-    runs-on: namespace-profile-endev-linux-amd64
+    # github-hosted runner: npm Trusted Publishing (--provenance) rejects
+    # self-hosted runner identities ("Unsupported GitHub Actions runner
+    # environment: self-hosted"). The publish job is light enough that
+    # the namespace runner saves nothing.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       # Required for npm Trusted Publishing (OIDC). GitHub mints a

--- a/crates/aube-resolver/build.rs
+++ b/crates/aube-resolver/build.rs
@@ -43,15 +43,19 @@ fn main() {
             .parent()
             .and_then(Path::parent)
             .map(|w| w.join("scripts/generate-primer.mjs"));
-        match script {
-            Some(s) if s.is_file() => generate(&manifest_dir, &source, primer_top()),
-            _ => {
-                // Published crate (or downstream consumer without the workspace
-                // generator script) and no primer data file: ship an empty
-                // primer. Runtime falls back to network packument fetches.
-                write_package_blob(&out_dir, &[]);
-                return;
-            }
+        let generated = matches!(&script, Some(s) if s.is_file())
+            && generate(&manifest_dir, &source, primer_top());
+        if !generated {
+            // No primer data file and no working generator. Three cases:
+            //   1. published crate / downstream consumer (no script),
+            //   2. cross-rs Docker container building Linux release
+            //      binaries (script visible via mount, but no `node`),
+            //   3. Fedora COPR mock chroot building the SRPM (script in
+            //      tarball, but no `node`).
+            // Ship an empty primer; runtime falls back to network packument
+            // fetches.
+            write_package_blob(&out_dir, &[]);
+            return;
         }
     }
 
@@ -85,7 +89,7 @@ fn primer_top() -> usize {
     }
 }
 
-fn generate(manifest_dir: &Path, source: &Path, top: usize) {
+fn generate(manifest_dir: &Path, source: &Path, top: usize) -> bool {
     let workspace = manifest_dir
         .parent()
         .and_then(Path::parent)
@@ -93,7 +97,7 @@ fn generate(manifest_dir: &Path, source: &Path, top: usize) {
     let json = source.with_extension("json");
     std::fs::create_dir_all(source.parent().unwrap()).unwrap();
 
-    let status = Command::new("node")
+    let status = match Command::new("node")
         .arg(workspace.join("scripts/generate-primer.mjs"))
         .arg("--top")
         .arg(top.to_string())
@@ -102,7 +106,17 @@ fn generate(manifest_dir: &Path, source: &Path, top: usize) {
         .arg("--out")
         .arg(&json)
         .status()
-        .expect("failed to run scripts/generate-primer.mjs");
+    {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            println!(
+                "cargo:warning=node not found in PATH; shipping empty primer \
+                 (runtime falls back to network packument fetches)"
+            );
+            return false;
+        }
+        Err(e) => panic!("failed to run scripts/generate-primer.mjs: {e}"),
+    };
     assert!(status.success(), "scripts/generate-primer.mjs failed");
 
     let input = std::fs::read(&json).unwrap();
@@ -112,6 +126,7 @@ fn generate(manifest_dir: &Path, source: &Path, top: usize) {
         zstd::stream::encode_all(Cursor::new(archived), primer_compression_level()).unwrap();
     std::fs::write(source, compressed).unwrap();
     let _ = std::fs::remove_file(json);
+    true
 }
 
 fn write_package_blob(out_dir: &Path, compressed: &[u8]) {


### PR DESCRIPTION
## Summary

The v1.6.0 release shipped to GitHub but only with darwin-arm64 and the two windows tarballs — all four Linux targets failed to upload, and the downstream npm/COPR/PPA publish jobs all failed too. Fixes the three independent root causes:

- **`crates/aube-resolver/build.rs`** panics via `.expect()` when `node` is absent. The cross-rs Docker container that builds Linux release binaries and the Fedora COPR mock chroot that builds the SRPM both have `scripts/generate-primer.mjs` visible (mounted / bundled in the source tarball) but no `node` binary, so the existing "no script → empty primer" fallback (#425) doesn't trigger. Fall back on `ErrorKind::NotFound` from `Command::status()` so the same empty-primer path covers all three "no node" environments. Verified locally with `env -i` + a node-less PATH: emits `cargo:warning=node not found in PATH; shipping empty primer` and builds clean.
- **`publish-npm`** fails with `Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.` Move the job from the namespace runner to `ubuntu-latest`. Trusted Publishing requires a github-hosted OIDC identity; the publish job is otherwise light enough that the namespace runner saves nothing.
- **`ppa-publish`** fails at `dput` with `Connection failed, aborting. Check your network` — namespace runners block outbound FTP (port 21) to `ppa.launchpad.net`. Move to `ubuntu-latest` which allows it.

After merge, re-run the failed jobs against `v1.6.0` to backfill the missing Linux assets and complete the npm/COPR/PPA publishes.

## Test plan

- [x] `cargo build -p aube-resolver` from a node-less PATH falls back to the empty primer with the new `cargo:warning=`
- [x] `cargo build -p aube-resolver` with node present still generates the primer and builds normally
- [x] `cargo clippy -p aube-resolver --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Re-run release-plz upload-assets for `v1.6.0` after merge → confirm Linux tarballs land on the GH release
- [ ] Re-run `publish-npm` for `v1.6.0` → confirm `@endevco/aube*` lands on npmjs.com with provenance
- [ ] Re-run `copr-publish` for `v1.6.0` → confirm Fedora 42/43/44/rawhide builds succeed
- [ ] Re-run `ppa-publish` for `v1.6.0` → confirm dput uploads the source package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes release/publishing CI runners and alters `aube-resolver` build-time primer generation behavior (now falling back to an empty primer when `node` is unavailable), which could affect release packaging and runtime performance if mis-triggered.
> 
> **Overview**
> Unblocks release publishing by switching the `publish-npm` and `ppa-publish` GitHub Actions jobs from the self-hosted namespace runner to `ubuntu-latest` to satisfy npm Trusted Publishing provenance requirements and allow outbound FTP for Launchpad `dput` uploads.
> 
> Makes `crates/aube-resolver/build.rs` resilient to environments where the primer generator script exists but `node` is not installed: `generate()` now returns a boolean and treats `ErrorKind::NotFound` as a non-fatal condition (emitting a `cargo:warning=`) so builds fall back to shipping an empty primer instead of panicking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa90723bfb769c3b7d79ce6367214fa82d45a29e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->