### PR TITLE
fix(install): handle workspace scripts and pnpm aliases

### DIFF
--- a/crates/aube-lockfile/src/pnpm.rs
+++ b/crates/aube-lockfile/src/pnpm.rs
@@ -501,7 +501,10 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         if packages.contains_key(&alias_dep_path) {
             continue;
         }
-        let Some(real_pkg) = packages.get(&real_dep_path) else {
+        let Some(real_pkg) = packages
+            .get(&real_dep_path)
+            .or_else(|| peerless_alias_target(&packages, &real_dep_path))
+        else {
             return Err(Error::parse(
                 path,
                 format!(
@@ -582,6 +585,10 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
 
 /// Write a LockfileGraph as pnpm-lock.yaml v9 format.
 pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Result<(), Error> {
+    let native_pnpm_aliases = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "pnpm-lock.yaml");
     let mut importers = BTreeMap::new();
     let exclude_links = graph.settings.exclude_links_from_lockfile;
     for (importer_path, deps) in &graph.importers {
@@ -637,6 +644,11 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 .and_then(|p| p.local_source.as_ref())
             {
                 local.specifier()
+            } else if native_pnpm_aliases
+                && let Some(pkg) = graph.packages.get(&dep.dep_path)
+                && let Some(real_name) = pkg.alias_of.as_deref()
+            {
+                format!("{real_name}@{}", dep_path_tail(&dep.dep_path, &dep.name))
             } else {
                 dep.dep_path
                     .strip_prefix(&format!("{}@", dep.name))
@@ -728,15 +740,20 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         let canonical = match pkg.local_source.as_ref() {
             Some(LocalSource::Link(_)) => continue,
             Some(local) => format!("{}@{}", pkg.name, local.specifier()),
-            None if url_keyed => {
-                // Strip any peer suffix; the packages section keys the
-                // canonical form (no peer contexts), the snapshots
-                // section keys the full dep_path.
-                let (name, version) = parse_dep_path(&pkg.dep_path)
-                    .unwrap_or_else(|| (pkg.name.clone(), pkg.version.clone()));
-                format!("{name}@{version}")
+            None => {
+                if native_pnpm_aliases && let Some(real_name) = pkg.alias_of.as_deref() {
+                    version_to_dep_path(real_name, &pkg.version)
+                } else if url_keyed {
+                    // Strip any peer suffix; the packages section keys the
+                    // canonical form (no peer contexts), the snapshots
+                    // section keys the full dep_path.
+                    let (name, version) = parse_dep_path(&pkg.dep_path)
+                        .unwrap_or_else(|| (pkg.name.clone(), pkg.version.clone()));
+                    format!("{name}@{version}")
+                } else {
+                    version_to_dep_path(&pkg.name, &pkg.version)
+                }
             }
-            None => version_to_dep_path(&pkg.name, &pkg.version),
         };
         let peer_deps = if pkg.peer_dependencies.is_empty() {
             None
@@ -875,11 +892,9 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 has_bin: !pkg.bin.is_empty(),
                 peer_dependencies: peer_deps,
                 peer_dependencies_meta: peer_meta,
-                // Preserve the alias→real-name mapping so a subsequent
-                // install from this lockfile still hits the real
-                // registry instead of re-404ing on the alias-qualified
-                // tarball URL.
-                alias_of: pkg.alias_of.clone(),
+                alias_of: (!native_pnpm_aliases)
+                    .then(|| pkg.alias_of.clone())
+                    .flatten(),
             },
         );
     }
@@ -893,12 +908,23 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
     let rewrite_local_deps = |deps: BTreeMap<String, String>| -> BTreeMap<String, String> {
         deps.into_iter()
             .map(|(name, value)| {
-                let dp = format!("{name}@{value}");
-                if let Some(target) = graph.packages.get(&dp)
+                let dp = version_to_dep_path(&name, &value);
+                if let Some(target) = graph
+                    .packages
+                    .get(&dp)
+                    .or_else(|| graph.packages.get(&peerless_dep_path(&name, &value)))
                     && let Some(ref local) = target.local_source
                     && !matches!(local, LocalSource::Link(_))
                 {
                     (name, local.specifier())
+                } else if native_pnpm_aliases
+                    && let Some(target) = graph
+                        .packages
+                        .get(&dp)
+                        .or_else(|| graph.packages.get(&peerless_dep_path(&name, &value)))
+                    && let Some(real_name) = target.alias_of.as_deref()
+                {
+                    (name, format!("{real_name}@{value}"))
                 } else {
                     (name, value)
                 }
@@ -913,7 +939,13 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         let key = match pkg.local_source.as_ref() {
             Some(LocalSource::Link(_)) => continue,
             Some(local) => format!("{}@{}", pkg.name, local.specifier()),
-            None => dep_path.clone(),
+            None => {
+                if native_pnpm_aliases && let Some(real_name) = pkg.alias_of.as_deref() {
+                    format!("{real_name}@{}", dep_path_tail(dep_path, &pkg.name))
+                } else {
+                    dep_path.clone()
+                }
+            }
         };
         let pkg_deps = rewrite_local_deps(pkg.dependencies.clone());
         let pkg_opt_deps = rewrite_local_deps(pkg.optional_dependencies.clone());
@@ -1126,6 +1158,24 @@ fn reformat_for_pnpm_parity(yaml: &str) -> String {
 
 fn version_to_dep_path(name: &str, version: &str) -> String {
     format!("{name}@{version}")
+}
+
+fn dep_path_tail<'a>(dep_path: &'a str, name: &str) -> &'a str {
+    dep_path
+        .strip_prefix(&format!("{name}@"))
+        .unwrap_or(dep_path)
+}
+
+fn peerless_dep_path(name: &str, value: &str) -> String {
+    version_to_dep_path(name, value.split('(').next().unwrap_or(value))
+}
+
+fn peerless_alias_target<'a>(
+    packages: &'a BTreeMap<String, LockedPackage>,
+    real_dep_path: &str,
+) -> Option<&'a LockedPackage> {
+    let (real_name, real_version) = parse_dep_path(real_dep_path)?;
+    packages.get(&version_to_dep_path(&real_name, &real_version))
 }
 
 /// Parse a dep path like "@scope/name@1.0.0" or "name@1.0.0" into (name, version).
@@ -3406,6 +3456,79 @@ snapshots:
             reparsed.skipped_optional_dependencies["."]["optional-native"],
             "^1.0.0"
         );
+    }
+
+    #[test]
+    fn write_pnpm_lockfile_uses_native_alias_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        let manifest = PackageJson {
+            name: Some("alias-native-pnpm".to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: [("odd-alias".to_string(), "npm:is-odd@3.0.1".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let graph = LockfileGraph {
+            importers: [(
+                ".".to_string(),
+                vec![DirectDep {
+                    name: "odd-alias".to_string(),
+                    dep_path: "odd-alias@3.0.1".to_string(),
+                    dep_type: DepType::Production,
+                    specifier: Some("npm:is-odd@3.0.1".to_string()),
+                }],
+            )]
+            .into_iter()
+            .collect(),
+            packages: [
+                (
+                    "odd-alias@3.0.1".to_string(),
+                    LockedPackage {
+                        name: "odd-alias".to_string(),
+                        version: "3.0.1".to_string(),
+                        integrity: Some("sha512-odd".to_string()),
+                        dep_path: "odd-alias@3.0.1".to_string(),
+                        alias_of: Some("is-odd".to_string()),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "consumer@1.0.0".to_string(),
+                    LockedPackage {
+                        name: "consumer".to_string(),
+                        version: "1.0.0".to_string(),
+                        integrity: Some("sha512-consumer".to_string()),
+                        dep_path: "consumer@1.0.0".to_string(),
+                        dependencies: [(
+                            "odd-alias".to_string(),
+                            "3.0.1(peer-host@1.0.0)".to_string(),
+                        )]
+                        .into_iter()
+                        .collect(),
+                        ..Default::default()
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+
+        write(&path, &graph, &manifest).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("version: is-odd@3.0.1"), "{written}");
+        assert!(written.contains("is-odd@3.0.1:"), "{written}");
+        assert!(
+            written.contains("odd-alias: is-odd@3.0.1(peer-host@1.0.0)"),
+            "{written}"
+        );
+        assert!(!written.contains("aliasOf:"), "{written}");
+
+        let reparsed = parse(&path).unwrap();
+        let alias_pkg = reparsed.packages.get("odd-alias@3.0.1").unwrap();
+        assert_eq!(alias_pkg.alias_of.as_deref(), Some("is-odd"));
     }
 
     #[test]

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -58,17 +58,39 @@ pub(crate) fn build_policy_from_sources(
     aube_scripts::BuildPolicy,
     Vec<aube_scripts::BuildPolicyError>,
 ) {
-    let mut merged = manifest.pnpm_allow_builds();
+    build_policy_from_manifest_sources(
+        std::iter::once(manifest),
+        workspace,
+        dangerously_allow_all_builds,
+    )
+}
+
+pub(crate) fn build_policy_from_manifest_sources<'a>(
+    manifests: impl IntoIterator<Item = &'a aube_manifest::PackageJson>,
+    workspace: &aube_manifest::WorkspaceConfig,
+    dangerously_allow_all_builds: bool,
+) -> (
+    aube_scripts::BuildPolicy,
+    Vec<aube_scripts::BuildPolicyError>,
+) {
+    let mut merged = std::collections::BTreeMap::new();
+    let mut only_built = Vec::new();
+    let mut never_built = Vec::new();
+    for manifest in manifests {
+        for (pattern, allow) in manifest.pnpm_allow_builds() {
+            merged
+                .entry(pattern)
+                .and_modify(|existing| merge_allow_build(existing, allow.clone()))
+                .or_insert(allow);
+        }
+        only_built.extend(manifest.pnpm_only_built_dependencies());
+        only_built.extend(manifest.trusted_dependencies());
+        never_built.extend(manifest.pnpm_never_built_dependencies());
+    }
     for (k, v) in workspace.allow_builds_raw() {
         merged.insert(k, v);
     }
-    let mut only_built = manifest.pnpm_only_built_dependencies();
     only_built.extend(workspace.only_built_dependencies.iter().cloned());
-    // Bun's top-level `trustedDependencies` feeds the same allowlist so
-    // bun projects migrating to aube keep running their install scripts
-    // without moving the list under `pnpm.onlyBuiltDependencies` first.
-    only_built.extend(manifest.trusted_dependencies());
-    let mut never_built = manifest.pnpm_never_built_dependencies();
     never_built.extend(workspace.never_built_dependencies.iter().cloned());
     aube_scripts::BuildPolicy::from_config(
         &merged,
@@ -76,6 +98,19 @@ pub(crate) fn build_policy_from_sources(
         &never_built,
         dangerously_allow_all_builds,
     )
+}
+
+fn merge_allow_build(
+    existing: &mut aube_manifest::AllowBuildRaw,
+    next: aube_manifest::AllowBuildRaw,
+) {
+    use aube_manifest::AllowBuildRaw;
+    match (&*existing, next) {
+        (AllowBuildRaw::Bool(false), _) | (_, AllowBuildRaw::Bool(true)) => {}
+        (_, AllowBuildRaw::Bool(false)) => *existing = AllowBuildRaw::Bool(false),
+        (AllowBuildRaw::Bool(true), other) => *existing = other,
+        (AllowBuildRaw::Other(_), AllowBuildRaw::Other(_)) => {}
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -792,4 +827,43 @@ pub(super) fn unreviewed_dep_builds(
     unreviewed.sort();
     unreviewed.dedup();
     Ok(unreviewed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn member_allow_build_conflict_denies() {
+        let allow_manifest = manifest_with_allow_build("native-dep", true);
+        let deny_manifest = manifest_with_allow_build("native-dep", false);
+        let workspace = aube_manifest::WorkspaceConfig::default();
+        let (policy, warnings) = build_policy_from_manifest_sources(
+            [&allow_manifest, &deny_manifest],
+            &workspace,
+            false,
+        );
+
+        assert!(warnings.is_empty());
+        assert_eq!(
+            policy.decide("native-dep", "1.0.0"),
+            aube_scripts::AllowDecision::Deny
+        );
+    }
+
+    fn manifest_with_allow_build(name: &str, allow: bool) -> aube_manifest::PackageJson {
+        let mut pnpm = serde_json::Map::new();
+        let mut allow_builds = serde_json::Map::new();
+        allow_builds.insert(name.to_string(), serde_json::Value::Bool(allow));
+        pnpm.insert(
+            "allowBuilds".to_string(),
+            serde_json::Value::Object(allow_builds),
+        );
+
+        let mut manifest = aube_manifest::PackageJson::default();
+        manifest
+            .extra
+            .insert("pnpm".to_string(), serde_json::Value::Object(pnpm));
+        manifest
+    }
 }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -23,7 +23,10 @@ use bin_linking::{link_bin_entries, link_bins, link_bins_for_dep};
 pub use dep_selection::DepSelection;
 pub use frozen::{FrozenMode, FrozenOverride, GlobalVirtualStoreFlags};
 use git_prepare::{prepare_scratch_copy, run_git_dep_prepare};
-pub(crate) use lifecycle::{JailBuildPolicy, build_policy_from_sources, run_dep_lifecycle_scripts};
+pub(crate) use lifecycle::{
+    JailBuildPolicy, build_policy_from_manifest_sources, build_policy_from_sources,
+    run_dep_lifecycle_scripts,
+};
 use lifecycle::{
     import_verified_tarball_streamed, resolve_link_strategy, run_root_lifecycle,
     unreviewed_dep_builds, validate_required_scripts,
@@ -1802,34 +1805,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // read-side encoding agrees with what the linker actually wrote.
     let virtual_store_dir_max_length = super::resolve_virtual_store_dir_max_length(&settings_ctx);
 
-    // 1b. Root `preinstall` lifecycle hook.
-    //     Runs before anything touches the dep graph, matching pnpm/npm.
-    //     Runs before the progress UI is started so script stdout can't
-    //     collide with the progress display. Skipped when --ignore-scripts
-    //     is set, under --lockfile-only, or with enableModulesDir=false
-    //     (both imply "no node_modules touched, so lifecycle scripts
-    //     have nothing to gate"). Dependency scripts are always
-    //     skipped.
-    if !opts.ignore_scripts && !lockfile_only_effective && !opts.skip_root_lifecycle {
-        let phase_start = std::time::Instant::now();
-        run_root_lifecycle(
-            &cwd,
-            &modules_dir_name,
-            &manifest,
-            aube_scripts::LifecycleHook::PreInstall,
-        )
-        .await?;
-        phase_timings.record("root_preinstall", phase_start.elapsed());
-    }
-
-    // Progress UI. `None` on non-TTY stderr, in text mode (e.g. `-v`), or
-    // when progress output is otherwise disabled. A normal install produces
-    // *no* output other than the bar itself — everything else is tracing at
-    // debug level, visible with `aube -v install`. Must be constructed after
-    // any lifecycle script that writes to stderr.
-    let prog = InstallProgress::try_new();
-    let prog_ref = prog.as_ref();
-
     // 2. Detect workspace
     let workspace_packages = aube_workspace::find_workspace_packages(&cwd)
         .into_diagnostic()
@@ -1895,6 +1870,46 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             }
         }
     }
+
+    let lifecycle_manifests: Vec<(String, aube_manifest::PackageJson)> =
+        if has_workspace && link_all_workspace_importers {
+            order_lifecycle_manifests(
+                manifests
+                    .iter()
+                    .filter(|(importer, _)| aube_linker::is_physical_importer(importer))
+                    .cloned()
+                    .collect(),
+            )
+        } else {
+            vec![(".".to_string(), manifest.clone())]
+        };
+
+    // 1b. Project `preinstall` lifecycle hooks.
+    //     Workspace installs run the hook for every physical importer
+    //     that will be linked, matching pnpm's recursive install
+    //     behavior. Runs before the progress UI starts so script output
+    //     cannot collide with the progress display.
+    if !opts.ignore_scripts && !lockfile_only_effective && !opts.skip_root_lifecycle {
+        let phase_start = std::time::Instant::now();
+        for (importer_path, importer_manifest) in &lifecycle_manifests {
+            let project_dir = importer_project_dir(&cwd, importer_path);
+            run_root_lifecycle(
+                &project_dir,
+                &modules_dir_name,
+                importer_manifest,
+                aube_scripts::LifecycleHook::PreInstall,
+            )
+            .await?;
+        }
+        phase_timings.record("root_preinstall", phase_start.elapsed());
+    }
+    // Progress UI. `None` on non-TTY stderr, in text mode (e.g. `-v`), or
+    // when progress output is otherwise disabled. A normal install produces
+    // *no* output other than the bar itself — everything else is tracing at
+    // debug level, visible with `aube -v install`. Must be constructed after
+    // any lifecycle script that writes to stderr.
+    let prog = InstallProgress::try_new();
+    let prog_ref = prog.as_ref();
 
     // Auto-disable the global virtual store when any importer depends
     // on a package listed in `disableGlobalVirtualStoreForPackages`
@@ -3518,8 +3533,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         virtual_store_dir_max_length,
     )?;
 
-    let (build_policy, policy_warnings) = build_policy_from_sources(
-        &manifest,
+    let (build_policy, policy_warnings) = build_policy_from_manifest_sources(
+        lifecycle_manifests.iter().map(|(_, manifest)| manifest),
         &ws_config_shared,
         opts.dangerously_allow_all_builds,
     );
@@ -3988,12 +4003,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     //     A hook that exits non-zero fails the install (fail-fast, matching pnpm).
     if !opts.ignore_scripts && !virtual_store_only && !opts.skip_root_lifecycle {
         let phase_start = std::time::Instant::now();
-        for hook in [
-            aube_scripts::LifecycleHook::Install,
-            aube_scripts::LifecycleHook::PostInstall,
-            aube_scripts::LifecycleHook::Prepare,
-        ] {
-            run_root_lifecycle(&cwd, &modules_dir_name, &manifest, hook).await?;
+        for (importer_path, importer_manifest) in &lifecycle_manifests {
+            let project_dir = importer_project_dir(&cwd, importer_path);
+            for hook in [
+                aube_scripts::LifecycleHook::Install,
+                aube_scripts::LifecycleHook::PostInstall,
+                aube_scripts::LifecycleHook::Prepare,
+            ] {
+                run_root_lifecycle(&project_dir, &modules_dir_name, importer_manifest, hook)
+                    .await?;
+            }
         }
         phase_timings.record("root_lifecycle", phase_start.elapsed());
     }
@@ -4646,6 +4665,101 @@ fn filter_graph_to_workspace_selection(
     Ok(filtered.filter_deps(|_| true))
 }
 
+fn importer_project_dir(
+    workspace_root: &std::path::Path,
+    importer_path: &str,
+) -> std::path::PathBuf {
+    if importer_path == "." {
+        workspace_root.to_path_buf()
+    } else {
+        workspace_root.join(importer_path)
+    }
+}
+
+fn order_lifecycle_manifests(
+    manifests: Vec<(String, aube_manifest::PackageJson)>,
+) -> Vec<(String, aube_manifest::PackageJson)> {
+    if manifests.len() < 2 {
+        return manifests;
+    }
+
+    let importer_index: std::collections::HashMap<&str, usize> = manifests
+        .iter()
+        .enumerate()
+        .map(|(idx, (importer, _))| (importer.as_str(), idx))
+        .collect();
+    let workspace_name_to_importer: std::collections::HashMap<&str, &str> = manifests
+        .iter()
+        .filter_map(|(importer, manifest)| {
+            manifest
+                .name
+                .as_deref()
+                .map(|name| (name, importer.as_str()))
+        })
+        .collect();
+
+    let mut edges = vec![Vec::<usize>::new(); manifests.len()];
+    let mut indegree = vec![0usize; manifests.len()];
+    for (dependent_idx, (dependent_importer, manifest)) in manifests.iter().enumerate() {
+        for dep_name in manifest
+            .dependencies
+            .keys()
+            .chain(manifest.dev_dependencies.keys())
+            .chain(manifest.optional_dependencies.keys())
+        {
+            let Some(dependency_importer) = workspace_name_to_importer.get(dep_name.as_str())
+            else {
+                continue;
+            };
+            if *dependency_importer == dependent_importer {
+                continue;
+            }
+            let Some(&dependency_idx) = importer_index.get(dependency_importer) else {
+                continue;
+            };
+            if !edges[dependency_idx].contains(&dependent_idx) {
+                edges[dependency_idx].push(dependent_idx);
+                indegree[dependent_idx] += 1;
+            }
+        }
+    }
+
+    let mut ready: std::collections::VecDeque<usize> = indegree
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, degree)| (*degree == 0).then_some(idx))
+        .collect();
+    let mut ordered = Vec::with_capacity(manifests.len());
+    let mut emitted = vec![false; manifests.len()];
+    while let Some(idx) = ready.pop_front() {
+        if emitted[idx] {
+            continue;
+        }
+        emitted[idx] = true;
+        ordered.push(idx);
+        for &dependent_idx in &edges[idx] {
+            indegree[dependent_idx] -= 1;
+            if indegree[dependent_idx] == 0 {
+                ready.push_back(dependent_idx);
+            }
+        }
+    }
+    for (idx, is_emitted) in emitted.iter().enumerate() {
+        if !is_emitted {
+            ordered.push(idx);
+        }
+    }
+
+    let mut manifests = manifests
+        .into_iter()
+        .map(Some)
+        .collect::<Vec<Option<(String, aube_manifest::PackageJson)>>>();
+    ordered
+        .into_iter()
+        .filter_map(|idx| manifests[idx].take())
+        .collect()
+}
+
 /// Write one lockfile per non-root workspace importer when
 /// `sharedWorkspaceLockfile=false` is set. Each lockfile contains
 /// only the importer's own deps (remapped to `.`) plus the transitive
@@ -4711,7 +4825,7 @@ fn filter_graph_to_importers<const N: usize>(
 
 #[cfg(test)]
 mod allow_build_review_tests {
-    use super::package_name_from_spec_key;
+    use super::{order_lifecycle_manifests, package_name_from_spec_key};
 
     #[test]
     fn package_name_from_spec_key_handles_scoped_names() {
@@ -4723,6 +4837,39 @@ mod allow_build_review_tests {
     fn package_name_from_spec_key_handles_unscoped_names() {
         assert_eq!(package_name_from_spec_key("esbuild@1.2.3"), "esbuild");
         assert_eq!(package_name_from_spec_key("esbuild"), "esbuild");
+    }
+
+    #[test]
+    fn lifecycle_manifests_follow_workspace_dependency_order() {
+        let ordered = order_lifecycle_manifests(vec![
+            (".".to_string(), named_manifest("root")),
+            (
+                "packages/app".to_string(),
+                manifest_with_dep("app", "@scope/lib"),
+            ),
+            ("packages/lib".to_string(), named_manifest("@scope/lib")),
+        ]);
+        let importers = ordered
+            .iter()
+            .map(|(importer, _)| importer.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(importers, [".", "packages/lib", "packages/app"]);
+    }
+
+    fn named_manifest(name: &str) -> aube_manifest::PackageJson {
+        aube_manifest::PackageJson {
+            name: Some(name.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn manifest_with_dep(name: &str, dep: &str) -> aube_manifest::PackageJson {
+        let mut manifest = named_manifest(name);
+        manifest
+            .dependencies
+            .insert(dep.to_string(), "workspace:*".to_string());
+        manifest
     }
 }
 

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -71,6 +71,73 @@ post
 prepare"
 }
 
+@test "workspace install runs member postinstall hooks after member deps are linked" {
+	cat >package.json <<'JSON'
+{
+  "name": "workspace-lifecycle-root",
+  "version": "1.0.0"
+}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	mkdir -p packages/app
+	cat >packages/app/package.json <<'JSON'
+{
+  "name": "workspace-lifecycle-app",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node -e 'require(\"is-odd\"); require(\"fs\").writeFileSync(\"postinstall.marker\", \"ran\")'"
+  },
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}
+JSON
+	run aube install
+	assert_success
+	assert_file_exists packages/app/postinstall.marker
+}
+
+@test "workspace member onlyBuiltDependencies allows member dep postinstall" {
+	cat >package.json <<'JSON'
+{
+  "name": "workspace-build-policy-root",
+  "version": "1.0.0"
+}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	mkdir -p packages/app/dep-with-build
+	cat >packages/app/dep-with-build/package.json <<'JSON'
+{
+  "name": "member-dep-with-build",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node -e 'require(\"fs\").writeFileSync(\"built.marker\", \"ran\")'"
+  }
+}
+JSON
+	cat >packages/app/package.json <<'JSON'
+{
+  "name": "workspace-build-policy-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "member-dep-with-build": "file:./dep-with-build"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["member-dep-with-build"]
+  }
+}
+JSON
+	run aube install
+	assert_success
+	assert_file_exists packages/app/node_modules/member-dep-with-build/built.marker
+}
+
 @test "requiredScripts enforces root package scripts" {
 	cat >.npmrc <<'EOF'
 requiredScripts=build,test


### PR DESCRIPTION
## Summary

- Run workspace importer lifecycle hooks during recursive workspace installs, not just root hooks.
- Merge build-script allowlists from linked workspace manifests so member `onlyBuiltDependencies` can approve their dependency builds.
- Write `pnpm-lock.yaml` npm aliases in pnpm's native shape while keeping `aube-lock.yaml`'s internal `aliasOf` round-trip.

## Root Cause

`aube install` collected all workspace importers for resolution/linking, but lifecycle execution and build policy construction still used only the root manifest. The pnpm writer also reused aube's internal alias metadata in `pnpm-lock.yaml`, which produced extra `aliasOf` fields instead of pnpm's native `<real>@<version>` alias encoding.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-lockfile write_pnpm_lockfile_uses_native_alias_shape -- --nocapture`
- `cargo test -p aube-lockfile npm_alias -- --nocapture`
- `mise run test:bats test/lifecycle_scripts.bats --filter 'workspace install runs member postinstall hooks|workspace member onlyBuiltDependencies'`
- `mise run test:bats test/install.bats --filter 'npm-alias'`
- `cargo clippy -p aube -p aube-lockfile --all-targets -- -D warnings`

Note: the full `test/lifecycle_scripts.bats` file still has two unrelated existing/environment failures in this checkout: `dep postinstall can invoke a transitive-dep bin by bare name` and the registry-backed `aube add --allow-build=<pkg> writes to workspace root under --filter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes installation-time lifecycle execution and build-policy merging across workspace members, which can affect which scripts run (and in what order) during workspace installs. Also changes `pnpm-lock.yaml` alias serialization, which could impact lockfile round-trips and dependency resolution if edge cases were missed.
> 
> **Overview**
> During recursive/workspace installs, `aube install` now runs project lifecycle hooks (`preinstall`/`install`/`postinstall`/`prepare`) for each linked workspace importer (in dependency order) instead of only the workspace root, and it builds the dependency build-script policy by merging `pnpm.allowBuilds`/`onlyBuiltDependencies`/`neverBuiltDependencies` across all participating manifests (with deny winning on conflicts).
> 
> `pnpm-lock.yaml` writing now emits npm aliases in pnpm’s *native* encoding (alias `version:` points at `<real>@<resolved>` and lockfile keys/snapshots use the real package name), while keeping aube’s internal `aliasOf` metadata for non-`pnpm-lock.yaml` outputs; parsing is hardened to resolve alias targets even when peer suffixes are present. Adds targeted Rust unit tests plus Bats integration tests covering workspace lifecycle execution and member `onlyBuiltDependencies` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 570182959c64e5e1cf464abc6c91a6454468167c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->