### PR TITLE
fix(install): require approve-builds selection

### DIFF
--- a/crates/aube/src/commands/approve_builds.rs
+++ b/crates/aube/src/commands/approve_builds.rs
@@ -17,6 +17,8 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::io::IsTerminal;
 use std::path::Path;
 
+const INTERACTIVE_TTY_ERROR: &str = "approve-builds needs stdin and stderr to be TTYs for the interactive picker; pass `--all` or name packages positionally to approve non-interactively";
+
 #[derive(Debug, Args)]
 pub struct ApproveBuildsArgs {
     /// Approve every pending ignored build without prompting.
@@ -104,10 +106,8 @@ fn run_global(args: ApproveBuildsArgs) -> miette::Result<()> {
     } else if !args.packages.is_empty() {
         select_global_packages(&global_ignored, args.packages)?
     } else {
-        if !std::io::stdin().is_terminal() {
-            return Err(miette!(
-                "approve-builds needs a TTY for the interactive picker; pass `--all` or name packages positionally to approve non-interactively"
-            ));
+        if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+            return Err(miette!(INTERACTIVE_TTY_ERROR));
         }
         pick_global_interactively(&global_ignored)?
     };
@@ -172,10 +172,8 @@ fn select_project(
         }
         return Ok(dedupe(packages));
     }
-    if !std::io::stdin().is_terminal() {
-        return Err(miette!(
-            "approve-builds needs a TTY for the interactive picker; pass `--all` or name packages positionally to approve non-interactively"
-        ));
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return Err(miette!(INTERACTIVE_TTY_ERROR));
     }
     pick_interactively(ignored)
 }
@@ -263,7 +261,8 @@ fn pick_interactively(
     ignored: &[super::ignored_builds::IgnoredEntry],
 ) -> miette::Result<Vec<String>> {
     let mut picker = demand::MultiSelect::new("Choose which packages to allow building")
-        .description("Space to toggle, Enter to confirm");
+        .description("Space to toggle, Enter to confirm")
+        .min(1);
     for entry in ignored {
         let label = format!("{}@{}", entry.name, entry.version);
         picker = picker.option(demand::DemandOption::new(entry.name.clone()).label(&label));
@@ -278,7 +277,8 @@ fn pick_global_interactively(
     global_ignored: &[GlobalIgnored],
 ) -> miette::Result<BTreeMap<std::path::PathBuf, Vec<String>>> {
     let mut picker = demand::MultiSelect::new("Choose which global packages to allow building")
-        .description("Space to toggle, Enter to confirm");
+        .description("Space to toggle, Enter to confirm")
+        .min(1);
     for (idx, entry) in global_ignored.iter().enumerate() {
         let aliases = entry.aliases.join(", ");
         for ignored in &entry.ignored {


### PR DESCRIPTION
## Summary

Fixes the interactive `aube approve-builds` empty-selection path reported in Discussion #536.

The picker now requires at least one package before Enter can submit, which avoids the empty-success terminal cleanup path that could overwrite the visible command line. The interactive TTY guard also now checks both stdin and stderr because the picker renders on stderr.

## Validation

- `cargo fmt --check`
- `cargo test -p aube approve_builds` (compiled successfully; no tests matched the filter)
- `cargo clippy -p aube --all-targets -- -D warnings`
- `git diff --check`

Note: `mise run test:bats test/approve_builds.bats` still has two existing failures in `--all` re-install marker checks, which do not exercise the interactive picker path changed here.

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `approve-builds` interactive UX/TTY gating and do not affect manifest-writing logic beyond preventing empty submissions.
> 
> **Overview**
> Fixes `aube approve-builds` interactive mode by **requiring at least one selection** before the picker can be submitted (`.min(1)`), avoiding the empty-selection path.
> 
> Also tightens the interactive TTY guard to require both `stdin` *and* `stderr` to be TTYs (the picker renders to stderr), and centralizes the error message into a shared constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85d3cd186031b5da17b9052aded7c80ce615490f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->