### PR TITLE
chore(ci): use !cancelled() instead of always() for final job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,9 @@ jobs:
       - windows
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 2
-    if: always()
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
     steps:
       - name: Gate on upstream job results
         env:


### PR DESCRIPTION
## Summary
- Combined with the workflow's `cancel-in-progress` group, `if: always()` overrides cancellation and runs the `final` aggregator even on superseded commits.
- `!cancelled()` still runs on upstream success or failure but skips when the workflow is cancelled — saves a runner and avoids confusing error annotations on already-superseded shas.
- Caught by Cursor Bugbot on a sibling repo (endevco/pitchfork#413). Same `final`-aggregator pattern + `cancel-in-progress: true` here, so the same fix applies.

## Test plan
- [ ] CI passes on this PR
- [ ] Push a follow-up commit to verify the prior workflow run gets cancelled cleanly (final no longer spinning up on superseded commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just prevents the `final` aggregator job from running on cancelled CI runs; it may affect required status reporting only in cancellation scenarios.
> 
> **Overview**
> Updates the CI workflow’s `final` aggregator job to run with `if: ${{ !cancelled() }}` instead of `always()`, so it still gates upstream success/failure but **does not** start when a run is cancelled (e.g., by `cancel-in-progress`). This avoids consuming runners and emitting status annotations on superseded commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae7997c9371f1b28f32312a2ae1e4c0524c5304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->