### PR TITLE
chore: release v1.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "aube-util",
  "miette",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "aube-manifest",
  "landlock",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "aube-util",
  "base64",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "blake3",
  "rustc-hash",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.6.1"
+version = "1.6.2"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -122,14 +122,14 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.6.1" }
-aube-settings = { path = "crates/aube-settings", version = "1.6.1" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.6.1" }
-aube-registry = { path = "crates/aube-registry", version = "1.6.1" }
-aube-store = { path = "crates/aube-store", version = "1.6.1" }
-aube-linker = { path = "crates/aube-linker", version = "1.6.1" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.6.1" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.6.1" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.6.1" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.6.1" }
-aube-util = { path = "crates/aube-util", version = "1.6.1" }
+aube = { path = "crates/aube", version = "1.6.2" }
+aube-settings = { path = "crates/aube-settings", version = "1.6.2" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.6.2" }
+aube-registry = { path = "crates/aube-registry", version = "1.6.2" }
+aube-store = { path = "crates/aube-store", version = "1.6.2" }
+aube-linker = { path = "crates/aube-linker", version = "1.6.2" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.6.2" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.6.2" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.6.2" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.6.2" }
+aube-util = { path = "crates/aube-util", version = "1.6.2" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.6.1"
+version "1.6.2"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2](https://github.com/endevco/aube/compare/aube-resolver-v1.6.1...aube-resolver-v1.6.2) - 2026-05-01
+
+### Added
+
+- *(cli)* check engines.{aube,pnpm} and workspace per-project engines ([#458](https://github.com/endevco/aube/pull/458))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/aube-resolver-v1.6.0...aube-resolver-v1.6.1) - 2026-05-01
 
 ### Fixed

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2](https://github.com/endevco/aube/compare/v1.6.1...v1.6.2) - 2026-05-01
+
+### Added
+
+- *(cli)* check engines.{aube,pnpm} and workspace per-project engines ([#458](https://github.com/endevco/aube/pull/458))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/v1.6.0...v1.6.1) - 2026-05-01
 
 ### Other

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6368,7 +6368,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.6.1",
+  "version": "1.6.2",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.6.1
+**Version**: 1.6.2
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.6.1",
-  "releasedAt": "2026-05-01T20:42:14Z"
+  "version": "1.6.2",
+  "releasedAt": "2026-05-01T22:10:07Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.6.2`

This PR bumps the workspace to `v1.6.2` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and `release.json`.

**Manually pinned to 1.6.2** (overriding release-plz's natural `feat:`-driven 1.7.0 minor bump). Merge ASAP — any new push to main will retrigger `release-plz-pr` which will recompute 1.7.0 and force-push this branch.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow, manually retargeted to v1.6.2.