### PR TITLE
fix(release): avoid duplicate sponsor blurbs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -177,8 +177,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
           TAG: ${{ needs.release-plz-release.outputs.tag }}
         run: |
+          body="$(gh release view "$TAG" --json body --jq .body)"
+          if grep -Fqx '## 💚 Sponsor aube' <<<"$body"; then
+            echo "Release notes already include the sponsor blurb; leaving them unchanged."
+            exit 0
+          fi
+
           {
-            gh release view "$TAG" --json body --jq .body
+            printf '%s\n' "$body"
             cat <<'EOF'
 
           ## 💚 Sponsor aube


### PR DESCRIPTION
## Summary

- Make the release sponsor-blurb append step idempotent
- Leave communique-generated sponsor text unchanged when it is already present

## Testing

- `actionlint .github/workflows/release-plz.yml`
- `git diff --check`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that makes release-note editing idempotent by detecting an existing sponsor section before appending.
> 
> **Overview**
> Makes the `enhance-release` workflow’s “Append en.dev sponsor blurb” step idempotent by fetching the current GitHub release body once, checking for the existing `## 💚 Sponsor aube` header, and skipping the edit when it’s already present.
> 
> When absent, it reuses the fetched body and appends the sponsor section as before, preventing duplicate blurbs across reruns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3bf330c6d7a2025f5e000148e47d74d2189aa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->