### PR TITLE
fix(cli): why/list/query work from a workspace subpackage

### DIFF
--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -166,18 +166,13 @@ pub async fn run(
         return run_global(&args);
     }
 
-    let cwd = crate::dirs::project_or_workspace_root()?;
-    // In yarn / npm / bun monorepos the lockfile lives only at the
-    // workspace root, not in the subpackage. When the caller asks for
-    // `--filter` we read manifest + lockfile from the root so
-    // `run_filtered` sees the real graph — otherwise `parse_lockfile`
-    // returns `NotFound` from the child and we exit before ever
-    // iterating the workspace.
-    let read_from = if !filter.is_empty() {
-        crate::dirs::find_workspace_root(&cwd).unwrap_or_else(|| cwd.clone())
-    } else {
-        cwd.clone()
-    };
+    // Workspace root wins over the nearest project root so `aube list`
+    // run from inside `packages/foo/` reads the lockfile + manifest at
+    // the workspace root instead of the subpackage (which has no
+    // lockfile of its own). yaml-only coordinator monorepos and plain
+    // single-project trees fall back to project root for free.
+    let cwd = crate::dirs::workspace_or_project_root()?;
+    let read_from = cwd.clone();
 
     // When a workspace filter is set, resolve workspace + selectors
     // first so a no-match case takes the warn-and-exit-0 path before

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -169,10 +169,9 @@ pub async fn run(
     // Workspace root wins over the nearest project root so `aube list`
     // run from inside `packages/foo/` reads the lockfile + manifest at
     // the workspace root instead of the subpackage (which has no
-    // lockfile of its own). yaml-only coordinator monorepos and plain
-    // single-project trees fall back to project root for free.
+    // lockfile of its own). Plain single-project trees fall back to
+    // the project root for free.
     let cwd = crate::dirs::workspace_or_project_root()?;
-    let read_from = cwd.clone();
 
     // When a workspace filter is set, resolve workspace + selectors
     // first so a no-match case takes the warn-and-exit-0 path before
@@ -198,20 +197,17 @@ pub async fn run(
     };
 
     let selected = if !filter.is_empty() {
-        let workspace_pkgs = aube_workspace::find_workspace_packages(&read_from)
+        let workspace_pkgs = aube_workspace::find_workspace_packages(&cwd)
             .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
         if workspace_pkgs.is_empty() {
             return Err(miette!(
                 "aube list: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
-                read_from.display()
+                cwd.display()
             ));
         }
-        let selected = aube_workspace::selector::select_workspace_packages(
-            &read_from,
-            &workspace_pkgs,
-            &filter,
-        )
-        .map_err(|e| miette!("invalid --filter selector: {e}"))?;
+        let selected =
+            aube_workspace::selector::select_workspace_packages(&cwd, &workspace_pkgs, &filter)
+                .map_err(|e| miette!("invalid --filter selector: {e}"))?;
         if selected.is_empty() {
             if filter.fail_if_no_match {
                 let shown: Vec<&str> = filter
@@ -225,7 +221,7 @@ pub async fn run(
                 ));
             }
             if format == ListFormat::Default {
-                println!("No projects matched the filters in {}", read_from.display());
+                println!("No projects matched the filters in {}", cwd.display());
             }
             return Ok(());
         }
@@ -239,11 +235,11 @@ pub async fn run(
     // Pure-coordinator workspaces (pnpm-workspace.yaml at the root, no root
     // package.json) read as a default manifest so the lockfile parser still
     // gets the same shape it expects.
-    let manifest = super::load_manifest_or_default(&read_from)?;
+    let manifest = super::load_manifest_or_default(&cwd)?;
 
     // Lockfile may be absent in a brand-new project — treat that as "nothing
     // installed yet" rather than a hard error, and print an empty tree.
-    let graph = match aube_lockfile::parse_lockfile(&read_from, &manifest) {
+    let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
             eprintln!("No lockfile found. Run `aube install` to populate node_modules.");
@@ -259,24 +255,23 @@ pub async fn run(
     // Resolve `virtualStoreDirMaxLength` once so `--long` mode prints
     // the same `.aube/<name>` filename the linker actually wrote.
     // Passing the default would mis-report long dep_paths on projects
-    // that customize the cap via `.npmrc`. Read from `read_from` so
-    // a yarn / npm / bun subpackage inherits the root's settings
-    // instead of falling back to defaults when the child has no
-    // `.npmrc` / `pnpm-workspace.yaml`.
-    let vstore_max_len = super::resolve_virtual_store_dir_max_length_for_cwd(&read_from);
+    // that customize the cap via `.npmrc`. `cwd` is the workspace root
+    // when one exists, so subpackages inherit the root's settings
+    // instead of falling back to defaults.
+    let vstore_max_len = super::resolve_virtual_store_dir_max_length_for_cwd(&cwd);
     // Resolve `virtualStoreDir` too — without this, `--long` would
     // always print `./node_modules/.aube/...` even when the user has
     // relocated the virtual store (e.g. `virtualStoreDir=node_modules/vstore`
     // or an out-of-tree absolute path), pointing at a path that
     // doesn't exist.
     let vstore_prefix = super::format_virtual_store_display_prefix(
-        &super::resolve_virtual_store_dir_for_cwd(&read_from),
-        &read_from,
+        &super::resolve_virtual_store_dir_for_cwd(&cwd),
+        &cwd,
     );
 
     if let Some(selected) = selected {
         return run_filtered(
-            &read_from,
+            &cwd,
             &manifest,
             &graph,
             &args,

--- a/crates/aube/src/commands/query.rs
+++ b/crates/aube/src/commands/query.rs
@@ -71,12 +71,11 @@ pub async fn run(
     args: QueryArgs,
     filter: aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<()> {
-    let cwd = crate::dirs::project_or_workspace_root()?;
-    let read_from = if !filter.is_empty() {
-        crate::dirs::find_workspace_root(&cwd).unwrap_or_else(|| cwd.clone())
-    } else {
-        cwd.clone()
-    };
+    // Workspace root wins over the nearest project root so `aube query`
+    // run from inside `packages/foo/` reads the lockfile + manifest at
+    // the workspace root instead of the subpackage (which has no
+    // lockfile of its own).
+    let read_from = crate::dirs::workspace_or_project_root()?;
     // Yaml-only workspace roots have no root `package.json`; the
     // lockfile parser only uses the manifest to classify yarn.lock
     // direct deps, so a default manifest is fine for the read path.

--- a/crates/aube/src/commands/why.rs
+++ b/crates/aube/src/commands/why.rs
@@ -72,7 +72,11 @@ pub async fn run(
     args: WhyArgs,
     filter: aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<()> {
-    let cwd = crate::dirs::project_or_workspace_root()?;
+    // Workspace root wins over the nearest project root so `aube why`
+    // run from inside `packages/foo/` reads the lockfile + manifest at
+    // the workspace root instead of the subpackage (which has no
+    // lockfile of its own).
+    let cwd = crate::dirs::workspace_or_project_root()?;
 
     if !filter.is_empty() {
         return run_filtered(&cwd, &args, &filter);

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -203,7 +203,7 @@ pub fn project_root_or_cwd() -> miette::Result<PathBuf> {
 /// `why`) so they read the workspace lockfile when invoked from inside
 /// a subpackage instead of failing with a "no lockfile" error against
 /// the subpackage's own directory. Falls back to the project root for
-/// non-workspace trees, including yaml-only coordinator monorepos.
+/// non-workspace trees (no workspace yaml and no `package.json#workspaces`).
 pub fn workspace_or_project_root() -> miette::Result<PathBuf> {
     let initial_cwd = cwd()?;
     if let Some(root) = find_workspace_root(&initial_cwd) {

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -193,36 +193,17 @@ pub fn project_root_or_cwd() -> miette::Result<PathBuf> {
     Ok(find_project_root(&initial_cwd).unwrap_or(initial_cwd))
 }
 
-/// Return the nearest project root, falling back to the workspace root
-/// when no ancestor has a `package.json` but a `pnpm-workspace.yaml` /
-/// `aube-workspace.yaml` (or `package.json#workspaces`) marks a
-/// workspace root above the cwd.
-///
-/// Used by workspace-scoped read commands (`list`, `query`, `why`) and
-/// by `install` so a "pure coordinator" monorepo — workspace yaml at
-/// the root, sub-packages under `packages/*`, no root `package.json` —
-/// still operates against the workspace as a whole. Single-project
-/// commands (`add`, `remove`, root-only `run <script>`) keep using
-/// [`project_root`], which still hard-errors without a manifest.
-pub fn project_or_workspace_root() -> miette::Result<PathBuf> {
-    let initial_cwd = cwd()?;
-    if let Some(root) = find_project_root(&initial_cwd) {
-        return Ok(root);
-    }
-    if let Some(root) = find_workspace_root(&initial_cwd) {
-        return Ok(root);
-    }
-    Err(no_root_error(&initial_cwd))
-}
-
 /// Return the workspace root if one exists above the cwd, falling back
-/// to the nearest project root. The opposite precedence of
-/// [`project_or_workspace_root`].
+/// to the nearest project root.
 ///
 /// Used by `install` and `patch` so `cd packages/app && aube install`
 /// writes the lockfile + `.aube/` virtual store at the workspace root
 /// (matching pnpm), and `aube patch` from a member finds the shared
-/// store. Falls back to the project root for non-workspace trees.
+/// store. Also used by workspace-scoped read commands (`list`, `query`,
+/// `why`) so they read the workspace lockfile when invoked from inside
+/// a subpackage instead of failing with a "no lockfile" error against
+/// the subpackage's own directory. Falls back to the project root for
+/// non-workspace trees, including yaml-only coordinator monorepos.
 pub fn workspace_or_project_root() -> miette::Result<PathBuf> {
     let initial_cwd = cwd()?;
     if let Some(root) = find_workspace_root(&initial_cwd) {

--- a/test/list.bats
+++ b/test/list.bats
@@ -187,6 +187,29 @@ JSON
 	refute_output --partial "is-number 7.0.0"
 }
 
+@test "aube list walks up to the workspace root from a subpackage cwd" {
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	cat >package.json <<'JSON'
+{ "name": "root", "version": "0.0.0", "private": true, "dependencies": { "is-odd": "3.0.1" } }
+JSON
+	mkdir -p packages/lib-a
+	cat >packages/lib-a/package.json <<'JSON'
+{ "name": "@scope/lib-a", "version": "1.0.0" }
+JSON
+
+	run aube install
+	assert_success
+
+	cd packages/lib-a
+	run aube list
+	assert_success
+	refute_output --partial "No lockfile found"
+	assert_output --partial "is-odd 3.0.1"
+}
+
 @test "aube list without a lockfile prints a friendly message" {
 	echo '{"name":"empty","version":"1.0.0"}' >package.json
 	run aube list

--- a/test/query.bats
+++ b/test/query.bats
@@ -9,6 +9,29 @@ teardown() {
 	_common_teardown
 }
 
+@test "aube query walks up to the workspace root from a subpackage cwd" {
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	cat >package.json <<'JSON'
+{ "name": "root", "version": "0.0.0", "private": true, "dependencies": { "is-odd": "3.0.1" } }
+JSON
+	mkdir -p packages/lib-a
+	cat >packages/lib-a/package.json <<'JSON'
+{ "name": "@scope/lib-a", "version": "1.0.0" }
+JSON
+
+	run aube install
+	assert_success
+
+	cd packages/lib-a
+	run aube query '[name=is-number]' --parseable
+	assert_success
+	refute_output --partial "No lockfile found"
+	assert_output --partial $'\tis-number\t'
+}
+
 @test "aube query filters lockfile packages by name" {
 	cat >package.json <<'JSON'
 {

--- a/test/why.bats
+++ b/test/why.bats
@@ -232,3 +232,30 @@ EOF
 	assert_output --partial "packages/lib-a"
 	refute_output --partial "packages/lib-b"
 }
+
+@test "aube why walks up to the workspace root from a subpackage cwd" {
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - packages/*
+EOF
+	cat >package.json <<'EOF'
+{"name":"root","version":"0.0.0","private":true}
+EOF
+	mkdir -p packages/lib-a
+	cat >packages/lib-a/package.json <<'EOF'
+{
+  "name": "@scope/lib-a",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "^3.0.1" }
+}
+EOF
+
+	run aube install
+	assert_success
+
+	cd packages/lib-a
+	run aube why is-number
+	assert_success
+	refute_output --partial "No lockfile found"
+	assert_output --partial "is-number"
+}


### PR DESCRIPTION
## Summary

- `aube why`, `aube list`, and `aube query` resolved cwd via `project_or_workspace_root`, which returns the nearest `package.json`. Inside a workspace member like `packages/foo/`, that returned the subpackage directory and `parse_lockfile` then failed with `No lockfile found. Run aube install first.` even though the workspace lockfile sat one level up.
- Switched all three commands to `workspace_or_project_root` so they walk up to the workspace root when one is present and fall back to the nearest project root for non-workspace trees (and yaml-only coordinator monorepos).
- Removed the now-dead `project_or_workspace_root` helper and the zero-call-site `read_from` override branches in `list` / `query`.

Reported in https://github.com/endevco/aube/discussions/345.

## Test plan
- [x] `cargo build`, `cargo fmt --check`, `cargo clippy -p aube --all-targets -- -D warnings`
- [x] `cargo test -p aube --bin aube` (393 tests pass)
- [x] `mise run test:bats test/why.bats test/list.bats test/query.bats test/project_root_walk_up.bats` (47/47 pass, including 3 new regression tests)
- [x] Manual repro: workspace with `packages/lib-a` declaring `is-odd`; `cd packages/lib-a && aube {why is-number, list, query '[name=is-number]' --parseable}` all succeed instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI cwd/root resolution for read-only commands and add regression tests; main risk is altered root selection in edge-case directory layouts.
> 
> **Overview**
> Fixes `aube list`, `aube query`, and `aube why` to prefer the workspace root (when present) over the nearest `package.json`, so running from a workspace member directory reads the correct root lockfile/manifest instead of erroring with missing lockfile.
> 
> Removes the now-unused `project_or_workspace_root` helper and simplifies the commands’ root-selection logic, and adds Bats regression tests covering running each command from a subpackage cwd in a pnpm workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e36fdc825931fc51dc86176f1c26daa1e169ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->