### PR TITLE
fix(cli): wrap doc comments so -h help stays one line per flag

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -107,8 +107,8 @@ cmd add help="Add a dependency" {
     alias a
     flag "-D --save-dev" help="Add as dev dependency"
     flag "-E --save-exact" help="Pin the exact resolved version (no `^` prefix)"
-    flag "-g --global" help="Install the package globally (into the aube/pnpm global directory) and link its binaries into the global bin directory" {
-        long_help "Install the package globally (into the aube/pnpm global directory) and link its binaries into the global bin directory.\n\nMirrors `pnpm add -g`."
+    flag "-g --global" help="Install the package globally" {
+        long_help "Install the package globally.\n\nInstalls into the aube/pnpm global directory and links its binaries into the global bin directory. Mirrors `pnpm add -g`."
     }
     flag "-O --save-optional" help="Add as optional dependency"
     flag --allow-build help="Pre-approve a dependency's lifecycle scripts as part of the add" var=#true {
@@ -116,30 +116,32 @@ cmd add help="Add a dependency" {
         arg <PKG>
     }
     flag --ignore-scripts help="Skip lifecycle scripts (no-op; aube already skips by default)"
-    flag --no-save help="Snapshot `package.json` and the lockfile, link the named packages into `node_modules`, and then restore both files — so the dependency is usable for the current process but the project's committed state is untouched" {
-        long_help "Snapshot `package.json` and the lockfile, link the named packages into `node_modules`, and then restore both files — so the dependency is usable for the current process but the project's committed state is untouched.\n\nHandy for one-off experiments and for scripts that install a tool transiently. Mirrors `pnpm add --no-save`. Conflicts with `-g`/`--global`, which has to persist the install to its global manifest."
+    flag --no-save help="Install without persisting the dependency to `package.json`" {
+        long_help "Install without persisting the dependency to `package.json`.\n\nSnapshots `package.json` and the lockfile, links the named packages into `node_modules`, and then restores both files — so the dependency is usable for the current process but the project's committed state is untouched.\n\nHandy for one-off experiments and for scripts that install a tool transiently. Mirrors `pnpm add --no-save`. Conflicts with `-g`/`--global`, which has to persist the install to its global manifest."
     }
-    flag --save-catalog help="Save the new dependency into the workspace's default catalog, writing `catalog:` into `package.json` and seeding/upserting the resolved range under `catalog:` in the workspace yaml. Mirrors `pnpm add --save-catalog`" {
-        long_help "Save the new dependency into the workspace's default catalog, writing `catalog:` into `package.json` and seeding/upserting the resolved range under `catalog:` in the workspace yaml. Mirrors `pnpm add --save-catalog`.\n\nWorkspace and aliased specs (`workspace:*`, `npm:`, `jsr:`) are never catalogized — the manifest gets the original spec and the catalog yaml is left alone. If the package is already in the target catalog, the existing entry is preserved (never overwritten); the manifest then gets `catalog:` only when the existing entry is compatible with the user's range.\n\nConflicts with `--no-save`: catalog mutations write to the workspace yaml, which the `--no-save` restore path doesn't snapshot — combining the two would silently leave an orphaned catalog entry behind."
+    flag --save-catalog help="Save the new dependency into the workspace's default catalog" {
+        long_help "Save the new dependency into the workspace's default catalog.\n\nWrites `catalog:` into `package.json` and seeds/upserts the resolved range under `catalog:` in the workspace yaml. Mirrors `pnpm add --save-catalog`.\n\nWorkspace and aliased specs (`workspace:*`, `npm:`, `jsr:`) are never catalogized — the manifest gets the original spec and the catalog yaml is left alone. If the package is already in the target catalog, the existing entry is preserved (never overwritten); the manifest then gets `catalog:` only when the existing entry is compatible with the user's range.\n\nConflicts with `--no-save`: catalog mutations write to the workspace yaml, which the `--no-save` restore path doesn't snapshot — combining the two would silently leave an orphaned catalog entry behind."
     }
-    flag --save-catalog-name help="Save the new dependency into a *named* catalog (`catalogs.<name>` in the workspace yaml), writing `catalog:<name>` into `package.json`. Same workspace/alias exclusions and `--no-save` conflict as `--save-catalog`. Mirrors `pnpm add --save-catalog-name=<name>`" {
+    flag --save-catalog-name help="Save the new dependency into a *named* catalog" {
+        long_help "Save the new dependency into a *named* catalog.\n\nWrites the entry to `catalogs.<name>` in the workspace yaml and `catalog:<name>` into `package.json`. Same workspace/alias exclusions and `--no-save` conflict as `--save-catalog`. Mirrors `pnpm add --save-catalog-name=<name>`."
         arg <NAME>
     }
     flag --save-peer help="Add as a peer dependency (written to `peerDependencies` in package.json)" {
         long_help "Add as a peer dependency (written to `peerDependencies` in package.json).\n\nBy convention you usually pair this with `--save-dev` so the peer is also installed for local development; that's what pnpm does."
     }
-    flag "-w --workspace" help="Add the dependency to the workspace root's `package.json`, regardless of the current working directory" {
-        long_help "Add the dependency to the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the add against that directory."
+    flag "-w --workspace" help="Add the dependency to the workspace root's `package.json`" {
+        long_help "Add the dependency to the workspace root's `package.json`.\n\nApplies regardless of the current working directory: walks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the add against that directory."
     }
     flag "-W --ignore-workspace-root-check" help="Allow `add` to run in a workspace root" {
         long_help "Allow `add` to run in a workspace root.\n\nBy default aube refuses to add dependencies to the root `package.json` of a workspace (a directory containing `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field) because deps added there end up shared by every package and usually reflect a mistake. Pass this flag to opt in. Mirrors `pnpm add -W`."
     }
     arg "[PACKAGES]…" help="Package(s) to add" required=#false var=#true
 }
-cmd approve-builds help="Approve ignored dependency build scripts in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present) under `allowBuilds`" {
+cmd approve-builds help="Approve ignored dependency build scripts" {
+    long_help "Approve ignored dependency build scripts.\n\nWrites entries under `allowBuilds` in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present)."
     flag --all help="Approve every pending ignored build without prompting"
     flag "-g --global" help="Operate on globally-installed packages instead of the current project"
-    arg "[PKG]…" help="Packages to approve directly, skipping the picker. Each name must match a currently-ignored build. Unknown names are rejected so a typo cannot silently no-op" required=#false var=#true
+    arg "[PKG]…" help="Packages to approve directly, skipping the picker" help_long="Packages to approve directly, skipping the picker.\n\nEach name must match a currently-ignored build. Unknown names are rejected so a typo cannot silently no-op." required=#false var=#true
 }
 cmd audit help="Check installed packages against the registry advisory DB" {
     after_long_help "Examples:\n\n  $ aube audit\n  Severity  Package    Vulnerable  Title\n  moderate  minimatch  <3.0.5      Regular Expression Denial of Service\n                                   https://github.com/advisories/GHSA-f8q6-p94x\n\n  1 vulnerability found\n\n  # Only fail on high and above\n  $ aube audit --audit-level high\n\n  # Skip optional deps and dev deps\n  $ aube audit --prod --no-optional\n\n  # Pipe into jq\n  $ aube audit --json | jq '.advisories | length'\n\n  # Clean\n  $ aube audit\n  No known vulnerabilities found\n"
@@ -163,8 +165,8 @@ cmd audit help="Check installed packages against the registry advisory DB" {
     flag --ignore-registry-errors help="Use exit code 0 if the registry responds with an error" {
         long_help "Use exit code 0 if the registry responds with an error.\n\nUseful when audit checks run in CI and the registry has a hiccup."
     }
-    flag --ignore-unfixable help="Drop advisories for which no non-vulnerable version is available in the package's packument" {
-        long_help "Drop advisories for which no non-vulnerable version is available in the package's packument.\n\nSame \"best non-vulnerable\" logic as `--fix`: an advisory is kept only when an upgrade path exists."
+    flag --ignore-unfixable help="Drop advisories that have no non-vulnerable upgrade" {
+        long_help "Drop advisories that have no non-vulnerable upgrade.\n\nFilters out advisories for which no non-vulnerable version is available in the package's packument. Same \"best non-vulnerable\" logic as `--fix`: an advisory is kept only when an upgrade path exists."
     }
     flag "-i --interactive" help="Pick which advisories to fix interactively"
     flag --json help="Emit the report as JSON (pnpm-compatible shape) instead of a table"
@@ -205,7 +207,8 @@ cmd cat-file help="Print a file from the global store by integrity or hex hash" 
 cmd cat-index help="Print the cached package index JSON for `<name>@<version>`" {
     arg <PACKAGE> help="Package to inspect, in `name@version` form (e.g. `lodash@4.17.21`, `@babel/core@7.26.0`)" help_long="Package to inspect, in `name@version` form (e.g. `lodash@4.17.21`, `@babel/core@7.26.0`).\n\nAn exact version is required — ranges and dist-tags aren't resolved here."
 }
-cmd check help="Verify that every installed package can resolve its declared deps through the `node_modules/` symlink tree" {
+cmd check help="Verify installed packages can resolve their declared deps" {
+    long_help "Verify installed packages can resolve their declared deps.\n\nWalks the `node_modules/` symlink tree and confirms every dependency in each `package.json` resolves to a real entry."
     after_long_help "Examples:\n\n  $ aube check\n  node_modules symlink tree is consistent (checked 248 packages).\n\n  # With issues\n  $ aube check\n  2 broken dependency links found:\n\n    vscode-languageserver@9.0.1\n      ✕ cannot resolve: vscode-languageserver-protocol@3.17.5\n\n    vscode-languageserver-protocol@3.17.5\n      ✕ cannot resolve: vscode-languageserver-types@3.17.5\n      ✕ cannot resolve: vscode-jsonrpc@8.2.1\n\n  # Machine-readable\n  $ aube check --json\n"
     flag --json help="Emit a JSON report instead of the human-readable list"
 }
@@ -218,18 +221,20 @@ cmd ci help="Clean install: delete node_modules, then install with frozen lockfi
 }
 cmd clean help="Remove `node_modules` across every workspace project" {
     long_help "Remove `node_modules` across every workspace project.\n\n`--lockfile` / `-l` also deletes lockfiles. A `clean` script in the root `package.json` overrides the built-in."
-    flag "-l --lockfile" help="Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)"
+    flag "-l --lockfile" help="Also remove lockfiles at the workspace root" {
+        long_help "Also remove lockfiles at the workspace root.\n\nTargets `aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock`."
+    }
 }
 cmd completion help="Generate shell completions (bash, zsh, fish)" {
     arg <SHELL> help="The shell to generate completions for (bash, zsh, fish)"
 }
 cmd config help="Read and write settings in `.npmrc`" {
     alias c hide=#true
-    flag --all help="Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered" {
-        long_help "Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered.\n\nOnly valid with `--location merged` (the default), since a per-file view can't distinguish \"not set anywhere\" from \"set in the other file\" and would render misleading defaults."
+    flag --all help="Also list settings that have no value set" {
+        long_help "Also list settings that have no value set.\n\nRenders one row per setting in `settings.toml`, with the default and description shown for unset entries.\n\nOnly valid with `--location merged` (the default), since a per-file view can't distinguish \"not set anywhere\" from \"set in the other file\" and would render misleading defaults."
     }
-    flag --json help="Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`" {
-        long_help "Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`.\n\nHonors `--all` and `--location` the same way the default text output does."
+    flag --json help="Emit all entries as a JSON object keyed by setting name" {
+        long_help "Emit all entries as a JSON object keyed by setting name.\n\nMatches `pnpm config list --json`. Honors `--all` and `--location` the same way the default text output does."
     }
     flag --local help="Shortcut for `--location project`" {
         long_help "Shortcut for `--location project`.\n\nConflicts with `--all` since `--all` only makes sense against the merged view — see the `--all` docs for why."
@@ -273,11 +278,11 @@ cmd config help="Read and write settings in `.npmrc`" {
     }
     cmd list help="Print every key/value from the selected `.npmrc` file(s)" {
         alias ls
-        flag --all help="Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered" {
-            long_help "Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered.\n\nOnly valid with `--location merged` (the default), since a per-file view can't distinguish \"not set anywhere\" from \"set in the other file\" and would render misleading defaults."
+        flag --all help="Also list settings that have no value set" {
+            long_help "Also list settings that have no value set.\n\nRenders one row per setting in `settings.toml`, with the default and description shown for unset entries.\n\nOnly valid with `--location merged` (the default), since a per-file view can't distinguish \"not set anywhere\" from \"set in the other file\" and would render misleading defaults."
         }
-        flag --json help="Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`" {
-            long_help "Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`.\n\nHonors `--all` and `--location` the same way the default text output does."
+        flag --json help="Emit all entries as a JSON object keyed by setting name" {
+            long_help "Emit all entries as a JSON object keyed by setting name.\n\nMatches `pnpm config list --json`. Honors `--all` and `--location` the same way the default text output does."
         }
         flag --local help="Shortcut for `--location project`" {
             long_help "Shortcut for `--location project`.\n\nConflicts with `--all` since `--all` only makes sense against the merged view — see the `--all` docs for why."
@@ -351,8 +356,8 @@ cmd dist-tag subcommand_required=#true help="Manage package distribution tags on
     }
 }
 cmd dlx help="Fetch a package into a throwaway environment and run its binary" {
-    flag "-c --shell-mode" help="Run the assembled command line through `sh -c` with `<scratch>/node_modules/.bin` prepended to `PATH`" {
-        long_help "Run the assembled command line through `sh -c` with `<scratch>/node_modules/.bin` prepended to `PATH`.\n\nUse this for pipelines, redirects, or env expansion (`aube dlx -p cowsay -c 'cowsay hello | tr a-z A-Z'`). Mirrors `pnpm dlx --shell-mode`."
+    flag "-c --shell-mode" help="Run the assembled command line through `sh -c`" {
+        long_help "Run the assembled command line through `sh -c`.\n\n`<scratch>/node_modules/.bin` is prepended to `PATH`. Use this for pipelines, redirects, or env expansion (`aube dlx -p cowsay -c 'cowsay hello | tr a-z A-Z'`). Mirrors `pnpm dlx --shell-mode`."
     }
     flag "-p --package" help="Install a specific package (repeatable)" var=#true {
         long_help "Install a specific package (repeatable).\n\nOverrides inferring from the command."
@@ -404,7 +409,9 @@ cmd fetch help="Download lockfile dependencies into the store without linking no
 }
 cmd find-hash help="List packages whose cached index references a given file hash" {
     after_long_help "Examples:\n\n  # Accepts integrity strings\n  $ aube find-hash sha512-abc123...\n  lodash@4.17.21\tpackage/lodash.js\n  express@4.19.2\tnode_modules/lodash/lodash.js\n\n  # ...or raw hex digests\n  $ aube find-hash 5d41402abc4b2a76b9719d911017c592...\n\n  # Machine-readable\n  $ aube find-hash --json sha512-abc123...\n"
-    flag --json help="Emit a machine-readable JSON array of `{ \"name\", \"version\", \"path\" }` objects instead of a plain text listing"
+    flag --json help="Emit machine-readable JSON instead of a plain text listing" {
+        long_help "Emit machine-readable JSON instead of a plain text listing.\n\nOutput is an array of `{ \"name\", \"version\", \"path\" }` objects."
+    }
     arg <HASH> help="Hash to look up" help_long="Hash to look up.\n\nAccepts `sha512-<base64>` (pnpm integrity format) or a raw hex CAS digest."
 }
 cmd get hide=#true help="Alias for `config get` (hidden; prefer `config get`)" {
@@ -435,7 +442,9 @@ cmd import help="Convert a supported lockfile into aube-lock.yaml" {
 }
 cmd init help="Create a `package.json` in the current directory" {
     flag --bare help="Create a `package.json` with only the bare minimum of required fields"
-    flag --init-package-manager help="Pin the project to the current aube version by adding a `packageManager` field to `package.json`"
+    flag --init-package-manager help="Pin the project to the current aube version" {
+        long_help "Pin the project to the current aube version.\n\nAdds a `packageManager` field to `package.json`."
+    }
     flag --init-type help="Set the module system for the package. Defaults to `commonjs`" {
         arg <commonjs|module> {
             choices commonjs module
@@ -449,11 +458,11 @@ cmd install help="Install all dependencies" {
     flag --dangerously-allow-all-builds help="Allow every dependency's lifecycle scripts to run" {
         long_help "Allow every dependency's lifecycle scripts to run.\n\nBypasses the `allowBuilds` allowlist. Do not use in CI."
     }
-    flag --fix-lockfile help="Re-resolve lockfile entries whose spec drifted from package.json, leaving everything else pinned at its locked version" {
-        long_help "Re-resolve lockfile entries whose spec drifted from package.json, leaving everything else pinned at its locked version.\n\nUnchanged specs keep their existing version and integrity hash; only drifted entries (and any new transitives they pull in) get re-resolved."
+    flag --fix-lockfile help="Re-resolve lockfile entries whose spec drifted from package.json" {
+        long_help "Re-resolve lockfile entries whose spec drifted from package.json.\n\nLeaves everything else pinned at its locked version. Unchanged specs keep their existing version and integrity hash; only drifted entries (and any new transitives they pull in) get re-resolved."
     }
-    flag --force help="Force reinstall: bypass the `node_modules/.aube-state` freshness check and re-resolve the lockfile even when nothing has drifted" {
-        long_help "Force reinstall: bypass the `node_modules/.aube-state` freshness check and re-resolve the lockfile even when nothing has drifted.\n\nMirrors pnpm's `install --force`."
+    flag --force help="Force reinstall, ignoring lockfile/state freshness" {
+        long_help "Force reinstall, ignoring lockfile/state freshness.\n\nBypasses the `node_modules/.aube-state` freshness check and re-resolves the lockfile even when nothing has drifted. Mirrors pnpm's `install --force`."
     }
     flag --global-pnpmfile help="Add a global pnpmfile that runs before the local one" {
         long_help "Add a global pnpmfile that runs before the local one.\n\nMirrors pnpm's `--global-pnpmfile <path>`. Relative paths resolve against the project root. The global hook runs first and the local hook (if any) runs second, so local mutations win on conflicts — matching pnpm's composition order."
@@ -461,14 +470,15 @@ cmd install help="Install all dependencies" {
     }
     flag --ignore-pnpmfile help="Skip running `.pnpmfile.mjs` / `.pnpmfile.cjs` hooks for this install"
     flag --ignore-scripts help="Skip lifecycle scripts (no-op; aube already skips by default)"
-    flag --lockfile-dir help="Read and write the lockfile in the given directory instead of alongside `package.json`. The project becomes an importer keyed by its relative path from the lockfile directory. Mirrors pnpm's `--lockfile-dir`" {
+    flag --lockfile-dir help="Read and write the lockfile in the given directory" {
+        long_help "Read and write the lockfile in the given directory.\n\nInstead of placing the lockfile alongside `package.json`, the project becomes an importer keyed by its relative path from the lockfile directory. Mirrors pnpm's `--lockfile-dir`."
         arg <PATH>
     }
     flag --lockfile-only help="Resolve dependencies and write the lockfile, but don't link `node_modules`" {
         long_help "Resolve dependencies and write the lockfile, but don't link `node_modules`.\n\nUseful for CI workflows that only update the lockfile."
     }
-    flag --merge-git-branch-lockfiles help="Merge every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yaml` and delete the branch files" {
-        long_help "Merge every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yaml` and delete the branch files.\n\nCompanion to `gitBranchLockfile`. When `mergeGitBranchLockfilesBranchPattern` is set in `pnpm-workspace.yaml`, this happens automatically on matching branches; the flag forces it regardless."
+    flag --merge-git-branch-lockfiles help="Merge per-branch lockfiles into the main `aube-lock.yaml`" {
+        long_help "Merge per-branch lockfiles into the main `aube-lock.yaml`.\n\nCombines every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yaml` and deletes the branch files. Companion to `gitBranchLockfile`. When `mergeGitBranchLockfilesBranchPattern` is set in `pnpm-workspace.yaml`, this happens automatically on matching branches; the flag forces it regardless."
     }
     flag --network-concurrency help="Cap concurrent tarball downloads" {
         long_help "Cap concurrent tarball downloads.\n\nOverrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to an auto-scaled default of worker count x3, clamped to 16-64."
@@ -499,8 +509,8 @@ cmd install help="Install all dependencies" {
         long_help "Selectively hoist matching transitive deps to the root node_modules.\n\nRepeatable; comma-separated values are also accepted."
         arg <GLOB>
     }
-    flag --resolution-mode help="How to resolve version ranges: `highest` (pnpm's classic behavior) or `time-based` (pick the lowest satisfying direct dep and constrain transitives by a publish-date cutoff)" {
-        long_help "How to resolve version ranges: `highest` (pnpm's classic behavior) or `time-based` (pick the lowest satisfying direct dep and constrain transitives by a publish-date cutoff).\n\nAccepts pnpm's aliases `time` and `lowest-direct`. When omitted, falls back to the `resolution-mode` key in `.npmrc` / `aube-workspace.yaml`."
+    flag --resolution-mode help="How to resolve version ranges" {
+        long_help "How to resolve version ranges.\n\n`highest` (pnpm's classic behavior) or `time-based` (pick the lowest satisfying direct dep and constrain transitives by a publish-date cutoff). Accepts pnpm's aliases `time` and `lowest-direct`. When omitted, falls back to the `resolution-mode` key in `.npmrc` / `aube-workspace.yaml`."
         arg <MODE>
     }
     flag --shamefully-hoist help="Hoist every non-local transitive dep to the top-level `node_modules/`" {
@@ -509,8 +519,8 @@ cmd install help="Install all dependencies" {
     flag --side-effects-cache help="Cache post-build side effects for dependency packages" {
         long_help "Cache post-build side effects for dependency packages.\n\nDefaults to on and only applies to packages allowed by `allowBuilds` / `onlyBuiltDependencies`. Pair with `--no-side-effects-cache` to opt out."
     }
-    flag --verify-store-integrity help="Verify tarball SHA-512 against the lockfile integrity before importing into the store" {
-        long_help "Verify tarball SHA-512 against the lockfile integrity before importing into the store.\n\nDefaults to `true` (pnpm parity); pair with `--no-verify-store-integrity` to skip."
+    flag --verify-store-integrity help="Verify tarball SHA-512 before importing into the store" {
+        long_help "Verify tarball SHA-512 before importing into the store.\n\nChecks each tarball against the lockfile integrity. Defaults to `true` (pnpm parity); pair with `--no-verify-store-integrity` to skip."
     }
     flag -w help="Short alias for the global `--workspace-root` flag" hide=#true {
         long_help "Short alias for the global `--workspace-root` flag.\n\nRuns install from the workspace root regardless of cwd (`pnpm install -w`)."
@@ -538,7 +548,9 @@ cmd la hide=#true help="Alias for `list --long` (hidden; prefer `list --long`)" 
     flag --json help="Shortcut for `--format json`" {
         long_help "Shortcut for `--format json`.\n\nEmit a JSON array of package entries."
     }
-    flag --long help="Show version and path for each entry (default output is already name + version; `--long` adds the store path for debugging)"
+    flag --long help="Show version and path for each entry" {
+        long_help "Show version and path for each entry.\n\nDefault output is already name + version; `--long` adds the store path for debugging."
+    }
     flag --parseable help="Shortcut for `--format parseable`" {
         long_help "Shortcut for `--format parseable`.\n\nEmit one tab-separated line per package."
     }
@@ -556,8 +568,8 @@ cmd licenses help="Report the licenses of installed dependencies" {
 }
 cmd link help="Link a local package globally, or into the current project" {
     alias ln
-    flag "-g --global" help="Register into (or resolve from) the global link registry under `$AUBE_HOME/global-links`" {
-        long_help "Register into (or resolve from) the global link registry under `$AUBE_HOME/global-links`.\n\nDefault behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit."
+    flag "-g --global" help="Register into (or resolve from) the global link registry" {
+        long_help "Register into (or resolve from) the global link registry.\n\nThe registry lives at `$AUBE_HOME/global-links`. Default behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit."
     }
     arg "[PACKAGE]" help="Package name, or path to a local directory" required=#false
 }
@@ -579,7 +591,9 @@ cmd list help="Print the installed dependency tree" {
     flag --json help="Shortcut for `--format json`" {
         long_help "Shortcut for `--format json`.\n\nEmit a JSON array of package entries."
     }
-    flag --long help="Show version and path for each entry (default output is already name + version; `--long` adds the store path for debugging)"
+    flag --long help="Show version and path for each entry" {
+        long_help "Show version and path for each entry.\n\nDefault output is already name + version; `--long` adds the store path for debugging."
+    }
     flag --parseable help="Shortcut for `--format parseable`" {
         long_help "Shortcut for `--format parseable`.\n\nEmit one tab-separated line per package."
     }
@@ -601,7 +615,9 @@ cmd ll hide=#true help="Alias for `list --long` (hidden; prefer `list --long`)" 
     flag --json help="Shortcut for `--format json`" {
         long_help "Shortcut for `--format json`.\n\nEmit a JSON array of package entries."
     }
-    flag --long help="Show version and path for each entry (default output is already name + version; `--long` adds the store path for debugging)"
+    flag --long help="Show version and path for each entry" {
+        long_help "Show version and path for each entry.\n\nDefault output is already name + version; `--long` adds the store path for debugging."
+    }
     flag --parseable help="Shortcut for `--format parseable`" {
         long_help "Shortcut for `--format parseable`.\n\nEmit one tab-separated line per package."
     }
@@ -646,8 +662,8 @@ cmd patch help="Extract a package into an edit directory so it can be patched" {
         long_help "Directory to extract the writable copy into.\n\nWhen omitted, `aube` picks a fresh temp dir under the system tmpdir."
         arg <DIR>
     }
-    flag --ignore-existing help="Ignore any existing patch entry for this package — extract a pristine copy from `node_modules` rather than re-applying the existing patch first" {
-        long_help "Ignore any existing patch entry for this package — extract a pristine copy from `node_modules` rather than re-applying the existing patch first.\n\nAccepted for pnpm parity; aube already extracts from the *linked* (post-patch) tree, so this flag is effectively informational here."
+    flag --ignore-existing help="Ignore any existing patch entry for this package" {
+        long_help "Ignore any existing patch entry for this package.\n\nExtracts a pristine copy from `node_modules` rather than re-applying the existing patch first. Accepted for pnpm parity; aube already extracts from the *linked* (post-patch) tree, so this flag is effectively informational here."
     }
     arg <PACKAGE> help="Package spec, `<name>@<version>`" help_long="Package spec, `<name>@<version>`.\n\nThe package must already be installed in `node_modules` (we copy from the linked virtual store, not from the registry, so the layout matches what install would later patch)."
 }
@@ -659,7 +675,7 @@ cmd patch-commit help="Generate a `.patch` file from a `aube patch` edit directo
     arg <DIR> help="The edit directory printed by `aube patch`" help_long="The edit directory printed by `aube patch`.\n\nThe matching source snapshot is read from a sibling `source/` dir, located via the `.aube_patch_state.json` sidecar."
 }
 cmd patch-remove help="Remove patch entries from `pnpm.patchedDependencies`" {
-    arg "[PACKAGES]…" help="Patch keys to remove, formatted as `<name>@<version>` (the same shape used as the `pnpm.patchedDependencies` map key)" help_long="Patch keys to remove, formatted as `<name>@<version>` (the same shape used as the `pnpm.patchedDependencies` map key).\n\nWith no arguments, every declared patch is removed." required=#false var=#true
+    arg "[PACKAGES]…" help="Patch keys to remove, formatted as `<name>@<version>`" help_long="Patch keys to remove, formatted as `<name>@<version>`.\n\nSame shape used as the `pnpm.patchedDependencies` map key. With no arguments, every declared patch is removed." required=#false var=#true
 }
 cmd peers subcommand_required=#true help="Inspect peer-dependency resolution from the lockfile" {
     cmd check help="Check for unmet and missing peer-dependency issues by reading the lockfile" {
@@ -681,11 +697,15 @@ cmd publish help="Publish the current package to the registry" {
         arg <LEVEL>
     }
     flag --dry-run help="Don't upload; print what would be published"
-    flag --force help="Republish `name@version` even when that version is already on the target registry" {
-        long_help "Republish `name@version` even when that version is already on the target registry.\n\nBy default `aube publish` issues a GET before the PUT and refuses to proceed when the version exists, surfacing a clear error instead of relying on the registry to return 409. In `--recursive` / `--filter` mode, `--force` overrides the silent \"already-published\" skip so every selected workspace package is re-PUT. The registry must still accept the republish — npm's public registry rejects re-publishes outright; Verdaccio and most private mirrors allow them."
+    flag --force help="Republish even when the version is already on the registry" {
+        long_help "Republish even when the version is already on the registry.\n\nBy default `aube publish` issues a GET before the PUT and refuses to proceed when the version exists, surfacing a clear error instead of relying on the registry to return 409. In `--recursive` / `--filter` mode, `--force` overrides the silent \"already-published\" skip so every selected workspace package is re-PUT. The registry must still accept the republish — npm's public registry rejects re-publishes outright; Verdaccio and most private mirrors allow them."
     }
-    flag --ignore-scripts help="Skip `prepublishOnly` / `prepublish` / `prepack` / `prepare` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish"
-    flag --json help="Emit the publish result as JSON: an array with one `{name, version, filename, files: [{path}]}` entry, matching `pnpm publish --json` / `aube pack --json`"
+    flag --ignore-scripts help="Skip publish lifecycle scripts" {
+        long_help "Skip publish lifecycle scripts.\n\nSuppresses `prepublishOnly`, `prepublish`, `prepack`, `prepare`, `postpack`, `publish`, and `postpublish` scripts for this publish."
+    }
+    flag --json help="Emit the publish result as JSON" {
+        long_help "Emit the publish result as JSON.\n\nOutput is an array with one `{name, version, filename, files: [{path}]}` entry, matching `pnpm publish --json` / `aube pack --json`."
+    }
     flag --no-git-checks help="Skip the \"working tree must be clean\" check" {
         long_help "Skip the \"working tree must be clean\" check.\n\nWhen unset, aube refuses to publish from a dirty git checkout (uncommitted tracked changes) or from a detached / non-release branch."
     }
@@ -702,7 +722,9 @@ cmd publish help="Publish the current package to the registry" {
 }
 cmd purge help="Alias for `clean` — remove `node_modules` across every workspace project" {
     long_help "Alias for `clean` — remove `node_modules` across every workspace project.\n\nA `purge` script in the root `package.json` overrides the built-in."
-    flag "-l --lockfile" help="Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)"
+    flag "-l --lockfile" help="Also remove lockfiles at the workspace root" {
+        long_help "Also remove lockfiles at the workspace root.\n\nTargets `aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock`."
+    }
 }
 cmd query help="Query packages in the resolved dependency graph" {
     after_long_help "Inspired by vlt's dependency selector model, but currently local-only:\nselectors read aube's lockfile graph without registry or security-service calls.\n\nExamples:\n\n  # Every reachable package\n  $ aube query '*'\n\n  # Exact package name\n  $ aube query '[name=react]'\n\n  # Direct prod dependencies with install scripts\n  $ aube query ':prod:scripts'\n\n  # Local file/link/git/tarball dependencies\n  $ aube query ':type(file), :type(link), :type(git), :type(remote)'\n\n  # Machine-readable\n  $ aube query ':bin' --json\n"
@@ -710,7 +732,7 @@ cmd query help="Query packages in the resolved dependency graph" {
     flag "-P --prod --production" help="Only match production/optional roots and their transitive deps"
     flag --json help="Emit a JSON array instead of the default text layout"
     flag --parseable help="Emit tab-separated rows: dep_path, name, version, source, flags"
-    arg <SELECTOR> help="Selector expression. Supports `*`, bare package names, `[name=value]`, `[version=value]`, `[license=value]`, `[depPath=value]`, `[source=value]`, `:prod`, `:dev`, `:optional`, `:peer`, `:transitive`, `:scripts`, `:bin`, `:deprecated`, `:license(value)`, and `:type(value)`"
+    arg <SELECTOR> help="Selector expression" help_long="Selector expression.\n\nSupports `*`, bare package names, `[name=value]`, `[version=value]`, `[license=value]`, `[depPath=value]`, `[source=value]`, `:prod`, `:dev`, `:optional`, `:peer`, `:transitive`, `:scripts`, `:bin`, `:deprecated`, `:license(value)`, and `:type(value)`."
 }
 cmd rebuild help="Re-run root lifecycle scripts and allowlisted dependency builds" {
     alias rb
@@ -725,8 +747,8 @@ cmd remove help="Remove a dependency" {
     flag "-D --save-dev" help="Remove only from devDependencies"
     flag "-g --global" help="Remove from the global install directory instead of the project"
     flag --ignore-scripts help="Skip root lifecycle scripts during the chained reinstall"
-    flag "-w --workspace" help="Remove the dependency from the workspace root's `package.json`, regardless of the current working directory" {
-        long_help "Remove the dependency from the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`)."
+    flag "-w --workspace" help="Remove the dependency from the workspace root's `package.json`" {
+        long_help "Remove the dependency from the workspace root's `package.json`.\n\nApplies regardless of the current working directory: walks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`)."
     }
     arg "[PACKAGES]…" help="Package(s) to remove" required=#false var=#true
 }
@@ -748,8 +770,8 @@ cmd run help="Run a script defined in package.json" {
     flag --no-sort help="Disable topological sorting" {
         long_help "Disable topological sorting.\n\nParsed for pnpm compatibility."
     }
-    flag --parallel help="Run the script in every matched workspace package concurrently, with unbounded parallelism" {
-        long_help "Run the script in every matched workspace package concurrently, with unbounded parallelism.\n\nPair with a filter (`-r` / `-F`) — single-package runs ignore it. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated."
+    flag --parallel help="Run the script in every matched workspace package concurrently" {
+        long_help "Run the script in every matched workspace package concurrently.\n\nUnbounded parallelism. Pair with a filter (`-r` / `-F`) — single-package runs ignore it. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated."
     }
     flag --report-summary help="Write a recursive run summary file" {
         long_help "Write a recursive run summary file.\n\nParsed for pnpm compatibility."
@@ -818,8 +840,8 @@ cmd store subcommand_required=#true help="Manage the global store" {
     }
     cmd path help="Show the store path"
     cmd prune help="Remove unreferenced packages from the global store"
-    cmd status help="Verify that every file referenced by a cached package index is still present in the store and its BLAKE3 hash matches" {
-        long_help "Verify that every file referenced by a cached package index is still present in the store and its BLAKE3 hash matches.\n\nExits non-zero when any corruption is detected."
+    cmd status help="Verify the store against cached package indexes" {
+        long_help "Verify the store against cached package indexes.\n\nConfirms every file referenced by a cached package index is still present in the store and that its BLAKE3 hash matches. Exits non-zero when any corruption is detected."
     }
 }
 cmd test help="Run the `test` script (shortcut for `run test`)" {
@@ -867,7 +889,9 @@ cmd update help="Update dependencies" {
     flag "-i --interactive" help="Interactive update picker" {
         long_help "Interactive update picker.\n\nParsed for pnpm compatibility."
     }
-    flag "-L --latest" help="Update past the manifest range: rewrite `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual)"
+    flag "-L --latest" help="Update past the manifest range" {
+        long_help "Update past the manifest range.\n\nRewrites `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual)."
+    }
     flag "-P --prod --production" help="Update only production dependencies"
     flag "-w --workspace" help="Update dependencies in the current workspace package"
     flag --depth help="Dependency traversal depth" {
@@ -909,7 +933,7 @@ cmd version help="Bump the version in package.json (and optionally create a git 
         arg <ID>
     }
     flag --sign-git-tag help="GPG-sign the created tag (`git tag -s`)"
-    arg "[NEW_VERSION]" help="Bump keyword (`major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`) or an explicit version string" help_long="Bump keyword (`major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`) or an explicit version string.\n\nWhen omitted, prints the current version." required=#false
+    arg "[NEW_VERSION]" help="Bump keyword or an explicit version string" help_long="Bump keyword or an explicit version string.\n\nAccepts `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`, or an explicit version. When omitted, prints the current version." required=#false
 }
 cmd view help="Print package metadata from the registry" {
     alias info show
@@ -918,8 +942,8 @@ cmd view help="Print package metadata from the registry" {
     flag --json help="Print the full JSON of the selected version instead of the summary" {
         long_help "Print the full JSON of the selected version instead of the summary.\n\nMutually exclusive with `field`."
     }
-    arg <PACKAGE> help="Package to view, optionally with a version or dist-tag (`lodash`, `lodash@4.17.21`, `react@next`, `express@^4`)"
-    arg "[FIELD]" help="Dotted path into the version metadata to print (`version`, `dependencies`, `dist.tarball`, `maintainers.0.name`)" help_long="Dotted path into the version metadata to print (`version`, `dependencies`, `dist.tarball`, `maintainers.0.name`).\n\nWhen omitted, prints a formatted summary." required=#false
+    arg <PACKAGE> help="Package to view, optionally with a version or dist-tag" help_long="Package to view, optionally with a version or dist-tag.\n\nExamples: `lodash`, `lodash@4.17.21`, `react@next`, `express@^4`."
+    arg "[FIELD]" help="Dotted path into the version metadata to print" help_long="Dotted path into the version metadata to print.\n\nExamples: `version`, `dependencies`, `dist.tarball`, `maintainers.0.name`. When omitted, prints a formatted summary." required=#false
 }
 cmd whoami hide=#true help="Report the current registry user (not implemented — use `npm whoami`)" {
     arg "[ARGS]…" help="Unused; captured so `aube <cmd> foo bar` parses instead of erroring on unexpected args before the fallback message prints" required=#false double_dash=automatic var=#true hide=#true

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -15,10 +15,10 @@ pub struct AddArgs {
     /// Pin the exact resolved version (no `^` prefix)
     #[arg(short = 'E', long)]
     pub save_exact: bool,
-    /// Install the package globally (into the aube/pnpm global directory)
-    /// and link its binaries into the global bin directory.
+    /// Install the package globally.
     ///
-    /// Mirrors `pnpm add -g`.
+    /// Installs into the aube/pnpm global directory and links its
+    /// binaries into the global bin directory. Mirrors `pnpm add -g`.
     #[arg(short = 'g', long)]
     pub global: bool,
     /// Add as optional dependency
@@ -69,8 +69,10 @@ pub struct AddArgs {
     /// Skip lifecycle scripts (no-op; aube already skips by default)
     #[arg(long)]
     pub ignore_scripts: bool,
-    /// Snapshot `package.json` and the lockfile, link the named
-    /// packages into `node_modules`, and then restore both files —
+    /// Install without persisting the dependency to `package.json`.
+    ///
+    /// Snapshots `package.json` and the lockfile, links the named
+    /// packages into `node_modules`, and then restores both files —
     /// so the dependency is usable for the current process but the
     /// project's committed state is untouched.
     ///
@@ -80,10 +82,11 @@ pub struct AddArgs {
     /// manifest.
     #[arg(long, conflicts_with = "global")]
     pub no_save: bool,
-    /// Save the new dependency into the workspace's default catalog,
-    /// writing `catalog:` into `package.json` and seeding/upserting
-    /// the resolved range under `catalog:` in the workspace yaml.
-    /// Mirrors `pnpm add --save-catalog`.
+    /// Save the new dependency into the workspace's default catalog.
+    ///
+    /// Writes `catalog:` into `package.json` and seeds/upserts the
+    /// resolved range under `catalog:` in the workspace yaml. Mirrors
+    /// `pnpm add --save-catalog`.
     ///
     /// Workspace and aliased specs (`workspace:*`, `npm:`, `jsr:`) are
     /// never catalogized — the manifest gets the original spec and
@@ -98,11 +101,12 @@ pub struct AddArgs {
     /// catalog entry behind.
     #[arg(long, conflicts_with_all = ["save_catalog_name", "no_save"])]
     pub save_catalog: bool,
-    /// Save the new dependency into a *named* catalog (`catalogs.<name>`
-    /// in the workspace yaml), writing `catalog:<name>` into
-    /// `package.json`. Same workspace/alias exclusions and `--no-save`
-    /// conflict as `--save-catalog`. Mirrors `pnpm add
-    /// --save-catalog-name=<name>`.
+    /// Save the new dependency into a *named* catalog.
+    ///
+    /// Writes the entry to `catalogs.<name>` in the workspace yaml and
+    /// `catalog:<name>` into `package.json`. Same workspace/alias
+    /// exclusions and `--no-save` conflict as `--save-catalog`. Mirrors
+    /// `pnpm add --save-catalog-name=<name>`.
     #[arg(long, value_name = "NAME", conflicts_with = "no_save")]
     pub save_catalog_name: Option<String>,
     /// Add as a peer dependency (written to `peerDependencies` in
@@ -113,12 +117,12 @@ pub struct AddArgs {
     /// does.
     #[arg(long, conflicts_with = "save_optional")]
     pub save_peer: bool,
-    /// Add the dependency to the workspace root's `package.json`,
-    /// regardless of the current working directory.
+    /// Add the dependency to the workspace root's `package.json`.
     ///
-    /// Walks up from cwd looking for `aube-workspace.yaml`,
-    /// `pnpm-workspace.yaml`, or a `package.json` with a `workspaces`
-    /// field and runs the add against that directory.
+    /// Applies regardless of the current working directory: walks up
+    /// from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`,
+    /// or a `package.json` with a `workspaces` field and runs the add
+    /// against that directory.
     #[arg(short = 'w', long, conflicts_with = "global")]
     pub workspace: bool,
     /// Allow `add` to run in a workspace root.

--- a/crates/aube/src/commands/approve_builds.rs
+++ b/crates/aube/src/commands/approve_builds.rs
@@ -27,9 +27,10 @@ pub struct ApproveBuildsArgs {
     #[arg(short = 'g', long)]
     pub global: bool,
 
-    /// Packages to approve directly, skipping the picker. Each name
-    /// must match a currently-ignored build. Unknown names are rejected
-    /// so a typo cannot silently no-op.
+    /// Packages to approve directly, skipping the picker.
+    ///
+    /// Each name must match a currently-ignored build. Unknown names
+    /// are rejected so a typo cannot silently no-op.
     #[arg(value_name = "PKG")]
     pub packages: Vec<String>,
 }

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -74,11 +74,12 @@ pub struct AuditArgs {
     #[arg(long)]
     pub ignore_registry_errors: bool,
 
-    /// Drop advisories for which no non-vulnerable version is available
-    /// in the package's packument.
+    /// Drop advisories that have no non-vulnerable upgrade.
     ///
-    /// Same "best non-vulnerable" logic as `--fix`: an advisory is kept
-    /// only when an upgrade path exists.
+    /// Filters out advisories for which no non-vulnerable version is
+    /// available in the package's packument. Same "best non-vulnerable"
+    /// logic as `--fix`: an advisory is kept only when an upgrade path
+    /// exists.
     #[arg(long)]
     pub ignore_unfixable: bool,
 

--- a/crates/aube/src/commands/clean.rs
+++ b/crates/aube/src/commands/clean.rs
@@ -20,9 +20,10 @@ use clap::Args;
 
 #[derive(Debug, Args)]
 pub struct CleanArgs {
-    /// Also remove lockfiles at the workspace root
-    /// (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`,
-    /// `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`).
+    /// Also remove lockfiles at the workspace root.
+    ///
+    /// Targets `aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`,
+    /// `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock`.
     #[arg(short = 'l', long)]
     pub lockfile: bool,
 }

--- a/crates/aube/src/commands/config/list.rs
+++ b/crates/aube/src/commands/config/list.rs
@@ -7,8 +7,10 @@ use miette::miette;
 
 #[derive(Debug, Args)]
 pub struct ListArgs {
-    /// Also list settings that have no value set — one row per setting
-    /// in `settings.toml`, with the default and description rendered.
+    /// Also list settings that have no value set.
+    ///
+    /// Renders one row per setting in `settings.toml`, with the
+    /// default and description shown for unset entries.
     ///
     /// Only valid with `--location merged` (the default), since a
     /// per-file view can't distinguish "not set anywhere" from "set in
@@ -16,11 +18,10 @@ pub struct ListArgs {
     #[arg(long)]
     pub all: bool,
 
-    /// Emit all entries as a JSON object keyed by setting name, matching
-    /// `pnpm config list --json`.
+    /// Emit all entries as a JSON object keyed by setting name.
     ///
-    /// Honors `--all` and `--location` the same way the default text
-    /// output does.
+    /// Matches `pnpm config list --json`. Honors `--all` and
+    /// `--location` the same way the default text output does.
     #[arg(long)]
     pub json: bool,
 

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -23,12 +23,11 @@ pub struct DlxArgs {
     /// looked up in `node_modules/.bin`.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub params: Vec<String>,
-    /// Run the assembled command line through `sh -c` with
-    /// `<scratch>/node_modules/.bin` prepended to `PATH`.
+    /// Run the assembled command line through `sh -c`.
     ///
-    /// Use this for pipelines, redirects, or env expansion (`aube dlx
-    /// -p cowsay -c 'cowsay hello | tr a-z A-Z'`). Mirrors `pnpm dlx
-    /// --shell-mode`.
+    /// `<scratch>/node_modules/.bin` is prepended to `PATH`. Use this
+    /// for pipelines, redirects, or env expansion (`aube dlx -p cowsay
+    /// -c 'cowsay hello | tr a-z A-Z'`). Mirrors `pnpm dlx --shell-mode`.
     #[arg(short = 'c', long)]
     pub shell_mode: bool,
     /// Install a specific package (repeatable).

--- a/crates/aube/src/commands/find_hash.rs
+++ b/crates/aube/src/commands/find_hash.rs
@@ -42,9 +42,9 @@ pub struct FindHashArgs {
     /// CAS digest.
     pub hash: String,
 
-    /// Emit a machine-readable JSON array of
-    /// `{ "name", "version", "path" }` objects instead of a plain text
-    /// listing.
+    /// Emit machine-readable JSON instead of a plain text listing.
+    ///
+    /// Output is an array of `{ "name", "version", "path" }` objects.
     #[arg(long)]
     pub json: bool,
 }

--- a/crates/aube/src/commands/init.rs
+++ b/crates/aube/src/commands/init.rs
@@ -14,8 +14,9 @@ pub struct InitArgs {
     #[arg(long)]
     pub bare: bool,
 
-    /// Pin the project to the current aube version by adding a `packageManager`
-    /// field to `package.json`
+    /// Pin the project to the current aube version.
+    ///
+    /// Adds a `packageManager` field to `package.json`.
     #[arg(long)]
     pub init_package_manager: bool,
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -57,18 +57,19 @@ pub struct InstallArgs {
     /// Bypasses the `allowBuilds` allowlist. Do not use in CI.
     #[arg(long)]
     pub dangerously_allow_all_builds: bool,
-    /// Re-resolve lockfile entries whose spec drifted from package.json,
-    /// leaving everything else pinned at its locked version.
+    /// Re-resolve lockfile entries whose spec drifted from package.json.
     ///
-    /// Unchanged specs keep their existing version and integrity
-    /// hash; only drifted entries (and any new transitives they pull
-    /// in) get re-resolved.
+    /// Leaves everything else pinned at its locked version. Unchanged
+    /// specs keep their existing version and integrity hash; only
+    /// drifted entries (and any new transitives they pull in) get
+    /// re-resolved.
     #[arg(long, conflicts_with_all = ["frozen_lockfile", "no_frozen_lockfile", "prefer_frozen_lockfile"])]
     pub fix_lockfile: bool,
-    /// Force reinstall: bypass the `node_modules/.aube-state` freshness check
-    /// and re-resolve the lockfile even when nothing has drifted.
+    /// Force reinstall, ignoring lockfile/state freshness.
     ///
-    /// Mirrors pnpm's `install --force`.
+    /// Bypasses the `node_modules/.aube-state` freshness check and
+    /// re-resolves the lockfile even when nothing has drifted. Mirrors
+    /// pnpm's `install --force`.
     #[arg(long)]
     pub force: bool,
     /// Add a global pnpmfile that runs before the local one.
@@ -85,10 +86,11 @@ pub struct InstallArgs {
     /// Skip lifecycle scripts (no-op; aube already skips by default)
     #[arg(long)]
     pub ignore_scripts: bool,
-    /// Read and write the lockfile in the given directory instead of
-    /// alongside `package.json`. The project becomes an importer
-    /// keyed by its relative path from the lockfile directory.
-    /// Mirrors pnpm's `--lockfile-dir`.
+    /// Read and write the lockfile in the given directory.
+    ///
+    /// Instead of placing the lockfile alongside `package.json`, the
+    /// project becomes an importer keyed by its relative path from the
+    /// lockfile directory. Mirrors pnpm's `--lockfile-dir`.
     #[arg(long, value_name = "PATH")]
     pub lockfile_dir: Option<String>,
     /// Resolve dependencies and write the lockfile, but don't link
@@ -97,10 +99,11 @@ pub struct InstallArgs {
     /// Useful for CI workflows that only update the lockfile.
     #[arg(long, conflicts_with = "frozen_lockfile")]
     pub lockfile_only: bool,
-    /// Merge every `aube-lock.<branch>.yaml` file in the project into
-    /// `aube-lock.yaml` and delete the branch files.
+    /// Merge per-branch lockfiles into the main `aube-lock.yaml`.
     ///
-    /// Companion to `gitBranchLockfile`. When
+    /// Combines every `aube-lock.<branch>.yaml` file in the project
+    /// into `aube-lock.yaml` and deletes the branch files. Companion
+    /// to `gitBranchLockfile`. When
     /// `mergeGitBranchLockfilesBranchPattern` is set in
     /// `pnpm-workspace.yaml`, this happens automatically on matching
     /// branches; the flag forces it regardless.
@@ -166,13 +169,13 @@ pub struct InstallArgs {
     /// Repeatable; comma-separated values are also accepted.
     #[arg(long, value_name = "GLOB", value_delimiter = ',')]
     pub public_hoist_pattern: Vec<String>,
-    /// How to resolve version ranges: `highest` (pnpm's classic
-    /// behavior) or `time-based` (pick the lowest satisfying direct dep
-    /// and constrain transitives by a publish-date cutoff).
+    /// How to resolve version ranges.
     ///
-    /// Accepts pnpm's aliases `time` and `lowest-direct`. When
-    /// omitted, falls back to the `resolution-mode` key in `.npmrc`
-    /// / `aube-workspace.yaml`.
+    /// `highest` (pnpm's classic behavior) or `time-based` (pick the
+    /// lowest satisfying direct dep and constrain transitives by a
+    /// publish-date cutoff). Accepts pnpm's aliases `time` and
+    /// `lowest-direct`. When omitted, falls back to the
+    /// `resolution-mode` key in `.npmrc` / `aube-workspace.yaml`.
     #[arg(long, value_name = "MODE")]
     pub resolution_mode: Option<String>,
     /// Hoist every non-local transitive dep to the top-level
@@ -189,11 +192,11 @@ pub struct InstallArgs {
     /// `--no-side-effects-cache` to opt out.
     #[arg(long, overrides_with = "no_side_effects_cache")]
     pub side_effects_cache: bool,
-    /// Verify tarball SHA-512 against the lockfile integrity before
-    /// importing into the store.
+    /// Verify tarball SHA-512 before importing into the store.
     ///
-    /// Defaults to `true` (pnpm parity); pair with
-    /// `--no-verify-store-integrity` to skip.
+    /// Checks each tarball against the lockfile integrity. Defaults to
+    /// `true` (pnpm parity); pair with `--no-verify-store-integrity`
+    /// to skip.
     #[arg(long, overrides_with = "no_verify_store_integrity")]
     pub verify_store_integrity: bool,
     /// Short alias for the global `--workspace-root` flag.

--- a/crates/aube/src/commands/link.rs
+++ b/crates/aube/src/commands/link.rs
@@ -6,11 +6,11 @@ use miette::{Context, IntoDiagnostic, miette};
 pub struct LinkArgs {
     /// Package name, or path to a local directory
     pub package: Option<String>,
-    /// Register into (or resolve from) the global link registry
-    /// under `$AUBE_HOME/global-links`.
+    /// Register into (or resolve from) the global link registry.
     ///
-    /// Default behavior for bare `aube link` / `aube link <name>` —
-    /// the flag exists for pnpm parity and makes the intent explicit.
+    /// The registry lives at `$AUBE_HOME/global-links`. Default
+    /// behavior for bare `aube link` / `aube link <name>` — the flag
+    /// exists for pnpm parity and makes the intent explicit.
     #[arg(short = 'g', long)]
     pub global: bool,
 }

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -93,8 +93,10 @@ pub struct ListArgs {
     #[arg(long, conflicts_with = "format")]
     pub json: bool,
 
-    /// Show version and path for each entry (default output is already
-    /// name + version; `--long` adds the store path for debugging).
+    /// Show version and path for each entry.
+    ///
+    /// Default output is already name + version; `--long` adds the
+    /// store path for debugging.
     #[arg(long)]
     pub long: bool,
 

--- a/crates/aube/src/commands/patch.rs
+++ b/crates/aube/src/commands/patch.rs
@@ -29,13 +29,12 @@ pub struct PatchArgs {
     #[arg(long, value_name = "DIR")]
     pub edit_dir: Option<PathBuf>,
 
-    /// Ignore any existing patch entry for this package — extract a
-    /// pristine copy from `node_modules` rather than re-applying the
-    /// existing patch first.
+    /// Ignore any existing patch entry for this package.
     ///
-    /// Accepted for pnpm parity; aube already extracts from the
-    /// *linked* (post-patch) tree, so this flag is effectively
-    /// informational here.
+    /// Extracts a pristine copy from `node_modules` rather than
+    /// re-applying the existing patch first. Accepted for pnpm parity;
+    /// aube already extracts from the *linked* (post-patch) tree, so
+    /// this flag is effectively informational here.
     #[arg(long)]
     pub ignore_existing: bool,
 }

--- a/crates/aube/src/commands/patch_remove.rs
+++ b/crates/aube/src/commands/patch_remove.rs
@@ -12,10 +12,10 @@ use miette::{IntoDiagnostic, Result, miette};
 
 #[derive(Debug, Args)]
 pub struct PatchRemoveArgs {
-    /// Patch keys to remove, formatted as `<name>@<version>` (the same
-    /// shape used as the `pnpm.patchedDependencies` map key).
+    /// Patch keys to remove, formatted as `<name>@<version>`.
     ///
-    /// With no arguments, every declared patch is removed.
+    /// Same shape used as the `pnpm.patchedDependencies` map key. With
+    /// no arguments, every declared patch is removed.
     pub packages: Vec<String>,
 }
 

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -53,8 +53,7 @@ pub struct PublishArgs {
     /// Don't upload; print what would be published.
     #[arg(long)]
     pub dry_run: bool,
-    /// Republish `name@version` even when that version is already on
-    /// the target registry.
+    /// Republish even when the version is already on the registry.
     ///
     /// By default `aube publish` issues a GET before the PUT and
     /// refuses to proceed when the version exists, surfacing a clear
@@ -66,12 +65,16 @@ pub struct PublishArgs {
     /// outright; Verdaccio and most private mirrors allow them.
     #[arg(long)]
     pub force: bool,
-    /// Skip `prepublishOnly` / `prepublish` / `prepack` / `prepare` /
-    /// `postpack` / `publish` / `postpublish` lifecycle scripts for
-    /// this publish.
+    /// Skip publish lifecycle scripts.
+    ///
+    /// Suppresses `prepublishOnly`, `prepublish`, `prepack`, `prepare`,
+    /// `postpack`, `publish`, and `postpublish` scripts for this
+    /// publish.
     #[arg(long)]
     pub ignore_scripts: bool,
-    /// Emit the publish result as JSON: an array with one
+    /// Emit the publish result as JSON.
+    ///
+    /// Output is an array with one
     /// `{name, version, filename, files: [{path}]}` entry, matching
     /// `pnpm publish --json` / `aube pack --json`.
     #[arg(long)]

--- a/crates/aube/src/commands/query.rs
+++ b/crates/aube/src/commands/query.rs
@@ -36,11 +36,13 @@ Examples:
 
 #[derive(Debug, Args)]
 pub struct QueryArgs {
-    /// Selector expression. Supports `*`, bare package names,
-    /// `[name=value]`, `[version=value]`, `[license=value]`,
-    /// `[depPath=value]`, `[source=value]`, `:prod`, `:dev`,
-    /// `:optional`, `:peer`, `:transitive`, `:scripts`, `:bin`,
-    /// `:deprecated`, `:license(value)`, and `:type(value)`.
+    /// Selector expression.
+    ///
+    /// Supports `*`, bare package names, `[name=value]`,
+    /// `[version=value]`, `[license=value]`, `[depPath=value]`,
+    /// `[source=value]`, `:prod`, `:dev`, `:optional`, `:peer`,
+    /// `:transitive`, `:scripts`, `:bin`, `:deprecated`,
+    /// `:license(value)`, and `:type(value)`.
     pub selector: String,
 
     /// Only match devDependency roots and their transitive deps.

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -15,14 +15,13 @@ pub struct RemoveArgs {
     /// Skip root lifecycle scripts during the chained reinstall
     #[arg(long)]
     pub ignore_scripts: bool,
-    /// Remove the dependency from the workspace root's `package.json`,
-    /// regardless of the current working directory.
+    /// Remove the dependency from the workspace root's `package.json`.
     ///
-    /// Walks up from cwd looking for `aube-workspace.yaml`,
-    /// `pnpm-workspace.yaml`, or a `package.json` with a `workspaces`
-    /// field and runs the remove against that directory. Takes
-    /// precedence over `--filter` when both are supplied (same as
-    /// `add --workspace`).
+    /// Applies regardless of the current working directory: walks up
+    /// from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`,
+    /// or a `package.json` with a `workspaces` field and runs the
+    /// remove against that directory. Takes precedence over `--filter`
+    /// when both are supplied (same as `add --workspace`).
     #[arg(short = 'w', long, conflicts_with = "global")]
     pub workspace: bool,
 }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -32,12 +32,12 @@ pub struct RunArgs {
     /// Parsed for pnpm compatibility.
     #[arg(long, overrides_with = "sort")]
     pub no_sort: bool,
-    /// Run the script in every matched workspace package
-    /// concurrently, with unbounded parallelism.
+    /// Run the script in every matched workspace package concurrently.
     ///
-    /// Pair with a filter (`-r` / `-F`) — single-package runs ignore
-    /// it. First non-zero exit fails the whole run, but siblings are
-    /// allowed to finish so their output isn't truncated.
+    /// Unbounded parallelism. Pair with a filter (`-r` / `-F`) —
+    /// single-package runs ignore it. First non-zero exit fails the
+    /// whole run, but siblings are allowed to finish so their output
+    /// isn't truncated.
     #[arg(long)]
     pub parallel: bool,
     /// Write a recursive run summary file.

--- a/crates/aube/src/commands/store.rs
+++ b/crates/aube/src/commands/store.rs
@@ -50,9 +50,10 @@ pub enum StoreCommand {
     Path,
     /// Remove unreferenced packages from the global store.
     Prune,
-    /// Verify that every file referenced by a cached package index is
-    /// still present in the store and its BLAKE3 hash matches.
+    /// Verify the store against cached package indexes.
     ///
+    /// Confirms every file referenced by a cached package index is
+    /// still present in the store and that its BLAKE3 hash matches.
     /// Exits non-zero when any corruption is detected.
     Status,
 }

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -29,10 +29,11 @@ pub struct UpdateArgs {
     /// Parsed for pnpm compatibility.
     #[arg(short = 'i', long)]
     pub interactive: bool,
-    /// Update past the manifest range: rewrite `package.json`
-    /// specifiers to match the newly resolved versions (the registry's
-    /// `latest` dist-tag, clamped by `minimumReleaseAge` /
-    /// `resolution-mode` as usual).
+    /// Update past the manifest range.
+    ///
+    /// Rewrites `package.json` specifiers to match the newly resolved
+    /// versions (the registry's `latest` dist-tag, clamped by
+    /// `minimumReleaseAge` / `resolution-mode` as usual).
     #[arg(short = 'L', long)]
     pub latest: bool,
     /// Update only production dependencies.

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -14,10 +14,11 @@ use std::process::Command;
 
 #[derive(Debug, Args)]
 pub struct VersionArgs {
-    /// Bump keyword (`major`, `minor`, `patch`, `premajor`, `preminor`,
-    /// `prepatch`, `prerelease`) or an explicit version string.
+    /// Bump keyword or an explicit version string.
     ///
-    /// When omitted, prints the current version.
+    /// Accepts `major`, `minor`, `patch`, `premajor`, `preminor`,
+    /// `prepatch`, `prerelease`, or an explicit version. When omitted,
+    /// prints the current version.
     pub new_version: Option<String>,
 
     /// Allow setting the version to its current value without erroring.

--- a/crates/aube/src/commands/view.rs
+++ b/crates/aube/src/commands/view.rs
@@ -47,14 +47,15 @@ Examples:
 
 #[derive(Debug, Args)]
 pub struct ViewArgs {
-    /// Package to view, optionally with a version or dist-tag
-    /// (`lodash`, `lodash@4.17.21`, `react@next`, `express@^4`).
+    /// Package to view, optionally with a version or dist-tag.
+    ///
+    /// Examples: `lodash`, `lodash@4.17.21`, `react@next`, `express@^4`.
     pub package: String,
 
-    /// Dotted path into the version metadata to print
-    /// (`version`, `dependencies`, `dist.tarball`, `maintainers.0.name`).
+    /// Dotted path into the version metadata to print.
     ///
-    /// When omitted, prints a formatted summary.
+    /// Examples: `version`, `dependencies`, `dist.tarball`,
+    /// `maintainers.0.name`. When omitted, prints a formatted summary.
     pub field: Option<String>,
 
     /// Print the full JSON of the selected version instead of the summary.

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -456,7 +456,10 @@ enum Commands {
     /// Add a dependency
     #[command(visible_alias = "a")]
     Add(commands::add::AddArgs),
-    /// Approve ignored dependency build scripts in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present) under `allowBuilds`
+    /// Approve ignored dependency build scripts.
+    ///
+    /// Writes entries under `allowBuilds` in `aube-workspace.yaml` (or
+    /// `pnpm-workspace.yaml` if present).
     ApproveBuilds(commands::approve_builds::ApproveBuildsArgs),
     /// Check installed packages against the registry advisory DB
     #[command(after_long_help = commands::audit::AFTER_LONG_HELP)]
@@ -470,7 +473,10 @@ enum Commands {
     CatFile(commands::cat_file::CatFileArgs),
     /// Print the cached package index JSON for `<name>@<version>`
     CatIndex(commands::cat_index::CatIndexArgs),
-    /// Verify that every installed package can resolve its declared deps through the `node_modules/` symlink tree
+    /// Verify installed packages can resolve their declared deps.
+    ///
+    /// Walks the `node_modules/` symlink tree and confirms every
+    /// dependency in each `package.json` resolves to a real entry.
     #[command(after_long_help = commands::check::AFTER_LONG_HELP)]
     Check(commands::check::CheckArgs),
     /// Clean install: delete node_modules, then install with frozen lockfile.

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -24,9 +24,9 @@ Pin the exact resolved version (no `^` prefix)
 
 ### `-g --global`
 
-Install the package globally (into the aube/pnpm global directory) and link its binaries into the global bin directory.
+Install the package globally.
 
-Mirrors `pnpm add -g`.
+Installs into the aube/pnpm global directory and links its binaries into the global bin directory. Mirrors `pnpm add -g`.
 
 ### `-O --save-optional`
 
@@ -52,13 +52,17 @@ Skip lifecycle scripts (no-op; aube already skips by default)
 
 ### `--no-save`
 
-Snapshot `package.json` and the lockfile, link the named packages into `node_modules`, and then restore both files — so the dependency is usable for the current process but the project's committed state is untouched.
+Install without persisting the dependency to `package.json`.
+
+Snapshots `package.json` and the lockfile, links the named packages into `node_modules`, and then restores both files — so the dependency is usable for the current process but the project's committed state is untouched.
 
 Handy for one-off experiments and for scripts that install a tool transiently. Mirrors `pnpm add --no-save`. Conflicts with `-g`/`--global`, which has to persist the install to its global manifest.
 
 ### `--save-catalog`
 
-Save the new dependency into the workspace's default catalog, writing `catalog:` into `package.json` and seeding/upserting the resolved range under `catalog:` in the workspace yaml. Mirrors `pnpm add --save-catalog`.
+Save the new dependency into the workspace's default catalog.
+
+Writes `catalog:` into `package.json` and seeds/upserts the resolved range under `catalog:` in the workspace yaml. Mirrors `pnpm add --save-catalog`.
 
 Workspace and aliased specs (`workspace:*`, `npm:`, `jsr:`) are never catalogized — the manifest gets the original spec and the catalog yaml is left alone. If the package is already in the target catalog, the existing entry is preserved (never overwritten); the manifest then gets `catalog:` only when the existing entry is compatible with the user's range.
 
@@ -66,7 +70,9 @@ Conflicts with `--no-save`: catalog mutations write to the workspace yaml, which
 
 ### `--save-catalog-name <NAME>`
 
-Save the new dependency into a *named* catalog (`catalogs.<name>` in the workspace yaml), writing `catalog:<name>` into `package.json`. Same workspace/alias exclusions and `--no-save` conflict as `--save-catalog`. Mirrors `pnpm add --save-catalog-name=<name>`
+Save the new dependency into a *named* catalog.
+
+Writes the entry to `catalogs.<name>` in the workspace yaml and `catalog:<name>` into `package.json`. Same workspace/alias exclusions and `--no-save` conflict as `--save-catalog`. Mirrors `pnpm add --save-catalog-name=<name>`.
 
 ### `--save-peer`
 
@@ -76,9 +82,9 @@ By convention you usually pair this with `--save-dev` so the peer is also instal
 
 ### `-w --workspace`
 
-Add the dependency to the workspace root's `package.json`, regardless of the current working directory.
+Add the dependency to the workspace root's `package.json`.
 
-Walks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the add against that directory.
+Applies regardless of the current working directory: walks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the add against that directory.
 
 ### `-W --ignore-workspace-root-check`
 

--- a/docs/cli/approve-builds.md
+++ b/docs/cli/approve-builds.md
@@ -3,13 +3,17 @@
 
 - **Usage**: `aube approve-builds [--all] [-g --global] [PKG]…`
 
-Approve ignored dependency build scripts in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present) under `allowBuilds`
+Approve ignored dependency build scripts.
+
+Writes entries under `allowBuilds` in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present).
 
 ## Arguments
 
 ### `[PKG]…`
 
-Packages to approve directly, skipping the picker. Each name must match a currently-ignored build. Unknown names are rejected so a typo cannot silently no-op
+Packages to approve directly, skipping the picker.
+
+Each name must match a currently-ignored build. Unknown names are rejected so a typo cannot silently no-op.
 
 ## Flags
 

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -51,9 +51,9 @@ Useful when audit checks run in CI and the registry has a hiccup.
 
 ### `--ignore-unfixable`
 
-Drop advisories for which no non-vulnerable version is available in the package's packument.
+Drop advisories that have no non-vulnerable upgrade.
 
-Same "best non-vulnerable" logic as `--fix`: an advisory is kept only when an upgrade path exists.
+Filters out advisories for which no non-vulnerable version is available in the package's packument. Same "best non-vulnerable" logic as `--fix`: an advisory is kept only when an upgrade path exists.
 
 ### `-i --interactive`
 

--- a/docs/cli/check.md
+++ b/docs/cli/check.md
@@ -3,7 +3,9 @@
 
 - **Usage**: `aube check [--json]`
 
-Verify that every installed package can resolve its declared deps through the `node_modules/` symlink tree
+Verify installed packages can resolve their declared deps.
+
+Walks the `node_modules/` symlink tree and confirms every dependency in each `package.json` resolves to a real entry.
 
 ## Flags
 

--- a/docs/cli/clean.md
+++ b/docs/cli/clean.md
@@ -11,4 +11,6 @@ Remove `node_modules` across every workspace project.
 
 ### `-l --lockfile`
 
-Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)
+Also remove lockfiles at the workspace root.
+
+Targets `aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock`.

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -55,9 +55,9 @@
           {
             "name": "global",
             "usage": "-g --global",
-            "help": "Install the package globally (into the aube/pnpm global directory) and link its binaries into the global bin directory",
-            "help_long": "Install the package globally (into the aube/pnpm global directory) and link its binaries into the global bin directory.\n\nMirrors `pnpm add -g`.",
-            "help_first_line": "Install the package globally (into the aube/pnpm global directory) and link its binaries into the global bin directory",
+            "help": "Install the package globally",
+            "help_long": "Install the package globally.\n\nInstalls into the aube/pnpm global directory and links its binaries into the global bin directory. Mirrors `pnpm add -g`.",
+            "help_first_line": "Install the package globally",
             "short": [
               "g"
             ],
@@ -117,9 +117,9 @@
           {
             "name": "no-save",
             "usage": "--no-save",
-            "help": "Snapshot `package.json` and the lockfile, link the named packages into `node_modules`, and then restore both files — so the dependency is usable for the current process but the project's committed state is untouched",
-            "help_long": "Snapshot `package.json` and the lockfile, link the named packages into `node_modules`, and then restore both files — so the dependency is usable for the current process but the project's committed state is untouched.\n\nHandy for one-off experiments and for scripts that install a tool transiently. Mirrors `pnpm add --no-save`. Conflicts with `-g`/`--global`, which has to persist the install to its global manifest.",
-            "help_first_line": "Snapshot `package.json` and the lockfile, link the named packages into `node_modules`, and then restore both files — so the dependency is usable for the current process but the project's committed state is untouched",
+            "help": "Install without persisting the dependency to `package.json`",
+            "help_long": "Install without persisting the dependency to `package.json`.\n\nSnapshots `package.json` and the lockfile, links the named packages into `node_modules`, and then restores both files — so the dependency is usable for the current process but the project's committed state is untouched.\n\nHandy for one-off experiments and for scripts that install a tool transiently. Mirrors `pnpm add --no-save`. Conflicts with `-g`/`--global`, which has to persist the install to its global manifest.",
+            "help_first_line": "Install without persisting the dependency to `package.json`",
             "short": [],
             "long": [
               "no-save"
@@ -130,9 +130,9 @@
           {
             "name": "save-catalog",
             "usage": "--save-catalog",
-            "help": "Save the new dependency into the workspace's default catalog, writing `catalog:` into `package.json` and seeding/upserting the resolved range under `catalog:` in the workspace yaml. Mirrors `pnpm add --save-catalog`",
-            "help_long": "Save the new dependency into the workspace's default catalog, writing `catalog:` into `package.json` and seeding/upserting the resolved range under `catalog:` in the workspace yaml. Mirrors `pnpm add --save-catalog`.\n\nWorkspace and aliased specs (`workspace:*`, `npm:`, `jsr:`) are never catalogized — the manifest gets the original spec and the catalog yaml is left alone. If the package is already in the target catalog, the existing entry is preserved (never overwritten); the manifest then gets `catalog:` only when the existing entry is compatible with the user's range.\n\nConflicts with `--no-save`: catalog mutations write to the workspace yaml, which the `--no-save` restore path doesn't snapshot — combining the two would silently leave an orphaned catalog entry behind.",
-            "help_first_line": "Save the new dependency into the workspace's default catalog, writing `catalog:` into `package.json` and seeding/upserting the resolved range under `catalog:` in the workspace yaml. Mirrors `pnpm add --save-catalog`",
+            "help": "Save the new dependency into the workspace's default catalog",
+            "help_long": "Save the new dependency into the workspace's default catalog.\n\nWrites `catalog:` into `package.json` and seeds/upserts the resolved range under `catalog:` in the workspace yaml. Mirrors `pnpm add --save-catalog`.\n\nWorkspace and aliased specs (`workspace:*`, `npm:`, `jsr:`) are never catalogized — the manifest gets the original spec and the catalog yaml is left alone. If the package is already in the target catalog, the existing entry is preserved (never overwritten); the manifest then gets `catalog:` only when the existing entry is compatible with the user's range.\n\nConflicts with `--no-save`: catalog mutations write to the workspace yaml, which the `--no-save` restore path doesn't snapshot — combining the two would silently leave an orphaned catalog entry behind.",
+            "help_first_line": "Save the new dependency into the workspace's default catalog",
             "short": [],
             "long": [
               "save-catalog"
@@ -143,8 +143,9 @@
           {
             "name": "save-catalog-name",
             "usage": "--save-catalog-name <NAME>",
-            "help": "Save the new dependency into a *named* catalog (`catalogs.<name>` in the workspace yaml), writing `catalog:<name>` into `package.json`. Same workspace/alias exclusions and `--no-save` conflict as `--save-catalog`. Mirrors `pnpm add --save-catalog-name=<name>`",
-            "help_first_line": "Save the new dependency into a *named* catalog (`catalogs.<name>` in the workspace yaml), writing `catalog:<name>` into `package.json`. Same workspace/alias exclusions and `--no-save` conflict as `--save-catalog`. Mirrors `pnpm add --save-catalog-name=<name>`",
+            "help": "Save the new dependency into a *named* catalog",
+            "help_long": "Save the new dependency into a *named* catalog.\n\nWrites the entry to `catalogs.<name>` in the workspace yaml and `catalog:<name>` into `package.json`. Same workspace/alias exclusions and `--no-save` conflict as `--save-catalog`. Mirrors `pnpm add --save-catalog-name=<name>`.",
+            "help_first_line": "Save the new dependency into a *named* catalog",
             "short": [],
             "long": [
               "save-catalog-name"
@@ -175,9 +176,9 @@
           {
             "name": "workspace",
             "usage": "-w --workspace",
-            "help": "Add the dependency to the workspace root's `package.json`, regardless of the current working directory",
-            "help_long": "Add the dependency to the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the add against that directory.",
-            "help_first_line": "Add the dependency to the workspace root's `package.json`, regardless of the current working directory",
+            "help": "Add the dependency to the workspace root's `package.json`",
+            "help_long": "Add the dependency to the workspace root's `package.json`.\n\nApplies regardless of the current working directory: walks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the add against that directory.",
+            "help_first_line": "Add the dependency to the workspace root's `package.json`",
             "short": [
               "w"
             ],
@@ -223,8 +224,9 @@
           {
             "name": "PKG",
             "usage": "[PKG]…",
-            "help": "Packages to approve directly, skipping the picker. Each name must match a currently-ignored build. Unknown names are rejected so a typo cannot silently no-op",
-            "help_first_line": "Packages to approve directly, skipping the picker. Each name must match a currently-ignored build. Unknown names are rejected so a typo cannot silently no-op",
+            "help": "Packages to approve directly, skipping the picker",
+            "help_long": "Packages to approve directly, skipping the picker.\n\nEach name must match a currently-ignored build. Unknown names are rejected so a typo cannot silently no-op.",
+            "help_first_line": "Packages to approve directly, skipping the picker",
             "required": false,
             "double_dash": "Optional",
             "var": true,
@@ -261,7 +263,8 @@
         ],
         "mounts": [],
         "hide": false,
-        "help": "Approve ignored dependency build scripts in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present) under `allowBuilds`",
+        "help": "Approve ignored dependency build scripts",
+        "help_long": "Approve ignored dependency build scripts.\n\nWrites entries under `allowBuilds` in `aube-workspace.yaml` (or `pnpm-workspace.yaml` if present).",
         "name": "approve-builds",
         "aliases": [],
         "hidden_aliases": [],
@@ -383,9 +386,9 @@
           {
             "name": "ignore-unfixable",
             "usage": "--ignore-unfixable",
-            "help": "Drop advisories for which no non-vulnerable version is available in the package's packument",
-            "help_long": "Drop advisories for which no non-vulnerable version is available in the package's packument.\n\nSame \"best non-vulnerable\" logic as `--fix`: an advisory is kept only when an upgrade path exists.",
-            "help_first_line": "Drop advisories for which no non-vulnerable version is available in the package's packument",
+            "help": "Drop advisories that have no non-vulnerable upgrade",
+            "help_long": "Drop advisories that have no non-vulnerable upgrade.\n\nFilters out advisories for which no non-vulnerable version is available in the package's packument. Same \"best non-vulnerable\" logic as `--fix`: an advisory is kept only when an upgrade path exists.",
+            "help_first_line": "Drop advisories that have no non-vulnerable upgrade",
             "short": [],
             "long": [
               "ignore-unfixable"
@@ -754,7 +757,8 @@
         ],
         "mounts": [],
         "hide": false,
-        "help": "Verify that every installed package can resolve its declared deps through the `node_modules/` symlink tree",
+        "help": "Verify installed packages can resolve their declared deps",
+        "help_long": "Verify installed packages can resolve their declared deps.\n\nWalks the `node_modules/` symlink tree and confirms every dependency in each `package.json` resolves to a real entry.",
         "name": "check",
         "aliases": [],
         "hidden_aliases": [],
@@ -819,8 +823,9 @@
           {
             "name": "lockfile",
             "usage": "-l --lockfile",
-            "help": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)",
-            "help_first_line": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)",
+            "help": "Also remove lockfiles at the workspace root",
+            "help_long": "Also remove lockfiles at the workspace root.\n\nTargets `aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock`.",
+            "help_first_line": "Also remove lockfiles at the workspace root",
             "short": [
               "l"
             ],
@@ -1101,9 +1106,9 @@
               {
                 "name": "all",
                 "usage": "--all",
-                "help": "Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered",
-                "help_long": "Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered.\n\nOnly valid with `--location merged` (the default), since a per-file view can't distinguish \"not set anywhere\" from \"set in the other file\" and would render misleading defaults.",
-                "help_first_line": "Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered",
+                "help": "Also list settings that have no value set",
+                "help_long": "Also list settings that have no value set.\n\nRenders one row per setting in `settings.toml`, with the default and description shown for unset entries.\n\nOnly valid with `--location merged` (the default), since a per-file view can't distinguish \"not set anywhere\" from \"set in the other file\" and would render misleading defaults.",
+                "help_first_line": "Also list settings that have no value set",
                 "short": [],
                 "long": [
                   "all"
@@ -1114,9 +1119,9 @@
               {
                 "name": "json",
                 "usage": "--json",
-                "help": "Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`",
-                "help_long": "Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`.\n\nHonors `--all` and `--location` the same way the default text output does.",
-                "help_first_line": "Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`",
+                "help": "Emit all entries as a JSON object keyed by setting name",
+                "help_long": "Emit all entries as a JSON object keyed by setting name.\n\nMatches `pnpm config list --json`. Honors `--all` and `--location` the same way the default text output does.",
+                "help_first_line": "Emit all entries as a JSON object keyed by setting name",
                 "short": [],
                 "long": [
                   "json"
@@ -1278,9 +1283,9 @@
           {
             "name": "all",
             "usage": "--all",
-            "help": "Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered",
-            "help_long": "Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered.\n\nOnly valid with `--location merged` (the default), since a per-file view can't distinguish \"not set anywhere\" from \"set in the other file\" and would render misleading defaults.",
-            "help_first_line": "Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered",
+            "help": "Also list settings that have no value set",
+            "help_long": "Also list settings that have no value set.\n\nRenders one row per setting in `settings.toml`, with the default and description shown for unset entries.\n\nOnly valid with `--location merged` (the default), since a per-file view can't distinguish \"not set anywhere\" from \"set in the other file\" and would render misleading defaults.",
+            "help_first_line": "Also list settings that have no value set",
             "short": [],
             "long": [
               "all"
@@ -1291,9 +1296,9 @@
           {
             "name": "json",
             "usage": "--json",
-            "help": "Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`",
-            "help_long": "Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`.\n\nHonors `--all` and `--location` the same way the default text output does.",
-            "help_first_line": "Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`",
+            "help": "Emit all entries as a JSON object keyed by setting name",
+            "help_long": "Emit all entries as a JSON object keyed by setting name.\n\nMatches `pnpm config list --json`. Honors `--all` and `--location` the same way the default text output does.",
+            "help_first_line": "Emit all entries as a JSON object keyed by setting name",
             "short": [],
             "long": [
               "json"
@@ -1751,9 +1756,9 @@
           {
             "name": "shell-mode",
             "usage": "-c --shell-mode",
-            "help": "Run the assembled command line through `sh -c` with `<scratch>/node_modules/.bin` prepended to `PATH`",
-            "help_long": "Run the assembled command line through `sh -c` with `<scratch>/node_modules/.bin` prepended to `PATH`.\n\nUse this for pipelines, redirects, or env expansion (`aube dlx -p cowsay -c 'cowsay hello | tr a-z A-Z'`). Mirrors `pnpm dlx --shell-mode`.",
-            "help_first_line": "Run the assembled command line through `sh -c` with `<scratch>/node_modules/.bin` prepended to `PATH`",
+            "help": "Run the assembled command line through `sh -c`",
+            "help_long": "Run the assembled command line through `sh -c`.\n\n`<scratch>/node_modules/.bin` is prepended to `PATH`. Use this for pipelines, redirects, or env expansion (`aube dlx -p cowsay -c 'cowsay hello | tr a-z A-Z'`). Mirrors `pnpm dlx --shell-mode`.",
+            "help_first_line": "Run the assembled command line through `sh -c`",
             "short": [
               "c"
             ],
@@ -2089,8 +2094,9 @@
           {
             "name": "json",
             "usage": "--json",
-            "help": "Emit a machine-readable JSON array of `{ \"name\", \"version\", \"path\" }` objects instead of a plain text listing",
-            "help_first_line": "Emit a machine-readable JSON array of `{ \"name\", \"version\", \"path\" }` objects instead of a plain text listing",
+            "help": "Emit machine-readable JSON instead of a plain text listing",
+            "help_long": "Emit machine-readable JSON instead of a plain text listing.\n\nOutput is an array of `{ \"name\", \"version\", \"path\" }` objects.",
+            "help_first_line": "Emit machine-readable JSON instead of a plain text listing",
             "short": [],
             "long": [
               "json"
@@ -2302,8 +2308,9 @@
           {
             "name": "init-package-manager",
             "usage": "--init-package-manager",
-            "help": "Pin the project to the current aube version by adding a `packageManager` field to `package.json`",
-            "help_first_line": "Pin the project to the current aube version by adding a `packageManager` field to `package.json`",
+            "help": "Pin the project to the current aube version",
+            "help_long": "Pin the project to the current aube version.\n\nAdds a `packageManager` field to `package.json`.",
+            "help_first_line": "Pin the project to the current aube version",
             "short": [],
             "long": [
               "init-package-manager"
@@ -2398,9 +2405,9 @@
           {
             "name": "fix-lockfile",
             "usage": "--fix-lockfile",
-            "help": "Re-resolve lockfile entries whose spec drifted from package.json, leaving everything else pinned at its locked version",
-            "help_long": "Re-resolve lockfile entries whose spec drifted from package.json, leaving everything else pinned at its locked version.\n\nUnchanged specs keep their existing version and integrity hash; only drifted entries (and any new transitives they pull in) get re-resolved.",
-            "help_first_line": "Re-resolve lockfile entries whose spec drifted from package.json, leaving everything else pinned at its locked version",
+            "help": "Re-resolve lockfile entries whose spec drifted from package.json",
+            "help_long": "Re-resolve lockfile entries whose spec drifted from package.json.\n\nLeaves everything else pinned at its locked version. Unchanged specs keep their existing version and integrity hash; only drifted entries (and any new transitives they pull in) get re-resolved.",
+            "help_first_line": "Re-resolve lockfile entries whose spec drifted from package.json",
             "short": [],
             "long": [
               "fix-lockfile"
@@ -2411,9 +2418,9 @@
           {
             "name": "force",
             "usage": "--force",
-            "help": "Force reinstall: bypass the `node_modules/.aube-state` freshness check and re-resolve the lockfile even when nothing has drifted",
-            "help_long": "Force reinstall: bypass the `node_modules/.aube-state` freshness check and re-resolve the lockfile even when nothing has drifted.\n\nMirrors pnpm's `install --force`.",
-            "help_first_line": "Force reinstall: bypass the `node_modules/.aube-state` freshness check and re-resolve the lockfile even when nothing has drifted",
+            "help": "Force reinstall, ignoring lockfile/state freshness",
+            "help_long": "Force reinstall, ignoring lockfile/state freshness.\n\nBypasses the `node_modules/.aube-state` freshness check and re-resolves the lockfile even when nothing has drifted. Mirrors pnpm's `install --force`.",
+            "help_first_line": "Force reinstall, ignoring lockfile/state freshness",
             "short": [],
             "long": [
               "force"
@@ -2468,8 +2475,9 @@
           {
             "name": "lockfile-dir",
             "usage": "--lockfile-dir <PATH>",
-            "help": "Read and write the lockfile in the given directory instead of alongside `package.json`. The project becomes an importer keyed by its relative path from the lockfile directory. Mirrors pnpm's `--lockfile-dir`",
-            "help_first_line": "Read and write the lockfile in the given directory instead of alongside `package.json`. The project becomes an importer keyed by its relative path from the lockfile directory. Mirrors pnpm's `--lockfile-dir`",
+            "help": "Read and write the lockfile in the given directory",
+            "help_long": "Read and write the lockfile in the given directory.\n\nInstead of placing the lockfile alongside `package.json`, the project becomes an importer keyed by its relative path from the lockfile directory. Mirrors pnpm's `--lockfile-dir`.",
+            "help_first_line": "Read and write the lockfile in the given directory",
             "short": [],
             "long": [
               "lockfile-dir"
@@ -2500,9 +2508,9 @@
           {
             "name": "merge-git-branch-lockfiles",
             "usage": "--merge-git-branch-lockfiles",
-            "help": "Merge every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yaml` and delete the branch files",
-            "help_long": "Merge every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yaml` and delete the branch files.\n\nCompanion to `gitBranchLockfile`. When `mergeGitBranchLockfilesBranchPattern` is set in `pnpm-workspace.yaml`, this happens automatically on matching branches; the flag forces it regardless.",
-            "help_first_line": "Merge every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yaml` and delete the branch files",
+            "help": "Merge per-branch lockfiles into the main `aube-lock.yaml`",
+            "help_long": "Merge per-branch lockfiles into the main `aube-lock.yaml`.\n\nCombines every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yaml` and deletes the branch files. Companion to `gitBranchLockfile`. When `mergeGitBranchLockfilesBranchPattern` is set in `pnpm-workspace.yaml`, this happens automatically on matching branches; the flag forces it regardless.",
+            "help_first_line": "Merge per-branch lockfiles into the main `aube-lock.yaml`",
             "short": [],
             "long": [
               "merge-git-branch-lockfiles"
@@ -2676,9 +2684,9 @@
           {
             "name": "resolution-mode",
             "usage": "--resolution-mode <MODE>",
-            "help": "How to resolve version ranges: `highest` (pnpm's classic behavior) or `time-based` (pick the lowest satisfying direct dep and constrain transitives by a publish-date cutoff)",
-            "help_long": "How to resolve version ranges: `highest` (pnpm's classic behavior) or `time-based` (pick the lowest satisfying direct dep and constrain transitives by a publish-date cutoff).\n\nAccepts pnpm's aliases `time` and `lowest-direct`. When omitted, falls back to the `resolution-mode` key in `.npmrc` / `aube-workspace.yaml`.",
-            "help_first_line": "How to resolve version ranges: `highest` (pnpm's classic behavior) or `time-based` (pick the lowest satisfying direct dep and constrain transitives by a publish-date cutoff)",
+            "help": "How to resolve version ranges",
+            "help_long": "How to resolve version ranges.\n\n`highest` (pnpm's classic behavior) or `time-based` (pick the lowest satisfying direct dep and constrain transitives by a publish-date cutoff). Accepts pnpm's aliases `time` and `lowest-direct`. When omitted, falls back to the `resolution-mode` key in `.npmrc` / `aube-workspace.yaml`.",
+            "help_first_line": "How to resolve version ranges",
             "short": [],
             "long": [
               "resolution-mode"
@@ -2722,9 +2730,9 @@
           {
             "name": "verify-store-integrity",
             "usage": "--verify-store-integrity",
-            "help": "Verify tarball SHA-512 against the lockfile integrity before importing into the store",
-            "help_long": "Verify tarball SHA-512 against the lockfile integrity before importing into the store.\n\nDefaults to `true` (pnpm parity); pair with `--no-verify-store-integrity` to skip.",
-            "help_first_line": "Verify tarball SHA-512 against the lockfile integrity before importing into the store",
+            "help": "Verify tarball SHA-512 before importing into the store",
+            "help_long": "Verify tarball SHA-512 before importing into the store.\n\nChecks each tarball against the lockfile integrity. Defaults to `true` (pnpm parity); pair with `--no-verify-store-integrity` to skip.",
+            "help_first_line": "Verify tarball SHA-512 before importing into the store",
             "short": [],
             "long": [
               "verify-store-integrity"
@@ -2928,8 +2936,9 @@
           {
             "name": "long",
             "usage": "--long",
-            "help": "Show version and path for each entry (default output is already name + version; `--long` adds the store path for debugging)",
-            "help_first_line": "Show version and path for each entry (default output is already name + version; `--long` adds the store path for debugging)",
+            "help": "Show version and path for each entry",
+            "help_long": "Show version and path for each entry.\n\nDefault output is already name + version; `--long` adds the store path for debugging.",
+            "help_first_line": "Show version and path for each entry",
             "short": [],
             "long": [
               "long"
@@ -3067,9 +3076,9 @@
           {
             "name": "global",
             "usage": "-g --global",
-            "help": "Register into (or resolve from) the global link registry under `$AUBE_HOME/global-links`",
-            "help_long": "Register into (or resolve from) the global link registry under `$AUBE_HOME/global-links`.\n\nDefault behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit.",
-            "help_first_line": "Register into (or resolve from) the global link registry under `$AUBE_HOME/global-links`",
+            "help": "Register into (or resolve from) the global link registry",
+            "help_long": "Register into (or resolve from) the global link registry.\n\nThe registry lives at `$AUBE_HOME/global-links`. Default behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit.",
+            "help_first_line": "Register into (or resolve from) the global link registry",
             "short": [
               "g"
             ],
@@ -3219,8 +3228,9 @@
           {
             "name": "long",
             "usage": "--long",
-            "help": "Show version and path for each entry (default output is already name + version; `--long` adds the store path for debugging)",
-            "help_first_line": "Show version and path for each entry (default output is already name + version; `--long` adds the store path for debugging)",
+            "help": "Show version and path for each entry",
+            "help_long": "Show version and path for each entry.\n\nDefault output is already name + version; `--long` adds the store path for debugging.",
+            "help_first_line": "Show version and path for each entry",
             "short": [],
             "long": [
               "long"
@@ -3382,8 +3392,9 @@
           {
             "name": "long",
             "usage": "--long",
-            "help": "Show version and path for each entry (default output is already name + version; `--long` adds the store path for debugging)",
-            "help_first_line": "Show version and path for each entry (default output is already name + version; `--long` adds the store path for debugging)",
+            "help": "Show version and path for each entry",
+            "help_long": "Show version and path for each entry.\n\nDefault output is already name + version; `--long` adds the store path for debugging.",
+            "help_first_line": "Show version and path for each entry",
             "short": [],
             "long": [
               "long"
@@ -3732,9 +3743,9 @@
           {
             "name": "ignore-existing",
             "usage": "--ignore-existing",
-            "help": "Ignore any existing patch entry for this package — extract a pristine copy from `node_modules` rather than re-applying the existing patch first",
-            "help_long": "Ignore any existing patch entry for this package — extract a pristine copy from `node_modules` rather than re-applying the existing patch first.\n\nAccepted for pnpm parity; aube already extracts from the *linked* (post-patch) tree, so this flag is effectively informational here.",
-            "help_first_line": "Ignore any existing patch entry for this package — extract a pristine copy from `node_modules` rather than re-applying the existing patch first",
+            "help": "Ignore any existing patch entry for this package",
+            "help_long": "Ignore any existing patch entry for this package.\n\nExtracts a pristine copy from `node_modules` rather than re-applying the existing patch first. Accepted for pnpm parity; aube already extracts from the *linked* (post-patch) tree, so this flag is effectively informational here.",
+            "help_first_line": "Ignore any existing patch entry for this package",
             "short": [],
             "long": [
               "ignore-existing"
@@ -3812,9 +3823,9 @@
           {
             "name": "PACKAGES",
             "usage": "[PACKAGES]…",
-            "help": "Patch keys to remove, formatted as `<name>@<version>` (the same shape used as the `pnpm.patchedDependencies` map key)",
-            "help_long": "Patch keys to remove, formatted as `<name>@<version>` (the same shape used as the `pnpm.patchedDependencies` map key).\n\nWith no arguments, every declared patch is removed.",
-            "help_first_line": "Patch keys to remove, formatted as `<name>@<version>` (the same shape used as the `pnpm.patchedDependencies` map key)",
+            "help": "Patch keys to remove, formatted as `<name>@<version>`",
+            "help_long": "Patch keys to remove, formatted as `<name>@<version>`.\n\nSame shape used as the `pnpm.patchedDependencies` map key. With no arguments, every declared patch is removed.",
+            "help_first_line": "Patch keys to remove, formatted as `<name>@<version>`",
             "required": false,
             "double_dash": "Optional",
             "var": true,
@@ -3994,9 +4005,9 @@
           {
             "name": "force",
             "usage": "--force",
-            "help": "Republish `name@version` even when that version is already on the target registry",
-            "help_long": "Republish `name@version` even when that version is already on the target registry.\n\nBy default `aube publish` issues a GET before the PUT and refuses to proceed when the version exists, surfacing a clear error instead of relying on the registry to return 409. In `--recursive` / `--filter` mode, `--force` overrides the silent \"already-published\" skip so every selected workspace package is re-PUT. The registry must still accept the republish — npm's public registry rejects re-publishes outright; Verdaccio and most private mirrors allow them.",
-            "help_first_line": "Republish `name@version` even when that version is already on the target registry",
+            "help": "Republish even when the version is already on the registry",
+            "help_long": "Republish even when the version is already on the registry.\n\nBy default `aube publish` issues a GET before the PUT and refuses to proceed when the version exists, surfacing a clear error instead of relying on the registry to return 409. In `--recursive` / `--filter` mode, `--force` overrides the silent \"already-published\" skip so every selected workspace package is re-PUT. The registry must still accept the republish — npm's public registry rejects re-publishes outright; Verdaccio and most private mirrors allow them.",
+            "help_first_line": "Republish even when the version is already on the registry",
             "short": [],
             "long": [
               "force"
@@ -4007,8 +4018,9 @@
           {
             "name": "ignore-scripts",
             "usage": "--ignore-scripts",
-            "help": "Skip `prepublishOnly` / `prepublish` / `prepack` / `prepare` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish",
-            "help_first_line": "Skip `prepublishOnly` / `prepublish` / `prepack` / `prepare` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish",
+            "help": "Skip publish lifecycle scripts",
+            "help_long": "Skip publish lifecycle scripts.\n\nSuppresses `prepublishOnly`, `prepublish`, `prepack`, `prepare`, `postpack`, `publish`, and `postpublish` scripts for this publish.",
+            "help_first_line": "Skip publish lifecycle scripts",
             "short": [],
             "long": [
               "ignore-scripts"
@@ -4019,8 +4031,9 @@
           {
             "name": "json",
             "usage": "--json",
-            "help": "Emit the publish result as JSON: an array with one `{name, version, filename, files: [{path}]}` entry, matching `pnpm publish --json` / `aube pack --json`",
-            "help_first_line": "Emit the publish result as JSON: an array with one `{name, version, filename, files: [{path}]}` entry, matching `pnpm publish --json` / `aube pack --json`",
+            "help": "Emit the publish result as JSON",
+            "help_long": "Emit the publish result as JSON.\n\nOutput is an array with one `{name, version, filename, files: [{path}]}` entry, matching `pnpm publish --json` / `aube pack --json`.",
+            "help_first_line": "Emit the publish result as JSON",
             "short": [],
             "long": [
               "json"
@@ -4113,8 +4126,9 @@
           {
             "name": "lockfile",
             "usage": "-l --lockfile",
-            "help": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)",
-            "help_first_line": "Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)",
+            "help": "Also remove lockfiles at the workspace root",
+            "help_long": "Also remove lockfiles at the workspace root.\n\nTargets `aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock`.",
+            "help_first_line": "Also remove lockfiles at the workspace root",
             "short": [
               "l"
             ],
@@ -4144,8 +4158,9 @@
           {
             "name": "SELECTOR",
             "usage": "<SELECTOR>",
-            "help": "Selector expression. Supports `*`, bare package names, `[name=value]`, `[version=value]`, `[license=value]`, `[depPath=value]`, `[source=value]`, `:prod`, `:dev`, `:optional`, `:peer`, `:transitive`, `:scripts`, `:bin`, `:deprecated`, `:license(value)`, and `:type(value)`",
-            "help_first_line": "Selector expression. Supports `*`, bare package names, `[name=value]`, `[version=value]`, `[license=value]`, `[depPath=value]`, `[source=value]`, `:prod`, `:dev`, `:optional`, `:peer`, `:transitive`, `:scripts`, `:bin`, `:deprecated`, `:license(value)`, and `:type(value)`",
+            "help": "Selector expression",
+            "help_long": "Selector expression.\n\nSupports `*`, bare package names, `[name=value]`, `[version=value]`, `[license=value]`, `[depPath=value]`, `[source=value]`, `:prod`, `:dev`, `:optional`, `:peer`, `:transitive`, `:scripts`, `:bin`, `:deprecated`, `:license(value)`, and `:type(value)`.",
+            "help_first_line": "Selector expression",
             "required": true,
             "double_dash": "Optional",
             "hide": false
@@ -4325,9 +4340,9 @@
           {
             "name": "workspace",
             "usage": "-w --workspace",
-            "help": "Remove the dependency from the workspace root's `package.json`, regardless of the current working directory",
-            "help_long": "Remove the dependency from the workspace root's `package.json`, regardless of the current working directory.\n\nWalks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`).",
-            "help_first_line": "Remove the dependency from the workspace root's `package.json`, regardless of the current working directory",
+            "help": "Remove the dependency from the workspace root's `package.json`",
+            "help_long": "Remove the dependency from the workspace root's `package.json`.\n\nApplies regardless of the current working directory: walks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`).",
+            "help_first_line": "Remove the dependency from the workspace root's `package.json`",
             "short": [
               "w"
             ],
@@ -4506,9 +4521,9 @@
           {
             "name": "parallel",
             "usage": "--parallel",
-            "help": "Run the script in every matched workspace package concurrently, with unbounded parallelism",
-            "help_long": "Run the script in every matched workspace package concurrently, with unbounded parallelism.\n\nPair with a filter (`-r` / `-F`) — single-package runs ignore it. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated.",
-            "help_first_line": "Run the script in every matched workspace package concurrently, with unbounded parallelism",
+            "help": "Run the script in every matched workspace package concurrently",
+            "help_long": "Run the script in every matched workspace package concurrently.\n\nUnbounded parallelism. Pair with a filter (`-r` / `-F`) — single-package runs ignore it. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated.",
+            "help_first_line": "Run the script in every matched workspace package concurrently",
             "short": [],
             "long": [
               "parallel"
@@ -4998,8 +5013,8 @@
             "flags": [],
             "mounts": [],
             "hide": false,
-            "help": "Verify that every file referenced by a cached package index is still present in the store and its BLAKE3 hash matches",
-            "help_long": "Verify that every file referenced by a cached package index is still present in the store and its BLAKE3 hash matches.\n\nExits non-zero when any corruption is detected.",
+            "help": "Verify the store against cached package indexes",
+            "help_long": "Verify the store against cached package indexes.\n\nConfirms every file referenced by a cached package index is still present in the store and that its BLAKE3 hash matches. Exits non-zero when any corruption is detected.",
             "name": "status",
             "aliases": [],
             "hidden_aliases": [],
@@ -5345,8 +5360,9 @@
           {
             "name": "latest",
             "usage": "-L --latest",
-            "help": "Update past the manifest range: rewrite `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual)",
-            "help_first_line": "Update past the manifest range: rewrite `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual)",
+            "help": "Update past the manifest range",
+            "help_long": "Update past the manifest range.\n\nRewrites `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual).",
+            "help_first_line": "Update past the manifest range",
             "short": [
               "L"
             ],
@@ -5533,9 +5549,9 @@
           {
             "name": "NEW_VERSION",
             "usage": "[NEW_VERSION]",
-            "help": "Bump keyword (`major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`) or an explicit version string",
-            "help_long": "Bump keyword (`major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`) or an explicit version string.\n\nWhen omitted, prints the current version.",
-            "help_first_line": "Bump keyword (`major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`) or an explicit version string",
+            "help": "Bump keyword or an explicit version string",
+            "help_long": "Bump keyword or an explicit version string.\n\nAccepts `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`, or an explicit version. When omitted, prints the current version.",
+            "help_first_line": "Bump keyword or an explicit version string",
             "required": false,
             "double_dash": "Optional",
             "hide": false
@@ -5675,8 +5691,9 @@
           {
             "name": "PACKAGE",
             "usage": "<PACKAGE>",
-            "help": "Package to view, optionally with a version or dist-tag (`lodash`, `lodash@4.17.21`, `react@next`, `express@^4`)",
-            "help_first_line": "Package to view, optionally with a version or dist-tag (`lodash`, `lodash@4.17.21`, `react@next`, `express@^4`)",
+            "help": "Package to view, optionally with a version or dist-tag",
+            "help_long": "Package to view, optionally with a version or dist-tag.\n\nExamples: `lodash`, `lodash@4.17.21`, `react@next`, `express@^4`.",
+            "help_first_line": "Package to view, optionally with a version or dist-tag",
             "required": true,
             "double_dash": "Optional",
             "hide": false
@@ -5684,9 +5701,9 @@
           {
             "name": "FIELD",
             "usage": "[FIELD]",
-            "help": "Dotted path into the version metadata to print (`version`, `dependencies`, `dist.tarball`, `maintainers.0.name`)",
-            "help_long": "Dotted path into the version metadata to print (`version`, `dependencies`, `dist.tarball`, `maintainers.0.name`).\n\nWhen omitted, prints a formatted summary.",
-            "help_first_line": "Dotted path into the version metadata to print (`version`, `dependencies`, `dist.tarball`, `maintainers.0.name`)",
+            "help": "Dotted path into the version metadata to print",
+            "help_long": "Dotted path into the version metadata to print.\n\nExamples: `version`, `dependencies`, `dist.tarball`, `maintainers.0.name`. When omitted, prints a formatted summary.",
+            "help_first_line": "Dotted path into the version metadata to print",
             "required": false,
             "double_dash": "Optional",
             "hide": false

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -9,15 +9,17 @@ Read and write settings in `.npmrc`
 
 ### `--all`
 
-Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered.
+Also list settings that have no value set.
+
+Renders one row per setting in `settings.toml`, with the default and description shown for unset entries.
 
 Only valid with `--location merged` (the default), since a per-file view can't distinguish "not set anywhere" from "set in the other file" and would render misleading defaults.
 
 ### `--json`
 
-Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`.
+Emit all entries as a JSON object keyed by setting name.
 
-Honors `--all` and `--location` the same way the default text output does.
+Matches `pnpm config list --json`. Honors `--all` and `--location` the same way the default text output does.
 
 ### `--local`
 

--- a/docs/cli/config/list.md
+++ b/docs/cli/config/list.md
@@ -10,15 +10,17 @@ Print every key/value from the selected `.npmrc` file(s)
 
 ### `--all`
 
-Also list settings that have no value set — one row per setting in `settings.toml`, with the default and description rendered.
+Also list settings that have no value set.
+
+Renders one row per setting in `settings.toml`, with the default and description shown for unset entries.
 
 Only valid with `--location merged` (the default), since a per-file view can't distinguish "not set anywhere" from "set in the other file" and would render misleading defaults.
 
 ### `--json`
 
-Emit all entries as a JSON object keyed by setting name, matching `pnpm config list --json`.
+Emit all entries as a JSON object keyed by setting name.
 
-Honors `--all` and `--location` the same way the default text output does.
+Matches `pnpm config list --json`. Honors `--all` and `--location` the same way the default text output does.
 
 ### `--local`
 

--- a/docs/cli/dlx.md
+++ b/docs/cli/dlx.md
@@ -17,9 +17,9 @@ The first positional is the command; the rest are forwarded verbatim to the inst
 
 ### `-c --shell-mode`
 
-Run the assembled command line through `sh -c` with `<scratch>/node_modules/.bin` prepended to `PATH`.
+Run the assembled command line through `sh -c`.
 
-Use this for pipelines, redirects, or env expansion (`aube dlx -p cowsay -c 'cowsay hello | tr a-z A-Z'`). Mirrors `pnpm dlx --shell-mode`.
+`<scratch>/node_modules/.bin` is prepended to `PATH`. Use this for pipelines, redirects, or env expansion (`aube dlx -p cowsay -c 'cowsay hello | tr a-z A-Z'`). Mirrors `pnpm dlx --shell-mode`.
 
 ### `-p --package… <PACKAGE>`
 

--- a/docs/cli/find-hash.md
+++ b/docs/cli/find-hash.md
@@ -17,7 +17,9 @@ Accepts `sha512-<base64>` (pnpm integrity format) or a raw hex CAS digest.
 
 ### `--json`
 
-Emit a machine-readable JSON array of `{ "name", "version", "path" }` objects instead of a plain text listing
+Emit machine-readable JSON instead of a plain text listing.
+
+Output is an array of `{ "name", "version", "path" }` objects.
 
 Examples:
 

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -13,7 +13,9 @@ Create a `package.json` with only the bare minimum of required fields
 
 ### `--init-package-manager`
 
-Pin the project to the current aube version by adding a `packageManager` field to `package.json`
+Pin the project to the current aube version.
+
+Adds a `packageManager` field to `package.json`.
 
 ### `--init-type <commonjs|module>`
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -23,15 +23,15 @@ Bypasses the `allowBuilds` allowlist. Do not use in CI.
 
 ### `--fix-lockfile`
 
-Re-resolve lockfile entries whose spec drifted from package.json, leaving everything else pinned at its locked version.
+Re-resolve lockfile entries whose spec drifted from package.json.
 
-Unchanged specs keep their existing version and integrity hash; only drifted entries (and any new transitives they pull in) get re-resolved.
+Leaves everything else pinned at its locked version. Unchanged specs keep their existing version and integrity hash; only drifted entries (and any new transitives they pull in) get re-resolved.
 
 ### `--force`
 
-Force reinstall: bypass the `node_modules/.aube-state` freshness check and re-resolve the lockfile even when nothing has drifted.
+Force reinstall, ignoring lockfile/state freshness.
 
-Mirrors pnpm's `install --force`.
+Bypasses the `node_modules/.aube-state` freshness check and re-resolves the lockfile even when nothing has drifted. Mirrors pnpm's `install --force`.
 
 ### `--global-pnpmfile <PATH>`
 
@@ -49,7 +49,9 @@ Skip lifecycle scripts (no-op; aube already skips by default)
 
 ### `--lockfile-dir <PATH>`
 
-Read and write the lockfile in the given directory instead of alongside `package.json`. The project becomes an importer keyed by its relative path from the lockfile directory. Mirrors pnpm's `--lockfile-dir`
+Read and write the lockfile in the given directory.
+
+Instead of placing the lockfile alongside `package.json`, the project becomes an importer keyed by its relative path from the lockfile directory. Mirrors pnpm's `--lockfile-dir`.
 
 ### `--lockfile-only`
 
@@ -59,9 +61,9 @@ Useful for CI workflows that only update the lockfile.
 
 ### `--merge-git-branch-lockfiles`
 
-Merge every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yaml` and delete the branch files.
+Merge per-branch lockfiles into the main `aube-lock.yaml`.
 
-Companion to `gitBranchLockfile`. When `mergeGitBranchLockfilesBranchPattern` is set in `pnpm-workspace.yaml`, this happens automatically on matching branches; the flag forces it regardless.
+Combines every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yaml` and deletes the branch files. Companion to `gitBranchLockfile`. When `mergeGitBranchLockfilesBranchPattern` is set in `pnpm-workspace.yaml`, this happens automatically on matching branches; the flag forces it regardless.
 
 ### `--network-concurrency <N>`
 
@@ -119,9 +121,9 @@ Repeatable; comma-separated values are also accepted.
 
 ### `--resolution-mode <MODE>`
 
-How to resolve version ranges: `highest` (pnpm's classic behavior) or `time-based` (pick the lowest satisfying direct dep and constrain transitives by a publish-date cutoff).
+How to resolve version ranges.
 
-Accepts pnpm's aliases `time` and `lowest-direct`. When omitted, falls back to the `resolution-mode` key in `.npmrc` / `aube-workspace.yaml`.
+`highest` (pnpm's classic behavior) or `time-based` (pick the lowest satisfying direct dep and constrain transitives by a publish-date cutoff). Accepts pnpm's aliases `time` and `lowest-direct`. When omitted, falls back to the `resolution-mode` key in `.npmrc` / `aube-workspace.yaml`.
 
 ### `--shamefully-hoist`
 
@@ -137,6 +139,6 @@ Defaults to on and only applies to packages allowed by `allowBuilds` / `onlyBuil
 
 ### `--verify-store-integrity`
 
-Verify tarball SHA-512 against the lockfile integrity before importing into the store.
+Verify tarball SHA-512 before importing into the store.
 
-Defaults to `true` (pnpm parity); pair with `--no-verify-store-integrity` to skip.
+Checks each tarball against the lockfile integrity. Defaults to `true` (pnpm parity); pair with `--no-verify-store-integrity` to skip.

--- a/docs/cli/link.md
+++ b/docs/cli/link.md
@@ -16,6 +16,6 @@ Package name, or path to a local directory
 
 ### `-g --global`
 
-Register into (or resolve from) the global link registry under `$AUBE_HOME/global-links`.
+Register into (or resolve from) the global link registry.
 
-Default behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit.
+The registry lives at `$AUBE_HOME/global-links`. Default behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit.

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -54,7 +54,9 @@ Emit a JSON array of package entries.
 
 ### `--long`
 
-Show version and path for each entry (default output is already name + version; `--long` adds the store path for debugging)
+Show version and path for each entry.
+
+Default output is already name + version; `--long` adds the store path for debugging.
 
 ### `--parseable`
 

--- a/docs/cli/patch-remove.md
+++ b/docs/cli/patch-remove.md
@@ -9,6 +9,6 @@ Remove patch entries from `pnpm.patchedDependencies`
 
 ### `[PACKAGES]…`
 
-Patch keys to remove, formatted as `<name>@<version>` (the same shape used as the `pnpm.patchedDependencies` map key).
+Patch keys to remove, formatted as `<name>@<version>`.
 
-With no arguments, every declared patch is removed.
+Same shape used as the `pnpm.patchedDependencies` map key. With no arguments, every declared patch is removed.

--- a/docs/cli/patch.md
+++ b/docs/cli/patch.md
@@ -23,6 +23,6 @@ When omitted, `aube` picks a fresh temp dir under the system tmpdir.
 
 ### `--ignore-existing`
 
-Ignore any existing patch entry for this package — extract a pristine copy from `node_modules` rather than re-applying the existing patch first.
+Ignore any existing patch entry for this package.
 
-Accepted for pnpm parity; aube already extracts from the *linked* (post-patch) tree, so this flag is effectively informational here.
+Extracts a pristine copy from `node_modules` rather than re-applying the existing patch first. Accepted for pnpm parity; aube already extracts from the *linked* (post-patch) tree, so this flag is effectively informational here.

--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -19,17 +19,21 @@ Don't upload; print what would be published
 
 ### `--force`
 
-Republish `name@version` even when that version is already on the target registry.
+Republish even when the version is already on the registry.
 
 By default `aube publish` issues a GET before the PUT and refuses to proceed when the version exists, surfacing a clear error instead of relying on the registry to return 409. In `--recursive` / `--filter` mode, `--force` overrides the silent "already-published" skip so every selected workspace package is re-PUT. The registry must still accept the republish — npm's public registry rejects re-publishes outright; Verdaccio and most private mirrors allow them.
 
 ### `--ignore-scripts`
 
-Skip `prepublishOnly` / `prepublish` / `prepack` / `prepare` / `postpack` / `publish` / `postpublish` lifecycle scripts for this publish
+Skip publish lifecycle scripts.
+
+Suppresses `prepublishOnly`, `prepublish`, `prepack`, `prepare`, `postpack`, `publish`, and `postpublish` scripts for this publish.
 
 ### `--json`
 
-Emit the publish result as JSON: an array with one `{name, version, filename, files: [{path}]}` entry, matching `pnpm publish --json` / `aube pack --json`
+Emit the publish result as JSON.
+
+Output is an array with one `{name, version, filename, files: [{path}]}` entry, matching `pnpm publish --json` / `aube pack --json`.
 
 ### `--no-git-checks`
 

--- a/docs/cli/purge.md
+++ b/docs/cli/purge.md
@@ -11,4 +11,6 @@ A `purge` script in the root `package.json` overrides the built-in.
 
 ### `-l --lockfile`
 
-Also remove lockfiles at the workspace root (`aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `bun.lock`)
+Also remove lockfiles at the workspace root.
+
+Targets `aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock`.

--- a/docs/cli/query.md
+++ b/docs/cli/query.md
@@ -9,7 +9,9 @@ Query packages in the resolved dependency graph
 
 ### `<SELECTOR>`
 
-Selector expression. Supports `*`, bare package names, `[name=value]`, `[version=value]`, `[license=value]`, `[depPath=value]`, `[source=value]`, `:prod`, `:dev`, `:optional`, `:peer`, `:transitive`, `:scripts`, `:bin`, `:deprecated`, `:license(value)`, and `:type(value)`
+Selector expression.
+
+Supports `*`, bare package names, `[name=value]`, `[version=value]`, `[license=value]`, `[depPath=value]`, `[source=value]`, `:prod`, `:dev`, `:optional`, `:peer`, `:transitive`, `:scripts`, `:bin`, `:deprecated`, `:license(value)`, and `:type(value)`.
 
 ## Flags
 

--- a/docs/cli/remove.md
+++ b/docs/cli/remove.md
@@ -28,6 +28,6 @@ Skip root lifecycle scripts during the chained reinstall
 
 ### `-w --workspace`
 
-Remove the dependency from the workspace root's `package.json`, regardless of the current working directory.
+Remove the dependency from the workspace root's `package.json`.
 
-Walks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`).
+Applies regardless of the current working directory: walks up from cwd looking for `aube-workspace.yaml`, `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field and runs the remove against that directory. Takes precedence over `--filter` when both are supplied (same as `add --workspace`).

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -41,9 +41,9 @@ Parsed for pnpm compatibility.
 
 ### `--parallel`
 
-Run the script in every matched workspace package concurrently, with unbounded parallelism.
+Run the script in every matched workspace package concurrently.
 
-Pair with a filter (`-r` / `-F`) — single-package runs ignore it. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated.
+Unbounded parallelism. Pair with a filter (`-r` / `-F`) — single-package runs ignore it. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated.
 
 ### `--report-summary`
 

--- a/docs/cli/store/status.md
+++ b/docs/cli/store/status.md
@@ -3,6 +3,6 @@
 
 - **Usage**: `aube store status`
 
-Verify that every file referenced by a cached package index is still present in the store and its BLAKE3 hash matches.
+Verify the store against cached package indexes.
 
-Exits non-zero when any corruption is detected.
+Confirms every file referenced by a cached package index is still present in the store and that its BLAKE3 hash matches. Exits non-zero when any corruption is detected.

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -37,7 +37,9 @@ Parsed for pnpm compatibility.
 
 ### `-L --latest`
 
-Update past the manifest range: rewrite `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual)
+Update past the manifest range.
+
+Rewrites `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual).
 
 ### `-P --prod`
 

--- a/docs/cli/version.md
+++ b/docs/cli/version.md
@@ -9,9 +9,9 @@ Bump the version in package.json (and optionally create a git commit + tag)
 
 ### `[NEW_VERSION]`
 
-Bump keyword (`major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`) or an explicit version string.
+Bump keyword or an explicit version string.
 
-When omitted, prints the current version.
+Accepts `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`, or an explicit version. When omitted, prints the current version.
 
 ## Flags
 

--- a/docs/cli/view.md
+++ b/docs/cli/view.md
@@ -10,13 +10,15 @@ Print package metadata from the registry
 
 ### `<PACKAGE>`
 
-Package to view, optionally with a version or dist-tag (`lodash`, `lodash@4.17.21`, `react@next`, `express@^4`)
+Package to view, optionally with a version or dist-tag.
+
+Examples: `lodash`, `lodash@4.17.21`, `react@next`, `express@^4`.
 
 ### `[FIELD]`
 
-Dotted path into the version metadata to print (`version`, `dependencies`, `dist.tarball`, `maintainers.0.name`).
+Dotted path into the version metadata to print.
 
-When omitted, prints a formatted summary.
+Examples: `version`, `dependencies`, `dist.tarball`, `maintainers.0.name`. When omitted, prints a formatted summary.
 
 ## Flags
 


### PR DESCRIPTION
## Summary

clap merges multi-line `///` doc comments into one paragraph for short help (`-h`) and only splits on the first blank `///` line to produce a separate first-line summary. Several flags across the CLI were written as one continuous paragraph, so `aube <cmd> -h` rendered them as 120+ char lines that wrapped awkwardly on standard terminals.

This PR splits each offender's doc comment into a short summary line + blank `///` separator + the longer prose — same shape `update --latest` already uses (precedent: #473).

## Flags fixed

- `add -g, --global`, `--no-save`, `--save-catalog`, `--save-catalog-name`, `-w, --workspace`
- `approve-builds [PKG]...` (positional doc), plus the subcommand summary on `aube --help`
- `audit --ignore-unfixable`
- `check` subcommand summary on `aube --help`
- `clean -l, --lockfile` (also reflects to `purge`)
- `config list --all`, `--json`
- `dlx -c, --shell-mode`
- `find-hash --json`
- `init --init-package-manager`
- `install --fix-lockfile`, `--force`, `--lockfile-dir`, `--merge-git-branch-lockfiles`, `--resolution-mode`, `--verify-store-integrity`
- `link -g, --global`
- `list --long`
- `patch --ignore-existing`
- `patch-remove [PACKAGES]...`
- `publish --force`, `--ignore-scripts`, `--json`
- `query <SELECTOR>`
- `remove -w, --workspace`
- `run --parallel`
- `store status` subcommand summary
- `update -L, --latest` (same fix as #473, included here since that PR is still open)
- `version [NEW_VERSION]`
- `view <PACKAGE>`, `[FIELD]`

## Validation

- `cargo build --workspace` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- Audit before/after: lines >120 chars went from 6 to 0; lines >115 from 1 to 0
- Sample audit script: `for cmd in $(aube --help | grep -E '^  [a-z]' | awk '{print $1}'); do aube "$cmd" -h 2>&1 | awk 'length > 120'; done | grep -vE '\[possible values:|\[aliases:'`

CLI docs regenerated via `mise run render` (`aube.usage.kdl`, `docs/cli/commands.json`, `docs/cli/*.md`).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Re-ran `aube <cmd> -h` for every fixed subcommand to confirm short help is now one clean summary line and `aube <cmd> --help` still shows the full prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CLI help-text/doc updates plus regenerated docs/command metadata; no behavior or parsing logic changes, so risk is low aside from potential wording/regeneration drift.
> 
> **Overview**
> Tightens CLI `-h` output by splitting many commands/flags’ descriptions into a short first-line summary plus separate long help, avoiding overly long wrapped lines in terminal help.
> 
> Updates the usage spec (`aube.usage.kdl`), clap doc comments across multiple command arg structs, and regenerates the derived CLI docs (`docs/cli/*.md`) and `docs/cli/commands.json` to reflect the new short/long help text (including `approve-builds`, `check`, `publish`, `install`, `run`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e243a37a45b93f1750ea60a743172c721c50bbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->