### PR TITLE
chore: set dev profile debug to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,3 +134,6 @@ aube-manifest = { path = "crates/aube-manifest", version = "1.7.0" }
 aube-scripts = { path = "crates/aube-scripts", version = "1.7.0" }
 aube-workspace = { path = "crates/aube-workspace", version = "1.7.0" }
 aube-util = { path = "crates/aube-util", version = "1.7.0" }
+
+[profile.dev]
+debug = 1


### PR DESCRIPTION
## Summary

Reduces `target/` disk usage by setting `[profile.dev] debug = 1`, while keeping backtrace file:line info intact.

The default `debug = 2` writes full DWARF — including variable/type info that's only needed when stepping through code in a debugger (lldb/gdb). With `debug = 1`, panics, `RUST_BACKTRACE=1`, and error chains still resolve to file:line; only debugger variable inspection is reduced.

In practice this typically shrinks `target/` by a meaningful percentage, which adds up across worktrees.

## Test plan

- [ ] `cargo build` still succeeds
- [ ] CI is green

---
*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only change that affects local/dev artifact size and debugging experience, without changing runtime code paths. Low risk aside from potentially reduced debugger variable/type inspection in dev builds.
> 
> **Overview**
> Updates workspace `Cargo.toml` to set `[profile.dev] debug = 1`, reducing dev-build DWARF/debug info (and typically `target/` disk usage) while keeping basic file/line backtraces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5753fee34c5cf2c4378d5b5b3bd9b02850dc58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->