### PR TITLE
fix(registry): accept duplicate bundle/bundledDependencies in payloads

### DIFF
--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -112,8 +112,15 @@ pub struct UpdateConfig {
     pub ignore_dependencies: Vec<String>,
 }
 
+/// Parsed `package.json`.
+///
+/// Deserializes via [`PackageJsonRaw`] (`#[serde(from = ...)]`) so a
+/// manifest carrying *both* `bundledDependencies` and the deprecated
+/// `bundleDependencies` alias parses without tripping serde's duplicate
+/// field check. Some real-world publishes (e.g. `@lingui/message-utils`)
+/// ship both.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", from = "PackageJsonRaw")]
 pub struct PackageJson {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -145,16 +152,14 @@ pub struct PackageJson {
     pub optional_dependencies: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub update_config: Option<UpdateConfig>,
-    /// `bundledDependencies` (or the alias `bundleDependencies`) from
-    /// package.json. Names listed here are shipped *inside* the package
-    /// tarball itself, under the package's own `node_modules/`. The
-    /// resolver must not recurse into them, and Node's directory walk
-    /// serves them straight out of the extracted tree.
-    #[serde(
-        default,
-        alias = "bundleDependencies",
-        skip_serializing_if = "Option::is_none"
-    )]
+    /// `bundledDependencies` from package.json. Names listed here are
+    /// shipped *inside* the package tarball itself, under the package's
+    /// own `node_modules/`. The resolver must not recurse into them, and
+    /// Node's directory walk serves them straight out of the extracted
+    /// tree. On deserialize we also accept the deprecated
+    /// `bundleDependencies` spelling and prefer the canonical when both
+    /// are present (handled in [`PackageJsonRaw`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bundled_dependencies: Option<BundledDependencies>,
     #[serde(
         default,
@@ -177,6 +182,59 @@ pub struct PackageJson {
     pub workspaces: Option<Workspaces>,
     #[serde(flatten)]
     pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+/// Deserialize-only mirror of [`PackageJson`] that splits the
+/// `bundled_dependencies` field into two name-distinct slots so a
+/// manifest carrying *both* `bundledDependencies` and `bundleDependencies`
+/// doesn't trip serde's duplicate field check the way `#[serde(alias)]`
+/// does. The canonical spelling wins on merge.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PackageJsonRaw {
+    name: Option<String>,
+    version: Option<String>,
+    #[serde(default, deserialize_with = "deps_tolerant")]
+    dependencies: BTreeMap<String, String>,
+    #[serde(default, deserialize_with = "deps_tolerant")]
+    dev_dependencies: BTreeMap<String, String>,
+    #[serde(default, deserialize_with = "deps_tolerant")]
+    peer_dependencies: BTreeMap<String, String>,
+    #[serde(default, deserialize_with = "deps_tolerant")]
+    optional_dependencies: BTreeMap<String, String>,
+    #[serde(default)]
+    update_config: Option<UpdateConfig>,
+    #[serde(default, rename = "bundledDependencies")]
+    bundled_dependencies: Option<BundledDependencies>,
+    #[serde(default, rename = "bundleDependencies")]
+    bundle_dependencies_alias: Option<BundledDependencies>,
+    #[serde(default, deserialize_with = "scripts_tolerant")]
+    scripts: BTreeMap<String, String>,
+    #[serde(default, deserialize_with = "engines_tolerant")]
+    engines: BTreeMap<String, String>,
+    #[serde(default)]
+    workspaces: Option<Workspaces>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl From<PackageJsonRaw> for PackageJson {
+    fn from(raw: PackageJsonRaw) -> Self {
+        Self {
+            name: raw.name,
+            version: raw.version,
+            dependencies: raw.dependencies,
+            dev_dependencies: raw.dev_dependencies,
+            peer_dependencies: raw.peer_dependencies,
+            optional_dependencies: raw.optional_dependencies,
+            update_config: raw.update_config,
+            bundled_dependencies: raw.bundled_dependencies.or(raw.bundle_dependencies_alias),
+            scripts: raw.scripts,
+            engines: raw.engines,
+            workspaces: raw.workspaces,
+            extra: raw.extra,
+        }
+    }
 }
 
 /// `bundledDependencies` shape from package.json. npm/pnpm accept
@@ -1463,6 +1521,34 @@ mod tests {
             p.bundled_dependencies,
             Some(BundledDependencies::List(_))
         ));
+    }
+
+    /// Regression: some publishes (e.g. `@lingui/message-utils@5.2.0`+)
+    /// ship both `bundledDependencies` and the deprecated
+    /// `bundleDependencies` alias in the same object. serde's default
+    /// `alias` rejects that as a duplicate field; we accept it and
+    /// prefer the canonical spelling.
+    #[test]
+    fn accepts_both_bundle_and_bundled_dependencies() {
+        let p = parse(
+            r#"{"name":"x","bundledDependencies":["canonical"],"bundleDependencies":["legacy"]}"#,
+        );
+        let deps = BTreeMap::new();
+        let names = p.bundled_dependencies.as_ref().unwrap().names(&deps);
+        assert_eq!(names, vec!["canonical"]);
+    }
+
+    /// Same regression with the keys in the other order, since serde
+    /// field-collection is order-sensitive when alias collisions are
+    /// involved.
+    #[test]
+    fn accepts_both_bundle_and_bundled_dependencies_reverse_order() {
+        let p = parse(
+            r#"{"name":"x","bundleDependencies":["legacy"],"bundledDependencies":["canonical"]}"#,
+        );
+        let deps = BTreeMap::new();
+        let names = p.bundled_dependencies.as_ref().unwrap().names(&deps);
+        assert_eq!(names, vec!["canonical"]);
     }
 
     #[test]

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -189,6 +189,16 @@ pub struct PackageJson {
 /// manifest carrying *both* `bundledDependencies` and `bundleDependencies`
 /// doesn't trip serde's duplicate field check the way `#[serde(alias)]`
 /// does. The canonical spelling wins on merge.
+///
+/// **Maintenance invariant:** every non-`bundled_dependencies` field
+/// here must mirror its counterpart on [`PackageJson`] *byte-for-byte*
+/// in serde attributes (`rename`, `deserialize_with`, `default`,
+/// `flatten`, etc.). The `From` impl below catches missing fields at
+/// compile time, but **attribute drift is silent** — e.g. forgetting
+/// `deserialize_with = "deps_tolerant"` here would make the deserialize
+/// path strict on dep-map shapes the public type silently tolerates.
+/// When adding or modifying a field on `PackageJson`, update this
+/// struct in lockstep.
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PackageJsonRaw {

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -200,6 +200,15 @@ pub struct VersionMetadata {
 /// field check the way `#[serde(alias = ...)]` does. The canonical
 /// spelling wins on merge — keeps parity with what npm renders for the
 /// installed-tree view of the same package.
+///
+/// **Maintenance invariant:** every non-`bundled_dependencies` field
+/// here must mirror its counterpart on [`VersionMetadata`] *byte-for-byte*
+/// in serde attributes (`rename`, `deserialize_with`, `default`, etc.).
+/// The `From` impl below catches missing fields at compile time, but
+/// **attribute drift is silent** — e.g. dropping a `deserialize_with`
+/// here makes the deserialize path strict on shapes the public type
+/// silently tolerates. When adding or modifying a field on
+/// `VersionMetadata`, update this struct in lockstep.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct VersionMetadataRaw {

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -96,8 +96,15 @@ pub struct Packument {
 }
 
 /// Metadata for a specific version of a package.
+///
+/// Deserializes via [`VersionMetadataRaw`] (`#[serde(from = ...)]`) so
+/// that publishes carrying *both* `bundledDependencies` (canonical) and
+/// `bundleDependencies` (deprecated alias) parse cleanly. serde's plain
+/// `#[serde(alias = ...)]` rejects that as a duplicate field, which
+/// blocks installs of every version of every package that ships both
+/// keys (e.g. `@lingui/message-utils@>=5.2.0`).
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", from = "VersionMetadataRaw")]
 pub struct VersionMetadata {
     pub name: String,
     pub version: String,
@@ -115,9 +122,9 @@ pub struct VersionMetadata {
     /// names or `true` (meaning "bundle every `dependencies` entry").
     /// Packages listed here are shipped inside the parent tarball, so
     /// the resolver must not recurse into them. npm serializes this
-    /// under both `bundledDependencies` and `bundleDependencies`; we
-    /// accept either via alias.
-    #[serde(default, alias = "bundleDependencies")]
+    /// under both `bundledDependencies` and `bundleDependencies`; on
+    /// deserialize we accept either, and prefer the canonical when both
+    /// are present (handled in [`VersionMetadataRaw`]).
     pub bundled_dependencies: Option<BundledDependencies>,
     pub dist: Option<Dist>,
     #[serde(default, deserialize_with = "aube_util::string_or_seq")]
@@ -184,6 +191,81 @@ pub struct VersionMetadata {
     /// degrades to `None` instead of failing the whole packument.
     #[serde(default, rename = "_npmUser", deserialize_with = "npm_user_tolerant")]
     pub npm_user: Option<NpmUser>,
+}
+
+/// Deserialize-only mirror of [`VersionMetadata`] that splits the
+/// `bundled_dependencies` field into two name-distinct slots so a
+/// payload carrying *both* `bundledDependencies` and `bundleDependencies`
+/// (e.g. `@lingui/message-utils@5.2.0`+) doesn't trip serde's duplicate
+/// field check the way `#[serde(alias = ...)]` does. The canonical
+/// spelling wins on merge — keeps parity with what npm renders for the
+/// installed-tree view of the same package.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VersionMetadataRaw {
+    name: String,
+    version: String,
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
+    dependencies: BTreeMap<String, String>,
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
+    dev_dependencies: BTreeMap<String, String>,
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
+    peer_dependencies: BTreeMap<String, String>,
+    #[serde(default)]
+    peer_dependencies_meta: BTreeMap<String, PeerDepMeta>,
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
+    optional_dependencies: BTreeMap<String, String>,
+    #[serde(default, rename = "bundledDependencies")]
+    bundled_dependencies: Option<BundledDependencies>,
+    #[serde(default, rename = "bundleDependencies")]
+    bundle_dependencies_alias: Option<BundledDependencies>,
+    dist: Option<Dist>,
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
+    os: Vec<String>,
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
+    cpu: Vec<String>,
+    #[serde(default, deserialize_with = "aube_util::string_or_seq")]
+    libc: Vec<String>,
+    #[serde(default, deserialize_with = "aube_manifest::engines_tolerant")]
+    engines: BTreeMap<String, String>,
+    #[serde(default, deserialize_with = "license_string")]
+    license: Option<String>,
+    #[serde(default, rename = "funding", deserialize_with = "funding_url")]
+    funding_url: Option<String>,
+    #[serde(default, rename = "bin", deserialize_with = "bin_map")]
+    bin: BTreeMap<String, String>,
+    #[serde(default)]
+    has_install_script: bool,
+    #[serde(default, deserialize_with = "deprecated_string")]
+    deprecated: Option<String>,
+    #[serde(default, rename = "_npmUser", deserialize_with = "npm_user_tolerant")]
+    npm_user: Option<NpmUser>,
+}
+
+impl From<VersionMetadataRaw> for VersionMetadata {
+    fn from(raw: VersionMetadataRaw) -> Self {
+        Self {
+            name: raw.name,
+            version: raw.version,
+            dependencies: raw.dependencies,
+            dev_dependencies: raw.dev_dependencies,
+            peer_dependencies: raw.peer_dependencies,
+            peer_dependencies_meta: raw.peer_dependencies_meta,
+            optional_dependencies: raw.optional_dependencies,
+            bundled_dependencies: raw.bundled_dependencies.or(raw.bundle_dependencies_alias),
+            dist: raw.dist,
+            os: raw.os,
+            cpu: raw.cpu,
+            libc: raw.libc,
+            engines: raw.engines,
+            license: raw.license,
+            funding_url: raw.funding_url,
+            bin: raw.bin,
+            has_install_script: raw.has_install_script,
+            deprecated: raw.deprecated,
+            npm_user: raw.npm_user,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -710,5 +792,32 @@ mod tests {
     fn engines_null_is_empty() {
         let v = parse(r#"{"name":"x","version":"1.0.0","engines":null}"#);
         assert!(v.engines.is_empty());
+    }
+
+    /// Regression: `@lingui/message-utils@5.2.0`+ ships the full
+    /// packument with both `bundledDependencies` (canonical) and
+    /// `bundleDependencies` (deprecated alias) carrying the same value.
+    /// serde's `#[serde(alias)]` rejects that as a duplicate field,
+    /// which used to fail the packument parse and abort install.
+    #[test]
+    fn bundled_deps_accepts_both_canonical_and_alias() {
+        let v = parse(
+            r#"{
+                "name":"x","version":"1.0.0",
+                "bundledDependencies":["canonical"],
+                "bundleDependencies":["legacy"]
+            }"#,
+        );
+        let deps = BTreeMap::new();
+        let names = v.bundled_dependencies.as_ref().unwrap().names(&deps);
+        assert_eq!(names, vec!["canonical"]);
+    }
+
+    #[test]
+    fn bundled_deps_falls_back_to_alias_only() {
+        let v = parse(r#"{"name":"x","version":"1.0.0","bundleDependencies":["legacy"]}"#);
+        let deps = BTreeMap::new();
+        let names = v.bundled_dependencies.as_ref().unwrap().names(&deps);
+        assert_eq!(names, vec!["legacy"]);
     }
 }


### PR DESCRIPTION
## Summary
- Some publishes (e.g. `@lingui/message-utils@>=5.2.0`) ship the full packument with both `bundledDependencies` (canonical) and `bundleDependencies` (deprecated alias) keys. serde's `#[serde(alias = ...)]` rejects that pair as a duplicate field, surfacing during install as `registry error for <pkg>: I/O error: duplicate field 'bundledDependencies'`. Aborts install of any range touching an affected version.
- Switch `VersionMetadata` (`aube-registry`) and `PackageJson` (`aube-manifest`) to deserialize via private `*Raw` shadow structs (`#[serde(from = ...)]`) that split the two spellings into separate fields. `From` impl prefers the canonical name when both are present, falls back to the alias otherwise.
- Path is hit when `--resolution-mode=time-based`, `minimumReleaseAge`, or `TrustPolicy::NoDowngrade` triggers the full-packument fetch — corgi only carries `bundleDependencies`, so the duplicate is unique to the full payload.
- Hot path stays simd_json-driven. The merge cost is trivial (one `Option::or` per version).

## Test plan
- [x] `cargo test -p aube-manifest -p aube-registry` — added 4 regression tests covering canonical+alias both orderings, alias-only fallback, and a list-shape case
- [x] `cargo test --workspace` — all crates green
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Smoke: `aube install @lingui/core @lingui/react` against npmjs.org with a config that forces the full-packument path (e.g. `minimum-release-age` set) — verifies the original repro is fixed end-to-end

*This PR was generated by Claude.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core deserialization for registry packuments and `package.json`, which could subtly alter parsing behavior if the new `*Raw` mirror structs drift from the public structs’ serde attributes. Scope is limited and covered by targeted regression tests, but it affects install-critical metadata parsing.
> 
> **Overview**
> Fixes install failures caused by npm payloads that include both `bundledDependencies` and the deprecated `bundleDependencies` key in the same object.
> 
> `PackageJson` (aube-manifest) and `VersionMetadata` (aube-registry) now deserialize via private `*Raw` shadow structs to accept both spellings without serde duplicate-field errors, merging them by **preferring the canonical** `bundledDependencies` value and falling back to the alias when it’s the only one present.
> 
> Adds regression tests covering canonical+alias presence (including reverse key order) and alias-only parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8072e480b1e1ebd9ec5a31545e4edf0972c78a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->