### PR TITLE
fix(ci): harden primer generation

### DIFF
--- a/crates/aube-resolver/build.rs
+++ b/crates/aube-resolver/build.rs
@@ -142,9 +142,28 @@ fn generate(manifest_dir: &Path, source: &Path, top: usize) -> bool {
             );
             return false;
         }
-        Err(e) => panic!("failed to run scripts/generate-primer.mjs: {e}"),
+        Err(e) => {
+            if primer_required() {
+                panic!("failed to run scripts/generate-primer.mjs: {e}");
+            }
+            println!(
+                "cargo:warning=failed to run scripts/generate-primer.mjs: {e}; \
+                 shipping empty primer (runtime falls back to network packument fetches)"
+            );
+            return false;
+        }
     };
-    assert!(status.success(), "scripts/generate-primer.mjs failed");
+    if !status.success() {
+        if primer_required() {
+            panic!("scripts/generate-primer.mjs failed");
+        }
+        println!(
+            "cargo:warning=scripts/generate-primer.mjs failed; shipping empty primer \
+             (runtime falls back to network packument fetches)"
+        );
+        let _ = std::fs::remove_file(&json);
+        return false;
+    }
 
     compress_json_primer(&json, source);
     let _ = std::fs::remove_file(json);

--- a/scripts/generate-primer.mjs
+++ b/scripts/generate-primer.mjs
@@ -47,14 +47,17 @@ console.error(`wrote ${Object.keys(primer).length} packages to ${out}`)
 
 async function packumentSeed(name, keepVersions) {
   const url = `https://registry.npmjs.org/${encodePackageName(name)}`
-  const res = await fetchWithRetry(url, {
-    headers: { accept: 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*' },
-  })
+  const { res, body: full } = await fetchBodyWithRetry(
+    url,
+    {
+      headers: { accept: 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*' },
+    },
+    (res) => res.json(),
+  )
   if (!res.ok) {
     console.error(`  skipped: HTTP ${res.status}`)
     return null
   }
-  const full = await res.json()
   const selected = selectVersions(full, keepVersions)
   const packument = {
     n: full.name ?? name,
@@ -183,22 +186,23 @@ function hasProvenance(attestations) {
 }
 
 async function fetchPopularNames(url) {
-  const res = await fetchWithRetry(url)
+  const { res, body } = await fetchBodyWithRetry(url, undefined, (res) => res.text())
   if (!res.ok) throw new Error(`${url}: HTTP ${res.status}`)
-  return parseNames(await res.text(), url)
+  return parseNames(body, url)
 }
 
-// Wrap fetch to retry transient failures: socket resets / TLS hangups
-// from npmjs.com hit a single uncached fetch hard during long primer
-// runs (786 of 2000 packages got us a SocketError once already). Also
-// retry 5xx and 429. 4xx other than 429 are permanent — propagate.
-async function fetchWithRetry(url, init, attempts = 5) {
+// Wrap fetch and body reads to retry transient failures: socket resets /
+// TLS hangups from npmjs.com can happen after headers arrive, while
+// res.json() is still reading the body. Also retry 5xx and 429. 4xx
+// other than 429 are permanent - propagate.
+async function fetchBodyWithRetry(url, init, readBody, attempts = 5) {
   let delay = 1000
   for (let i = 1; i <= attempts; i++) {
     try {
       const res = await fetch(url, init)
-      if (res.ok || (res.status >= 400 && res.status < 500 && res.status !== 429)) return res
-      if (i === attempts) return res
+      if (res.ok) return { res, body: await readBody(res) }
+      if (res.status >= 400 && res.status < 500 && res.status !== 429) return { res }
+      if (i === attempts) return { res }
       console.error(`  retry ${i}/${attempts - 1}: HTTP ${res.status}`)
     } catch (err) {
       if (i === attempts) throw err


### PR DESCRIPTION
## Summary

Harden primer generation after the macOS build job failed while running `scripts/generate-primer.mjs` with a transient npm registry socket close during `res.json()`.

- Retry fetch response body reads, not just the initial `fetch()` call.
- Let optional build-time primer generation fall back to an empty embedded primer when the generator exits nonzero.
- Keep release primer builds strict when `AUBE_REQUIRE_PRIMER=1`.

## Validation

- `node --check scripts/generate-primer.mjs`
- `cargo fmt --check`
- `cargo check -p aube-resolver`
- One-package primer generator smoke test
- Simulated failing `node` fallback smoke test with `AUBE_PRIMER_TOP=101 cargo check -p aube-resolver`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes build-time artifact generation to tolerate failures and ship an empty primer unless `AUBE_REQUIRE_PRIMER` is set, which could mask primer-generation regressions and alter runtime network behavior. Also adjusts fetch retry logic in the generator, affecting how registry data is retrieved under flaky conditions.
> 
> **Overview**
> Makes primer generation more resilient in CI/dev builds by **treating `scripts/generate-primer.mjs` failures as non-fatal** unless `AUBE_REQUIRE_PRIMER` is enabled; on failure it now logs a cargo warning, cleans up the partial JSON output, and ships an *empty embedded primer* so runtime falls back to network packument fetches.
> 
> Hardens `scripts/generate-primer.mjs` by replacing `fetchWithRetry` with `fetchBodyWithRetry`, so retries cover **response body reads** (e.g., failures during `res.json()`/`res.text()`), not just the initial HTTP request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b08a6311ec7d0bbbade05bdd2664aa6ea805416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->