### PR TITLE
feat(run): prefer local bins for run and dlx

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 **[Existing lockfiles](https://aube.en.dev/package-manager/lockfiles).** Reads and writes `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock` in place.
 
-**[Cheap repeat commands](https://aube.en.dev/package-manager/scripts).** `aubr test`, `aube test`, and `aube exec vitest` auto-install when dependencies are stale, then skip that work when nothing changed. `aubx` runs one-off tools in a throwaway environment.
+**[Cheap repeat commands](https://aube.en.dev/package-manager/scripts).** `aubr test`, `aube test`, and `aube exec vitest` auto-install when dependencies are stale, then skip that work when nothing changed. `aubx` uses a local binary when one is installed, or a throwaway environment for one-off tools.
 
 **[Less disk use](https://aube.en.dev/package-manager/node-modules).** A global content-addressable store lets projects share package files instead of keeping a full copy of the same dependencies in every checkout.
 
@@ -122,7 +122,7 @@ aube update               # update dependencies within package.json ranges
 aubr build                # run a package.json script, auto-installing first if needed
 aube test                 # run the test script, auto-installing first if needed
 aube exec vitest          # run a local binary, auto-installing first if needed
-aubx cowsay hi            # run a package in a throwaway environment
+aubx cowsay hi            # run a local bin, or fetch one in a throwaway environment
 aube install              # install only, for setup or lockfile/install modes
 aube ci                   # clean, frozen install for CI
 ```
@@ -147,6 +147,11 @@ that works on the full command also works on the shim:
 aubr build            # aube run build
 aubx cowsay hi        # aube dlx cowsay hi
 ```
+
+`aubr <name>` runs a package script first, then falls back to a matching
+local binary. `aubx <name>` prefers an installed local binary before fetching
+into a throwaway environment; pass `-p` / `--package` to force the package
+that should be installed for a one-off command.
 
 The release archives ship all three binaries side by side; no extra
 setup is needed when you install aube via mise or the tarball.

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -363,7 +363,7 @@ cmd dlx help="Fetch a package into a throwaway environment and run its binary" {
         long_help "Install a specific package (repeatable).\n\nOverrides inferring from the command."
         arg <PACKAGE>
     }
-    arg "[PARAMS]…" help="Command (binary) to run, followed by arguments to pass through to it" help_long="Command (binary) to run, followed by arguments to pass through to it.\n\nThe first positional is the command; the rest are forwarded verbatim to the installed binary. Under `--shell-mode`/`-c` the positionals are joined and evaluated by `sh -c` instead of looked up in `node_modules/.bin`." required=#false double_dash=automatic var=#true
+    arg "[PARAMS]…" help="Command (binary) to run, followed by arguments to pass through to it" help_long="Command (binary) to run, followed by arguments to pass through to it.\n\nThe first positional is the command; the rest are forwarded verbatim to the binary. Without `--package`, a local `node_modules/.bin/<command>` wins when present; otherwise dlx installs into a throwaway project. Under `--shell-mode`/`-c` the positionals are joined and evaluated by `sh -c` instead of looked up directly." required=#false double_dash=automatic var=#true
 }
 cmd doctor help="Run broad install-health diagnostics" {
     after_long_help "Examples:\n\n  $ aube doctor\n  version: 1.0.0-beta.4\n  node: v22.11.0\n  ...\n  No problems found\n\n  $ aube doctor --json | jq .warnings\n"
@@ -797,7 +797,7 @@ cmd run help="Run a script defined in package.json" {
         long_help "Recursive workspace concurrency.\n\nParsed for pnpm compatibility."
         arg <N>
     }
-    arg "[SCRIPT]" help="Script name" help_long="Script name.\n\nOmit on an interactive TTY to pick from `package.json` scripts." required=#false
+    arg "[SCRIPT]" help="Script or local binary name" help_long="Script or local binary name.\n\nOmit on an interactive TTY to pick from `package.json` scripts. If no script matches, aube falls back to `node_modules/.bin/<name>`." required=#false
     arg "[ARGS]…" help="Arguments to pass to the script" required=#false double_dash=automatic var=#true
 }
 cmd sbom help="Generate a Software Bill of Materials (CycloneDX or SPDX)" {

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -237,7 +237,7 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
         // it the sh shim fails with `%1 is not a valid Win32 application`
         // (os error 193). Prefer the `.cmd` shim on Windows; on Unix
         // the bare shim is the executable.
-        let exec_path = resolve_exec_shim(&bin_path);
+        let exec_path = super::exec::resolve_exec_shim(&bin_path);
         tokio::process::Command::new(&exec_path)
             .args(&bin_args)
             .current_dir(&prev_cwd)
@@ -412,32 +412,6 @@ fn bin_name_for(command: &str) -> String {
     name.rsplit('/').next().unwrap_or(name).to_string()
 }
 
-/// Pick the executable variant of a `node_modules/.bin/<name>` shim.
-///
-/// On Unix the bare path is a sh shebang script and is what we want.
-/// On Windows the linker writes three shim files for every bin —
-/// `<name>.cmd`, `<name>.ps1`, and a bare `<name>` sh shim — because
-/// the same `node_modules` may be shared with bash / git-bash. The
-/// bare shim is a sh script that CreateProcess can't execute (and so
-/// `Command::new` fails with `%1 is not a valid Win32 application`).
-/// Pick the `.cmd` shim, which is what npm/pnpm/yarn run.
-///
-/// We don't fall back to `.ps1` here: PowerShell scripts can't be
-/// launched by `Command::new` either (they need `powershell.exe -File`),
-/// and the linker always writes `.cmd` whenever it writes `.ps1`.
-fn resolve_exec_shim(bin_path: &std::path::Path) -> std::path::PathBuf {
-    #[cfg(windows)]
-    {
-        if bin_path.extension().is_none() {
-            let cmd_path = bin_path.with_extension("cmd");
-            if cmd_path.exists() {
-                return cmd_path;
-            }
-        }
-    }
-    bin_path.to_path_buf()
-}
-
 /// When the bin derived from the package name doesn't match the installed
 /// package's actual bin, fall back to reading the package's `bin` field to
 /// find the right name. Matches `npx`/`pnpm dlx` behavior so e.g.
@@ -505,36 +479,6 @@ mod tests {
         assert_eq!(bin_name_for("cowsay@1.5.0"), "cowsay");
         assert_eq!(bin_name_for("@scope/foo@2"), "foo");
         assert_eq!(bin_name_for("@scope/foo"), "foo");
-    }
-
-    #[test]
-    fn resolve_exec_shim_returns_bare_path_when_no_sibling() {
-        let tmp = tempfile::tempdir().unwrap();
-        let bare = tmp.path().join("loner");
-        std::fs::write(&bare, b"#!/bin/sh\n").unwrap();
-        assert_eq!(resolve_exec_shim(&bare), bare);
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn resolve_exec_shim_prefers_cmd_sibling_on_windows() {
-        let tmp = tempfile::tempdir().unwrap();
-        let bare = tmp.path().join("cowsay");
-        let cmd_shim = tmp.path().join("cowsay.cmd");
-        std::fs::write(&bare, b"#!/bin/sh\n").unwrap();
-        std::fs::write(&cmd_shim, b"@echo off\n").unwrap();
-        assert_eq!(resolve_exec_shim(&bare), cmd_shim);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn resolve_exec_shim_keeps_bare_path_on_unix() {
-        let tmp = tempfile::tempdir().unwrap();
-        let bare = tmp.path().join("cowsay");
-        let cmd_shim = tmp.path().join("cowsay.cmd");
-        std::fs::write(&bare, b"#!/bin/sh\n").unwrap();
-        std::fs::write(&cmd_shim, b"@echo off\n").unwrap();
-        assert_eq!(resolve_exec_shim(&bare), bare);
     }
 
     #[test]

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -112,7 +112,7 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
     // user assembles their own line and we run it through `sh -c`, so any
     // bin lookup is the shell's job.
     let bin_name = bin_name_for(&command);
-    if !explicit_package && !shell_mode {
+    if !explicit_package && !shell_mode && can_use_local_bin(&command) {
         let initial_cwd = crate::dirs::cwd()?;
         if let Some(project_dir) = crate::dirs::find_project_root(&initial_cwd) {
             let bin_path = super::project_modules_dir(&project_dir)
@@ -412,6 +412,10 @@ fn bin_name_for(command: &str) -> String {
     name.rsplit('/').next().unwrap_or(name).to_string()
 }
 
+fn can_use_local_bin(command: &str) -> bool {
+    !is_non_registry_spec(command) && super::split_name_spec(command).1.is_none()
+}
+
 /// When the bin derived from the package name doesn't match the installed
 /// package's actual bin, fall back to reading the package's `bin` field to
 /// find the right name. Matches `npx`/`pnpm dlx` behavior so e.g.
@@ -479,6 +483,16 @@ mod tests {
         assert_eq!(bin_name_for("cowsay@1.5.0"), "cowsay");
         assert_eq!(bin_name_for("@scope/foo@2"), "foo");
         assert_eq!(bin_name_for("@scope/foo"), "foo");
+    }
+
+    #[test]
+    fn local_bin_shortcut_only_applies_to_bare_registry_names() {
+        assert!(can_use_local_bin("cowsay"));
+        assert!(can_use_local_bin("@scope/foo"));
+        assert!(!can_use_local_bin("cowsay@1.5.0"));
+        assert!(!can_use_local_bin("cowsay@next"));
+        assert!(!can_use_local_bin("@scope/foo@2"));
+        assert!(!can_use_local_bin("github:owner/repo"));
     }
 
     #[test]

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -18,9 +18,11 @@ pub struct DlxArgs {
     /// it.
     ///
     /// The first positional is the command; the rest are forwarded
-    /// verbatim to the installed binary. Under `--shell-mode`/`-c` the
+    /// verbatim to the binary. Without `--package`, a local
+    /// `node_modules/.bin/<command>` wins when present; otherwise dlx
+    /// installs into a throwaway project. Under `--shell-mode`/`-c` the
     /// positionals are joined and evaluated by `sh -c` instead of
-    /// looked up in `node_modules/.bin`.
+    /// looked up directly.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub params: Vec<String>,
     /// Run the assembled command line through `sh -c`.
@@ -110,6 +112,18 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
     // user assembles their own line and we run it through `sh -c`, so any
     // bin lookup is the shell's job.
     let bin_name = bin_name_for(&command);
+    if !explicit_package && !shell_mode {
+        let initial_cwd = crate::dirs::cwd()?;
+        if let Some(project_dir) = crate::dirs::find_project_root(&initial_cwd) {
+            let bin_path = super::project_modules_dir(&project_dir)
+                .join(".bin")
+                .join(&bin_name);
+            if bin_path.exists() {
+                return super::exec::exec_bin(&initial_cwd, &bin_path, &bin_name, &bin_args, false)
+                    .await;
+            }
+        }
+    }
 
     let tmp = tempfile::Builder::new()
         .prefix("aube-dlx-")

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -194,7 +194,8 @@ pub(crate) async fn exec_bin(
         cmd.env("PATH", &new_path);
         cmd
     } else {
-        let mut cmd = tokio::process::Command::new(bin_path);
+        let exec_path = resolve_exec_shim(bin_path);
+        let mut cmd = tokio::process::Command::new(exec_path);
         cmd.args(args);
         cmd
     };
@@ -213,7 +214,7 @@ pub(crate) async fn exec_bin(
     Ok(())
 }
 
-async fn exec_bin_status(
+pub(crate) async fn exec_bin_status(
     cwd: &Path,
     bin_path: &Path,
     bin: &str,
@@ -237,7 +238,8 @@ async fn exec_bin_status(
         cmd.env("PATH", &new_path);
         cmd
     } else {
-        let mut cmd = tokio::process::Command::new(bin_path);
+        let exec_path = resolve_exec_shim(bin_path);
+        let mut cmd = tokio::process::Command::new(exec_path);
         cmd.args(args);
         cmd
     };
@@ -248,4 +250,58 @@ async fn exec_bin_status(
         .await
         .into_diagnostic()
         .wrap_err("failed to execute binary")
+}
+
+/// Pick the executable variant of a `node_modules/.bin/<name>` shim.
+///
+/// On Unix the bare path is a sh shebang script and is what we want.
+/// On Windows the linker writes `<name>.cmd`, `<name>.ps1`, and a bare
+/// `<name>` sh shim. `Command::new` can launch the `.cmd` shim, but the
+/// bare sh shim fails with OS error 193.
+pub(crate) fn resolve_exec_shim(bin_path: &Path) -> std::path::PathBuf {
+    #[cfg(windows)]
+    {
+        if bin_path.extension().is_none() {
+            let cmd_path = bin_path.with_extension("cmd");
+            if cmd_path.exists() {
+                return cmd_path;
+            }
+        }
+    }
+    bin_path.to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_exec_shim;
+
+    #[test]
+    fn resolve_exec_shim_returns_bare_path_when_no_sibling() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bare = tmp.path().join("loner");
+        std::fs::write(&bare, b"#!/bin/sh\n").unwrap();
+        assert_eq!(resolve_exec_shim(&bare), bare);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_exec_shim_prefers_cmd_sibling_on_windows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bare = tmp.path().join("cowsay");
+        let cmd_shim = tmp.path().join("cowsay.cmd");
+        std::fs::write(&bare, b"#!/bin/sh\n").unwrap();
+        std::fs::write(&cmd_shim, b"@echo off\n").unwrap();
+        assert_eq!(resolve_exec_shim(&bare), cmd_shim);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_exec_shim_keeps_bare_path_on_unix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bare = tmp.path().join("cowsay");
+        let cmd_shim = tmp.path().join("cowsay.cmd");
+        std::fs::write(&bare, b"#!/bin/sh\n").unwrap();
+        std::fs::write(&cmd_shim, b"@echo off\n").unwrap();
+        assert_eq!(resolve_exec_shim(&bare), bare);
+    }
 }

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -170,7 +170,7 @@ async fn run_filtered(
     Ok(())
 }
 
-async fn exec_bin(
+pub(crate) async fn exec_bin(
     cwd: &Path,
     bin_path: &Path,
     bin: &str,

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -7,10 +7,11 @@ use std::path::Path;
 
 #[derive(Debug, Args)]
 pub struct RunArgs {
-    /// Script name.
+    /// Script or local binary name.
     ///
     /// Omit on an interactive TTY to pick from `package.json`
-    /// scripts.
+    /// scripts. If no script matches, aube falls back to
+    /// `node_modules/.bin/<name>`.
     pub script: Option<String>,
     /// Arguments to pass to the script
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -267,6 +268,11 @@ pub(crate) async fn run_script_with(
     if !manifest.scripts.contains_key(script) {
         if if_present {
             return Ok(());
+        }
+        ensure_installed(no_install).await?;
+        let bin_path = super::project_modules_dir(&cwd).join(".bin").join(script);
+        if bin_path.exists() {
+            return super::exec::exec_bin(&cwd, &bin_path, script, args, false).await;
         }
         // Old error was "script not found: foo" with no list. User
         // has to cat package.json to figure out what to type. npm

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -266,13 +266,13 @@ pub(crate) async fn run_script_with(
 
     let manifest = load_manifest(&cwd)?;
     if !manifest.scripts.contains_key(script) {
-        if if_present {
-            return Ok(());
-        }
         ensure_installed(no_install).await?;
         let bin_path = super::project_modules_dir(&cwd).join(".bin").join(script);
         if bin_path.exists() {
             return super::exec::exec_bin(&cwd, &bin_path, script, args, false).await;
+        }
+        if if_present {
+            return Ok(());
         }
         // Old error was "script not found: foo" with no list. User
         // has to cat package.json to figure out what to type. npm
@@ -342,10 +342,17 @@ async fn run_script_filtered(
             .into_iter()
             .filter_map(|pkg| {
                 if pkg.manifest.scripts.contains_key(script) {
-                    Some(Ok(pkg))
-                } else if if_present {
-                    None
+                    Some(Ok((pkg, None)))
                 } else {
+                    let bin_path = super::project_modules_dir(&pkg.dir)
+                        .join(".bin")
+                        .join(script);
+                    if bin_path.exists() {
+                        return Some(Ok((pkg, Some(bin_path))));
+                    }
+                    if if_present {
+                        return None;
+                    }
                     let name = pkg
                         .name
                         .clone()
@@ -360,7 +367,7 @@ async fn run_script_filtered(
         let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
             Vec::with_capacity(runnable.len());
         let mut task_names: Vec<String> = Vec::with_capacity(runnable.len());
-        for pkg in runnable {
+        for (pkg, bin_path) in runnable {
             let name = pkg
                 .name
                 .clone()
@@ -374,8 +381,18 @@ async fn run_script_filtered(
             let manifest = pkg.manifest.clone();
             task_names.push(name);
             tasks.push(tokio::spawn(async move {
-                exec_script_status_chain(&dir, &manifest, &script, &args, enable_pre_post_scripts)
+                if let Some(bin_path) = bin_path {
+                    super::exec::exec_bin_status(&dir, &bin_path, &script, &args, false).await
+                } else {
+                    exec_script_status_chain(
+                        &dir,
+                        &manifest,
+                        &script,
+                        &args,
+                        enable_pre_post_scripts,
+                    )
                     .await
+                }
             }));
         }
         let mut first_err: Option<miette::Report> = None;
@@ -412,6 +429,16 @@ async fn run_script_filtered(
             .as_deref()
             .unwrap_or_else(|| pkg.dir.to_str().unwrap_or("(unnamed)"));
         if !pkg.manifest.scripts.contains_key(script) {
+            let bin_path = super::project_modules_dir(&pkg.dir)
+                .join(".bin")
+                .join(script);
+            if bin_path.exists() {
+                if !silent {
+                    tracing::info!("aube run: {name} -> {script}");
+                }
+                super::exec::exec_bin(&pkg.dir, &bin_path, script, args, false).await?;
+                continue;
+            }
             if if_present {
                 continue;
             }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1744,7 +1744,7 @@
             "name": "PARAMS",
             "usage": "[PARAMS]…",
             "help": "Command (binary) to run, followed by arguments to pass through to it",
-            "help_long": "Command (binary) to run, followed by arguments to pass through to it.\n\nThe first positional is the command; the rest are forwarded verbatim to the installed binary. Under `--shell-mode`/`-c` the positionals are joined and evaluated by `sh -c` instead of looked up in `node_modules/.bin`.",
+            "help_long": "Command (binary) to run, followed by arguments to pass through to it.\n\nThe first positional is the command; the rest are forwarded verbatim to the binary. Without `--package`, a local `node_modules/.bin/<command>` wins when present; otherwise dlx installs into a throwaway project. Under `--shell-mode`/`-c` the positionals are joined and evaluated by `sh -c` instead of looked up directly.",
             "help_first_line": "Command (binary) to run, followed by arguments to pass through to it",
             "required": false,
             "double_dash": "Automatic",
@@ -4460,9 +4460,9 @@
           {
             "name": "SCRIPT",
             "usage": "[SCRIPT]",
-            "help": "Script name",
-            "help_long": "Script name.\n\nOmit on an interactive TTY to pick from `package.json` scripts.",
-            "help_first_line": "Script name",
+            "help": "Script or local binary name",
+            "help_long": "Script or local binary name.\n\nOmit on an interactive TTY to pick from `package.json` scripts. If no script matches, aube falls back to `node_modules/.bin/<name>`.",
+            "help_first_line": "Script or local binary name",
             "required": false,
             "double_dash": "Optional",
             "hide": false

--- a/docs/cli/dlx.md
+++ b/docs/cli/dlx.md
@@ -11,7 +11,7 @@ Fetch a package into a throwaway environment and run its binary
 
 Command (binary) to run, followed by arguments to pass through to it.
 
-The first positional is the command; the rest are forwarded verbatim to the installed binary. Under `--shell-mode`/`-c` the positionals are joined and evaluated by `sh -c` instead of looked up in `node_modules/.bin`.
+The first positional is the command; the rest are forwarded verbatim to the binary. Without `--package`, a local `node_modules/.bin/<command>` wins when present; otherwise dlx installs into a throwaway project. Under `--shell-mode`/`-c` the positionals are joined and evaluated by `sh -c` instead of looked up directly.
 
 ## Flags
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -9,9 +9,9 @@ Run a script defined in package.json
 
 ### `[SCRIPT]`
 
-Script name.
+Script or local binary name.
 
-Omit on an interactive TTY to pick from `package.json` scripts.
+Omit on an interactive TTY to pick from `package.json` scripts. If no script matches, aube falls back to `node_modules/.bin/<name>`.
 
 ### `[ARGS]…`
 

--- a/docs/package-manager/scripts.md
+++ b/docs/package-manager/scripts.md
@@ -28,6 +28,10 @@ Use `--if-present` for optional scripts:
 aube run --if-present lint
 ```
 
+When no `package.json` script matches, `aube run <name>` falls back to a
+local binary with the same name in `node_modules/.bin`. Scripts still win over
+bins, so a project can override a tool command with its own script.
+
 ## Local binaries
 
 ```sh
@@ -45,8 +49,10 @@ aubx cowsay hi
 aubx -p create-vite create-vite my-app
 ```
 
-`aubx` is shorthand for `aube dlx`. It installs into a throwaway project and
-runs the requested binary.
+`aubx` is shorthand for `aube dlx`. It first checks for a matching local binary
+in the current project. If none is installed, it installs into a throwaway
+project and runs the requested binary. Pass `-p` / `--package` when the package
+name differs from the binary name or when you want to force a throwaway install.
 
 ## Shortcuts: `aubr` and `aubx`
 

--- a/test/dlx.bats
+++ b/test/dlx.bats
@@ -91,6 +91,40 @@ teardown() {
 	assert_line "1.2.3-alpha.1"
 }
 
+@test "aube dlx version spec bypasses local binary shortcut" {
+	mkdir -p tools/semver
+	cat >package.json <<-'JSON'
+		{
+		  "name": "dlx-versioned-local-bin",
+		  "version": "1.0.0",
+		  "private": true,
+		  "dependencies": {
+		    "semver": "file:tools/semver"
+		  }
+		}
+	JSON
+	cat >tools/semver/package.json <<-'JSON'
+		{
+		  "name": "semver",
+		  "version": "0.0.0",
+		  "bin": {
+		    "semver": "index.js"
+		  }
+		}
+	JSON
+	cat >tools/semver/index.js <<-'JS'
+		#!/usr/bin/env node
+		console.log("local-semver")
+	JS
+	chmod +x tools/semver/index.js
+
+	aube install
+	run aube dlx semver@7.7.4 1.2.3-alpha.1
+	assert_success
+	assert_line "1.2.3-alpha.1"
+	refute_output --partial "local-semver"
+}
+
 @test "aube dlx --shell-mode runs the joined line through sh -c" {
 	# `semver 1.2.3` would print "1.2.3"; piping through tr proves the
 	# command actually ran inside a shell instead of being exec'd as a

--- a/test/dlx.bats
+++ b/test/dlx.bats
@@ -30,6 +30,39 @@ teardown() {
 	assert_line "1.2.3"
 }
 
+@test "aube dlx prefers an installed local binary" {
+	mkdir -p tools/local-bin
+	cat >package.json <<-'JSON'
+		{
+		  "name": "dlx-local-bin",
+		  "version": "1.0.0",
+		  "private": true,
+		  "dependencies": {
+		    "local-bin": "file:tools/local-bin"
+		  }
+		}
+	JSON
+	cat >tools/local-bin/package.json <<-'JSON'
+		{
+		  "name": "local-bin",
+		  "version": "1.0.0",
+		  "bin": {
+		    "local-bin": "index.js"
+		  }
+		}
+	JSON
+	cat >tools/local-bin/index.js <<-'JS'
+		#!/usr/bin/env node
+		console.log(`local-dlx:${process.argv.slice(2).join(",")}`)
+	JS
+	chmod +x tools/local-bin/index.js
+
+	aube install
+	run aube dlx local-bin alpha beta
+	assert_success
+	assert_line "local-dlx:alpha,beta"
+}
+
 @test "aube dlx -p installs a different package than the bin name" {
 	# The `which` npm package ships a binary named `node-which`, not `which`.
 	# Running `node-which node` prints the absolute path of the `node`

--- a/test/run.bats
+++ b/test/run.bats
@@ -66,6 +66,113 @@ teardown() {
 	assert_line "local-bin:alpha,beta"
 }
 
+@test "aube run --if-present still falls back to local binary" {
+	mkdir -p tools/local-bin
+	cat >package.json <<-'JSON'
+		{
+		  "name": "run-bin-if-present",
+		  "version": "1.0.0",
+		  "private": true,
+		  "dependencies": {
+		    "local-bin": "file:tools/local-bin"
+		  }
+		}
+	JSON
+	cat >tools/local-bin/package.json <<-'JSON'
+		{
+		  "name": "local-bin",
+		  "version": "1.0.0",
+		  "bin": {
+		    "local-bin": "index.js"
+		  }
+		}
+	JSON
+	cat >tools/local-bin/index.js <<-'JS'
+		#!/usr/bin/env node
+		console.log(`local-bin-if-present:${process.argv.slice(2).join(",")}`)
+	JS
+	chmod +x tools/local-bin/index.js
+
+	aube install
+	run aube run --if-present local-bin alpha beta
+	assert_success
+	assert_line "local-bin-if-present:alpha,beta"
+}
+
+@test "aube run filtered falls back to local binaries" {
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/*
+	EOF
+	cat >package.json <<-'JSON'
+		{"name":"root","version":"0.0.0","private":true}
+	JSON
+	mkdir -p packages/a packages/b tools/local-bin
+	cat >packages/a/package.json <<-'JSON'
+		{"name":"a","version":"0.0.0","dependencies":{"local-bin":"file:../../tools/local-bin"}}
+	JSON
+	cat >packages/b/package.json <<-'JSON'
+		{"name":"b","version":"0.0.0","dependencies":{"local-bin":"file:../../tools/local-bin"}}
+	JSON
+	cat >tools/local-bin/package.json <<-'JSON'
+		{
+		  "name": "local-bin",
+		  "version": "1.0.0",
+		  "bin": {
+		    "local-bin": "index.js"
+		  }
+		}
+	JSON
+	cat >tools/local-bin/index.js <<-'JS'
+		#!/usr/bin/env node
+		console.log(`filtered-bin:${process.cwd().split("/").pop()}`)
+	JS
+	chmod +x tools/local-bin/index.js
+
+	aube install
+	run aube -r run local-bin
+	assert_success
+	assert_output --partial "filtered-bin:a"
+	assert_output --partial "filtered-bin:b"
+}
+
+@test "aube run filtered parallel falls back to local binaries" {
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/*
+	EOF
+	cat >package.json <<-'JSON'
+		{"name":"root","version":"0.0.0","private":true}
+	JSON
+	mkdir -p packages/a packages/b tools/local-bin
+	cat >packages/a/package.json <<-'JSON'
+		{"name":"a","version":"0.0.0","dependencies":{"local-bin":"file:../../tools/local-bin"}}
+	JSON
+	cat >packages/b/package.json <<-'JSON'
+		{"name":"b","version":"0.0.0","dependencies":{"local-bin":"file:../../tools/local-bin"}}
+	JSON
+	cat >tools/local-bin/package.json <<-'JSON'
+		{
+		  "name": "local-bin",
+		  "version": "1.0.0",
+		  "bin": {
+		    "local-bin": "index.js"
+		  }
+		}
+	JSON
+	cat >tools/local-bin/index.js <<-'JS'
+		#!/usr/bin/env node
+		console.log(`filtered-parallel-bin:${process.cwd().split("/").pop()}`)
+	JS
+	chmod +x tools/local-bin/index.js
+
+	aube install
+	run aube -r run --parallel local-bin
+	assert_success
+	assert_output --partial "filtered-parallel-bin:a"
+	assert_output --partial "filtered-parallel-bin:b"
+}
+
 @test "aube run without a script errors with available scripts when stdin isn't a TTY" {
 	_setup_basic_fixture
 	aube install

--- a/test/run.bats
+++ b/test/run.bats
@@ -33,6 +33,39 @@ teardown() {
 	assert_output --partial "script not found"
 }
 
+@test "aube run falls back to local binary when no script matches" {
+	mkdir -p tools/local-bin
+	cat >package.json <<-'JSON'
+		{
+		  "name": "run-bin-fallback",
+		  "version": "1.0.0",
+		  "private": true,
+		  "dependencies": {
+		    "local-bin": "file:tools/local-bin"
+		  }
+		}
+	JSON
+	cat >tools/local-bin/package.json <<-'JSON'
+		{
+		  "name": "local-bin",
+		  "version": "1.0.0",
+		  "bin": {
+		    "local-bin": "index.js"
+		  }
+		}
+	JSON
+	cat >tools/local-bin/index.js <<-'JS'
+		#!/usr/bin/env node
+		console.log(`local-bin:${process.argv.slice(2).join(",")}`)
+	JS
+	chmod +x tools/local-bin/index.js
+
+	aube install
+	run aube run local-bin alpha beta
+	assert_success
+	assert_line "local-bin:alpha,beta"
+}
+
 @test "aube run without a script errors with available scripts when stdin isn't a TTY" {
 	_setup_basic_fixture
 	aube install


### PR DESCRIPTION
## Summary

- let `aube run <name>` fall back to `node_modules/.bin/<name>` when no package script matches
- make `aube dlx` / `aubx` prefer an installed local binary unless `-p` / `--package` is used
- document the script/bin precedence in README, package-manager docs, and CLI reference output

## Validation

- `cargo fmt --check`
- `cargo test -p aube dlx`
- `cargo test -p aube allow_build_review_tests`
- `mise run test:bats test/run.bats`
- `mise run test:bats test/dlx.bats`
- `cargo clippy -p aube --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes command-resolution behavior for `aube run`/`aube dlx` to execute local `node_modules/.bin` entries in more cases, which could affect existing automation that relied on throwaway installs or missing-script failures.
> 
> **Overview**
> **Changes CLI command resolution to prefer local project binaries.** `aube run <name>` now falls back to executing `node_modules/.bin/<name>` when no `package.json` script matches (including filtered/recursive and `--parallel` runs).
> 
> **Updates `aube dlx`/`aubx` behavior to avoid unnecessary throwaway installs.** When `--package` is not provided (and not in `--shell-mode`), `dlx` will run an already-installed local bin if present; versioned/non-registry specs bypass this shortcut.
> 
> Documentation and generated CLI reference output are updated accordingly, and new bats tests cover local-bin preference and the version-spec bypass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d03ec26bcdc89b08b382db5b674f05dd747431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->