### PR TITLE
fix(ci): retry transient registry fetches in primer generator

### DIFF
--- a/scripts/generate-primer.mjs
+++ b/scripts/generate-primer.mjs
@@ -47,7 +47,7 @@ console.error(`wrote ${Object.keys(primer).length} packages to ${out}`)
 
 async function packumentSeed(name, keepVersions) {
   const url = `https://registry.npmjs.org/${encodePackageName(name)}`
-  const res = await fetch(url, {
+  const res = await fetchWithRetry(url, {
     headers: { accept: 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*' },
   })
   if (!res.ok) {
@@ -183,9 +183,31 @@ function hasProvenance(attestations) {
 }
 
 async function fetchPopularNames(url) {
-  const res = await fetch(url)
+  const res = await fetchWithRetry(url)
   if (!res.ok) throw new Error(`${url}: HTTP ${res.status}`)
   return parseNames(await res.text(), url)
+}
+
+// Wrap fetch to retry transient failures: socket resets / TLS hangups
+// from npmjs.com hit a single uncached fetch hard during long primer
+// runs (786 of 2000 packages got us a SocketError once already). Also
+// retry 5xx and 429. 4xx other than 429 are permanent — propagate.
+async function fetchWithRetry(url, init, attempts = 5) {
+  let delay = 1000
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      const res = await fetch(url, init)
+      if (res.ok || (res.status >= 400 && res.status < 500 && res.status !== 429)) return res
+      if (i === attempts) return res
+      console.error(`  retry ${i}/${attempts - 1}: HTTP ${res.status}`)
+    } catch (err) {
+      if (i === attempts) throw err
+      console.error(`  retry ${i}/${attempts - 1}: ${err.cause?.code ?? err.code ?? err.message}`)
+    }
+    await new Promise((r) => setTimeout(r, delay))
+    delay *= 2
+  }
+  throw new Error('unreachable')
 }
 
 function parseNames(text, source) {


### PR DESCRIPTION
## Summary

The v1.6.1 release-plz macOS upload-assets job (https://github.com/endevco/aube/actions/runs/25232551216/job/73991667575) failed mid-primer-generation when a single `fetch(registry.npmjs.org/<pkg>)` hit a TLS socket close at package 786/2000:

```
[TypeError: fetch failed] {
  [cause]: SocketError: other side closed
  ...
  code: 'UND_ERR_SOCKET',
}
```

The script had no retry, so a transient blip during a 2000-package run crashed the whole release. Wrap fetch with up-to-5-attempt exponential backoff (1s/2s/4s/8s) that retries network errors, 5xx, and 429, and propagates other 4xx as terminal.

Linux upload-assets jobs in the same run already pass via the empty-primer fallback from #460 — only macOS (which has node and runs the script for real) was hitting the transient blip. Windows builds will benefit from the same retry.

After merge, re-run the failed `Upload assets / upload-assets (aarch64-apple-darwin, ...)` job for v1.6.1 to backfill the macOS tarball.

## Test plan

- [x] `node --check scripts/generate-primer.mjs` clean
- [x] Smoke-test the retry helper with stubbed `fetch` that throws `UND_ERR_SOCKET` twice — third attempt returns 200, retries logged
- [ ] Re-run the v1.6.1 macOS upload-assets job after merge → confirm the primer generates and the tarball lands on the GH release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the `scripts/generate-primer.mjs` fetch behavior by adding retries/backoff for transient network/HTTP failures, which may slightly increase run time but should reduce flaky CI failures.
> 
> **Overview**
> Improves primer generation robustness by wrapping registry/name-list `fetch` calls in a new `fetchWithRetry` helper with exponential backoff.
> 
> The script now retries transient network errors plus HTTP `5xx` and `429`, while treating other `4xx` responses as terminal and preserving existing failure/skip behavior when the final attempt still fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637800f0696748eaaf8870da16b487e13a021e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->