### PR TITLE
fix(run): add node-gyp bootstrap to script PATH

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -64,6 +64,9 @@ flag --workspace-root help="Run from the workspace root regardless of the curren
 flag "-y --yes" help="Automatically answer yes to prompts" hide=#true global=#true {
     long_help "Automatically answer yes to prompts.\n\nParsed for pnpm compatibility; aube does not currently prompt on these paths."
 }
+cmd __node-gyp-bootstrap hide=#true help="Bootstrap aube's cached node-gyp and print the executable path" {
+    arg <PROJECT_DIR>
+}
 cmd add help="Add a dependency" {
     alias a
     flag "-D --save-dev" help="Add as dev dependency"

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -14,7 +14,7 @@ mod dep_selection;
 mod frozen;
 mod git_prepare;
 mod lifecycle;
-mod node_gyp_bootstrap;
+pub(crate) mod node_gyp_bootstrap;
 mod settings;
 mod side_effects_cache;
 

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -62,6 +62,10 @@ pub(crate) fn node_gyp_bin_exists(bin_dir: &Path) -> bool {
     BINARY_NAMES.iter().any(|name| bin_dir.join(name).exists())
 }
 
+fn primary_binary_name() -> &'static str {
+    BINARY_NAMES[0]
+}
+
 fn tool_root() -> miette::Result<PathBuf> {
     let cache = aube_store::dirs::cache_dir()
         .ok_or_else(|| miette!("could not resolve cache dir for node-gyp bootstrap"))?;
@@ -80,11 +84,15 @@ pub async fn ensure(project_dir: &Path) -> miette::Result<Option<PathBuf>> {
     if node_gyp_on_path() {
         return Ok(None);
     }
+    ensure_cached(project_dir).await.map(Some)
+}
+
+pub async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf> {
     let root = tool_root()?;
     let tool_dir = root.join(BUCKET);
     let bin_dir = tool_dir.join("node_modules").join(".bin");
     if node_gyp_bin_exists(&bin_dir) {
-        return Ok(Some(bin_dir));
+        return Ok(bin_dir);
     }
     let lock_key = root.join(format!("{BUCKET}.lock"));
     let tool_dir_blocking = tool_dir.clone();
@@ -101,7 +109,52 @@ pub async fn ensure(project_dir: &Path) -> miette::Result<Option<PathBuf>> {
     .await
     .into_diagnostic()
     .wrap_err("node-gyp bootstrap task panicked")??;
-    Ok(Some(bin_dir))
+    Ok(bin_dir)
+}
+
+pub(crate) fn lazy_shim_bin_dir(project_bin_dir: &Path) -> miette::Result<Option<PathBuf>> {
+    if node_gyp_bin_exists(project_bin_dir) || node_gyp_on_path() {
+        return Ok(None);
+    }
+    let shim_dir = tool_root()?.join("lazy-bin");
+    std::fs::create_dir_all(&shim_dir).into_diagnostic()?;
+    write_lazy_shims(&shim_dir)?;
+    Ok(Some(shim_dir))
+}
+
+pub(crate) async fn print_bootstrapped_binary(project_dir: &Path) -> miette::Result<()> {
+    let bin_dir = ensure_cached(project_dir).await?;
+    println!("{}", bin_dir.join(primary_binary_name()).display());
+    Ok(())
+}
+
+fn write_lazy_shims(shim_dir: &Path) -> miette::Result<()> {
+    let sh = r#"#!/usr/bin/env sh
+set -eu
+real="$("$AUBE_NODE_GYP_EXE" __node-gyp-bootstrap "$AUBE_NODE_GYP_PROJECT_DIR")"
+exec "$real" "$@"
+"#;
+    let sh_path = shim_dir.join("node-gyp");
+    aube_util::fs_atomic::atomic_write(&sh_path, sh.as_bytes()).into_diagnostic()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&sh_path, std::fs::Permissions::from_mode(0o755))
+            .into_diagnostic()?;
+    }
+
+    #[cfg(windows)]
+    {
+        let cmd = r#"@echo off
+for /f "usebackq delims=" %%i in (`"%AUBE_NODE_GYP_EXE%" __node-gyp-bootstrap "%AUBE_NODE_GYP_PROJECT_DIR%"`) do set "AUBE_REAL_NODE_GYP=%%i"
+if not defined AUBE_REAL_NODE_GYP exit /b 1
+"%AUBE_REAL_NODE_GYP%" %*
+"#;
+        aube_util::fs_atomic::atomic_write(&shim_dir.join("node-gyp.cmd"), cmd.as_bytes())
+            .into_diagnostic()?;
+    }
+
+    Ok(())
 }
 
 fn bootstrap_blocking(

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -58,7 +58,7 @@ fn node_gyp_on_path() -> bool {
 /// `node-gyp` shim filenames. On Windows npm installs `node-gyp.cmd`
 /// (sometimes `.exe` alongside), so a bare-string check would always
 /// miss the bootstrapped shim and the fast-path would never fire.
-fn node_gyp_bin_exists(bin_dir: &Path) -> bool {
+pub(crate) fn node_gyp_bin_exists(bin_dir: &Path) -> bool {
     BINARY_NAMES.iter().any(|name| bin_dir.join(name).exists())
 }
 

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -596,14 +596,14 @@ pub(crate) async fn exec_script(
 /// so the parallel path can collect all outcomes). Keeping one place
 /// to configure these means future security fixes land once, not
 /// twice.
-fn build_script_command(
+async fn build_script_command(
     cwd: &Path,
     manifest: &PackageJson,
     script: &str,
     cmd: &str,
     args: &[String],
     node_args: &[String],
-) -> tokio::process::Command {
+) -> miette::Result<tokio::process::Command> {
     let cmd = inject_node_args(cmd, node_args);
     let shell_cmd = if args.is_empty() {
         cmd
@@ -624,7 +624,21 @@ fn build_script_command(
     };
 
     let bin_dir = super::project_modules_dir(cwd).join(".bin");
-    let new_path = aube_scripts::prepend_path(&bin_dir);
+    let node_gyp_bin_dir = if script_references_node_gyp(&shell_cmd)
+        && !super::install::node_gyp_bootstrap::node_gyp_bin_exists(&bin_dir)
+    {
+        super::install::node_gyp_bootstrap::ensure(cwd).await?
+    } else {
+        None
+    };
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let mut entries = Vec::with_capacity(2 + usize::from(node_gyp_bin_dir.is_some()));
+    entries.push(bin_dir);
+    if let Some(dir) = node_gyp_bin_dir {
+        entries.push(dir);
+    }
+    entries.extend(std::env::split_paths(&path));
+    let new_path = std::env::join_paths(entries).unwrap_or(path);
 
     // npm-compat env vars. Lifecycle path sets these in
     // aube-scripts::run_root_hook, `aube run` was bare env before.
@@ -655,7 +669,7 @@ fn build_script_command(
         let init_cwd = crate::dirs::cwd().ok().unwrap_or_else(|| cwd.to_path_buf());
         command.env("INIT_CWD", init_cwd);
     }
-    command
+    Ok(command)
 }
 
 fn inject_node_args(cmd: &str, node_args: &[String]) -> String {
@@ -679,6 +693,11 @@ fn inject_node_args(cmd: &str, node_args: &[String]) -> String {
     }
     out.push_str(rest);
     out
+}
+
+fn script_references_node_gyp(cmd: &str) -> bool {
+    cmd.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '_'))
+        .any(|word| word == "node-gyp")
 }
 
 pub(crate) async fn exec_script_chain(
@@ -713,7 +732,7 @@ async fn exec_script_with_node_args(
         .get(script)
         .ok_or_else(|| miette!("script not found: {script}"))?;
 
-    let mut command = build_script_command(cwd, manifest, script, cmd, args, node_args);
+    let mut command = build_script_command(cwd, manifest, script, cmd, args, node_args).await?;
 
     let status = command
         .status()
@@ -783,6 +802,7 @@ async fn exec_script_status_with_node_args(
         .get(script)
         .ok_or_else(|| miette!("script not found: {script}"))?;
     build_script_command(cwd, manifest, script, cmd, args, node_args)
+        .await?
         .status()
         .await
         .into_diagnostic()
@@ -791,7 +811,7 @@ async fn exec_script_status_with_node_args(
 
 #[cfg(test)]
 mod tests {
-    use super::{inject_node_args, node_args_from_run_flags};
+    use super::{inject_node_args, node_args_from_run_flags, script_references_node_gyp};
 
     #[test]
     fn node_args_from_flags_supports_optional_values() {
@@ -819,5 +839,13 @@ mod tests {
             inject_node_args("node-gyp rebuild", &args),
             "node-gyp rebuild"
         );
+    }
+
+    #[test]
+    fn script_references_node_gyp_matches_command_token() {
+        assert!(script_references_node_gyp("node-gyp --help"));
+        assert!(script_references_node_gyp("cd native && node-gyp rebuild"));
+        assert!(!script_references_node_gyp("echo node-gyp-build"));
+        assert!(!script_references_node_gyp("node ./scripts/build.js"));
     }
 }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -624,13 +624,7 @@ async fn build_script_command(
     };
 
     let bin_dir = super::project_modules_dir(cwd).join(".bin");
-    let node_gyp_bin_dir = if script_references_node_gyp(&shell_cmd)
-        && !super::install::node_gyp_bootstrap::node_gyp_bin_exists(&bin_dir)
-    {
-        super::install::node_gyp_bootstrap::ensure(cwd).await?
-    } else {
-        None
-    };
+    let node_gyp_bin_dir = super::install::node_gyp_bootstrap::lazy_shim_bin_dir(&bin_dir)?;
     let path = std::env::var_os("PATH").unwrap_or_default();
     let mut entries = Vec::with_capacity(2 + usize::from(node_gyp_bin_dir.is_some()));
     entries.push(bin_dir);
@@ -639,6 +633,13 @@ async fn build_script_command(
     }
     entries.extend(std::env::split_paths(&path));
     let new_path = std::env::join_paths(entries).unwrap_or(path);
+    let script_dir = if cwd.is_absolute() {
+        cwd.to_path_buf()
+    } else {
+        crate::dirs::cwd()?.join(cwd)
+    };
+    let node_gyp_project_dir =
+        crate::dirs::find_workspace_root(&script_dir).unwrap_or_else(|| script_dir.clone());
 
     // npm-compat env vars. Lifecycle path sets these in
     // aube-scripts::run_root_hook, `aube run` was bare env before.
@@ -650,6 +651,11 @@ async fn build_script_command(
     command
         .env("PATH", &new_path)
         .current_dir(cwd)
+        .env(
+            "AUBE_NODE_GYP_EXE",
+            std::env::current_exe().into_diagnostic()?,
+        )
+        .env("AUBE_NODE_GYP_PROJECT_DIR", node_gyp_project_dir)
         .env("npm_lifecycle_event", script)
         .stderr(aube_scripts::child_stderr());
     if let Some(ref name) = manifest.name {
@@ -693,11 +699,6 @@ fn inject_node_args(cmd: &str, node_args: &[String]) -> String {
     }
     out.push_str(rest);
     out
-}
-
-fn script_references_node_gyp(cmd: &str) -> bool {
-    cmd.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '_'))
-        .any(|word| word == "node-gyp")
 }
 
 pub(crate) async fn exec_script_chain(
@@ -811,7 +812,7 @@ async fn exec_script_status_with_node_args(
 
 #[cfg(test)]
 mod tests {
-    use super::{inject_node_args, node_args_from_run_flags, script_references_node_gyp};
+    use super::{inject_node_args, node_args_from_run_flags};
 
     #[test]
     fn node_args_from_flags_supports_optional_values() {
@@ -839,13 +840,5 @@ mod tests {
             inject_node_args("node-gyp rebuild", &args),
             "node-gyp rebuild"
         );
-    }
-
-    #[test]
-    fn script_references_node_gyp_matches_command_token() {
-        assert!(script_references_node_gyp("node-gyp --help"));
-        assert!(script_references_node_gyp("cd native && node-gyp rebuild"));
-        assert!(!script_references_node_gyp("echo node-gyp-build"));
-        assert!(!script_references_node_gyp("node ./scripts/build.js"));
     }
 }

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -510,6 +510,9 @@ impl Drop for SilentStderrGuard {
 // has no fixed name so the sort check skips it.
 #[derive(Subcommand)]
 enum Commands {
+    /// Bootstrap aube's cached node-gyp and print the executable path.
+    #[command(name = "__node-gyp-bootstrap", hide = true)]
+    NodeGypBootstrap { project_dir: PathBuf },
     /// Add a dependency
     #[command(visible_alias = "a")]
     Add(commands::add::AddArgs),
@@ -909,6 +912,9 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
     });
 
     match cli.command {
+        Some(Commands::NodeGypBootstrap { project_dir }) => {
+            commands::install::node_gyp_bootstrap::print_bootstrapped_binary(&project_dir).await?
+        }
         Some(Commands::Add(args)) => {
             commands::add::run(args, effective_filter.clone()).await?;
         }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5,6 +5,30 @@
     "full_cmd": [],
     "usage": "[FLAGS] <SUBCOMMAND>",
     "subcommands": {
+      "__node-gyp-bootstrap": {
+        "full_cmd": [
+          "__node-gyp-bootstrap"
+        ],
+        "usage": "__node-gyp-bootstrap <PROJECT_DIR>",
+        "subcommands": {},
+        "args": [
+          {
+            "name": "PROJECT_DIR",
+            "usage": "<PROJECT_DIR>",
+            "required": true,
+            "double_dash": "Optional",
+            "hide": false
+          }
+        ],
+        "flags": [],
+        "mounts": [],
+        "hide": true,
+        "help": "Bootstrap aube's cached node-gyp and print the executable path",
+        "name": "__node-gyp-bootstrap",
+        "aliases": [],
+        "hidden_aliases": [],
+        "examples": []
+      },
       "add": {
         "full_cmd": [
           "add"

--- a/test/PNPM_TEST_IMPORT.md
+++ b/test/PNPM_TEST_IMPORT.md
@@ -17,7 +17,7 @@ Network is acceptable for tests when the offline registry can't host the fixture
 Triaged (decisions recorded, awaiting work):
 
 - ~~**support** — hooks.ts:580 — readPackage during `aube remove` in a workspace.~~ Ported in [test/pnpm_install_hooks.bats](pnpm_install_hooks.bats) — workspace install with a hook injecting a peerDep into `is-odd`, then `aube remove is-even` from the sub-project; the survivor's snapshot retains the injected peerDep through the chained install.
-- **support** — lifecycleScripts.ts:128 — node-gyp on PATH (test-only). Port with network, gate slow.
+- ~~**support** — lifecycleScripts.ts:128 — node-gyp on PATH.~~ Aube now reuses the node-gyp bootstrap for `aube run` / `aube test` scripts when ambient `PATH` has no `node-gyp`; ported in [test/node_gyp_bootstrap.bats](node_gyp_bootstrap.bats) using the offline mirrored node-gyp fixture.
 - **support, landed** — lifecycleScripts.ts:245 — repeat-install warning preservation. Aube fix shipped: `.aube-state` now persists the unreviewed-build set (`InstallState::unreviewed_builds`) and the warm-path short-circuit re-emits the same `tracing::warn!` line. Test ported to `lifecycle_scripts.bats`.
 - **support** — lifecycleScripts.ts:336 — git-dep prepare under `dangerouslyAllowAllBuilds`. Port with network + a stable upstream pin (prefer a repo under github.com/endevco), gate slow.
 - **support — landed** — monorepo/index.ts:56 — workspace-yaml-only-root for `list/run/install/query/why`. `project_or_workspace_root()` shipped in [crates/aube/src/dirs.rs](../crates/aube/src/dirs.rs); the five commands route through it and synthesize an empty manifest when the workspace root has no `package.json`. Coverage in [test/yaml_only_root.bats](yaml_only_root.bats).
@@ -68,7 +68,7 @@ Goal: highest install-path parity coverage for lowest cost. Each row is a pnpm s
   - Aube divergence worth noting in ports: aube's strict-dep-builds error reads "dependencies with build scripts must be reviewed before install" where pnpm's reads "Ignored build scripts:". Aube now writes the same `"set this to true or false"` placeholder string as pnpm, so review-placeholder ports can assert verbatim.
   - Equivalent coverage already exists in aube: installation-fails-on-lifecycle-script-error (17 — aube's "fails fast if a root lifecycle script exits non-zero" at lifecycle_scripts.bats:187 covers the same contract).
   - **Support** (aube fix needed before / alongside port):
-    - node-gyp on PATH (128) — port with network, gate slow.
+    - ~~node-gyp on PATH (128)~~ — ported in [test/node_gyp_bootstrap.bats](node_gyp_bootstrap.bats); uses the offline mirrored node-gyp fixture, so no slow/network gate is needed.
     - git-dep prepare under dangerouslyAllowAllBuilds (336) — port with network + a stable upstream pin (prefer a repo under github.com/endevco), gate slow.
     - selective `aube rebuild <pkg>` (282) — **landed** as the CLI-side feature: [rebuild.rs](../crates/aube/src/commands/rebuild.rs) now accepts positional package names, filters `run_dep_lifecycle_scripts` to those, bypasses the build policy for the named deps, and skips root preinstall/install/postinstall/prepare hooks. Bats coverage in [test/rebuild.bats](rebuild.bats). Pnpm test port pending.
   - **Support — real bug, not test-only** (aube fix needed before port):

--- a/test/node_gyp_bootstrap.bats
+++ b/test/node_gyp_bootstrap.bats
@@ -98,6 +98,8 @@ JSON
 @test "aube test does not bootstrap node-gyp for unrelated scripts" {
 	# Regression for PR review feedback: a cold node-gyp cache plus an
 	# unreachable registry must not break scripts that don't call node-gyp.
+	# A cheap lazy shim may be written, but the real node-gyp install must
+	# not run unless that shim is executed.
 	cat >.npmrc <<'EOF'
 registry=http://127.0.0.1:9/
 EOF
@@ -114,7 +116,60 @@ JSON
 	run aube test
 	assert_success
 	assert_file_exists plain-ok
-	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp"
+	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp/v12"
+}
+
+@test "aube test exposes node-gyp to indirect script subprocesses" {
+	# pnpm adds its own node-gyp-bin directory to every script PATH. Aube
+	# mirrors that with a lazy shim so `node build.js` can spawn node-gyp
+	# without sniffing the package.json script text up front.
+	if [ -z "${AUBE_TEST_REGISTRY:-}" ]; then
+		skip "AUBE_TEST_REGISTRY not set (Verdaccio not running)"
+	fi
+	cat >package.json <<'JSON'
+{
+  "name": "node-gyp-indirect-path-test",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node build.js"
+  }
+}
+JSON
+	cat >build.js <<'JS'
+const cp = require('child_process');
+const fs = require('fs');
+const result = cp.spawnSync('node-gyp', ['--help'], {stdio: 'ignore'});
+if (result.status === 0) {
+  fs.writeFileSync('node-gyp-indirect-ok', 'ok');
+}
+process.exit(result.status ?? 1);
+JS
+
+	run aube test
+	assert_success
+	assert_file_exists node-gyp-indirect-ok
+}
+
+@test "aube run passes workspace root to lazy node-gyp bootstrap" {
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	mkdir -p packages/app
+	cat >packages/app/package.json <<'JSON'
+{
+  "name": "node-gyp-workspace-root-test",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node -e 'require(\"fs\").writeFileSync(\"node-gyp-project-dir\", process.env.AUBE_NODE_GYP_PROJECT_DIR)'"
+  }
+}
+JSON
+
+	run aube --filter node-gyp-workspace-root-test test --no-install
+	assert_success
+	assert_file_contains packages/app/node-gyp-project-dir "$TEST_TEMP_DIR"
+	refute grep -q 'packages/app' packages/app/node-gyp-project-dir
 }
 
 @test "aube test uses project node-gyp bin without bootstrapping" {

--- a/test/node_gyp_bootstrap.bats
+++ b/test/node_gyp_bootstrap.bats
@@ -72,3 +72,76 @@ JSON
 	assert_dir_exists "$XDG_CACHE_HOME/aube/tools/node-gyp/v12/node_modules/.bin"
 	assert_file_exists "$XDG_CACHE_HOME/aube/tools/node-gyp/v12/node_modules/.bin/node-gyp"
 }
+
+@test "aube test adds bootstrapped node-gyp to PATH" {
+	# Ported from pnpm/test/install/lifecycleScripts.ts:128
+	# ('node-gyp is in the PATH'). The setup scrubbed ambient node-gyp,
+	# so success means aube supplied its cached tool shim to the script.
+	if [ -z "${AUBE_TEST_REGISTRY:-}" ]; then
+		skip "AUBE_TEST_REGISTRY not set (Verdaccio not running)"
+	fi
+	cat >package.json <<'JSON'
+{
+  "name": "node-gyp-path-test",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node-gyp --help >/dev/null && node -e 'require(\"fs\").writeFileSync(\"node-gyp-ok\", \"ok\")'"
+  }
+}
+JSON
+
+	run aube test
+	assert_success
+	assert_file_exists node-gyp-ok
+}
+
+@test "aube test does not bootstrap node-gyp for unrelated scripts" {
+	# Regression for PR review feedback: a cold node-gyp cache plus an
+	# unreachable registry must not break scripts that don't call node-gyp.
+	cat >.npmrc <<'EOF'
+registry=http://127.0.0.1:9/
+EOF
+	cat >package.json <<'JSON'
+{
+  "name": "node-gyp-unrelated-script-test",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node -e 'require(\"fs\").writeFileSync(\"plain-ok\", \"ok\")'"
+  }
+}
+JSON
+
+	run aube test
+	assert_success
+	assert_file_exists plain-ok
+	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp"
+}
+
+@test "aube test uses project node-gyp bin without bootstrapping" {
+	# Regression for PR review feedback: if the project already installed
+	# node-gyp, a cold aube tool cache and unreachable registry must not
+	# block the script.
+	cat >.npmrc <<'EOF'
+registry=http://127.0.0.1:9/
+EOF
+	mkdir -p node_modules/.bin
+	cat >node_modules/.bin/node-gyp <<SHIM
+#!/usr/bin/env bash
+printf 'project-node-gyp\n' > "$TEST_TEMP_DIR/project-node-gyp"
+SHIM
+	chmod +x node_modules/.bin/node-gyp
+	cat >package.json <<'JSON'
+{
+  "name": "node-gyp-project-bin-test",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node-gyp --help"
+  }
+}
+JSON
+
+	run aube test --no-install
+	assert_success
+	assert_file_exists project-node-gyp
+	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp"
+}


### PR DESCRIPTION
## Summary

- Reuse the existing node-gyp bootstrap when running package scripts through `aube run` / `aube test`.
- Prepend the bootstrapped node-gyp `.bin` to script `PATH` when ambient `PATH` has no `node-gyp`.
- Port pnpm's lifecycleScripts.ts:128 coverage into the offline node-gyp bootstrap BATS file and update the import tracker.

## Root Cause

Dependency lifecycle scripts already used aube's node-gyp bootstrap path, but regular package script execution only prepended the project's `node_modules/.bin`. If the host PATH did not already contain `node-gyp`, `aube test` could fail with `node-gyp: not found`, diverging from pnpm/npm script behavior.

## Validation

- `cargo fmt --check`
- `cargo check -p aube`
- `cargo build`
- `mise run test:bats test/node_gyp_bootstrap.bats`
- `cargo clippy -p aube --all-targets -- -D warnings`
- commit hook: `cargo fmt`, `shellcheck`, `shfmt`, `cargo clippy`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches script execution environment (`PATH` + new env vars) and adds a hidden bootstrap subcommand, which could affect how `aube run/test` executes user scripts across platforms if the shim/lookup logic misbehaves.
> 
> **Overview**
> `aube run`/`aube test` now ensure `node-gyp` is available to package scripts when it’s not already on the ambient `PATH`, by prepending a **lazy node-gyp shim bin dir** (and passing `AUBE_NODE_GYP_EXE`/`AUBE_NODE_GYP_PROJECT_DIR`) alongside the project’s `node_modules/.bin`.
> 
> The existing install-time node-gyp bootstrap has been refactored to expose cached-ensure and shim helpers, and a hidden `__node-gyp-bootstrap` CLI subcommand was added to print the resolved bootstrapped binary path (used by the lazy shim). Tests and the pnpm import tracker were updated to cover direct, indirect, workspace-root, and no-bootstrap scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 365d26c69a19b1b993b6cfc458170948eb7aabb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->