### PR TITLE
fix(cli): skip registry for workspace deps

### DIFF
--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -35,6 +35,8 @@ pub const WARN_AUBE_CONCURRENCY_ENV_INVALID: &str = "WARN_AUBE_CONCURRENCY_ENV_I
 
 // ── update / prerelease ─────────────────────────────────────────────
 pub const WARN_AUBE_PRERELEASE_CHECK_SKIPPED: &str = "WARN_AUBE_PRERELEASE_CHECK_SKIPPED";
+pub const WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME: &str =
+    "WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME";
 
 // ── audit / npmrc ───────────────────────────────────────────────────
 pub const WARN_AUBE_AUDIT_FETCH_FAILED: &str = "WARN_AUBE_AUDIT_FETCH_FAILED";
@@ -231,6 +233,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_PRERELEASE_CHECK_SKIPPED,
         category: category::UPDATE_PRERELEASE,
         description: "`aube update` couldn't fetch the packument or got a non-semver `latest` tag; preserved-prerelease check skipped for that package.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME,
+        category: category::UPDATE_PRERELEASE,
+        description: "A discovered workspace package had no `name` field, so update skipped local workspace version registration for it.",
         exit_code: None,
     },
     // Audit / npmrc

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -213,6 +213,22 @@ async fn run_graph(
         }
         return Ok(false);
     }
+    let roots: Vec<&DirectDep> = roots
+        .into_iter()
+        .filter(|d| {
+            !d.specifier
+                .as_deref()
+                .is_some_and(aube_util::pkg::is_workspace_spec)
+        })
+        .collect();
+    if roots.is_empty() {
+        if args.json {
+            println!("{{}}");
+        } else {
+            println!("(no matching dependencies)");
+        }
+        return Ok(false);
+    }
 
     let client = std::sync::Arc::new(make_client(cwd));
     let cache_dir = packument_cache_dir();

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1,7 +1,7 @@
 use super::install;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 #[derive(Debug, Clone, Args)]
 pub struct UpdateArgs {
@@ -512,13 +512,19 @@ pub async fn run(
             None => (None, Vec::new()),
         };
     let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
+    let workspace_package_versions = workspace_package_versions(&cwd)?;
     let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
     if let Some(host) = read_package_host {
         resolver = resolver
             .with_read_package_hook(Box::new(host) as Box<dyn aube_resolver::ReadPackageHook>);
     }
+    let resolver_manifests = [(".".to_string(), resolver_manifest)];
     let mut graph = resolver
-        .resolve(&resolver_manifest, filtered_existing.as_ref())
+        .resolve_workspace(
+            &resolver_manifests,
+            filtered_existing.as_ref(),
+            &workspace_package_versions,
+        )
         .await
         .map_err(miette::Report::new)
         .wrap_err("failed to resolve dependencies")?;
@@ -660,6 +666,30 @@ pub async fn run(
     install::run(chained).await?;
 
     Ok(())
+}
+
+fn workspace_package_versions(cwd: &std::path::Path) -> miette::Result<HashMap<String, String>> {
+    let workspace_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+    let workspace_packages = aube_workspace::find_workspace_packages(&workspace_root)
+        .into_diagnostic()
+        .wrap_err("failed to discover workspace packages")?;
+    let mut versions = HashMap::new();
+    for pkg_dir in workspace_packages {
+        let pkg_manifest = aube_manifest::PackageJson::from_path(&pkg_dir.join("package.json"))
+            .map_err(miette::Report::new)
+            .wrap_err_with(|| format!("failed to read {}/package.json", pkg_dir.display()))?;
+        if let Some(name) = pkg_manifest.name {
+            let version = pkg_manifest.version.unwrap_or_else(|| "0.0.0".to_string());
+            versions.insert(name, version);
+        } else {
+            tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME,
+                "workspace package at {} has no 'name' field; skipping workspace version registration",
+                pkg_dir.display()
+            );
+        }
+    }
+    Ok(versions)
 }
 
 struct UpdateSettings {

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -423,6 +423,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME",
+      "category": "Update / prerelease",
+      "description": "A discovered workspace package had no `name` field, so update skipped local workspace version registration for it.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_AUDIT_FETCH_FAILED",
       "category": "Audit / npmrc",
       "description": "`aube audit --ignore-unfixable` couldn't fetch a packument; advisories for that package are kept verbatim.",

--- a/test/outdated.bats
+++ b/test/outdated.bats
@@ -76,6 +76,24 @@ _write_pkg_with_old_is_odd() {
 	refute_output --partial "is-odd  "
 }
 
+@test "aube outdated skips registry for package.json workspace deps" {
+	cat >package.json <<'EOF'
+{"workspaces":["sub"],"dependencies":{"happy-sunny-hippo":"workspace:"}}
+EOF
+	mkdir sub
+	cat >sub/package.json <<'EOF'
+{"name":"happy-sunny-hippo"}
+EOF
+
+	run aube install
+	assert_success
+
+	run aube outdated
+	assert_success
+	assert_output --partial "(no matching dependencies)"
+	refute_output --partial "package not found"
+}
+
 @test "aube outdated --recursive reports workspace importers" {
 	cat >package.json <<'EOF'
 {"name":"root","version":"0.0.0","private":true}

--- a/test/update.bats
+++ b/test/update.bats
@@ -88,6 +88,21 @@ EOF
 	assert_success
 }
 
+@test "aube update: skips registry for package.json workspace deps" {
+	cat >package.json <<'EOF'
+{"workspaces":["sub"],"dependencies":{"happy-sunny-hippo":"workspace:"}}
+EOF
+	mkdir sub
+	cat >sub/package.json <<'EOF'
+{"name":"happy-sunny-hippo"}
+EOF
+
+	run aube update
+	assert_success
+	refute_output --partial "package not found"
+	assert_file_exists node_modules/happy-sunny-hippo/package.json
+}
+
 @test "aube update: updateConfig.ignoreDependencies skips all-deps updates" {
 	_setup_outdated_project
 	cat >package.json <<'EOF'


### PR DESCRIPTION
## Summary

Fixes the workspace dependency regression reported in Discussion #520.

- passes discovered workspace package versions into `aube update` resolution so `workspace:` deps from `package.json#workspaces` resolve locally
- skips registry packument fetches for `workspace:` root dependencies in `aube outdated`
- adds Bats regressions for both commands using an unpublished workspace package name

## Validation

- `cargo fmt --check`
- `cargo check -p aube`
- `cargo build -p aube`
- `mise run test:bats test/update.bats`
- `mise run test:bats test/outdated.bats`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency resolution and registry-fetch behavior in `aube update`/`aube outdated`, which can affect what versions are selected and when the CLI exits early. Risk is mitigated by targeted regression tests for workspace `workspace:` specs.
> 
> **Overview**
> Fixes a regression where `workspace:` dependencies from `package.json#workspaces` could trigger unnecessary registry lookups and fail to resolve locally.
> 
> `aube update` now discovers workspace package `name`/`version` pairs and passes them into resolver workspace resolution (with a new `WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME` when a workspace package lacks `name`). `aube outdated` now filters out direct deps whose specifier is `workspace:` so it reports “no matching dependencies” instead of attempting packument fetches.
> 
> Adds Bats regression tests covering both commands when the only dependency is an unpublished workspace package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5280b2fe15d97dc190f84b0b6a0f7c2bf789cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->