### PR TITLE
feat(progress): redesign install progress UI

### DIFF
--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -79,6 +79,9 @@ pub const WARN_AUBE_LOCKFILE_MERGE_CONFLICT: &str = "WARN_AUBE_LOCKFILE_MERGE_CO
 pub const WARN_AUBE_LOCKFILE_MERGE_CLEANUP_FAILED: &str = "WARN_AUBE_LOCKFILE_MERGE_CLEANUP_FAILED";
 pub const WARN_AUBE_YARN_BERRY_UNSUPPORTED: &str = "WARN_AUBE_YARN_BERRY_UNSUPPORTED";
 
+// ── progress UI ─────────────────────────────────────────────────────
+pub const WARN_AUBE_PROGRESS_OVERFLOW: &str = "WARN_AUBE_PROGRESS_OVERFLOW";
+
 /// Stable category labels that group codes in the generated docs.
 /// Public so the docs generator can iterate them deterministically.
 pub mod category {
@@ -93,6 +96,7 @@ pub mod category {
     pub const REGISTRY_TLS: &str = "Registry TLS / proxy";
     pub const RESOLVER: &str = "Resolver";
     pub const LOCKFILE: &str = "Lockfile";
+    pub const PROGRESS_UI: &str = "Progress UI";
 }
 
 /// Registry of every warning code with its category and description.
@@ -408,6 +412,13 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_YARN_BERRY_UNSUPPORTED,
         category: category::LOCKFILE,
         description: "A Yarn Berry `patch:` / `portal:` / `exec:` protocol — or any unrecognized protocol — was found in `yarn.lock`. Entry was skipped.",
+        exit_code: None,
+    },
+    // Progress UI
+    CodeMeta {
+        name: WARN_AUBE_PROGRESS_OVERFLOW,
+        category: category::PROGRESS_UI,
+        description: "Install progress numerator exceeded the resolved-package denominator. Display clamps to total; the warning surfaces the bookkeeping mismatch so the underlying race can be diagnosed.",
         exit_code: None,
     },
 ];

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -206,6 +206,12 @@ pub struct Dist {
     pub tarball: String,
     pub integrity: Option<String>,
     pub shasum: Option<String>,
+    /// Unpacked tarball size in bytes (`dist.unpackedSize`). Present
+    /// on most modern packuments, absent on older ones — used as the
+    /// best-effort install-size estimate that the progress bar shows
+    /// as `4.2 MB / ~13.8 MB`. Decimal MB to match every other PM.
+    #[serde(default, rename = "unpackedSize")]
+    pub unpacked_size: Option<u64>,
     /// Sigstore attestations block. The trust-policy check reads
     /// `dist.attestations.provenance` as rank-1 trust evidence when
     /// it is an object with an SLSA provenance `predicateType`. aube

--- a/crates/aube-resolver/src/primer.rs
+++ b/crates/aube-resolver/src/primer.rs
@@ -118,6 +118,7 @@ impl PrimerDist {
             tarball: self.tarball.clone(),
             integrity: self.integrity.clone(),
             shasum: self.shasum.clone(),
+            unpacked_size: None,
             attestations: self.provenance.then(|| Attestations {
                 provenance: Some(serde_json::json!({
                     "predicateType": "https://slsa.dev/provenance/v1"

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -886,6 +886,7 @@ impl Resolver {
                                     cpu: aube_lockfile::PlatformList::new(),
                                     libc: aube_lockfile::PlatformList::new(),
                                     deprecated: None,
+                                    unpacked_size: None,
                                 })
                                 .await;
                         }
@@ -1155,6 +1156,15 @@ impl Resolver {
                                         // packuments live for the
                                         // after-the-fact view.
                                         deprecated: None,
+                                        // Same reasoning: lockfile reuse
+                                        // doesn't refetch the packument and
+                                        // LockedPackage doesn't carry size
+                                        // metadata, so the size-estimate
+                                        // segment stays absent for these
+                                        // packages. The progress UI displays
+                                        // a running download total instead
+                                        // when the estimate is unavailable.
+                                        unpacked_size: None,
                                     })
                                     .await;
                             }
@@ -1648,6 +1658,7 @@ impl Resolver {
                             cpu: version_meta.cpu.iter().cloned().collect(),
                             libc: version_meta.libc.iter().cloned().collect(),
                             deprecated: deprecated_msg.clone(),
+                            unpacked_size: version_meta.dist.as_ref().and_then(|d| d.unpacked_size),
                         })
                         .await;
                 }

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -579,6 +579,7 @@ fn make_version(name: &str, version: &str) -> VersionMetadata {
             tarball: format!("https://registry.npmjs.org/{name}/-/{name}-{version}.tgz"),
             integrity: Some(format!("sha512-fake-{name}-{version}")),
             shasum: None,
+            unpacked_size: None,
             attestations: None,
         }),
         os: vec![],

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -501,6 +501,7 @@ mod tests {
                 tarball: format!("https://r/{name}/-/{name}-{ver}.tgz"),
                 integrity: None,
                 shasum: None,
+                unpacked_size: None,
                 attestations: None,
             }),
             os: vec![],

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -182,6 +182,12 @@ pub struct ResolvedPackage {
     /// suppression is applied upstream, so anything set here is meant
     /// to surface to the user.
     pub deprecated: Option<Arc<str>>,
+    /// Best-effort install-size hint from the packument's
+    /// `dist.unpackedSize`. Summed across the resolve stream to drive
+    /// the `4.2 MB / ~13.8 MB` segment in the progress bar. `None`
+    /// when the packument doesn't carry the field (older publishes,
+    /// `file:`/`link:` deps, JSR packages without npm metadata).
+    pub unpacked_size: Option<u64>,
 }
 
 impl ResolvedPackage {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2723,6 +2723,26 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             },
                         );
                     }
+                    // Each resolved package bumps the overall denominator by
+                    // one. Cached packages are immediately credited against
+                    // the numerator; missing ones get a transient child row.
+                    //
+                    // Bumping the denominator *before* the platform-deferred
+                    // skip below is intentional: the catch-up pass (after
+                    // `filter_graph`) credits surviving deferred packages
+                    // against the numerator, and skipping the increment
+                    // here would let the numerator overrun the denominator
+                    // (the historical "2/1 packages" display bug). The
+                    // overcount on dropped optionals is reconciled by a
+                    // single `set_total(graph.packages.len())` after
+                    // `filter_graph` runs.
+                    if let Some(p) = fetch_progress.as_ref() {
+                        p.inc_total(1);
+                        if let Some(sz) = pkg.unpacked_size {
+                            p.inc_estimated_bytes(sz);
+                        }
+                    }
+
                     // Defer platform-mismatched registry packages to
                     // the post-filter_graph catch-up pass: almost all
                     // of them are optional natives that `filter_graph`
@@ -2745,13 +2765,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             pkg.version
                         );
                         continue;
-                    }
-
-                    // Each resolved package bumps the overall denominator by
-                    // one. Cached packages are immediately credited against
-                    // the numerator; missing ones get a transient child row.
-                    if let Some(p) = fetch_progress.as_ref() {
-                        p.inc_total(1);
                     }
 
                     // Local (`file:` / `link:`) deps materialize from
@@ -3339,6 +3352,18 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 &install_supported_architectures,
                 &install_ignored_optional,
             );
+
+            // Reconcile the progress denominator. The streaming pass
+            // bumped `inc_total` once per *resolved* package; `filter_graph`
+            // just dropped the platform-mismatched optionals, so the
+            // denominator now overcounts by the number of culled entries
+            // and the bar would otherwise stick well below 100%
+            // (historical "stays at 90%" bug). Resetting to the surviving
+            // graph size produces a stable cur/total ratio for the
+            // remaining fetch + link work.
+            if let Some(p) = prog_ref {
+                p.set_total(graph.packages.len());
+            }
 
             // Catch-up fetch: the streaming coordinator deferred
             // platform-mismatched registry tarballs on the assumption

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -4470,19 +4470,15 @@ fn print_already_up_to_date() {
     }
     use clx::style;
     use std::io::Write;
-    // Only the check mark is green — same shape as the
-    // `print_install_summary` no-op branch so the two sites stay
-    // visually consistent across the install code paths that emit
-    // this line.
-    let line = format!(
-        "{} {} {} {} {} {}",
-        style::emagenta("aube").bold(),
-        style::edim(crate::version::VERSION.as_str()),
-        style::edim("by en.dev"),
-        style::edim("·"),
+    // Routed through the shared `aube_prefix_line` helper so this
+    // site and `print_install_summary`'s no-op branch can't drift —
+    // both produce `aube VERSION by en.dev · ✓ Already up to date`.
+    let msg = format!(
+        "{} {}",
         style::egreen("✓").bold(),
         style::ebold("Already up to date"),
     );
+    let line = crate::progress::aube_prefix_line(&msg);
     let _ = writeln!(std::io::stderr(), "{line}");
 }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2739,7 +2739,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     if let Some(p) = fetch_progress.as_ref() {
                         p.inc_total(1);
                         if let Some(sz) = pkg.unpacked_size {
-                            p.inc_estimated_bytes(sz);
+                            p.inc_estimated_bytes(&pkg.dep_path, sz);
                         }
                     }
 
@@ -3353,16 +3353,19 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 &install_ignored_optional,
             );
 
-            // Reconcile the progress denominator. The streaming pass
-            // bumped `inc_total` once per *resolved* package; `filter_graph`
-            // just dropped the platform-mismatched optionals, so the
-            // denominator now overcounts by the number of culled entries
-            // and the bar would otherwise stick well below 100%
-            // (historical "stays at 90%" bug). Resetting to the surviving
-            // graph size produces a stable cur/total ratio for the
-            // remaining fetch + link work.
+            // Reconcile the progress denominator and the running
+            // estimated-download total. The streaming pass bumped
+            // `inc_total` once per *resolved* package and recorded
+            // each `unpacked_size`; `filter_graph` just dropped the
+            // platform-mismatched optionals, so both totals overcount
+            // by the culled entries (the historical "stays at 90%"
+            // and over-inflated `~X MB` segments). Resetting against
+            // the surviving graph produces a stable cur/total ratio
+            // and a size estimate that reflects only what will
+            // actually install.
             if let Some(p) = prog_ref {
                 p.set_total(graph.packages.len());
+                p.reconcile_estimated_bytes(graph.packages.keys());
             }
 
             // Catch-up fetch: the streaming coordinator deferred
@@ -4467,13 +4470,18 @@ fn print_already_up_to_date() {
     }
     use clx::style;
     use std::io::Write;
+    // Only the check mark is green — same shape as the
+    // `print_install_summary` no-op branch so the two sites stay
+    // visually consistent across the install code paths that emit
+    // this line.
     let line = format!(
-        "{} {} {} {} {}",
+        "{} {} {} {} {} {}",
         style::emagenta("aube").bold(),
         style::edim(crate::version::VERSION.as_str()),
         style::edim("by en.dev"),
         style::edim("·"),
-        style::egreen("Already up to date").bold(),
+        style::egreen("✓").bold(),
+        style::ebold("Already up to date"),
     );
     let _ = writeln!(std::io::stderr(), "{line}");
 }

--- a/crates/aube/src/progress/ci.rs
+++ b/crates/aube/src/progress/ci.rs
@@ -1,13 +1,14 @@
-//! CI-mode progress: append-only `Progress:` line on a ~2s heartbeat,
-//! plus a framed header and final summary. No spinners, no child rows,
-//! no redraws — shape safe for GitHub Actions / plain pipes, where
-//! cursor-control escapes get stripped and each animation frame would
-//! otherwise land as its own log line.
+//! CI-mode progress: append-only line on a ~2s heartbeat with a
+//! left-aligned bar and stats on the right. No spinners, no child
+//! rows, no redraws — shape safe for GitHub Actions / plain pipes,
+//! where cursor-control escapes get stripped and each animation frame
+//! would otherwise land as its own log line.
 //!
-//! `CiState` owns the heartbeat thread; callers in `super` poke atomic
-//! counters (`resolved`, `reused`, `downloaded`, `downloaded_bytes`) and
-//! the heartbeat renders from those snapshots. See `super::InstallProgress`
-//! for how TTY vs CI is selected and how these counters are updated.
+//! `CiState` owns the heartbeat thread; callers in `super` poke
+//! atomic counters (`resolved`, `reused`, `downloaded`,
+//! `downloaded_bytes`, `estimated_bytes`) and the heartbeat renders
+//! from those snapshots. See `super::InstallProgress` for how TTY vs
+//! CI is selected and how these counters are updated.
 
 use clx::style;
 use std::io::Write;
@@ -19,7 +20,7 @@ use std::time::{Duration, Instant};
 /// How often the CI heartbeat thread wakes to check whether to print a
 /// progress line. Kept long enough that a 142-package fetch produces a
 /// handful of lines, not a flood.
-const CI_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
+pub(super) const CI_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Fallback width used when the terminal size can't be detected and
 /// `$COLUMNS` isn't set. 80 is the historical terminal default and
@@ -34,20 +35,33 @@ const MIN_BAR_WIDTH: usize = 40;
 /// 200-column bar that the CI log viewer wraps awkwardly.
 const MAX_BAR_WIDTH: usize = 120;
 
+/// Width of the standalone progress bar in CI mode. Small on purpose:
+/// the bar is an indicator, the numbers next to it carry the precise
+/// state. Wider bars dominate narrow terminals and waste columns the
+/// rate / ETA segments need.
+const CI_BAR_WIDTH: usize = 15;
+
 /// CI-mode shared state. Owns the heartbeat thread.
 ///
-/// The status line has three moving parts: a phase counter (`[N/3]`
-/// where 1=resolving, 2=fetching, 3=linking), the byte total for
-/// downloaded tarballs, and an ASCII bar for `completed / resolved`
-/// (where completed = reused + downloaded). One line, same shape each
-/// time — reprinted only when something actually changed since the
-/// previous line.
+/// The status line has a fixed-width bar followed by a label that
+/// adapts to the current phase: in `resolving` it shows "N pkgs ·
+/// resolving · ETA …"; in `fetching` it shows
+/// "cur/total pkgs · downloaded[/ ~estimated] · rate · ETA"; in
+/// `linking` the rate / ETA segments drop out and the word "linking"
+/// takes their place. Reprinted only when the rendered string
+/// actually changes since the previous line.
 pub(super) struct CiState {
     phase: AtomicUsize,
     pub(super) resolved: AtomicUsize,
     pub(super) reused: AtomicUsize,
     pub(super) downloaded: AtomicUsize,
     pub(super) downloaded_bytes: AtomicU64,
+    /// Running sum of `dist.unpackedSize` from packuments seen during
+    /// the streaming resolve. `0` until the first packument with the
+    /// field arrives, and stays `0` on the lockfile fast path (where
+    /// no packument fetch happens). The display gates the
+    /// `/ ~13.8 MB` estimated-total segment on this being non-zero.
+    pub(super) estimated_bytes: AtomicU64,
     start: Instant,
     /// Captured the first time `set_phase("fetching")` is called. Used
     /// as the denominator for the transfer rate so it measures network
@@ -61,10 +75,10 @@ pub(super) struct CiState {
     /// bucket, or a phase change when phase isn't in the render — stay
     /// quiet instead of reprinting an identical line.
     last_printed: Mutex<String>,
-    /// Whether the heartbeat has ever emitted the header + a progress
-    /// line. Stays `false` for fast installs that finish before the
-    /// first 2s tick — those stay completely silent, including in the
-    /// final summary.
+    /// Whether the heartbeat has ever emitted a progress line. Stays
+    /// `false` for fast installs that finish before the first 2s tick
+    /// — `print_install_summary` then takes the no-bar single-line
+    /// fast-mode path instead of writing a final framed bar.
     pub(super) shown: AtomicBool,
     done: AtomicBool,
     /// Live `InstallProgress` clone count. Incremented in `Clone`,
@@ -73,7 +87,10 @@ pub(super) struct CiState {
     /// because the heartbeat thread owns its own strong `Arc<CiState>`
     /// for the entire run.
     pub(super) alive: AtomicUsize,
-    /// Signals the heartbeat thread to wake early (phase change / stop).
+    /// Signals the heartbeat thread to wake early on shutdown. Phase
+    /// transitions deliberately do *not* wake the heartbeat — letting
+    /// every phase change punch through the 2s gate would flood the
+    /// log with one extra line per phase on every fast install.
     wake: Condvar,
     wake_lock: Mutex<()>,
     /// The heartbeat thread's join handle, taken by `stop()` so the
@@ -109,6 +126,7 @@ impl CiState {
             reused: AtomicUsize::new(0),
             downloaded: AtomicUsize::new(0),
             downloaded_bytes: AtomicU64::new(0),
+            estimated_bytes: AtomicU64::new(0),
             start: Instant::now(),
             fetch_start: OnceLock::new(),
             last_printed: Mutex::new(String::new()),
@@ -121,7 +139,7 @@ impl CiState {
         }
     }
 
-    fn snapshot(&self) -> (usize, usize, usize, usize, u64, u64, u64) {
+    fn snapshot(&self) -> Snap {
         // `fetch_elapsed_ms` is 0 until fetching has started, and
         // frozen at the elapsed-so-far value once it does — so after
         // fetching ends the rate no longer decays, and before it
@@ -131,59 +149,32 @@ impl CiState {
             .get()
             .map(|t| t.elapsed().as_millis() as u64)
             .unwrap_or(0);
-        (
-            self.phase.load(Ordering::Relaxed),
-            self.resolved.load(Ordering::Relaxed),
-            self.reused.load(Ordering::Relaxed),
-            self.downloaded.load(Ordering::Relaxed),
-            self.downloaded_bytes.load(Ordering::Relaxed),
-            self.start.elapsed().as_millis() as u64,
+        Snap {
+            phase: self.phase.load(Ordering::Relaxed),
+            resolved: self.resolved.load(Ordering::Relaxed),
+            reused: self.reused.load(Ordering::Relaxed),
+            downloaded: self.downloaded.load(Ordering::Relaxed),
+            bytes: self.downloaded_bytes.load(Ordering::Relaxed),
+            estimated: self.estimated_bytes.load(Ordering::Relaxed),
+            elapsed_ms: self.start.elapsed().as_millis() as u64,
             fetch_elapsed_ms,
-        )
+        }
     }
 
-    fn render(snap: (usize, usize, usize, usize, u64, u64, u64)) -> String {
-        let (phase, resolved, reused, downloaded, bytes, elapsed_ms, fetch_elapsed_ms) = snap;
-        let completed = reused + downloaded;
-        let phase_str = if phase > 0 {
-            format!(" [{phase}/3]")
-        } else {
-            String::new()
-        };
-        // Only show transfer rate during the fetching phase, and only when
-        // at least one byte has landed. Before fetch starts it's always 0;
-        // after fetch finishes it becomes stale (decaying toward 0 as
-        // elapsed grows with no new bytes). Gating to phase == 2 keeps it
-        // meaningful. Denominator is `fetch_elapsed_ms` (time since the
-        // fetching transition), not total install time — otherwise
-        // multi-second resolves would deflate the displayed rate.
-        let rate_str = if phase == 2 && bytes > 0 && fetch_elapsed_ms > 0 {
-            let rate = bytes.saturating_mul(1000) / fetch_elapsed_ms;
-            format!(" · {}/s", format_bytes(rate))
-        } else {
-            String::new()
-        };
-        let elapsed_str = format!(" · {}", format_duration(Duration::from_millis(elapsed_ms)));
-        let label = format!(
-            "{completed}/{resolved} pkgs{phase_str} · {}{rate_str}{elapsed_str}",
-            format_bytes(bytes)
-        );
-        render_bar_with_label(completed, resolved, term_width(), &label)
+    fn render(snap: Snap) -> String {
+        super::render::progress_line(snap, term_width(), CI_BAR_WIDTH)
     }
 
-    /// Framed header line. Emitted once, on the first heartbeat tick
-    /// where there's something to show — so the CI log only grows an
-    /// aube banner when an install is actually happening. Styling
-    /// routes through `style::e*`, so `NO_COLOR` / `--no-color` drops
-    /// the ANSI escapes automatically.
+    /// Render the one-line header banner that prints once above the
+    /// first heartbeat-emitted progress line. Plain whitespace
+    /// alignment, no frame: `aube VERSION by en.dev`.
     fn render_header() -> String {
-        let header_text = format!(
+        format!(
             "{} {} {}",
             style::emagenta("aube").bold(),
             style::edim(crate::version::VERSION.as_str()),
             style::edim("by en.dev"),
-        );
-        render_centered_line(&header_text, term_width())
+        )
     }
 
     pub(super) fn spawn_heartbeat(state: &Arc<Self>) {
@@ -211,12 +202,15 @@ impl CiState {
                 let snap = state.snapshot();
                 // Don't make noise until an install is actually underway.
                 // Until then there's nothing to bar-graph and no reason to
-                // print the aube header — a no-op install should remain
+                // print anything — a no-op install should remain
                 // completely silent.
-                if snap.1 == 0 {
+                if snap.resolved == 0 || snap.phase == 0 {
                     continue;
                 }
                 let line = Self::render(snap);
+                if line.is_empty() {
+                    continue;
+                }
                 let mut last = state.last_printed.lock().unwrap();
                 if *last == line {
                     // Same rendered line as before — stay quiet.
@@ -224,8 +218,10 @@ impl CiState {
                 }
                 *last = line.clone();
                 drop(last);
-                // First time we actually print, emit the framed header
-                // above the bar so the CI log shows the aube banner.
+                // First time we actually print, emit the unframed
+                // `aube VERSION by en.dev` header above the bar so
+                // the CI log shows the aube banner. Only printed
+                // once per install — `shown` flips true here.
                 if !state.shown.swap(true, Ordering::Relaxed) {
                     let _ = writeln!(std::io::stderr(), "{}", Self::render_header());
                 }
@@ -237,7 +233,8 @@ impl CiState {
 
     pub(super) fn set_phase(&self, phase: &str) {
         // Map the free-form phase label from `install::run` onto the fixed
-        // `[N/3]` counter. Unknown labels leave the counter alone.
+        // 1=resolving / 2=fetching / 3=linking counter. Unknown labels
+        // leave the counter alone.
         let n = match phase {
             "resolving" => 1,
             "fetching" => 2,
@@ -249,17 +246,20 @@ impl CiState {
             // happen but defend against it) doesn't reset the rate window.
             let _ = self.fetch_start.set(Instant::now());
         }
-        if self.phase.swap(n, Ordering::Relaxed) != n {
-            self.wake.notify_all();
-        }
+        self.phase.store(n, Ordering::Relaxed);
+        // Phase transitions deliberately do *not* notify the heartbeat:
+        // a sub-2s install runs through resolving → fetching → linking
+        // in tens of milliseconds, and waking the heartbeat on every
+        // transition would defeat the fast-mode quiet path. The next
+        // natural 2s tick (or `stop()`) picks up the new phase.
     }
 
     /// Stop the heartbeat and (optionally) write the final summary.
     ///
-    /// Crucially, we `join()` the heartbeat thread *before* writing the
-    /// `Done in …` line so there's no race where a heartbeat tick lands
-    /// after the summary. Idempotent via `done.swap`: the second caller
-    /// (Drop after explicit `finish()`, etc.) finds `done == true` and
+    /// We `join()` the heartbeat thread *before* writing the summary
+    /// line so there's no race where a heartbeat tick lands after the
+    /// summary. Idempotent via `done.swap`: the second caller (Drop
+    /// after explicit `finish()`, etc.) finds `done == true` and
     /// returns without doing anything.
     pub(super) fn stop(&self, print_summary: bool) {
         if self.done.swap(true, Ordering::Relaxed) {
@@ -273,8 +273,9 @@ impl CiState {
             return;
         }
         // If the heartbeat never printed anything (fast install, no-op,
-        // or error before the first tick), stay completely silent — no
-        // header, no final bar, no summary.
+        // or error before the first tick), stay completely silent — the
+        // separate `print_install_summary` call writes the single-line
+        // fast-mode summary.
         if !self.shown.load(Ordering::Relaxed) {
             return;
         }
@@ -282,39 +283,59 @@ impl CiState {
         // taking two separate snapshots would let a concurrent
         // `FetchRow::drop` land between them and desync the numbers.
         let snap = self.snapshot();
-        // Emit one final bar so CI logs end on a complete snapshot even
-        // if the last heartbeat was skipped (fast install, or the last
-        // tarball landed between ticks).
-        let line = Self::render(snap);
-        let mut last = self.last_printed.lock().unwrap();
-        if *last != line {
-            *last = line.clone();
-            drop(last);
-            let _ = writeln!(std::io::stderr(), "{line}");
+        // Emit one final bar so CI logs end on a complete snapshot
+        // even when the last heartbeat was skipped (fast fetch+link
+        // between ticks). Skipped if it would duplicate the previous
+        // line.
+        let final_bar = Self::render(snap);
+        if !final_bar.is_empty() {
+            let mut last = self.last_printed.lock().unwrap();
+            if *last != final_bar {
+                *last = final_bar.clone();
+                drop(last);
+                let _ = writeln!(std::io::stderr(), "{final_bar}");
+            }
         }
         // Final stats line: elapsed time plus the full resolve / reuse /
-        // download breakdown, framed in the same `[ ]` block as the
-        // header and the progress bar so the three lines read as one
-        // coherent unit. Each segment is labeled so the numbers are
-        // self-describing in a CI log weeks later without needing
-        // context about aube's vocabulary.
-        let (_phase, resolved, reused, downloaded, bytes, _elapsed_ms, _fetch_elapsed_ms) = snap;
+        // download breakdown, color-styled so the green check stands
+        // out against the dim text of the timing. No `aube` prefix —
+        // the header line above already identified the install.
+        // Drops the `downloaded N (X B)` segment entirely when nothing
+        // was downloaded (warm cache); same with the parenthesized
+        // byte count when the download count itself is non-zero but
+        // the byte total is — `0 B` is just noise.
         let elapsed = self.start.elapsed();
-        let summary = format!(
-            "{} {} · resolved {} · reused {} · downloaded {} ({})",
-            style::egreen("✓"),
-            style::edim(format_duration(elapsed)),
-            resolved,
-            reused,
-            downloaded,
-            format_bytes(bytes),
+        let mut summary = format!(
+            "{} resolved {} · reused {}",
+            style::egreen("✓").bold(),
+            style::ebold(snap.resolved),
+            style::ebold(snap.reused),
         );
-        let _ = writeln!(
-            std::io::stderr(),
-            "{}",
-            render_centered_line(&summary, term_width()),
-        );
+        if snap.downloaded > 0 || snap.bytes > 0 {
+            summary.push_str(&format!(" · downloaded {}", style::ebold(snap.downloaded)));
+            if snap.bytes > 0 {
+                summary.push_str(&format!(
+                    " ({})",
+                    style::edim(super::render::format_bytes(snap.bytes))
+                ));
+            }
+        }
+        summary.push_str(&format!(" in {}", style::edim(format_duration(elapsed))));
+        let _ = writeln!(std::io::stderr(), "{summary}");
     }
+}
+
+/// Snapshot of the atomic counters at one heartbeat tick.
+#[derive(Clone, Copy)]
+pub(super) struct Snap {
+    pub(super) phase: usize,
+    pub(super) resolved: usize,
+    pub(super) reused: usize,
+    pub(super) downloaded: usize,
+    pub(super) bytes: u64,
+    pub(super) estimated: u64,
+    pub(super) elapsed_ms: u64,
+    pub(super) fetch_elapsed_ms: u64,
 }
 
 /// Format an elapsed duration compactly: sub-second → `240ms`,
@@ -329,85 +350,5 @@ pub(super) fn format_duration(d: Duration) -> String {
     } else {
         let total = d.as_secs();
         format!("{}m{:02}s", total / 60, total % 60)
-    }
-}
-
-/// Render a plain-text line centered inside the same `[ ]` bracket
-/// frame as the progress bar. Used for the header and the final
-/// summary so all three lines share one consistent visual block.
-///
-/// `text` may contain ANSI escape sequences (for colored / dim /
-/// bold styling); width is measured with `console::measure_text_width`
-/// so escapes are excluded from the layout math. Text longer than the
-/// inner width is returned as-is inside the brackets with no padding.
-pub(super) fn render_centered_line(text: &str, outer_width: usize) -> String {
-    let outer_width = outer_width.max(MIN_BAR_WIDTH);
-    let inner_width = outer_width.saturating_sub(2);
-    let text_width = console::measure_text_width(text);
-    if text_width >= inner_width {
-        return format!("[{text}]");
-    }
-    let pad = inner_width - text_width;
-    let left = pad / 2;
-    let right = pad - left;
-    format!("[{}{text}{}]", " ".repeat(left), " ".repeat(right))
-}
-
-/// Render a progress bar of `outer_width` characters with a label
-/// centered inside it. The bar fills from the left with `#` up to
-/// `current / total`, pads with `-`, and overlays `label` across the
-/// middle positions — so the text stays visible whether the cursor is
-/// in the filled or unfilled region.
-///
-/// Output shape (outer_width=60, 40% complete):
-///   `[########################  183/239 pkgs · 13.8 MB  -----------]`
-fn render_bar_with_label(current: usize, total: usize, outer_width: usize, label: &str) -> String {
-    let outer_width = outer_width.max(MIN_BAR_WIDTH);
-    // Two slots for the enclosing brackets.
-    let inner_width = outer_width.saturating_sub(2);
-    // Pad the label with a space on each side so it doesn't butt up
-    // against the fill / empty characters — makes the text legible
-    // inside a dense `#` run.
-    let padded = format!(" {label} ");
-    let padded_chars: Vec<char> = padded.chars().collect();
-    let label_len = padded_chars.len().min(inner_width);
-    let label_start = inner_width.saturating_sub(label_len) / 2;
-    let label_end = label_start + label_len;
-
-    let filled = current
-        .checked_mul(inner_width)
-        .and_then(|value| value.checked_div(total))
-        .unwrap_or(0)
-        .min(inner_width);
-
-    let mut body = String::with_capacity(inner_width);
-    for i in 0..inner_width {
-        if i >= label_start && i < label_end {
-            body.push(padded_chars[i - label_start]);
-        } else if i < filled {
-            body.push('#');
-        } else {
-            body.push('-');
-        }
-    }
-    format!("[{body}]")
-}
-
-/// Format a byte count using the same SI units pnpm / npm show: `B`, `kB`,
-/// `MB`, `GB`. Decimal (1000-based) because that's what every package
-/// manager uses for on-the-wire sizes — closer to what the registry
-/// `Content-Length` reports.
-pub(super) fn format_bytes(bytes: u64) -> String {
-    const KB: u64 = 1_000;
-    const MB: u64 = 1_000_000;
-    const GB: u64 = 1_000_000_000;
-    if bytes >= GB {
-        format!("{:.1} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.1} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.0} kB", bytes as f64 / KB as f64)
-    } else {
-        format!("{bytes} B")
     }
 }

--- a/crates/aube/src/progress/ci.rs
+++ b/crates/aube/src/progress/ci.rs
@@ -62,6 +62,13 @@ pub(super) struct CiState {
     /// no packument fetch happens). The display gates the
     /// `/ ~13.8 MB` estimated-total segment on this being non-zero.
     pub(super) estimated_bytes: AtomicU64,
+    /// Snapshot of `reused + downloaded` at the moment
+    /// `set_phase("fetching")` first fires. Used as the baseline for
+    /// the fetch-window ETA so the displayed estimate reflects
+    /// per-package throughput *during fetching*, not the inflated
+    /// install-elapsed denominator that includes lockfile parse and
+    /// resolve time. `usize::MAX` sentinel = "not captured yet".
+    completed_at_fetch_start: AtomicUsize,
     start: Instant,
     /// Captured the first time `set_phase("fetching")` is called. Used
     /// as the denominator for the transfer rate so it measures network
@@ -127,6 +134,7 @@ impl CiState {
             downloaded: AtomicUsize::new(0),
             downloaded_bytes: AtomicU64::new(0),
             estimated_bytes: AtomicU64::new(0),
+            completed_at_fetch_start: AtomicUsize::new(usize::MAX),
             start: Instant::now(),
             fetch_start: OnceLock::new(),
             last_printed: Mutex::new(String::new()),
@@ -149,6 +157,7 @@ impl CiState {
             .get()
             .map(|t| t.elapsed().as_millis() as u64)
             .unwrap_or(0);
+        let baseline = self.completed_at_fetch_start.load(Ordering::Relaxed);
         Snap {
             phase: self.phase.load(Ordering::Relaxed),
             resolved: self.resolved.load(Ordering::Relaxed),
@@ -156,8 +165,15 @@ impl CiState {
             downloaded: self.downloaded.load(Ordering::Relaxed),
             bytes: self.downloaded_bytes.load(Ordering::Relaxed),
             estimated: self.estimated_bytes.load(Ordering::Relaxed),
-            elapsed_ms: self.start.elapsed().as_millis() as u64,
             fetch_elapsed_ms,
+            // `usize::MAX` means the baseline hasn't been captured yet
+            // (still pre-fetching). Render layer treats that as
+            // "ETA …" rather than computing against a missing baseline.
+            completed_at_fetch_start: if baseline == usize::MAX {
+                None
+            } else {
+                Some(baseline)
+            },
         }
     }
 
@@ -245,6 +261,18 @@ impl CiState {
             // First-writer-wins; a second "fetching" transition (shouldn't
             // happen but defend against it) doesn't reset the rate window.
             let _ = self.fetch_start.set(Instant::now());
+            // Capture the completion baseline for the fetch-window ETA.
+            // `compare_exchange` so a duplicate phase=2 transition doesn't
+            // overwrite the original snapshot (matches `fetch_start` first-
+            // writer-wins semantics).
+            let completed =
+                self.reused.load(Ordering::Relaxed) + self.downloaded.load(Ordering::Relaxed);
+            let _ = self.completed_at_fetch_start.compare_exchange(
+                usize::MAX,
+                completed,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
         }
         self.phase.store(n, Ordering::Relaxed);
         // Phase transitions deliberately do *not* notify the heartbeat:
@@ -334,8 +362,11 @@ pub(super) struct Snap {
     pub(super) downloaded: usize,
     pub(super) bytes: u64,
     pub(super) estimated: u64,
-    pub(super) elapsed_ms: u64,
     pub(super) fetch_elapsed_ms: u64,
+    /// Numerator (`reused + downloaded`) at the moment fetching
+    /// started. `None` until phase=2 first fires; render layer falls
+    /// back to `ETA …` while it's missing.
+    pub(super) completed_at_fetch_start: Option<usize>,
 }
 
 /// Format an elapsed duration compactly: sub-second → `240ms`,

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -54,7 +54,7 @@ fn overflow_fetch_label(count: usize) -> String {
 /// header used by the no-op and fast-mode summaries. Centralizes the
 /// header shape so the install-finished, already-up-to-date, and
 /// fast-mode-summary paths all read consistently.
-fn aube_prefix_line(msg: &str) -> String {
+pub(crate) fn aube_prefix_line(msg: &str) -> String {
     format!(
         "{} {} {} {} {msg}",
         style::emagenta("aube").bold(),
@@ -283,20 +283,33 @@ impl InstallProgress {
     /// packument lacks the field.
     pub fn inc_estimated_bytes(&self, dep_path: &str, bytes: u64) {
         // Streaming resolver should only see each dep_path once, but
-        // `insert` is the right semantics either way: a duplicate stream
-        // would correctly overwrite, never double-count.
-        self.unpacked_sizes
+        // a defensive duplicate stream would otherwise have the map
+        // overwrite cleanly while the atomic running total
+        // double-counts (the next `reconcile_estimated_bytes` would
+        // re-sync from the map, but the bar would display an
+        // inflated estimate in the meantime). Add only the *delta*
+        // between the new value and any prior recorded value, so the
+        // atomic stays in lockstep with the map.
+        let prior = self
+            .unpacked_sizes
             .lock()
             .unwrap()
-            .insert(dep_path.to_string(), bytes);
+            .insert(dep_path.to_string(), bytes)
+            .unwrap_or(0);
         match &self.mode {
             Mode::Tty {
                 estimated_bytes, ..
             } => {
+                if prior > 0 {
+                    estimated_bytes.fetch_sub(prior, Ordering::Relaxed);
+                }
                 estimated_bytes.fetch_add(bytes, Ordering::Relaxed);
                 self.refresh_bytes_segment();
             }
             Mode::Ci(s) => {
+                if prior > 0 {
+                    s.estimated_bytes.fetch_sub(prior, Ordering::Relaxed);
+                }
                 s.estimated_bytes.fetch_add(bytes, Ordering::Relaxed);
             }
         }

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -32,6 +32,7 @@ use clx::progress::{
     ProgressJob, ProgressJobBuilder, ProgressJobDoneBehavior, ProgressOutput, ProgressStatus,
 };
 use clx::style;
+use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
@@ -66,6 +67,16 @@ fn aube_prefix_line(msg: &str) -> String {
 /// Install-time progress UI. Cheap to clone (internally `Arc`).
 pub struct InstallProgress {
     mode: Mode,
+    /// Per-dep_path `unpacked_size` values captured during streaming
+    /// resolve. The running `estimated_bytes` total is the sum, but
+    /// `filter_graph` later prunes platform-mismatched optionals from
+    /// `graph.packages` — leaving that pruned size still folded into
+    /// the estimate would overstate the `~13.8 MB` segment. The post-
+    /// `filter_graph` reconcile walks the surviving dep_paths through
+    /// this map and resets the estimate to the survivors' sum. `Mutex`
+    /// is fine: the streaming pass is the only writer and the
+    /// reconcile reads once at the phase boundary.
+    unpacked_sizes: Arc<Mutex<HashMap<String, u64>>>,
 }
 
 #[derive(Clone)]
@@ -100,9 +111,13 @@ enum Mode {
         /// measures the fetch window only, not `bytes / (resolve_time +
         /// fetch_time)`.
         fetch_start: Arc<OnceLock<Instant>>,
-        /// Wall-clock start of the install, used by `eta` recomputation
-        /// to derive elapsed time without re-querying clx.
-        install_start: Arc<Instant>,
+        /// Snapshot of `reused + downloaded` at the moment
+        /// `set_phase("fetching")` first fires. Used as the baseline
+        /// for the fetch-window ETA so the displayed estimate
+        /// reflects per-package throughput *during fetching*, not the
+        /// install-elapsed denominator. `usize::MAX` sentinel = "not
+        /// captured yet"; render falls back to `ETA …`.
+        completed_at_fetch_start: Arc<AtomicUsize>,
         /// Bounded visible-fetch-row bookkeeping. `visible` is the count
         /// of live per-package child rows (capped at
         /// `TTY_MAX_VISIBLE_FETCH_ROWS`); `overflow` is the count of
@@ -131,6 +146,7 @@ impl Clone for InstallProgress {
         }
         Self {
             mode: self.mode.clone(),
+            unpacked_sizes: self.unpacked_sizes.clone(),
         }
     }
 }
@@ -200,13 +216,14 @@ impl InstallProgress {
                 downloaded_bytes: Arc::new(AtomicU64::new(0)),
                 estimated_bytes: Arc::new(AtomicU64::new(0)),
                 fetch_start: Arc::new(OnceLock::new()),
-                install_start: Arc::new(Instant::now()),
+                completed_at_fetch_start: Arc::new(AtomicUsize::new(usize::MAX)),
                 fetch_state: Arc::new(Mutex::new(FetchState {
                     visible: 0,
                     overflow: 0,
                     overflow_row: None,
                 })),
             },
+            unpacked_sizes: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -220,6 +237,7 @@ impl InstallProgress {
         CiState::spawn_heartbeat(&state);
         Self {
             mode: Mode::Ci(state),
+            unpacked_sizes: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -251,21 +269,67 @@ impl InstallProgress {
         }
     }
 
-    /// Add `n` bytes to the running estimated-total-download counter.
-    /// Fed from `dist.unpackedSize` as resolver streams in packuments.
-    /// Surfaces in the bar's `bytes` segment as the `/ ~13.8 MB`
-    /// suffix so users have a sense of total install scope before the
-    /// fetch finishes. No-op when the packument lacks the field.
-    pub fn inc_estimated_bytes(&self, n: u64) {
+    /// Add `bytes` to the running estimated-total-download counter
+    /// and record the per-`dep_path` contribution. Fed from
+    /// `dist.unpackedSize` as resolver streams in packuments;
+    /// surfaces as the `/ ~13.8 MB` suffix on the bytes segment so
+    /// users have a sense of total install scope before the fetch
+    /// finishes.
+    ///
+    /// The `dep_path` map lets [`reconcile_estimated_bytes`] later
+    /// subtract platform-mismatched optionals that `filter_graph`
+    /// drops, so the displayed estimate doesn't overstate the install
+    /// size by the dropped-optionals' unpacked sizes. No-op when the
+    /// packument lacks the field.
+    pub fn inc_estimated_bytes(&self, dep_path: &str, bytes: u64) {
+        // Streaming resolver should only see each dep_path once, but
+        // `insert` is the right semantics either way: a duplicate stream
+        // would correctly overwrite, never double-count.
+        self.unpacked_sizes
+            .lock()
+            .unwrap()
+            .insert(dep_path.to_string(), bytes);
         match &self.mode {
             Mode::Tty {
                 estimated_bytes, ..
             } => {
-                estimated_bytes.fetch_add(n, Ordering::Relaxed);
+                estimated_bytes.fetch_add(bytes, Ordering::Relaxed);
                 self.refresh_bytes_segment();
             }
             Mode::Ci(s) => {
-                s.estimated_bytes.fetch_add(n, Ordering::Relaxed);
+                s.estimated_bytes.fetch_add(bytes, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Recompute the estimated-total-download from the surviving set
+    /// of dep_paths after `filter_graph` has pruned the resolver
+    /// graph. Called from `install::run` once filtering completes —
+    /// the running sum from `inc_estimated_bytes` includes platform-
+    /// mismatched optionals that `filter_graph` just dropped, and
+    /// without this reconcile the `~X MB` segment would overcount by
+    /// their cumulative size. Mirrors the `set_total(graph.packages.len())`
+    /// reconcile applied to the package denominator at the same site.
+    pub fn reconcile_estimated_bytes<I, S>(&self, surviving_dep_paths: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let map = self.unpacked_sizes.lock().unwrap();
+        let sum: u64 = surviving_dep_paths
+            .into_iter()
+            .filter_map(|k| map.get(k.as_ref()).copied())
+            .sum();
+        drop(map);
+        match &self.mode {
+            Mode::Tty {
+                estimated_bytes, ..
+            } => {
+                estimated_bytes.store(sum, Ordering::Relaxed);
+                self.refresh_bytes_segment();
+            }
+            Mode::Ci(s) => {
+                s.estimated_bytes.store(sum, Ordering::Relaxed);
             }
         }
     }
@@ -278,6 +342,9 @@ impl InstallProgress {
                 root,
                 phase_num,
                 fetch_start,
+                reused,
+                downloaded,
+                completed_at_fetch_start,
                 ..
             } => {
                 if phase.is_empty() {
@@ -301,6 +368,19 @@ impl InstallProgress {
                     // Seed the rate denominator on the fetching transition.
                     // First-writer-wins; repeated calls are no-ops.
                     let _ = fetch_start.set(Instant::now());
+                    // Capture the completion baseline so the ETA divides
+                    // remaining work by *fetch-window* throughput, not by
+                    // total install elapsed (which would inflate the
+                    // estimate when resolve was slow). `compare_exchange`
+                    // matches `fetch_start` first-writer-wins.
+                    let baseline =
+                        reused.load(Ordering::Relaxed) + downloaded.load(Ordering::Relaxed);
+                    let _ = completed_at_fetch_start.compare_exchange(
+                        usize::MAX,
+                        baseline,
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                    );
                 } else if n == 3 {
                     // Linking phase: rate / ETA aren't meaningful — the
                     // network's done, the linker work is dominated by
@@ -349,6 +429,13 @@ impl InstallProgress {
                 downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
                 self.refresh_bytes_segment();
                 self.refresh_rate();
+                // The package counter that drives ETA only changes via
+                // `inc_reused` and `FetchRow::drop`, but bytes landing
+                // is the strongest signal that fetch-window throughput
+                // is still alive — refresh ETA on every byte event so
+                // it keeps ticking down through long-lived downloads
+                // even when no new package completion has fired.
+                self.refresh_eta();
             }
             Mode::Ci(s) => {
                 s.downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
@@ -374,7 +461,12 @@ impl InstallProgress {
             return;
         };
         let bytes = downloaded_bytes.load(Ordering::Relaxed);
-        let estimated = estimated_bytes.load(Ordering::Relaxed);
+        // `estimated_bytes` is the raw `unpackedSize` sum; convert to
+        // the same compressed-tarball units that `bytes` is in so the
+        // `/ ~13.8 MB` segment compares apples-to-apples. CI mode
+        // does the same conversion inside its render path.
+        let estimated_unpacked = estimated_bytes.load(Ordering::Relaxed);
+        let estimated = render::estimated_download_bytes(estimated_unpacked);
         let phase = phase_num.load(Ordering::Relaxed);
         // The bytes segment only carries useful information from
         // fetching onward. Hide it in resolving — there's nothing
@@ -439,7 +531,11 @@ impl InstallProgress {
     }
 
     /// TTY-only: rebuild the `eta` prop. `ETA …` while we don't have
-    /// enough data to extrapolate; `ETA Xs` once we do.
+    /// enough fetch-window data to extrapolate; `ETA Xs` once we do.
+    /// Mirrors the CI render's eta_segment logic: divides remaining
+    /// work by fetch-window throughput (`completed - baseline / fetch_elapsed_ms`)
+    /// instead of total install elapsed, so a slow resolve doesn't
+    /// inflate the early-fetching estimate.
     fn refresh_eta(&self) {
         let Mode::Tty {
             root,
@@ -447,7 +543,8 @@ impl InstallProgress {
             reused,
             downloaded,
             phase_num,
-            install_start,
+            fetch_start,
+            completed_at_fetch_start,
             ..
         } = &self.mode
         else {
@@ -463,13 +560,24 @@ impl InstallProgress {
         let total_n = total.load(Ordering::Relaxed);
         let completed =
             (reused.load(Ordering::Relaxed) + downloaded.load(Ordering::Relaxed)).min(total_n);
-        let elapsed_ms = install_start.elapsed().as_millis() as u64;
-        if completed == 0 || completed >= total_n || total_n == 0 || elapsed_ms == 0 {
-            root.prop("eta", &format!(" · {}", style::edim("ETA …")));
+        let baseline = completed_at_fetch_start.load(Ordering::Relaxed);
+        let placeholder = || root.prop("eta", &format!(" · {}", style::edim("ETA …")));
+        if completed >= total_n || total_n == 0 || baseline == usize::MAX {
+            placeholder();
+            return;
+        }
+        let Some(start) = fetch_start.get() else {
+            placeholder();
+            return;
+        };
+        let fetch_elapsed_ms = start.elapsed().as_millis() as u64;
+        let fetch_completed = completed.saturating_sub(baseline);
+        if fetch_completed == 0 || fetch_elapsed_ms == 0 {
+            placeholder();
             return;
         }
         let remaining = total_n - completed;
-        let eta_ms = elapsed_ms.saturating_mul(remaining as u64) / completed as u64;
+        let eta_ms = fetch_elapsed_ms.saturating_mul(remaining as u64) / fetch_completed as u64;
         let eta_str = format_duration(Duration::from_millis(eta_ms));
         root.prop(
             "eta",
@@ -602,7 +710,7 @@ impl InstallProgress {
         elapsed: Duration,
     ) {
         if linked == 0 && top_level_linked == 0 {
-            let msg = if total_packages == 0 {
+            let body = if total_packages == 0 {
                 "Already up to date".to_string()
             } else {
                 format!(
@@ -610,12 +718,13 @@ impl InstallProgress {
                     pluralizer::pluralize("package", total_packages as isize, true)
                 )
             };
+            // Only the check mark is green so it stays the visual
+            // success cue without the whole message bleeding green.
             // Same single-line `aube VERSION by en.dev · ✓ msg` shape
-            // for both TTY and CI modes. CI mode's heartbeat may have
-            // emitted intermediate progress lines above this; the
-            // self-identifying summary still reads fine as the closing
-            // line of a multi-line CI block.
-            let line = aube_prefix_line(&style::egreen(&msg).bold().to_string());
+            // for both TTY and CI modes; CI mode's heartbeat may have
+            // emitted intermediate progress lines above this.
+            let msg = format!("{} {}", style::egreen("✓").bold(), style::ebold(&body));
+            let line = aube_prefix_line(&msg);
             let _ = writeln!(std::io::stderr(), "{line}");
             return;
         }
@@ -634,12 +743,15 @@ impl InstallProgress {
         if !needs_summary {
             return;
         }
+        // Only the check mark is green so the success cue is sharp
+        // without the whole sentence bleeding into one color block.
         let msg = format!(
-            "✓ installed {} in {}",
-            pluralizer::pluralize("package", linked as isize, true),
-            format_duration(elapsed)
+            "{} installed {} in {}",
+            style::egreen("✓").bold(),
+            style::ebold(pluralizer::pluralize("package", linked as isize, true)),
+            style::edim(format_duration(elapsed)),
         );
-        let line = aube_prefix_line(&style::egreen(msg).bold().to_string());
+        let line = aube_prefix_line(&msg);
         let _ = writeln!(std::io::stderr(), "{line}");
     }
 }
@@ -723,6 +835,18 @@ impl FetchRow {
                 downloaded,
                 visible,
             } => {
+                // Note: this site bumps `downloaded` but doesn't call
+                // `refresh_eta` — the ETA prop is recomputed on every
+                // `inc_downloaded_bytes` event, which fires once per
+                // tarball *before* this drop. The off-by-one (ETA
+                // computed against pre-bump `downloaded`) self-corrects
+                // on the next fetch's bytes; for the very last fetch,
+                // `set_phase("linking")` immediately clears the prop.
+                // Wiring a refresh here would require either bundling
+                // every refresh-related Arc into the FetchRow weak ref
+                // or holding a back-pointer to InstallProgress; the
+                // observable lag is ≤ one fetch worth of time and the
+                // last-fetch case never reaches the user.
                 if let Some(root) = root.upgrade() {
                     root.increment(1);
                 }

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -25,6 +25,7 @@
 //! their own output and we stay out of the way.
 
 mod ci;
+mod render;
 
 use ci::{CiState, format_duration};
 use clx::progress::{
@@ -48,6 +49,20 @@ fn overflow_fetch_label(count: usize) -> String {
     format!("{count} more {word}…")
 }
 
+/// Build the standard `aube VERSION by en.dev · <msg>` one-line
+/// header used by the no-op and fast-mode summaries. Centralizes the
+/// header shape so the install-finished, already-up-to-date, and
+/// fast-mode-summary paths all read consistently.
+fn aube_prefix_line(msg: &str) -> String {
+    format!(
+        "{} {} {} {} {msg}",
+        style::emagenta("aube").bold(),
+        style::edim(crate::version::VERSION.as_str()),
+        style::edim("by en.dev"),
+        style::edim("·"),
+    )
+}
+
 /// Install-time progress UI. Cheap to clone (internally `Arc`).
 pub struct InstallProgress {
     mode: Mode,
@@ -61,19 +76,33 @@ enum Mode {
         /// fetch-add without racing a concurrent reader/writer through clx's
         /// separate `overall_progress()` / `progress_total()` calls.
         total: Arc<AtomicUsize>,
+        /// Mirror of cumulative reused-package count so the TTY bar can
+        /// recompute the live numerator without taking a round-trip
+        /// through clx's progress accessors.
+        reused: Arc<AtomicUsize>,
+        /// Mirror of cumulative downloaded-package count for the same
+        /// reason.
+        downloaded: Arc<AtomicUsize>,
         /// Phase number: 0=init, 1=resolving, 2=fetching, 3=linking. Used
-        /// by `inc_downloaded_bytes` to gate the transfer-rate prop to the
-        /// fetching window — before/after that the rate is either zero or
-        /// stale.
+        /// by the rate / ETA props to gate display to the fetching
+        /// window and switch to the `linking` label in phase 3.
         phase_num: Arc<AtomicUsize>,
         /// Cumulative downloaded bytes. Fed into the transfer-rate
         /// calculation displayed in the TTY bar's `rate` prop.
         downloaded_bytes: Arc<AtomicU64>,
+        /// Running sum of `dist.unpackedSize` from packuments seen
+        /// during the streaming resolve. `0` on the lockfile fast path.
+        /// The bar's `bytes` prop renders `4.2 MB / ~13.8 MB` when this
+        /// is set; otherwise just `4.2 MB`.
+        estimated_bytes: Arc<AtomicU64>,
         /// Captured the first time `set_phase("fetching")` is called.
         /// Used as the rate denominator so the displayed throughput
         /// measures the fetch window only, not `bytes / (resolve_time +
         /// fetch_time)`.
         fetch_start: Arc<OnceLock<Instant>>,
+        /// Wall-clock start of the install, used by `eta` recomputation
+        /// to derive elapsed time without re-querying clx.
+        install_start: Arc<Instant>,
         /// Bounded visible-fetch-row bookkeeping. `visible` is the count
         /// of live per-package child rows (capped at
         /// `TTY_MAX_VISIBLE_FETCH_ROWS`); `overflow` is the count of
@@ -140,16 +169,23 @@ impl InstallProgress {
             style::edim(crate::version::VERSION.as_str()),
             style::edim("by en.dev"),
         );
+        // Layout: header, animated bar, cur/total, optional bytes
+        // segment (running download, with `/ ~estimated` when
+        // available), phase-gated rate, ETA. Mirrors the CI-mode
+        // label segment-for-segment so both modes show the same
+        // information.
         let root = ProgressJobBuilder::new()
             .body(
-                "{{aube}}{{phase}}  {{progress_bar(flex=true)}} {{cur}}/{{total}}{{rate}} · {{ elapsed() }}",
+                "{{aube}}{{phase}}  {{progress_bar(flex=true)}} {{cur}}/{{total}}{{bytes}}{{rate}}{{eta}}",
             )
             .body_text(Some(
-                "{{aube}}{{phase}} {{cur}}/{{total}}{{rate}} · {{ elapsed() }}",
+                "{{aube}}{{phase}} {{cur}}/{{total}}{{bytes}}{{rate}}{{eta}}",
             ))
             .prop("aube", &header)
             .prop("phase", "")
+            .prop("bytes", "")
             .prop("rate", "")
+            .prop("eta", "")
             .progress_current(0)
             .progress_total(0)
             .on_done(ProgressJobDoneBehavior::Hide)
@@ -158,9 +194,13 @@ impl InstallProgress {
             mode: Mode::Tty {
                 root,
                 total: Arc::new(AtomicUsize::new(0)),
+                reused: Arc::new(AtomicUsize::new(0)),
+                downloaded: Arc::new(AtomicUsize::new(0)),
                 phase_num: Arc::new(AtomicUsize::new(0)),
                 downloaded_bytes: Arc::new(AtomicU64::new(0)),
+                estimated_bytes: Arc::new(AtomicU64::new(0)),
                 fetch_start: Arc::new(OnceLock::new()),
+                install_start: Arc::new(Instant::now()),
                 fetch_state: Arc::new(Mutex::new(FetchState {
                     visible: 0,
                     overflow: 0,
@@ -189,6 +229,7 @@ impl InstallProgress {
             Mode::Tty { root, total: t, .. } => {
                 t.store(total, Ordering::Relaxed);
                 root.progress_total(total);
+                self.refresh_eta();
             }
             Mode::Ci(s) => {
                 s.resolved.store(total, Ordering::Relaxed);
@@ -202,6 +243,7 @@ impl InstallProgress {
             Mode::Tty { root, total, .. } => {
                 let new_total = total.fetch_add(n, Ordering::Relaxed) + n;
                 root.progress_total(new_total);
+                self.refresh_eta();
             }
             Mode::Ci(s) => {
                 s.resolved.fetch_add(n, Ordering::Relaxed);
@@ -209,9 +251,27 @@ impl InstallProgress {
         }
     }
 
+    /// Add `n` bytes to the running estimated-total-download counter.
+    /// Fed from `dist.unpackedSize` as resolver streams in packuments.
+    /// Surfaces in the bar's `bytes` segment as the `/ ~13.8 MB`
+    /// suffix so users have a sense of total install scope before the
+    /// fetch finishes. No-op when the packument lacks the field.
+    pub fn inc_estimated_bytes(&self, n: u64) {
+        match &self.mode {
+            Mode::Tty {
+                estimated_bytes, ..
+            } => {
+                estimated_bytes.fetch_add(n, Ordering::Relaxed);
+                self.refresh_bytes_segment();
+            }
+            Mode::Ci(s) => {
+                s.estimated_bytes.fetch_add(n, Ordering::Relaxed);
+            }
+        }
+    }
+
     /// Set the phase label shown to the right of the header (e.g. "resolving",
-    /// "fetching", "linking"). Empty string clears it. In CI mode this
-    /// bumps the `[N/3]` phase counter shown on the status line.
+    /// "fetching", "linking"). Empty string clears it.
     pub fn set_phase(&self, phase: &str) {
         match &self.mode {
             Mode::Tty {
@@ -223,7 +283,12 @@ impl InstallProgress {
                 if phase.is_empty() {
                     root.prop("phase", "");
                 } else {
-                    root.prop("phase", &format!("{}", style::edim(format!(" — {phase}"))));
+                    let colored_phase = match phase {
+                        "resolving" => style::eyellow(phase).to_string(),
+                        "linking" => style::ecyan(phase).to_string(),
+                        _ => style::edim(phase).to_string(),
+                    };
+                    root.prop("phase", &format!(" {} {}", style::edim("—"), colored_phase));
                 }
                 let n = match phase {
                     "resolving" => 1,
@@ -236,12 +301,17 @@ impl InstallProgress {
                     // Seed the rate denominator on the fetching transition.
                     // First-writer-wins; repeated calls are no-ops.
                     let _ = fetch_start.set(Instant::now());
-                } else {
-                    // Transfer rate is only meaningful *during* fetching — clear
-                    // the prop when we leave the phase so the label doesn't
-                    // carry a stale number into `linking`.
+                } else if n == 3 {
+                    // Linking phase: rate / ETA aren't meaningful — the
+                    // network's done, the linker work is dominated by
+                    // filesystem ops on a fixed package count. Clear
+                    // both props so the "linking" word reads cleanly.
                     root.prop("rate", "");
+                    root.prop("eta", "");
                 }
+                self.refresh_bytes_segment();
+                self.refresh_rate();
+                self.refresh_eta();
             }
             Mode::Ci(s) => s.set_phase(phase),
         }
@@ -252,7 +322,11 @@ impl InstallProgress {
     /// `file:` / `link:` source — anything that didn't touch the network.
     pub fn inc_reused(&self, n: usize) {
         match &self.mode {
-            Mode::Tty { root, .. } => root.increment(n),
+            Mode::Tty { root, reused, .. } => {
+                reused.fetch_add(n, Ordering::Relaxed);
+                root.increment(n);
+                self.refresh_eta();
+            }
             Mode::Ci(s) => {
                 s.reused.fetch_add(n, Ordering::Relaxed);
             }
@@ -263,48 +337,144 @@ impl InstallProgress {
     /// tarball after the registry fetch completes, on top of the per-package
     /// increment that `FetchRow::drop` contributes to the downloaded count.
     ///
-    /// In TTY mode this updates the transfer-rate prop rendered to the right
-    /// of `cur/total` — gated to `phase == fetching && bytes > 0` so the
-    /// label stays clean before/after the fetch window. In CI mode the
-    /// heartbeat re-renders the rate from the cumulative byte counter on
-    /// each tick; here we just bump that counter.
+    /// In TTY mode this refreshes the bytes / rate / ETA props on the
+    /// animated bar. In CI mode the heartbeat re-renders from the
+    /// cumulative byte counter on each tick; here we just bump that
+    /// counter.
     pub fn inc_downloaded_bytes(&self, bytes: u64) {
         match &self.mode {
             Mode::Tty {
-                root,
-                phase_num,
-                downloaded_bytes,
-                fetch_start,
-                ..
+                downloaded_bytes, ..
             } => {
-                let total = downloaded_bytes.fetch_add(bytes, Ordering::Relaxed) + bytes;
-                if phase_num.load(Ordering::Relaxed) != 2 || total == 0 {
-                    return;
-                }
-                // `fetch_start` is seeded by `set_phase("fetching")`; if
-                // bytes land before that (shouldn't happen but defend
-                // against it), skip the update instead of computing against
-                // install start time.
-                let Some(fetch_start) = fetch_start.get() else {
-                    return;
-                };
-                let elapsed_ms = fetch_start.elapsed().as_millis() as u64;
-                if elapsed_ms == 0 {
-                    return;
-                }
-                let rate = total.saturating_mul(1000) / elapsed_ms;
-                root.prop(
-                    "rate",
-                    &format!(
-                        " · {}",
-                        style::edim(format!("{}/s", ci::format_bytes(rate)))
-                    ),
-                );
+                downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+                self.refresh_bytes_segment();
+                self.refresh_rate();
             }
             Mode::Ci(s) => {
                 s.downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
             }
         }
+    }
+
+    /// TTY-only: rebuild the `bytes` prop from the current downloaded /
+    /// estimated counters. Picks shape based on what we know:
+    ///   `4.2 MB / ~13.8 MB` when both are available, `4.2 MB` when
+    ///   only the running total is, `~13.8 MB` when only the estimate
+    ///   is, empty otherwise. CI mode does this inside the heartbeat
+    ///   render — no per-call refresh needed there.
+    fn refresh_bytes_segment(&self) {
+        let Mode::Tty {
+            root,
+            downloaded_bytes,
+            estimated_bytes,
+            phase_num,
+            ..
+        } = &self.mode
+        else {
+            return;
+        };
+        let bytes = downloaded_bytes.load(Ordering::Relaxed);
+        let estimated = estimated_bytes.load(Ordering::Relaxed);
+        let phase = phase_num.load(Ordering::Relaxed);
+        // The bytes segment only carries useful information from
+        // fetching onward. Hide it in resolving — there's nothing
+        // downloaded yet — and during phase 0 (pre-progress).
+        if phase < 2 || (bytes == 0 && estimated == 0) {
+            root.prop("bytes", "");
+            return;
+        }
+        let segment = if estimated > bytes && bytes > 0 {
+            format!(
+                " · {} {} {}",
+                style::ebold(render::format_bytes(bytes)),
+                style::edim("/"),
+                style::edim(format!("~{}", render::format_bytes(estimated))),
+            )
+        } else if bytes > 0 {
+            format!(" · {}", style::ebold(render::format_bytes(bytes)))
+        } else {
+            // bytes == 0, estimated > 0
+            format!(
+                " · {}",
+                style::edim(format!("~{}", render::format_bytes(estimated)))
+            )
+        };
+        root.prop("bytes", &segment);
+    }
+
+    /// TTY-only: rebuild the `rate` prop. Active during fetching only;
+    /// cleared in resolving (no data) and linking (network done).
+    fn refresh_rate(&self) {
+        let Mode::Tty {
+            root,
+            phase_num,
+            downloaded_bytes,
+            fetch_start,
+            ..
+        } = &self.mode
+        else {
+            return;
+        };
+        if phase_num.load(Ordering::Relaxed) != 2 {
+            root.prop("rate", "");
+            return;
+        }
+        let bytes = downloaded_bytes.load(Ordering::Relaxed);
+        let Some(start) = fetch_start.get() else {
+            return;
+        };
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        if bytes == 0 || elapsed_ms == 0 {
+            root.prop("rate", "");
+            return;
+        }
+        let rate = bytes.saturating_mul(1000) / elapsed_ms;
+        root.prop(
+            "rate",
+            &format!(
+                " · {}",
+                style::edim(format!("{}/s", render::format_bytes(rate)))
+            ),
+        );
+    }
+
+    /// TTY-only: rebuild the `eta` prop. `ETA …` while we don't have
+    /// enough data to extrapolate; `ETA Xs` once we do.
+    fn refresh_eta(&self) {
+        let Mode::Tty {
+            root,
+            total,
+            reused,
+            downloaded,
+            phase_num,
+            install_start,
+            ..
+        } = &self.mode
+        else {
+            return;
+        };
+        let phase = phase_num.load(Ordering::Relaxed);
+        // Only show ETA in resolving + fetching. Linking is fast and
+        // bounded — adding an ETA there would just flap around 0s.
+        if phase == 0 || phase == 3 {
+            root.prop("eta", "");
+            return;
+        }
+        let total_n = total.load(Ordering::Relaxed);
+        let completed =
+            (reused.load(Ordering::Relaxed) + downloaded.load(Ordering::Relaxed)).min(total_n);
+        let elapsed_ms = install_start.elapsed().as_millis() as u64;
+        if completed == 0 || completed >= total_n || total_n == 0 || elapsed_ms == 0 {
+            root.prop("eta", &format!(" · {}", style::edim("ETA …")));
+            return;
+        }
+        let remaining = total_n - completed;
+        let eta_ms = elapsed_ms.saturating_mul(remaining as u64) / completed as u64;
+        let eta_str = format_duration(Duration::from_millis(eta_ms));
+        root.prop(
+            "eta",
+            &format!(" · {}", style::edim(format!("ETA {eta_str}"))),
+        );
     }
 
     /// Add a transient child row for an in-flight tarball fetch. Drop the
@@ -316,7 +486,10 @@ impl InstallProgress {
     pub fn start_fetch(&self, name: &str, version: &str) -> FetchRow {
         match &self.mode {
             Mode::Tty {
-                root, fetch_state, ..
+                root,
+                fetch_state,
+                downloaded,
+                ..
             } => {
                 let mut st = fetch_state.lock().unwrap();
                 if st.visible < TTY_MAX_VISIBLE_FETCH_ROWS {
@@ -335,6 +508,7 @@ impl InstallProgress {
                             child,
                             root: Arc::downgrade(root),
                             fetch_state: Arc::downgrade(fetch_state),
+                            downloaded: Arc::downgrade(downloaded),
                             visible: true,
                         },
                         completed: false,
@@ -363,6 +537,7 @@ impl InstallProgress {
                         child: st.overflow_row.as_ref().unwrap().clone(),
                         root: Arc::downgrade(root),
                         fetch_state: Arc::downgrade(fetch_state),
+                        downloaded: Arc::downgrade(downloaded),
                         visible: false,
                     },
                     completed: false,
@@ -435,57 +610,36 @@ impl InstallProgress {
                     pluralizer::pluralize("package", total_packages as isize, true)
                 )
             };
-            // In CI mode the framed `aube VERSION by en.dev` header prints
-            // above the bar on the first heartbeat tick, so repeating the
-            // prefix in the summary is noise — use the bracketed frame
-            // instead, matching the `[ ✓ resolved … ]` summary from the
-            // non-empty path. *But* if the install finished before the
-            // first heartbeat tick (`shown == false`), the framed header
-            // was never printed; a framed summary would then appear as an
-            // orphaned bracketed block with no context. Fall back to the
-            // unframed `aube VERSION · …` shape in that case so the
-            // no-op line still identifies itself.
-            let framed_ci = matches!(&self.mode, Mode::Ci(s) if s.shown.load(Ordering::Relaxed));
-            let line = if framed_ci {
-                let inner = format!("{} {}", style::egreen("✓"), style::egreen(&msg).bold());
-                ci::render_centered_line(&inner, ci::term_width())
-            } else {
-                format!(
-                    "{} {} {} {} {}",
-                    style::emagenta("aube").bold(),
-                    style::edim(crate::version::VERSION.as_str()),
-                    style::edim("by en.dev"),
-                    style::edim("·"),
-                    style::egreen(&msg).bold(),
-                )
-            };
+            // Same single-line `aube VERSION by en.dev · ✓ msg` shape
+            // for both TTY and CI modes. CI mode's heartbeat may have
+            // emitted intermediate progress lines above this; the
+            // self-identifying summary still reads fine as the closing
+            // line of a multi-line CI block.
+            let line = aube_prefix_line(&style::egreen(&msg).bold().to_string());
             let _ = writeln!(std::io::stderr(), "{line}");
             return;
         }
         if linked == 0 {
             return;
         }
-        if !matches!(self.mode, Mode::Tty { .. }) {
+        // CI mode prints its own multi-segment summary from the
+        // heartbeat's final tick (resolve / reused / downloaded
+        // breakdown). For fast installs that never hit the heartbeat,
+        // print the single-line summary here so the user still sees
+        // a confirmation. TTY mode always prints here.
+        let needs_summary = match &self.mode {
+            Mode::Tty { .. } => true,
+            Mode::Ci(s) => !s.shown.load(Ordering::Relaxed),
+        };
+        if !needs_summary {
             return;
         }
-        // Single line: `aube VERSION by en.dev · ✓ installed N packages in Xs`.
-        // Same `aube VERSION by en.dev` shape the progress bar drew
-        // while the install was running, joined to the green
-        // success line by a middle dot so the whole thing reads as
-        // one continuous status.
         let msg = format!(
             "✓ installed {} in {}",
             pluralizer::pluralize("package", linked as isize, true),
             format_duration(elapsed)
         );
-        let line = format!(
-            "{} {} {} {} {}",
-            style::emagenta("aube").bold(),
-            style::edim(crate::version::VERSION.as_str()),
-            style::edim("by en.dev"),
-            style::edim("·"),
-            style::egreen(msg).bold(),
-        );
+        let line = aube_prefix_line(&style::egreen(msg).bold().to_string());
         let _ = writeln!(std::io::stderr(), "{line}");
     }
 }
@@ -539,6 +693,11 @@ enum FetchRowInner {
         /// decrement visible/overflow counters and refresh the
         /// overflow row label without pinning it alive.
         fetch_state: Weak<Mutex<FetchState>>,
+        /// Weak ref to the TTY mirror of the downloaded counter so
+        /// drop can bump it without holding the root alive. Mirrors
+        /// CI mode's `downloaded` counter — used by the ETA / clamp
+        /// computations in the bar render.
+        downloaded: Weak<AtomicUsize>,
         /// Whether this row occupies one of the `TTY_MAX_VISIBLE_FETCH_ROWS`
         /// visible slots. Overflow rows share a single child job; they
         /// only bump the overflow counter and the label on drop.
@@ -561,10 +720,14 @@ impl FetchRow {
                 child,
                 root,
                 fetch_state,
+                downloaded,
                 visible,
             } => {
                 if let Some(root) = root.upgrade() {
                     root.increment(1);
+                }
+                if let Some(d) = downloaded.upgrade() {
+                    d.fetch_add(1, Ordering::Relaxed);
                 }
                 if *visible {
                     child.set_status(ProgressStatus::Done);

--- a/crates/aube/src/progress/render.rs
+++ b/crates/aube/src/progress/render.rs
@@ -8,6 +8,7 @@
 
 use super::ci::Snap;
 use clx::style;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Rough gzip compression ratio for npm tarballs. `dist.unpackedSize`
 /// is what aube installs to disk, not what crosses the wire — typical
@@ -26,11 +27,21 @@ pub(super) fn progress_line(snap: Snap, term_width: usize, bar_width: usize) -> 
     if snap.phase == 0 {
         return String::new();
     }
-    let label = label_for(snap);
+    // Compute the clamped numerator once per render so the
+    // `WARN_AUBE_PROGRESS_OVERFLOW` warning isn't double-fired across
+    // the bar + label call sites; both helpers consume the result via
+    // a parameter rather than re-loading the atomics. Resolving phase
+    // doesn't display a numerator so we don't bother computing it.
+    let completed = if snap.phase == 1 {
+        0
+    } else {
+        clamped_completed(snap)
+    };
+    let label = label_for(snap, completed);
     if label.is_empty() {
         return String::new();
     }
-    let bar = bar_only(snap, bar_width);
+    let bar = bar_only(snap, bar_width, completed);
     let _ = term_width; // reserved for future right-align/truncate logic
     format!("{bar} {label}")
 }
@@ -38,11 +49,10 @@ pub(super) fn progress_line(snap: Snap, term_width: usize, bar_width: usize) -> 
 /// The fixed-width left-aligned bar. Filled portion is green, empty
 /// portion is dim. During resolving the bar is empty (the work hasn't
 /// started yet); during linking it's effectively full.
-pub(super) fn bar_only(snap: Snap, width: usize) -> String {
+pub(super) fn bar_only(snap: Snap, width: usize, completed: usize) -> String {
     let (numerator, denominator) = if snap.phase == 1 {
         (0, 1)
     } else {
-        let completed = clamped_completed(snap);
         let denom = snap.resolved.max(1);
         (completed, denom)
     };
@@ -62,7 +72,7 @@ pub(super) fn bar_only(snap: Snap, width: usize) -> String {
 /// * resolving: `N pkgs · resolving · ETA …`
 /// * fetching:  `cur/total pkgs · 4.2 MB / ~13.8 MB · 1.4 MB/s · ETA 5s`
 /// * linking:   `cur/total pkgs · 13.8 MB · linking`
-fn label_for(snap: Snap) -> String {
+fn label_for(snap: Snap, completed: usize) -> String {
     match snap.phase {
         1 => {
             // No bar to fill yet — show the running resolved count and
@@ -76,7 +86,6 @@ fn label_for(snap: Snap) -> String {
             )
         }
         2 => {
-            let completed = clamped_completed(snap);
             let mut parts = Vec::with_capacity(4);
             parts.push(format!(
                 "{}/{} pkgs",
@@ -99,7 +108,6 @@ fn label_for(snap: Snap) -> String {
             parts.join(&format!(" {} ", style::edim("·")))
         }
         3 => {
-            let completed = clamped_completed(snap);
             // Suppress the bytes segment when nothing was downloaded
             // (fully warm cache) — `0 B` would be visual noise.
             let mut parts = vec![format!(
@@ -194,17 +202,22 @@ fn transfer_rate(snap: Snap) -> Option<u64> {
     Some(snap.bytes.saturating_mul(1000) / snap.fetch_elapsed_ms)
 }
 
+/// Process-wide latch: once the overflow warning has fired, every
+/// subsequent render skips it. The bookkeeping condition tends to
+/// recur across multiple heartbeats once tripped — without this
+/// gate the CLI would log dozens of identical warnings to stderr,
+/// drowning out the actual install output. One warning per CLI
+/// session is enough to flag the regression for diagnosis.
+static OVERFLOW_WARNED: AtomicBool = AtomicBool::new(false);
+
 /// Defensive clamp: numerator can never exceed denominator. The two
 /// known sources of overrun (the catch-up bookkeeping bug and
 /// streamed-then-pruned packages) are fixed at their roots, but if a
 /// new code path regresses we want the display to stay sane and the
-/// `WARN_AUBE_PROGRESS_OVERFLOW` warning to fire.
+/// `WARN_AUBE_PROGRESS_OVERFLOW` warning to fire — once.
 fn clamped_completed(snap: Snap) -> usize {
     let raw = snap.reused + snap.downloaded;
-    if raw > snap.resolved && snap.resolved > 0 {
-        // The warning fires on the rendering path so it's emitted at
-        // most once per heartbeat, not once per increment. The
-        // tracing layer already deduplicates identical events.
+    if raw > snap.resolved && snap.resolved > 0 && !OVERFLOW_WARNED.swap(true, Ordering::Relaxed) {
         tracing::warn!(
             code = aube_codes::warnings::WARN_AUBE_PROGRESS_OVERFLOW,
             raw_completed = raw,

--- a/crates/aube/src/progress/render.rs
+++ b/crates/aube/src/progress/render.rs
@@ -1,0 +1,317 @@
+//! Shared rendering primitives for the install progress UI.
+//!
+//! CI mode and TTY mode both want the same label content (cur/total
+//! pkgs, downloaded / estimated bytes, transfer rate, ETA, phase
+//! word) — only the bar and frame differ. The label assembly lives
+//! here so a tweak to the segment order or styling lands in both
+//! modes without drift.
+
+use super::ci::Snap;
+use clx::style;
+
+/// Rough gzip compression ratio for npm tarballs. `dist.unpackedSize`
+/// is what aube installs to disk, not what crosses the wire — typical
+/// JS/TS code minified through gzip lands around 0.20-0.35×, with a
+/// long tail. 0.30 is a middle-of-the-distribution constant that
+/// keeps the estimate within ~30% on most installs without per-package
+/// content-type tuning. Used solely for the `~13.8 MB` display
+/// segment, never persisted to lockfiles or the store.
+const TARBALL_COMPRESSION_RATIO: f64 = 0.30;
+
+/// Build the full `<bar> <label>` line for one heartbeat tick.
+/// Returns an empty string when the snapshot has nothing meaningful
+/// to show — the heartbeat skips empty lines so a phase=0 snapshot
+/// stays quiet instead of printing a blank.
+pub(super) fn progress_line(snap: Snap, term_width: usize, bar_width: usize) -> String {
+    if snap.phase == 0 {
+        return String::new();
+    }
+    let label = label_for(snap);
+    if label.is_empty() {
+        return String::new();
+    }
+    let bar = bar_only(snap, bar_width);
+    let _ = term_width; // reserved for future right-align/truncate logic
+    format!("{bar} {label}")
+}
+
+/// The fixed-width left-aligned bar. Filled portion is green, empty
+/// portion is dim. During resolving the bar is empty (the work hasn't
+/// started yet); during linking it's effectively full.
+pub(super) fn bar_only(snap: Snap, width: usize) -> String {
+    let (numerator, denominator) = if snap.phase == 1 {
+        (0, 1)
+    } else {
+        let completed = clamped_completed(snap);
+        let denom = snap.resolved.max(1);
+        (completed, denom)
+    };
+    let filled = numerator
+        .checked_mul(width)
+        .and_then(|v| v.checked_div(denominator))
+        .unwrap_or(0)
+        .min(width);
+    let empty = width - filled;
+    let fill = "█".repeat(filled);
+    let empty = "░".repeat(empty);
+    format!("{}{}", style::egreen(fill), style::edim(empty))
+}
+
+/// Phase-specific label content. Format:
+///
+/// * resolving: `N pkgs · resolving · ETA …`
+/// * fetching:  `cur/total pkgs · 4.2 MB / ~13.8 MB · 1.4 MB/s · ETA 5s`
+/// * linking:   `cur/total pkgs · 13.8 MB · linking`
+fn label_for(snap: Snap) -> String {
+    match snap.phase {
+        1 => {
+            // No bar to fill yet — show the running resolved count and
+            // a placeholder ETA. `…` reads as "still figuring it out"
+            // instead of blank.
+            format!(
+                "{} pkgs · {} · {}",
+                style::ebold(snap.resolved),
+                style::eyellow("resolving"),
+                style::edim("ETA …"),
+            )
+        }
+        2 => {
+            let completed = clamped_completed(snap);
+            let mut parts = Vec::with_capacity(4);
+            parts.push(format!(
+                "{}/{} pkgs",
+                style::ebold(completed),
+                style::ebold(snap.resolved),
+            ));
+            parts.push(bytes_segment(snap));
+            if let Some(rate) = transfer_rate(snap) {
+                parts.push(style::edim(format!("{}/s", format_bytes(rate))).to_string());
+            }
+            parts.push(eta_segment(snap, completed));
+            parts.join(&format!(" {} ", style::edim("·")))
+        }
+        3 => {
+            let completed = clamped_completed(snap);
+            // Suppress the bytes segment when nothing was downloaded
+            // (fully warm cache) — `0 B` would be visual noise.
+            let mut parts = vec![format!(
+                "{}/{} pkgs",
+                style::ebold(completed),
+                style::ebold(snap.resolved),
+            )];
+            if snap.bytes > 0 {
+                parts.push(style::edim(format_bytes(snap.bytes)).to_string());
+            }
+            parts.push(style::ecyan("linking").to_string());
+            parts.join(&format!(" {} ", style::edim("·")))
+        }
+        _ => String::new(),
+    }
+}
+
+/// `4.2 MB` running, optionally `4.2 MB / ~13.8 MB` when the
+/// estimated total is known. The estimate is `unpackedSize ×
+/// TARBALL_COMPRESSION_RATIO` so it lands in the same units as the
+/// running download counter. Drops the estimate suffix once the
+/// running total has caught up — at that point we know the actual
+/// total and the estimate is just noise.
+fn bytes_segment(snap: Snap) -> String {
+    let estimated_download = estimated_download_bytes(snap.estimated);
+    if estimated_download > snap.bytes && snap.bytes > 0 {
+        format!(
+            "{} / ~{}",
+            style::ebold(format_bytes(snap.bytes)),
+            style::edim(format_bytes(estimated_download)),
+        )
+    } else if snap.bytes > 0 {
+        style::ebold(format_bytes(snap.bytes)).to_string()
+    } else if estimated_download > 0 {
+        // Fetching just started but no bytes have landed — show the
+        // estimated size so the user has a sense of total scope.
+        format!("~{}", style::edim(format_bytes(estimated_download)),)
+    } else {
+        // No bytes, no estimate. Avoid emitting a stray `0 B` segment
+        // that would just be visual noise.
+        String::new()
+    }
+}
+
+/// Convert a sum of `unpackedSize` values to an estimated tarball
+/// (download) byte count. Pure helper so the call sites that build
+/// the segment, and the eventual ETA-based-on-bytes calculation,
+/// stay aligned on the same conversion.
+fn estimated_download_bytes(unpacked: u64) -> u64 {
+    if unpacked == 0 {
+        return 0;
+    }
+    (unpacked as f64 * TARBALL_COMPRESSION_RATIO) as u64
+}
+
+/// `ETA 5s` once we have enough data to extrapolate; `ETA …`
+/// otherwise. The ETA assumes the per-package work rate stays
+/// constant from now on, which is good enough for "is this 5 seconds
+/// or 5 minutes" UX.
+fn eta_segment(snap: Snap, completed: usize) -> String {
+    if completed == 0 || completed >= snap.resolved || snap.elapsed_ms == 0 {
+        return style::edim("ETA …").to_string();
+    }
+    let remaining = snap.resolved - completed;
+    let eta_ms = snap.elapsed_ms.saturating_mul(remaining as u64) / completed as u64;
+    style::edim(format!(
+        "ETA {}",
+        format_duration(std::time::Duration::from_millis(eta_ms))
+    ))
+    .to_string()
+}
+
+/// Bytes-per-second over the fetching window only. Returns `None`
+/// when no bytes have landed or the fetch window hasn't opened yet —
+/// the rate segment is then dropped from the label.
+fn transfer_rate(snap: Snap) -> Option<u64> {
+    if snap.bytes == 0 || snap.fetch_elapsed_ms == 0 {
+        return None;
+    }
+    Some(snap.bytes.saturating_mul(1000) / snap.fetch_elapsed_ms)
+}
+
+/// Defensive clamp: numerator can never exceed denominator. The two
+/// known sources of overrun (the catch-up bookkeeping bug and
+/// streamed-then-pruned packages) are fixed at their roots, but if a
+/// new code path regresses we want the display to stay sane and the
+/// `WARN_AUBE_PROGRESS_OVERFLOW` warning to fire.
+fn clamped_completed(snap: Snap) -> usize {
+    let raw = snap.reused + snap.downloaded;
+    if raw > snap.resolved && snap.resolved > 0 {
+        // The warning fires on the rendering path so it's emitted at
+        // most once per heartbeat, not once per increment. The
+        // tracing layer already deduplicates identical events.
+        tracing::warn!(
+            code = aube_codes::warnings::WARN_AUBE_PROGRESS_OVERFLOW,
+            raw_completed = raw,
+            resolved = snap.resolved,
+            "progress numerator exceeded resolved-package denominator; clamping display"
+        );
+    }
+    raw.min(snap.resolved)
+}
+
+/// Format a byte count using the same SI units pnpm / npm show: `B`,
+/// `kB`, `MB`, `GB`. Decimal (1000-based) because that's what every
+/// package manager uses for on-the-wire sizes.
+pub(super) fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1_000;
+    const MB: u64 = 1_000_000;
+    const GB: u64 = 1_000_000_000;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.0} kB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// Format an elapsed duration compactly. Mirrors `ci::format_duration`
+/// to avoid a cross-module call from the inline summary path; kept
+/// as a single function so future tweaks land in one place.
+pub(super) fn format_duration(d: std::time::Duration) -> String {
+    super::ci::format_duration(d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(phase: usize, resolved: usize, completed: usize, bytes: u64, estimated: u64) -> Snap {
+        Snap {
+            phase,
+            resolved,
+            reused: completed,
+            downloaded: 0,
+            bytes,
+            estimated,
+            elapsed_ms: 5_000,
+            fetch_elapsed_ms: 3_000,
+        }
+    }
+
+    fn strip_ansi(s: &str) -> String {
+        // Strip simple SGR sequences for assertion stability (env-dependent
+        // colors_enabled would otherwise break expected-string tests).
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' && chars.peek() == Some(&'[') {
+                chars.next();
+                for esc_c in chars.by_ref() {
+                    if esc_c.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+                continue;
+            }
+            out.push(c);
+        }
+        out
+    }
+
+    #[test]
+    fn resolving_phase_shows_count_and_eta_placeholder() {
+        let line = strip_ansi(&progress_line(snap(1, 89, 0, 0, 0), 80, 15));
+        assert!(line.contains("89 pkgs"), "got: {line}");
+        assert!(line.contains("resolving"), "got: {line}");
+        assert!(line.contains("ETA …"), "got: {line}");
+    }
+
+    #[test]
+    fn fetching_phase_shows_bytes_and_estimate() {
+        // Estimated unpacked = 46 MB → 0.30× = ~13.8 MB compressed,
+        // which exceeds the 4.2 MB downloaded so far so the
+        // `/ ~estimated` segment renders.
+        let line = strip_ansi(&progress_line(
+            snap(2, 142, 23, 4_200_000, 46_000_000),
+            80,
+            15,
+        ));
+        assert!(line.contains("23/142 pkgs"), "got: {line}");
+        assert!(line.contains("4.2 MB"), "got: {line}");
+        assert!(line.contains("~13.8 MB"), "got: {line}");
+    }
+
+    #[test]
+    fn fetching_phase_drops_estimate_when_running_exceeds_it() {
+        // Estimated unpacked × 0.30 (≈ 4.1 MB) is below the running
+        // 4.2 MB, so the `/ ~estimated` segment is dropped — at that
+        // point the running figure is the better number anyway.
+        let line = strip_ansi(&progress_line(
+            snap(2, 142, 23, 4_200_000, 13_800_000),
+            80,
+            15,
+        ));
+        assert!(line.contains("4.2 MB"), "got: {line}");
+        assert!(!line.contains("~"), "estimate should drop: {line}");
+    }
+
+    #[test]
+    fn linking_phase_drops_rate_and_eta() {
+        let line = strip_ansi(&progress_line(
+            snap(3, 142, 142, 13_800_000, 13_800_000),
+            80,
+            15,
+        ));
+        assert!(line.contains("142/142"), "got: {line}");
+        assert!(line.contains("linking"), "got: {line}");
+        assert!(!line.contains("MB/s"), "rate must drop in linking: {line}");
+        assert!(!line.contains("ETA"), "eta must drop in linking: {line}");
+    }
+
+    #[test]
+    fn clamps_overflow_to_resolved() {
+        let mut s = snap(2, 5, 7, 0, 0);
+        s.reused = 7;
+        let line = strip_ansi(&progress_line(s, 80, 15));
+        assert!(line.contains("5/5 pkgs"), "got: {line}");
+    }
+}

--- a/crates/aube/src/progress/render.rs
+++ b/crates/aube/src/progress/render.rs
@@ -83,7 +83,15 @@ fn label_for(snap: Snap) -> String {
                 style::ebold(completed),
                 style::ebold(snap.resolved),
             ));
-            parts.push(bytes_segment(snap));
+            // Skip the bytes segment when nothing has landed and no
+            // unpackedSize estimate is available — older publishes
+            // and the lockfile fast path both miss the field. Pushing
+            // an empty string would produce `pkgs ·  · ETA …` with a
+            // doubled separator after the `parts.join` below.
+            let seg = bytes_segment(snap);
+            if !seg.is_empty() {
+                parts.push(seg);
+            }
             if let Some(rate) = transfer_rate(snap) {
                 parts.push(style::edim(format!("{}/s", format_bytes(rate))).to_string());
             }
@@ -138,9 +146,11 @@ fn bytes_segment(snap: Snap) -> String {
 
 /// Convert a sum of `unpackedSize` values to an estimated tarball
 /// (download) byte count. Pure helper so the call sites that build
-/// the segment, and the eventual ETA-based-on-bytes calculation,
-/// stay aligned on the same conversion.
-fn estimated_download_bytes(unpacked: u64) -> u64 {
+/// the segment — CI's heartbeat render and TTY's `refresh_bytes_segment`
+/// — stay aligned on the same conversion. Without this both modes
+/// would have to copy the constant; TTY previously displayed the raw
+/// unpacked sum (~3.3× too high) before this was hoisted.
+pub(super) fn estimated_download_bytes(unpacked: u64) -> u64 {
     if unpacked == 0 {
         return 0;
     }
@@ -148,15 +158,25 @@ fn estimated_download_bytes(unpacked: u64) -> u64 {
 }
 
 /// `ETA 5s` once we have enough data to extrapolate; `ETA …`
-/// otherwise. The ETA assumes the per-package work rate stays
-/// constant from now on, which is good enough for "is this 5 seconds
-/// or 5 minutes" UX.
+/// otherwise. Uses *fetch-window* throughput (completions since
+/// `set_phase("fetching")` divided by `fetch_elapsed_ms`) so the
+/// estimate reflects per-package work-rate during fetching, not the
+/// inflated install-elapsed denominator that would include lockfile
+/// parse and resolve time. Falls back to `ETA …` until enough fetch-
+/// window data has accrued for a non-flapping number.
 fn eta_segment(snap: Snap, completed: usize) -> String {
-    if completed == 0 || completed >= snap.resolved || snap.elapsed_ms == 0 {
+    if completed >= snap.resolved {
+        return style::edim("ETA …").to_string();
+    }
+    let Some(baseline) = snap.completed_at_fetch_start else {
+        return style::edim("ETA …").to_string();
+    };
+    let fetch_completed = completed.saturating_sub(baseline);
+    if fetch_completed == 0 || snap.fetch_elapsed_ms == 0 {
         return style::edim("ETA …").to_string();
     }
     let remaining = snap.resolved - completed;
-    let eta_ms = snap.elapsed_ms.saturating_mul(remaining as u64) / completed as u64;
+    let eta_ms = snap.fetch_elapsed_ms.saturating_mul(remaining as u64) / fetch_completed as u64;
     style::edim(format!(
         "ETA {}",
         format_duration(std::time::Duration::from_millis(eta_ms))
@@ -232,8 +252,11 @@ mod tests {
             downloaded: 0,
             bytes,
             estimated,
-            elapsed_ms: 5_000,
             fetch_elapsed_ms: 3_000,
+            // Tests model an install where fetching started at zero
+            // completions; the eta_segment then derives its rate from
+            // `completed - 0 / fetch_elapsed_ms`.
+            completed_at_fetch_start: Some(0),
         }
     }
 

--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -113,7 +113,7 @@ function formatReleasePhrase() {
 const progressBar = computed(() => {
   const width = progressBarColumns.value;
   const filled = Math.floor(progress.value * width);
-  return "#".repeat(filled) + "-".repeat(width - filled);
+  return "█".repeat(filled) + "░".repeat(width - filled);
 });
 const packageRows = computed(() => [
   packages[packageIndex.value % packages.length],
@@ -289,7 +289,7 @@ watch(progressBarEl, (el, previousEl) => {
                 <span class="aube-byline">by en.dev</span>
                 <span class="aube-phase">fetching</span>
                 <span ref="progressBarEl" class="aube-progress-bar">{{ progressBar }}</span>
-                <span class="aube-progress-count">{{ installed }}/{{ installedPackageTotal }}</span>
+                <span class="aube-progress-count">{{ installed }}/{{ installedPackageTotal }} pkgs</span>
               </div>
               <div
                 v-for="(pkg, index) in packageRows"

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -595,6 +595,12 @@
       "category": "Lockfile",
       "description": "A Yarn Berry `patch:` / `portal:` / `exec:` protocol — or any unrecognized protocol — was found in `yarn.lock`. Entry was skipped.",
       "exit_code": null
+    },
+    {
+      "name": "WARN_AUBE_PROGRESS_OVERFLOW",
+      "category": "Progress UI",
+      "description": "Install progress numerator exceeded the resolved-package denominator. Display clamps to total; the warning surfaces the bookkeeping mismatch so the underlying race can be diagnosed.",
+      "exit_code": null
     }
   ],
   "categories": {
@@ -620,7 +626,8 @@
       "Registry caching / perf",
       "Registry TLS / proxy",
       "Resolver",
-      "Lockfile"
+      "Lockfile",
+      "Progress UI"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Reworks the install progress display and fixes two real bookkeeping bugs that surfaced during the redesign.

**New visual shape (CI / piped stderr):**

```
aube 1.7.0 by en.dev
░░░░░░░░░░░░░░░ 325 pkgs · resolving · ETA …
█████░░░░░░░░░░ 23/142 pkgs · 4.2 MB / ~13.8 MB · 1.4 MB/s · ETA 5s
███████████████ 1230/1230 pkgs · linking
✓ resolved 1230 · reused 98 · downloaded 1132 (54.6 MB) in 6.8s
```

**Fast-mode (<2s, no heartbeat fires):**

```
aube 1.7.0 by en.dev · ✓ installed 5 packages in 423ms
aube 1.7.0 by en.dev · ✓ Already up to date (1 package)
```

### What changed

- **Bar-left, no frame.** Dropped the `[…]` brackets, switched `#`/`-` to `█`/`░`, and made the bar a fixed 15 chars on the left. Stats live to the right.
- **Dropped `[N/3]` phase counter** (redundant with `cur/total pkgs`); replaced with the word `linking` during phase 3 so the phase is still visible.
- **Replaced elapsed-during-install with ETA.** Final summary still carries `in Xs`.
- **Estimated install size** via new `dist.unpackedSize` field, summed across the resolve stream and adjusted by a 0.30 gzip ratio: `4.2 MB / ~13.8 MB`.
- **Fast-mode bypass** for installs that finish before the first 2s heartbeat — a single self-identifying summary line, no bar, no header. Phase transitions no longer wake the heartbeat early (the previous behavior produced one frame per phase change on every fast install).
- **TTY mode parity** — same ETA, estimated-size, and bytes-segment refresh wiring on the clx-driven animated bar.
- **Color in both modes** via existing `style::e*` helpers. GHA color detection at `main.rs:724` already routes through.
- **Homepage demo** (`HomeLanding.vue`) updated to match new bar chars.

### Bookkeeping fixes

Two related root-cause bugs in the install progress denominator/numerator pipeline:

- **`2/1 packages` overflow.** Fresh-resolve streaming pass `continue`d on platform-mismatched non-local packages *before* `inc_total(1)`. The `filter_graph` step usually dropped those, but the rare survivor (package declares `os`/`cpu` without `optional`) flowed through the catch-up fetch, which credited the numerator via `inc_reused` / `FetchRow::drop` without ever bumping the denominator. **Fixed** by moving `inc_total(1)` ahead of the deferred-skip.

- **`Stuck at 90%` undercount.** Streamed `inc_total` ran for every resolved package, including platform-mismatched optionals that `filter_graph` subsequently dropped. Denominator inflated, numerator could never catch up. **Fixed** by reconciling `set_total(graph.packages.len())` immediately after `filter_graph`.

Display clamp (`completed = (reused + downloaded).min(resolved)`) plus a new `WARN_AUBE_PROGRESS_OVERFLOW` warning code stay in as defensive guards in case a new code path regresses.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1300+ tests; 6 new render unit tests for the new shapes)
- [x] Manual verification with `fixtures/medium`, `fixtures/vlt-benchmarks/svelte`, and `benchmarks/fixture.package.json` (cold + warm + no-op cases)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reworks install progress bookkeeping and output across TTY/CI, including new size/ETA calculations and denominator reconciliation; mistakes could regress progress accuracy or log output, but changes are confined to progress rendering and associated resolver metadata.
> 
> **Overview**
> Redesigns the install progress UI for both CI and TTY: CI now prints an append-only left-aligned fixed-width bar with phase-aware labels (resolving/fetching/linking), transfer rate, and ETA; TTY gains matching `bytes`/rate/ETA segments and more consistent summary lines via a shared `aube_prefix_line` helper.
> 
> Adds a best-effort total-size estimate by threading `dist.unpackedSize` from registry packuments (`aube-registry::Dist`) through `ResolvedPackage::unpacked_size` and summing it during streaming resolve; after `filter_graph`, the estimate and total package denominator are reconciled against the surviving graph to avoid inflated totals.
> 
> Fixes progress bookkeeping edge cases by incrementing the total before platform-deferred skips, clamping `completed` to `resolved`, and introducing `WARN_AUBE_PROGRESS_OVERFLOW` (documented in error-code data) to surface any future numerator>denominator mismatches; progress-line rendering is centralized in new `progress/render.rs`. Also updates the docs homepage demo bar glyphs to match the new UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9dd5e334bc688fee755251464f2800796d41a59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->