### PR TITLE
fix(docs): banner-aware bottom padding + drop error-code chips

### DIFF
--- a/docs/.vitepress/theme/ErrorCodesTable.vue
+++ b/docs/.vitepress/theme/ErrorCodesTable.vue
@@ -5,7 +5,6 @@
 // first-seen order) and toggles whether to show the Exit column.
 //
 // Search filters by code name + description (case-insensitive).
-// Category chips toggle individual categories on/off; "All" resets.
 // State is purely local to the component — no router updates, no
 // query params, no localStorage. Two of these mount on the same
 // page (one for errors, one for warnings) so cross-component state
@@ -32,27 +31,17 @@ const props = defineProps<{
 }>();
 
 const search = ref("");
-// `null` = all categories shown. A specific string = only that one.
-// We deliberately keep this single-select rather than multi-select:
-// users almost always want either "everything" or "this one
-// category", and a multi-select chip row adds visual noise without
-// a real workflow win.
-const activeCategory = ref<string | null>(null);
 
 const filtered = computed<CodeMeta[]>(() => {
   const needle = search.value.trim().toLowerCase();
-  return props.codes.filter((c) => {
-    if (activeCategory.value && c.category !== activeCategory.value) {
-      return false;
-    }
-    if (!needle) {
-      return true;
-    }
-    return (
+  if (!needle) {
+    return props.codes;
+  }
+  return props.codes.filter(
+    (c) =>
       c.name.toLowerCase().includes(needle) ||
-      c.description.toLowerCase().includes(needle)
-    );
-  });
+      c.description.toLowerCase().includes(needle),
+  );
 });
 
 // Group filtered results by category, preserving the first-seen
@@ -75,10 +64,6 @@ const grouped = computed<Array<{ category: string; rows: CodeMeta[] }>>(
       .filter((g) => g.rows.length > 0);
   },
 );
-
-function setCategory(cat: string | null) {
-  activeCategory.value = cat;
-}
 
 function exitLabel(code: CodeMeta): string {
   // Errors with no bespoke entry fall through to `EXIT_GENERIC = 1`
@@ -103,28 +88,6 @@ function exitLabel(code: CodeMeta): string {
             : 'Filter warning codes by code or description'
         "
       />
-      <div class="error-codes-table__chips" role="tablist">
-        <button
-          type="button"
-          class="error-codes-table__chip"
-          :class="{ 'error-codes-table__chip--active': activeCategory === null }"
-          :aria-pressed="activeCategory === null"
-          @click="setCategory(null)"
-        >
-          All
-        </button>
-        <button
-          v-for="cat in categories"
-          :key="cat"
-          type="button"
-          class="error-codes-table__chip"
-          :class="{ 'error-codes-table__chip--active': activeCategory === cat }"
-          :aria-pressed="activeCategory === cat"
-          @click="setCategory(cat)"
-        >
-          {{ cat }}
-        </button>
-      </div>
     </div>
 
     <p
@@ -251,35 +214,6 @@ function escapeHtml(s: string): string {
 
 .error-codes-table__search:focus {
   outline: none;
-  border-color: var(--vp-c-brand-1);
-}
-
-.error-codes-table__chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-}
-
-.error-codes-table__chip {
-  font-size: 0.825rem;
-  padding: 0.25rem 0.65rem;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 999px;
-  background: var(--vp-c-bg-soft);
-  color: var(--vp-c-text-2);
-  cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
-  font-family: inherit;
-}
-
-.error-codes-table__chip:hover {
-  border-color: var(--vp-c-brand-1);
-  color: var(--vp-c-text-1);
-}
-
-.error-codes-table__chip--active {
-  background: var(--vp-c-brand-1);
-  color: var(--vp-c-bg);
   border-color: var(--vp-c-brand-1);
 }
 

--- a/docs/.vitepress/theme/ErrorCodesTable.vue
+++ b/docs/.vitepress/theme/ErrorCodesTable.vue
@@ -231,7 +231,16 @@ function escapeHtml(s: string): string {
 .error-codes-table__heading {
   font-size: 1.1rem;
   margin: 1.25rem 0 0.5rem;
-  scroll-margin-top: calc(var(--vp-nav-height, 64px) + 1rem);
+  /* Anchor jumps need to clear the same banner+navbar overlay the
+     sticky `top:` above accounts for. Without the
+     `--vp-layout-top-height` term, jumping to a category heading
+     when the jdx-banner is active scrolls the heading text behind
+     the banner — same offset bug, this side. The trailing `1rem`
+     leaves a small visual gap between the navbar's bottom edge and
+     the heading. */
+  scroll-margin-top: calc(
+    var(--vp-layout-top-height, 0px) + var(--vp-nav-height, 64px) + 1rem
+  );
 }
 
 .error-codes-table__table {

--- a/docs/.vitepress/theme/ErrorCodesTable.vue
+++ b/docs/.vitepress/theme/ErrorCodesTable.vue
@@ -194,7 +194,14 @@ function escapeHtml(s: string): string {
   gap: 0.75rem;
   margin-bottom: 1.5rem;
   position: sticky;
-  top: var(--vp-nav-height, 64px);
+  /* Stick just below the fixed banner+navbar overlay. The banner
+     contributes `--vp-layout-top-height` (0 when not rendered);
+     `--vp-nav-height` is the navbar itself. Using only
+     `--vp-nav-height` would tuck the top ~36px of the search input
+     behind the navbar whenever the jdx-banner is active — same
+     class of bug the layout's `padding-bottom` fix in banner.css
+     addresses for the page-bottom side. */
+  top: calc(var(--vp-layout-top-height, 0px) + var(--vp-nav-height, 64px));
   background: var(--vp-c-bg);
   padding: 0.75rem 0;
   z-index: 1;

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -15,6 +15,22 @@
   line-height: 1.4;
   text-align: center;
 }
+
+/* Reserve breathing room at the layout bottom so content near the
+   document bottom (the final H2 / paragraph on a long page) doesn't
+   end up stuck behind the fixed banner + navbar at maxScroll.
+   Without this, the last in-flow content lands at viewport y ≈ 0–100
+   when the user scrolls all the way down — partially covered by the
+   banner-and-navbar overlay. Only kicks in when banner.ts has
+   actually rendered the banner, so doc-layout pages that skip the
+   banner aren't affected. The `:has()` lookup matches the dom shape
+   banner.ts produces (`document.body.prepend(banner)`).
+   --vp-nav-height defaults to 64 (VitePress' navbar) so callers
+   don't need a fallback for the banner-less case if we later relax
+   the gate. */
+body:has(> .jdx-banner) .Layout {
+  padding-bottom: calc(var(--vp-layout-top-height, 0px) + var(--vp-nav-height, 64px));
+}
 .jdx-banner a {
   color: #fff;
   text-decoration: underline;

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -31,6 +31,7 @@
 body:has(> .jdx-banner) .Layout {
   padding-bottom: calc(var(--vp-layout-top-height, 0px) + var(--vp-nav-height, 64px));
 }
+
 .jdx-banner a {
   color: #fff;
   text-decoration: underline;


### PR DESCRIPTION
## Summary

Two fixes to the `/error-codes` page surfaced when scrolling to the bottom with the jdx.dev banner active.

### Banner not pushing content down

When the banner is rendered, the fixed banner (y=0–36) plus VitePress's fixed navbar (y=36–100) overlay the top 100px of the viewport at every scroll position. On `/error-codes`, the last H2 (\"Adding a code\") sits ~65px from the document bottom, so at maxScroll it lands at viewport y≈64 — *inside* the navbar overlay zone, with the top half of the heading text clipped.

The fix: when `body:has(> .jdx-banner)` matches, give `.Layout` `padding-bottom: calc(var(--vp-layout-top-height) + var(--vp-nav-height))`. That extends the document by 100px so the user can scroll the last bit of content above the overlay zone. Gated on the banner being present so doc pages without the banner are unaffected.

### Filter chips removed

The `<ErrorCodesTable>` component shipped with both a free-text search box *and* a row of category chips. The chips were visual noise on top of an already-dense table, and the search box covers \"find a specific code\" without them. Dropped the chip row + its CSS + the `activeCategory` state. The `categories` prop stays — it's still used to preserve declaration-order grouping in the rendered output.

## Test plan

- [x] Locally rebuild docs with `vitepress build`; renders cleanly.
- [x] Inject a fake `.jdx-banner` and `--vp-layout-top-height: 36px` on the locally-served `/error-codes`, scroll to maxScroll: \"Adding a code\" heading is now scrolled past the top of the viewport (y=-35) instead of being clipped behind the navbar at y=64. Footer + prev/next nav visible at bottom with no overlap.
- [x] Confirmed chips are gone from the rendered HTML; search box still functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-only UI/CSS tweaks that adjust scroll/spacing behavior and remove a non-essential filter UI; main risk is minor layout regressions in browsers without `:has()` support.
> 
> **Overview**
> Improves `/error-codes` page behavior when the fixed `jdx-banner` is present by adding banner-aware spacing: `.Layout` gets conditional bottom padding in `banner.css`, and `ErrorCodesTable` updates its sticky controls offset and heading `scroll-margin-top` to account for `--vp-layout-top-height + --vp-nav-height`.
> 
> Simplifies `ErrorCodesTable` filtering by removing the category chip UI and its associated state/CSS, leaving only the free-text search while keeping category grouping order via the `categories` prop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8bc03e749b88beb1233abec8904a767305d315e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->