### PR TITLE
fix(release): embed primer in linux tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  AUBE_PRIMER_TOP: "2000"
+  AUBE_PRIMER_VERSION_CAP: "1000"
+  AUBE_REQUIRE_PRIMER: "1"
 
 jobs:
   upload-assets:
@@ -76,6 +79,16 @@ jobs:
         if: ${{ matrix.runner != 'windows-latest' }}
         with:
           cache: rust
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+      - name: Generate metadata primer
+        shell: bash
+        run: |
+          node scripts/generate-primer.mjs \
+            --top "$AUBE_PRIMER_TOP" \
+            --versions "$AUBE_PRIMER_VERSION_CAP" \
+            --out "crates/aube-resolver/data/primer-top${AUBE_PRIMER_TOP}-v${AUBE_PRIMER_VERSION_CAP}.rkyv.json"
       - name: Import codesign certs
         if: startsWith(matrix.os, 'macos')
         uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,6 @@
+[build.env]
+passthrough = [
+    "AUBE_PRIMER_TOP",
+    "AUBE_PRIMER_VERSION_CAP",
+    "AUBE_REQUIRE_PRIMER",
+]

--- a/crates/aube-resolver/build.rs
+++ b/crates/aube-resolver/build.rs
@@ -12,7 +12,7 @@ use primer_schema::Seed;
 
 const DEV_TOP: usize = 100;
 const RELEASE_TOP: usize = 2000;
-const VERSION_CAP: usize = 1000;
+const DEFAULT_VERSION_CAP: usize = 1000;
 const FAST_COMPRESSION_LEVEL: i32 = 10;
 const RELEASE_CI_COMPRESSION_LEVEL: i32 = 19;
 
@@ -23,14 +23,19 @@ fn main() {
         .map(PathBuf::from)
         .unwrap_or_else(|| {
             let top = primer_top();
+            let version_cap = version_cap();
             manifest_dir
                 .join("data")
-                .join(format!("primer-top{top}-v{VERSION_CAP}.rkyv.zst"))
+                .join(format!("primer-top{top}-v{version_cap}.rkyv.zst"))
         });
 
     println!("cargo:rerun-if-env-changed=AUBE_PRIMER_PATH");
     println!("cargo:rerun-if-env-changed=AUBE_PRIMER_TOP");
+    println!("cargo:rerun-if-env-changed=AUBE_PRIMER_VERSION_CAP");
+    println!("cargo:rerun-if-env-changed=AUBE_REQUIRE_PRIMER");
     println!("cargo:rerun-if-changed={}", source.display());
+    let json = source.with_extension("json");
+    println!("cargo:rerun-if-changed={}", json.display());
 
     if !source.is_file() {
         if std::env::var_os("AUBE_PRIMER_PATH").is_some() {
@@ -39,13 +44,25 @@ fn main() {
                 source.display()
             );
         }
-        let script = manifest_dir
-            .parent()
-            .and_then(Path::parent)
-            .map(|w| w.join("scripts/generate-primer.mjs"));
-        let generated = matches!(&script, Some(s) if s.is_file())
-            && generate(&manifest_dir, &source, primer_top());
+        let generated = if json.is_file() {
+            compress_json_primer(&json, &source);
+            let _ = std::fs::remove_file(&json);
+            true
+        } else {
+            let script = manifest_dir
+                .parent()
+                .and_then(Path::parent)
+                .map(|w| w.join("scripts/generate-primer.mjs"));
+            matches!(&script, Some(s) if s.is_file())
+                && generate(&manifest_dir, &source, primer_top())
+        };
         if !generated {
+            if primer_required() {
+                panic!(
+                    "metadata primer is required, but {} was missing and could not be generated",
+                    source.display()
+                );
+            }
             // No primer data file and no working generator. Three cases:
             //   1. published crate / downstream consumer (no script),
             //   2. cross-rs Docker container building Linux release
@@ -89,6 +106,16 @@ fn primer_top() -> usize {
     }
 }
 
+fn version_cap() -> usize {
+    if let Some(cap) = std::env::var_os("AUBE_PRIMER_VERSION_CAP") {
+        return cap
+            .to_string_lossy()
+            .parse()
+            .expect("AUBE_PRIMER_VERSION_CAP must be a positive integer");
+    }
+    DEFAULT_VERSION_CAP
+}
+
 fn generate(manifest_dir: &Path, source: &Path, top: usize) -> bool {
     let workspace = manifest_dir
         .parent()
@@ -102,7 +129,7 @@ fn generate(manifest_dir: &Path, source: &Path, top: usize) -> bool {
         .arg("--top")
         .arg(top.to_string())
         .arg("--versions")
-        .arg(VERSION_CAP.to_string())
+        .arg(version_cap().to_string())
         .arg("--out")
         .arg(&json)
         .status()
@@ -119,14 +146,19 @@ fn generate(manifest_dir: &Path, source: &Path, top: usize) -> bool {
     };
     assert!(status.success(), "scripts/generate-primer.mjs failed");
 
-    let input = std::fs::read(&json).unwrap();
+    compress_json_primer(&json, source);
+    let _ = std::fs::remove_file(json);
+    true
+}
+
+fn compress_json_primer(json: &Path, source: &Path) {
+    let input = std::fs::read(json)
+        .unwrap_or_else(|e| panic!("failed to read primer JSON {}: {e}", json.display()));
     let primer: BTreeMap<String, Seed> = serde_json::from_slice(&input).unwrap();
     let archived = rkyv::to_bytes::<rkyv::rancor::Error>(&primer).unwrap();
     let compressed =
         zstd::stream::encode_all(Cursor::new(archived), primer_compression_level()).unwrap();
     std::fs::write(source, compressed).unwrap();
-    let _ = std::fs::remove_file(json);
-    true
 }
 
 fn write_package_blob(out_dir: &Path, compressed: &[u8]) {
@@ -147,6 +179,9 @@ fn write_package_blob(out_dir: &Path, compressed: &[u8]) {
             index.push((name, offset, len));
         }
     }
+    if primer_required() && index.is_empty() {
+        panic!("metadata primer is required, but the embedded primer is empty");
+    }
     std::fs::write(out_dir.join("primer-packages.bin"), blob).unwrap();
 
     let mut generated =
@@ -157,6 +192,13 @@ fn write_package_blob(out_dir: &Path, compressed: &[u8]) {
     }
     generated.push_str("];\n");
     std::fs::write(out_dir.join("primer_index.rs"), generated).unwrap();
+}
+
+fn primer_required() -> bool {
+    matches!(
+        std::env::var("AUBE_REQUIRE_PRIMER").as_deref(),
+        Ok("1" | "true" | "TRUE" | "yes" | "YES")
+    )
 }
 
 fn primer_compression_level() -> i32 {


### PR DESCRIPTION
## Summary

- generate the release metadata primer on the host before the binary upload action runs
- let the resolver build script consume that generated JSON inside cross builds
- require a non-empty primer for official release builds so empty Linux assets fail before upload

## Root Cause

Linux release artifacts are built through `cross`, where the resolver build script could not run `node scripts/generate-primer.mjs`. The existing fallback intentionally embedded an empty primer, so Linux tarballs were much smaller than macOS and Windows assets.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `actionlint .github/workflows/release.yml`
- `AUBE_PRIMER_TOP=1 AUBE_REQUIRE_PRIMER=1 cargo check -p aube-resolver`
- `cargo test -p aube-resolver`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release pipeline and `aube-resolver` build-time behavior to hard-fail when primer generation/embedding is missing or empty, which could block releases if CI env/paths diverge.
> 
> **Overview**
> Ensures release artifacts embed a non-empty metadata primer by generating the primer JSON in the GitHub release workflow (via Node) before cross/cargo builds, and by passing primer-related env vars into `cross` builds.
> 
> Updates `crates/aube-resolver/build.rs` to support a configurable `AUBE_PRIMER_VERSION_CAP`, to consume a pre-generated `*.rkyv.json` by compressing it into the expected `*.rkyv.zst`, and to enforce `AUBE_REQUIRE_PRIMER` so official builds fail early if the primer is missing or embeds empty data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9056fea9ade5ba7fd5c0f4cd72561dd121af83ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->