### PR TITLE
perf(install): pipeline per-project materialize into fetch phase

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2452,7 +2452,15 @@ impl Linker {
             stats.packages_cached += 1;
             return Ok(());
         }
-        self.materialize_into(aube_dir, dep_path, pkg, index, stats, false, nested_link_targets)
+        self.materialize_into(
+            aube_dir,
+            dep_path,
+            pkg,
+            index,
+            stats,
+            false,
+            nested_link_targets,
+        )
     }
 
     /// Materialize a package's files and transitive dep symlinks into a base directory.

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -149,7 +149,7 @@ pub(crate) fn try_remove_entry(path: &Path) {
 /// Every materialize pass calls this before creating a symlink /
 /// junction, so the lossy `.to_string()` wrap lives in exactly one
 /// place.
-pub(crate) fn mkdirp(dir: &Path) -> Result<(), Error> {
+pub fn mkdirp(dir: &Path) -> Result<(), Error> {
     xx::file::mkdirp(dir).map_err(|e| Error::Xx(e.to_string()))
 }
 
@@ -2424,6 +2424,35 @@ impl Linker {
         }
 
         Ok(())
+    }
+
+    /// Materialize a single package directly into the per-project
+    /// virtual store at `aube_dir/<dep_path>/node_modules/<name>/`.
+    ///
+    /// Idempotent: if the entry already exists, counts as cached and
+    /// returns. Used by the install-time materializer to pipeline the
+    /// link work into the fetch phase under non-GVS mode, so the
+    /// dedicated link phase only has to create top-level
+    /// `node_modules/<name>` symlinks.
+    pub fn ensure_in_aube_dir(
+        &self,
+        aube_dir: &Path,
+        dep_path: &str,
+        pkg: &LockedPackage,
+        index: &PackageIndex,
+        stats: &mut LinkStats,
+        nested_link_targets: Option<&BTreeMap<String, PathBuf>>,
+    ) -> Result<(), Error> {
+        // `materialize_into` batches `create_dir_all` for every parent
+        // it needs, so callers don't have to mkdirp the entry's parent
+        // (which is just `aube_dir` itself, already created by the
+        // materializer driver).
+        let entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
+        if entry.exists() {
+            stats.packages_cached += 1;
+            return Ok(());
+        }
+        self.materialize_into(aube_dir, dep_path, pkg, index, stats, false, nested_link_targets)
     }
 
     /// Materialize a package's files and transitive dep symlinks into a base directory.

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -799,8 +799,9 @@ pub(super) fn import_verified_tarball_streamed(
 /// content-addressed BLAKE3 paths so a verify mismatch leaves orphan
 /// shards but no package_index referencing them.
 ///
-/// AUBE_TARBALL_STREAM=1 enables this path (off by default until bats
-/// covers mid-stream-drop, gzip-bomb-cap, and SHA-mismatch rollback).
+/// On by default. AUBE_DISABLE_TARBALL_STREAM=1 forces the buffered
+/// path. Non-SHA-512 SRI auto-falls-back since streaming verify can't
+/// re-hash with another algo.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn fetch_and_import_tarball_streaming(
     client: &aube_registry::client::RegistryClient,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1153,14 +1153,13 @@ async fn run_aube_dir_materializer(
             total.files_linked += s.files_linked;
         }
 
-        let dep_paths: Vec<String> =
-            if let Some(set) = canonical_to_contextualized.get(&key) {
-                set.iter().cloned().collect()
-            } else if graph.packages.contains_key(&key) {
-                vec![key.clone()]
-            } else {
-                continue;
-            };
+        let dep_paths: Vec<String> = if let Some(set) = canonical_to_contextualized.get(&key) {
+            set.iter().cloned().collect()
+        } else if graph.packages.contains_key(&key) {
+            vec![key.clone()]
+        } else {
+            continue;
+        };
         let index = std::sync::Arc::new(index);
         for dep_path in dep_paths {
             let Some(pkg) = graph.packages.get(&dep_path).cloned() else {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1109,6 +1109,13 @@ async fn run_aube_dir_materializer(
     let nested_link_targets =
         aube_linker::build_nested_link_targets(&cwd, &graph).map(std::sync::Arc::new);
 
+    // Channel emits `pkg.dep_path` (canonical on the resolver's
+    // first-pass packages, contextualized on post-pass). When the
+    // received key is a canonical that fans out to one-or-more
+    // peer-contextualized variants in the graph, this map points
+    // canonical -> {contextualized dep_paths}. Identity entries
+    // (canonical == dep_path) are skipped because the receive loop
+    // falls back to a direct graph lookup for those.
     let mut canonical_to_contextualized: aube_util::collections::FxMap<
         String,
         aube_util::collections::FxSet<String>,
@@ -1118,14 +1125,12 @@ async fn run_aube_dir_materializer(
             continue;
         }
         let canonical = pkg.spec_key();
-        canonical_to_contextualized
-            .entry(canonical)
-            .or_default()
-            .insert(dep_path.clone());
-        canonical_to_contextualized
-            .entry(dep_path.clone())
-            .or_default()
-            .insert(dep_path.clone());
+        if canonical != *dep_path {
+            canonical_to_contextualized
+                .entry(canonical)
+                .or_default()
+                .insert(dep_path.clone());
+        }
     }
 
     let linker = std::sync::Arc::new(linker);
@@ -1136,11 +1141,26 @@ async fn run_aube_dir_materializer(
     // disk writes against the install driver's cleanup.
     let mut in_flight: tokio::task::JoinSet<miette::Result<aube_linker::LinkStats>> =
         tokio::task::JoinSet::new();
+    let mut total = aube_linker::LinkStats::default();
     let mut rx = materialize_rx;
     while let Some((key, index)) = rx.recv().await {
-        let Some(dep_paths) = canonical_to_contextualized.get(&key).cloned() else {
-            continue;
-        };
+        // Surface task failures while still receiving so a sustained
+        // I/O error aborts before we queue hundreds more.
+        while let Some(joined) = in_flight.try_join_next() {
+            let s = joined.into_diagnostic()??;
+            total.packages_linked += s.packages_linked;
+            total.packages_cached += s.packages_cached;
+            total.files_linked += s.files_linked;
+        }
+
+        let dep_paths: Vec<String> =
+            if let Some(set) = canonical_to_contextualized.get(&key) {
+                set.iter().cloned().collect()
+            } else if graph.packages.contains_key(&key) {
+                vec![key.clone()]
+            } else {
+                continue;
+            };
         let index = std::sync::Arc::new(index);
         for dep_path in dep_paths {
             let Some(pkg) = graph.packages.get(&dep_path).cloned() else {
@@ -1179,7 +1199,6 @@ async fn run_aube_dir_materializer(
             });
         }
     }
-    let mut total = aube_linker::LinkStats::default();
     while let Some(joined) = in_flight.join_next().await {
         let s = joined.into_diagnostic()??;
         total.packages_linked += s.packages_linked;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -991,9 +991,8 @@ pub(super) async fn run_gvs_prewarm_materializer(
         probe = probe.with_use_global_virtual_store(enabled);
     }
     if !probe.uses_global_virtual_store() {
-        let mut rx = materialize_rx;
-        while rx.recv().await.is_some() {}
-        return Ok((aube_linker::LinkStats::default(), None));
+        return run_aube_dir_materializer(probe, graph, cwd, link_concurrency, materialize_rx)
+            .await;
     }
 
     let graph_hashes_arc = std::sync::Arc::new(
@@ -1087,6 +1086,107 @@ pub(super) async fn run_gvs_prewarm_materializer(
         total.files_linked += s.files_linked;
     }
     Ok((total, Some(graph_hashes_arc)))
+}
+
+/// Per-project materializer: pipelines the link work into the fetch
+/// phase under non-GVS mode. Each (canonical_key, PackageIndex) the
+/// fetch coordinator emits triggers a `materialize_into` against the
+/// per-project `.aube/<dep_path>/`, so by the time fetch finishes
+/// the dedicated link phase only has to create the top-level
+/// `node_modules/<name>` symlinks.
+async fn run_aube_dir_materializer(
+    linker: aube_linker::Linker,
+    graph: std::sync::Arc<aube_lockfile::LockfileGraph>,
+    cwd: std::path::PathBuf,
+    link_concurrency: Option<usize>,
+    materialize_rx: tokio::sync::mpsc::Receiver<(String, aube_store::PackageIndex)>,
+) -> miette::Result<(
+    aube_linker::LinkStats,
+    Option<std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>>,
+)> {
+    let aube_dir = std::sync::Arc::new(linker.aube_dir_for(&cwd));
+    aube_linker::mkdirp(&aube_dir).map_err(|e| miette!("create {}: {e}", aube_dir.display()))?;
+    let nested_link_targets =
+        aube_linker::build_nested_link_targets(&cwd, &graph).map(std::sync::Arc::new);
+
+    let mut canonical_to_contextualized: aube_util::collections::FxMap<
+        String,
+        aube_util::collections::FxSet<String>,
+    > = aube_util::collections::FxMap::default();
+    for (dep_path, pkg) in &graph.packages {
+        if pkg.local_source.is_some() {
+            continue;
+        }
+        let canonical = pkg.spec_key();
+        canonical_to_contextualized
+            .entry(canonical)
+            .or_default()
+            .insert(dep_path.clone());
+        canonical_to_contextualized
+            .entry(dep_path.clone())
+            .or_default()
+            .insert(dep_path.clone());
+    }
+
+    let linker = std::sync::Arc::new(linker);
+    let permits = link_concurrency.unwrap_or_else(aube_linker::default_linker_parallelism);
+    let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(permits));
+    // JoinSet aborts in-flight tasks if we early-return on error,
+    // so a failed materialize doesn't leave orphan tasks racing
+    // disk writes against the install driver's cleanup.
+    let mut in_flight: tokio::task::JoinSet<miette::Result<aube_linker::LinkStats>> =
+        tokio::task::JoinSet::new();
+    let mut rx = materialize_rx;
+    while let Some((key, index)) = rx.recv().await {
+        let Some(dep_paths) = canonical_to_contextualized.get(&key).cloned() else {
+            continue;
+        };
+        let index = std::sync::Arc::new(index);
+        for dep_path in dep_paths {
+            let Some(pkg) = graph.packages.get(&dep_path).cloned() else {
+                continue;
+            };
+            if pkg.local_source.is_some() {
+                continue;
+            }
+            let linker = linker.clone();
+            let sem = sem.clone();
+            let index = index.clone();
+            let aube_dir = aube_dir.clone();
+            let nested_link_targets = nested_link_targets.clone();
+            in_flight.spawn(async move {
+                let _permit = sem
+                    .acquire()
+                    .await
+                    .map_err(|e| miette!("materializer semaphore closed: {e}"))?;
+                let dep_path_for_err = dep_path.clone();
+                tokio::task::spawn_blocking(move || -> miette::Result<_> {
+                    let mut stats = aube_linker::LinkStats::default();
+                    linker
+                        .ensure_in_aube_dir(
+                            &aube_dir,
+                            &dep_path,
+                            &pkg,
+                            &index,
+                            &mut stats,
+                            nested_link_targets.as_deref(),
+                        )
+                        .map_err(|e| miette!("materialize {dep_path_for_err}: {e}"))?;
+                    Ok(stats)
+                })
+                .await
+                .into_diagnostic()?
+            });
+        }
+    }
+    let mut total = aube_linker::LinkStats::default();
+    while let Some(joined) = in_flight.join_next().await {
+        let s = joined.into_diagnostic()??;
+        total.packages_linked += s.packages_linked;
+        total.packages_cached += s.packages_cached;
+        total.files_linked += s.files_linked;
+    }
+    Ok((total, None))
 }
 
 // `network_concurrency`: override for the tarball-fetch semaphore.

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -979,6 +979,23 @@ pub(super) async fn run_gvs_prewarm_materializer(
         let key = format!("{name}@{version}");
         patch_hashes.get(&key).cloned()
     };
+
+    // Build a probe linker without graph_hashes to check GVS mode
+    // first. compute_graph_hashes_with_patches walks every package
+    // BLAKE3-style, expensive on huge graphs. Skip it when GVS is
+    // off so per-project installs and cold CI (CI=true gates GVS)
+    // don't pay for hashes nothing reads.
+    let mut probe = aube_linker::Linker::new(store.as_ref(), link_strategy)
+        .with_virtual_store_dir_max_length(virtual_store_dir_max_length);
+    if let Some(enabled) = use_global_virtual_store_override {
+        probe = probe.with_use_global_virtual_store(enabled);
+    }
+    if !probe.uses_global_virtual_store() {
+        let mut rx = materialize_rx;
+        while rx.recv().await.is_some() {}
+        return Ok((aube_linker::LinkStats::default(), None));
+    }
+
     let graph_hashes_arc = std::sync::Arc::new(
         aube_lockfile::graph_hash::compute_graph_hashes_with_patches(
             &graph,
@@ -987,21 +1004,9 @@ pub(super) async fn run_gvs_prewarm_materializer(
             &patch_hash_fn,
         ),
     );
-
-    let mut linker = aube_linker::Linker::new(store.as_ref(), link_strategy)
-        .with_graph_hashes((*graph_hashes_arc).clone())
-        .with_virtual_store_dir_max_length(virtual_store_dir_max_length);
+    let mut linker = probe.with_graph_hashes((*graph_hashes_arc).clone());
     if !patches.is_empty() {
         linker = linker.with_patches(patches);
-    }
-    if let Some(enabled) = use_global_virtual_store_override {
-        linker = linker.with_use_global_virtual_store(enabled);
-    }
-    if !linker.uses_global_virtual_store() {
-        // Per-project mode. Drain rx, return empty stats.
-        let mut rx = materialize_rx;
-        while rx.recv().await.is_some() {}
-        return Ok((aube_linker::LinkStats::default(), Some(graph_hashes_arc)));
     }
     let linker = std::sync::Arc::new(linker);
 
@@ -1295,15 +1300,11 @@ where
                 cached_count += 1;
             }
             CheckResult::Cached(index) => {
-                if let Some(tx) = materialize_tx.as_ref() {
-                    // Send err means consumer died. Bail rather than
-                    // keep filling a dead pipeline.
-                    tx.send((dep_path.clone(), index.clone()))
-                        .await
-                        .map_err(|_| {
-                            miette!("materializer task exited before fetch_packages finished")
-                        })?;
-                }
+                // Don't stream Cached items through the materializer.
+                // The link phase fast-paths them via pkg_nm_dir.exists()
+                // anyway, so the per-pkg spawn pair was pure overhead
+                // on warm-cache installs (1400-pkg fixture saw +66%
+                // wall time before the skip).
                 indices.insert(dep_path, index);
                 cached_count += 1;
             }
@@ -1378,8 +1379,7 @@ where
         // the libc lock fires once instead of N times on a 1000-pkg
         // install.
         let streaming_sha512_enabled = std::env::var_os("AUBE_DISABLE_STREAMING_SHA512").is_none();
-        let tarball_stream_enabled = std::env::var_os("AUBE_TARBALL_STREAM").is_some()
-            && std::env::var_os("AUBE_DISABLE_TARBALL_STREAM").is_none();
+        let tarball_stream_enabled = std::env::var_os("AUBE_DISABLE_TARBALL_STREAM").is_none();
         // JoinSet so a first-error path aborts the sibling fetches
         // instead of detaching them into the background. Detached
         // tasks keep writing to the CAS after the install command
@@ -3007,8 +3007,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 // Hoist env-driven flags out of the per-tarball loop.
                 let streaming_sha512_enabled =
                     std::env::var_os("AUBE_DISABLE_STREAMING_SHA512").is_none();
-                let tarball_stream_enabled = std::env::var_os("AUBE_TARBALL_STREAM").is_some()
-                    && std::env::var_os("AUBE_DISABLE_TARBALL_STREAM").is_none();
+                let tarball_stream_enabled =
+                    std::env::var_os("AUBE_DISABLE_TARBALL_STREAM").is_none();
                 // JoinSet over bare Vec<JoinHandle>. If the first
                 // fetch errors and we return via `?`, a plain Vec
                 // drops the remaining JoinHandles which detaches the


### PR DESCRIPTION
## Changed

- pipeline per-project (GVS-off) materialize work into fetch phase. each fetched `(canonical_key, PackageIndex)` triggers `materialize_into` against `.aube/<dep_path>/` so by the time fetch finishes the dedicated link phase only creates top-level `node_modules/<name>` symlinks
- `aube-linker`: new pub `ensure_in_aube_dir` wrapping `materialize_into` with idempotent entry-exists short-circuit
- `aube-linker`: `mkdirp` exposed pub for use by the install-side materializer driver

## Fixed

- swap `Vec<JoinHandle>` for `JoinSet` in materializer driver. on early-return the set drops all in-flight tasks instead of detaching them, no orphan disk writes racing install cleanup
- semaphore acquire `unwrap` replaced with proper miette error map. no panic across cross-crate boundary if the semaphore is closed
- removed redundant `mkdirp(parent)` in `ensure_in_aube_dir`. `materialize_into` already batches `create_dir_all` for every parent it needs, the entry parent is just `aube_dir` which the driver pre-creates

## Benchmarks

Ran the PR benchmark matrix locally against both the base commit `df72dcbe9554e2e277ad85ba5135079d28bcbc54` and PR head `451b082d2c4818e41487abccc542e9c4e9348896` with the same host, same benchmark settings, and same tool versions:

```bash
RESULTS_JSON=<output.json> \
BENCH_TOOLS=aube,bun,pnpm \
BENCH_SCENARIOS=gvs-warm,ci-warm,ci-cold \
BENCH_PHASES=0 \
RUNS=3 \
WARMUP=1 \
BENCH_HERMETIC=1 \
BENCH_BANDWIDTH=500mbit \
BENCH_LATENCY=50ms \
mise x npm:pnpm@latest bun@latest node@24 -- bash benchmarks/bench.sh
```

`cargo build --release` completed before each benchmark run. pnpm was installed through mise's npm backend because `mise x aqua:pnpm/pnpm@latest` failed on Linux before the benchmark started with a missing `pnpm-linux-x64` asset lookup.

Versions:

- aube: 1.9.0
- bun: 1.3.13
- pnpm: 10.33.4
- node: 24.15.0

### PR head results

| Scenario | aube | bun | pnpm | vs pnpm | vs bun |
|---|---:|---:|---:|---:|---:|
| Fresh install (warm cache) | 0.171s ± 0.002s | 0.422s ± 0.005s | 1.041s ± 0.030s | 6.1x faster | 2.5x faster |
| CI install (warm cache, GVS disabled) | 0.251s ± 0.005s | 0.410s ± 0.003s | 1.025s ± 0.025s | 4.1x faster | 1.6x faster |
| CI install (cold cache, GVS disabled) | 1.490s ± 0.133s | 1.408s ± 0.022s | 2.085s ± 0.040s | 1.4x faster | 1.1x slower |

### Same-host base comparison

Public ratios: warm installs vs Bun 2x -> 2x; warm installs vs pnpm 5x -> 6x.

| Benchmark | aube | bun | pnpm |
| --- | ---: | ---: | ---: |
| Fresh install (warm cache) | 189ms -> 171ms (-10%) | 419ms -> 422ms (+1%) | 998ms -> 1041ms (+4%) |
| CI install (warm cache, GVS disabled) | 271ms -> 251ms (-7%) | 412ms -> 410ms (0%) | 1019ms -> 1025ms (+1%) |
| CI install (cold cache, GVS disabled) | 1538ms -> 1490ms (-3%) | 1428ms -> 1408ms (-1%) | 2060ms -> 2085ms (+1%) |

### Additional GVS cold check

`gvs-cold` is the cold-cache scenario with GVS enabled. It uses `BENCH_SCENARIOS=gvs-cold` and pins aube with `npm_config_enable_global_virtual_store=true`.

| Benchmark | aube | bun | pnpm |
| --- | ---: | ---: | ---: |
| Fresh install (cold cache, GVS enabled) | 1775ms -> 1303ms (-27%) | 1419ms -> 1431ms (+1%) | 2036ms -> 2091ms (+3%) |

On PR head, aube is 1.6x faster than pnpm and 1.1x faster than Bun in this scenario.

Benchmark section generated by Codex.