### PR TITLE
ci(release): harden upload asset builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,31 @@ env:
   AUBE_REQUIRE_PRIMER: "1"
 
 jobs:
+  generate-primer:
+    runs-on: namespace-profile-endev-linux-amd64
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          submodules: recursive
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+      - name: Generate metadata primer
+        shell: bash
+        run: |
+          node scripts/generate-primer.mjs \
+            --top "$AUBE_PRIMER_TOP" \
+            --versions "$AUBE_PRIMER_VERSION_CAP" \
+            --out "crates/aube-resolver/data/primer-top${AUBE_PRIMER_TOP}-v${AUBE_PRIMER_VERSION_CAP}.rkyv.json"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: metadata-primer
+          path: crates/aube-resolver/data/primer-top${{ env.AUBE_PRIMER_TOP }}-v${{ env.AUBE_PRIMER_VERSION_CAP }}.rkyv.json
+
   upload-assets:
+    needs: generate-primer
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
@@ -75,20 +99,10 @@ jobs:
         with:
           ref: refs/tags/${{ inputs.tag }}
           submodules: recursive
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
-        if: ${{ matrix.runner != 'windows-latest' }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          cache: rust
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: '24'
-      - name: Generate metadata primer
-        shell: bash
-        run: |
-          node scripts/generate-primer.mjs \
-            --top "$AUBE_PRIMER_TOP" \
-            --versions "$AUBE_PRIMER_VERSION_CAP" \
-            --out "crates/aube-resolver/data/primer-top${AUBE_PRIMER_TOP}-v${AUBE_PRIMER_VERSION_CAP}.rkyv.json"
+          name: metadata-primer
+          path: crates/aube-resolver/data
       - name: Import codesign certs
         if: startsWith(matrix.os, 'macos')
         uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3


### PR DESCRIPTION
## Summary

- generate the release metadata primer once before the upload-assets matrix starts
- pass the shared primer into each asset build through a workflow artifact
- remove Namespace's shared Rust cache restore from release upload-assets jobs

## Why

The v1.8.0 release failed in the x86_64 GNU upload job because a restored `./target` cache contained build-script binaries linked against a newer host glibc. `cross` then tried to execute those cached artifacts inside the older `ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5` image, producing `GLIBC_2.25` / `GLIBC_2.27` loader errors.

Release asset jobs are packaging boundaries, so they should avoid reusing shared native/cross build-script state. Since clean builds would otherwise make every matrix entry fetch the same npm metadata primer independently, this also moves primer generation into one upstream job and downloads the same snapshot into each upload-assets job.

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check -- .github/workflows/release.yml`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release build pipeline ordering and artifacts, which could impact release automation if the primer artifact isn’t produced or downloaded as expected. It also intentionally disables caching, increasing build time but reducing cross/glibc cache-related failures.
> 
> **Overview**
> Release CI now generates the resolver metadata primer in a dedicated `generate-primer` job (Node 24), uploads it as a workflow artifact, and makes `upload-assets` depend on it.
> 
> `upload-assets` no longer restores Namespace’s shared Rust cache or regenerates the primer per target; instead it downloads the prebuilt primer into `crates/aube-resolver/data` before building and uploading release archives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0b2a29f02dd275e645b701c2a390c642d4fa397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->