### PR TITLE
chore: release v1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aube-manifest",
  "landlock",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -1259,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -3879,7 +3879,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -122,18 +122,18 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.7.0" }
-aube-codes = { path = "crates/aube-codes", version = "1.7.0" }
-aube-settings = { path = "crates/aube-settings", version = "1.7.0" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.7.0" }
-aube-registry = { path = "crates/aube-registry", version = "1.7.0" }
-aube-store = { path = "crates/aube-store", version = "1.7.0" }
-aube-linker = { path = "crates/aube-linker", version = "1.7.0" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.7.0" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.7.0" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.7.0" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.7.0" }
-aube-util = { path = "crates/aube-util", version = "1.7.0" }
+aube = { path = "crates/aube", version = "1.8.0" }
+aube-codes = { path = "crates/aube-codes", version = "1.8.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.8.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.8.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.8.0" }
+aube-store = { path = "crates/aube-store", version = "1.8.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.8.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.8.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.8.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.8.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.8.0" }
+aube-util = { path = "crates/aube-util", version = "1.8.0" }
 
 [profile.dev]
 debug = 1

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.7.0"
+version "1.8.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-codes/CHANGELOG.md
+++ b/crates/aube-codes/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.8.0](https://github.com/endevco/aube/compare/aube-codes-v1.7.0...aube-codes-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(progress)* redesign install progress UI ([#501](https://github.com/endevco/aube/pull/501))
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/aube-linker-v1.7.0...aube-linker-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+- *(codes)* introduce ERR_AUBE_/WARN_AUBE_ codes, exit codes, dep chains ([#492](https://github.com/endevco/aube/pull/492))
+
+### Other
+
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/aube-linker-v1.6.2...aube-linker-v1.7.0) - 2026-05-03
 
 ### Fixed

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.7.0...aube-lockfile-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+- *(codes)* introduce ERR_AUBE_/WARN_AUBE_ codes, exit codes, dep chains ([#492](https://github.com/endevco/aube/pull/492))
+
+### Fixed
+
+- *(install)* handle workspace scripts and pnpm aliases ([#500](https://github.com/endevco/aube/pull/500))
+- *(lockfile)* honor bun workspace-scoped direct deps ([#489](https://github.com/endevco/aube/pull/489))
+
+### Other
+
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.6.2...aube-lockfile-v1.7.0) - 2026-05-03
 
 ### Fixed

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/aube-manifest-v1.7.0...aube-manifest-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+- *(codes)* introduce ERR_AUBE_/WARN_AUBE_ codes, exit codes, dep chains ([#492](https://github.com/endevco/aube/pull/492))
+
+### Other
+
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/aube-manifest-v1.6.2...aube-manifest-v1.7.0) - 2026-05-03
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/aube-registry-v1.7.0...aube-registry-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(progress)* redesign install progress UI ([#501](https://github.com/endevco/aube/pull/501))
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+- *(codes)* introduce ERR_AUBE_/WARN_AUBE_ codes, exit codes, dep chains ([#492](https://github.com/endevco/aube/pull/492))
+
+### Other
+
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/aube-registry-v1.6.2...aube-registry-v1.7.0) - 2026-05-03
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/aube-resolver-v1.7.0...aube-resolver-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(progress)* redesign install progress UI ([#501](https://github.com/endevco/aube/pull/501))
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+- *(codes)* introduce ERR_AUBE_/WARN_AUBE_ codes, exit codes, dep chains ([#492](https://github.com/endevco/aube/pull/492))
+
+### Fixed
+
+- *(resolver)* prefer closest ancestor for unmet peers over distant matches ([#503](https://github.com/endevco/aube/pull/503))
+- *(release)* embed primer in linux tarballs ([#493](https://github.com/endevco/aube/pull/493))
+- *(lockfile)* honor bun workspace-scoped direct deps ([#489](https://github.com/endevco/aube/pull/489))
+
+### Other
+
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/aube-resolver-v1.6.2...aube-resolver-v1.7.0) - 2026-05-03
 
 ### Fixed

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/aube-scripts-v1.7.0...aube-scripts-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+- *(codes)* introduce ERR_AUBE_/WARN_AUBE_ codes, exit codes, dep chains ([#492](https://github.com/endevco/aube/pull/492))
+
+### Other
+
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/aube-scripts-v1.6.2...aube-scripts-v1.7.0) - 2026-05-03
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/aube-settings-v1.7.0...aube-settings-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+
+### Other
+
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/aube-settings-v1.6.2...aube-settings-v1.7.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/aube-store-v1.7.0...aube-store-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+- *(codes)* introduce ERR_AUBE_/WARN_AUBE_ codes, exit codes, dep chains ([#492](https://github.com/endevco/aube/pull/492))
+
+### Other
+
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/aube-store-v1.6.2...aube-store-v1.7.0) - 2026-05-03
 
 ### Other

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/aube-util-v1.7.0...aube-util-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+- *(codes)* introduce ERR_AUBE_/WARN_AUBE_ codes, exit codes, dep chains ([#492](https://github.com/endevco/aube/pull/492))
+
+### Fixed
+
+- *(lockfile)* honor bun workspace-scoped direct deps ([#489](https://github.com/endevco/aube/pull/489))
+
+### Other
+
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/aube-util-v1.6.2...aube-util-v1.7.0) - 2026-05-03
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/aube-workspace-v1.7.0...aube-workspace-v1.8.0) - 2026-05-03
+
+### Added
+
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+- *(codes)* introduce ERR_AUBE_/WARN_AUBE_ codes, exit codes, dep chains ([#492](https://github.com/endevco/aube/pull/492))
+
+### Other
+
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/aube-workspace-v1.6.2...aube-workspace-v1.7.0) - 2026-05-03
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/endevco/aube/compare/v1.7.0...v1.8.0) - 2026-05-03
+
+### Added
+
+- *(progress)* redesign install progress UI ([#501](https://github.com/endevco/aube/pull/501))
+- *(run)* prefer local bins for run and dlx ([#502](https://github.com/endevco/aube/pull/502))
+- *(codes)* introduce ERR_AUBE_/WARN_AUBE_ codes, exit codes, dep chains ([#492](https://github.com/endevco/aube/pull/492))
+
+### Fixed
+
+- *(cli)* why/list/query work from a workspace subpackage ([#504](https://github.com/endevco/aube/pull/504))
+- *(install)* handle workspace scripts and pnpm aliases ([#500](https://github.com/endevco/aube/pull/500))
+- *(add)* auto-detect local-path specs instead of hitting the registry ([#499](https://github.com/endevco/aube/pull/499))
+
+### Other
+
+- *(cli)* bucket per-command --help by moving cross-cutting flags off global ([#505](https://github.com/endevco/aube/pull/505))
+- refresh benchmarks for v1.7.0 ([#490](https://github.com/endevco/aube/pull/490))
+
 ## [1.7.0](https://github.com/endevco/aube/compare/v1.6.2...v1.7.0) - 2026-05-03
 
 ### Added

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -11801,7 +11801,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.7.0",
+  "version": "1.8.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.7.0
+**Version**: 1.8.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.7.0",
-  "releasedAt": "2026-05-03T00:45:57Z"
+  "version": "1.8.0",
+  "releasedAt": "2026-05-03T19:53:44Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.8.0`

This PR bumps the workspace to `v1.8.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
