### PR TITLE
ci: don't publish release if any upload-assets target failed

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -122,14 +122,20 @@ jobs:
       tag: ${{ needs.release-plz-release.outputs.tag }}
     secrets: inherit
 
-  # Flip the draft release to non-draft once assets are uploaded.
-  # `always()` means we still publish the release even if one target
-  # in the upload matrix failed — a partial-asset release is better
-  # than a permanent draft once crates.io has already been updated.
+  # Flip the draft release to non-draft once *every* asset uploaded
+  # cleanly. With immutable GitHub releases enabled, a published
+  # release can't have its assets replaced — so if any matrix target
+  # failed, we leave the draft in place rather than ship a release
+  # with missing platform binaries (downstream npm / COPR / PPA jobs
+  # would also fail trying to fetch the holes). To recover: manually
+  # re-run `release.yml` via workflow_dispatch with the tag input,
+  # which fills in the missing assets, then either flip the draft by
+  # hand (`gh release edit $TAG --draft=false`) or workflow_dispatch
+  # the whole release-plz workflow again so this job runs.
   publish-release:
     name: Publish release
     needs: [release-plz-release, upload-assets]
-    if: ${{ always() && needs.release-plz-release.outputs.tag != '' && needs.release-plz-release.result == 'success' }}
+    if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

GitHub immutable releases are enabled — a published release's assets can't be replaced after the fact. The previous `always()` gate on `publish-release` would flip the draft to non-draft even if one platform tarball was missing, leaving the downstream npm / COPR / PPA jobs (triggered by the `release: published` event) to fail fetching holes. Once published with missing assets, the only fix is to bump the version and re-cut the whole release.

This PR drops `always()` so `publish-release` skips when any matrix target in `upload-assets` fails. Without `always()`, the default GitHub Actions semantic is "skip if any needed job didn't succeed", which is exactly what we want here. `enhance-release` (which `needs: publish-release`) skips transitively, so a half-built release also doesn't get communique-ed notes attached to it.

## Recovery flow when this kicks in

1. The draft release stays in place with whatever tarballs did upload.
2. Re-run `release.yml` via workflow_dispatch with `tag: vX.Y.Z` to fill the missing assets onto the existing draft.
3. Either flip the draft by hand: `gh release edit vX.Y.Z --draft=false` (which fires `release: published` and triggers the downstream publishers), or workflow_dispatch `release-plz.yml` again so `publish-release` runs.

## Test plan

- [x] `actionlint` clean
- [ ] On the next release: confirm the workflow proceeds normally when all targets succeed
- [ ] On a forced upload-assets failure (e.g. via a one-target injected error in a test branch): confirm `publish-release` is skipped and the draft remains a draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation gating so a GitHub release will no longer be published if any `upload-assets` matrix target fails, which could delay releases if the dependency chain or job conditions are misconfigured.
> 
> **Overview**
> Prevents `publish-release` in `release-plz.yml` from flipping a draft GitHub release to published unless the `upload-assets` job succeeds, avoiding immutable published releases with missing binaries.
> 
> Updates the workflow documentation to explain why partial uploads must keep the release in draft and outlines the manual recovery flow (re-run `release.yml` for the tag, then publish).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cced3d894d395aedf45c515aee7e3c009324a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->