### PR TITLE
ci: limit pr benchmarks to release-plz branches

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   bench:
     name: Compare PR performance
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-plz-')
     runs-on: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
     timeout-minutes: 25
     steps:


### PR DESCRIPTION
## Summary

- skip the `pr-bench` benchmark job for ordinary pull request branches
- keep the job active for `release-plz-*` PR branches
- preserve `workflow_dispatch` so benchmarks can still be run manually

## Validation

- `actionlint .github/workflows/bench-pr.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a GitHub Actions job condition to skip expensive benchmarks on most PRs, without altering build/test logic.
> 
> **Overview**
> Limits the `pr-bench` workflow’s `bench` job to run only for manual `workflow_dispatch` runs or PR branches starting with `release-plz-`, skipping benchmark comparisons on ordinary pull requests to reduce CI load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2e840f6ac91b9ca6f716c815999804965ee9d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->