### PR TITLE
fix(resolver): prefer closest ancestor for unmet peers over distant matches

### DIFF
--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -1050,28 +1050,41 @@ fn visit_peer_context<'g>(
     // of the fixed-point loop.
     // Resolution source priority for each declared peer:
     //   1. Ancestor scope — if the ancestor's version actually
-    //      satisfies the declared peer range. Different subtrees can
-    //      pin different versions of the same peer name (classic
-    //      `lib-a peers on react@^17`, `lib-b peers on react@^18`),
-    //      and silently reusing the ancestor's version regardless of
-    //      the declared range would force both libs onto the same
-    //      version — exactly the behavior we want to fix here.
+    //      satisfies the declared peer range. Different subtrees
+    //      naturally see different ancestors (lib-a in subtree-A
+    //      and lib-b in subtree-B keep their own peer pins), so
+    //      preferring the closest ancestor here doesn't conflate
+    //      cross-subtree variants.
     //   2. The current package's own `pkg.dependencies` entry — the
     //      BFS peer-walk enqueued this peer with the declared range,
     //      so whatever got picked there is guaranteed to satisfy.
-    //   3. A graph-wide scan as a last resort: any package whose name
-    //      matches and whose version satisfies the declared range.
-    //      This keeps nested-context callers from losing their peer
-    //      resolution when neither ancestor nor own-deps has it.
-    //   4. If no satisfying version exists, fall back to the nearest
-    //      incompatible ancestor/root/pkg dependency. pnpm still wires
-    //      that user-declared version into the peer context and then
-    //      reports the semver mismatch; omitting it would produce a
-    //      weaker "missing peer" warning and an unsuffixed snapshot.
+    //      Captures the case where a single subtree holds two
+    //      consumers with conflicting peer ranges (lib-a@^17 next to
+    //      a parent that pins react@18): the BFS auto-installs the
+    //      satisfying version into lib-a's own deps, which beats the
+    //      ancestor's incompatible version.
+    //   3. Ancestor scope — even when the version doesn't satisfy
+    //      the declared range. This mirrors what Node's module
+    //      resolution would surface (`require('peer')` from the
+    //      package would walk up node_modules and find the parent's
+    //      version). pnpm and bun do the same and emit an unmet-peer
+    //      warning rather than picking a more-distant matching
+    //      version. `detect_unmet_peers` flags the mismatch after
+    //      the pass.
+    //   4. The current package's own `pkg.dependencies` entry,
+    //      ignoring range satisfaction — symmetric to (3) for the
+    //      BFS-installed case.
+    //   5. Workspace root scope (compatible) — `resolve-peers-from-
+    //      workspace-root` fallback for monorepos that pin shared
+    //      peers at the root.
+    //   6. A graph-wide scan: any package whose name matches and
+    //      whose version satisfies the declared range. Last resort
+    //      for nested-context callers when nothing closer has it.
+    //   7. Workspace root scope, ignoring range satisfaction.
     //
-    // If nothing in the graph satisfies, the peer is left out of the
-    // context entirely — `detect_unmet_peers` will surface it as a
-    // warning after the pass.
+    // If nothing in the graph holds a version of this peer at all,
+    // it's left out of the context entirely — `detect_unmet_peers`
+    // will surface it as a warning after the pass.
     let mut peer_context: Vec<(String, String)> = Vec::new();
     for (peer_name, declared_range) in &pkg.peer_dependencies {
         let satisfies_declared = |v: &str| -> bool {
@@ -1147,10 +1160,10 @@ fn visit_peer_context<'g>(
 
         if let Some(version) = from_ancestor
             .or(from_pkg_deps)
-            .or(from_root)
-            .or_else(from_graph_scan)
             .or(from_ancestor_incompatible)
             .or(from_pkg_deps_incompatible)
+            .or(from_root)
+            .or_else(from_graph_scan)
             .or(from_root_incompatible)
         {
             peer_context.push((peer_name.clone(), version));

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -1301,6 +1301,89 @@ fn apply_peer_contexts_produces_nested_peer_suffixes() {
     }
 }
 
+// Repro for the johnpyp/aube-vite-peer-variant case: a workspace
+// importer pins a peer version that DOESN'T satisfy a sibling's
+// declared peer range, while the workspace ROOT pins a satisfying
+// one. The peer context must follow node_modules-resolution order
+// — closest-ancestor-wins, even when its version misses the range
+// — and emit an unmet-peer warning rather than reaching past the
+// importer to grab a more-distant matching version. Matches what
+// pnpm and bun produce for the same shape.
+#[test]
+fn apply_peer_contexts_prefers_incompatible_ancestor_over_root() {
+    // consumer peers on dep@^5. Workspace `app` directly depends on
+    // BOTH consumer and dep@8 (out of range). Root pins dep@5 (in
+    // range). The expected pick is the closest provider — `app`'s
+    // dep@8 — not root's dep@5.
+    let mut consumer = mk_locked("consumer", "1.0.0", &[], &[("dep", "^5")]);
+    consumer.dep_path = "consumer@1.0.0".to_string();
+    let dep5 = mk_locked("dep", "5.0.0", &[], &[]);
+    let dep8 = mk_locked("dep", "8.0.0", &[], &[]);
+
+    let mut packages = BTreeMap::new();
+    packages.insert("consumer@1.0.0".to_string(), consumer);
+    packages.insert("dep@5.0.0".to_string(), dep5);
+    packages.insert("dep@8.0.0".to_string(), dep8);
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "dep".to_string(),
+            dep_path: "dep@5.0.0".to_string(),
+            dep_type: DepType::Production,
+            specifier: Some("5.0.0".to_string()),
+        }],
+    );
+    importers.insert(
+        "packages/app".to_string(),
+        vec![
+            DirectDep {
+                name: "consumer".to_string(),
+                dep_path: "consumer@1.0.0".to_string(),
+                dep_type: DepType::Production,
+                specifier: Some("^1".to_string()),
+            },
+            DirectDep {
+                name: "dep".to_string(),
+                dep_path: "dep@8.0.0".to_string(),
+                dep_type: DepType::Production,
+                specifier: Some("8.0.0".to_string()),
+            },
+        ],
+    );
+
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+    let out = apply_peer_contexts(graph, &PeerContextOptions::default());
+
+    // consumer must follow `app`'s dep@8 (its actual node_modules
+    // sibling), even though dep@8 doesn't satisfy `^5`.
+    assert!(
+        out.packages.contains_key("consumer@1.0.0(dep@8.0.0)"),
+        "consumer must pick app's incompatible dep@8 over root's compatible dep@5: {:?}",
+        out.packages.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !out.packages.contains_key("consumer@1.0.0(dep@5.0.0)"),
+        "consumer was incorrectly pinned to root's dep@5: {:?}",
+        out.packages.keys().collect::<Vec<_>>()
+    );
+
+    // detect_unmet_peers should flag the mismatch so the CLI prints
+    // a warning, matching pnpm/bun behavior.
+    let unmet = detect_unmet_peers(&out);
+    assert!(
+        unmet
+            .iter()
+            .any(|u| u.peer_name == "dep" && u.found.as_deref() == Some("8.0.0")),
+        "expected unmet-peer warning for consumer's dep peer: {unmet:?}"
+    );
+}
+
 // Per-peer-range cross-subtree satisfaction: two sibling packages
 // that declare peer react with INCOMPATIBLE ranges should each
 // end up pinned to the version satisfying their own range, even


### PR DESCRIPTION
## Summary

- A workspace package that pins `vite@8` next to `@tailwindcss/vite@4.1.18` (peer `vite: ^5.2 || ^6 || ^7`) was getting linked to the workspace **root**'s `vite@5.4.21` instead of the workspace's own `vite@8.0.10`.
- Bun and pnpm both follow node_modules-resolution order — the closest provider wins, mismatch is a warning, never a redirect to a more-distant matching version. Aube now does the same.
- Fix is in `visit_peer_context`'s priority chain: `from_ancestor_incompatible` and `from_pkg_deps_incompatible` now beat `from_root` / `from_graph_scan` / `from_root_incompatible`.

Repro: https://github.com/johnpyp/2026-05-03-aube-vite-peer-variant-repro

Before (aube 1.7.0):
```
tailwindPeerViteVersion: '5.4.21'
tailwindLink: …@tailwindcss+vite@4.1.18_vite@5.4.21_…
```

After (this PR):
```
tailwindPeerViteVersion: '8.0.10'
tailwindLink: …@tailwindcss+vite@4.1.18_vite@8.0.10_…
```

The mismatch still shows up via `detect_unmet_peers`; the existing strict-peer-dependencies surface continues to flag it.

## Why the existing tests still pass

- `apply_peer_contexts_per_range_satisfaction` covers the "two consumers in one subtree with conflicting peer ranges" case via `pkg.dependencies` (the BFS-auto-installed peer). That tier is higher-priority than the ancestor scope and still wins, so consumer18 still picks `react@18` even when the ancestor has `react@17`.
- `resolve_peers_from_workspace_root_prefers_root` exercises a graph where no ancestor holds the peer at all. Workspace-root fallback is unchanged when nothing closer exists.

## Test plan

- [x] `cargo test -p aube-resolver` — 170 passed (added `apply_peer_contexts_prefers_incompatible_ancestor_over_root` regression test, `detect_unmet_peers` assertion included)
- [x] `cargo test` (workspace) — all crates green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] End-to-end repro install matches pnpm/bun output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes peer-dependency context resolution order, which can alter lockfile `dep_path` suffixes and resulting `node_modules` wiring across workspaces; risk is limited to peer-resolution behavior but affects install determinism.
> 
> **Overview**
> Adjusts peer-context resolution to follow Node/pnpm/bun lookup order when peers are *unmet*: the closest ancestor (or BFS auto-installed `pkg.dependencies`) now wins **even if it does not satisfy** the declared peer range, instead of reaching to workspace-root or doing a graph-wide satisfying-version scan.
> 
> Adds a regression test covering the workspace scenario where an importer pins an incompatible peer version while the workspace root pins a compatible one, asserting the resolver keeps the importer’s version and relies on `detect_unmet_peers` to warn about the mismatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a185645234a31c9bf2ea6005c177245bbf709b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->