### PR TITLE
fix(install): allow workspace members without `version` field

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1856,23 +1856,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 .replace('\\', "/");
 
             if let Some(ref name) = pkg_manifest.name {
-                // Workspace members MUST carry a version. Old code
-                // silently defaulted to "0.0.0", which collided any
-                // two unversioned members under one dep_path and made
-                // `workspace:^2.0.0` match nothing. pnpm refuses to
-                // install here, aube should too. Private packages
-                // without a version are fine in package.json but not
-                // once they enter a workspace graph where siblings
-                // pin them. User fix: add a version field. Skip
-                // silently only when name is also missing (pure-root
-                // scratch manifest case).
-                let version = pkg_manifest.version.as_deref().ok_or_else(|| {
-                    miette!(
-                        "workspace package {name} at {rel_path} has no `version` field. \
-                         add one to its package.json. workspace members must be versioned \
-                         so siblings can pin them via workspace: protocol"
-                    )
-                })?;
+                // `version` is optional. pnpm accepts workspace
+                // members without one (real-world: build-only design
+                // systems consumed by an external toolchain, like
+                // tuist's `noora`). When absent, fall back to "0.0.0":
+                // siblings pinning via `workspace:*` / `workspace:^` /
+                // `workspace:~` or bare `*` still link locally
+                // (those branches in resolve_workspace accept any
+                // ws version), and a specific range like
+                // `workspace:^2.0.0` correctly fails to satisfy.
+                let version = pkg_manifest.version.as_deref().unwrap_or("0.0.0");
                 ws_package_versions.insert(name.clone(), version.to_string());
                 ws_dirs.insert(name.clone(), pkg_dir.clone());
                 tracing::debug!("  {name}@{version} ({rel_path})");

--- a/test/workspace.bats
+++ b/test/workspace.bats
@@ -184,6 +184,44 @@ _setup_workspace_fixture() {
 	assert_dir_exists packages/standalone/node_modules/is-odd
 }
 
+@test "aube install: sibling \`workspace:*\` links to unversioned member" {
+	# Locks the "0.0.0" fallback path: when an unversioned member is
+	# pinned via workspace:*, the resolver's wildcard branch matches
+	# unconditionally and the linker creates the cross-package symlink.
+	# Regression guard for the version-required check that errored
+	# before any resolver work could happen.
+	mkdir -p packages/lib packages/app
+	cat >package.json <<-'EOF'
+		{ "name": "root-ws", "version": "0.0.0", "private": true }
+	EOF
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/lib
+		  - packages/app
+	EOF
+	cat >packages/lib/package.json <<-'EOF'
+		{ "name": "@test/lib", "private": true, "main": "index.js" }
+	EOF
+	echo "module.exports = 42;" >packages/lib/index.js
+	cat >packages/app/package.json <<-'EOF'
+		{
+		  "name": "@test/app",
+		  "version": "1.0.0",
+		  "private": true,
+		  "dependencies": { "@test/lib": "workspace:*" }
+		}
+	EOF
+
+	run aube install
+	assert_success
+
+	assert_link_exists packages/app/node_modules/@test/lib
+	cd packages/app
+	run node -e 'console.log(require("@test/lib"))'
+	assert_success
+	assert_output "42"
+}
+
 @test "aube install: detects workspace from pnpm-workspace.yaml" {
 	_setup_workspace_fixture
 

--- a/test/workspace.bats
+++ b/test/workspace.bats
@@ -154,6 +154,36 @@ _setup_workspace_fixture() {
 	assert_output --partial "isOdd(3): true"
 }
 
+@test "aube install: workspace member without \`version\` field installs cleanly" {
+	# Regression: aube errored with `workspace package <name> at <path>
+	# has no \`version\` field` whenever any pnpm-workspace.yaml member
+	# omitted version, even when no sibling depended on it. pnpm
+	# permits unversioned members in this case (real-world: tuist's
+	# `noora` design system, consumed by an external Mix toolchain).
+	mkdir -p packages/standalone
+	cat >package.json <<-'EOF'
+		{ "name": "root-ws", "version": "0.0.0", "private": true }
+	EOF
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/standalone
+	EOF
+	cat >packages/standalone/package.json <<-'EOF'
+		{
+		  "name": "standalone",
+		  "private": true,
+		  "dependencies": {
+		    "is-odd": "^3.0.1"
+		  }
+		}
+	EOF
+
+	run aube install
+	assert_success
+
+	assert_dir_exists packages/standalone/node_modules/is-odd
+}
+
 @test "aube install: detects workspace from pnpm-workspace.yaml" {
 	_setup_workspace_fixture
 


### PR DESCRIPTION
## Summary
Real-world failure: [tuist/tuist#10584](https://github.com/tuist/tuist/pull/10584) tried to swap pnpm for aube and CI hit `workspace package noora at noora has no \`version\` field` from [crates/aube/src/commands/install/mod.rs:1869](crates/aube/src/commands/install/mod.rs:1869). pnpm accepts the same repo without complaint.

The unconditional check predates the resolver's current `workspace:*` / `workspace:^` / `workspace:~` / bare-`*` fallback. The comment's collision rationale ("two unversioned members under one dep_path") doesn't hold either: `dep_path` keys on `(name, version)` and two members have distinct names by construction.

Fix: fall back to `"0.0.0"` when `version` is absent. `workspace:*` / `workspace:^` / `workspace:~` / bare-`*` siblings still link locally (those branches in `resolve_workspace` accept any ws version regardless). A specific range like `workspace:^2.0.0` against an unversioned member correctly fails to satisfy, matching pnpm.

## Test plan
- [x] `cargo test` (full suite green)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `mise run test:bats test/workspace.bats` — 19 pass, including the new regression #4
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace package discovery to accept unversioned members by defaulting their version to `0.0.0`, which can affect workspace resolution/linking behavior in monorepos. Risk is contained and covered by new Bats regression tests, but it touches core install/workspace logic.
> 
> **Overview**
> Allows `aube install` to proceed when a workspace member’s `package.json` omits `version` by defaulting the workspace version to `0.0.0` instead of hard-erroring during workspace manifest collection.
> 
> Adds Bats regression coverage for (1) installing a workspace containing an unversioned standalone member and (2) ensuring a sibling dependency using `workspace:*` correctly links to an unversioned workspace package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b8f5e75aa1ce951e3809ca7685fe52ab1fc5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->