### PR TITLE
feat(run): forward inspect flags to node targets

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1448,6 +1448,12 @@ cmd root help="Print the path to `node_modules`" {
 cmd run help="Run a script defined in package.json" {
     alias run-script hide=#true
     flag --if-present help="Don't error if the script is missing from package.json"
+    flag --inspect help="Forward `--inspect` to a Node-backed script or local binary" {
+        arg "<[HOST:]PORT>"
+    }
+    flag --inspect-brk help="Forward `--inspect-brk` to a Node-backed script or local binary" {
+        arg "<[HOST:]PORT>"
+    }
     flag --no-bail help="Continue recursive execution after a script fails" {
         long_help "Continue recursive execution after a script fails.\n\nParsed for pnpm compatibility; aube's sequential fanout still stops on first failure."
     }

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1449,10 +1449,10 @@ cmd run help="Run a script defined in package.json" {
     alias run-script hide=#true
     flag --if-present help="Don't error if the script is missing from package.json"
     flag --inspect help="Forward `--inspect` to a Node-backed script or local binary" {
-        arg "<[HOST:]PORT>"
+        arg "[[HOST:]PORT]" required=#false
     }
     flag --inspect-brk help="Forward `--inspect-brk` to a Node-backed script or local binary" {
-        arg "<[HOST:]PORT>"
+        arg "[[HOST:]PORT]" required=#false
     }
     flag --no-bail help="Continue recursive execution after a script fails" {
         long_help "Continue recursive execution after a script fails.\n\nParsed for pnpm compatibility; aube's sequential fanout still stops on first failure."

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -300,31 +300,62 @@ fn node_bin_command(
         return None;
     }
     let target = resolve_node_bin_target(bin_path)?;
-    if !is_node_backed_bin(&target) {
+    if !is_node_backed_bin(&target.path) {
         return None;
     }
-    let mut cmd = tokio::process::Command::new("node");
-    cmd.args(node_args).arg(target).args(args);
+    let mut cmd = tokio::process::Command::new(target.node.unwrap_or_else(|| "node".into()));
+    if let Some(node_path) = target.node_path {
+        cmd.env("NODE_PATH", node_path);
+    }
+    cmd.args(node_args).arg(target.path).args(args);
     Some(cmd)
 }
 
-fn resolve_node_bin_target(bin_path: &Path) -> Option<std::path::PathBuf> {
-    let path = resolve_exec_shim(bin_path);
-    resolve_node_bin_target_path(&path).or(Some(path))
+struct NodeBinTarget {
+    path: std::path::PathBuf,
+    node: Option<std::path::PathBuf>,
+    node_path: Option<std::path::PathBuf>,
 }
 
-fn resolve_node_bin_target_path(path: &Path) -> Option<std::path::PathBuf> {
+fn resolve_node_bin_target(bin_path: &Path) -> Option<NodeBinTarget> {
+    let path = resolve_exec_shim(bin_path);
+    resolve_node_bin_target_path(&path).or(Some(NodeBinTarget {
+        path,
+        node: None,
+        node_path: None,
+    }))
+}
+
+fn resolve_node_bin_target_path(path: &Path) -> Option<NodeBinTarget> {
     if let Ok(target) = std::fs::read_link(path) {
-        return Some(if target.is_absolute() {
+        let path = if target.is_absolute() {
             target
         } else {
             aube_linker::normalize_path(&path.parent()?.join(target))
+        };
+        return Some(NodeBinTarget {
+            path,
+            node: None,
+            node_path: None,
         });
     }
     let content = std::fs::read_to_string(path).ok()?;
-    let rel = aube_linker::parse_posix_shim_target(&content)
-        .or_else(|| parse_cmd_shim_target(&content))?;
-    Some(aube_linker::normalize_path(&path.parent()?.join(rel)))
+    let parent = path.parent()?;
+    if let Some(rel) = aube_linker::parse_posix_shim_target(&content) {
+        return Some(NodeBinTarget {
+            path: aube_linker::normalize_path(&parent.join(rel)),
+            node: local_node_program(parent),
+            node_path: parse_posix_node_path(&content)
+                .map(|rel| aube_linker::normalize_path(&parent.join(rel))),
+        });
+    }
+    let rel = parse_cmd_shim_target(&content)?;
+    Some(NodeBinTarget {
+        path: aube_linker::normalize_path(&parent.join(rel)),
+        node: local_node_program(parent),
+        node_path: parse_cmd_node_path(&content)
+            .map(|rel| aube_linker::normalize_path(&parent.join(rel))),
+    })
 }
 
 fn parse_cmd_shim_target(content: &str) -> Option<&str> {
@@ -332,7 +363,9 @@ fn parse_cmd_shim_target(content: &str) -> Option<&str> {
     let mut rest = content;
     while let Some(start) = rest.find(marker) {
         let after_marker = &rest[start + marker.len()..];
-        let end = after_marker.find('"')?;
+        let Some(end) = after_marker.find('"') else {
+            break;
+        };
         let candidate = &after_marker[..end];
         if !candidate.ends_with(".exe") {
             return Some(candidate);
@@ -340,6 +373,25 @@ fn parse_cmd_shim_target(content: &str) -> Option<&str> {
         rest = &after_marker[end + 1..];
     }
     None
+}
+
+fn parse_cmd_node_path(content: &str) -> Option<&str> {
+    let rest = content
+        .lines()
+        .find_map(|line| line.strip_prefix("@SET NODE_PATH=%~dp0"))?;
+    Some(rest.trim_end_matches('\r'))
+}
+
+fn parse_posix_node_path(content: &str) -> Option<&str> {
+    content.lines().find_map(|line| {
+        line.strip_prefix("export NODE_PATH=\"$basedir/")
+            .and_then(|rest| rest.strip_suffix('"'))
+    })
+}
+
+fn local_node_program(parent: &Path) -> Option<std::path::PathBuf> {
+    let node = parent.join(if cfg!(windows) { "node.exe" } else { "node" });
+    node.exists().then_some(node)
 }
 
 fn is_node_backed_bin(target: &Path) -> bool {
@@ -405,7 +457,10 @@ pub(crate) fn resolve_exec_shim(bin_path: &Path) -> std::path::PathBuf {
 #[cfg(test)]
 mod tests {
     use super::resolve_node_bin_target;
-    use super::{is_node_backed_bin, parse_cmd_shim_target, resolve_exec_shim};
+    use super::{
+        is_node_backed_bin, parse_cmd_node_path, parse_cmd_shim_target, parse_posix_node_path,
+        resolve_exec_shim,
+    };
 
     #[test]
     fn resolve_exec_shim_returns_bare_path_when_no_sibling() {
@@ -445,7 +500,10 @@ mod tests {
         let shim = tmp.path().join("shim");
         std::fs::write(&target, b"#!/usr/bin/env node\n").unwrap();
         std::os::unix::fs::symlink("bin.js", &shim).unwrap();
-        assert_eq!(resolve_node_bin_target(&shim).unwrap(), target);
+        let resolved = resolve_node_bin_target(&shim).unwrap();
+        assert_eq!(resolved.path, target);
+        assert_eq!(resolved.node, None);
+        assert_eq!(resolved.node_path, None);
     }
 
     #[test]
@@ -460,6 +518,54 @@ mod tests {
         assert_eq!(parse_cmd_shim_target(content), Some("pkg\\bin.js"));
     }
 
+    #[test]
+    fn parse_cmd_shim_target_stops_on_truncated_marker() {
+        assert_eq!(parse_cmd_shim_target("\"%~dp0\\node.exe"), None);
+    }
+
+    #[test]
+    fn parse_cmd_node_path_reads_generated_env() {
+        let content = "@SETLOCAL\r\n@SET NODE_PATH=%~dp0..\\..\r\n";
+
+        assert_eq!(parse_cmd_node_path(content), Some("..\\.."));
+    }
+
+    #[test]
+    fn parse_posix_node_path_reads_generated_env() {
+        let content = "#!/bin/sh\nexport NODE_PATH=\"$basedir/../..\"\n";
+
+        assert_eq!(parse_posix_node_path(content), Some("../.."));
+    }
+
+    #[test]
+    fn resolve_node_bin_target_preserves_posix_shim_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("pkg").join("bin.js");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, b"#!/usr/bin/env node\n").unwrap();
+
+        let shim = tmp.path().join("mycli");
+        let local_node = tmp
+            .path()
+            .join(if cfg!(windows) { "node.exe" } else { "node" });
+        let node_path = tmp.path().join("node_modules");
+        std::fs::write(&local_node, b"").unwrap();
+        std::fs::write(
+            &shim,
+            "#!/bin/sh\n\
+             # aube-bin-shim v1 target=pkg/bin.js\n\
+             basedir=$(dirname \"$0\")\n\
+             export NODE_PATH=\"$basedir/node_modules\"\n\
+             exec node \"$basedir/pkg/bin.js\" \"$@\"\n",
+        )
+        .unwrap();
+
+        let resolved = resolve_node_bin_target(&shim).unwrap();
+        assert_eq!(resolved.path, target);
+        assert_eq!(resolved.node, Some(local_node));
+        assert_eq!(resolved.node_path, Some(node_path));
+    }
+
     #[cfg(windows)]
     #[test]
     fn resolve_node_bin_target_reads_cmd_shim_on_windows() {
@@ -467,6 +573,9 @@ mod tests {
         let target = tmp.path().join("pkg").join("bin.js");
         std::fs::create_dir_all(target.parent().unwrap()).unwrap();
         std::fs::write(&target, b"#!/usr/bin/env node\n").unwrap();
+        let local_node = tmp.path().join("node.exe");
+        let node_path = tmp.path().join("node_modules");
+        std::fs::write(&local_node, b"").unwrap();
 
         let bare = tmp.path().join("mycli");
         std::fs::write(
@@ -477,6 +586,7 @@ mod tests {
         std::fs::write(
             tmp.path().join("mycli.cmd"),
             b"@SETLOCAL\r\n\
+              @SET NODE_PATH=%~dp0node_modules\r\n\
               @IF EXIST \"%~dp0\\node.exe\" (\r\n\
               \x20 \"%~dp0\\node.exe\" \"%~dp0\\pkg\\bin.js\" %*\r\n\
               ) ELSE (\r\n\
@@ -485,7 +595,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(resolve_node_bin_target(&bare).unwrap(), target);
+        let resolved = resolve_node_bin_target(&bare).unwrap();
+        assert_eq!(resolved.path, target);
+        assert_eq!(resolved.node, Some(local_node));
+        assert_eq!(resolved.node_path, Some(node_path));
     }
 
     #[test]

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -189,13 +189,26 @@ pub(crate) async fn exec_bin(
     args: &[String],
     shell_mode: bool,
 ) -> miette::Result<()> {
+    exec_bin_with_node_args(cwd, bin_path, bin, args, &[], shell_mode).await
+}
+
+pub(crate) async fn exec_bin_with_node_args(
+    cwd: &Path,
+    bin_path: &Path,
+    bin: &str,
+    args: &[String],
+    node_args: &[String],
+    shell_mode: bool,
+) -> miette::Result<()> {
     if !shell_mode && !bin_path.exists() {
         return Err(miette!(
             "binary not found: {bin}\nTry running `aube install` first, or check that the package providing '{bin}' is in your dependencies."
         ));
     }
 
-    let mut command = if shell_mode {
+    let mut command = if let Some(cmd) = node_bin_command(bin_path, args, node_args, shell_mode) {
+        cmd
+    } else if shell_mode {
         let line = std::iter::once(aube_scripts::shell_quote_arg(bin))
             .chain(args.iter().map(|arg| aube_scripts::shell_quote_arg(arg)))
             .collect::<Vec<_>>()
@@ -233,13 +246,26 @@ pub(crate) async fn exec_bin_status(
     args: &[String],
     shell_mode: bool,
 ) -> miette::Result<std::process::ExitStatus> {
+    exec_bin_status_with_node_args(cwd, bin_path, bin, args, &[], shell_mode).await
+}
+
+pub(crate) async fn exec_bin_status_with_node_args(
+    cwd: &Path,
+    bin_path: &Path,
+    bin: &str,
+    args: &[String],
+    node_args: &[String],
+    shell_mode: bool,
+) -> miette::Result<std::process::ExitStatus> {
     if !shell_mode && !bin_path.exists() {
         return Err(miette!(
             "binary not found: {bin}\nTry running `aube install` first, or check that the package providing '{bin}' is in your dependencies."
         ));
     }
 
-    let mut command = if shell_mode {
+    let mut command = if let Some(cmd) = node_bin_command(bin_path, args, node_args, shell_mode) {
+        cmd
+    } else if shell_mode {
         let line = std::iter::once(aube_scripts::shell_quote_arg(bin))
             .chain(args.iter().map(|arg| aube_scripts::shell_quote_arg(arg)))
             .collect::<Vec<_>>()
@@ -264,6 +290,61 @@ pub(crate) async fn exec_bin_status(
         .wrap_err("failed to execute binary")
 }
 
+fn node_bin_command(
+    bin_path: &Path,
+    args: &[String],
+    node_args: &[String],
+    shell_mode: bool,
+) -> Option<tokio::process::Command> {
+    if shell_mode || node_args.is_empty() {
+        return None;
+    }
+    let target = resolve_node_bin_target(bin_path)?;
+    if !is_node_backed_bin(&target) {
+        return None;
+    }
+    let mut cmd = tokio::process::Command::new("node");
+    cmd.args(node_args).arg(target).args(args);
+    Some(cmd)
+}
+
+fn resolve_node_bin_target(bin_path: &Path) -> Option<std::path::PathBuf> {
+    let path = resolve_exec_shim(bin_path);
+    if let Ok(target) = std::fs::read_link(&path) {
+        return Some(if target.is_absolute() {
+            target
+        } else {
+            aube_linker::normalize_path(&path.parent()?.join(target))
+        });
+    }
+    #[cfg(unix)]
+    {
+        let content = std::fs::read_to_string(&path).ok()?;
+        let rel = aube_linker::parse_posix_shim_target(&content)?;
+        return Some(aube_linker::normalize_path(&path.parent()?.join(rel)));
+    }
+    #[allow(unreachable_code)]
+    Some(path)
+}
+
+fn is_node_backed_bin(target: &Path) -> bool {
+    let Ok(bytes) = std::fs::read(target) else {
+        return false;
+    };
+    let first_line = bytes
+        .split(|b| *b == b'\n')
+        .next()
+        .and_then(|line| std::str::from_utf8(line).ok())
+        .unwrap_or("");
+    if first_line.starts_with("#!") && first_line.contains("node") {
+        return true;
+    }
+    matches!(
+        target.extension().and_then(|ext| ext.to_str()),
+        Some("js" | "cjs" | "mjs")
+    )
+}
+
 /// Pick the executable variant of a `node_modules/.bin/<name>` shim.
 ///
 /// On Unix the bare path is a sh shebang script and is what we want.
@@ -285,7 +366,7 @@ pub(crate) fn resolve_exec_shim(bin_path: &Path) -> std::path::PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_exec_shim;
+    use super::{is_node_backed_bin, resolve_exec_shim, resolve_node_bin_target};
 
     #[test]
     fn resolve_exec_shim_returns_bare_path_when_no_sibling() {
@@ -315,5 +396,24 @@ mod tests {
         std::fs::write(&bare, b"#!/bin/sh\n").unwrap();
         std::fs::write(&cmd_shim, b"@echo off\n").unwrap();
         assert_eq!(resolve_exec_shim(&bare), bare);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_node_bin_target_follows_symlink() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("bin.js");
+        let shim = tmp.path().join("shim");
+        std::fs::write(&target, b"#!/usr/bin/env node\n").unwrap();
+        std::os::unix::fs::symlink("bin.js", &shim).unwrap();
+        assert_eq!(resolve_node_bin_target(&shim).unwrap(), target);
+    }
+
+    #[test]
+    fn is_node_backed_bin_detects_node_shebang() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("bin");
+        std::fs::write(&target, b"#!/usr/bin/env node\nconsole.log(1)\n").unwrap();
+        assert!(is_node_backed_bin(&target));
     }
 }

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -328,21 +328,44 @@ fn resolve_node_bin_target(bin_path: &Path) -> Option<std::path::PathBuf> {
 }
 
 fn is_node_backed_bin(target: &Path) -> bool {
-    let Ok(bytes) = std::fs::read(target) else {
+    use std::io::Read;
+
+    let Ok(mut file) = std::fs::File::open(target) else {
         return false;
     };
-    let first_line = bytes
+    let mut buf = [0u8; 256];
+    let n = file.read(&mut buf).unwrap_or(0);
+    let first_line = buf[..n]
         .split(|b| *b == b'\n')
         .next()
         .and_then(|line| std::str::from_utf8(line).ok())
-        .unwrap_or("");
-    if first_line.starts_with("#!") && first_line.contains("node") {
-        return true;
+        .unwrap_or("")
+        .trim_end_matches('\r');
+    if let Some(interpreter) = first_line.strip_prefix("#!") {
+        return is_node_interpreter(interpreter);
     }
     matches!(
         target.extension().and_then(|ext| ext.to_str()),
         Some("js" | "cjs" | "mjs")
     )
+}
+
+fn is_node_interpreter(raw: &str) -> bool {
+    let interpreter = raw.trim();
+    let name = if let Some(rest) = interpreter.strip_prefix("/usr/bin/env") {
+        let rest = rest.trim_start();
+        let rest = rest.strip_prefix("-S").map_or(rest, |r| r.trim_start());
+        rest.split_whitespace()
+            .find(|part| !part.contains('='))
+            .unwrap_or("")
+    } else {
+        interpreter.split_whitespace().next().unwrap_or("")
+    };
+    let basename = std::path::Path::new(name)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    matches!(basename, "node" | "nodejs")
 }
 
 /// Pick the executable variant of a `node_modules/.bin/<name>` shim.
@@ -414,6 +437,31 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let target = tmp.path().join("bin");
         std::fs::write(&target, b"#!/usr/bin/env node\nconsole.log(1)\n").unwrap();
+        assert!(is_node_backed_bin(&target));
+    }
+
+    #[test]
+    fn is_node_backed_bin_rejects_node_substring_interpreters() {
+        let tmp = tempfile::tempdir().unwrap();
+        for interpreter in ["nodemon", "nodeenv", "node-gyp", "node-18"] {
+            let target = tmp.path().join(interpreter);
+            std::fs::write(
+                &target,
+                format!("#!/usr/bin/env {interpreter}\n").as_bytes(),
+            )
+            .unwrap();
+            assert!(
+                !is_node_backed_bin(&target),
+                "{interpreter} should not be treated as node"
+            );
+        }
+    }
+
+    #[test]
+    fn is_node_backed_bin_accepts_nodejs_shebang() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("bin");
+        std::fs::write(&target, b"#!/usr/bin/nodejs\nconsole.log(1)\n").unwrap();
         assert!(is_node_backed_bin(&target));
     }
 }

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -389,7 +389,9 @@ pub(crate) fn resolve_exec_shim(bin_path: &Path) -> std::path::PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_node_backed_bin, resolve_exec_shim, resolve_node_bin_target};
+    #[cfg(unix)]
+    use super::resolve_node_bin_target;
+    use super::{is_node_backed_bin, resolve_exec_shim};
 
     #[test]
     fn resolve_exec_shim_returns_bare_path_when_no_sibling() {

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -310,21 +310,36 @@ fn node_bin_command(
 
 fn resolve_node_bin_target(bin_path: &Path) -> Option<std::path::PathBuf> {
     let path = resolve_exec_shim(bin_path);
-    if let Ok(target) = std::fs::read_link(&path) {
+    resolve_node_bin_target_path(&path).or(Some(path))
+}
+
+fn resolve_node_bin_target_path(path: &Path) -> Option<std::path::PathBuf> {
+    if let Ok(target) = std::fs::read_link(path) {
         return Some(if target.is_absolute() {
             target
         } else {
             aube_linker::normalize_path(&path.parent()?.join(target))
         });
     }
-    #[cfg(unix)]
-    {
-        let content = std::fs::read_to_string(&path).ok()?;
-        let rel = aube_linker::parse_posix_shim_target(&content)?;
-        return Some(aube_linker::normalize_path(&path.parent()?.join(rel)));
+    let content = std::fs::read_to_string(path).ok()?;
+    let rel = aube_linker::parse_posix_shim_target(&content)
+        .or_else(|| parse_cmd_shim_target(&content))?;
+    Some(aube_linker::normalize_path(&path.parent()?.join(rel)))
+}
+
+fn parse_cmd_shim_target(content: &str) -> Option<&str> {
+    let marker = "\"%~dp0\\";
+    let mut rest = content;
+    while let Some(start) = rest.find(marker) {
+        let after_marker = &rest[start + marker.len()..];
+        let end = after_marker.find('"')?;
+        let candidate = &after_marker[..end];
+        if !candidate.ends_with(".exe") {
+            return Some(candidate);
+        }
+        rest = &after_marker[end + 1..];
     }
-    #[allow(unreachable_code)]
-    Some(path)
+    None
 }
 
 fn is_node_backed_bin(target: &Path) -> bool {
@@ -389,9 +404,8 @@ pub(crate) fn resolve_exec_shim(bin_path: &Path) -> std::path::PathBuf {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(unix)]
     use super::resolve_node_bin_target;
-    use super::{is_node_backed_bin, resolve_exec_shim};
+    use super::{is_node_backed_bin, parse_cmd_shim_target, resolve_exec_shim};
 
     #[test]
     fn resolve_exec_shim_returns_bare_path_when_no_sibling() {
@@ -432,6 +446,46 @@ mod tests {
         std::fs::write(&target, b"#!/usr/bin/env node\n").unwrap();
         std::os::unix::fs::symlink("bin.js", &shim).unwrap();
         assert_eq!(resolve_node_bin_target(&shim).unwrap(), target);
+    }
+
+    #[test]
+    fn parse_cmd_shim_target_skips_program_exe() {
+        let content = "@SETLOCAL\r\n\
+             @IF EXIST \"%~dp0\\node.exe\" (\r\n\
+             \x20 \"%~dp0\\node.exe\" \"%~dp0\\pkg\\bin.js\" %*\r\n\
+             ) ELSE (\r\n\
+             \x20 node \"%~dp0\\pkg\\bin.js\" %*\r\n\
+             )\r\n";
+
+        assert_eq!(parse_cmd_shim_target(content), Some("pkg\\bin.js"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_node_bin_target_reads_cmd_shim_on_windows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("pkg").join("bin.js");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, b"#!/usr/bin/env node\n").unwrap();
+
+        let bare = tmp.path().join("mycli");
+        std::fs::write(
+            &bare,
+            b"#!/bin/sh\nexec node \"$basedir/pkg/bin.js\" \"$@\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("mycli.cmd"),
+            b"@SETLOCAL\r\n\
+              @IF EXIST \"%~dp0\\node.exe\" (\r\n\
+              \x20 \"%~dp0\\node.exe\" \"%~dp0\\pkg\\bin.js\" %*\r\n\
+              ) ELSE (\r\n\
+              \x20 node \"%~dp0\\pkg\\bin.js\" %*\r\n\
+              )\r\n",
+        )
+        .unwrap();
+
+        assert_eq!(resolve_node_bin_target(&bare).unwrap(), target);
     }
 
     #[test]

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -20,10 +20,10 @@ pub struct RunArgs {
     #[arg(long)]
     pub if_present: bool,
     /// Forward `--inspect` to a Node-backed script or local binary.
-    #[arg(long, value_name = "[HOST:]PORT", num_args = 0..=1, require_equals = true, default_missing_value = "")]
+    #[arg(long, value_name = "[[HOST:]PORT]", num_args = 0..=1, require_equals = true, default_missing_value = "")]
     pub inspect: Option<String>,
     /// Forward `--inspect-brk` to a Node-backed script or local binary.
-    #[arg(long, value_name = "[HOST:]PORT", num_args = 0..=1, require_equals = true, default_missing_value = "")]
+    #[arg(long, value_name = "[[HOST:]PORT]", num_args = 0..=1, require_equals = true, default_missing_value = "")]
     pub inspect_brk: Option<String>,
     /// Continue recursive execution after a script fails.
     ///
@@ -584,24 +584,7 @@ pub(crate) async fn exec_script(
     script: &str,
     args: &[String],
 ) -> miette::Result<()> {
-    let cmd = manifest
-        .scripts
-        .get(script)
-        .ok_or_else(|| miette!("script not found: {script}"))?;
-
-    let mut command = build_script_command(cwd, manifest, script, cmd, args, &[]);
-
-    let status = command
-        .status()
-        .await
-        .into_diagnostic()
-        .wrap_err("failed to execute script")?;
-
-    if !status.success() {
-        std::process::exit(aube_scripts::exit_code_from_status(status));
-    }
-
-    Ok(())
+    exec_script_with_node_args(cwd, manifest, script, args, &[]).await
 }
 
 /// Build a fully-configured `tokio::process::Command` for running a
@@ -753,15 +736,7 @@ pub(crate) async fn exec_script_status(
     script: &str,
     args: &[String],
 ) -> miette::Result<std::process::ExitStatus> {
-    let cmd = manifest
-        .scripts
-        .get(script)
-        .ok_or_else(|| miette!("script not found: {script}"))?;
-    build_script_command(cwd, manifest, script, cmd, args, &[])
-        .status()
-        .await
-        .into_diagnostic()
-        .wrap_err("failed to execute script")
+    exec_script_status_with_node_args(cwd, manifest, script, args, &[]).await
 }
 
 pub(crate) async fn exec_script_status_chain(
@@ -832,7 +807,10 @@ mod tests {
         let args = vec!["--inspect".to_string()];
         assert_eq!(
             inject_node_args("node test.js", &args),
-            "node '--inspect' test.js"
+            format!(
+                "node {} test.js",
+                aube_scripts::shell_quote_arg("--inspect")
+            )
         );
         assert_eq!(inject_node_args("tsx test.ts", &args), "tsx test.ts");
         assert_eq!(

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -19,6 +19,12 @@ pub struct RunArgs {
     /// Don't error if the script is missing from package.json
     #[arg(long)]
     pub if_present: bool,
+    /// Forward `--inspect` to a Node-backed script or local binary.
+    #[arg(long, value_name = "[HOST:]PORT", num_args = 0..=1, require_equals = true, default_missing_value = "")]
+    pub inspect: Option<String>,
+    /// Forward `--inspect-brk` to a Node-backed script or local binary.
+    #[arg(long, value_name = "[HOST:]PORT", num_args = 0..=1, require_equals = true, default_missing_value = "")]
+    pub inspect_brk: Option<String>,
     /// Continue recursive execution after a script fails.
     ///
     /// Parsed for pnpm compatibility; aube's sequential fanout still
@@ -121,6 +127,8 @@ pub async fn run(
         no_install,
         no_sort: _,
         if_present,
+        inspect,
+        inspect_brk,
         parallel,
         no_bail: _,
         report_summary: _,
@@ -139,10 +147,30 @@ pub async fn run(
         Some(s) => s,
         None => prompt_for_script()?,
     };
+    let node_args = node_args_from_run_flags(inspect, inspect_brk);
     run_script_with(
-        &script, &args, no_install, if_present, parallel, silent, &filter,
+        &script, &args, &node_args, no_install, if_present, parallel, silent, &filter,
     )
     .await
+}
+
+fn node_args_from_run_flags(inspect: Option<String>, inspect_brk: Option<String>) -> Vec<String> {
+    let mut args = Vec::with_capacity(2);
+    if let Some(value) = inspect {
+        args.push(node_arg("--inspect", &value));
+    }
+    if let Some(value) = inspect_brk {
+        args.push(node_arg("--inspect-brk", &value));
+    }
+    args
+}
+
+fn node_arg(flag: &str, value: &str) -> String {
+    if value.is_empty() {
+        flag.to_string()
+    } else {
+        format!("{flag}={value}")
+    }
 }
 
 /// Prompt the user to pick a script from the project root's
@@ -228,12 +256,24 @@ pub(crate) async fn run_script(
     filter: &aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<()> {
     let silent = super::global_output_flags().silent;
-    run_script_with(script, args, no_install, if_present, false, silent, filter).await
+    run_script_with(
+        script,
+        args,
+        &[],
+        no_install,
+        if_present,
+        false,
+        silent,
+        filter,
+    )
+    .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_script_with(
     script: &str,
     args: &[String],
+    node_args: &[String],
     no_install: bool,
     if_present: bool,
     parallel: bool,
@@ -272,6 +312,7 @@ pub(crate) async fn run_script_with(
             &cwd,
             script,
             args,
+            node_args,
             no_install,
             if_present,
             parallel,
@@ -287,7 +328,10 @@ pub(crate) async fn run_script_with(
         ensure_installed(no_install).await?;
         let bin_path = super::project_modules_dir(&cwd).join(".bin").join(script);
         if bin_path.exists() {
-            return super::exec::exec_bin(&cwd, &bin_path, script, args, false).await;
+            return super::exec::exec_bin_with_node_args(
+                &cwd, &bin_path, script, args, node_args, false,
+            )
+            .await;
         }
         if if_present {
             return Ok(());
@@ -308,7 +352,15 @@ pub(crate) async fn run_script_with(
     }
 
     ensure_installed(no_install).await?;
-    exec_script_chain(&cwd, &manifest, script, args, enable_pre_post_scripts).await
+    exec_script_chain(
+        &cwd,
+        &manifest,
+        script,
+        args,
+        node_args,
+        enable_pre_post_scripts,
+    )
+    .await
 }
 
 /// Fan out a script over workspace packages matched by `filter`. Runs
@@ -321,6 +373,7 @@ async fn run_script_filtered(
     cwd: &Path,
     script: &str,
     args: &[String],
+    node_args: &[String],
     no_install: bool,
     if_present: bool,
     parallel: bool,
@@ -395,18 +448,23 @@ async fn run_script_filtered(
             }
             let script = script.to_string();
             let args = args.to_vec();
+            let node_args = node_args.to_vec();
             let dir = pkg.dir.clone();
             let manifest = pkg.manifest.clone();
             task_names.push(name);
             tasks.push(tokio::spawn(async move {
                 if let Some(bin_path) = bin_path {
-                    super::exec::exec_bin_status(&dir, &bin_path, &script, &args, false).await
+                    super::exec::exec_bin_status_with_node_args(
+                        &dir, &bin_path, &script, &args, &node_args, false,
+                    )
+                    .await
                 } else {
                     exec_script_status_chain(
                         &dir,
                         &manifest,
                         &script,
                         &args,
+                        &node_args,
                         enable_pre_post_scripts,
                     )
                     .await
@@ -454,7 +512,10 @@ async fn run_script_filtered(
                 if !silent {
                     tracing::info!("aube run: {name} -> {script}");
                 }
-                super::exec::exec_bin(&pkg.dir, &bin_path, script, args, false).await?;
+                super::exec::exec_bin_with_node_args(
+                    &pkg.dir, &bin_path, script, args, node_args, false,
+                )
+                .await?;
                 continue;
             }
             if if_present {
@@ -470,6 +531,7 @@ async fn run_script_filtered(
             &pkg.manifest,
             script,
             args,
+            node_args,
             enable_pre_post_scripts,
         )
         .await?;
@@ -527,7 +589,7 @@ pub(crate) async fn exec_script(
         .get(script)
         .ok_or_else(|| miette!("script not found: {script}"))?;
 
-    let mut command = build_script_command(cwd, manifest, script, cmd, args);
+    let mut command = build_script_command(cwd, manifest, script, cmd, args, &[]);
 
     let status = command
         .status()
@@ -555,9 +617,11 @@ fn build_script_command(
     script: &str,
     cmd: &str,
     args: &[String],
+    node_args: &[String],
 ) -> tokio::process::Command {
+    let cmd = inject_node_args(cmd, node_args);
     let shell_cmd = if args.is_empty() {
-        cmd.to_string()
+        cmd
     } else {
         // Quote each forwarded arg. Args land inside `sh -c "..."` or
         // cmd `/c "..."` which reparses. Unquoted $, backticks, ;, |,
@@ -566,7 +630,7 @@ fn build_script_command(
         // shell_quote_arg wraps per-platform. See aube-scripts.
         let mut buf =
             String::with_capacity(cmd.len() + args.iter().map(|a| a.len() + 3).sum::<usize>());
-        buf.push_str(cmd);
+        buf.push_str(&cmd);
         for a in args {
             buf.push(' ');
             buf.push_str(&aube_scripts::shell_quote_arg(a));
@@ -609,22 +673,73 @@ fn build_script_command(
     command
 }
 
+fn inject_node_args(cmd: &str, node_args: &[String]) -> String {
+    if node_args.is_empty() {
+        return cmd.to_string();
+    }
+    let trimmed = cmd.trim_start();
+    let leading_len = cmd.len() - trimmed.len();
+    let Some(rest) = trimmed.strip_prefix("node") else {
+        return cmd.to_string();
+    };
+    if !rest.is_empty() && !rest.starts_with(char::is_whitespace) {
+        return cmd.to_string();
+    }
+    let mut out =
+        String::with_capacity(cmd.len() + node_args.iter().map(|arg| arg.len() + 1).sum::<usize>());
+    out.push_str(&cmd[..leading_len + 4]);
+    for arg in node_args {
+        out.push(' ');
+        out.push_str(&aube_scripts::shell_quote_arg(arg));
+    }
+    out.push_str(rest);
+    out
+}
+
 pub(crate) async fn exec_script_chain(
     cwd: &Path,
     manifest: &PackageJson,
     script: &str,
     args: &[String],
+    node_args: &[String],
     enable_pre_post_scripts: bool,
 ) -> miette::Result<()> {
     if enable_pre_post_scripts {
         let pre = format!("pre{script}");
         exec_optional(cwd, manifest, &pre, &[]).await?;
     }
-    exec_script(cwd, manifest, script, args).await?;
+    exec_script_with_node_args(cwd, manifest, script, args, node_args).await?;
     if enable_pre_post_scripts {
         let post = format!("post{script}");
         exec_optional(cwd, manifest, &post, &[]).await?;
     }
+    Ok(())
+}
+
+async fn exec_script_with_node_args(
+    cwd: &Path,
+    manifest: &PackageJson,
+    script: &str,
+    args: &[String],
+    node_args: &[String],
+) -> miette::Result<()> {
+    let cmd = manifest
+        .scripts
+        .get(script)
+        .ok_or_else(|| miette!("script not found: {script}"))?;
+
+    let mut command = build_script_command(cwd, manifest, script, cmd, args, node_args);
+
+    let status = command
+        .status()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to execute script")?;
+
+    if !status.success() {
+        std::process::exit(aube_scripts::exit_code_from_status(status));
+    }
+
     Ok(())
 }
 
@@ -642,7 +757,7 @@ pub(crate) async fn exec_script_status(
         .scripts
         .get(script)
         .ok_or_else(|| miette!("script not found: {script}"))?;
-    build_script_command(cwd, manifest, script, cmd, args)
+    build_script_command(cwd, manifest, script, cmd, args, &[])
         .status()
         .await
         .into_diagnostic()
@@ -654,6 +769,7 @@ pub(crate) async fn exec_script_status_chain(
     manifest: &PackageJson,
     script: &str,
     args: &[String],
+    node_args: &[String],
     enable_pre_post_scripts: bool,
 ) -> miette::Result<std::process::ExitStatus> {
     if enable_pre_post_scripts {
@@ -665,7 +781,7 @@ pub(crate) async fn exec_script_status_chain(
             }
         }
     }
-    let status = exec_script_status(cwd, manifest, script, args).await?;
+    let status = exec_script_status_with_node_args(cwd, manifest, script, args, node_args).await?;
     if !status.success() {
         return Ok(status);
     }
@@ -676,4 +792,52 @@ pub(crate) async fn exec_script_status_chain(
         }
     }
     Ok(status)
+}
+
+async fn exec_script_status_with_node_args(
+    cwd: &Path,
+    manifest: &PackageJson,
+    script: &str,
+    args: &[String],
+    node_args: &[String],
+) -> miette::Result<std::process::ExitStatus> {
+    let cmd = manifest
+        .scripts
+        .get(script)
+        .ok_or_else(|| miette!("script not found: {script}"))?;
+    build_script_command(cwd, manifest, script, cmd, args, node_args)
+        .status()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to execute script")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{inject_node_args, node_args_from_run_flags};
+
+    #[test]
+    fn node_args_from_flags_supports_optional_values() {
+        assert_eq!(
+            node_args_from_run_flags(Some(String::new()), Some("0.0.0.0:9230".to_string())),
+            vec![
+                "--inspect".to_string(),
+                "--inspect-brk=0.0.0.0:9230".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inject_node_args_only_touches_direct_node_commands() {
+        let args = vec!["--inspect".to_string()];
+        assert_eq!(
+            inject_node_args("node test.js", &args),
+            "node '--inspect' test.js"
+        );
+        assert_eq!(inject_node_args("tsx test.ts", &args), "tsx test.ts");
+        assert_eq!(
+            inject_node_args("node-gyp rebuild", &args),
+            "node-gyp rebuild"
+        );
+    }
 }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -8320,6 +8320,44 @@
             "global": false
           },
           {
+            "name": "inspect",
+            "usage": "--inspect <[HOST:]PORT>",
+            "help": "Forward `--inspect` to a Node-backed script or local binary",
+            "help_first_line": "Forward `--inspect` to a Node-backed script or local binary",
+            "short": [],
+            "long": [
+              "inspect"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "[HOST:]PORT",
+              "usage": "<[HOST:]PORT>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
+            "name": "inspect-brk",
+            "usage": "--inspect-brk <[HOST:]PORT>",
+            "help": "Forward `--inspect-brk` to a Node-backed script or local binary",
+            "help_first_line": "Forward `--inspect-brk` to a Node-backed script or local binary",
+            "short": [],
+            "long": [
+              "inspect-brk"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "[HOST:]PORT",
+              "usage": "<[HOST:]PORT>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
             "name": "no-bail",
             "usage": "--no-bail",
             "help": "Continue recursive execution after a script fails",

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -8321,7 +8321,7 @@
           },
           {
             "name": "inspect",
-            "usage": "--inspect <[HOST:]PORT>",
+            "usage": "--inspect [[HOST:]PORT]",
             "help": "Forward `--inspect` to a Node-backed script or local binary",
             "help_first_line": "Forward `--inspect` to a Node-backed script or local binary",
             "short": [],
@@ -8332,15 +8332,15 @@
             "global": false,
             "arg": {
               "name": "[HOST:]PORT",
-              "usage": "<[HOST:]PORT>",
-              "required": true,
+              "usage": "[[HOST:]PORT]",
+              "required": false,
               "double_dash": "Optional",
               "hide": false
             }
           },
           {
             "name": "inspect-brk",
-            "usage": "--inspect-brk <[HOST:]PORT>",
+            "usage": "--inspect-brk [[HOST:]PORT]",
             "help": "Forward `--inspect-brk` to a Node-backed script or local binary",
             "help_first_line": "Forward `--inspect-brk` to a Node-backed script or local binary",
             "short": [],
@@ -8351,8 +8351,8 @@
             "global": false,
             "arg": {
               "name": "[HOST:]PORT",
-              "usage": "<[HOST:]PORT>",
-              "required": true,
+              "usage": "[[HOST:]PORT]",
+              "required": false,
               "double_dash": "Optional",
               "hide": false
             }

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -23,6 +23,14 @@ Arguments to pass to the script
 
 Don't error if the script is missing from package.json
 
+### `--inspect <[HOST:]PORT>`
+
+Forward `--inspect` to a Node-backed script or local binary
+
+### `--inspect-brk <[HOST:]PORT>`
+
+Forward `--inspect-brk` to a Node-backed script or local binary
+
 ### `--no-bail`
 
 Continue recursive execution after a script fails.

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -23,11 +23,11 @@ Arguments to pass to the script
 
 Don't error if the script is missing from package.json
 
-### `--inspect <[HOST:]PORT>`
+### `--inspect [[HOST:]PORT]`
 
 Forward `--inspect` to a Node-backed script or local binary
 
-### `--inspect-brk <[HOST:]PORT>`
+### `--inspect-brk [[HOST:]PORT]`
 
 Forward `--inspect-brk` to a Node-backed script or local binary
 

--- a/test/run.bats
+++ b/test/run.bats
@@ -25,6 +25,26 @@ teardown() {
 	assert_output --partial "is-odd(3): true"
 }
 
+@test "aube run forwards inspect flags to direct node scripts" {
+	cat >package.json <<-'JSON'
+		{
+		  "name": "run-inspect-script",
+		  "version": "1.0.0",
+		  "private": true,
+		  "scripts": {
+		    "show-argv": "node show-argv.js"
+		  }
+		}
+	JSON
+	cat >show-argv.js <<-'JS'
+		console.log(JSON.stringify(process.execArgv))
+	JS
+
+	run aube run --inspect=0 --no-install show-argv
+	assert_success
+	assert_output --partial '"--inspect=0"'
+}
+
 @test "aube run fails for unknown script" {
 	_setup_basic_fixture
 	aube install
@@ -64,6 +84,39 @@ teardown() {
 	run aube run local-bin alpha beta
 	assert_success
 	assert_line "local-bin:alpha,beta"
+}
+
+@test "aube run forwards inspect flags to local node binaries" {
+	mkdir -p tools/local-bin
+	cat >package.json <<-'JSON'
+		{
+		  "name": "run-bin-inspect",
+		  "version": "1.0.0",
+		  "private": true,
+		  "dependencies": {
+		    "local-bin": "file:tools/local-bin"
+		  }
+		}
+	JSON
+	cat >tools/local-bin/package.json <<-'JSON'
+		{
+		  "name": "local-bin",
+		  "version": "1.0.0",
+		  "bin": {
+		    "local-bin": "index.js"
+		  }
+		}
+	JSON
+	cat >tools/local-bin/index.js <<-'JS'
+		#!/usr/bin/env node
+		console.log(JSON.stringify(process.execArgv))
+	JS
+	chmod +x tools/local-bin/index.js
+
+	aube install
+	run aube run --inspect=0 local-bin
+	assert_success
+	assert_output --partial '"--inspect=0"'
 }
 
 @test "aube run --if-present still falls back to local binary" {


### PR DESCRIPTION
## Summary

- Add `aube run --inspect[=port]` and `--inspect-brk[=port]`.
- Forward those flags as explicit Node argv for direct `node ...` scripts and local Node-backed `.bin` fallbacks.
- Avoid using `NODE_OPTIONS`, so debugger flags do not leak into every nested Node process.
- Add Bats coverage for direct Node scripts and local Node binary fallback.

## Context

This addresses feedback from Discussion #345 asking for `aube run --inspect test` / `--inspect-brk` support. Yarn supports this shape for Node-backed binaries; npm and pnpm do not appear to forward these flags for `run`, so aube keeps the behavior narrowly scoped to commands it can identify as Node-backed.

## Validation

- `cargo test -p aube commands::run::tests`
- `cargo test -p aube commands::exec::tests`
- `mise run test:bats test/run.bats`
- `cargo fmt --check`
- `cargo clippy -p aube --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `aube run` constructs and executes commands (including `.bin` fallback resolution), which could affect script/binary invocation across platforms. Scope is constrained to detected Node-backed targets and covered by new unit/Bats tests.
> 
> **Overview**
> `aube run` now accepts `--inspect[=[[HOST:]PORT]]` and `--inspect-brk[=[[HOST:]PORT]]` and forwards them as explicit Node argv when running **direct `node ...` package.json scripts** or when falling back to **local Node-backed `node_modules/.bin` binaries**.
> 
> This refactors execution helpers to thread `node_args` through script/bin execution, adds cross-platform logic in `exec` to resolve `.bin` shims/symlinks and detect Node interpreters before injecting args, and updates CLI docs plus Bats/unit test coverage for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9498953c21684eb6fad43f08795267655b0a99be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->