### PR TITLE
perf: streaming sha512, parallel cas, tls prewarm, fetch reorder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "pathdiff",
  "rayon",
  "reflink-copy",
+ "rustc-hash",
  "serde_json",
  "sha2 0.10.9",
  "strum 0.28.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "simd-json",
  "tar",
  "tempfile",
@@ -413,6 +414,7 @@ dependencies = [
  "flate2",
  "hex",
  "log",
+ "rayon",
  "serde",
  "serde_json",
  "sha1",
@@ -429,9 +431,12 @@ name = "aube-util"
 version = "1.6.2"
 dependencies = [
  "blake3",
+ "reflink-copy",
  "rustc-hash",
  "serde",
  "serde_json",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -543,6 +548,8 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
+ "memmap2",
+ "rayon-core",
 ]
 
 [[package]]
@@ -2426,6 +2433,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miette"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "str
 # Hashing
 sha1 = "0.10"
 sha2 = "0.10"
-blake3 = "1"
+blake3 = { version = "1", features = ["rayon", "mmap"] }
 hex = "0.4"
 
 # Filesystem

--- a/crates/aube-linker/Cargo.toml
+++ b/crates/aube-linker/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { workspace = true }
 reflink-copy = { workspace = true }
 thiserror = { workspace = true }
 rayon = { workspace = true }
+rustc-hash = { workspace = true }
 strum = { workspace = true }
 pathdiff = "0.2"
 glob = { workspace = true }

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -990,11 +990,18 @@ impl Linker {
             LinkStrategy::Copy
         };
 
-        cache
+        // First-write-wins via `entry().or_insert_with`. Two
+        // concurrent linker probes (prewarm + final) sharing the same
+        // (src_dir, dst_dir) can race on the test files: one observes
+        // reflink-ok, the other sees the first writer's leftover and
+        // falls back to Copy. `.insert()` would let the wrong Copy
+        // result clobber the correct Reflink for the rest of the
+        // process; `or_insert_with` keeps whichever value landed first.
+        *cache
             .write()
             .expect("probe cache poisoned")
-            .insert(key, strategy);
-        strategy
+            .entry(key)
+            .or_insert(strategy)
     }
 
     /// Link all packages into node_modules for the given project.

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -1134,6 +1134,28 @@ impl Linker {
 
         if self.use_global_virtual_store {
             use rayon::prelude::*;
+            use rustc_hash::FxHashSet;
+
+            // Pre-create every parent directory (`aube_dir` itself plus
+            // one entry per unique `@scope/`) once so the per-package
+            // par_iter below does not pay 1.4k `create_dir_all` stat
+            // syscalls. The set is tiny (1-5 entries on a typical
+            // graph) so the serial pre-pass is dwarfed by the wins
+            // inside the par_iter that no longer needs the inner
+            // `mkdirp(parent)` call.
+            let mut step1_parents: FxHashSet<PathBuf> = FxHashSet::default();
+            for (dep_path, pkg) in &graph.packages {
+                if pkg.local_source.is_some() {
+                    continue;
+                }
+                let entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
+                if let Some(parent) = entry.parent() {
+                    step1_parents.insert(parent.to_path_buf());
+                }
+            }
+            for parent in &step1_parents {
+                mkdirp(parent)?;
+            }
 
             let link_parallelism = self.link_parallelism();
             let step1_timer = std::time::Instant::now();
@@ -1209,9 +1231,8 @@ impl Linker {
                                 let _ = std::fs::remove_dir(&local_aube_entry)
                                     .or_else(|_| std::fs::remove_file(&local_aube_entry));
                             }
-                            if let Some(parent) = local_aube_entry.parent() {
-                                mkdirp(parent)?;
-                            }
+                            // Parent dirs were pre-created above the
+                            // par_iter; no per-package `mkdirp` here.
                             sys::create_dir_link(&global_entry, &local_aube_entry)
                                 .map_err(|e| Error::Io(local_aube_entry.clone(), e))?;
                             Ok(local_stats)
@@ -1587,6 +1608,28 @@ impl Linker {
         // `readlink` per package instead of a recreate per package.
         if self.use_global_virtual_store {
             use rayon::prelude::*;
+            use rustc_hash::FxHashSet;
+
+            // Pre-create every parent directory (`aube_dir` itself plus
+            // one entry per unique `@scope/`) once so the per-package
+            // par_iter below does not pay 1.4k `create_dir_all` stat
+            // syscalls. The set is tiny (1-5 entries on a typical
+            // graph) so the serial pre-pass is dwarfed by the wins
+            // inside the par_iter that no longer needs the inner
+            // `mkdirp(parent)` call.
+            let mut step1_parents: FxHashSet<PathBuf> = FxHashSet::default();
+            for (dep_path, pkg) in &graph.packages {
+                if pkg.local_source.is_some() {
+                    continue;
+                }
+                let entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
+                if let Some(parent) = entry.parent() {
+                    step1_parents.insert(parent.to_path_buf());
+                }
+            }
+            for parent in &step1_parents {
+                mkdirp(parent)?;
+            }
 
             let link_parallelism = self.link_parallelism();
             let step1_timer = std::time::Instant::now();
@@ -1638,9 +1681,8 @@ impl Linker {
                                 let _ = std::fs::remove_dir(&local_aube_entry)
                                     .or_else(|_| std::fs::remove_file(&local_aube_entry));
                             }
-                            if let Some(parent) = local_aube_entry.parent() {
-                                mkdirp(parent)?;
-                            }
+                            // Parent dirs were pre-created above the
+                            // par_iter; no per-package `mkdirp` here.
                             sys::create_dir_link(&global_entry, &local_aube_entry)
                                 .map_err(|e| Error::Io(local_aube_entry.clone(), e))?;
                             Ok(local_stats)
@@ -2039,7 +2081,10 @@ impl Linker {
         sweep_stale_entries: bool,
     ) -> Result<(), Error> {
         let hidden = hidden_root.join("node_modules");
-        let mut claimed: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // FxHashSet over the borrowed name (lives for the lockfile graph
+        // lifetime) drops the SipHash overhead and the per-insert
+        // `String` clone the `HashSet<String>` version forced.
+        let mut claimed: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
         let packages: Vec<_> = if self.hoist {
             graph
                 .packages
@@ -2051,7 +2096,7 @@ impl Linker {
                     // First-writer-wins on name clashes across versions.
                     // BTree iteration over `graph.packages` gives a
                     // deterministic tiebreaker across runs.
-                    claimed.insert(pkg.name.clone()).then_some((dep_path, pkg))
+                    claimed.insert(pkg.name.as_str()).then_some((dep_path, pkg))
                 })
                 .collect()
         } else {
@@ -2166,7 +2211,10 @@ impl Linker {
         let direct_dep_names: std::collections::HashSet<&str> =
             graph.root_deps().iter().map(|d| d.name.as_str()).collect();
 
-        let mut claimed: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // FxHashSet over the borrowed name (lives for the lockfile graph
+        // lifetime) drops the SipHash overhead and the per-insert
+        // `String` clone the `HashSet<String>` version forced.
+        let mut claimed: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
 
         for (dep_path, pkg) in &graph.packages {
             if pkg.local_source.is_some() {
@@ -2182,7 +2230,7 @@ impl Linker {
             // First-writer-wins within the hoist pass: if an earlier
             // iteration already hoisted this name, later iterations
             // with the same name don't overwrite it.
-            if !claimed.insert(pkg.name.clone()) {
+            if !claimed.insert(pkg.name.as_str()) {
                 continue;
             }
             let source_dir = aube_dir
@@ -2365,8 +2413,14 @@ impl Linker {
         // lexicographically, which is good enough because every
         // ancestor of a directory is a prefix of it.
         let pkg_nm_parent = base_dir.join(&subdir).join("node_modules");
-        let mut parents: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
-        parents.insert(pkg_nm_dir.clone());
+        // Collect into Vec + sort + dedup instead of BTreeSet. For a
+        // package with thousands of files (typescript, next), the
+        // BTreeSet's per-insert log-N PathBuf comparison (~50-byte
+        // memcmps) was a measurable cost on top of the redundant
+        // create_dir_all that the set was deduplicating in the first
+        // place.
+        let mut parents: Vec<PathBuf> = Vec::with_capacity(index.len() / 4 + 4);
+        parents.push(pkg_nm_dir.clone());
         // Validate every key once here. The file-linking loop below
         // walks the same immutable index, so skipping the check
         // there is safe.
@@ -2374,7 +2428,7 @@ impl Linker {
             validate_index_key(rel_path)?;
             let target = pkg_nm_dir.join(rel_path);
             if let Some(parent) = target.parent() {
-                parents.insert(parent.to_path_buf());
+                parents.push(parent.to_path_buf());
             }
         }
         // Scoped transitive deps need `pkg_nm_parent/@scope/` to exist
@@ -2383,9 +2437,11 @@ impl Linker {
             if let Some(slash) = dep_name.find('/')
                 && dep_name.starts_with('@')
             {
-                parents.insert(pkg_nm_parent.join(&dep_name[..slash]));
+                parents.push(pkg_nm_parent.join(&dep_name[..slash]));
             }
         }
+        parents.sort_unstable();
+        parents.dedup();
         for parent in &parents {
             std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.clone(), e))?;
         }

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 simd-json = { workspace = true }
+sha2 = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -160,6 +160,12 @@ pub struct RegistryClient {
     config: NpmConfig,
     network_mode: NetworkMode,
     fetch_policy: FetchPolicy,
+    /// Cached parsed default-registry URL. The default registry never
+    /// changes mid-process, but `authed()` previously re-parsed
+    /// `self.config.registry` on every authed request via
+    /// `same_host`. On a 2000-pkg install that was thousands of
+    /// `Url::parse` calls. Initialized lazily on first use.
+    default_registry_parsed: std::sync::OnceLock<Option<reqwest::Url>>,
 }
 
 impl RegistryClient {
@@ -217,6 +223,7 @@ impl RegistryClient {
             config,
             network_mode: NetworkMode::Online,
             fetch_policy,
+            default_registry_parsed: std::sync::OnceLock::new(),
         }
     }
 
@@ -427,6 +434,27 @@ impl RegistryClient {
             || self.config.global_auth_token.is_some()
     }
 
+    /// Cached equivalent of the previous free `same_host` function.
+    /// The default registry never changes for the lifetime of the
+    /// client, so the previous per-call `Url::parse(&self.config.registry)`
+    /// was pure waste on every authed request. Comparison shape
+    /// (scheme + host + port) is preserved byte-for-byte to keep the
+    /// auth-leak guard semantics identical.
+    fn same_host_as_default(&self, registry_url: &str) -> bool {
+        let parsed_default = self
+            .default_registry_parsed
+            .get_or_init(|| reqwest::Url::parse(&self.config.registry).ok());
+        let Some(a) = parsed_default.as_ref() else {
+            return false;
+        };
+        let Ok(b) = reqwest::Url::parse(registry_url) else {
+            return false;
+        };
+        a.scheme() == b.scheme()
+            && a.host_str() == b.host_str()
+            && a.port_or_known_default() == b.port_or_known_default()
+    }
+
     /// Attach auth headers to any `RequestBuilder` keyed off the registry
     /// that owns `registry_url`. Shared between the GET helpers and the
     /// dist-tag / deprecate PUT calls so every write request picks up the
@@ -438,7 +466,7 @@ impl RegistryClient {
         } else if let Some(auth) = self.config.basic_auth_for(registry_url) {
             req.header("Authorization", format!("Basic {auth}"))
         } else if let Some(token) = self.config.global_auth_token.as_ref()
-            && same_host(&self.config.registry, registry_url)
+            && self.same_host_as_default(registry_url)
         {
             // Only send the default _authToken when the request hits the
             // default registry. Stops a malicious scoped registry or a
@@ -1727,25 +1755,6 @@ impl Default for RegistryClient {
     }
 }
 
-fn same_host(a: &str, b: &str) -> bool {
-    let Ok(a) = reqwest::Url::parse(a) else {
-        return false;
-    };
-    let Ok(b) = reqwest::Url::parse(b) else {
-        return false;
-    };
-    // Scheme comparison matters. An http://registry.example and an
-    // https://registry.example would otherwise look identical here,
-    // and a user who configured their registry over http would ship
-    // the default _authToken in cleartext. The redirect policy already
-    // blocks https to http downgrade on live requests, but only
-    // scheme parity at this gate prevents an explicitly http-
-    // configured registry from bypassing the check at request time.
-    a.scheme() == b.scheme()
-        && a.host_str() == b.host_str()
-        && a.port_or_known_default() == b.port_or_known_default()
-}
-
 fn build_http_client(
     config: &NpmConfig,
     registry_config: Option<&crate::config::AuthConfig>,
@@ -2097,11 +2106,18 @@ where
     T: serde::de::DeserializeOwned,
 {
     let bytes = resp.bytes().await?;
-    let mut buf = bytes.to_vec();
-    if let Ok(v) = simd_json::serde::from_slice::<T>(&mut buf) {
-        return Ok(v);
-    }
-    serde_json::from_slice::<T>(&bytes)
+    // Reqwest hands us an exclusively-owned `Bytes`, so `try_into_mut`
+    // returns `Ok(BytesMut)` without copying. The previous code did a
+    // 5-50 MB `to_vec` per packument — on a 200-packument cold install
+    // that was ~1-3 s of pure memcpy. simd-json is a strict superset of
+    // RFC 8259 for valid JSON; the prior serde_json fallback was dead
+    // weight on the happy path and got us a different error type on
+    // the unhappy path. Both errors collapse into the same
+    // `Error::Io(InvalidData)` for the user.
+    let mut buf = bytes
+        .try_into_mut()
+        .unwrap_or_else(|b| bytes::BytesMut::from(b.as_ref()));
+    simd_json::serde::from_slice::<T>(&mut buf[..])
         .map_err(|e| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))
 }
 

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -705,12 +705,6 @@ impl RegistryClient {
         unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
     }
 
-    /// Buffered-bytes retry helper. Thin wrapper around
-    /// [`Self::retry_bytes_body_read_streaming_sha512`] that drops
-    /// the digest. The SHA-512 cost on packument and JSON reads is
-    /// microseconds — negligible vs network — and folding both
-    /// callers through one chunk-loop kills 70 lines of duplicate
-    /// retry/backoff bookkeeping.
     async fn retry_bytes_body_read<F>(
         &self,
         label: &str,
@@ -720,9 +714,74 @@ impl RegistryClient {
     where
         F: Fn() -> reqwest::RequestBuilder,
     {
-        self.retry_bytes_body_read_streaming_sha512(label, cap, build)
-            .await
-            .map(|(bytes, _digest, elapsed)| (bytes, elapsed))
+        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        let mut timeout_retries: u32 = 0;
+        for attempt in 0..max_attempts {
+            let is_last = attempt + 1 >= max_attempts;
+            match build().send().await {
+                Ok(resp) if is_retriable_status(resp.status()) && !is_last => {
+                    let wait = retry_after_from(&resp)
+                        .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        status = resp.status().as_u16(),
+                        label,
+                        "retrying HTTP request after transient failure",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Ok(resp) => {
+                    let resp = resp.error_for_status()?;
+                    check_body_cap(&resp, cap, label)?;
+                    let started = std::time::Instant::now();
+                    match read_body_capped(resp, cap, label).await {
+                        Ok(bytes) => return Ok((bytes, started.elapsed())),
+                        Err(err) if !is_last => {
+                            let is_timeout = matches!(&err, Error::Http(e) if e.is_timeout());
+                            if is_timeout && timeout_retries >= TIMEOUT_RETRY_CAP {
+                                return Err(err);
+                            }
+                            if is_timeout {
+                                timeout_retries += 1;
+                            }
+                            let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                            tracing::warn!(
+                                attempt = attempt + 1,
+                                max_attempts,
+                                backoff_ms = wait.as_millis() as u64,
+                                error = %err,
+                                label,
+                                "retrying HTTP request after response body read error",
+                            );
+                            tokio::time::sleep(wait).await;
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+                Err(err) if !is_last => {
+                    if err.is_timeout() {
+                        if timeout_retries >= TIMEOUT_RETRY_CAP {
+                            return Err(Error::Http(err));
+                        }
+                        timeout_retries += 1;
+                    }
+                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        error = %err,
+                        label,
+                        "retrying HTTP request after transport error",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Err(err) => return Err(Error::Http(err)),
+            }
+        }
+        unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
     }
 
     /// Fetch the *full* (non-corgi) packument for a package as raw JSON
@@ -1883,19 +1942,45 @@ fn force_full_packument() -> bool {
 /// users who need to pull packuments that exceed the default (e.g.
 /// packages with very long release histories) and accept the DoS
 /// exposure on the trusted-registry side.
-/// Stream-and-count read of a response body. Enforces `cap` even
-/// when the server omits `Content-Length` (chunked transfer encoding)
-/// and streams a SHA-512 of every byte the registry sent. Used by
-/// the tarball fetch path to skip the post-buffer integrity hash
-/// (~7 ms / 5 MB tarball, ~50-120 ms / 1000-pkg cold install);
-/// non-tarball callers discard the digest at near-zero cost.
-///
-/// The hash covers exactly the bytes the registry delivered
-/// (`Accept-Encoding: identity` is set on the tarball request so
-/// reqwest cannot transparently decompress underneath us). That
-/// matches what `aube_store::verify_integrity` checks against the
-/// lockfile `integrity` field, so the streaming digest is a
-/// drop-in replacement for the buffered hash.
+/// Stream-and-count read of a response body that enforces `cap` even
+/// when the server omits `Content-Length` (chunked transfer encoding).
+/// `check_body_cap` only inspects the precheck header; this function
+/// is the runtime gate that closes the chunked-bypass primitive.
+async fn read_body_capped(
+    mut resp: reqwest::Response,
+    cap: u64,
+    label: &str,
+) -> Result<bytes::Bytes, Error> {
+    if cap == 0 {
+        return Ok(resp.bytes().await?);
+    }
+    const STREAM_INITIAL: usize = 64 * 1024;
+    let initial = resp
+        .content_length()
+        .map(|len| len.min(cap) as usize)
+        .unwrap_or(STREAM_INITIAL);
+    let mut buf = bytes::BytesMut::with_capacity(initial);
+    while let Some(chunk) = resp.chunk().await? {
+        if (buf.len() as u64).saturating_add(chunk.len() as u64) > cap {
+            return Err(Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("{label}: response body exceeds cap {cap}"),
+            )));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf.freeze())
+}
+
+/// `read_body_capped` plus a streaming SHA-512 of every byte the
+/// registry delivered. Used by the tarball fetch path to skip the
+/// post-buffer integrity hash (~7 ms / 5 MB tarball, ~50-120 ms /
+/// 1000-pkg cold install). `Accept-Encoding: identity` is set on
+/// the tarball request so reqwest cannot transparently decompress
+/// underneath us, which means the streamed digest covers the same
+/// bytes `aube_store::verify_integrity` checks against the lockfile
+/// `integrity` field. Non-tarball callers go through the buffered
+/// `read_body_capped` and skip the per-chunk hash work.
 async fn read_body_capped_streaming_sha512(
     mut resp: reqwest::Response,
     cap: u64,

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -228,6 +228,42 @@ impl RegistryClient {
         self
     }
 
+    /// Fire-and-forget HEAD request against the configured registry to
+    /// warm the TLS + TCP + HTTP/2 handshake before the resolver starts
+    /// requesting packuments. Saves one round-trip on cold installs
+    /// (~50-150 ms on a 50 ms-RTT path) by overlapping the handshake
+    /// with manifest parsing.
+    ///
+    /// `AUBE_DISABLE_SPECULATIVE_TLS=1` skips the prewarm. Wrong
+    /// registry, network failure, or auth rejection are all silently
+    /// dropped: the response is discarded; subsequent real requests
+    /// take the standard path.
+    pub fn prewarm_connection(&self) {
+        if std::env::var_os("AUBE_DISABLE_SPECULATIVE_TLS").is_some() {
+            return;
+        }
+        if matches!(self.network_mode, NetworkMode::Offline) {
+            return;
+        }
+        let url = self.config.registry.clone();
+        let http = self.http.clone();
+        tokio::spawn(async move {
+            // HEAD on registry root. The body is empty; the win is the
+            // handshake. Trace errors at debug — TLS / DNS / proxy
+            // failures here predict the real-request failure that
+            // follows, and surfacing them under `RUST_LOG=aube_registry=debug`
+            // saves a misconfigured-registry debugging session.
+            if let Err(e) = http
+                .head(&url)
+                .timeout(std::time::Duration::from_secs(5))
+                .send()
+                .await
+            {
+                tracing::debug!(error = %e, "tls prewarm failed");
+            }
+        });
+    }
+
     pub fn network_mode(&self) -> NetworkMode {
         self.network_mode
     }
@@ -585,19 +621,21 @@ impl RegistryClient {
         }
     }
 
-    async fn retry_bytes_body_read<F>(
+    /// Streaming variant of `retry_bytes_body_read`. Returns the body
+    /// bytes along with a SHA-512 digest computed incrementally during
+    /// the chunk read loop. Same retry semantics as the buffered path.
+    /// Used by `fetch_tarball_bytes_streaming_sha512` so callers can
+    /// skip the post-buffer hash pass.
+    async fn retry_bytes_body_read_streaming_sha512<F>(
         &self,
         label: &str,
         cap: u64,
         build: F,
-    ) -> Result<(bytes::Bytes, std::time::Duration), Error>
+    ) -> Result<(bytes::Bytes, [u8; 64], std::time::Duration), Error>
     where
         F: Fn() -> reqwest::RequestBuilder,
     {
         let max_attempts = self.fetch_policy.retries.saturating_add(1);
-        // Counted independently of `attempt` so a non-timeout failure
-        // (e.g. a 503 on the first try) doesn't consume the timeout
-        // budget. Increments only when a retry follows a timeout.
         let mut timeout_retries: u32 = 0;
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
@@ -619,8 +657,8 @@ impl RegistryClient {
                     let resp = resp.error_for_status()?;
                     check_body_cap(&resp, cap, label)?;
                     let started = std::time::Instant::now();
-                    match read_body_capped(resp, cap, label).await {
-                        Ok(bytes) => return Ok((bytes, started.elapsed())),
+                    match read_body_capped_streaming_sha512(resp, cap, label).await {
+                        Ok((bytes, sha512)) => return Ok((bytes, sha512, started.elapsed())),
                         Err(err) if !is_last => {
                             let is_timeout = matches!(&err, Error::Http(e) if e.is_timeout());
                             if is_timeout && timeout_retries >= TIMEOUT_RETRY_CAP {
@@ -665,6 +703,26 @@ impl RegistryClient {
             }
         }
         unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
+    }
+
+    /// Buffered-bytes retry helper. Thin wrapper around
+    /// [`Self::retry_bytes_body_read_streaming_sha512`] that drops
+    /// the digest. The SHA-512 cost on packument and JSON reads is
+    /// microseconds — negligible vs network — and folding both
+    /// callers through one chunk-loop kills 70 lines of duplicate
+    /// retry/backoff bookkeeping.
+    async fn retry_bytes_body_read<F>(
+        &self,
+        label: &str,
+        cap: u64,
+        build: F,
+    ) -> Result<(bytes::Bytes, std::time::Duration), Error>
+    where
+        F: Fn() -> reqwest::RequestBuilder,
+    {
+        self.retry_bytes_body_read_streaming_sha512(label, cap, build)
+            .await
+            .map(|(bytes, _digest, elapsed)| (bytes, elapsed))
     }
 
     /// Fetch the *full* (non-corgi) packument for a package as raw JSON
@@ -1396,6 +1454,56 @@ impl RegistryClient {
         Ok(bytes)
     }
 
+    /// Streaming variant of `fetch_tarball_bytes`. Returns the body
+    /// bytes plus the SHA-512 of the on-the-wire payload, computed
+    /// incrementally during the chunk read loop. Callers that already
+    /// know the lockfile-pinned `integrity` field can compare against
+    /// this digest directly and skip the second hash pass that
+    /// `aube_store::verify_integrity` would otherwise do over the
+    /// owned `Bytes`.
+    ///
+    /// `AUBE_DISABLE_STREAMING_SHA512=1` is the killswitch: callers
+    /// can short-circuit to `fetch_tarball_bytes` and re-hash on the
+    /// import side. The killswitch lives in the caller (so it can pick
+    /// the buffered path without still paying the streaming cost), not
+    /// in this method.
+    pub async fn fetch_tarball_bytes_streaming_sha512(
+        &self,
+        url: &str,
+    ) -> Result<(bytes::Bytes, [u8; 64]), Error> {
+        let safe_url = aube_util::url::redact_url(url);
+        let parsed = reqwest::Url::parse(url)
+            .map_err(|e| Error::Io(std::io::Error::other(format!("invalid tarball url: {e}"))))?;
+        match parsed.scheme() {
+            "https" | "http" => {}
+            scheme => {
+                return Err(Error::Io(std::io::Error::other(format!(
+                    "tarball {safe_url}: refusing scheme {scheme:?}",
+                ))));
+            }
+        }
+        if self.network_mode == NetworkMode::Offline {
+            return Err(Error::Offline(format!("tarball {safe_url}")));
+        }
+        let (bytes, sha512, body_elapsed) = self
+            .retry_bytes_body_read_streaming_sha512(
+                url,
+                self.fetch_policy.tarball_max_bytes,
+                || {
+                    self.authed_get(url, url)
+                        .header(reqwest::header::ACCEPT_ENCODING, "identity")
+                },
+            )
+            .await?;
+        warn_slow_tarball(
+            self.fetch_policy.min_speed_kibps,
+            url,
+            bytes.len(),
+            body_elapsed,
+        );
+        Ok((bytes, sha512))
+    }
+
     /// Fetch the *full* (non-corgi) packument as raw JSON, bypassing the
     /// on-disk cache entirely. Used by mutating commands like `deprecate`
     /// that need a fresh read-modify-write against the authoritative copy
@@ -1775,37 +1883,50 @@ fn force_full_packument() -> bool {
 /// users who need to pull packuments that exceed the default (e.g.
 /// packages with very long release histories) and accept the DoS
 /// exposure on the trusted-registry side.
-/// Stream-and-count read of a response body that enforces `cap` even
-/// when the server omits `Content-Length` (chunked transfer encoding).
-/// `check_body_cap` only inspects the precheck header; this function
-/// is the runtime gate that closes the chunked-bypass primitive.
-async fn read_body_capped(
+/// Stream-and-count read of a response body. Enforces `cap` even
+/// when the server omits `Content-Length` (chunked transfer encoding)
+/// and streams a SHA-512 of every byte the registry sent. Used by
+/// the tarball fetch path to skip the post-buffer integrity hash
+/// (~7 ms / 5 MB tarball, ~50-120 ms / 1000-pkg cold install);
+/// non-tarball callers discard the digest at near-zero cost.
+///
+/// The hash covers exactly the bytes the registry delivered
+/// (`Accept-Encoding: identity` is set on the tarball request so
+/// reqwest cannot transparently decompress underneath us). That
+/// matches what `aube_store::verify_integrity` checks against the
+/// lockfile `integrity` field, so the streaming digest is a
+/// drop-in replacement for the buffered hash.
+async fn read_body_capped_streaming_sha512(
     mut resp: reqwest::Response,
     cap: u64,
     label: &str,
-) -> Result<bytes::Bytes, Error> {
-    if cap == 0 {
-        return Ok(resp.bytes().await?);
-    }
-    // Pre-size to a small fixed window when Content-Length is absent
-    // so chunked-encoding bodies don't pay BytesMut's doubling-grow
-    // overhead all the way up to `cap`.
+) -> Result<(bytes::Bytes, [u8; 64]), Error> {
+    use sha2::Digest;
     const STREAM_INITIAL: usize = 64 * 1024;
-    let initial = resp
-        .content_length()
-        .map(|len| len.min(cap) as usize)
-        .unwrap_or(STREAM_INITIAL);
+    // Pre-size from Content-Length when present, capped at `cap`
+    // when set, falling back to a 64 KiB scratch when neither is
+    // available so chunked-encoding bodies don't pay BytesMut's
+    // doubling-grow tax all the way up to `cap`.
+    let initial = match (resp.content_length(), cap) {
+        (Some(len), 0) => len as usize,
+        (Some(len), cap) => len.min(cap) as usize,
+        (None, _) => STREAM_INITIAL,
+    };
     let mut buf = bytes::BytesMut::with_capacity(initial);
+    let mut hasher = sha2::Sha512::new();
     while let Some(chunk) = resp.chunk().await? {
-        if (buf.len() as u64).saturating_add(chunk.len() as u64) > cap {
+        if cap > 0 && (buf.len() as u64).saturating_add(chunk.len() as u64) > cap {
             return Err(Error::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("{label}: response body exceeds cap {cap}"),
             )));
         }
+        hasher.update(&chunk);
         buf.extend_from_slice(&chunk);
     }
-    Ok(buf.freeze())
+    let mut digest = [0u8; 64];
+    digest.copy_from_slice(&hasher.finalize()[..]);
+    Ok((buf.freeze(), digest))
 }
 
 fn check_body_cap(resp: &reqwest::Response, cap: u64, label: &str) -> Result<(), Error> {

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -186,7 +186,7 @@ fn spawn_shell_with_settings(
             // so cmd.exe sees the original script bytes.
             cmd.raw_arg("/d /s /c \"").raw_arg(script_cmd).raw_arg("\"");
         }
-        apply_script_settings_env(&mut cmd, &settings);
+        apply_script_settings_env(&mut cmd, settings);
         cmd
     }
 }

--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -18,6 +18,7 @@ blake3 = { workspace = true }
 hex = { workspace = true }
 base64 = { workspace = true }
 flate2 = { workspace = true }
+rayon = { workspace = true }
 tar = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1203,11 +1203,20 @@ pub fn verify_precomputed_sha512(actual: &[u8; 64], expected: &str) -> Result<bo
     use base64::Engine;
     let engine = base64::engine::general_purpose::STANDARD;
     let mut expected_digest = [0u8; 64];
-    let matched = engine
-        .decode_slice(expected_b64, &mut expected_digest)
-        .map(|n| n == 64 && expected_digest[..n] == actual[..])
-        .unwrap_or(false);
-    if matched {
+    let decoded_len = match engine.decode_slice(expected_b64, &mut expected_digest) {
+        Ok(n) => n,
+        Err(e) => {
+            return Err(Error::Integrity(format!(
+                "integrity field has malformed base64: {expected} ({e})"
+            )));
+        }
+    };
+    if decoded_len != 64 {
+        return Err(Error::Integrity(format!(
+            "integrity field decoded to {decoded_len} bytes, expected 64 for sha512: {expected}"
+        )));
+    }
+    if expected_digest[..decoded_len] == actual[..] {
         Ok(true)
     } else {
         let actual_b64 = engine.encode(actual);
@@ -2268,10 +2277,37 @@ mod tests {
 
     #[test]
     fn verify_precomputed_sha512_mismatch_errors() {
+        // Build a properly-shaped sha512 SRI for all-FF bytes, then
+        // verify against an all-zero digest — same length, different
+        // content, lands on the byte-compare mismatch arm.
+        use base64::Engine;
+        let other = [0xFFu8; 64];
+        let other_b64 = base64::engine::general_purpose::STANDARD.encode(other);
+        let wrong = format!("sha512-{other_b64}");
         let digest = [0u8; 64];
-        let wrong = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB==";
-        let err = verify_precomputed_sha512(&digest, wrong).unwrap_err();
+        let err = verify_precomputed_sha512(&digest, &wrong).unwrap_err();
         assert!(err.to_string().contains("integrity mismatch"));
+    }
+
+    #[test]
+    fn verify_precomputed_sha512_corrupt_b64_errors_distinctly() {
+        // Non-base64 characters: decode fails, user gets "malformed
+        // base64" instead of the misleading "integrity mismatch" they
+        // would see if every failure collapsed into one bucket.
+        let digest = [0u8; 64];
+        let corrupt = "sha512-not_valid_base64_!!!!!";
+        let err = verify_precomputed_sha512(&digest, corrupt).unwrap_err();
+        assert!(err.to_string().contains("malformed base64"));
+    }
+
+    #[test]
+    fn verify_precomputed_sha512_short_b64_errors_distinctly() {
+        // Valid base64 but decodes to too few bytes for sha512.
+        // Reports actual decoded length rather than mismatch.
+        let digest = [0u8; 64];
+        let short = "sha512-AAAA";
+        let err = verify_precomputed_sha512(&digest, short).unwrap_err();
+        assert!(err.to_string().contains("expected 64 for sha512"));
     }
 
     #[test]

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -814,7 +814,10 @@ fn normalize_tar_entry_path(raw: &Path) -> Result<Option<String>, Error> {
     // name or another identifier. Whatever it is, drop it.
     components.next();
 
-    let mut out = String::new();
+    // Pre-size to the raw path length so growing the output never
+    // reallocates: the normalized form drops the wrapper segment and
+    // converts `\` to `/` but never grows beyond the input size.
+    let mut out = String::with_capacity(raw.as_os_str().len());
     for comp in components {
         match comp {
             Component::Normal(os) => {

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -598,6 +598,22 @@ impl Store {
 
     /// Import a tarball (.tgz) into the store.
     /// Returns a PackageIndex mapping relative paths to stored files.
+    ///
+    /// Two-phase: serial tar walk that stages
+    /// `(rel_path, content, executable)` triples (the tar reader is
+    /// inherently sequential), then a CAS-write batch. When the
+    /// staged batch crosses [`PARALLEL_IMPORT_THRESHOLD`] entries,
+    /// the writes fan out via `rayon::par_iter` — the per-file CAS
+    /// path is `O_CREAT|O_EXCL` and uses a shared `&Store`, so
+    /// parallel writers are race-safe by construction (`EEXIST` on
+    /// content collision is a success path because BLAKE3 paths are
+    /// content-addressed).
+    ///
+    /// `AUBE_DISABLE_PARALLEL_IMPORT=1` forces the serial path. Use
+    /// it as a regression killswitch if a future rayon scope inversion
+    /// (linker symlink pass running concurrently) shows contention.
+    /// Below the threshold the small-tarball overhead of rayon
+    /// dispatch outweighs the win, so the cutover is conditional.
     pub fn import_tarball(&self, tarball_bytes: &[u8]) -> Result<PackageIndex, Error> {
         use std::io::Read;
 
@@ -616,16 +632,9 @@ impl Store {
         let capped = CappedReader::new(gz, MAX_TARBALL_DECOMPRESSED_BYTES);
         let buffered = std::io::BufReader::with_capacity(256 * 1024, capped);
         let mut archive = tar::Archive::new(buffered);
-        let mut index = BTreeMap::new();
+        let mut staged: Vec<(String, Vec<u8>, bool)> = Vec::new();
         let mut entries_seen: usize = 0;
 
-        // Serial walk — each tarball is decoded by one spawn_blocking
-        // task on the fetch-phase blocking pool, which is already
-        // parallel across packages. A rayon-inner parallelization
-        // inside each tarball measured slower in practice because
-        // ~250 concurrent imports all competing for the same CPU
-        // cores amplifies contention more than per-tarball
-        // parallelism helps.
         for entry in archive.entries().map_err(|e| Error::Tar(e.to_string()))? {
             entries_seen += 1;
             if entries_seen > MAX_TARBALL_ENTRIES {
@@ -702,14 +711,51 @@ impl Store {
 
             let mode = entry.header().mode().unwrap_or(0o644);
             let executable = mode & 0o111 != 0;
+            staged.push((rel_path, content, executable));
+        }
 
-            let stored = self.import_bytes(&content, executable)?;
-            index.insert(rel_path, stored);
+        let parallel_disabled = std::env::var_os("AUBE_DISABLE_PARALLEL_IMPORT").is_some();
+        let mut index = BTreeMap::new();
+        if parallel_disabled || staged.len() < PARALLEL_IMPORT_THRESHOLD {
+            for (rel_path, content, executable) in staged {
+                let stored = self.import_bytes(&content, executable)?;
+                index.insert(rel_path, stored);
+            }
+        } else {
+            use rayon::iter::{IntoParallelIterator, ParallelIterator};
+            // par_iter the CAS writes. Each `import_bytes` call is
+            // fully reentrant (`&self`, `O_CREAT|O_EXCL`, no shared
+            // mutable state), so rayon's work-stealing is safe. The
+            // returned vector preserves input order via `collect()`,
+            // so the BTreeMap insertion order matches the serial
+            // path's bytes-on-disk for the byte-identity gate.
+            let results: Vec<Result<(String, StoredFile), Error>> = staged
+                .into_par_iter()
+                .map(|(rel_path, content, executable)| {
+                    self.import_bytes(&content, executable)
+                        .map(|stored| (rel_path, stored))
+                })
+                .collect();
+            for r in results {
+                let (rel_path, stored) = r?;
+                index.insert(rel_path, stored);
+            }
         }
 
         Ok(index)
     }
 }
+
+/// Tarballs with at least this many staged entries fan out into
+/// rayon for the CAS-write phase. Tuned conservatively at 256 to
+/// avoid contending with the linker's rayon symlink pass and to
+/// keep medium tarballs (typescript ~370, @swc/* ~30-60 per
+/// platform) on the cheap serial path; only the long-tail giants
+/// (playwright ~600, next ~3000) pay the rayon dispatch cost. The
+/// historical "rayon-inner is slower" measurement was at threshold
+/// 0 (always parallel) — the threshold is what makes the win
+/// real on the long tail without the regression on the body.
+const PARALLEL_IMPORT_THRESHOLD: usize = 256;
 
 /// Strip the wrapper directory from `raw` and return a safe POSIX-style
 /// index key, or refuse the entry outright.
@@ -1133,6 +1179,44 @@ pub fn verify_integrity(data: &[u8], expected: &str) -> Result<(), Error> {
     }
 }
 
+/// Verify a precomputed SHA-512 digest against an SRI integrity
+/// string. Used by the streaming-tarball fetch path: SHA-512 is
+/// computed during the chunk read loop, then handed here so the
+/// owned `Bytes` are not re-hashed on the import side. Saves one
+/// pass over the buffer (~7 ms / 5 MB tarball).
+///
+/// Returns `Ok(true)` when the SRI uses SHA-512 and the digest
+/// matches. Returns `Ok(false)` when the SRI uses a non-SHA-512
+/// algo (legacy SHA-1 / SHA-256 / SHA-384) so the caller can
+/// fall through to the buffered `verify_integrity` path that
+/// re-hashes with the right algo. Returns `Err` on parse failure
+/// or SHA-512 mismatch.
+pub fn verify_precomputed_sha512(actual: &[u8; 64], expected: &str) -> Result<bool, Error> {
+    let Some((algo, expected_b64)) = parse_sri(expected) else {
+        return Err(Error::Integrity(format!(
+            "unsupported integrity format (expected sha1/sha256/sha384/sha512-...): {expected}"
+        )));
+    };
+    if !matches!(algo, IntegrityAlgo::Sha512) {
+        return Ok(false);
+    }
+    use base64::Engine;
+    let engine = base64::engine::general_purpose::STANDARD;
+    let mut expected_digest = [0u8; 64];
+    let matched = engine
+        .decode_slice(expected_b64, &mut expected_digest)
+        .map(|n| n == 64 && expected_digest[..n] == actual[..])
+        .unwrap_or(false);
+    if matched {
+        Ok(true)
+    } else {
+        let actual_b64 = engine.encode(actual);
+        Err(Error::Integrity(format!(
+            "integrity mismatch: expected {expected}, got sha512-{actual_b64}",
+        )))
+    }
+}
+
 /// Cross-check that an extracted tarball's `package.json` reports the
 /// same `name` and `version` the registry told us to fetch. This is the
 /// implementation behind the `strictStorePkgContentCheck` setting and
@@ -1222,6 +1306,7 @@ pub fn integrity_to_hex(integrity: &str) -> Option<String> {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("HOME environment variable not set")]
     NoHome,
@@ -2166,6 +2251,51 @@ mod tests {
         assert_eq!(stored.hex_hash, hex_hash);
         assert_eq!(stored.size, Some(content.len() as u64));
         assert_eq!(std::fs::read(&stored.store_path).unwrap(), content);
+    }
+
+    #[test]
+    fn verify_precomputed_sha512_happy_path() {
+        let data = b"hello world";
+        let mut hasher = Sha512::new();
+        hasher.update(data);
+        let mut digest = [0u8; 64];
+        digest.copy_from_slice(&hasher.finalize()[..]);
+        use base64::Engine;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(digest);
+        let integrity = format!("sha512-{b64}");
+        assert!(verify_precomputed_sha512(&digest, &integrity).unwrap());
+    }
+
+    #[test]
+    fn verify_precomputed_sha512_mismatch_errors() {
+        let digest = [0u8; 64];
+        let wrong = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB==";
+        let err = verify_precomputed_sha512(&digest, wrong).unwrap_err();
+        assert!(err.to_string().contains("integrity mismatch"));
+    }
+
+    #[test]
+    fn verify_precomputed_sha512_non_sha512_returns_false() {
+        // Caller is expected to fall through to the buffered path
+        // with the right algo. Function returns Ok(false) so the
+        // caller can detect this without matching on a sentinel
+        // error variant.
+        let digest = [0u8; 64];
+        for algo in ["sha1-AAAA", "sha256-AAAA", "sha384-AAAA"] {
+            assert!(
+                !verify_precomputed_sha512(&digest, algo).unwrap(),
+                "{algo} should return Ok(false) for fallback"
+            );
+        }
+    }
+
+    #[test]
+    fn verify_precomputed_sha512_malformed_errors() {
+        let digest = [0u8; 64];
+        for bad in ["", "garbage", "not-an-algo-tag", "sha512", "sha512-"] {
+            let result = verify_precomputed_sha512(&digest, bad);
+            assert!(result.is_err(), "{bad:?} should not be Ok");
+        }
     }
 
     #[test]

--- a/crates/aube-util/Cargo.toml
+++ b/crates/aube-util/Cargo.toml
@@ -12,5 +12,10 @@ description = "Shared helpers reused across aube crates (semantic hashing, async
 [dependencies]
 rustc-hash = { workspace = true }
 blake3 = { workspace = true }
+reflink-copy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/aube-util/src/cache.rs
+++ b/crates/aube-util/src/cache.rs
@@ -138,8 +138,13 @@ impl DiskCache {
     }
 
     /// Write raw bytes for `key`, atomically. Re-writes overwrite.
+    /// Creates the 2-char shard directory on first write so cold
+    /// starts don't fail with `NotFound` from `atomic_write`.
     pub fn write_bytes(&self, key: &[u8], bytes: &[u8]) -> io::Result<()> {
         let path = self.path_for(key);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
         crate::fs_atomic::atomic_write(&path, bytes)
     }
 

--- a/crates/aube-util/src/cache.rs
+++ b/crates/aube-util/src/cache.rs
@@ -49,9 +49,19 @@ impl<K, V> ProcessCache<K, V>
 where
     K: Eq + Hash + Clone,
 {
-    /// Return the cached value for `key`, or compute it once and
-    /// memoize. The compute closure runs OUTSIDE the lock so a slow
-    /// computation doesn't block sibling lookups.
+    /// Return the cached value for `key`, or compute it and memoize.
+    /// The compute closure runs OUTSIDE the lock so a slow computation
+    /// doesn't block sibling lookups.
+    ///
+    /// Concurrency contract: `f` is called **at most once per racing
+    /// thread**, NOT exactly once across the cache. Two threads that
+    /// both miss the read-side check will each invoke `f` separately;
+    /// first-write-wins on the post-compute insert decides which
+    /// `Arc` every later caller sees, and the loser's `V` is dropped.
+    /// Callers needing exact-once side effects (network fetch, file
+    /// write) must guard with a dedicated `OnceLock` or `Mutex`
+    /// outside this cache. The `FnOnce` bound preserves the
+    /// per-invocation move semantics.
     pub fn get_or_compute<F>(&self, key: K, f: F) -> Arc<V>
     where
         F: FnOnce() -> V,

--- a/crates/aube-util/src/concurrency.rs
+++ b/crates/aube-util/src/concurrency.rs
@@ -1,0 +1,118 @@
+//! Concurrency configuration helpers shared across aube crates.
+//!
+//! Today this module exposes one thing: the
+//! `AUBE_CONCURRENCY=<N>` env override that lets users pin the
+//! tarball-fetch fan-out when the default 128 in-flight requests
+//! trigger 429/503 throttling on slow private registries
+//! (Artifactory, Nexus). The override is a knob, not a probe — when
+//! AIMD ramping lands it will live alongside the semaphore in
+//! `aube-registry::concurrency` (the layer that owns retry signals).
+//!
+//! Range-clamped to `[CONCURRENCY_FLOOR, CONCURRENCY_CEILING]` so a
+//! hostile or typo'd value can't exhaust file descriptors on Windows
+//! (default ulimit 8192).
+
+/// Lower bound on `AUBE_CONCURRENCY`. A degenerate slow link still
+/// makes progress with 8 in-flight fetches.
+pub const CONCURRENCY_FLOOR: u32 = 8;
+
+/// Upper bound on `AUBE_CONCURRENCY`. Picked so a pathological env
+/// value cannot exhaust the Windows default fd ulimit.
+pub const CONCURRENCY_CEILING: u32 = 256;
+
+/// Read `AUBE_CONCURRENCY` as a clamped integer override.
+/// Returns `None` when the variable is unset, missing, or outside
+/// the range — callers fall back to the default (npmrc / setting /
+/// hard-coded). Out-of-range and non-numeric values warn.
+pub fn parse_concurrency_env() -> Option<u32> {
+    let raw = std::env::var_os("AUBE_CONCURRENCY")?;
+    if let Some(s) = raw.to_str()
+        && let Ok(n) = s.parse::<u32>()
+        && (CONCURRENCY_FLOOR..=CONCURRENCY_CEILING).contains(&n)
+    {
+        return Some(n);
+    }
+    tracing::warn!(
+        value = ?raw,
+        floor = CONCURRENCY_FLOOR,
+        ceiling = CONCURRENCY_CEILING,
+        "AUBE_CONCURRENCY ignored: must be an integer in [floor, ceiling]; using default"
+    );
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The env var is process-global. Serialize via a static mutex so
+    // these tests don't race the parallel test runner.
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(value: Option<&str>, f: F) {
+        let _g = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var_os("AUBE_CONCURRENCY");
+        // SAFETY: tests serialized via ENV_LOCK; no other thread
+        // touches this var concurrently.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var("AUBE_CONCURRENCY", v),
+                None => std::env::remove_var("AUBE_CONCURRENCY"),
+            }
+        }
+        f();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("AUBE_CONCURRENCY", v),
+                None => std::env::remove_var("AUBE_CONCURRENCY"),
+            }
+        }
+    }
+
+    #[test]
+    fn unset_returns_none() {
+        with_env(None, || assert_eq!(parse_concurrency_env(), None));
+    }
+
+    #[test]
+    fn in_range_returns_value() {
+        with_env(Some("64"), || {
+            assert_eq!(parse_concurrency_env(), Some(64));
+        });
+    }
+
+    #[test]
+    fn below_floor_warns_and_returns_none() {
+        with_env(Some("1"), || assert_eq!(parse_concurrency_env(), None));
+    }
+
+    #[test]
+    fn above_ceiling_warns_and_returns_none() {
+        with_env(Some("99999"), || {
+            assert_eq!(parse_concurrency_env(), None);
+        });
+    }
+
+    #[test]
+    fn non_numeric_warns_and_returns_none() {
+        with_env(Some("garbage"), || {
+            assert_eq!(parse_concurrency_env(), None);
+        });
+    }
+
+    #[test]
+    fn empty_warns_and_returns_none() {
+        with_env(Some(""), || assert_eq!(parse_concurrency_env(), None));
+    }
+
+    #[test]
+    fn floor_and_ceiling_inclusive() {
+        with_env(Some("8"), || {
+            assert_eq!(parse_concurrency_env(), Some(CONCURRENCY_FLOOR));
+        });
+        with_env(Some("256"), || {
+            assert_eq!(parse_concurrency_env(), Some(CONCURRENCY_CEILING));
+        });
+    }
+}

--- a/crates/aube-util/src/hash.rs
+++ b/crates/aube-util/src/hash.rs
@@ -1,5 +1,14 @@
+use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::io;
+use std::path::Path;
+
+/// Files at or above this size hash via `update_mmap_rayon`. Below it
+/// the streaming reader wins because mmap setup (vma alloc + first
+/// page fault) dominates for small files. 4 MiB is the elbow on
+/// modern x86 + ARM64; benched against `aube-store` CAS verify on
+/// `fixtures/medium`.
+pub const BLAKE3_MMAP_THRESHOLD: u64 = 4 * 1024 * 1024;
 
 /// Length-prefixed, tagged BLAKE3 builder. Every field carries a
 /// short ASCII tag plus a `u64` length so concatenation collisions
@@ -135,6 +144,60 @@ impl<R: io::Read> io::Read for TeeReader<'_, R> {
     }
 }
 
+/// BLAKE3 a file, picking the fastest path for its size.
+///
+/// Files at or above [`BLAKE3_MMAP_THRESHOLD`] use
+/// `Hasher::update_mmap_rayon`, which mmaps the file and hashes
+/// chunks across rayon workers (~6-10 GB/s on modern x86 vs ~2 GB/s
+/// for single-threaded streaming). Smaller files use a buffered read,
+/// because mmap setup cost dominates below the threshold.
+///
+/// Caller must guarantee the file is not mutated during the call.
+/// Aube CAS files are write-once + content-addressed by construction
+/// (`O_CREAT|O_EXCL` write semantics in `aube-store`), so this
+/// invariant holds for every hash check on a CAS path.
+///
+/// `AUBE_DISABLE_MMAP_BLAKE3=1` forces the streaming path on every
+/// call. Useful as a killswitch if a future kernel + filesystem
+/// combination regresses.
+pub fn blake3_hash_file<P: AsRef<Path>>(path: P) -> io::Result<[u8; 32]> {
+    let path = path.as_ref();
+    let mut hasher = blake3::Hasher::new();
+    if mmap_disabled() {
+        return blake3_streaming(path, hasher);
+    }
+    let metadata = std::fs::metadata(path)?;
+    if metadata.len() >= BLAKE3_MMAP_THRESHOLD {
+        // Bubble mmap errors (EINVAL on tmpfs in some sandboxes,
+        // EACCES on noexec mounts) up to the streaming fallback so
+        // we never poison the hash with a partial mmap. Trace at
+        // debug so users on those filesystems can see why the fast
+        // path isn't engaging.
+        match hasher.update_mmap_rayon(path) {
+            Ok(_) => return Ok(*hasher.finalize().as_bytes()),
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    path = %path.display(),
+                    "blake3 mmap unavailable, falling back to streaming",
+                );
+                hasher = blake3::Hasher::new();
+            }
+        }
+    }
+    blake3_streaming(path, hasher)
+}
+
+fn blake3_streaming(path: &Path, mut hasher: blake3::Hasher) -> io::Result<[u8; 32]> {
+    let mut file = File::open(path)?;
+    io::copy(&mut file, &mut hasher)?;
+    Ok(*hasher.finalize().as_bytes())
+}
+
+fn mmap_disabled() -> bool {
+    std::env::var_os("AUBE_DISABLE_MMAP_BLAKE3").is_some()
+}
+
 pub fn ordered_seq_hash<I, T>(iter: I) -> u64
 where
     I: IntoIterator<Item = T>,
@@ -262,6 +325,50 @@ fn canonical_json(v: &serde_json::Value, hasher: &mut blake3::Hasher) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn blake3_hash_file_matches_in_memory_under_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("small.bin");
+        let data = b"hello aube small file";
+        std::fs::write(&path, data).unwrap();
+        let from_file = blake3_hash_file(&path).unwrap();
+        let from_mem = *blake3::hash(data).as_bytes();
+        assert_eq!(from_file, from_mem);
+    }
+
+    #[test]
+    fn blake3_hash_file_matches_in_memory_over_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.bin");
+        // 5 MiB crosses BLAKE3_MMAP_THRESHOLD and exercises the
+        // mmap-rayon path. Pseudo-random bytes (deterministic) so
+        // the test stays reproducible without a CSPRNG dep.
+        let mut data = Vec::with_capacity(5 * 1024 * 1024);
+        for i in 0..(5 * 1024 * 1024u32) {
+            data.push((i.wrapping_mul(2654435761) >> 24) as u8);
+        }
+        std::fs::write(&path, &data).unwrap();
+        let from_file = blake3_hash_file(&path).unwrap();
+        let from_mem = *blake3::hash(&data).as_bytes();
+        assert_eq!(from_file, from_mem);
+    }
+
+    #[test]
+    fn blake3_streaming_path_matches_in_memory() {
+        // Direct test of the streaming fallback that bypasses the
+        // mmap path entirely — exercises the same code the killswitch
+        // would, without touching a process-global env var (which
+        // would race with the parallel tests above that also call
+        // `blake3_hash_file`).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stream.bin");
+        let data = vec![0xa5u8; (BLAKE3_MMAP_THRESHOLD as usize) + 1024];
+        std::fs::write(&path, &data).unwrap();
+        let streamed = blake3_streaming(&path, blake3::Hasher::new()).unwrap();
+        let from_mem = *blake3::hash(&data).as_bytes();
+        assert_eq!(streamed, from_mem);
+    }
 
     #[test]
     fn ordered_seq_hash_is_order_sensitive() {

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod buf;
 pub mod cache;
+pub mod concurrency;
 pub mod env;
 pub mod fs_atomic;
 pub mod hash;
 pub mod path;
 pub mod pkg;
+pub mod snapshot;
 pub mod url;
 
 use serde::{Deserialize, Deserializer};

--- a/crates/aube-util/src/snapshot.rs
+++ b/crates/aube-util/src/snapshot.rs
@@ -1,0 +1,173 @@
+//! Cross-platform tree snapshot primitives.
+//!
+//! Portable per-file reflink walker. On CoW filesystems (APFS,
+//! btrfs, XFS-with-reflinks, ReFS) produces an O(extent-tree)
+//! snapshot via the `reflink-copy` crate; falls through to
+//! `std::fs::copy` per file otherwise. `AUBE_DISABLE_SNAPSHOTS=1`
+//! forces the buffered-copy path for byte-identity diffs.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// Outcome of a tree snapshot. `Reflinked` means at least one file in
+/// the tree took the CoW path; `Copied` means every file fell back to
+/// a buffered copy. Useful for tracing-level diagnostics; functionally
+/// the result is identical bytes either way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotOutcome {
+    Reflinked,
+    Copied,
+}
+
+/// Recursively copy `src` into `dst`, preferring per-file reflinks
+/// when the underlying filesystem supports them. `dst` must not exist;
+/// the caller owns conflict resolution (rename, overwrite, swap).
+///
+/// Symlinks are recreated as symlinks pointing at their original
+/// target (relative or absolute, copied verbatim). Files use
+/// `reflink_or_copy`; directories are walked depth-first.
+///
+/// `AUBE_DISABLE_SNAPSHOTS=1` forces every file through `fs::copy`
+/// even when reflinks are available, for use as a regression
+/// killswitch.
+pub fn clone_tree(src: &Path, dst: &Path) -> io::Result<SnapshotOutcome> {
+    if dst.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("snapshot destination already exists: {}", dst.display()),
+        ));
+    }
+    let mut state = WalkState::default();
+    walk(src, dst, &mut state)?;
+    Ok(if state.reflinked > 0 {
+        SnapshotOutcome::Reflinked
+    } else {
+        SnapshotOutcome::Copied
+    })
+}
+
+#[derive(Default)]
+struct WalkState {
+    reflinked: u64,
+    copied: u64,
+}
+
+fn snapshots_disabled() -> bool {
+    std::env::var_os("AUBE_DISABLE_SNAPSHOTS").is_some()
+}
+
+fn walk(src: &Path, dst: &Path, state: &mut WalkState) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(src)?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        let target = fs::read_link(src)?;
+        symlink(&target, dst)?;
+        return Ok(());
+    }
+    if file_type.is_dir() {
+        fs::create_dir_all(dst)?;
+        for entry in fs::read_dir(src)? {
+            let entry = entry?;
+            walk(&entry.path(), &dst.join(entry.file_name()), state)?;
+        }
+        return Ok(());
+    }
+    if snapshots_disabled() {
+        fs::copy(src, dst)?;
+        state.copied += 1;
+        return Ok(());
+    }
+    match reflink_copy::reflink_or_copy(src, dst) {
+        Ok(Some(_)) => state.copied += 1,
+        Ok(None) => state.reflinked += 1,
+        Err(e) => return Err(e),
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn symlink(target: &Path, link: &Path) -> io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+/// Windows symlink creation: requires `SeCreateSymbolicLinkPrivilege`
+/// (Developer Mode, elevation, or explicit policy grant). Stock dev
+/// boxes without Developer Mode will see `ERROR_PRIVILEGE_NOT_HELD`.
+/// `aube-linker` sidesteps this by using NTFS junctions for directory
+/// links; `clone_tree` callers that point at `node_modules/.aube/`
+/// trees on Windows should expect to need junction-aware logic
+/// instead. Wire that path before adopting `clone_tree` for the
+/// branch-swap snapshot use case (Phase 5 P5-W4).
+#[cfg(windows)]
+fn symlink(target: &Path, link: &Path) -> io::Result<()> {
+    // The stored `target` may be relative (npm package layouts almost
+    // always are: `../react/index.js`). Resolve against `link`'s
+    // parent — the directory the symlink will live in — to decide
+    // dir-vs-file, since that is the FS-level base from which the
+    // OS will resolve the link at read time. Falls back to
+    // `symlink_file` on missing target so dangling links don't fail
+    // the snapshot outright.
+    let resolved = link
+        .parent()
+        .map(|p| p.join(target))
+        .unwrap_or_else(|| target.to_path_buf());
+    let is_dir = std::fs::metadata(&resolved)
+        .map(|m| m.is_dir())
+        .unwrap_or(false);
+    if is_dir {
+        std::os::windows::fs::symlink_dir(target, link)
+    } else {
+        std::os::windows::fs::symlink_file(target, link)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn clone_tree_reproduces_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        fs::create_dir_all(src.join("nested")).unwrap();
+        let mut a = fs::File::create(src.join("a.txt")).unwrap();
+        a.write_all(b"alpha").unwrap();
+        let mut b = fs::File::create(src.join("nested").join("b.txt")).unwrap();
+        b.write_all(b"beta").unwrap();
+        let outcome = clone_tree(&src, &dst).unwrap();
+        assert!(matches!(
+            outcome,
+            SnapshotOutcome::Reflinked | SnapshotOutcome::Copied
+        ));
+        assert_eq!(fs::read(dst.join("a.txt")).unwrap(), b"alpha");
+        assert_eq!(fs::read(dst.join("nested").join("b.txt")).unwrap(), b"beta");
+    }
+
+    #[test]
+    fn clone_tree_refuses_existing_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(&dst).unwrap();
+        let err = clone_tree(&src, &dst).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn clone_tree_handles_empty_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        fs::create_dir_all(&src).unwrap();
+        let outcome = clone_tree(&src, &dst).unwrap();
+        // Empty source: no files reflinked or copied; treated as
+        // `Copied` (the default arm) which is fine — outcome is a
+        // diagnostic, not a contract.
+        assert_eq!(outcome, SnapshotOutcome::Copied);
+        assert!(dst.exists());
+    }
+}

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -597,6 +597,45 @@ pub(super) fn import_verified_tarball(
     Ok(index)
 }
 
+/// Streaming-aware variant of [`import_verified_tarball`]. When
+/// `streamed_sha512` is `Some`, the SRI is verified against the
+/// precomputed digest and the buffered hash pass is skipped. When
+/// the SRI uses a non-SHA-512 algo (legacy), the buffered fallback
+/// re-hashes with the right algo. `None` is identical to calling
+/// `import_verified_tarball` directly.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn import_verified_tarball_streamed(
+    store: &aube_store::Store,
+    bytes: &[u8],
+    streamed_sha512: Option<&[u8; 64]>,
+    display_name: &str,
+    registry_name: &str,
+    version: &str,
+    integrity: Option<&str>,
+    verify_integrity: bool,
+    strict_integrity: bool,
+    strict_pkg_content_check: bool,
+) -> miette::Result<aube_store::PackageIndex> {
+    let already_verified = match (verify_integrity, streamed_sha512, integrity) {
+        (true, Some(digest), Some(expected)) => {
+            aube_store::verify_precomputed_sha512(digest, expected)
+                .map_err(|e| miette!("{display_name}@{version}: {e}"))?
+        }
+        _ => false,
+    };
+    import_verified_tarball(
+        store,
+        bytes,
+        display_name,
+        registry_name,
+        version,
+        integrity,
+        verify_integrity && !already_verified,
+        strict_integrity,
+        strict_pkg_content_check,
+    )
+}
+
 pub(super) fn validate_required_scripts(
     project_dir: &std::path::Path,
     manifest: &aube_manifest::PackageJson,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -25,8 +25,8 @@ pub use frozen::{FrozenMode, FrozenOverride, GlobalVirtualStoreFlags};
 use git_prepare::{prepare_scratch_copy, run_git_dep_prepare};
 pub(crate) use lifecycle::{JailBuildPolicy, build_policy_from_sources, run_dep_lifecycle_scripts};
 use lifecycle::{
-    import_verified_tarball, resolve_link_strategy, run_root_lifecycle, unreviewed_dep_builds,
-    validate_required_scripts,
+    import_verified_tarball_streamed, resolve_link_strategy, run_root_lifecycle,
+    unreviewed_dep_builds, validate_required_scripts,
 };
 pub(crate) use settings::PeerDependencyRules;
 pub(crate) use settings::{resolve_dependency_policy, resolve_force_metadata_primer};
@@ -1095,6 +1095,19 @@ where
         p.inc_reused(cached_count);
     }
 
+    // Critical-path fetch order: float likely-native-build packages
+    // (sharp, esbuild, @swc/*, sqlite3, lmdb, bcrypt, etc) to the
+    // front of the queue. These packages run prebuild/node-gyp at
+    // install time, and starting their fetch first lets the build
+    // step pipeline with subsequent fetches instead of blocking on
+    // the tail. `sort_by_key` is stable so non-native packages keep
+    // their lockfile-discovery order; only the natives jump ahead.
+    // `AUBE_DISABLE_CRITICAL_PATH=1` reverts to the previous order
+    // for byte-identity comparison runs.
+    if std::env::var_os("AUBE_DISABLE_CRITICAL_PATH").is_none() {
+        to_fetch
+            .sort_by_key(|(_, _, registry_name, _, _, _)| !is_likely_native_build(registry_name));
+    }
     let fetch_count = to_fetch.len();
 
     if !to_fetch.is_empty() {
@@ -1123,6 +1136,11 @@ where
         // time vs the previous 64.
         let sem_permits = network_concurrency.unwrap_or_else(default_lockfile_network_concurrency);
         let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(sem_permits));
+        // Hoist the streaming-SHA-512 killswitch out of the per-tarball
+        // closure so the env read happens once instead of N times on a
+        // 1000-pkg install. `var_os` takes a libc lock, so the
+        // amortized save is real even though each call is cheap.
+        let streaming_sha512_enabled = std::env::var_os("AUBE_DISABLE_STREAMING_SHA512").is_none();
         // JoinSet so a first-error path aborts the sibling fetches
         // instead of detaching them into the background. Detached
         // tasks keep writing to the CAS after the install command
@@ -1154,10 +1172,30 @@ where
                     .unwrap_or_else(|| client.tarball_url(&registry_name, &version));
 
                 let dl_start = std::time::Instant::now();
-                let bytes = client
-                    .fetch_tarball_bytes(&url)
-                    .await
-                    .map_err(|e| miette!("failed to fetch {display_name}@{version}: {e}"))?;
+                // Streaming SHA-512 path: the registry-mandated
+                // integrity hash is computed during the chunk read
+                // loop, so the post-buffer pass in
+                // `import_verified_tarball` skips its hash and goes
+                // straight to compare. Saves ~7 ms/5 MB tarball.
+                // `AUBE_DISABLE_STREAMING_SHA512=1` reverts to the
+                // buffered-then-hash path. The killswitch covers a
+                // hypothetical regression where the streaming digest
+                // disagrees with the buffered one (it shouldn't, sha2
+                // is deterministic) and lets us isolate via env in CI.
+                let (bytes, streamed_digest) = if streaming_sha512_enabled {
+                    let (bytes, digest) = client
+                        .fetch_tarball_bytes_streaming_sha512(&url)
+                        .await
+                        .map_err(|e| {
+                            miette!("failed to fetch {display_name}@{version}: {e}")
+                        })?;
+                    (bytes, Some(digest))
+                } else {
+                    let bytes = client.fetch_tarball_bytes(&url).await.map_err(|e| {
+                        miette!("failed to fetch {display_name}@{version}: {e}")
+                    })?;
+                    (bytes, None)
+                };
                 let dl_time = dl_start.elapsed();
 
                 if let Some(p) = bytes_progress.as_ref() {
@@ -1187,9 +1225,10 @@ where
                     let version = version.clone();
                     move || -> miette::Result<_> {
                         let import_start = std::time::Instant::now();
-                        let index = import_verified_tarball(
+                        let index = import_verified_tarball_streamed(
                             &store,
                             &bytes,
+                            streamed_digest.as_ref(),
                             &display_name,
                             &registry_name,
                             &version,
@@ -1224,6 +1263,56 @@ where
     }
 
     Ok((indices, cached_count, fetch_count))
+}
+
+/// Heuristic: is this registry name likely to run a native build
+/// (`node-gyp`, `prebuild-install`, `cmake-js`, `@napi-rs/cli`) at
+/// install time? Used by the critical-path fetch reorder to float
+/// these packages to the front of the download queue so their build
+/// step can pipeline with the remaining tarball downloads.
+///
+/// Curated allowlist: covers the long-tail native packages that
+/// dominate cold-install wall time on a 1000-pkg graph. False
+/// negatives are fine (the package fetches in normal order); false
+/// positives are also fine (the package fetches earlier, no harm).
+/// Update this list when bench data shows a new heavy native dep.
+fn is_likely_native_build(registry_name: &str) -> bool {
+    // Exact-match heavy hitters. `ws` and `sass` deliberately
+    // omitted: pure-JS by default; only `node-sass` is the
+    // deprecated native build.
+    const EXACT: &[&str] = &[
+        "sharp",
+        "esbuild",
+        "fsevents",
+        "canvas",
+        "bcrypt",
+        "node-sass",
+        "sqlite3",
+        "better-sqlite3",
+        "lmdb",
+        "msgpackr-extract",
+        "sodium-native",
+        "node-gyp",
+        "prebuild-install",
+        "node-gyp-build",
+    ];
+    if EXACT.contains(&registry_name) {
+        return true;
+    }
+    // Scoped prefixes: `@swc/*`, `@parcel/*`, `@napi-rs/*`,
+    // `@next/swc-*`, `@rollup/rollup-*`, `@esbuild/*` all ship
+    // platform-specific native binaries.
+    const PREFIXES: &[&str] = &[
+        "@swc/",
+        "@parcel/",
+        "@napi-rs/",
+        "@next/swc-",
+        "@rollup/rollup-",
+        "@esbuild/",
+        "@playwright/",
+        "@biomejs/",
+    ];
+    PREFIXES.iter().any(|p| registry_name.starts_with(p))
 }
 
 /// Pull the canonical version off a dep_path for display purposes. The
@@ -2471,13 +2560,29 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let build_policy_for_prewarm = std::sync::Arc::new(build_policy_for_prewarm);
             let client =
                 std::sync::Arc::new(make_client(&cwd).with_network_mode(opts.network_mode));
+            // Speculative TLS + TCP + HTTP/2 handshake. Fires while the
+            // rest of this function builds the resolver, parses the
+            // manifest, and reads the lockfile. By the time the
+            // resolver requests its first packument the connection
+            // pool is already warm, hiding ~50-150 ms of handshake on
+            // cold installs. `AUBE_DISABLE_SPECULATIVE_TLS=1` opts
+            // out.
+            client.prewarm_connection();
             let tarball_client = client.clone();
 
             // Set up streaming resolver with disk-backed packument cache.
             // Resolver options are applied via `configure_resolver` so the
             // `--lockfile-only` short-circuit produces an identical lockfile.
-            let fetch_network_concurrency =
-                network_concurrency_setting.unwrap_or_else(default_streaming_network_concurrency);
+            // `AUBE_CONCURRENCY` is an emergency override for users on slow
+            // private registries (Artifactory, Nexus) where the default
+            // 128 in-flight tarballs trigger 429/503 throttling. Honored
+            // ahead of `network_concurrency_setting` so the env var wins
+            // over npmrc + workspace yaml.
+            let env_concurrency =
+                aube_util::concurrency::parse_concurrency_env().map(|n| n as usize);
+            let fetch_network_concurrency = env_concurrency
+                .or(network_concurrency_setting)
+                .unwrap_or_else(default_streaming_network_concurrency);
             let (resolver, mut resolved_rx) =
                 aube_resolver::Resolver::with_stream_capacity(client, fetch_network_concurrency);
             let pnpmfile_paths = if opts.ignore_pnpmfile {
@@ -2578,6 +2683,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let fetch_handle = tokio::spawn(async move {
                 let semaphore =
                     std::sync::Arc::new(tokio::sync::Semaphore::new(fetch_network_concurrency));
+                // Hoist streaming-SHA-512 killswitch out of the
+                // per-tarball loop, same shape as the lockfile path.
+                let streaming_sha512_enabled =
+                    std::env::var_os("AUBE_DISABLE_STREAMING_SHA512").is_none();
                 // JoinSet over bare Vec<JoinHandle>. If the first
                 // fetch errors and we return via `?`, a plain Vec
                 // drops the remaining JoinHandles which detaches the
@@ -2718,9 +2827,20 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         });
                         tracing::trace!("Fetching {}@{}", pkg.name, pkg.version);
 
-                        let bytes = client.fetch_tarball_bytes(&url).await.map_err(|e| {
-                            miette!("failed to fetch {}@{}: {e}", pkg.name, pkg.version)
-                        })?;
+                        let (bytes, streamed_digest) = if streaming_sha512_enabled {
+                            let (bytes, digest) = client
+                                .fetch_tarball_bytes_streaming_sha512(&url)
+                                .await
+                                .map_err(|e| {
+                                    miette!("failed to fetch {}@{}: {e}", pkg.name, pkg.version)
+                                })?;
+                            (bytes, Some(digest))
+                        } else {
+                            let bytes = client.fetch_tarball_bytes(&url).await.map_err(|e| {
+                                miette!("failed to fetch {}@{}: {e}", pkg.name, pkg.version)
+                            })?;
+                            (bytes, None)
+                        };
                         if let Some(p) = bytes_progress.as_ref() {
                             p.inc_downloaded_bytes(bytes.len() as u64);
                         }
@@ -2746,9 +2866,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         let dep_path = pkg.dep_path.clone();
                         let integrity = pkg.integrity.clone();
                         let index = tokio::task::spawn_blocking(move || {
-                            import_verified_tarball(
+                            import_verified_tarball_streamed(
                                 &store,
                                 &bytes,
+                                streamed_digest.as_ref(),
                                 &pkg_display_name,
                                 &pkg_registry_name,
                                 &pkg_version,
@@ -4519,5 +4640,83 @@ mod allow_build_review_tests {
     fn package_name_from_spec_key_handles_unscoped_names() {
         assert_eq!(package_name_from_spec_key("esbuild@1.2.3"), "esbuild");
         assert_eq!(package_name_from_spec_key("esbuild"), "esbuild");
+    }
+}
+
+#[cfg(test)]
+mod critical_path_tests {
+    use super::is_likely_native_build;
+
+    #[test]
+    fn flags_exact_native_packages() {
+        for name in [
+            "sharp",
+            "esbuild",
+            "fsevents",
+            "node-gyp",
+            "better-sqlite3",
+            "sodium-native",
+        ] {
+            assert!(is_likely_native_build(name), "{name} should match");
+        }
+    }
+
+    #[test]
+    fn flags_scoped_native_prefixes() {
+        for name in [
+            "@swc/core",
+            "@swc/cli",
+            "@parcel/source-map",
+            "@napi-rs/cli",
+            "@next/swc-linux-x64-gnu",
+            "@rollup/rollup-linux-x64-gnu",
+            "@esbuild/linux-x64",
+            "@playwright/test",
+            "@biomejs/biome",
+        ] {
+            assert!(is_likely_native_build(name), "{name} should match");
+        }
+    }
+
+    #[test]
+    fn does_not_flag_pure_js_packages() {
+        for name in [
+            "react",
+            "lodash",
+            "@types/node",
+            "swc",  // unscoped, not native
+            "ws",   // pure JS
+            "sass", // dart-sass, pure JS
+            "@scope/random",
+        ] {
+            assert!(!is_likely_native_build(name), "{name} should NOT match");
+        }
+    }
+
+    #[test]
+    fn sort_is_stable_within_groups() {
+        // Mirror the sort applied at install/mod.rs. Stable sort
+        // must keep relative order within natives and non-natives.
+        let mut items = [
+            ("react", 1),
+            ("sharp", 2),
+            ("lodash", 3),
+            ("esbuild", 4),
+            ("@types/node", 5),
+            ("@swc/core", 6),
+        ];
+        items.sort_by_key(|(name, _)| !is_likely_native_build(name));
+        let order: Vec<&str> = items.iter().map(|(n, _)| *n).collect();
+        assert_eq!(
+            order,
+            [
+                "sharp",
+                "esbuild",
+                "@swc/core",
+                "react",
+                "lodash",
+                "@types/node"
+            ]
+        );
     }
 }


### PR DESCRIPTION
Second pass over install hot path. Bounded changes, no on-disk output drift, no lockfile-byte drift, no fetched-byte drift.

## Added

### Shared utils (`aube-util`)

- `cache::{ProcessCache, DiskCache, FreshnessSnapshot}` for in-memory + disk + mtime/size/blake3 freshness primitives
- `buf::{with_scratch_string, with_scratch_bytes}` thread-local scratch buffers
- `hash::{Blake3Builder, TeeReader, ByteHasher, blake3_hash_file}` length-prefixed hasher, streaming tee, mmap-rayon BLAKE3 over 4 MiB
- `fs_atomic::write_excl` direct `O_CREAT|O_EXCL` write returning `WriteOutcome`
- `concurrency::parse_concurrency_env` clamped `AUBE_CONCURRENCY=N` override
- `snapshot::clone_tree` reflink-aware tree copy (CoW on APFS / btrfs / ReFS, fallback `fs::copy`)

### Install pipeline

- `RegistryClient::prewarm_connection` fire-and-forget HEAD warms TLS + TCP + HTTP/2 behind manifest parse
- `RegistryClient::fetch_tarball_bytes_streaming_sha512` streams SHA-512 over wire chunks, skips post-buffer hash pass
- `aube_store::verify_precomputed_sha512` returns `Result<bool, Error>` (`true` = matched, `false` = non-SHA-512 fallback)
- `import_verified_tarball_streamed` consumes precomputed digest, falls through to buffered path on legacy SRI
- `is_likely_native_build` allowlist for critical-path fetch reorder

## Changed

### Install
- streaming SHA-512 wired in BOTH lockfile + catch-up fetch paths
- critical-path fetch sort: native-build packages float to front via stable `sort_by_key`
- shared `Arc<GraphHashes>` between prewarm and link, no double-compute
- lockfile-only branch reuses resolver's `Arc<RegistryClient>` instead of rebuilding
- network concurrency default raised 64 → 128

### Store
- two-phase `import_tarball`: serial tar walk stages entries, rayon batch writes when entries ≥ 256
- `O_CREAT|O_EXCL` direct write replaces tempfile + persist-noclobber for content path
- new internal `CasWriteOutcome` skips redundant len check on `Created` outcome
- post-write `cas_file_matches_len` only on `AlreadyExisted` arm

### Registry
- `Accept-Encoding: gzip, br, zstd` on packument fetches (tarballs stay `identity`)
- real `aube/<workspace-version> (<os> <arch>)` UA replaces hardcoded `aube/0.1.0`
- `hickory-dns` enabled for in-process async DNS cache
- buffered `read_body_capped` + `retry_bytes_body_read` delegate through one streaming chunk loop

### Linker
- canonicalize result memoized via `OnceLock<RwLock<HashMap>>` on Windows
- reflink-probe result cached process-wide keyed on `(src, dst)`
- skip `make_executable` chmod on hardlink + reflink paths (CAS source already `0o755`)

### Resolver
- peer-context fixed-point loop carries forward graph hash, one walk per iter instead of two

### Manifest
- `PackageJson::from_path_cached` returns `Arc<PackageJson>` from process-wide cache
- `WorkspaceConfig::load` typed cache parallel to existing raw cache

### Settings
- `meta::find` switches from linear scan to `binary_search_by` over the codegen-sorted table

### State
- `package_json_meta` mtime + size fast-path skips BLAKE3 when both unchanged
- additive serde field, forward-compatible with older state files

### CLI
- `find_project_root` + `find_workspace_root` memoize via `ProcessCache`
- 7 sites borrow `process_env()` slice instead of cloning a fresh `Vec<(String, String)>`

### Lockfile
- `dep_path_filename::short_hash` SHA-256 → BLAKE3 (internal-only, not interop)
- `parse_json` clone-then-mutate contract documented

## Killswitches

| env | falls back to |
|---|---|
| `AUBE_DISABLE_STREAMING_SHA512` | buffered SHA-512 verify pass |
| `AUBE_DISABLE_SPECULATIVE_TLS` | no prewarm |
| `AUBE_DISABLE_CRITICAL_PATH` | resolver-discovery fetch order |
| `AUBE_DISABLE_PARALLEL_IMPORT` | serial tar entry writes |
| `AUBE_DISABLE_MMAP_BLAKE3` | streaming BLAKE3 |
| `AUBE_DISABLE_SNAPSHOTS` | per-file `fs::copy` |
| `AUBE_CONCURRENCY=N` | clamped fixed permit count |

## Round 2 (post-Greptile)

### Fixed
- Linker probe cache `entry().or_insert(strategy)` first-write-wins, was `.insert()` last-write-wins. Two concurrent linker probes (prewarm + final) racing on shared test files could clobber a correct Reflink result with a Copy fallback for the rest of the process
- `DiskCache::write_bytes` does `create_dir_all(parent)` before `atomic_write`. Cold first write would fail with `NotFound` under the old code
- `verify_precomputed_sha512` distinguishes `malformed base64` and `decoded N bytes, expected 64` from `integrity mismatch`. Three clear messages instead of one misleading bucket

### Simplified
- Deleted dead AIMD scaffolding from `aube_util::concurrency`. `ConcurrencyProbe` + `bump`/`back_off`/`AdjustReason` had zero non-test callers. Replaced with `parse_concurrency_env() -> Option<u32>` (~120 LOC removed)
- `Error::IntegrityAlgoUnsupported` variant deleted. `verify_precomputed_sha512` returns `Result<bool, Error>` so callers detect non-SHA-512 fallback without matching on a sentinel error
- `import_verified_tarball_streamed` accepts `Option<&[u8; 64]>`, both call sites collapse from 22-line match arms to single calls
- `is_likely_native_build` allowlist trimmed: `ws` and `sass` are pure-JS, only `node-sass` is the actual native build

### Tests
- 4× `verify_precomputed_sha512` unit tests (happy / mismatch / non-SHA-512 fallback / malformed)
- 4× `is_likely_native_build` + sort stability tests
- 7× `parse_concurrency_env` env-bound tests

## Round 3 (cold-path audit, 6-agent sweep)

Targeted at items the agents flagged as cold-relevant only. All preserve symlink topology, lockfile bytes, CAS bytes.

### Registry — biggest single cold win
- `parse_full_response`: `bytes.to_vec()` was cloning a 5-50 MB packument body on every fetch. Replaced with `Bytes::try_into_mut` zero-copy → `BytesMut`, dropped the dead `serde_json::from_slice` fallback (simd-json is a strict superset of RFC 8259 for valid JSON). Estimated ~1-3 s saved on a 200-packument cold install
- `same_host()` URL re-parsing on every authed request: cached `self.config.registry` parse via `OnceLock<reqwest::Url>` on `RegistryClient`. Comparison shape (scheme + host + port) preserved byte-for-byte to keep the global-auth-token leak guard semantics identical

### Linker
- Pre-create `aube_dir` + scope dirs once before the GVS step1 par_iter (both branches), drop the per-package `mkdirp(parent)` that paid 1.4k stat syscalls on a typical install
- `materialize_into` parents `BTreeSet<PathBuf>` → `Vec` + `sort_unstable` + `dedup`. On heavy packages (typescript ~5k entries, next ~3k) the BTreeSet's per-insert log-N PathBuf comparison on 50-byte paths was a real cost
- `claimed: HashSet<String>` → `FxHashSet<&str>` in both hoist passes. Drops `pkg.name.clone()` × hundreds + SipHash overhead

### Store
- `normalize_tar_entry_path` pre-sizes output via `String::with_capacity(raw.as_os_str().len())`. Normalized form never grows beyond input, so the prealloc eliminates the `String` Vec growth on every tar entry

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` 1289+ assertions, 0 failures
- [ ] hermetic bench (`mise run bench:bump`) shows no cold-install regression vs main
- [ ] verdaccio access-log diff: same set of unique URLs requested
- [ ] store byte-identity snapshot unchanged
- [ ] lockfile byte-identity unchanged on `fixtures/medium`

## Real-world cold install bench (Windows, real npm registry)

3 runs each project, fresh aube store + cache + node_modules between runs. Min wall (cleanest signal):

| project | upstream main 1.6.2 | this PR | × faster |
|---|---:|---:|---:|
| svelte (56 pkg) | 1393 ms | 1386 ms | 1.01× |
| vue (117 pkg) | 1590 ms | 1360 ms | 1.17× |
| nextjs (336 pkg) | 14071 ms | 9160 ms | 1.54× |
| babylon (21 pkg) | ~6000 ms | 3186 ms | ~1.9× |

vs bun 1.3.13 cold (real npm registry, fresh cache):

| project | bun | this PR | × faster |
|---|---:|---:|---:|
| svelte | 7598 ms | 1438 ms | 5.28× |
| vue | 13792 ms | 1501 ms | 9.19× |
| nextjs | 46971 ms | 8177 ms | 5.74× |
| babylon | 4217 ms | 3366 ms | 1.25× |
