### PR TITLE
fix(lockfile): honor bun workspace-scoped direct deps

### DIFF
--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -725,6 +725,10 @@ fn rebase_workspace_scoped_local_source(
     let Some(local_path) = local.path() else {
         return local;
     };
+    // Bun may write workspace-name-scoped local entries with
+    // root-relative bare paths (`vendor/local-dir`) or
+    // importer-relative climbs (`../../vendor/local.tgz`). Only the
+    // latter needs rebasing to project-root form.
     if !local_path
         .components()
         .any(|c| matches!(c, Component::ParentDir))

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Deserialize)]
 struct RawBunLockfile {
@@ -251,6 +251,18 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         let entry = BunEntry::from_array(key, value).map_err(|e| Error::parse(path, e))?;
         entries.insert(key.clone(), entry);
     }
+    let mut workspace_scopes: Vec<(&str, &str)> = raw
+        .workspaces
+        .iter()
+        .filter(|(ws_path, _)| !ws_path.is_empty())
+        .filter_map(|(ws_path, ws)| {
+            ws.extra
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(|name| (name, ws_path.as_str()))
+        })
+        .collect();
+    workspace_scopes.sort_by_key(|(name, _)| std::cmp::Reverse(name.len()));
 
     // First pass: parse (name, version) for each entry. bun.lock keys look
     // like the package name ("foo") for the hoisted version, or a nested
@@ -286,6 +298,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             entry.integrity.as_deref(),
             path,
         )?;
+        let local_source = local_source
+            .map(|local| rebase_workspace_scoped_local_source(key, local, &workspace_scopes));
         key_info.insert(key.clone(), (name.clone(), version.clone()));
 
         let dep_path = format!("{name}@{version}");
@@ -701,6 +715,57 @@ fn classify_bun_ident(
     }
     // Plain registry pin.
     Ok((name, raw_version.to_string(), None, alias_of))
+}
+
+fn rebase_workspace_scoped_local_source(
+    key: &str,
+    local: LocalSource,
+    workspace_scopes: &[(&str, &str)],
+) -> LocalSource {
+    let Some(local_path) = local.path() else {
+        return local;
+    };
+    if !local_path
+        .components()
+        .any(|c| matches!(c, Component::ParentDir))
+    {
+        return local;
+    }
+    let Some((_, ws_path)) = workspace_scopes.iter().find(|(name, _)| {
+        key.strip_prefix(*name)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+    }) else {
+        return local;
+    };
+    let rebased = normalize_path(&Path::new(ws_path).join(local_path));
+    match local {
+        LocalSource::Directory(_) => LocalSource::Directory(rebased),
+        LocalSource::Tarball(_) => LocalSource::Tarball(rebased),
+        LocalSource::Link(_) => LocalSource::Link(rebased),
+        LocalSource::Git(_) | LocalSource::RemoteTarball(_) => local,
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::ParentDir => {
+                if out
+                    .components()
+                    .next_back()
+                    .is_some_and(|c| matches!(c, Component::Normal(_)))
+                {
+                    out.pop();
+                } else {
+                    out.push("..");
+                }
+            }
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
 }
 
 fn split_committish(spec: &str) -> (String, Option<String>) {
@@ -2722,6 +2787,42 @@ mod tests {
         assert_eq!(
             tslib.dep_path, "tslib@2.4.0",
             "workspace dep must resolve to z-app/tslib, not hoisted tslib"
+        );
+    }
+
+    #[test]
+    fn test_parse_rebases_workspace_scoped_local_tarball() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sri = fake_sri('a');
+        let content = r#"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "root" },
+    "packages/app": {
+      "name": "app",
+      "dependencies": { "local-tar": "file:../../vendor/local-tar-1.0.0.tgz" }
+    }
+  },
+  "packages": {
+    "app": ["app@workspace:packages/app"],
+    "app/local-tar": ["local-tar@../../vendor/local-tar-1.0.0.tgz", {}, "SRI"]
+  }
+}"#
+        .replace("SRI", &sri);
+        std::fs::write(tmp.path(), &content).unwrap();
+        let graph = parse(tmp.path()).unwrap();
+
+        let local_tar = graph
+            .packages
+            .values()
+            .find(|p| p.name == "local-tar")
+            .expect("local-tar package");
+        assert_eq!(local_tar.version, "../../vendor/local-tar-1.0.0.tgz");
+        assert_eq!(
+            local_tar.local_source,
+            Some(LocalSource::Tarball(PathBuf::from(
+                "vendor/local-tar-1.0.0.tgz"
+            )))
         );
     }
 

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -440,13 +440,14 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     // Workspace importers. bun.lock keys workspace paths as `""` for
     // the root and relative paths (`packages/app`, etc.) for each
     // workspace package. Each importer's direct deps resolve first
-    // to a workspace-scoped override (`packages/app/foo`) when one
-    // exists, falling back to the hoisted entry (`foo`). We don't
-    // walk intermediate ancestors like `packages/foo` the way
-    // `resolve_nested_bun` does for package-nesting — workspace path
-    // segments are directories, not package-nesting scopes, so a
-    // partial walk could wrongly match a literal npm package named
-    // `packages` that has its own nested `foo` entry.
+    // to a name-scoped override (`app/foo`) or path-scoped override
+    // (`packages/app/foo`) when one exists, falling back to the
+    // hoisted entry (`foo`). We don't walk intermediate ancestors
+    // like `packages/foo` the way `resolve_nested_bun` does for
+    // package-nesting — workspace path segments are directories, not
+    // package-nesting scopes, so a partial walk could wrongly match a
+    // literal npm package named `packages` that has its own nested
+    // `foo` entry.
     let mut importers: BTreeMap<String, Vec<DirectDep>> = BTreeMap::new();
     let mut workspace_extra_fields: BTreeMap<String, BTreeMap<String, serde_json::Value>> =
         BTreeMap::new();
@@ -2702,6 +2703,16 @@ mod tests {
         .replace("SRI", &sri);
         std::fs::write(tmp.path(), &content).unwrap();
         let graph = parse(tmp.path()).unwrap();
+
+        let other = graph
+            .importers
+            .get("packages/a-other")
+            .expect("packages/a-other importer");
+        let hoisted_tslib = other.iter().find(|d| d.name == "tslib").expect("tslib dep");
+        assert_eq!(
+            hoisted_tslib.dep_path, "tslib@2.8.1",
+            "sibling workspace must still resolve to the hoisted tslib"
+        );
 
         let app = graph
             .importers

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -35,9 +35,10 @@ use crate::{
     DepType, DirectDep, Error, GitSource, LocalSource, LockedPackage, LockfileGraph, PeerDepMeta,
     RemoteTarballSource,
 };
+use aube_util::path::normalize_lexical;
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 
 #[derive(Debug, Deserialize)]
 struct RawBunLockfile {
@@ -741,35 +742,13 @@ fn rebase_workspace_scoped_local_source(
     }) else {
         return local;
     };
-    let rebased = normalize_path(&Path::new(ws_path).join(local_path));
+    let rebased = normalize_lexical(&Path::new(ws_path).join(local_path));
     match local {
         LocalSource::Directory(_) => LocalSource::Directory(rebased),
         LocalSource::Tarball(_) => LocalSource::Tarball(rebased),
         LocalSource::Link(_) => LocalSource::Link(rebased),
         LocalSource::Git(_) | LocalSource::RemoteTarball(_) => local,
     }
-}
-
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for comp in path.components() {
-        match comp {
-            Component::ParentDir => {
-                if out
-                    .components()
-                    .next_back()
-                    .is_some_and(|c| matches!(c, Component::Normal(_)))
-                {
-                    out.pop();
-                } else {
-                    out.push("..");
-                }
-            }
-            Component::CurDir => {}
-            other => out.push(other.as_os_str()),
-        }
-    }
-    out
 }
 
 fn split_committish(spec: &str) -> (String, Option<String>) {
@@ -1708,6 +1687,7 @@ fn inline_json(value: &serde_json::Value, _base_indent: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn test_split_ident() {

--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -456,10 +456,13 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         } else {
             ws_path.clone()
         };
+        let ws_name = (!ws_path.is_empty())
+            .then(|| ws_raw.extra.get("name").and_then(serde_json::Value::as_str))
+            .flatten();
         let mut direct: Vec<DirectDep> = Vec::new();
         let push_dep =
             |name: &str, specifier: &str, dep_type: DepType, direct: &mut Vec<DirectDep>| {
-                if let Some(target_key) = resolve_workspace_dep(ws_path, name, &key_info)
+                if let Some(target_key) = resolve_workspace_dep(ws_path, ws_name, name, &key_info)
                     && let Some((dname, dver)) = key_info.get(&target_key)
                 {
                     direct.push(DirectDep {
@@ -784,7 +787,8 @@ fn resolve_nested_bun(
 /// Resolve a direct dep of a workspace importer at path `ws_path`
 /// (e.g. `""` for root, `"packages/app"` for a nested workspace) to
 /// its `key_info` key. Checks the workspace-scoped override
-/// (`<ws_path>/<dep_name>`) first, then the hoisted bare key
+/// (`<workspace_name>/<dep_name>`), the path-scoped override
+/// (`<ws_path>/<dep_name>`), then the hoisted bare key
 /// (`<dep_name>`). Intentionally does *not* walk intermediate
 /// ancestors like `packages/<dep_name>` — those are
 /// package-nesting keys that belong to `resolve_nested_bun`, and
@@ -793,9 +797,16 @@ fn resolve_nested_bun(
 /// entry.
 fn resolve_workspace_dep(
     ws_path: &str,
+    ws_name: Option<&str>,
     dep_name: &str,
     key_info: &BTreeMap<String, (String, String)>,
 ) -> Option<String> {
+    if let Some(ws_name) = ws_name {
+        let ws_specific = format!("{ws_name}/{dep_name}");
+        if key_info.contains_key(&ws_specific) {
+            return Some(ws_specific);
+        }
+    }
     if !ws_path.is_empty() {
         let ws_specific = format!("{ws_path}/{dep_name}");
         if key_info.contains_key(&ws_specific) {
@@ -2657,6 +2668,49 @@ mod tests {
         assert_eq!(
             bar.dep_path, "bar@1.0.0",
             "workspace `bar` must resolve to hoisted 1.0.0, not packages/bar@9.9.9"
+        );
+    }
+
+    /// Bun scopes non-hoisted direct deps under the workspace package
+    /// name, not the workspace directory path. A workspace at
+    /// `packages/z-app` named `z-app` can therefore depend on
+    /// `z-app/tslib` while another workspace gets the hoisted `tslib`.
+    #[test]
+    fn test_parse_workspace_dep_prefers_workspace_name_scope() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sri = fake_sri('a');
+        let content = r#"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "root" },
+    "packages/a-other": {
+      "name": "a-other",
+      "dependencies": { "tslib": "2.8.1" }
+    },
+    "packages/z-app": {
+      "name": "z-app",
+      "dependencies": { "tslib": "2.4.0" }
+    }
+  },
+  "packages": {
+    "a-other": ["a-other@workspace:packages/a-other"],
+    "tslib": ["tslib@2.8.1", "", {}, "SRI"],
+    "z-app": ["z-app@workspace:packages/z-app"],
+    "z-app/tslib": ["tslib@2.4.0", "", {}, "SRI"]
+  }
+}"#
+        .replace("SRI", &sri);
+        std::fs::write(tmp.path(), &content).unwrap();
+        let graph = parse(tmp.path()).unwrap();
+
+        let app = graph
+            .importers
+            .get("packages/z-app")
+            .expect("packages/z-app importer");
+        let tslib = app.iter().find(|d| d.name == "tslib").expect("tslib dep");
+        assert_eq!(
+            tslib.dep_path, "tslib@2.4.0",
+            "workspace dep must resolve to z-app/tslib, not hoisted tslib"
         );
     }
 

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -1,39 +1,8 @@
 use crate::{Error, ResolveTask};
 use aube_lockfile::{LocalSource, LockedPackage};
 use aube_registry::client::RegistryClient;
+use aube_util::path::normalize_lexical;
 use std::collections::BTreeMap;
-
-/// Lexical path normalization — collapse `.` and `..` components
-/// against earlier components without touching the filesystem. Unlike
-/// `canonicalize`, this doesn't require the path to exist and doesn't
-/// follow symlinks, which matters because `link:` deps deliberately
-/// point at symlinks the user controls. Leading `..` that can't be
-/// collapsed are preserved (e.g. `../foo` stays `../foo`).
-fn normalize_path(path: &std::path::Path) -> std::path::PathBuf {
-    use std::path::{Component, PathBuf};
-    let mut out = PathBuf::new();
-    for comp in path.components() {
-        match comp {
-            Component::ParentDir => {
-                // Pop the previous component if it was a plain name;
-                // otherwise record the `..` literally so leading
-                // ascents out of the base don't silently disappear.
-                let prev_is_normal = out
-                    .components()
-                    .next_back()
-                    .is_some_and(|c| matches!(c, Component::Normal(_)));
-                if prev_is_normal {
-                    out.pop();
-                } else {
-                    out.push("..");
-                }
-            }
-            Component::CurDir => {}
-            other => out.push(other.as_os_str()),
-        }
-    }
-    out
-}
 
 /// Rewrite a `LocalSource` whose path is relative to `importer_root`
 /// into one whose path is relative to `project_root`, so downstream
@@ -65,8 +34,8 @@ pub(crate) fn rebase_local(
         // Non-path sources (git) have nothing to rebase.
         return local.clone();
     };
-    let abs = normalize_path(&importer_root.join(local_path));
-    let rebased = pathdiff::diff_paths(&abs, project_root).map_or(abs, |p| normalize_path(&p));
+    let abs = normalize_lexical(&importer_root.join(local_path));
+    let rebased = pathdiff::diff_paths(&abs, project_root).map_or(abs, |p| normalize_lexical(&p));
     match local {
         LocalSource::Directory(_) => LocalSource::Directory(rebased),
         LocalSource::Tarball(_) => LocalSource::Tarball(rebased),
@@ -548,7 +517,7 @@ mod rebase_local_tests {
         // `..` at the root of the project is still meaningful —
         // don't silently drop it.
         assert_eq!(
-            normalize_path(Path::new("../vendor")),
+            normalize_lexical(Path::new("../vendor")),
             PathBuf::from("../vendor")
         );
     }

--- a/crates/aube-util/src/path.rs
+++ b/crates/aube-util/src/path.rs
@@ -1,6 +1,34 @@
 //! Cross-crate path normalization helpers.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
+
+/// Collapse `.` and resolvable `..` components without touching the
+/// filesystem.
+///
+/// Unlike `canonicalize`, this does not require the path to exist and
+/// does not follow symlinks. Leading `..` components that cannot be
+/// collapsed are preserved.
+pub fn normalize_lexical(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::ParentDir => {
+                let prev_is_normal = out
+                    .components()
+                    .next_back()
+                    .is_some_and(|c| matches!(c, Component::Normal(_)));
+                if prev_is_normal {
+                    out.pop();
+                } else {
+                    out.push("..");
+                }
+            }
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
 
 /// Strip a Windows `\\?\` verbatim drive prefix from `path` so callers
 /// that interpolate it into a path-concatenating template (`%~dp0\{rel}`
@@ -30,6 +58,30 @@ pub fn strip_verbatim_prefix(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lexical_normalization_collapses_internal_parent_dirs() {
+        assert_eq!(
+            normalize_lexical(Path::new("packages/app/../../vendor")),
+            PathBuf::from("vendor")
+        );
+    }
+
+    #[test]
+    fn lexical_normalization_preserves_leading_parent_dirs() {
+        assert_eq!(
+            normalize_lexical(Path::new("../vendor")),
+            PathBuf::from("../vendor")
+        );
+    }
+
+    #[test]
+    fn lexical_normalization_ignores_current_dirs() {
+        assert_eq!(
+            normalize_lexical(Path::new("./vendor/./pkg")),
+            PathBuf::from("vendor/pkg")
+        );
+    }
 
     #[cfg(windows)]
     #[test]


### PR DESCRIPTION
## Summary
- resolve Bun workspace direct dependencies through `<workspace package name>/<dep>` before falling back to hoisted entries
- keep the existing workspace-path guard so directory segments do not alias package nesting
- add a regression for the `z-app/tslib` shape from https://github.com/johnpyp/aube-bun-lock-scoped-entry-repro

## Validation
- cargo fmt --check
- cargo test -p aube-lockfile workspace_dep
- cargo test -p aube-lockfile test_parse_workspace_path_does_not_alias_npm_package
- cargo clippy -p aube-lockfile --all-targets -- -D warnings
- cargo build
- cloned johnpyp/aube-bun-lock-scoped-entry-repro and verified `aube install --disable-global-virtual-store` links `packages/z-app/node_modules/tslib` to `../../../node_modules/.aube/tslib@2.4.0/node_modules/tslib`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bun.lock parsing for workspace direct-dep resolution and rewrites certain workspace-scoped local paths, which can affect which package versions/paths are installed in monorepos.
> 
> **Overview**
> Fixes bun workspace direct-dependency resolution to prefer **workspace package name-scoped** entries (e.g. `z-app/tslib`) before falling back to workspace-path scoped (e.g. `packages/z-app/tslib`) and finally hoisted keys.
> 
> Adds rebasing for bun workspace-scoped `file:`/local entries that contain `..` so importer-relative paths are normalized back to project-root-relative form, and centralizes lexical path normalization in `aube-util` (reused by the resolver). New regression tests cover both the name-scoped workspace dep shape and the local tarball rebasing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a2342a93e8a371e3442a67fe224b9bd234418d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->