### PR TITLE
ci: bump release upload-assets timeout to 60 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   upload-assets:
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Windows release builds consistently land 25-28 min against the 30-min cap (v1.6.0: 25m43s / 27m11s; v1.6.1 just timed out at 30m on aarch64-pc-windows-msvc). Bump every upload-assets target to 60 min so runner variance doesn't tip releases over.

## Test plan

- [ ] Re-run `release.yml` for v1.6.1 with `tag: v1.6.1` after merge → confirm Windows tarballs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that just allows more time for release build/upload jobs; no product code or security logic is modified.
> 
> **Overview**
> Increases the GitHub Actions `release.yml` `upload-assets` job timeout from **30** to **60 minutes** to reduce release failures from long/variable build times (notably on Windows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daf6cbdc93cc6a249b4f030c58bc320aa1e0f855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->