### PR TITLE
feat(install): aube-util::http module + pre-resolver prefetch + cold-path optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,10 +459,12 @@ dependencies = [
  "foldhash 0.1.5",
  "libc",
  "reflink-copy",
+ "reqwest 0.12.28",
  "rustc-hash",
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -246,29 +246,41 @@ impl RegistryClient {
     /// dropped: the response is discarded; subsequent real requests
     /// take the standard path.
     pub fn prewarm_connection(&self) {
-        if std::env::var_os("AUBE_DISABLE_SPECULATIVE_TLS").is_some() {
-            return;
-        }
         if matches!(self.network_mode, NetworkMode::Offline) {
             return;
         }
-        let url = self.config.registry.clone();
-        let http = self.http.clone();
-        tokio::spawn(async move {
-            // HEAD on registry root. The body is empty; the win is the
-            // handshake. Trace errors at debug — TLS / DNS / proxy
-            // failures here predict the real-request failure that
-            // follows, and surfacing them under `RUST_LOG=aube_registry=debug`
-            // saves a misconfigured-registry debugging session.
-            if let Err(e) = http
-                .head(&url)
-                .timeout(std::time::Duration::from_secs(5))
-                .send()
-                .await
-            {
-                tracing::debug!(error = %e, "tls prewarm failed");
+        // HEAD on every distinct registry root the install may touch:
+        // the default registry, every scoped registry from `.npmrc`
+        // (`@org:registry=...`), and every per-uri auth registry that
+        // owns its own pool. Prewarming only the default registry
+        // forces the first scoped/auth-uri packument to pay the full
+        // TLS+TCP+ALPN cost on the cold path.
+        //
+        // `aube_util::http::prewarm` honors `AUBE_DISABLE_SPECULATIVE_TLS=1`.
+        let mut targets: Vec<(reqwest::Client, String)> =
+            vec![(self.http.clone(), self.config.registry.clone())];
+        for url in self.config.scoped_registries.values() {
+            let trimmed = url.trim_end_matches('/');
+            if !targets.iter().any(|(_, u)| u.trim_end_matches('/') == trimmed) {
+                let client = self.http_for(url).clone();
+                targets.push((client, url.clone()));
             }
-        });
+        }
+        // Pre-resolve DNS for every prewarmed origin in parallel before
+        // the HEAD requests fire. The HEAD itself triggers another
+        // lookup if hickory-dns hasn't seen the host yet; spawning the
+        // explicit lookups first hides the round trip behind the
+        // handshake instead of stacking it.
+        let resolve_targets: Vec<(String, u16)> = targets
+            .iter()
+            .filter_map(|(_, url)| aube_util::http::resolve::host_port(url))
+            .collect();
+        if !resolve_targets.is_empty() {
+            tokio::spawn(async move {
+                let _ = aube_util::http::resolve::lookup_all(resolve_targets).await;
+            });
+        }
+        aube_util::http::prewarm::spawn_head(targets);
     }
 
     pub fn network_mode(&self) -> NetworkMode {
@@ -1211,7 +1223,19 @@ impl RegistryClient {
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
             match {
-                let req = self.authed_get(&url, registry_url);
+                let req = self
+                    .authed_get(&url, registry_url)
+                    // RFC 9218: packument metadata is resolver-blocking,
+                    // mark Critical so Cloudflare/Fastly H2 schedulers
+                    // prioritize it ahead of pending tarball frames on
+                    // the shared connection.
+                    .header(
+                        "Priority",
+                        aube_util::http::priority::header_value(
+                            aube_util::http::priority::Urgency::Critical,
+                            false,
+                        ),
+                    );
                 if force_full_packument() {
                     req
                 } else {

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -259,12 +259,13 @@ impl RegistryClient {
         // `aube_util::http::prewarm` honors `AUBE_DISABLE_SPECULATIVE_TLS=1`.
         let mut targets: Vec<(reqwest::Client, String)> =
             vec![(self.http.clone(), self.config.registry.clone())];
+        // Lowercase + trim trailing `/` so `Registry.NPMjs.org` and
+        // `https://registry.npmjs.org/` collapse to the same prewarm
+        // target. URL hosts are case-insensitive per RFC 3986 §3.2.2.
+        let normalize = |u: &str| u.trim_end_matches('/').to_ascii_lowercase();
         for url in self.config.scoped_registries.values() {
-            let trimmed = url.trim_end_matches('/');
-            if !targets
-                .iter()
-                .any(|(_, u)| u.trim_end_matches('/') == trimmed)
-            {
+            let trimmed = normalize(url);
+            if !targets.iter().any(|(_, u)| normalize(u) == trimmed) {
                 let client = self.http_for(url).clone();
                 targets.push((client, url.clone()));
             }
@@ -881,7 +882,17 @@ impl RegistryClient {
             match {
                 let mut req = self
                     .authed_get(&url, registry_url)
-                    .header("Accept", PACKUMENT_FULL_ACCEPT);
+                    .header("Accept", PACKUMENT_FULL_ACCEPT)
+                    // RFC 9218: packument metadata is resolver-blocking,
+                    // mark Critical so H2-aware origins prioritize it
+                    // ahead of pending tarball frames.
+                    .header(
+                        "Priority",
+                        aube_util::http::priority::header_value(
+                            aube_util::http::priority::Urgency::Critical,
+                            false,
+                        ),
+                    );
                 if let Some(c) = cached_ref {
                     if let Some(ref etag) = c.etag {
                         req = req.header("If-None-Match", etag);
@@ -1373,7 +1384,13 @@ impl RegistryClient {
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
             match {
-                let mut req = self.authed_get(&url, registry_url);
+                let mut req = self.authed_get(&url, registry_url).header(
+                    "Priority",
+                    aube_util::http::priority::header_value(
+                        aube_util::http::priority::Urgency::Critical,
+                        false,
+                    ),
+                );
                 if !force_full_packument() {
                     req = req.header("Accept", PACKUMENT_ACCEPT);
                 }

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -261,7 +261,10 @@ impl RegistryClient {
             vec![(self.http.clone(), self.config.registry.clone())];
         for url in self.config.scoped_registries.values() {
             let trimmed = url.trim_end_matches('/');
-            if !targets.iter().any(|(_, u)| u.trim_end_matches('/') == trimmed) {
+            if !targets
+                .iter()
+                .any(|(_, u)| u.trim_end_matches('/') == trimmed)
+            {
                 let client = self.http_for(url).clone();
                 targets.push((client, url.clone()));
             }

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -269,20 +269,12 @@ impl RegistryClient {
                 targets.push((client, url.clone()));
             }
         }
-        // Pre-resolve DNS for every prewarmed origin in parallel before
-        // the HEAD requests fire. The HEAD itself triggers another
-        // lookup if hickory-dns hasn't seen the host yet; spawning the
-        // explicit lookups first hides the round trip behind the
-        // handshake instead of stacking it.
-        let resolve_targets: Vec<(String, u16)> = targets
-            .iter()
-            .filter_map(|(_, url)| aube_util::http::resolve::host_port(url))
-            .collect();
-        if !resolve_targets.is_empty() {
-            tokio::spawn(async move {
-                let _ = aube_util::http::resolve::lookup_all(resolve_targets).await;
-            });
-        }
+        // The HEAD requests below populate hickory-dns's in-process
+        // cache as a side effect of issuing the request. A separate
+        // `tokio::net::lookup_host` preresolve would only warm the
+        // OS-level resolver (getaddrinfo), which reqwest's hickory
+        // path does not consult. So the prewarm itself is the DNS
+        // warm-up; no extra lookup needed.
         aube_util::http::prewarm::spawn_head(targets);
     }
 

--- a/crates/aube-util/Cargo.toml
+++ b/crates/aube-util/Cargo.toml
@@ -20,6 +20,8 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 bytes = "1"
 tokio = { workspace = true }
+reqwest = { workspace = true }
+thiserror = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { workspace = true }

--- a/crates/aube-util/src/concurrency.rs
+++ b/crates/aube-util/src/concurrency.rs
@@ -46,10 +46,12 @@ pub fn parse_concurrency_env() -> Option<u32> {
 mod tests {
     use super::*;
 
-    // The env var is process-global. Serialize via a static mutex so
-    // these tests don't race the parallel test runner.
-    use std::sync::Mutex;
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // The env var is process-global. Serialize via the crate-shared
+    // mutex so these tests don't race the parallel test runner. Other
+    // env-mutating tests in this crate (e.g. http::ticket_cache) take
+    // the same lock so concurrent setenv/getenv across tests can't
+    // collide on the libc environ pointer.
+    use crate::test_env::ENV_LOCK;
 
     fn with_env<F: FnOnce()>(value: Option<&str>, f: F) {
         let _g = ENV_LOCK.lock().unwrap();

--- a/crates/aube-util/src/http/mod.rs
+++ b/crates/aube-util/src/http/mod.rs
@@ -1,0 +1,17 @@
+//! HTTP client helpers reused across aube crates.
+//!
+//! The npm registry path is dominated by cold TCP+TLS handshakes,
+//! per-origin DNS lookups, and per-request priority noise. Each helper
+//! here addresses one of those costs without owning a `reqwest::Client`
+//! itself — call sites keep their builders and pass them in.
+//!
+//! Killswitch convention follows aube-util: every optimization that
+//! defaults ON ships an `AUBE_DISABLE_*` env var. Each killswitch is
+//! named in the doc comment of the function reading it so cargo doc
+//! enumerates them.
+
+pub mod prewarm;
+pub mod priority;
+pub mod race;
+pub mod resolve;
+pub mod ticket_cache;

--- a/crates/aube-util/src/http/prewarm.rs
+++ b/crates/aube-util/src/http/prewarm.rs
@@ -29,11 +29,19 @@ pub fn is_disabled() -> bool {
 /// Each pair carries its own `reqwest::Client` because aube tracks one
 /// pool per auth-uri (`http_by_uri`); a single shared client would
 /// merge pools for registries with different auth headers.
+///
+/// No-op when called outside a tokio runtime context. The function
+/// lives in `aube-util` and may be reached from sync bootstrap before
+/// the runtime is entered; rather than panic in `tokio::spawn` it
+/// silently skips so callers don't have to defensively guard.
 pub fn spawn_head<I>(targets: I)
 where
     I: IntoIterator<Item = (reqwest::Client, String)>,
 {
     if is_disabled() {
+        return;
+    }
+    if tokio::runtime::Handle::try_current().is_err() {
         return;
     }
     for (http, url) in targets {

--- a/crates/aube-util/src/http/prewarm.rs
+++ b/crates/aube-util/src/http/prewarm.rs
@@ -1,0 +1,46 @@
+//! Speculative TCP+TLS handshake before the first real request.
+//!
+//! Cold installs pay one full handshake per distinct origin (~50-150 ms
+//! on a 50 ms-RTT path). Issuing a HEAD against each known origin in
+//! parallel during manifest parsing overlaps the handshake with the
+//! resolver's first packument decision. The HEAD response itself is
+//! discarded; the win is the warm pool entry the next real request
+//! reuses.
+//!
+//! `AUBE_DISABLE_SPECULATIVE_TLS=1` skips the prewarm entirely. Wrong
+//! registry, network failure, or auth rejection are silently dropped:
+//! subsequent real requests take the standard path and surface their
+//! own errors.
+
+use std::time::Duration;
+
+const PREWARM_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Returns true when the speculative TLS prewarm is disabled.
+#[inline]
+pub fn is_disabled() -> bool {
+    std::env::var_os("AUBE_DISABLE_SPECULATIVE_TLS").is_some()
+}
+
+/// Spawn a fire-and-forget HEAD against each `(client, url)` pair on
+/// the current tokio runtime. Errors trace at debug — handshake
+/// failures here predict the real-request failure that follows.
+///
+/// Each pair carries its own `reqwest::Client` because aube tracks one
+/// pool per auth-uri (`http_by_uri`); a single shared client would
+/// merge pools for registries with different auth headers.
+pub fn spawn_head<I>(targets: I)
+where
+    I: IntoIterator<Item = (reqwest::Client, String)>,
+{
+    if is_disabled() {
+        return;
+    }
+    for (http, url) in targets {
+        tokio::spawn(async move {
+            if let Err(e) = http.head(&url).timeout(PREWARM_TIMEOUT).send().await {
+                tracing::debug!(error = %e, url = %url, "tls prewarm failed");
+            }
+        });
+    }
+}

--- a/crates/aube-util/src/http/priority.rs
+++ b/crates/aube-util/src/http/priority.rs
@@ -1,0 +1,61 @@
+//! RFC 9218 HTTP priority signal builder.
+//!
+//! Cold install issues two request classes against the same origin:
+//! tiny critical packuments (resolver-blocking) and large tarballs
+//! (fetch-phase, can stream lazily). Marking packuments urgent lets
+//! HTTP/2-aware origins schedule them ahead of pending tarball frames
+//! on the same connection.
+
+use std::fmt::Write;
+
+/// RFC 9218 §4.1 — request urgency, 0 = highest, 7 = lowest. Default
+/// 3 matches RFC §4.1 when no header is sent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Urgency {
+    /// Resolver-blocking packument metadata.
+    Critical = 0,
+    /// Lockfile-driven tarball reads.
+    High = 1,
+    /// Default per RFC 9218 §4.1.
+    Default = 3,
+    /// Background prefetch / speculative fetches.
+    Background = 7,
+}
+
+/// Build the `Priority:` header value per RFC 9218 §4. `incremental`
+/// signals the server may deliver the response in chunks (true for
+/// tarballs, false for packuments where the consumer parses JSON whole).
+pub fn header_value(urgency: Urgency, incremental: bool) -> String {
+    let mut out = String::with_capacity(16);
+    let _ = write!(out, "u={}", urgency as u8);
+    if incremental {
+        out.push_str(", i");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_default_is_u3() {
+        assert_eq!(header_value(Urgency::Default, false), "u=3");
+    }
+
+    #[test]
+    fn header_critical_packument() {
+        assert_eq!(header_value(Urgency::Critical, false), "u=0");
+    }
+
+    #[test]
+    fn header_tarball_incremental() {
+        assert_eq!(header_value(Urgency::High, true), "u=1, i");
+    }
+
+    #[test]
+    fn header_background_streaming() {
+        assert_eq!(header_value(Urgency::Background, true), "u=7, i");
+    }
+}

--- a/crates/aube-util/src/http/race.rs
+++ b/crates/aube-util/src/http/race.rs
@@ -64,7 +64,12 @@ where
         });
     }
 
-    let mut errors: Vec<(String, reqwest::Error)> = Vec::new();
+    // Both transport errors and intermediate non-2xx responses fold
+    // into the same failure list. Dropping a non-2xx (e.g. 401 from
+    // a misconfigured-token candidate) when sibling tasks fail with
+    // transport errors would hide the actual root cause from the
+    // caller's diagnostic chain.
+    let mut failures: Vec<CandidateFailure> = Vec::new();
     while let Some(joined) = joinset.join_next().await {
         match joined {
             Ok(Ok(resp)) if resp.status().is_success() => {
@@ -75,24 +80,34 @@ where
                 let status = resp.status();
                 let url = resp.url().to_string();
                 tracing::debug!(status = %status, url = %url, "race candidate non-2xx");
-                if joinset.is_empty() {
-                    // Prior transport errors fold into AllFailed so the
-                    // caller's diagnostic chain shows every candidate's
-                    // failure. NonSuccess only fires when no transport
-                    // errors accumulated.
-                    if errors.is_empty() {
-                        return Err(RaceError::NonSuccess { status, url });
-                    }
-                    return Err(RaceError::AllFailed(errors));
-                }
+                failures.push(CandidateFailure::NonSuccess { url, status });
             }
-            Ok(Err((url, e))) => errors.push((url, e)),
+            Ok(Err((url, source))) => failures.push(CandidateFailure::Transport { url, source }),
             Err(join_err) => {
                 tracing::debug!(error = %join_err, "race candidate task panicked");
             }
         }
     }
-    Err(RaceError::AllFailed(errors))
+    Err(RaceError::AllFailed(failures))
+}
+
+/// One candidate's failure shape — transport error or non-2xx HTTP
+/// status. `race_get` collects every candidate's failure under
+/// `RaceError::AllFailed` so the caller sees all of them, not just
+/// the last one polled.
+#[derive(Debug, thiserror::Error)]
+pub enum CandidateFailure {
+    #[error("{url} transport failure: {source}")]
+    Transport {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("{url} returned {status}")]
+    NonSuccess {
+        url: String,
+        status: reqwest::StatusCode,
+    },
 }
 
 /// Errors that can surface from `race_get`.
@@ -106,13 +121,8 @@ pub enum RaceError {
         #[source]
         source: reqwest::Error,
     },
-    #[error("all {} candidates failed (first: {})", .0.len(), .0.first().map(|(_, e)| e.to_string()).unwrap_or_default())]
-    AllFailed(Vec<(String, reqwest::Error)>),
-    #[error("only candidate returned {status}: {url}")]
-    NonSuccess {
-        status: reqwest::StatusCode,
-        url: String,
-    },
+    #[error("all {} candidates failed (first: {})", .0.len(), .0.first().map(|f| f.to_string()).unwrap_or_default())]
+    AllFailed(Vec<CandidateFailure>),
 }
 
 impl RaceError {

--- a/crates/aube-util/src/http/race.rs
+++ b/crates/aube-util/src/http/race.rs
@@ -1,0 +1,115 @@
+//! Speculative parallel GET: issue N concurrent requests for the same
+//! resource and return the first successful response, aborting the
+//! rest. Trades extra bandwidth for tail-latency reduction on flaky
+//! networks where one of `N` mirror URLs lands fast.
+//!
+//! Useful when a packument or tarball is mirrored across multiple
+//! CDN edges (e.g. Cloudflare anycast IP variants for
+//! `registry.npmjs.org`) and the slowest path dominates a sequential
+//! fallback. A 2-3 way race against the same Cloudflare zone is
+//! near-free because the request hits the same edge cache.
+//!
+//! `AUBE_DISABLE_REQUEST_RACING=1` collapses to a single-URL fallback
+//! (the first URL in the list) so a debugging session can isolate
+//! per-mirror behaviour without changing call sites.
+
+use std::time::Duration;
+
+const DEFAULT_RACE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Returns true when speculative request racing is disabled.
+#[inline]
+pub fn is_disabled() -> bool {
+    std::env::var_os("AUBE_DISABLE_REQUEST_RACING").is_some()
+}
+
+/// Race the given `(client, url)` candidates in parallel. The first
+/// 2xx response wins; the rest abort. Returns the winning response.
+///
+/// `Err(RaceError::AllFailed)` collects every candidate's failure for
+/// the diagnostic chain — a single upstream outage that fails all
+/// mirrors should still surface a useful error rather than just the
+/// last one polled.
+pub async fn race_get<I>(targets: I) -> Result<reqwest::Response, RaceError>
+where
+    I: IntoIterator<Item = (reqwest::Client, String)>,
+{
+    let candidates: Vec<(reqwest::Client, String)> = targets.into_iter().collect();
+    if candidates.is_empty() {
+        return Err(RaceError::Empty);
+    }
+    if is_disabled() || candidates.len() == 1 {
+        // Disabled or a one-url race is just a normal GET; skip the
+        // join-set scaffolding so the killswitch path stays cheap.
+        let (client, url) = candidates.into_iter().next().expect("len >= 1");
+        return client
+            .get(&url)
+            .timeout(DEFAULT_RACE_TIMEOUT)
+            .send()
+            .await
+            .map_err(|e| RaceError::single(url, e));
+    }
+
+    let mut joinset: tokio::task::JoinSet<Result<reqwest::Response, (String, reqwest::Error)>> =
+        tokio::task::JoinSet::new();
+    for (client, url) in candidates {
+        let url_for_err = url.clone();
+        joinset.spawn(async move {
+            client
+                .get(&url)
+                .timeout(DEFAULT_RACE_TIMEOUT)
+                .send()
+                .await
+                .map_err(|e| (url_for_err, e))
+        });
+    }
+
+    let mut errors: Vec<(String, reqwest::Error)> = Vec::new();
+    while let Some(joined) = joinset.join_next().await {
+        match joined {
+            Ok(Ok(resp)) if resp.status().is_success() => {
+                joinset.abort_all();
+                return Ok(resp);
+            }
+            Ok(Ok(resp)) => {
+                let status = resp.status();
+                let url = resp.url().to_string();
+                tracing::debug!(status = %status, url = %url, "race candidate non-2xx");
+                if joinset.is_empty() {
+                    return Err(RaceError::NonSuccess { status, url });
+                }
+            }
+            Ok(Err((url, e))) => errors.push((url, e)),
+            Err(join_err) => {
+                tracing::debug!(error = %join_err, "race candidate task panicked");
+            }
+        }
+    }
+    Err(RaceError::AllFailed(errors))
+}
+
+/// Errors that can surface from `race_get`.
+#[derive(Debug, thiserror::Error)]
+pub enum RaceError {
+    #[error("no candidates supplied to race_get")]
+    Empty,
+    #[error("{url} failed: {source}")]
+    Single {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("all {} candidates failed (first: {})", .0.len(), .0.first().map(|(_, e)| e.to_string()).unwrap_or_default())]
+    AllFailed(Vec<(String, reqwest::Error)>),
+    #[error("only candidate returned {status}: {url}")]
+    NonSuccess {
+        status: reqwest::StatusCode,
+        url: String,
+    },
+}
+
+impl RaceError {
+    fn single(url: String, source: reqwest::Error) -> Self {
+        Self::Single { url, source }
+    }
+}

--- a/crates/aube-util/src/http/race.rs
+++ b/crates/aube-util/src/http/race.rs
@@ -76,7 +76,14 @@ where
                 let url = resp.url().to_string();
                 tracing::debug!(status = %status, url = %url, "race candidate non-2xx");
                 if joinset.is_empty() {
-                    return Err(RaceError::NonSuccess { status, url });
+                    // Prior transport errors fold into AllFailed so the
+                    // caller's diagnostic chain shows every candidate's
+                    // failure. NonSuccess only fires when no transport
+                    // errors accumulated.
+                    if errors.is_empty() {
+                        return Err(RaceError::NonSuccess { status, url });
+                    }
+                    return Err(RaceError::AllFailed(errors));
                 }
             }
             Ok(Err((url, e))) => errors.push((url, e)),

--- a/crates/aube-util/src/http/resolve.rs
+++ b/crates/aube-util/src/http/resolve.rs
@@ -76,6 +76,10 @@ where
 /// `http` / `https` schemes are recognized — anything else returns
 /// `None` because the registry path never sees other schemes and a
 /// fallback default port would be guesswork.
+/// Splits an `http`/`https` URL into `(host, port)`. IPv6 literals
+/// follow RFC 3986 §3.2.2 (brackets bound the host). userinfo
+/// (`user:pass@`) and trailing `?query` / `#fragment` are stripped
+/// before the port split so neither collides with the colon.
 pub fn host_port(url: &str) -> Option<(String, u16)> {
     let (scheme, rest) = url.split_once("://")?;
     let default_port = match scheme {
@@ -85,8 +89,24 @@ pub fn host_port(url: &str) -> Option<(String, u16)> {
     };
     let authority = rest.split('/').next()?;
     let authority = authority.split('?').next()?;
+    let authority = authority.split('#').next()?;
     if authority.is_empty() {
         return None;
+    }
+    let authority = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    if let Some(after_open) = authority.strip_prefix('[') {
+        let close = after_open.find(']')?;
+        let host = &after_open[..close];
+        if host.is_empty() {
+            return None;
+        }
+        let tail = &after_open[close + 1..];
+        if tail.is_empty() {
+            return Some((host.to_owned(), default_port));
+        }
+        let port_str = tail.strip_prefix(':')?;
+        let port = port_str.parse::<u16>().ok()?;
+        return Some((host.to_owned(), port));
     }
     if let Some((host, port_str)) = authority.rsplit_once(':') {
         if host.is_empty() {
@@ -132,5 +152,37 @@ mod tests {
         assert!(host_port("not a url").is_none());
         assert!(host_port("ftp://example.com").is_none());
         assert!(host_port("https://example.com:notnum").is_none());
+    }
+
+    #[test]
+    fn host_port_ipv6_default() {
+        assert_eq!(
+            host_port("https://[::1]/"),
+            Some(("::1".to_owned(), 443))
+        );
+    }
+
+    #[test]
+    fn host_port_ipv6_explicit() {
+        assert_eq!(
+            host_port("https://[2001:db8::1]:8443/foo"),
+            Some(("2001:db8::1".to_owned(), 8443))
+        );
+    }
+
+    #[test]
+    fn host_port_strips_userinfo() {
+        assert_eq!(
+            host_port("https://user:pass@example.com:9443/"),
+            Some(("example.com".to_owned(), 9443))
+        );
+    }
+
+    #[test]
+    fn host_port_strips_fragment() {
+        assert_eq!(
+            host_port("https://example.com/path#frag"),
+            Some(("example.com".to_owned(), 443))
+        );
     }
 }

--- a/crates/aube-util/src/http/resolve.rs
+++ b/crates/aube-util/src/http/resolve.rs
@@ -1,0 +1,136 @@
+//! DNS pre-resolution and anycast pinning helpers.
+//!
+//! The system resolver does not cache and uses a thread pool for
+//! `getaddrinfo`, which serializes the first cold lookup per origin.
+//! Pre-resolving every origin the install will touch in parallel during
+//! manifest parsing overlaps DNS with the rest of the cold pipeline.
+//!
+//! The npm registry and `*.tgz` tarballs both ride Cloudflare anycast.
+//! Pinning a known IP set per host (`reqwest::ClientBuilder::resolve_to_addrs`)
+//! lets one TCP+TLS connection serve many SNIs on the same edge — useful
+//! when the pool is otherwise empty on a fresh process.
+//!
+//! `AUBE_DISABLE_DNS_PRERESOLVE=1` falls through to the system resolver.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+const DEFAULT_RESOLVE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Returns true when DNS pre-resolution is disabled.
+#[inline]
+pub fn is_disabled() -> bool {
+    std::env::var_os("AUBE_DISABLE_DNS_PRERESOLVE").is_some()
+}
+
+/// Pre-resolve `(host, port)` pairs in parallel via tokio's runtime,
+/// returning resolved socket addresses. Failed lookups are logged at
+/// debug and skipped; callers fall back to lazy resolution at request
+/// time.
+pub async fn lookup_all<I>(targets: I) -> Vec<(String, Vec<SocketAddr>)>
+where
+    I: IntoIterator<Item = (String, u16)>,
+{
+    use std::collections::HashMap;
+    if is_disabled() {
+        return Vec::new();
+    }
+    let mut handles: tokio::task::JoinSet<(String, Vec<SocketAddr>)> = tokio::task::JoinSet::new();
+    let mut seen: HashMap<String, ()> = HashMap::new();
+    for (host, port) in targets {
+        if seen.insert(host.clone(), ()).is_some() {
+            continue;
+        }
+        handles.spawn(async move {
+            let endpoint = format!("{host}:{port}");
+            let resolved = match tokio::time::timeout(
+                DEFAULT_RESOLVE_TIMEOUT,
+                tokio::net::lookup_host(endpoint),
+            )
+            .await
+            {
+                Ok(Ok(iter)) => iter.collect::<Vec<_>>(),
+                Ok(Err(e)) => {
+                    tracing::debug!(host = %host, error = %e, "dns preresolve failed");
+                    Vec::new()
+                }
+                Err(_) => {
+                    tracing::debug!(host = %host, "dns preresolve timed out");
+                    Vec::new()
+                }
+            };
+            (host, resolved)
+        });
+    }
+    let mut out = Vec::new();
+    while let Some(joined) = handles.join_next().await {
+        if let Ok(pair) = joined {
+            out.push(pair);
+        }
+    }
+    out
+}
+
+/// Best-effort split of a registry-style URL into `(host, port)`.
+/// Returns `None` on parse failure or when the URL has no host. Only
+/// `http` / `https` schemes are recognized — anything else returns
+/// `None` because the registry path never sees other schemes and a
+/// fallback default port would be guesswork.
+pub fn host_port(url: &str) -> Option<(String, u16)> {
+    let (scheme, rest) = url.split_once("://")?;
+    let default_port = match scheme {
+        "https" => 443,
+        "http" => 80,
+        _ => return None,
+    };
+    let authority = rest.split('/').next()?;
+    let authority = authority.split('?').next()?;
+    if authority.is_empty() {
+        return None;
+    }
+    if let Some((host, port_str)) = authority.rsplit_once(':') {
+        if host.is_empty() {
+            return None;
+        }
+        let port = port_str.parse::<u16>().ok()?;
+        Some((host.to_owned(), port))
+    } else {
+        Some((authority.to_owned(), default_port))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_port_https_default() {
+        assert_eq!(
+            host_port("https://registry.npmjs.org/"),
+            Some(("registry.npmjs.org".to_owned(), 443))
+        );
+    }
+
+    #[test]
+    fn host_port_explicit() {
+        assert_eq!(
+            host_port("https://example.com:8443/foo"),
+            Some(("example.com".to_owned(), 8443))
+        );
+    }
+
+    #[test]
+    fn host_port_http_default() {
+        assert_eq!(
+            host_port("http://example.com/foo"),
+            Some(("example.com".to_owned(), 80))
+        );
+    }
+
+    #[test]
+    fn host_port_invalid() {
+        assert!(host_port("not a url").is_none());
+        assert!(host_port("ftp://example.com").is_none());
+        assert!(host_port("https://example.com:notnum").is_none());
+    }
+}

--- a/crates/aube-util/src/http/resolve.rs
+++ b/crates/aube-util/src/http/resolve.rs
@@ -156,10 +156,7 @@ mod tests {
 
     #[test]
     fn host_port_ipv6_default() {
-        assert_eq!(
-            host_port("https://[::1]/"),
-            Some(("::1".to_owned(), 443))
-        );
+        assert_eq!(host_port("https://[::1]/"), Some(("::1".to_owned(), 443)));
     }
 
     #[test]

--- a/crates/aube-util/src/http/ticket_cache.rs
+++ b/crates/aube-util/src/http/ticket_cache.rs
@@ -12,10 +12,14 @@
 //! Format: serde-json blob at `$XDG_CACHE_HOME/aube/tls-tickets.json`
 //! containing per-host entries `(server_name, port) -> TicketEntry`.
 //! Each entry holds the rustls ticket bytes plus the SPKI fingerprint
-//! observed at ticket-acquire time. On load the fingerprint is
-//! re-validated against the live cert; mismatch invalidates the
-//! ticket so a rotated cert never silently downgrades to a stale
-//! resumption. Entries past `MAX_AGE` (24 h) are pruned at load.
+//! observed at ticket-acquire time. The rustls wiring layer compares
+//! the live cert's SPKI fingerprint against `spki_fp` and calls
+//! `invalidate(host, port)` on mismatch so a rotated cert never
+//! silently downgrades to a stale resumption. Entries past `MAX_AGE`
+//! (24 h) are pruned at load.
+//!
+//! On Unix the on-disk file is created with mode 0600 so ticket bytes
+//! are not world-readable on multi-user hosts.
 //!
 //! `AUBE_DISABLE_TLS_TICKET_CACHE=1` skips load + save; rustls falls
 //! back to its per-process in-memory store.
@@ -179,7 +183,17 @@ impl TicketCache {
             entries: inner.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
         };
         let bytes = serde_json::to_vec(&payload).map_err(std::io::Error::other)?;
-        crate::fs_atomic::atomic_write(&self.path, &bytes)
+        crate::fs_atomic::atomic_write(&self.path, &bytes)?;
+        // Tighten POSIX perms after the atomic rename so ticket bytes
+        // are not world-readable. Windows inherits the parent ACL,
+        // which already restricts %LOCALAPPDATA% to the user; nothing
+        // to do there.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let _ = std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o600));
+        }
+        Ok(())
     }
 
     /// Total ticket count across all hosts (for diagnostics).
@@ -301,10 +315,13 @@ mod tests {
 
     #[test]
     fn killswitch_short_circuits() {
+        // Acquire the crate-shared env lock so concurrent tests in
+        // other modules (e.g. concurrency) can't race setenv/getenv.
+        let _g = crate::test_env::ENV_LOCK.lock().unwrap();
         let dir = tempdir().unwrap();
-        // SAFETY: tests run serialized via aube-util's concurrency
-        // module convention, and the killswitch is read by our own
-        // code only.
+        // SAFETY: ENV_LOCK serializes every env-mutating test in this
+        // crate; no other thread touches the process environment
+        // while this guard is held.
         unsafe { std::env::set_var("AUBE_DISABLE_TLS_TICKET_CACHE", "1") };
         let cache = TicketCache::open(dir.path().join("tickets.json"));
         cache.put("a.example", 443, entry(1));

--- a/crates/aube-util/src/http/ticket_cache.rs
+++ b/crates/aube-util/src/http/ticket_cache.rs
@@ -1,0 +1,330 @@
+//! Cross-invocation TLS session ticket cache.
+//!
+//! rustls 0.23+ exposes `ClientSessionStore` for caching session
+//! tickets in-memory; the default impl is per-process and dies with
+//! the CLI. Persisting tickets on disk lets the second `aube install`
+//! invocation skip the full TLS handshake and resume against the
+//! cached session, saving 1 RTT (~50-150 ms per origin) on cold
+//! invocations after the first one. No PM in the npm-CM-space ships
+//! this — npm/pnpm/yarn/bun/vlt all start with an empty session
+//! store every invocation.
+//!
+//! Format: serde-json blob at `$XDG_CACHE_HOME/aube/tls-tickets.json`
+//! containing per-host entries `(server_name, port) -> TicketEntry`.
+//! Each entry holds the rustls ticket bytes plus the SPKI fingerprint
+//! observed at ticket-acquire time. On load the fingerprint is
+//! re-validated against the live cert; mismatch invalidates the
+//! ticket so a rotated cert never silently downgrades to a stale
+//! resumption. Entries past `MAX_AGE` (24 h) are pruned at load.
+//!
+//! `AUBE_DISABLE_TLS_TICKET_CACHE=1` skips load + save; rustls falls
+//! back to its per-process in-memory store.
+//!
+//! The rustls `ClientSessionStore` trait wiring lives at the
+//! `aube-registry` integration site so `aube-util` keeps zero rustls
+//! dependency. This module ships the on-disk format, the in-memory
+//! map, and the load/save/expire/invalidate APIs the wiring layer
+//! reads.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Tickets older than this are pruned at load. Matches the typical
+/// session-ticket-lifetime hint Cloudflare/Fastly send (~24 h).
+pub const MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+
+const FORMAT_MAGIC: &str = "aube-tls-tickets/v1";
+
+/// Returns true when the on-disk ticket cache is disabled.
+#[inline]
+pub fn is_disabled() -> bool {
+    std::env::var_os("AUBE_DISABLE_TLS_TICKET_CACHE").is_some()
+}
+
+/// One serialized ticket entry. `ticket` is opaque to this module —
+/// the rustls `ClientSessionStore` wiring layer encodes/decodes it.
+/// `spki_fp` binds the ticket to the cert observed when it was
+/// acquired so a rotated cert force-invalidates the resumption.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TicketEntry {
+    /// Opaque rustls ticket bytes.
+    pub ticket: Vec<u8>,
+    /// SHA-256 over the server's SubjectPublicKeyInfo at ticket-acquire time.
+    pub spki_fp: [u8; 32],
+    /// Wall-clock (UNIX seconds) when the ticket was stored. Used for `MAX_AGE` pruning.
+    pub stored_at_unix_secs: u64,
+}
+
+/// Storage key — `(host, port)`. Lowercased host, normalized port.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct HostPort {
+    pub host: String,
+    pub port: u16,
+}
+
+impl HostPort {
+    pub fn new(host: impl Into<String>, port: u16) -> Self {
+        Self {
+            host: host.into().to_ascii_lowercase(),
+            port,
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct OnDisk {
+    /// Format magic; bumping invalidates the whole file.
+    magic: String,
+    /// Per-host tickets serialized as a flat list because serde_json
+    /// refuses non-string map keys (`HostPort` is a struct). Vec lets
+    /// rustls' multi-ticket convention through (most servers issue 2
+    /// NewSessionTicket frames per handshake).
+    entries: Vec<(HostPort, Vec<TicketEntry>)>,
+}
+
+/// In-memory ticket cache. Backed by an on-disk JSON blob; load and
+/// save are explicit so the rustls wiring layer can drive them at
+/// install start / install end.
+#[derive(Debug)]
+pub struct TicketCache {
+    path: PathBuf,
+    inner: RwLock<HashMap<HostPort, Vec<TicketEntry>>>,
+    /// Serializes file reads/writes against concurrent open() calls
+    /// in the same process; cross-process is best-effort (last-writer
+    /// wins, idempotent payload).
+    file_lock: Mutex<()>,
+}
+
+impl TicketCache {
+    /// Open the cache at the canonical path under
+    /// `XDG_CACHE_HOME/aube/tls-tickets.json`. Caller responsible for
+    /// `XDG_CACHE_HOME` resolution; pass an explicit path here.
+    pub fn open(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        let inner = if is_disabled() {
+            HashMap::new()
+        } else {
+            load_from_disk(&path).unwrap_or_default()
+        };
+        Self {
+            path,
+            inner: RwLock::new(inner),
+            file_lock: Mutex::new(()),
+        }
+    }
+
+    /// Look up cached tickets for `(host, port)`. Stale entries beyond
+    /// `MAX_AGE` are filtered transparently; callers receive only
+    /// fresh tickets.
+    pub fn get(&self, host: &str, port: u16) -> Vec<TicketEntry> {
+        if is_disabled() {
+            return Vec::new();
+        }
+        let key = HostPort::new(host, port);
+        let now = unix_now();
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        inner
+            .get(&key)
+            .map(|tickets| {
+                tickets
+                    .iter()
+                    .filter(|t| now.saturating_sub(t.stored_at_unix_secs) < MAX_AGE.as_secs())
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Store a fresh ticket for `(host, port)`. Multiple tickets per
+    /// origin are kept (rustls servers typically issue 2 per
+    /// handshake); `prune_max_per_host` caps the queue.
+    pub fn put(&self, host: &str, port: u16, entry: TicketEntry) {
+        if is_disabled() {
+            return;
+        }
+        const MAX_PER_HOST: usize = 4;
+        let key = HostPort::new(host, port);
+        let mut inner = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        let bucket = inner.entry(key).or_default();
+        bucket.push(entry);
+        if bucket.len() > MAX_PER_HOST {
+            let drop = bucket.len() - MAX_PER_HOST;
+            bucket.drain(..drop);
+        }
+    }
+
+    /// Evict every ticket for `(host, port)`. Called when a TLS
+    /// handshake observes a cert whose SPKI fingerprint does not
+    /// match the cached entry — the cert rotated, so the ticket is
+    /// stale.
+    pub fn invalidate(&self, host: &str, port: u16) {
+        let key = HostPort::new(host, port);
+        let mut inner = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        inner.remove(&key);
+    }
+
+    /// Persist the in-memory cache to disk. Atomic via
+    /// `aube_util::fs_atomic::atomic_write`.
+    pub fn save(&self) -> std::io::Result<()> {
+        if is_disabled() {
+            return Ok(());
+        }
+        let _guard = self.file_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        let payload = OnDisk {
+            magic: FORMAT_MAGIC.to_string(),
+            entries: inner.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+        };
+        let bytes = serde_json::to_vec(&payload).map_err(std::io::Error::other)?;
+        crate::fs_atomic::atomic_write(&self.path, &bytes)
+    }
+
+    /// Total ticket count across all hosts (for diagnostics).
+    pub fn len(&self) -> usize {
+        let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        inner.values().map(|v| v.len()).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+fn load_from_disk(path: &Path) -> Option<HashMap<HostPort, Vec<TicketEntry>>> {
+    let bytes = std::fs::read(path).ok()?;
+    let payload: OnDisk = serde_json::from_slice(&bytes).ok()?;
+    if payload.magic != FORMAT_MAGIC {
+        return None;
+    }
+    let now = unix_now();
+    let map: HashMap<HostPort, Vec<TicketEntry>> = payload
+        .entries
+        .into_iter()
+        .filter_map(|(k, v)| {
+            let fresh: Vec<TicketEntry> = v
+                .into_iter()
+                .filter(|t| now.saturating_sub(t.stored_at_unix_secs) < MAX_AGE.as_secs())
+                .collect();
+            if fresh.is_empty() {
+                None
+            } else {
+                Some((k, fresh))
+            }
+        })
+        .collect();
+    Some(map)
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn entry(label: u8) -> TicketEntry {
+        TicketEntry {
+            ticket: vec![label, label + 1, label + 2],
+            spki_fp: [label; 32],
+            stored_at_unix_secs: unix_now(),
+        }
+    }
+
+    #[test]
+    fn roundtrip_persists_across_open() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("tickets.json");
+        {
+            let cache = TicketCache::open(&path);
+            cache.put("registry.npmjs.org", 443, entry(1));
+            cache.save().unwrap();
+        }
+        let reopened = TicketCache::open(&path);
+        let tickets = reopened.get("registry.npmjs.org", 443);
+        assert_eq!(tickets.len(), 1);
+        assert_eq!(tickets[0].ticket, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn host_port_lowercases() {
+        let a = HostPort::new("Registry.NPMJS.ORG", 443);
+        let b = HostPort::new("registry.npmjs.org", 443);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn invalidate_removes_all_for_host() {
+        let dir = tempdir().unwrap();
+        let cache = TicketCache::open(dir.path().join("tickets.json"));
+        cache.put("a.example", 443, entry(1));
+        cache.put("a.example", 443, entry(2));
+        assert_eq!(cache.len(), 2);
+        cache.invalidate("a.example", 443);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn max_per_host_evicts_oldest() {
+        let dir = tempdir().unwrap();
+        let cache = TicketCache::open(dir.path().join("tickets.json"));
+        for i in 0..6u8 {
+            cache.put("a.example", 443, entry(i));
+        }
+        let kept = cache.get("a.example", 443);
+        assert_eq!(kept.len(), 4, "MAX_PER_HOST = 4");
+        // Oldest two (label 0, 1) should be gone.
+        assert!(kept.iter().all(|t| t.ticket[0] >= 2));
+    }
+
+    #[test]
+    fn stale_entries_filtered_at_load() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("tickets.json");
+        {
+            let cache = TicketCache::open(&path);
+            let mut stale = entry(9);
+            stale.stored_at_unix_secs = 0;
+            cache.put("a.example", 443, stale);
+            cache.save().unwrap();
+        }
+        let reopened = TicketCache::open(&path);
+        assert!(reopened.get("a.example", 443).is_empty());
+    }
+
+    #[test]
+    fn killswitch_short_circuits() {
+        let dir = tempdir().unwrap();
+        // SAFETY: tests run serialized via aube-util's concurrency
+        // module convention, and the killswitch is read by our own
+        // code only.
+        unsafe { std::env::set_var("AUBE_DISABLE_TLS_TICKET_CACHE", "1") };
+        let cache = TicketCache::open(dir.path().join("tickets.json"));
+        cache.put("a.example", 443, entry(1));
+        assert!(cache.get("a.example", 443).is_empty());
+        unsafe { std::env::remove_var("AUBE_DISABLE_TLS_TICKET_CACHE") };
+    }
+
+    #[test]
+    fn missing_file_loads_empty() {
+        let dir = tempdir().unwrap();
+        let cache = TicketCache::open(dir.path().join("nonexistent.json"));
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn corrupt_magic_loads_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("tickets.json");
+        std::fs::write(&path, br#"{"magic":"wrong","entries":[]}"#).unwrap();
+        let cache = TicketCache::open(&path);
+        assert!(cache.is_empty());
+    }
+}

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -6,6 +6,7 @@ pub mod env;
 pub mod fs;
 pub mod fs_atomic;
 pub mod hash;
+pub mod http;
 pub mod io;
 pub mod path;
 pub mod pkg;

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -12,6 +12,8 @@ pub mod path;
 pub mod pkg;
 pub mod snapshot;
 pub mod url;
+#[cfg(test)]
+mod test_env;
 
 use serde::{Deserialize, Deserializer};
 

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -11,9 +11,9 @@ pub mod io;
 pub mod path;
 pub mod pkg;
 pub mod snapshot;
-pub mod url;
 #[cfg(test)]
 mod test_env;
+pub mod url;
 
 use serde::{Deserialize, Deserializer};
 

--- a/crates/aube-util/src/test_env.rs
+++ b/crates/aube-util/src/test_env.rs
@@ -1,0 +1,10 @@
+//! Crate-shared test helper for serializing env-mutating tests.
+//!
+//! Rust 2024's `unsafe { std::env::set_var }` reflects the libc
+//! reality: setenv/getenv are not thread-safe across each other
+//! because setenv can realloc the environ pointer. Tests in this
+//! crate that touch the process environment all acquire `ENV_LOCK`
+//! to serialize against the parallel test runner.
+
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -14,6 +14,7 @@ mod dep_selection;
 mod frozen;
 mod git_prepare;
 mod lifecycle;
+mod prefetch;
 pub(crate) mod node_gyp_bootstrap;
 mod settings;
 mod side_effects_cache;
@@ -969,16 +970,6 @@ pub(super) async fn run_gvs_prewarm_materializer(
     let engine = node_version
         .as_deref()
         .map(aube_lockfile::graph_hash::engine_name_default);
-    let allow = move |name: &str, version: &str| {
-        matches!(
-            build_policy.decide(name, version),
-            aube_scripts::AllowDecision::Allow
-        )
-    };
-    let patch_hash_fn = |name: &str, version: &str| -> Option<String> {
-        let key = format!("{name}@{version}");
-        patch_hashes.get(&key).cloned()
-    };
 
     // Build a probe linker without graph_hashes to check GVS mode
     // first. compute_graph_hashes_with_patches walks every package
@@ -995,28 +986,43 @@ pub(super) async fn run_gvs_prewarm_materializer(
             .await;
     }
 
-    let graph_hashes_arc = std::sync::Arc::new(
+    // Hash compute walks every package BLAKE3-style. spawn_blocking
+    // pushes it off the tokio worker so the canonical_to_contextualized
+    // build below + nested_link_targets walk + first materialize_rx
+    // recv keep making progress in parallel. compute_graph_hashes_with_patches
+    // is CPU-bound and was previously blocking the executor.
+    let graph_for_hash = graph.clone();
+    let build_policy_for_hash = build_policy.clone();
+    let engine_for_hash = engine.clone();
+    let patch_hashes_for_hash = patch_hashes.clone();
+    let hash_handle = tokio::task::spawn_blocking(move || {
+        let allow = |name: &str, version: &str| {
+            matches!(
+                build_policy_for_hash.decide(name, version),
+                aube_scripts::AllowDecision::Allow
+            )
+        };
+        let patch_hash_fn = |name: &str, version: &str| -> Option<String> {
+            let key = format!("{name}@{version}");
+            patch_hashes_for_hash.get(&key).cloned()
+        };
         aube_lockfile::graph_hash::compute_graph_hashes_with_patches(
-            &graph,
+            &graph_for_hash,
             &allow,
-            engine.as_ref(),
+            engine_for_hash.as_ref(),
             &patch_hash_fn,
-        ),
-    );
-    let mut linker = probe.with_graph_hashes((*graph_hashes_arc).clone());
-    if !patches.is_empty() {
-        linker = linker.with_patches(patches);
-    }
-    let linker = std::sync::Arc::new(linker);
+        )
+    });
 
     let nested_link_targets =
         aube_linker::build_nested_link_targets(&cwd, &graph).map(std::sync::Arc::new);
 
-    // Map canonical name@version to set of contextualized dep_paths.
-    // Resolver no-lockfile path keys by canonical, lockfile path emits
-    // contextualized. Accept both. foldhash here matches the resolver
-    // and lockfile graph_hash hot maps so the streaming GVS-prewarm
-    // loop hits one consistent hasher.
+    // Channel emits `pkg.dep_path` (canonical on resolver first-pass,
+    // contextualized on post-pass). When the received key is canonical
+    // and fans out to one-or-more peer-contextualized variants in the
+    // graph, this map points canonical -> {contextualized}. Identity
+    // entries (canonical == dep_path) skip the map and fall back to a
+    // direct graph lookup at receive time.
     let mut canonical_to_contextualized: aube_util::collections::FxMap<
         String,
         aube_util::collections::FxSet<String>,
@@ -1026,15 +1032,24 @@ pub(super) async fn run_gvs_prewarm_materializer(
             continue;
         }
         let canonical = pkg.spec_key();
-        canonical_to_contextualized
-            .entry(canonical)
-            .or_default()
-            .insert(dep_path.clone());
-        canonical_to_contextualized
-            .entry(dep_path.clone())
-            .or_default()
-            .insert(dep_path.clone());
+        if canonical != *dep_path {
+            canonical_to_contextualized
+                .entry(canonical)
+                .or_default()
+                .insert(dep_path.clone());
+        }
     }
+
+    let graph_hashes = hash_handle
+        .await
+        .into_diagnostic()
+        .wrap_err("graph_hash compute task failed")?;
+    let graph_hashes_arc = std::sync::Arc::new(graph_hashes);
+    let mut linker = probe.with_graph_hashes((*graph_hashes_arc).clone());
+    if !patches.is_empty() {
+        linker = linker.with_patches(patches);
+    }
+    let linker = std::sync::Arc::new(linker);
 
     let permits = link_concurrency.unwrap_or_else(aube_linker::default_linker_parallelism);
     let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(permits));
@@ -1846,6 +1861,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // no direct deps would.
     let manifest = super::load_manifest_or_default(&cwd)?;
     let project_name = manifest.name.as_deref().unwrap_or("(unnamed)");
+
+    // Pre-resolver packument prefetch. Reads `package.json` keys and
+    // fires fire-and-forget GETs for every registry-shaped direct dep
+    // before workspace yaml load, settings resolve, lockfile parse,
+    // pnpmfile setup, and resolver construction run. By the time the
+    // resolver pops its first task, the packument is in the on-disk
+    // cache and the reqwest pool is hot. Honors `AUBE_DISABLE_PREFETCH=1`.
+    prefetch::spawn_direct_dep_prefetch(&manifest, &cwd, opts.network_mode);
 
     // Load the workspace yaml *once* — both as the typed
     // `WorkspaceConfig` (used below for `allow_builds_raw` and

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -14,8 +14,8 @@ mod dep_selection;
 mod frozen;
 mod git_prepare;
 mod lifecycle;
-mod prefetch;
 pub(crate) mod node_gyp_bootstrap;
+mod prefetch;
 mod settings;
 mod side_effects_cache;
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1057,7 +1057,17 @@ pub(super) async fn run_gvs_prewarm_materializer(
         Vec::new();
     let mut rx = materialize_rx;
     while let Some((key, index)) = rx.recv().await {
-        let Some(dep_paths) = canonical_to_contextualized.get(&key).cloned() else {
+        // canonical_to_contextualized only stores entries where
+        // canonical != dep_path. Identity packages (the common case)
+        // fall through to a direct graph lookup. Without this fallback
+        // the lockfile path — which emits dep_path == canonical for
+        // every non-peer-suffixed package — would silently skip
+        // materialize for every identity entry.
+        let dep_paths: Vec<String> = if let Some(set) = canonical_to_contextualized.get(&key) {
+            set.iter().cloned().collect()
+        } else if graph.packages.contains_key(&key) {
+            vec![key.clone()]
+        } else {
             continue;
         };
         let index = std::sync::Arc::new(index);

--- a/crates/aube/src/commands/install/prefetch.rs
+++ b/crates/aube/src/commands/install/prefetch.rs
@@ -1,0 +1,165 @@
+//! Pre-resolver direct-dep packument prefetch.
+//!
+//! aube reads `package.json` keys as raw strings and fires packument
+//! GETs for every registry-shaped direct dep before the resolver
+//! constructs its first task. The resolver then hits the warm
+//! on-disk packument cache + warm reqwest pool when it formally
+//! requests them, hiding the manifest-validation / pnpmfile-setup /
+//! workspace-yaml / settings-resolution cost behind real network work.
+//!
+//! The fetches are best-effort fire-and-forget. Failures, 404s, and
+//! offline mode silently no-op; the resolver re-fetches via its own
+//! retry path. No PM in the npm-CM-space ships this — npm/pnpm/yarn/bun
+//! all wait until the resolver pops its first task before issuing any
+//! packument GET.
+//!
+//! `AUBE_DISABLE_PREFETCH=1` skips the prefetch.
+
+use std::sync::Arc;
+
+const REGISTRY_LIKE_PREFIXES: &[&str] = &["npm:"];
+const NON_REGISTRY_SPEC_MARKERS: &[&str] = &[
+    "workspace:",
+    "file:",
+    "link:",
+    "github:",
+    "git+",
+    "git:",
+    "http://",
+    "https://",
+    "catalog:",
+];
+
+/// Returns true when prefetch is disabled.
+#[inline]
+pub fn is_disabled() -> bool {
+    std::env::var_os("AUBE_DISABLE_PREFETCH").is_some()
+}
+
+/// Spawn a fire-and-forget packument GET for every registry-shaped
+/// direct dep in the manifest. Returns immediately; results are
+/// discarded — the win is the warm reqwest pool + warm on-disk
+/// packument cache the resolver hits next.
+///
+/// Honors `AUBE_DISABLE_PREFETCH=1`. No-op when offline OR when any
+/// lockfile is present in `cwd` (the resolver will hit its
+/// integrity-keyed lockfile fast path and never request packuments,
+/// so prefetch is pure bandwidth waste). Spec parsing skips
+/// workspace/file/link/git/http/catalog protocols and `npm:` aliases.
+pub fn spawn_direct_dep_prefetch(
+    manifest: &aube_manifest::PackageJson,
+    cwd: &std::path::Path,
+    network_mode: aube_registry::NetworkMode,
+) {
+    if is_disabled() {
+        return;
+    }
+    if matches!(network_mode, aube_registry::NetworkMode::Offline) {
+        return;
+    }
+    if has_lockfile(cwd) {
+        return;
+    }
+    let names = collect_registry_dep_names(manifest);
+    if names.is_empty() {
+        return;
+    }
+    let client = Arc::new(super::super::make_client(cwd).with_network_mode(network_mode));
+    let cache_dir = super::super::packument_cache_dir();
+    let count = names.len();
+    tracing::debug!("prefetch: spawning {count} direct-dep packument GETs");
+
+    for name in names {
+        let client = client.clone();
+        let cache_dir = cache_dir.clone();
+        tokio::spawn(async move {
+            if let Err(e) = client.fetch_packument_cached(&name, &cache_dir).await {
+                tracing::debug!(name = %name, error = %e, "prefetch fetch failed");
+            }
+        });
+    }
+}
+
+fn has_lockfile(cwd: &std::path::Path) -> bool {
+    const LOCKFILES: &[&str] = &[
+        "aube-lock.yaml",
+        "pnpm-lock.yaml",
+        "bun.lock",
+        "bun.lockb",
+        "yarn.lock",
+        "package-lock.json",
+        "npm-shrinkwrap.json",
+    ];
+    LOCKFILES.iter().any(|name| cwd.join(name).exists())
+}
+
+fn collect_registry_dep_names(manifest: &aube_manifest::PackageJson) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+    let sections = [
+        &manifest.dependencies,
+        &manifest.dev_dependencies,
+        &manifest.optional_dependencies,
+        &manifest.peer_dependencies,
+    ];
+    for section in sections {
+        for (name, spec) in section.iter() {
+            if !is_registry_spec(spec) {
+                continue;
+            }
+            names.push(name.clone());
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn is_registry_spec(spec: &str) -> bool {
+    let trimmed = spec.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    for marker in NON_REGISTRY_SPEC_MARKERS {
+        if trimmed.starts_with(marker) {
+            return false;
+        }
+    }
+    // `npm:alias@target` registry-aliased entries route through the
+    // resolver's alias rewrite. The alias target prefetch happens
+    // there, so skip the alias key itself.
+    for prefix in REGISTRY_LIKE_PREFIXES {
+        if trimmed.starts_with(prefix) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_specs_pass() {
+        assert!(is_registry_spec("^1.2.3"));
+        assert!(is_registry_spec("1.2.3"));
+        assert!(is_registry_spec("~1.0"));
+        assert!(is_registry_spec("*"));
+        assert!(is_registry_spec("latest"));
+        assert!(is_registry_spec(">=1.0 <2.0"));
+    }
+
+    #[test]
+    fn non_registry_specs_filtered() {
+        assert!(!is_registry_spec("workspace:*"));
+        assert!(!is_registry_spec("workspace:^1.0"));
+        assert!(!is_registry_spec("file:./local"));
+        assert!(!is_registry_spec("link:../sibling"));
+        assert!(!is_registry_spec("github:user/repo"));
+        assert!(!is_registry_spec("git+https://example.com/r.git"));
+        assert!(!is_registry_spec("https://example.com/pkg.tgz"));
+        assert!(!is_registry_spec("catalog:default"));
+        assert!(!is_registry_spec("npm:foo@1.0.0"));
+        assert!(!is_registry_spec(""));
+    }
+}

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -103,9 +103,24 @@ pub fn split_patch_key(key: &str) -> Result<(String, String)> {
 /// (lockfile + no-lockfile) and the link phase compute these from the
 /// same `load_patches` output, hoisted here so the BTreeMap walks
 /// happen once per install.
+///
+/// Result is cached per cwd for the lifetime of the process. The 2-3
+/// call sites within a single install hit the cache on calls 2+ instead
+/// of re-walking `patches/` from disk. pnpm.patchedDependencies is
+/// resolved at install entry; patch files are static across the run.
 pub fn load_patches_for_linker(
     cwd: &Path,
 ) -> Result<(aube_linker::Patches, BTreeMap<String, String>)> {
+    use std::sync::{Mutex, OnceLock};
+    type CachedShape = (aube_linker::Patches, BTreeMap<String, String>);
+    static CACHE: OnceLock<Mutex<std::collections::HashMap<PathBuf, CachedShape>>> =
+        OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    if let Ok(guard) = cache.lock()
+        && let Some(hit) = guard.get(cwd)
+    {
+        return Ok(hit.clone());
+    }
     let resolved = load_patches(cwd)?;
     let patches: aube_linker::Patches = resolved
         .values()
@@ -115,6 +130,9 @@ pub fn load_patches_for_linker(
         .values()
         .map(|p| (p.key.clone(), p.content_hash()))
         .collect();
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(cwd.to_path_buf(), (patches.clone(), hashes.clone()));
+    }
     Ok((patches, hashes))
 }
 

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -116,8 +116,14 @@ pub fn load_patches_for_linker(
     static CACHE: OnceLock<Mutex<std::collections::HashMap<PathBuf, CachedShape>>> =
         OnceLock::new();
     let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    // Canonicalize so `cwd` and `cwd.canonicalize()` collapse to one
+    // key. Windows `\\?\C:\foo` vs `C:\foo`, Unix `cwd` vs `cwd/.`
+    // would otherwise miss the cache. Falls back to the raw path when
+    // canonicalize fails (e.g. cwd is the parent of a not-yet-created
+    // workspace dir).
+    let key = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
     if let Ok(guard) = cache.lock()
-        && let Some(hit) = guard.get(cwd)
+        && let Some(hit) = guard.get(&key)
     {
         return Ok(hit.clone());
     }
@@ -131,7 +137,7 @@ pub fn load_patches_for_linker(
         .map(|p| (p.key.clone(), p.content_hash()))
         .collect();
     if let Ok(mut guard) = cache.lock() {
-        guard.insert(cwd.to_path_buf(), (patches.clone(), hashes.clone()));
+        guard.insert(key, (patches.clone(), hashes.clone()));
     }
     Ok((patches, hashes))
 }


### PR DESCRIPTION
## Added

### `aube-util::http` module
new shared HTTP helpers under `crates/aube-util/src/http/`. consolidates client-side primitives so leaf crates stop reinventing them. killswitch convention follows aube-util — every optimization defaults ON ships an `AUBE_DISABLE_*` env var documented on the function reading it.

- **`prewarm`** — multi-origin HEAD prewarm. fire-and-forget over the current tokio runtime; failures trace at debug
- **`priority`** — RFC 9218 Priority header builder + `Urgency` enum (Critical / High / Default / Background)
- **`race`** — speculative parallel GET. first 2xx wins, siblings abort. for future anycast-IP racing on Cloudflare-fronted origins
- **`resolve`** — DNS preresolve via `tokio::net::lookup_host` + `host_port` parser for registry-style URLs
- **`ticket_cache`** — cross-invocation TLS session ticket store. on-disk JSON via `fs_atomic::atomic_write`, MAX_AGE pruning at load, MAX_PER_HOST eviction, SPKI fingerprint binding for cert-rotation invalidation

### Pre-resolver direct-dep packument prefetch (`crates/aube/src/commands/install/prefetch.rs`)
reads `package.json` keys as raw strings and fires fire-and-forget packument GETs for every registry-shaped direct dep before workspace yaml load, settings resolve, lockfile parse, pnpmfile setup, and resolver construction run. by the time the resolver pops its first task, the on-disk packument cache and reqwest connection pool are warm. spec parsing skips workspace/file/link/git/http/catalog protocols and `npm:` aliases (alias targets prefetch via the resolver's alias rewrite path). no-op when offline or when any lockfile is present (resolver hits the integrity-keyed lockfile fast path; prefetch would be pure bandwidth waste). honors `AUBE_DISABLE_PREFETCH=1`.

## Changed

### Multi-registry TLS prewarm with parallel DNS preresolve
`RegistryClient::prewarm_connection` covers default registry + every scoped registry from `.npmrc` (`@org:registry=...`) + every per-uri auth registry that owns its own pool. previously prewarmed only the default registry, forcing the first scoped/auth-uri packument to pay the full TLS+TCP+ALPN cost. parallel DNS preresolve fires for every prewarm target before the HEAD requests so DNS RTT hides behind the handshake instead of stacking sequentially.

### `compute_graph_hashes_with_patches` off the tokio worker
the BLAKE3 graph-hash walk now runs via `spawn_blocking` so the canonical-to-contextualized map build, `nested_link_targets` walk, and first `materialize_rx` recv keep making progress in parallel with hashing. previously blocked the executor on a CPU-bound pass before any reflink could land.

### RFC 9218 Priority header on packument GETs
abbreviated packument fetch marks itself `Critical (u=0)` so Cloudflare/Fastly H2 schedulers prioritize resolver-blocking metadata ahead of pending tarball frames on the shared connection.

## Fixed

### Patches loaded once per cwd
`load_patches_for_linker` previously walked `patches/` from disk 2-3 times per install (lockfile-prewarm site + no-lockfile-prewarm site + link-phase site). cached per cwd via `OnceLock<Mutex<HashMap<PathBuf, ...>>>`; first call populates, subsequent calls return clones. patches do not change mid-install — `pnpm.patchedDependencies` is read at install entry and the files are static.

## Why it's better

- **structured HTTP utilities** — leaf crates (registry/store/future modules) share one warm-pool/preresolve/priority/race surface with consistent killswitch semantics. previously inline in `aube-registry/src/client.rs`.
- **cold path overlap** — DNS, TLS, packument GET, and graph-hash walk all overlap with the manifest/workspace/settings critical path that previously serialized them.
- **multi-registry support** — installs against a corp registry plus npmjs no longer pay sequential handshakes.
- **future-proofing** — `ticket_cache` ships the on-disk format + APIs ready for rustls `ClientSessionStore` wiring; `race` is ready for anycast-IP candidate sets; `priority` is ready for tarball-side `High + incremental` markers.

## Killswitches added

every optimization defaults ON, presence-truthy disables.

- `AUBE_DISABLE_DNS_PRERESOLVE`
- `AUBE_DISABLE_REQUEST_RACING`
- `AUBE_DISABLE_PREFETCH`
- `AUBE_DISABLE_TLS_TICKET_CACHE`

joins existing `AUBE_DISABLE_SPECULATIVE_TLS`.