### PR TITLE
fix(resolver): resolve nested link:/file: deps from local parents and overrides

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2520,13 +2520,25 @@ impl Linker {
             // on-disk target. Skip the virtual-store sibling lookup
             // (there is no `.aube/<dep>@link+...` entry for these) and
             // symlink straight at the source directory.
+            //
+            // Store the absolute target verbatim. A relative path
+            // would have to thread two pitfalls at once: the GVS
+            // tmp→final rename (link's own depth changes by one) AND
+            // macOS `/tmp`→`/private/tmp` symlink expansion (the dir
+            // the OS resolves the link from is one level deeper than
+            // `self.virtual_store` lexically suggests). Either alone
+            // is fixable; together every `pathdiff` variant lands one
+            // component off and the link dangles. Sibling symlinks
+            // get away with relative paths because both endpoints
+            // live inside `base_dir` and move together; nested-link
+            // targets are *external* (under `project_dir`) so the
+            // tricks that work for siblings don't apply. Windows
+            // already uses absolute targets for the same reason (see
+            // the `#[cfg(windows)]` block below).
             if let Some(map) = nested_link_targets
                 && let Some(abs_target) = map.get(&dep_dep_path)
             {
-                let link_parent = symlink_path.parent().unwrap_or(&pkg_nm_parent);
-                let target = pathdiff::diff_paths(abs_target, link_parent)
-                    .unwrap_or_else(|| abs_target.clone());
-                sys::create_dir_link(&target, &symlink_path)
+                sys::create_dir_link(abs_target, &symlink_path)
                     .map_err(|e| Error::Io(symlink_path.clone(), e))?;
                 continue;
             }

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -1100,6 +1100,8 @@ impl Linker {
             );
         }
 
+        let nested_link_targets = build_nested_link_targets(project_dir, graph);
+
         // Step 1: Populate .aube virtual store
         //
         // Local packages (file:/link:) never go into the shared global
@@ -1119,7 +1121,15 @@ impl Linker {
             };
             let aube_entry = aube_dir.join(dep_path);
             if !aube_entry.exists() {
-                self.materialize_into(&aube_dir, dep_path, pkg, index, &mut stats, false)?;
+                self.materialize_into(
+                    &aube_dir,
+                    dep_path,
+                    pkg,
+                    index,
+                    &mut stats,
+                    false,
+                    nested_link_targets.as_ref(),
+                )?;
             } else {
                 stats.packages_cached += 1;
             }
@@ -1283,6 +1293,7 @@ impl Linker {
                                 index,
                                 &mut local_stats,
                                 false,
+                                nested_link_targets.as_ref(),
                             )?;
                             Ok(local_stats)
                         })
@@ -1551,6 +1562,8 @@ impl Linker {
             );
         }
 
+        let nested_link_targets = build_nested_link_targets(root_dir, graph);
+
         // Step 1a: Materialize local (`file:` dir/tarball) packages
         // straight into the shared per-project `.aube/`. They never
         // participate in the global virtual store since their source
@@ -1571,7 +1584,15 @@ impl Linker {
                 stats.packages_cached += 1;
                 continue;
             }
-            self.materialize_into(&aube_dir, dep_path, pkg, index, &mut stats, false)?;
+            self.materialize_into(
+                &aube_dir,
+                dep_path,
+                pkg,
+                index,
+                &mut stats,
+                false,
+                nested_link_targets.as_ref(),
+            )?;
         }
 
         // Step 1b: Populate shared .aube virtual store at root for
@@ -1697,6 +1718,7 @@ impl Linker {
                                 index,
                                 &mut local_stats,
                                 false,
+                                nested_link_targets.as_ref(),
                             )?;
                             Ok(local_stats)
                         })
@@ -2257,7 +2279,11 @@ impl Linker {
         let tmp_name = format!(".tmp-{}-{subdir}", std::process::id());
         let tmp_base = self.virtual_store.join(&tmp_name);
 
-        let result = self.materialize_into(&tmp_base, dep_path, pkg, index, stats, true);
+        // Global virtual store is registry-only. Transitive `link:`
+        // deps only live under per-project `.aube/` (their parent must
+        // be a `Directory`/`Link` source), so the nested-link map is
+        // never relevant here.
+        let result = self.materialize_into(&tmp_base, dep_path, pkg, index, stats, true, None);
 
         if result.is_err() {
             let _ = std::fs::remove_dir_all(&tmp_base);
@@ -2328,6 +2354,7 @@ impl Linker {
     /// copies for each `(deps_hash, engine)` combination;
     /// per-project `.aube/` callers pass `false` because node's
     /// runtime module walk resolves by dep_path only.
+    #[allow(clippy::too_many_arguments)]
     fn materialize_into(
         &self,
         base_dir: &Path,
@@ -2336,6 +2363,16 @@ impl Linker {
         index: &PackageIndex,
         stats: &mut LinkStats,
         apply_hashes: bool,
+        // dep_path → absolute on-disk target for any `link:` packages
+        // referenced as transitive deps. When the parent itself is a
+        // `file:` Directory or `link:` Link (workspace-style locals),
+        // its `package.json` may declare `link:./libs/foo` deps that
+        // point inside the parent's source tree. We sidestep the
+        // virtual store for those — there is no `.aube/<dep>@link+...`
+        // entry — and symlink straight to the on-disk path the
+        // resolver pinned. `None` means "no nested link transitives in
+        // this graph", which is the common case.
+        nested_link_targets: Option<&BTreeMap<String, PathBuf>>,
     ) -> Result<(), Error> {
         let subdir = if apply_hashes {
             self.virtual_store_subdir(dep_path)
@@ -2456,6 +2493,21 @@ impl Linker {
             if dep_name == &pkg.name {
                 continue;
             }
+            let symlink_path = pkg_nm_parent.join(dep_name);
+            // `link:` transitive: the resolver pinned an absolute
+            // on-disk target. Skip the virtual-store sibling lookup
+            // (there is no `.aube/<dep>@link+...` entry for these) and
+            // symlink straight at the source directory.
+            if let Some(map) = nested_link_targets
+                && let Some(abs_target) = map.get(&dep_dep_path)
+            {
+                let link_parent = symlink_path.parent().unwrap_or(&pkg_nm_parent);
+                let target = pathdiff::diff_paths(abs_target, link_parent)
+                    .unwrap_or_else(|| abs_target.clone());
+                sys::create_dir_link(&target, &symlink_path)
+                    .map_err(|e| Error::Io(symlink_path.clone(), e))?;
+                continue;
+            }
             // Match the parent's convention: global-store materialization
             // walks sibling subdirs under their hashed names, while the
             // per-project `.aube/` layout uses raw dep_paths.
@@ -2464,7 +2516,6 @@ impl Linker {
             } else {
                 self.aube_dir_entry_name(&dep_dep_path)
             };
-            let symlink_path = pkg_nm_parent.join(dep_name);
             // Compute the relative path from the symlink's parent to
             // the sibling dep directory. The symlink's parent is
             // `pkg_nm_parent/` for a bare name but
@@ -2833,6 +2884,25 @@ fn current_patch_hashes(patches: &Patches) -> std::collections::BTreeMap<String,
             (k.clone(), hex::encode(h.finalize()))
         })
         .collect()
+}
+
+/// Build a `dep_path → absolute on-disk target` map for every
+/// `LocalSource::Link` in the graph. Returned `None` when the graph
+/// has no link entries (vast majority of installs), so the materialize
+/// hot path can short-circuit without a per-dep lookup.
+fn build_nested_link_targets(
+    project_dir: &Path,
+    graph: &LockfileGraph,
+) -> Option<BTreeMap<String, PathBuf>> {
+    let map: BTreeMap<String, PathBuf> = graph
+        .packages
+        .iter()
+        .filter_map(|(dp, pkg)| match pkg.local_source.as_ref() {
+            Some(LocalSource::Link(rel)) => Some((dp.clone(), project_dir.join(rel))),
+            _ => None,
+        })
+        .collect();
+    if map.is_empty() { None } else { Some(map) }
 }
 
 /// Read the previously-applied patch sidecar at

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -1198,7 +1198,13 @@ impl Linker {
                                     &owned_index
                                 }
                             };
-                            self.ensure_in_virtual_store(dep_path, pkg, index, &mut local_stats)?;
+                            self.ensure_in_virtual_store(
+                                dep_path,
+                                pkg,
+                                index,
+                                &mut local_stats,
+                                nested_link_targets.as_ref(),
+                            )?;
 
                             // Only pay the `remove_dir`/`remove_file` syscalls
                             // when we actually have something to remove.
@@ -1646,7 +1652,13 @@ impl Linker {
                                     &owned_index
                                 }
                             };
-                            self.ensure_in_virtual_store(dep_path, pkg, index, &mut local_stats)?;
+                            self.ensure_in_virtual_store(
+                                dep_path,
+                                pkg,
+                                index,
+                                &mut local_stats,
+                                nested_link_targets.as_ref(),
+                            )?;
 
                             if matches!(state, EntryState::Stale) {
                                 let _ = std::fs::remove_dir(&local_aube_entry)
@@ -2253,6 +2265,12 @@ impl Linker {
         pkg: &LockedPackage,
         index: &PackageIndex,
         stats: &mut LinkStats,
+        // `link:` transitives the resolver pinned (e.g. via root
+        // `pnpm.overrides`) need their on-disk target so the parent's
+        // sibling symlink doesn't dangle into a non-existent
+        // `.aube/<name>@link+...`. `None` means "no nested links in
+        // this graph" and the materialize hot path stays unchanged.
+        nested_link_targets: Option<&BTreeMap<String, PathBuf>>,
     ) -> Result<(), Error> {
         // Global-store paths always run through the vstore_key map —
         // when hashes are installed this folds dep-graph + engine
@@ -2279,11 +2297,15 @@ impl Linker {
         let tmp_name = format!(".tmp-{}-{subdir}", std::process::id());
         let tmp_base = self.virtual_store.join(&tmp_name);
 
-        // Global virtual store is registry-only. Transitive `link:`
-        // deps only live under per-project `.aube/` (their parent must
-        // be a `Directory`/`Link` source), so the nested-link map is
-        // never relevant here.
-        let result = self.materialize_into(&tmp_base, dep_path, pkg, index, stats, true, None);
+        let result = self.materialize_into(
+            &tmp_base,
+            dep_path,
+            pkg,
+            index,
+            stats,
+            true,
+            nested_link_targets,
+        );
 
         if result.is_err() {
             let _ = std::fs::remove_dir_all(&tmp_base);
@@ -2890,7 +2912,7 @@ fn current_patch_hashes(patches: &Patches) -> std::collections::BTreeMap<String,
 /// `LocalSource::Link` in the graph. Returned `None` when the graph
 /// has no link entries (vast majority of installs), so the materialize
 /// hot path can short-circuit without a per-dep lookup.
-fn build_nested_link_targets(
+pub fn build_nested_link_targets(
     project_dir: &Path,
     graph: &LockfileGraph,
 ) -> Option<BTreeMap<String, PathBuf>> {

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -236,6 +236,13 @@ pub(crate) struct ResolveTask {
     /// site is responsible for extending its parent's chain with the
     /// parent's own `(name, version)` frame.
     pub(crate) ancestors: Vec<(String, String)>,
+    /// `true` when an override rewrote `range` to a `link:`/`file:`
+    /// path. Override paths are anchored at the project root (where the
+    /// override is declared), not at the consuming workspace package or
+    /// transitive parent — same convention pnpm follows. Without this
+    /// signal the local-source resolver would re-anchor `link:./libs/x`
+    /// against the importer or parent dir and walk to a phantom path.
+    pub(crate) range_from_override: bool,
 }
 
 impl ResolveTask {
@@ -264,6 +271,7 @@ impl ResolveTask {
             original_specifier: Some(original),
             real_name: None,
             ancestors: Vec::new(),
+            range_from_override: false,
         }
     }
 
@@ -288,6 +296,7 @@ impl ResolveTask {
             original_specifier: None,
             real_name: None,
             ancestors,
+            range_from_override: false,
         }
     }
 }

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -542,6 +542,17 @@ impl Resolver {
                                 task.range,
                                 effective_spec
                             );
+                            // Overrides are declared at the project root,
+                            // so a substituted `link:./libs/x` /
+                            // `file:./vendor/y` path is project-root-
+                            // relative — never importer- or parent-
+                            // relative. Mark the task so the local-source
+                            // branch anchors the path correctly even when
+                            // the consumer is a workspace pkg or a nested
+                            // local parent.
+                            if is_non_registry_specifier(&effective_spec) {
+                                task.range_from_override = true;
+                            }
                             task.range = effective_spec;
                             // If the override replaced the spec with a
                             // bare range (not itself an `npm:` / `jsr:`
@@ -657,10 +668,14 @@ impl Resolver {
 
                 // Handle file: / link: / git: protocols — the dep points
                 // at a path on disk or a remote git repo rather than a
-                // registry package. Only valid on root deps; a nested
-                // package.json that declares its own `file:` dep silently
-                // falls through to the normal resolver path and fails
-                // loudly there.
+                // registry package. Root deps anchor on the importer's
+                // directory; transitive `link:`/`file:` deps anchor on
+                // the parent package's source root, but only when the
+                // parent itself was a `file:`/`link:` source (a workspace
+                // sibling or a directly-linked local dir). Registry-
+                // hosted parents have no on-disk source to resolve a
+                // relative path against, so transitive `link:`/`file:`
+                // from them stays an error.
                 if is_non_registry_specifier(&task.range) {
                     if should_block_exotic_subdep(
                         &task,
@@ -678,10 +693,39 @@ impl Resolver {
                             importer: task.importer.clone(),
                         })));
                     }
-                    let importer_root = if task.importer == "." {
+                    // Pull the parent's on-disk source root, when the
+                    // parent is a Directory/Link source. The BFS always
+                    // inserts a parent into `resolved` before enqueuing
+                    // its children, so for transitive tasks the parent
+                    // record is reliably present here.
+                    let parent_source_root: Option<std::path::PathBuf> = (!task.is_root)
+                        .then(|| {
+                            task.parent
+                                .as_ref()
+                                .and_then(|dp| resolved.get(dp))
+                                .and_then(|pkg| pkg.local_source.as_ref())
+                                .and_then(|src| match src {
+                                    LocalSource::Directory(p) | LocalSource::Link(p) => {
+                                        Some(self.project_root.join(p))
+                                    }
+                                    _ => None,
+                                })
+                        })
+                        .flatten();
+                    // Override-substituted link:/file: paths are
+                    // project-root-relative regardless of where the
+                    // consumer lives — pin them at the root before any
+                    // importer/parent fallback wins.
+                    let importer_root = if task.range_from_override {
                         self.project_root.clone()
                     } else {
-                        self.project_root.join(&task.importer)
+                        parent_source_root.clone().unwrap_or_else(|| {
+                            if task.importer == "." {
+                                self.project_root.clone()
+                            } else {
+                                self.project_root.join(&task.importer)
+                            }
+                        })
                     };
                     let Some(raw_local) = LocalSource::parse(&task.range, &importer_root) else {
                         return Err(Error::Registry(
@@ -689,19 +733,20 @@ impl Resolver {
                             format!("unparseable local specifier: {}", task.range),
                         ));
                     };
-                    // For git sources we have to talk to the remote
-                    // right now so the resolver can (a) pin the
-                    // committish to a full SHA for the lockfile and
-                    // (b) read the cloned repo's `package.json` for
-                    // transitive deps. `resolve_git_source` does the
-                    // `ls-remote` + shallow clone dance and returns a
-                    // `LocalSource::Git` with `resolved` populated,
-                    // plus the manifest tuple the rest of the branch
-                    // already expects.
+                    // Git and remote-tarball specifiers don't reference
+                    // a path, so they pass through regardless of parent
+                    // shape. `link:`/`file:` transitives only resolve
+                    // when we either (a) located a parent source root
+                    // or (b) inherited the path from a project-root-
+                    // anchored override.
                     if !task.is_root
-                        && !matches!(
+                        && parent_source_root.is_none()
+                        && !task.range_from_override
+                        && matches!(
                             raw_local,
-                            LocalSource::Git(_) | LocalSource::RemoteTarball(_)
+                            LocalSource::Directory(_)
+                                | LocalSource::Tarball(_)
+                                | LocalSource::Link(_)
                         )
                     {
                         return Err(Error::Registry(

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -677,11 +677,19 @@ impl Resolver {
                 // relative path against, so transitive `link:`/`file:`
                 // from them stays an error.
                 if is_non_registry_specifier(&task.range) {
-                    if should_block_exotic_subdep(
-                        &task,
-                        &resolved,
-                        self.dependency_policy.block_exotic_subdeps,
-                    ) {
+                    // Root-declared `pnpm.overrides` opts the user into
+                    // the rewritten `link:`/`file:` target by name, so
+                    // they bypass the exotic-subdep block — otherwise
+                    // an override aimed at a transitive of a registry
+                    // package would always lose to the default-on
+                    // guard.
+                    if !task.range_from_override
+                        && should_block_exotic_subdep(
+                            &task,
+                            &resolved,
+                            self.dependency_policy.block_exotic_subdeps,
+                        )
+                    {
                         return Err(Error::BlockedExoticSubdep(Box::new(ExoticSubdepDetails {
                             name: task.name.clone(),
                             spec: task.range.clone(),

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -70,6 +70,7 @@ fn build_age_gate_resolves_dist_tag_range() {
         original_specifier: None,
         real_name: None,
         ancestors: Vec::new(),
+        range_from_override: false,
     };
     let d = build_age_gate(&task, &packument, 60);
     // `latest` → 3.0.0; the exact-version range only matches 3.0.0.
@@ -93,6 +94,7 @@ fn build_no_match_falls_back_to_prereleases() {
         original_specifier: None,
         real_name: None,
         ancestors: Vec::new(),
+        range_from_override: false,
     };
     let d = build_no_match(&task, &packument);
     assert!(d.only_prereleases);
@@ -338,6 +340,7 @@ fn exotic_subdeps_from_local_parents_are_allowed() {
         original_specifier: None,
         real_name: None,
         ancestors: Vec::new(),
+        range_from_override: false,
     };
     let mut resolved = BTreeMap::new();
     resolved.insert(
@@ -366,6 +369,7 @@ fn exotic_subdeps_from_unknown_parents_stay_blocked() {
         original_specifier: None,
         real_name: None,
         ancestors: Vec::new(),
+        range_from_override: false,
     };
 
     assert!(should_block_exotic_subdep(&task, &BTreeMap::new(), true));
@@ -383,6 +387,7 @@ fn exotic_subdeps_from_registry_parents_stay_blocked() {
         original_specifier: None,
         real_name: None,
         ancestors: Vec::new(),
+        range_from_override: false,
     };
     let mut resolved = BTreeMap::new();
     resolved.insert(

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2888,6 +2888,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     )
                 }
             };
+            let materialize_cwd = cwd.clone();
             let materialize_handle: tokio::task::JoinHandle<
                 miette::Result<(
                     aube_linker::LinkStats,
@@ -2947,6 +2948,17 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 }
                 let linker = std::sync::Arc::new(linker);
                 let graph = materialize_graph;
+
+                // Pre-compute the `link:` target map once, so each
+                // sibling-symlink pass inside `materialize_into` can
+                // route override-rewritten transitives at the on-disk
+                // path instead of dangling into a phantom
+                // `.aube/<name>@link+...`. `None` when the graph has
+                // no `link:` entries at all (the common case), keeping
+                // the materialize hot path one Option check per dep.
+                let nested_link_targets =
+                    aube_linker::build_nested_link_targets(&materialize_cwd, &graph)
+                        .map(std::sync::Arc::new);
 
                 // Build a reverse-index from canonical `name@version`
                 // to the set of contextualized dep_paths that share it.
@@ -3009,6 +3021,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         let linker = linker.clone();
                         let sem = sem.clone();
                         let index = index.clone();
+                        let nested_link_targets = nested_link_targets.clone();
                         // spawn_blocking dispatches straight to the tokio
                         // blocking pool; the outer `tokio::spawn`
                         // wrapper that earlier versions used added a
@@ -3021,7 +3034,13 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             tokio::task::spawn_blocking(move || -> miette::Result<_> {
                                 let mut stats = aube_linker::LinkStats::default();
                                 linker
-                                    .ensure_in_virtual_store(&dep_path, &pkg, &index, &mut stats)
+                                    .ensure_in_virtual_store(
+                                        &dep_path,
+                                        &pkg,
+                                        &index,
+                                        &mut stats,
+                                        nested_link_targets.as_deref(),
+                                    )
                                     .map_err(|e| {
                                         miette!("prewarm GVS for {dep_path_for_err}: {e}")
                                     })?;

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -219,6 +219,40 @@ EOF
 	refute_output --partial 'libs/foo/libs/bar'
 }
 
+@test "aube install: pnpm.overrides redirects a registry parent's transitive to link: (GVS)" {
+	# True registry parent + override-rewritten transitive `link:`. The
+	# parent goes through the global virtual store, and without the
+	# nested-link map threading through `ensure_in_virtual_store` the
+	# sibling symlink at `<gvs>/is-odd@.../node_modules/is-number` would
+	# dangle into a non-existent `.aube/is-number@link+...` entry. GVS
+	# is on by default outside CI (and `_common_setup` clears `CI`), so
+	# this exercises the default install path.
+	if [ -z "${AUBE_TEST_REGISTRY:-}" ]; then
+		skip "AUBE_TEST_REGISTRY not set (Verdaccio not running)"
+	fi
+
+	mkdir -p libs/is-number
+	cat >libs/is-number/package.json <<'EOF'
+{"name":"is-number","version":"9.9.9","main":"index.js"}
+EOF
+	cat >.npmrc <<EOF
+registry=${AUBE_TEST_REGISTRY}
+EOF
+	cat >package.json <<'EOF'
+{"name":"root","version":"0.0.0","dependencies":{"is-odd":"^3.0.0"},"pnpm":{"overrides":{"is-number":"link:./libs/is-number"}}}
+EOF
+
+	run aube install
+	assert_success
+
+	local nested
+	nested=$(echo node_modules/.aube/is-odd@*/node_modules/is-number)
+	[ -L "$nested" ]
+	assert_file_exists "$nested/package.json"
+	run cat "$nested/package.json"
+	assert_output --partial '"version":"9.9.9"'
+}
+
 @test "aube install lets pnpm.overrides redirect transitive registry deps to link:" {
 	# Registry parent → `link:` override. The exotic-subdep guard is on
 	# by default, but a root-declared override is an opt-in — without a

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -219,6 +219,43 @@ EOF
 	refute_output --partial 'libs/foo/libs/bar'
 }
 
+@test "aube install lets pnpm.overrides redirect transitive registry deps to link:" {
+	# Registry parent → `link:` override. The exotic-subdep guard is on
+	# by default, but a root-declared override is an opt-in — without a
+	# `range_from_override` short-circuit the guard would block the
+	# override before the resolver ever read it.
+	mkdir -p libs/bar
+	cat >libs/bar/package.json <<'EOF'
+{"name":"@company/bar","version":"9.9.9","main":"index.js"}
+EOF
+	# Vendored registry parent: a tarball whose package.json declares
+	# `@company/bar@1.2.3` as a registry dep, which the override redirects
+	# to libs/bar. file:./parent.tgz keeps the test offline.
+	mkdir -p staging/package
+	cat >staging/package/package.json <<'EOF'
+{"name":"parent-reg","version":"2.0.0","dependencies":{"@company/bar":"1.2.3"}}
+EOF
+	(cd staging && tar -czf ../parent-reg.tgz package)
+	rm -rf staging
+
+	cat >package.json <<'EOF'
+{"name":"root","version":"0.0.0","dependencies":{"parent-reg":"file:./parent-reg.tgz"},"pnpm":{"overrides":{"@company/bar":"link:./libs/bar"}}}
+EOF
+
+	run aube install
+	assert_success
+
+	# The override fires for the transitive — no `BlockedExoticSubdep`.
+	# Sibling symlink in the parent's virtual-store node_modules points
+	# straight at libs/bar.
+	local nested
+	nested=$(echo node_modules/.aube/parent-reg@file+*/node_modules/@company/bar)
+	[ -L "$nested" ]
+	assert_file_exists "$nested/package.json"
+	run cat "$nested/package.json"
+	assert_output --partial '"version":"9.9.9"'
+}
+
 @test "aube install resolves transitive link: against the parent's source root" {
 	# A `file:`-linked parent with its own `link:./libs/...` transitive
 	# dep. The resolver must anchor `./libs/...` on the parent's source

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -245,12 +245,21 @@ EOF
 	run aube install
 	assert_success
 
+	# Walk through the symlink chain. Per-project entry resolves to
+	# either a real dir (per-project mode) or the GVS subdir; either
+	# way the sibling `is-number` must point at the on-disk override
+	# target (libs/is-number), NOT a phantom `.aube/is-number@link+...`
+	# that would dangle. Asserting against the symlink target string
+	# avoids cross-platform pathdiff quirks with absolute traversal.
 	local nested
 	nested=$(echo node_modules/.aube/is-odd@*/node_modules/is-number)
 	[ -L "$nested" ]
-	assert_file_exists "$nested/package.json"
-	run cat "$nested/package.json"
-	assert_output --partial '"version":"9.9.9"'
+	local target
+	target=$(readlink "$nested")
+	echo "symlink target: $target" >&3
+	[[ "$target" == *libs/is-number ]]
+	# The dangling form looks like `../../is-number@link+<hash>/node_modules/is-number`.
+	[[ "$target" != *@link+* ]]
 }
 
 @test "aube install lets pnpm.overrides redirect transitive registry deps to link:" {

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -182,3 +182,79 @@ EOF
 	run cat packages/app/node_modules/vendor-link/package.json
 	assert_output --partial '"version":"9.9.9"'
 }
+
+@test "aube install honors link: paths in pnpm.overrides as project-root-relative" {
+	# Workspace consumer pinned `@company/bar@1.2.3` (registry version),
+	# but root `pnpm.overrides` rewrites that to `link:./libs/bar`.
+	# Without project-root anchoring the resolver would parse `./libs/bar`
+	# against the consumer (`libs/foo`) and walk to a phantom `libs/foo/libs/bar`.
+	mkdir -p libs/foo libs/bar
+	cat >package.json <<'EOF'
+{"name":"root","version":"0.0.0","private":true,"pnpm":{"overrides":{"@company/bar":"link:./libs/bar"}}}
+EOF
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - libs/*
+EOF
+	cat >libs/foo/package.json <<'EOF'
+{"name":"@company/foo","version":"0.0.0","dependencies":{"@company/bar":"1.2.3"}}
+EOF
+	cat >libs/bar/package.json <<'EOF'
+{"name":"@company/bar","version":"9.9.9","main":"index.js"}
+EOF
+
+	run aube install
+	assert_success
+
+	# Symlink lands at the actual on-disk target.
+	[ -L libs/foo/node_modules/@company/bar ]
+	assert_file_exists libs/foo/node_modules/@company/bar/package.json
+	run cat libs/foo/node_modules/@company/bar/package.json
+	assert_output --partial '"version":"9.9.9"'
+
+	# Lockfile records the canonical project-root-relative form, not
+	# the importer-rebased form.
+	run cat aube-lock.yaml
+	assert_output --partial 'version: link:./libs/bar'
+	refute_output --partial 'libs/foo/libs/bar'
+}
+
+@test "aube install resolves transitive link: against the parent's source root" {
+	# A `file:`-linked parent with its own `link:./libs/...` transitive
+	# dep. The resolver must anchor `./libs/...` on the parent's source
+	# directory, not the importer's, otherwise it bails with "transitive
+	# local specifier ... cannot be resolved without the parent package
+	# source root".
+	mkdir -p parent-pkg/libs/child-link
+	cat >parent-pkg/package.json <<'EOF'
+{"name":"parent-pkg","version":"1.0.0","dependencies":{"child-link":"link:./libs/child-link"}}
+EOF
+	cat >parent-pkg/libs/child-link/package.json <<'EOF'
+{"name":"child-link","version":"4.5.6","main":"index.js"}
+EOF
+	cat >parent-pkg/libs/child-link/index.js <<'EOF'
+module.exports = "from child-link";
+EOF
+
+	mkdir -p app
+	cd app
+	cat >package.json <<'EOF'
+{"name":"app","version":"0.0.0","dependencies":{"parent-pkg":"file:../parent-pkg"}}
+EOF
+
+	run aube install
+	assert_success
+
+	# parent-pkg is materialized through the virtual store under
+	# `.aube/parent-pkg@file+<hash>/node_modules/`. The transitive
+	# `child-link` lives as a sibling there — symlinked straight at the
+	# parent's on-disk libs/ subdir, bypassing any `.aube/` entry of its
+	# own (mirrors how root-level `link:` deps work).
+	assert_file_exists node_modules/parent-pkg/package.json
+	local nested
+	nested=$(echo node_modules/.aube/parent-pkg@file+*/node_modules/child-link)
+	[ -L "$nested" ]
+	assert_file_exists "$nested/package.json"
+	run cat "$nested/package.json"
+	assert_output --partial '"version":"4.5.6"'
+}

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -249,17 +249,23 @@ EOF
 	# either a real dir (per-project mode) or the GVS subdir; either
 	# way the sibling `is-number` must point at the on-disk override
 	# target (libs/is-number), NOT a phantom `.aube/is-number@link+...`
-	# that would dangle. Asserting against the symlink target string
-	# avoids cross-platform pathdiff quirks with absolute traversal.
+	# that would dangle.
 	local nested
 	nested=$(echo node_modules/.aube/is-odd@*/node_modules/is-number)
 	[ -L "$nested" ]
 	local target
 	target=$(readlink "$nested")
-	echo "symlink target: $target" >&3
+	# Stored target must end at libs/is-number (the override target),
+	# not at a phantom `.aube/is-number@link+...` entry.
 	[[ "$target" == *libs/is-number ]]
-	# The dangling form looks like `../../is-number@link+<hash>/node_modules/is-number`.
 	[[ "$target" != *@link+* ]]
+	# And must actually resolve through the symlink chain. A
+	# tmp→final off-by-one in the GVS materialize would land one dir
+	# short on Windows / strict-`..` resolvers and clamp at `/` on
+	# POSIX, so chase to the real file.
+	assert_file_exists "$nested/package.json"
+	run cat "$nested/package.json"
+	assert_output --partial '"version":"9.9.9"'
 }
 
 @test "aube install lets pnpm.overrides redirect transitive registry deps to link:" {


### PR DESCRIPTION
## Summary

Fixes the install-time error:

```
× failed to resolve dependencies
  ╰─▶ registry error for @scope/foo: transitive local specifier
      link:./libs/foo cannot be resolved without the parent
      package source root
```

Two cases that previously bailed:

- **`file:`/`link:` parent declares a transitive `link:`** in its own `package.json`. The resolver now anchors the relative path on the parent's source root (already on the parent's `LockedPackage.local_source`) instead of the importer dir.
- **Root `pnpm.overrides` rewriting a registry dep to `link:./libs/foo`.** Override paths are anchored at the project root regardless of which workspace package consumes them — mirrors pnpm. The resolver tags override-substituted local specs and routes them through `project_root` rather than the consumer's importer dir.

Linker side, transitive `link:` deps from a `file:`/`link:` parent get no `.aube/<name>@link+...` entry of their own; the parent's sibling symlink points straight at the on-disk target, matching how root-level `link:` deps already work.

## Test plan

- [x] Two new bats cases in [test/local_deps.bats](test/local_deps.bats) — one for the parent-anchored path, one for the override-anchored path.
- [x] Existing `local_deps.bats` keeps passing (file:/link:/tarball + workspace importer + roundtrip + excludeLinksFromLockfile).
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` clean.
- [x] No new failures elsewhere in the bats suite (regressions checked against `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dependency resolution and virtual-store materialization for `link:`/`file:` specs, which can affect install correctness and on-disk symlink layout across workspaces and the global virtual store. Changes are localized and covered by new bats tests, but regressions could break installs for edge-case graphs.
> 
> **Overview**
> Fixes resolution and linking of *nested* `link:`/`file:` dependencies.
> 
> The resolver now (1) anchors override-rewritten local specs to the project root via a new `range_from_override` flag, and (2) allows transitive local specs to resolve relative to a local (`file:`/`link:`) parent’s source root while keeping registry-parent exotic subdeps blocked.
> 
> The linker threads a precomputed `dep_path -> absolute target` map for `link:` packages through `materialize_into`/`ensure_in_virtual_store` so transitive `link:` deps create sibling symlinks directly to the on-disk target (avoiding dangling `.aube/<name>@link+...` paths), including during GVS prewarming. New `local_deps.bats` cases cover override anchoring, GVS behavior, and parent-root anchoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d293c98901e6efb4745312456b9706565841785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->