### PR TITLE
fix(registry): expand env vars in npmrc keys

### DIFF
--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -996,7 +996,15 @@ fn parse_npmrc(path: &Path) -> Result<Vec<(String, String)>, std::io::Error> {
         }
 
         if let Some((key, value)) = line.split_once('=') {
-            let key = key.trim().to_string();
+            // Expand env vars on both sides. pnpm/npm both substitute
+            // `${VAR}` in keys as well as values, which lets users
+            // template the registry-prefix portion of per-URI auth
+            // keys like `${NEXUS_URL}:_auth=${TOKEN}` (common for
+            // Nexus / Artifactory setups where the registry host is
+            // injected by sops/CI). Without key-side expansion the
+            // entry lands in `auth_by_uri` keyed by the literal
+            // `${NEXUS_URL}` and never matches the real tarball URL.
+            let key = substitute_env(key.trim());
             let value = substitute_env(strip_matched_quotes(value.trim()));
             entries.push((key, value));
         }
@@ -1375,6 +1383,61 @@ mod tests {
                 ("unmatched".to_string(), "\"only-leading".to_string()),
                 ("plain".to_string(), "value".to_string()),
             ]
+        );
+    }
+
+    #[test]
+    fn parse_npmrc_expands_env_in_keys_for_per_uri_auth() {
+        // Regression for endevco/aube#519. Nexus / Artifactory setups
+        // commonly template the registry-prefix portion of per-URI
+        // auth keys via env vars injected by sops/CI:
+        //
+        //     ${NEXUS_NPM_AUTH_URL}:_auth=${NEXUS_NPM_TOKEN}
+        //
+        // pnpm/npm both expand `${VAR}` on the key side as well as
+        // the value side, so the entry lands in `auth_by_uri` keyed
+        // by the real host. Without key-side expansion the entry was
+        // stored under the literal `${NEXUS_NPM_AUTH_URL}` and the
+        // tarball request never picked up the basic-auth credential.
+        unsafe {
+            std::env::set_var(
+                "AUBE_TEST_NEXUS_HOST_CFG",
+                "//nexus.example.com/repository/npm/",
+            );
+            std::env::set_var("AUBE_TEST_NEXUS_TOKEN_CFG", "dXNlcjpwYXNz");
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let rc = dir.path().join(".npmrc");
+        std::fs::write(
+            &rc,
+            "${AUBE_TEST_NEXUS_HOST_CFG}:_auth=${AUBE_TEST_NEXUS_TOKEN_CFG}\n",
+        )
+        .unwrap();
+
+        let entries = parse_npmrc(&rc).unwrap();
+
+        unsafe {
+            std::env::remove_var("AUBE_TEST_NEXUS_HOST_CFG");
+            std::env::remove_var("AUBE_TEST_NEXUS_TOKEN_CFG");
+        }
+
+        assert_eq!(
+            entries,
+            vec![(
+                "//nexus.example.com/repository/npm/:_auth".to_string(),
+                "dXNlcjpwYXNz".to_string(),
+            )]
+        );
+
+        let mut config = NpmConfig::default();
+        config.apply(entries);
+        assert_eq!(
+            config.basic_auth_for(
+                "https://nexus.example.com/repository/npm/@scope/pkg/-/pkg-1.0.0.tgz"
+            ),
+            Some("dXNlcjpwYXNz".to_string()),
+            "tarball URL under the env-templated host must pick up _auth",
         );
     }
 

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -1399,6 +1399,20 @@ mod tests {
         // by the real host. Without key-side expansion the entry was
         // stored under the literal `${NEXUS_NPM_AUTH_URL}` and the
         // tarball request never picked up the basic-auth credential.
+        //
+        // RAII guard so a panic between `set_var` and the manual
+        // cleanup can't leak these names into the rest of the test
+        // run (the harness runs cases in parallel threads on shared
+        // process-wide env).
+        struct EnvVars(&'static [&'static str]);
+        impl Drop for EnvVars {
+            fn drop(&mut self) {
+                for name in self.0 {
+                    unsafe { std::env::remove_var(name) };
+                }
+            }
+        }
+        let _vars = EnvVars(&["AUBE_TEST_NEXUS_HOST_CFG", "AUBE_TEST_NEXUS_TOKEN_CFG"]);
         unsafe {
             std::env::set_var(
                 "AUBE_TEST_NEXUS_HOST_CFG",
@@ -1416,11 +1430,6 @@ mod tests {
         .unwrap();
 
         let entries = parse_npmrc(&rc).unwrap();
-
-        unsafe {
-            std::env::remove_var("AUBE_TEST_NEXUS_HOST_CFG");
-            std::env::remove_var("AUBE_TEST_NEXUS_TOKEN_CFG");
-        }
 
         assert_eq!(
             entries,


### PR DESCRIPTION
## Summary
- aube's `.npmrc` parser only ran `${VAR}` substitution on the **value** side of each line, so per-URI auth keys templated through env vars never matched the real registry host.
- pnpm/npm both expand `${VAR}` on keys and values. The Nexus / Artifactory pattern below works under npm but breaks under aube:

  ```ini
  registry=${NEXUS_NPM_URL}
  ${NEXUS_NPM_AUTH_URL}:_auth=${NEXUS_NPM_TOKEN}
  ```

  The `registry=` value got expanded fine (so aube found the registry), but the auth entry landed in `auth_by_uri` under the literal `${NEXUS_NPM_AUTH_URL}` and the tarball request went out unauthenticated → 401.
- Fix is one line in `parse_npmrc`: also call `substitute_env` on the trimmed key. Each side is expanded independently after `split_once('=')`, so an `=` inside an env-var value still survives in the auth payload.

Closes endevco/aube#519

## Test plan
- [x] New regression test `parse_npmrc_expands_env_in_keys_for_per_uri_auth` in `crates/aube-registry/src/config.rs` writes `${HOST}:_auth=${TOKEN}` style npmrc, parses it, asserts the entry key is the expanded host and that `basic_auth_for(<tarball under that host>)` returns the token.
- [x] `cargo test -p aube-registry --lib`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to `.npmrc` parsing that only affects env-templated keys; main risk is behavior change for users who intentionally relied on literal `${VAR}` in keys.
> 
> **Overview**
> Fixes `.npmrc` parsing to expand `${VAR}` environment substitutions in **keys** as well as values, so env-templated per-registry auth entries (e.g. `${HOST}:_auth=...`) correctly match real tarball URLs.
> 
> Adds a regression test covering Nexus/Artifactory-style per-URI auth with env-templated host prefixes and asserts `basic_auth_for` resolves credentials for a URL under that host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff442dc1460c43905108e19438b7952c8dc99f9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->