### PR TITLE
fix(resolver): fetch registry on primer range miss

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -344,6 +344,27 @@ impl RegistryClient {
         }
     }
 
+    pub fn replace_packument_cache(&self, name: &str, cache_dir: &Path, packument: &Packument) {
+        let registry_url = self.config.registry_for(name);
+        let Some(cache_path) = packument_cache_path(cache_dir, name, registry_url) else {
+            return;
+        };
+        let cached = CachedPackument {
+            etag: None,
+            last_modified: None,
+            fetched_at: now_secs(),
+            max_age_secs: None,
+            packument: packument.clone(),
+        };
+        if let Err(e) = write_cached_packument(&cache_path, &cached) {
+            tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
+                "failed to write packument cache {}: {e}",
+                cache_path.display()
+            );
+        }
+    }
+
     pub fn seed_full_packument_cache(
         &self,
         name: &str,
@@ -2460,6 +2481,25 @@ mod seed_tests {
         let lookup = client.cached_packument_lookup("demo", dir.path());
         assert!(lookup.stale);
         assert!(lookup.packument.is_none());
+    }
+
+    #[test]
+    fn replace_packument_cache_overwrites_stale_seed() {
+        let dir = tempfile::tempdir().unwrap();
+        let client = RegistryClient::new("https://registry.npmjs.org/");
+        let primer = packument();
+        let mut live = packument();
+        live.name = "demo-live".to_owned();
+
+        client.seed_packument_cache("demo", dir.path(), &primer, Some("etag"), None, false);
+        client.replace_packument_cache("demo", dir.path(), &live);
+
+        let path = packument_cache_path(dir.path(), "demo", "https://registry.npmjs.org/").unwrap();
+        let cached = read_cached_packument(&path).unwrap();
+        assert_eq!(cached.packument.name, "demo-live");
+        assert!(cached.fetched_at > 0);
+        assert_eq!(cached.max_age_secs, None);
+        assert!(cached_is_fresh(cached.fetched_at, cached.max_age_secs));
     }
 
     #[test]

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -1372,7 +1372,7 @@ impl Resolver {
                     None => true,
                 };
                 let registry_name = task.registry_name().to_string();
-                let picked_version = loop {
+                let selected_pick = loop {
                     let packument = self.cache.get(&registry_name).ok_or_else(|| {
                         Error::Registry(registry_name.clone(), "packument not in cache".to_string())
                     })?;
@@ -1385,18 +1385,24 @@ impl Resolver {
                         strict,
                     );
                     match pick {
-                        PickResult::Found(meta) => break meta.version.clone(),
+                        PickResult::Found(meta) => break meta.clone(),
                         PickResult::AgeGated | PickResult::NoMatch
                             if primer_seeded_names.remove(&registry_name) =>
                         {
                             let fetch_start = std::time::Instant::now();
-                            let live =
-                                self.client
-                                    .fetch_packument(&registry_name)
-                                    .await
-                                    .map_err(|e| {
-                                        Error::Registry(registry_name.clone(), e.to_string())
-                                    })?;
+                            let live = if needs_time {
+                                match self.packument_full_cache_dir.as_ref() {
+                                    Some(dir) => {
+                                        self.client
+                                            .fetch_packument_with_time_cached(&registry_name, dir)
+                                            .await
+                                    }
+                                    None => self.client.fetch_packument(&registry_name).await,
+                                }
+                            } else {
+                                self.client.fetch_packument(&registry_name).await
+                            }
+                            .map_err(|e| Error::Registry(registry_name.clone(), e.to_string()))?;
                             packument_fetch_time += fetch_start.elapsed();
                             packument_fetch_count += 1;
                             self.cache.insert(registry_name.clone(), live);
@@ -1431,17 +1437,11 @@ impl Resolver {
                 let packument = self.cache.get(&registry_name).ok_or_else(|| {
                     Error::Registry(registry_name.clone(), "packument not in cache".to_string())
                 })?;
-                let picked_ref = packument.versions.get(&picked_version).ok_or_else(|| {
-                    Error::Registry(
-                        registry_name.clone(),
-                        format!("picked version {picked_version} missing from packument"),
-                    )
-                })?;
                 let picked_ref = prefer_non_vulnerable_pick(
                     task.registry_name(),
                     packument,
                     &task.range,
-                    picked_ref,
+                    &selected_pick,
                     pick_lowest,
                     cutoff_for_pkg,
                     &self.vulnerable_ranges,

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -158,16 +158,21 @@ impl Resolver {
         // modern dependency graphs are dominated by those active packages.
 
         // In-flight packument fetches. The spawned task returns the
-        // `(name, packument)` tuple so `join_next` gives us back the
-        // identity of whichever fetch landed next without a side
-        // table lookup.
+        // `(name, packument, from_primer)` tuple so `join_next` gives
+        // us back the identity of whichever fetch landed next without
+        // a side table lookup. `from_primer` matters because the
+        // bundled primer intentionally keeps only a capped slice of
+        // high-traffic package histories; a range miss against that
+        // slice must fall through to the live registry before we
+        // report `ERR_AUBE_NO_MATCHING_VERSION`.
         #[allow(clippy::type_complexity)]
-        let mut in_flight: tokio::task::JoinSet<Result<(String, Packument), Error>> =
+        let mut in_flight: tokio::task::JoinSet<Result<(String, Packument, bool), Error>> =
             tokio::task::JoinSet::new();
         // Names whose fetch has been spawned but not yet harvested.
         // Dedupes spawn calls when multiple tasks discover the same
         // transitive before any of them has been processed.
         let mut in_flight_names: FxHashSet<String> = FxHashSet::default();
+        let mut primer_seeded_names: FxHashSet<String> = FxHashSet::default();
         // TimeBased wave-0 gate: the publish-time cutoff is derived
         // from the direct deps' resolved versions, so transitives
         // that reach the version-pick step before all directs have
@@ -244,7 +249,7 @@ impl Resolver {
                             Default::default()
                         };
                         if let Some(packument) = cached.packument.take() {
-                            return Ok::<_, Error>((name_owned, packument));
+                            return Ok::<_, Error>((name_owned, packument, false));
                         }
                         if use_metadata_primer
                             && !cached.stale
@@ -282,7 +287,7 @@ impl Resolver {
                                     false,
                                 );
                             }
-                            return Ok::<_, Error>((name_owned, packument));
+                            return Ok::<_, Error>((name_owned, packument, true));
                         }
                         let packument = if needs_time {
                             match full_cache_dir.as_ref() {
@@ -305,7 +310,7 @@ impl Resolver {
                             client.fetch_packument(&name_owned).await
                         }
                         .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
-                        Ok::<_, Error>((name_owned, packument))
+                        Ok::<_, Error>((name_owned, packument, false))
                     });
                 }
             }};
@@ -1277,8 +1282,11 @@ impl Resolver {
                 while !self.cache.contains_key(&fetch_name) {
                     ensure_fetch!(&fetch_name);
                     match in_flight.join_next().await {
-                        Some(Ok(Ok((name, packument)))) => {
+                        Some(Ok(Ok((name, packument, from_primer)))) => {
                             in_flight_names.remove(&name);
+                            if from_primer {
+                                primer_seeded_names.insert(name.clone());
+                            }
                             self.cache.insert(name, packument);
                             packument_fetch_count += 1;
                         }
@@ -1323,13 +1331,6 @@ impl Resolver {
                 // cache. `registry_name()` is the cache key for
                 // aliased tasks (cache is populated under the real
                 // registry name), so use the same accessor here.
-                let packument = self.cache.get(task.registry_name()).ok_or_else(|| {
-                    Error::Registry(
-                        task.registry_name().to_string(),
-                        "packument not in cache".to_string(),
-                    )
-                })?;
-
                 // Find locked version
                 let locked_version = existing.and_then(|g| {
                     g.packages
@@ -1370,42 +1371,72 @@ impl Resolver {
                     Some(m) => m.strict,
                     None => true,
                 };
-                let pick = pick_version(
-                    packument,
-                    &task.range,
-                    locked_version,
-                    pick_lowest,
-                    cutoff_for_pkg,
-                    strict,
-                );
-                let picked_ref = match pick {
-                    PickResult::Found(meta) => meta,
-                    // Only surface `AgeGate` when the cutoff actually
-                    // came from `minimumReleaseAge`. When it came from
-                    // `--resolution-mode=time-based` alone, the user
-                    // never opted into the supply-chain age gate, so
-                    // the failure should report as a plain no-match
-                    // instead of a misleading "older than 0 minutes".
-                    PickResult::AgeGated => match self.minimum_release_age.as_ref() {
-                        Some(mra) => {
-                            return Err(Error::AgeGate(Box::new(error::build_age_gate(
-                                &task,
-                                packument,
-                                mra.minutes,
-                            ))));
+                let registry_name = task.registry_name().to_string();
+                let picked_version = loop {
+                    let packument = self.cache.get(&registry_name).ok_or_else(|| {
+                        Error::Registry(registry_name.clone(), "packument not in cache".to_string())
+                    })?;
+                    let pick = pick_version(
+                        packument,
+                        &task.range,
+                        locked_version,
+                        pick_lowest,
+                        cutoff_for_pkg,
+                        strict,
+                    );
+                    match pick {
+                        PickResult::Found(meta) => break meta.version.clone(),
+                        PickResult::AgeGated | PickResult::NoMatch
+                            if primer_seeded_names.remove(&registry_name) =>
+                        {
+                            let fetch_start = std::time::Instant::now();
+                            let live =
+                                self.client
+                                    .fetch_packument(&registry_name)
+                                    .await
+                                    .map_err(|e| {
+                                        Error::Registry(registry_name.clone(), e.to_string())
+                                    })?;
+                            packument_fetch_time += fetch_start.elapsed();
+                            packument_fetch_count += 1;
+                            self.cache.insert(registry_name.clone(), live);
                         }
-                        None => {
+                        // Only surface `AgeGate` when the cutoff actually
+                        // came from `minimumReleaseAge`. When it came from
+                        // `--resolution-mode=time-based` alone, the user
+                        // never opted into the supply-chain age gate, so
+                        // the failure should report as a plain no-match
+                        // instead of a misleading "older than 0 minutes".
+                        PickResult::AgeGated => match self.minimum_release_age.as_ref() {
+                            Some(mra) => {
+                                return Err(Error::AgeGate(Box::new(error::build_age_gate(
+                                    &task,
+                                    packument,
+                                    mra.minutes,
+                                ))));
+                            }
+                            None => {
+                                return Err(Error::NoMatch(Box::new(error::build_no_match(
+                                    &task, packument,
+                                ))));
+                            }
+                        },
+                        PickResult::NoMatch => {
                             return Err(Error::NoMatch(Box::new(error::build_no_match(
                                 &task, packument,
                             ))));
                         }
-                    },
-                    PickResult::NoMatch => {
-                        return Err(Error::NoMatch(Box::new(error::build_no_match(
-                            &task, packument,
-                        ))));
                     }
                 };
+                let packument = self.cache.get(&registry_name).ok_or_else(|| {
+                    Error::Registry(registry_name.clone(), "packument not in cache".to_string())
+                })?;
+                let picked_ref = packument.versions.get(&picked_version).ok_or_else(|| {
+                    Error::Registry(
+                        registry_name.clone(),
+                        format!("picked version {picked_version} missing from packument"),
+                    )
+                })?;
                 let picked_ref = prefer_non_vulnerable_pick(
                     task.registry_name(),
                     packument,

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -1400,7 +1400,19 @@ impl Resolver {
                                     None => self.client.fetch_packument(&registry_name).await,
                                 }
                             } else {
-                                self.client.fetch_packument(&registry_name).await
+                                match self.client.fetch_packument(&registry_name).await {
+                                    Ok(live) => {
+                                        if let Some(dir) = self.packument_cache_dir.as_ref() {
+                                            self.client.replace_packument_cache(
+                                                &registry_name,
+                                                dir,
+                                                &live,
+                                            );
+                                        }
+                                        Ok(live)
+                                    }
+                                    Err(err) => Err(err),
+                                }
                             }
                             .map_err(|e| Error::Registry(registry_name.clone(), e.to_string()))?;
                             packument_fetch_time += fetch_start.elapsed();


### PR DESCRIPTION
## Summary

- Track whether an in-memory packument came from the bundled metadata primer.
- Retry version picking against live registry metadata when a primer-sourced packument returns `NoMatch` or `AgeGated`.
- Keep real registry no-match behavior unchanged after the live metadata retry.

## Root Cause

The bundled primer intentionally keeps a capped slice of high-traffic package histories. For packages with very large version histories, such as `react` and `react-is`, older valid versions can be absent from the primer. The resolver treated that primer slice as authoritative, which surfaced `ERR_AUBE_NO_MATCHING_VERSION` before fetching the full registry packument.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-resolver`
- `cargo build`
- Smoke installed the vlt `next`, `large`, and `babylon` fixtures with the patched debug binary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core version-selection behavior by retrying against live registry metadata when primer-sourced packuments yield `NoMatch`/`AgeGated`, which can affect resolved versions and add extra network/cache writes in edge cases.
> 
> **Overview**
> Fixes false `ERR_AUBE_NO_MATCHING_VERSION` outcomes caused by the bundled metadata primer’s truncated version history by **tracking whether a packument came from the primer** and, on a `NoMatch`/`AgeGated` result, **refetching the authoritative packument from the live registry and re-running version selection**.
> 
> Adds `RegistryClient::replace_packument_cache` to overwrite previously seeded (stale) abbreviated packument cache entries with freshly fetched registry metadata, plus a regression test ensuring the overwrite is fresh and takes effect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1bdd266c28c811de17220a2e1772268d7b5eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->