### PR TITLE
chore: release v1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aube-manifest",
  "landlock",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aube-manifest",
  "glob",
@@ -1164,9 +1164,9 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "demand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fbd3e6864d5351323ef4fa5db803386adf73cce6b42fcdf6a542804dc83c61"
+checksum = "4e75be0d8a6175692cd9f9e7a7e18acd14612be09e166391a8093b7823295cd4"
 dependencies = [
  "console",
  "fuzzy-matcher",
@@ -1676,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2156,16 +2156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,7 +2357,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3381,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -4245,9 +4235,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -4661,9 +4651,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -4768,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -4780,13 +4770,13 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.8.0"
+version = "1.9.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -132,18 +132,18 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.8.0" }
-aube-codes = { path = "crates/aube-codes", version = "1.8.0" }
-aube-settings = { path = "crates/aube-settings", version = "1.8.0" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.8.0" }
-aube-registry = { path = "crates/aube-registry", version = "1.8.0" }
-aube-store = { path = "crates/aube-store", version = "1.8.0" }
-aube-linker = { path = "crates/aube-linker", version = "1.8.0" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.8.0" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.8.0" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.8.0" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.8.0" }
-aube-util = { path = "crates/aube-util", version = "1.8.0" }
+aube = { path = "crates/aube", version = "1.9.0" }
+aube-codes = { path = "crates/aube-codes", version = "1.9.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.9.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.9.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.9.0" }
+aube-store = { path = "crates/aube-store", version = "1.9.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.9.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.9.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.9.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.9.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.9.0" }
+aube-util = { path = "crates/aube-util", version = "1.9.0" }
 
 [profile.dev]
 debug = 1

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.8.0"
+version "1.9.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-codes/CHANGELOG.md
+++ b/crates/aube-codes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-codes-v1.8.0...aube-codes-v1.9.0) - 2026-05-05
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-codes-v1.7.0...aube-codes-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-linker-v1.8.0...aube-linker-v1.9.0) - 2026-05-05
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-linker-v1.7.0...aube-linker-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.8.0...aube-lockfile-v1.9.0) - 2026-05-05
+
+### Fixed
+
+- *(lockfile)* tolerate legacy license shapes in package-lock.json ([#512](https://github.com/endevco/aube/pull/512))
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.7.0...aube-lockfile-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-manifest-v1.8.0...aube-manifest-v1.9.0) - 2026-05-05
+
+### Added
+
+- *(workspace)* preserve comments in workspace yaml edits via yamlpatch ([#511](https://github.com/endevco/aube/pull/511))
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-manifest-v1.7.0...aube-manifest-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-registry-v1.8.0...aube-registry-v1.9.0) - 2026-05-05
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-registry-v1.7.0...aube-registry-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-resolver-v1.8.0...aube-resolver-v1.9.0) - 2026-05-05
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-resolver-v1.7.0...aube-resolver-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-scripts-v1.8.0...aube-scripts-v1.9.0) - 2026-05-05
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-scripts-v1.7.0...aube-scripts-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-settings-v1.8.0...aube-settings-v1.9.0) - 2026-05-05
+
+### Added
+
+- *(config)* store aube settings outside npmrc ([#517](https://github.com/endevco/aube/pull/517))
+- *(workspace)* preserve comments in workspace yaml edits via yamlpatch ([#511](https://github.com/endevco/aube/pull/511))
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-settings-v1.7.0...aube-settings-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-store-v1.8.0...aube-store-v1.9.0) - 2026-05-05
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-store-v1.7.0...aube-store-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-util-v1.8.0...aube-util-v1.9.0) - 2026-05-05
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-util-v1.7.0...aube-util-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/aube-workspace-v1.8.0...aube-workspace-v1.9.0) - 2026-05-05
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/aube-workspace-v1.7.0...aube-workspace-v1.8.0) - 2026-05-03
 
 ### Added

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/endevco/aube/compare/v1.8.0...v1.9.0) - 2026-05-05
+
+### Added
+
+- *(config)* store aube settings outside npmrc ([#517](https://github.com/endevco/aube/pull/517))
+- *(run)* forward inspect flags to node targets ([#515](https://github.com/endevco/aube/pull/515))
+- *(workspace)* preserve comments in workspace yaml edits via yamlpatch ([#511](https://github.com/endevco/aube/pull/511))
+
+### Fixed
+
+- *(deploy)* bundle workspace siblings and file: deps; add --no-prod ([#507](https://github.com/endevco/aube/pull/507))
+
+### Other
+
+- refresh benchmarks for v1.8.0 ([#508](https://github.com/endevco/aube/pull/508))
+
 ## [1.8.0](https://github.com/endevco/aube/compare/v1.7.0...v1.8.0) - 2026-05-03
 
 ### Added

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -11852,7 +11852,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.8.0",
+  "version": "1.9.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.8.0
+**Version**: 1.9.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.8.0",
-  "releasedAt": "2026-05-03T19:53:44Z"
+  "version": "1.9.0",
+  "releasedAt": "2026-05-05T18:06:44Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.9.0`

This PR bumps the workspace to `v1.9.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
