### PR TITLE
fix(registry): honor top-level cafile/ca in .npmrc

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -1912,6 +1912,48 @@ impl Default for RegistryClient {
     }
 }
 
+/// Add inline PEM strings and a PEM-bundle file to a reqwest client
+/// builder as additional trust roots. Shared between the top-level
+/// (unscoped) and per-registry cert paths so both go through the same
+/// parse + warn pipeline.
+fn apply_extra_root_certs(
+    mut builder: reqwest::ClientBuilder,
+    ca: &[String],
+    cafile: Option<&Path>,
+) -> reqwest::ClientBuilder {
+    for pem in ca {
+        match reqwest::Certificate::from_pem(pem.as_bytes()) {
+            Ok(cert) => builder = builder.add_root_certificate(cert),
+            Err(e) => tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_INVALID_CA,
+                "ignoring invalid ca: {e}"
+            ),
+        }
+    }
+    if let Some(cafile) = cafile {
+        match std::fs::read(cafile) {
+            Ok(bytes) => match reqwest::Certificate::from_pem_bundle(&bytes) {
+                Ok(certs) => {
+                    for cert in certs {
+                        builder = builder.add_root_certificate(cert);
+                    }
+                }
+                Err(e) => tracing::warn!(
+                    code = aube_codes::warnings::WARN_AUBE_INVALID_CAFILE,
+                    "ignoring invalid cafile {}: {e}",
+                    cafile.display()
+                ),
+            },
+            Err(e) => tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_UNREADABLE_CAFILE,
+                "ignoring unreadable cafile {}: {e}",
+                cafile.display()
+            ),
+        }
+    }
+    builder
+}
+
 fn build_http_client(
     config: &NpmConfig,
     registry_config: Option<&crate::config::AuthConfig>,
@@ -2045,37 +2087,16 @@ fn build_http_client(
         }
     }
 
+    // Top-level `cafile` / `ca` (unscoped npmrc keys) apply to every
+    // client built from this config, matching npm/pnpm semantics.
+    builder = apply_extra_root_certs(builder, &config.ca, config.cafile.as_deref());
+
     if let Some(registry_config) = registry_config {
-        for ca in &registry_config.tls.ca {
-            match reqwest::Certificate::from_pem(ca.as_bytes()) {
-                Ok(cert) => builder = builder.add_root_certificate(cert),
-                Err(e) => tracing::warn!(
-                    code = aube_codes::warnings::WARN_AUBE_INVALID_CA,
-                    "ignoring invalid per-registry ca: {e}"
-                ),
-            }
-        }
-        if let Some(cafile) = &registry_config.tls.cafile {
-            match std::fs::read(cafile) {
-                Ok(bytes) => match reqwest::Certificate::from_pem_bundle(&bytes) {
-                    Ok(certs) => {
-                        for cert in certs {
-                            builder = builder.add_root_certificate(cert);
-                        }
-                    }
-                    Err(e) => tracing::warn!(
-                        code = aube_codes::warnings::WARN_AUBE_INVALID_CAFILE,
-                        "ignoring invalid cafile {}: {e}",
-                        cafile.display()
-                    ),
-                },
-                Err(e) => tracing::warn!(
-                    code = aube_codes::warnings::WARN_AUBE_UNREADABLE_CAFILE,
-                    "ignoring unreadable cafile {}: {e}",
-                    cafile.display()
-                ),
-            }
-        }
+        builder = apply_extra_root_certs(
+            builder,
+            &registry_config.tls.ca,
+            registry_config.tls.cafile.as_deref(),
+        );
         if let (Some(cert), Some(key)) = (&registry_config.tls.cert, &registry_config.tls.key) {
             let mut pem = Vec::with_capacity(cert.len() + key.len() + 1);
             pem.extend_from_slice(cert.as_bytes());

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -1920,13 +1920,14 @@ fn apply_extra_root_certs(
     mut builder: reqwest::ClientBuilder,
     ca: &[String],
     cafile: Option<&Path>,
+    scope: &str,
 ) -> reqwest::ClientBuilder {
     for pem in ca {
         match reqwest::Certificate::from_pem(pem.as_bytes()) {
             Ok(cert) => builder = builder.add_root_certificate(cert),
             Err(e) => tracing::warn!(
                 code = aube_codes::warnings::WARN_AUBE_INVALID_CA,
-                "ignoring invalid ca: {e}"
+                "ignoring invalid {scope} ca: {e}"
             ),
         }
     }
@@ -1940,13 +1941,13 @@ fn apply_extra_root_certs(
                 }
                 Err(e) => tracing::warn!(
                     code = aube_codes::warnings::WARN_AUBE_INVALID_CAFILE,
-                    "ignoring invalid cafile {}: {e}",
+                    "ignoring invalid {scope} cafile {}: {e}",
                     cafile.display()
                 ),
             },
             Err(e) => tracing::warn!(
                 code = aube_codes::warnings::WARN_AUBE_UNREADABLE_CAFILE,
-                "ignoring unreadable cafile {}: {e}",
+                "ignoring unreadable {scope} cafile {}: {e}",
                 cafile.display()
             ),
         }
@@ -2089,13 +2090,14 @@ fn build_http_client(
 
     // Top-level `cafile` / `ca` (unscoped npmrc keys) apply to every
     // client built from this config, matching npm/pnpm semantics.
-    builder = apply_extra_root_certs(builder, &config.ca, config.cafile.as_deref());
+    builder = apply_extra_root_certs(builder, &config.ca, config.cafile.as_deref(), "top-level");
 
     if let Some(registry_config) = registry_config {
         builder = apply_extra_root_certs(
             builder,
             &registry_config.tls.ca,
             registry_config.tls.cafile.as_deref(),
+            "per-registry",
         );
         if let (Some(cert), Some(key)) = (&registry_config.tls.cert, &registry_config.tls.key) {
             let mut pem = Vec::with_capacity(cert.len() + key.len() + 1);

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -79,6 +79,15 @@ pub struct NpmConfig {
     /// Plumbed into reqwest's `pool_max_idle_per_host`, which is the
     /// closest analogue to npm/pnpm's per-origin socket cap.
     pub max_sockets: Option<usize>,
+    /// Top-level `cafile=...` from `.npmrc`. Applied to every HTTP
+    /// client built from this config (default + per-registry), matching
+    /// npm/pnpm semantics where an unscoped `cafile` augments the trust
+    /// store for all registries. Per-registry `//host/:cafile=...`
+    /// stacks on top via [`AuthConfig::tls`].
+    pub cafile: Option<PathBuf>,
+    /// Top-level inline `ca=...` / `ca[]=...` PEM strings from
+    /// `.npmrc`. Same semantics as [`Self::cafile`].
+    pub ca: Vec<String>,
     /// Value of `.npmrc`'s legacy `proxy=` key, tracked separately
     /// from `https_proxy` / `http_proxy` because pnpm treats it as
     /// the fallback for `httpsProxy` (and secondarily for
@@ -127,6 +136,8 @@ impl Default for NpmConfig {
             strict_ssl: true,
             local_address: None,
             max_sockets: None,
+            cafile: None,
+            ca: Vec::new(),
             npmrc_proxy: None,
         }
     }
@@ -416,6 +427,16 @@ impl NpmConfig {
                         "ignoring invalid maxsockets {value:?}: {e}"
                     ),
                 }
+            } else if matches!(key.as_str(), "cafile" | "caFile") {
+                // Top-level (unscoped) cafile — applies to all registries.
+                // Diverges from the URI-scoped form in the `//` block
+                // below; both can coexist and stack additively.
+                self.cafile = Some(PathBuf::from(value));
+            } else if matches!(key.as_str(), "ca" | "ca[]") {
+                // Top-level inline PEM, single or array form. npm/pnpm
+                // accept repeated `ca[]=...` lines to build up a list;
+                // mirror that by pushing instead of replacing.
+                self.ca.push(pem_value(value));
             } else if let Some(scope) = key.strip_suffix(":registry") {
                 if scope.starts_with('@') {
                     self.scoped_registries
@@ -1851,6 +1872,33 @@ mod tests {
         assert_eq!(tls.cafile.as_deref(), Some(Path::new("corp-ca.pem")));
         assert!(tls.cert.as_deref().unwrap().contains("\nclient\n"));
         assert!(tls.key.as_deref().unwrap().contains("\nkey\n"));
+    }
+
+    #[test]
+    fn top_level_cafile_and_ca_are_parsed() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".npmrc"),
+            "cafile=/etc/ssl/corp-bundle.pem\n\
+             ca=-----BEGIN CERTIFICATE-----\\nfirst\\n-----END CERTIFICATE-----\n\
+             ca[]=-----BEGIN CERTIFICATE-----\\nsecond\\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+
+        let config = NpmConfig::load_isolated(dir.path());
+        assert_eq!(
+            config.cafile.as_deref(),
+            Some(Path::new("/etc/ssl/corp-bundle.pem"))
+        );
+        assert_eq!(config.ca.len(), 2);
+        assert!(config.ca[0].contains("\nfirst\n"));
+        assert!(config.ca[1].contains("\nsecond\n"));
+        // Top-level keys must not leak into per-registry config.
+        assert!(
+            config
+                .registry_config_for("https://registry.npmjs.org/")
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Top-level `cafile=...` and `ca=...` lines in .npmrc were silently ignored — only URI-scoped forms (`//host/:cafile=...`) were parsed, diverging from npm/pnpm which apply an unscoped value to every registry. Users behind corporate TLS-intercepting proxies who configured `cafile=/path/to/bundle.pem` (the same line npm/pnpm respect) hit transport errors with no obvious cause.

Currently you can work around this with `//registry.npmjs.org/:caFile=/path/to/bundle.pem` but this becomes problematic when global TLS inspection is enabled in a corporate environment.

- Add `cafile: Option<PathBuf>` and `ca: Vec<String>` to NpmConfig.
- Parse unscoped `cafile`/`caFile`/`ca`/`ca[]` in apply().
- Extract apply_extra_root_certs() helper, called once with the top-level config and again with per-registry config so they stack additively (matching npm/pnpm precedence).

Co-authored with Claude Code