### PR TITLE
chore(docs): remove shrill.en.dev analytics script

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -73,15 +73,6 @@ export default defineConfig({
     ],
     ["link", { rel: "manifest", href: "/site.webmanifest" }],
     ["meta", { name: "theme-color", content: "#FFB13B" }],
-    [
-      "script",
-      {
-        defer: "",
-        "data-domain": "aube.en.dev",
-        "data-api": "https://shrill.en.dev/f5f1/event",
-        src: "https://shrill.en.dev/shrill/script.js",
-      },
-    ],
   ],
   themeConfig: {
     logo: "/logo.svg",


### PR DESCRIPTION
Removes the proxied shrill.en.dev analytics snippet from the VitePress docs config — the endpoint is going away.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a client-side analytics `<script>` from the VitePress docs head; no app/runtime logic or data flows are altered beyond stopping event beacons.
> 
> **Overview**
> **Removes the proxied `shrill.en.dev` analytics snippet** from the VitePress docs configuration by deleting the injected `<script>` entry in `docs/.vitepress/config.mts`.
> 
> Docs pages will no longer load or send analytics events to `https://shrill.en.dev/...`, aligning with the endpoint being retired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd84cb6df1c596f4c2b79d8ab10da64204108f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->