### PR TITLE
chore: release v1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aube-manifest",
  "aube-util",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aube-manifest",
  "serde",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1407,13 +1407,12 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1741,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1877,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2119,7 +2118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2272,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2356,18 +2355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2838,7 +2825,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2975,12 +2962,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pluralizer"
@@ -3380,15 +3361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,7 +3543,7 @@ checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "munge",
  "ptr_meta",
@@ -4661,9 +4633,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5150,9 +5122,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5163,9 +5135,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5173,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5183,9 +5155,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5196,9 +5168,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -5252,9 +5224,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.package]
-version = "1.9.1"
+version = "1.10.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT"
@@ -135,18 +135,18 @@ diffy = "0.4"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.9.1" }
-aube-codes = { path = "crates/aube-codes", version = "1.9.1" }
-aube-settings = { path = "crates/aube-settings", version = "1.9.1" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.9.1" }
-aube-registry = { path = "crates/aube-registry", version = "1.9.1" }
-aube-store = { path = "crates/aube-store", version = "1.9.1" }
-aube-linker = { path = "crates/aube-linker", version = "1.9.1" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.9.1" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.9.1" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.9.1" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.9.1" }
-aube-util = { path = "crates/aube-util", version = "1.9.1" }
+aube = { path = "crates/aube", version = "1.10.0" }
+aube-codes = { path = "crates/aube-codes", version = "1.10.0" }
+aube-settings = { path = "crates/aube-settings", version = "1.10.0" }
+aube-resolver = { path = "crates/aube-resolver", version = "1.10.0" }
+aube-registry = { path = "crates/aube-registry", version = "1.10.0" }
+aube-store = { path = "crates/aube-store", version = "1.10.0" }
+aube-linker = { path = "crates/aube-linker", version = "1.10.0" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1.10.0" }
+aube-manifest = { path = "crates/aube-manifest", version = "1.10.0" }
+aube-scripts = { path = "crates/aube-scripts", version = "1.10.0" }
+aube-workspace = { path = "crates/aube-workspace", version = "1.10.0" }
+aube-util = { path = "crates/aube-util", version = "1.10.0" }
 
 [profile.dev]
 debug = 1

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1,6 +1,6 @@
 name aube
 bin aube
-version "1.9.1"
+version "1.10.0"
 about "A fast Node.js package manager"
 usage "Usage: aube [OPTIONS] [COMMAND]"
 flag "-C --dir --cd --prefix" help="Change to directory before running (like `make -C` or `mise --cd`)" global=#true {

--- a/crates/aube-codes/CHANGELOG.md
+++ b/crates/aube-codes/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-codes-v1.9.1...aube-codes-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(cli)* finish recursive-run flags and parallel output ([#545](https://github.com/endevco/aube/pull/545))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-codes-v1.9.0...aube-codes-v1.9.1) - 2026-05-06
 
 ### Fixed

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-linker-v1.9.1...aube-linker-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(diag)* instrument install and add aube diag subcommand ([#547](https://github.com/endevco/aube/pull/547))
+
+### Fixed
+
+- *(workspace)* three workspace install correctness fixes from pnpm test port ([#564](https://github.com/endevco/aube/pull/564))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-linker-v1.9.0...aube-linker-v1.9.1) - 2026-05-06
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-lockfile-v1.9.1...aube-lockfile-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(diag)* instrument install and add aube diag subcommand ([#547](https://github.com/endevco/aube/pull/547))
+
+### Fixed
+
+- *(workspace)* three workspace install correctness fixes from pnpm test port ([#564](https://github.com/endevco/aube/pull/564))
+- *(lockfile)* recognize file: resolved field in npm package-lock ([#553](https://github.com/endevco/aube/pull/553))
+- *(lockfile)* preserve imported workspace links ([#535](https://github.com/endevco/aube/pull/535))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-lockfile-v1.9.0...aube-lockfile-v1.9.1) - 2026-05-06
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-manifest-v1.9.1...aube-manifest-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(diag)* instrument install and add aube diag subcommand ([#547](https://github.com/endevco/aube/pull/547))
+- *(add)* linkWorkspacePackages + saveWorkspaceProtocol ([#539](https://github.com/endevco/aube/pull/539))
+
+### Fixed
+
+- *(workspace)* include root in filtered runs ([#556](https://github.com/endevco/aube/pull/556))
+- *(registry)* accept duplicate bundle/bundledDependencies in payloads ([#544](https://github.com/endevco/aube/pull/544))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-manifest-v1.9.0...aube-manifest-v1.9.1) - 2026-05-06
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-registry-v1.9.1...aube-registry-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(diag)* instrument install and add aube diag subcommand ([#547](https://github.com/endevco/aube/pull/547))
+
+### Fixed
+
+- *(registry)* accept duplicate bundle/bundledDependencies in payloads ([#544](https://github.com/endevco/aube/pull/544))
+- *(registry)* honor top-level cafile/ca in .npmrc ([#542](https://github.com/endevco/aube/pull/542))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- *(install)* adaptive limiter + tarball http1 split ([#548](https://github.com/endevco/aube/pull/548))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-registry-v1.9.0...aube-registry-v1.9.1) - 2026-05-06
 
 ### Added

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-resolver-v1.9.1...aube-resolver-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(resolver)* propagate peer suffix through non-peer-declaring ancestors ([#563](https://github.com/endevco/aube/pull/563))
+- *(diag)* instrument install and add aube diag subcommand ([#547](https://github.com/endevco/aube/pull/547))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- *(install)* adaptive limiter + tarball http1 split ([#548](https://github.com/endevco/aube/pull/548))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-resolver-v1.9.0...aube-resolver-v1.9.1) - 2026-05-06
 
 ### Fixed

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-scripts-v1.9.1...aube-scripts-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(cli)* finish recursive-run flags and parallel output ([#545](https://github.com/endevco/aube/pull/545))
+- *(diag)* instrument install and add aube diag subcommand ([#547](https://github.com/endevco/aube/pull/547))
+
+### Fixed
+
+- *(install)* inherit build approvals for git prepare ([#546](https://github.com/endevco/aube/pull/546))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-scripts-v1.9.0...aube-scripts-v1.9.1) - 2026-05-06
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-settings-v1.9.1...aube-settings-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(add)* linkWorkspacePackages + saveWorkspaceProtocol ([#539](https://github.com/endevco/aube/pull/539))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-settings-v1.9.0...aube-settings-v1.9.1) - 2026-05-06
 
 ### Other

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-store-v1.9.1...aube-store-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(diag)* instrument install and add aube diag subcommand ([#547](https://github.com/endevco/aube/pull/547))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- *(install)* adaptive limiter + tarball http1 split ([#548](https://github.com/endevco/aube/pull/548))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-store-v1.9.0...aube-store-v1.9.1) - 2026-05-06
 
 ### Other

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-util-v1.9.1...aube-util-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(diag)* instrument install and add aube diag subcommand ([#547](https://github.com/endevco/aube/pull/547))
+
+### Fixed
+
+- *(workspace)* include root in filtered runs ([#556](https://github.com/endevco/aube/pull/556))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- *(install)* adaptive limiter + tarball http1 split ([#548](https://github.com/endevco/aube/pull/548))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-util-v1.9.0...aube-util-v1.9.1) - 2026-05-06
 
 ### Added

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/aube-workspace-v1.9.1...aube-workspace-v1.10.0) - 2026-05-10
+
+### Added
+
+- *(cli)* finish recursive-run flags and parallel output ([#545](https://github.com/endevco/aube/pull/545))
+
+### Fixed
+
+- *(workspace)* three workspace install correctness fixes from pnpm test port ([#564](https://github.com/endevco/aube/pull/564))
+- *(workspace)* include root in filtered runs ([#556](https://github.com/endevco/aube/pull/556))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/aube-workspace-v1.9.0...aube-workspace-v1.9.1) - 2026-05-06
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/endevco/aube/compare/v1.9.1...v1.10.0) - 2026-05-10
+
+### Added
+
+- *(install)* show post-install dependency summary ([#559](https://github.com/endevco/aube/pull/559))
+- *(update)* add --lockfile-only flag ([#560](https://github.com/endevco/aube/pull/560))
+- *(cli)* finish recursive-run flags and parallel output ([#545](https://github.com/endevco/aube/pull/545))
+- *(diag)* instrument install and add aube diag subcommand ([#547](https://github.com/endevco/aube/pull/547))
+- *(add)* linkWorkspacePackages + saveWorkspaceProtocol ([#539](https://github.com/endevco/aube/pull/539))
+
+### Fixed
+
+- *(workspace)* three workspace install correctness fixes from pnpm test port ([#564](https://github.com/endevco/aube/pull/564))
+- *(update)* keep filtered workspace lockfile at root ([#558](https://github.com/endevco/aube/pull/558))
+- *(pnpmfile)* fail install when readPackage returns non-object ([#562](https://github.com/endevco/aube/pull/562))
+- *(workspace)* include root in filtered runs ([#556](https://github.com/endevco/aube/pull/556))
+- *(update)* add interactive picker ([#552](https://github.com/endevco/aube/pull/552))
+- *(deploy)* preserve filtered packages missing version ([#549](https://github.com/endevco/aube/pull/549))
+- *(install)* inherit build approvals for git prepare ([#546](https://github.com/endevco/aube/pull/546))
+- *(cli)* skip verify-deps inside lifecycle scripts ([#538](https://github.com/endevco/aube/pull/538))
+- *(install)* require approve-builds selection ([#537](https://github.com/endevco/aube/pull/537))
+
+### Other
+
+- refresh benchmarks for v1.9.1 ([#555](https://github.com/endevco/aube/pull/555))
+- lead hero with auto-install promise over speed ([#557](https://github.com/endevco/aube/pull/557))
+- add global virtual store page ([#550](https://github.com/endevco/aube/pull/550))
+- *(install)* adaptive limiter + tarball http1 split ([#548](https://github.com/endevco/aube/pull/548))
+- refresh benchmarks for v1.9.1 ([#534](https://github.com/endevco/aube/pull/534))
+- refresh benchmarks for v1.9.0 ([#532](https://github.com/endevco/aube/pull/532))
+
 ## [1.9.1](https://github.com/endevco/aube/compare/v1.9.0...v1.9.1) - 2026-05-06
 
 ### Added

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -12098,7 +12098,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.9.1",
+  "version": "1.10.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.9.1
+**Version**: 1.10.0
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.9.1",
-  "releasedAt": "2026-05-06T23:03:55Z"
+  "version": "1.10.0",
+  "releasedAt": "2026-05-10T16:46:53Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v1.10.0`

This PR bumps the workspace to `v1.10.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
