### PR TITLE
chore: release v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "aube-lockfile",
  "aube-store",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "aube-util",
  "miette",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "aube-manifest",
  "aube-settings",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "aube-lockfile",
  "aube-manifest",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "aube-manifest",
  "landlock",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "blake3",
  "reflink-copy",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "aube-manifest",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.6.2"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -122,14 +122,14 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.6.2" }
-aube-settings = { path = "crates/aube-settings", version = "1.6.2" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.6.2" }
-aube-registry = { path = "crates/aube-registry", version = "1.6.2" }
-aube-store = { path = "crates/aube-store", version = "1.6.2" }
-aube-linker = { path = "crates/aube-linker", version = "1.6.2" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.6.2" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.6.2" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.6.2" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.6.2" }
-aube-util = { path = "crates/aube-util", version = "1.6.2" }
+aube = { path = "crates/aube", version = "1.7.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.7.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.7.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.7.0" }
+aube-store = { path = "crates/aube-store", version = "1.7.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.7.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.7.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.7.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.7.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.7.0" }
+aube-util = { path = "crates/aube-util", version = "1.7.0" }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.6.2"
+version "1.7.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/aube-linker-v1.6.2...aube-linker-v1.7.0) - 2026-05-03
+
+### Fixed
+
+- *(resolver)* resolve nested link:/file: deps from local parents and overrides ([#470](https://github.com/endevco/aube/pull/470))
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- streaming sha512, parallel cas, tls prewarm, fetch reorder ([#469](https://github.com/endevco/aube/pull/469))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/aube-linker-v1.6.0...aube-linker-v1.6.1) - 2026-05-01
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.6.2...aube-lockfile-v1.7.0) - 2026-05-03
+
+### Fixed
+
+- *(lockfile)* parse bare user/repo as github shorthand ([#472](https://github.com/endevco/aube/pull/472))
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/aube-lockfile-v1.6.0...aube-lockfile-v1.6.1) - 2026-05-01
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/aube-manifest-v1.6.2...aube-manifest-v1.7.0) - 2026-05-03
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/aube-manifest-v1.6.0...aube-manifest-v1.6.1) - 2026-05-01
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/aube-registry-v1.6.2...aube-registry-v1.7.0) - 2026-05-03
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- streaming sha512, parallel cas, tls prewarm, fetch reorder ([#469](https://github.com/endevco/aube/pull/469))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/aube-registry-v1.6.0...aube-registry-v1.6.1) - 2026-05-01
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/aube-resolver-v1.6.2...aube-resolver-v1.7.0) - 2026-05-03
+
+### Fixed
+
+- *(resolver)* resolve nested link:/file: deps from local parents and overrides ([#470](https://github.com/endevco/aube/pull/470))
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.2](https://github.com/endevco/aube/compare/aube-resolver-v1.6.1...aube-resolver-v1.6.2) - 2026-05-01
 
 ### Added

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/aube-scripts-v1.6.2...aube-scripts-v1.7.0) - 2026-05-03
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- streaming sha512, parallel cas, tls prewarm, fetch reorder ([#469](https://github.com/endevco/aube/pull/469))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/aube-scripts-v1.6.0...aube-scripts-v1.6.1) - 2026-05-01
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/aube-settings-v1.6.2...aube-settings-v1.7.0) - 2026-05-03
+
+### Added
+
+- *(cli)* rewrite manifest specifier on update without --latest ([#479](https://github.com/endevco/aube/pull/479))
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/aube-settings-v1.6.0...aube-settings-v1.6.1) - 2026-05-01
 
 ### Other

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/aube-store-v1.6.2...aube-store-v1.7.0) - 2026-05-03
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- streaming sha512, parallel cas, tls prewarm, fetch reorder ([#469](https://github.com/endevco/aube/pull/469))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/aube-store-v1.6.0...aube-store-v1.6.1) - 2026-05-01
 
 ### Other

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/aube-util-v1.6.2...aube-util-v1.7.0) - 2026-05-03
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- streaming sha512, parallel cas, tls prewarm, fetch reorder ([#469](https://github.com/endevco/aube/pull/469))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/aube-util-v1.6.0...aube-util-v1.6.1) - 2026-05-01
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/aube-workspace-v1.6.2...aube-workspace-v1.7.0) - 2026-05-03
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.1](https://github.com/endevco/aube/compare/aube-workspace-v1.6.0...aube-workspace-v1.6.1) - 2026-05-01
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/endevco/aube/compare/v1.6.2...v1.7.0) - 2026-05-03
+
+### Added
+
+- *(cli)* support link: and file: specs in aube add ([#487](https://github.com/endevco/aube/pull/487))
+- *(cli)* support yaml-only workspace roots in list/run/install/query/why ([#486](https://github.com/endevco/aube/pull/486))
+- *(cli)* support git specs in aube add ([#483](https://github.com/endevco/aube/pull/483))
+- *(cli)* rewrite manifest specifier on update without --latest ([#479](https://github.com/endevco/aube/pull/479))
+- *(cli)* aube rebuild <pkg> targets a specific package ([#477](https://github.com/endevco/aube/pull/477))
+- *(install)* persist unreviewed-builds warning across repeat installs ([#476](https://github.com/endevco/aube/pull/476))
+- *(cli)* warn when aube update --depth is set ([#473](https://github.com/endevco/aube/pull/473))
+
+### Fixed
+
+- *(cli)* wrap doc comments so -h help stays one line per flag ([#478](https://github.com/endevco/aube/pull/478))
+- *(install)* allow workspace members without `version` field ([#480](https://github.com/endevco/aube/pull/480))
+- *(resolver)* resolve nested link:/file: deps from local parents and overrides ([#470](https://github.com/endevco/aube/pull/470))
+- *(lockfile)* parse bare user/repo as github shorthand ([#472](https://github.com/endevco/aube/pull/472))
+
+### Other
+
+- refresh benchmarks for v1.6.2 ([#474](https://github.com/endevco/aube/pull/474))
+- streaming sha512, parallel cas, tls prewarm, fetch reorder ([#469](https://github.com/endevco/aube/pull/469))
+- refresh benchmarks for v1.6.2 ([#467](https://github.com/endevco/aube/pull/467))
+
 ## [1.6.2](https://github.com/endevco/aube/compare/v1.6.1...v1.6.2) - 2026-05-01
 
 ### Added

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6396,7 +6396,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.6.2",
+  "version": "1.7.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.6.2
+**Version**: 1.7.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.6.2",
-  "releasedAt": "2026-05-01T22:10:07Z"
+  "version": "1.7.0",
+  "releasedAt": "2026-05-03T00:45:57Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.7.0`

This PR bumps the workspace to `v1.7.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
