### PR TITLE
feat(cli): finish recursive-run flags and parallel output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,11 +473,13 @@ dependencies = [
 name = "aube-workspace"
 version = "1.9.1"
 dependencies = [
+ "aube-codes",
  "aube-manifest",
  "glob",
  "miette",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -634,8 +634,8 @@ cmd exec help="Execute a locally installed binary" {
     flag --report-summary help="Write a recursive exec summary file" {
         long_help "Write a recursive exec summary file.\n\nParsed for pnpm compatibility."
     }
-    flag --reporter-hide-prefix help="Hide package prefixes in recursive reporter output" {
-        long_help "Hide package prefixes in recursive reporter output.\n\nParsed for pnpm compatibility."
+    flag --reporter-hide-prefix help="Hide the `<package>: ` label on parallel-exec output lines" {
+        long_help "Hide the `<package>: ` label on parallel-exec output lines.\n\nLines are still piped (clean line breaks even with concurrent children) but the source package isn't named on each line. Sequential execs ignore this flag."
     }
     flag --resume-from help="Resume recursive execution starting at this package name" {
         long_help "Resume recursive execution starting at this package name.\n\nPackages before the named one in the post-sort, post-reverse order are skipped. Errors if the name isn't in the matched set."
@@ -1466,13 +1466,13 @@ cmd run help="Run a script defined in package.json" {
         long_help "Disable topological sorting (default is on).\n\nWithout this, recursive runs visit packages in a deps-first order so a `build` script in a shared library finishes before a dependent app's `build` starts. Pass this to fall back to the raw workspace-listing order."
     }
     flag --parallel help="Run the script in every matched workspace package concurrently" {
-        long_help "Run the script in every matched workspace package concurrently.\n\nUnbounded parallelism. Pair with a filter (`-r` / `-F`) — single-package runs ignore it. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated."
+        long_help "Run the script in every matched workspace package concurrently.\n\nUnbounded parallelism. Pair with `--workspace-concurrency=N` to cap the worker count. Single-package runs ignore this flag. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated. Child stdio is piped and lines are emitted with a `<package>: ` prefix; pass `--reporter-hide-prefix` to drop the labels."
     }
     flag --report-summary help="Write a recursive run summary file" {
         long_help "Write a recursive run summary file.\n\nParsed for pnpm compatibility."
     }
-    flag --reporter-hide-prefix help="Hide package prefixes in recursive reporter output" {
-        long_help "Hide package prefixes in recursive reporter output.\n\nParsed for pnpm compatibility."
+    flag --reporter-hide-prefix help="Hide the `<package>: ` label on parallel-run output lines" {
+        long_help "Hide the `<package>: ` label on parallel-run output lines.\n\nLines are still piped through aube (so the line breaks are clean even when many packages run at once), but the source package isn't named on each line. Sequential runs ignore this flag."
     }
     flag --resume-from help="Resume recursive execution starting at this package name" {
         long_help "Resume recursive execution starting at this package name.\n\nAfter the topo sort and `--reverse` are applied, packages before the named one in the resulting order are skipped. Errors if the name isn't in the matched workspace set."

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -627,8 +627,8 @@ cmd exec help="Execute a locally installed binary" {
         long_help "Continue recursive execution after a command fails.\n\nParsed for pnpm compatibility; aube currently stops on the first failure."
     }
     flag --no-install help="Skip auto-install check"
-    flag --no-sort help="Disable topological sorting" {
-        long_help "Disable topological sorting.\n\nParsed for pnpm compatibility."
+    flag --no-sort help="Disable topological sorting (default is on)" {
+        long_help "Disable topological sorting (default is on).\n\nWithout this, recursive execs visit packages in a deps-first order. Pass this to fall back to raw workspace-listing order."
     }
     flag --parallel help="Run recursive workspace executions concurrently"
     flag --report-summary help="Write a recursive exec summary file" {
@@ -637,19 +637,17 @@ cmd exec help="Execute a locally installed binary" {
     flag --reporter-hide-prefix help="Hide package prefixes in recursive reporter output" {
         long_help "Hide package prefixes in recursive reporter output.\n\nParsed for pnpm compatibility."
     }
-    flag --resume-from help="Resume recursive execution from a package name" {
-        long_help "Resume recursive execution from a package name.\n\nParsed for pnpm compatibility."
+    flag --resume-from help="Resume recursive execution starting at this package name" {
+        long_help "Resume recursive execution starting at this package name.\n\nPackages before the named one in the post-sort, post-reverse order are skipped. Errors if the name isn't in the matched set."
         arg <PACKAGE>
     }
-    flag --reverse help="Run recursive packages in reverse order" {
-        long_help "Run recursive packages in reverse order.\n\nParsed for pnpm compatibility."
-    }
+    flag --reverse help="Reverse the recursive execution order (after topo sort)"
     flag "-c --shell-mode" help="Run the command through `sh -c`"
-    flag --sort help="Sort recursive packages topologically" {
-        long_help "Sort recursive packages topologically.\n\nParsed for pnpm compatibility."
+    flag --sort help="Sort recursive packages topologically (this is the default)" {
+        long_help "Sort recursive packages topologically (this is the default).\n\nPass to override an earlier `--no-sort` on the same invocation."
     }
-    flag --workspace-concurrency help="Recursive workspace concurrency" {
-        long_help "Recursive workspace concurrency.\n\nParsed for pnpm compatibility."
+    flag --workspace-concurrency help="Cap the number of recursive packages running at once" {
+        long_help "Cap the number of recursive packages running at once.\n\nSetting this implicitly enables parallel mode at width `N`. `0` means \"use the available CPU count\". Without this flag, `--parallel` stays unbounded."
         arg <N>
     }
     flag --frozen-lockfile help="Error if the lockfile drifts from package.json"
@@ -1464,8 +1462,8 @@ cmd run help="Run a script defined in package.json" {
         long_help "Continue recursive execution after a script fails.\n\nParsed for pnpm compatibility; aube's sequential fanout still stops on first failure."
     }
     flag --no-install help="Skip auto-install check"
-    flag --no-sort help="Disable topological sorting" {
-        long_help "Disable topological sorting.\n\nParsed for pnpm compatibility."
+    flag --no-sort help="Disable topological sorting (default is on)" {
+        long_help "Disable topological sorting (default is on).\n\nWithout this, recursive runs visit packages in a deps-first order so a `build` script in a shared library finishes before a dependent app's `build` starts. Pass this to fall back to the raw workspace-listing order."
     }
     flag --parallel help="Run the script in every matched workspace package concurrently" {
         long_help "Run the script in every matched workspace package concurrently.\n\nUnbounded parallelism. Pair with a filter (`-r` / `-F`) — single-package runs ignore it. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated."
@@ -1476,21 +1474,21 @@ cmd run help="Run a script defined in package.json" {
     flag --reporter-hide-prefix help="Hide package prefixes in recursive reporter output" {
         long_help "Hide package prefixes in recursive reporter output.\n\nParsed for pnpm compatibility."
     }
-    flag --resume-from help="Resume recursive execution from a package name" {
-        long_help "Resume recursive execution from a package name.\n\nParsed for pnpm compatibility."
+    flag --resume-from help="Resume recursive execution starting at this package name" {
+        long_help "Resume recursive execution starting at this package name.\n\nAfter the topo sort and `--reverse` are applied, packages before the named one in the resulting order are skipped. Errors if the name isn't in the matched workspace set."
         arg <PACKAGE>
     }
-    flag --reverse help="Run recursive packages in reverse order" {
-        long_help "Run recursive packages in reverse order.\n\nParsed for pnpm compatibility."
+    flag --reverse help="Reverse the recursive execution order (after topo sort)" {
+        long_help "Reverse the recursive execution order (after topo sort).\n\nUseful for teardown-style scripts where dependents must shut down before their deps."
     }
-    flag --sort help="Sort recursive packages topologically" {
-        long_help "Sort recursive packages topologically.\n\nParsed for pnpm compatibility."
+    flag --sort help="Sort recursive packages topologically (this is the default)" {
+        long_help "Sort recursive packages topologically (this is the default).\n\nPass to override an earlier `--no-sort` on the same invocation."
     }
     flag -s help="Suppress aube's wrapper output while still showing script stdout/stderr" {
         long_help "Suppress aube's wrapper output while still showing script stdout/stderr.\n\nShort alias for the global `--silent` flag; long form is intentionally omitted to avoid shadowing the global `--silent` in clap's dispatch."
     }
-    flag --workspace-concurrency help="Recursive workspace concurrency" {
-        long_help "Recursive workspace concurrency.\n\nParsed for pnpm compatibility."
+    flag --workspace-concurrency help="Cap the number of recursive packages running at once" {
+        long_help "Cap the number of recursive packages running at once.\n\nSetting this implicitly enables parallel mode at width `N`. `0` means \"use the available CPU count\". Without this flag, `--parallel` stays unbounded."
         arg <N>
     }
     flag --frozen-lockfile help="Error if the lockfile drifts from package.json"

--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -84,6 +84,9 @@ pub const WARN_AUBE_YARN_BERRY_UNSUPPORTED: &str = "WARN_AUBE_YARN_BERRY_UNSUPPO
 // ── progress UI ─────────────────────────────────────────────────────
 pub const WARN_AUBE_PROGRESS_OVERFLOW: &str = "WARN_AUBE_PROGRESS_OVERFLOW";
 
+// ── workspace recursion ─────────────────────────────────────────────
+pub const WARN_AUBE_WORKSPACE_TOPO_CYCLE: &str = "WARN_AUBE_WORKSPACE_TOPO_CYCLE";
+
 /// Stable category labels that group codes in the generated docs.
 /// Public so the docs generator can iterate them deterministically.
 pub mod category {
@@ -99,6 +102,7 @@ pub mod category {
     pub const RESOLVER: &str = "Resolver";
     pub const LOCKFILE: &str = "Lockfile";
     pub const PROGRESS_UI: &str = "Progress UI";
+    pub const WORKSPACE_RECURSION: &str = "Workspace recursion";
 }
 
 /// Registry of every warning code with its category and description.
@@ -427,6 +431,13 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_PROGRESS_OVERFLOW,
         category: category::PROGRESS_UI,
         description: "Install progress numerator exceeded the resolved-package denominator. Display clamps to total; the warning surfaces the bookkeeping mismatch so the underlying race can be diagnosed.",
+        exit_code: None,
+    },
+    // Workspace recursion
+    CodeMeta {
+        name: WARN_AUBE_WORKSPACE_TOPO_CYCLE,
+        category: category::WORKSPACE_RECURSION,
+        description: "Topological sort of `aube run -r` / `aube exec -r` selected packages found a dependency cycle. Cycle members run in workspace-listing order after the rest of the topo-sorted set.",
         exit_code: None,
     },
 ];

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -664,23 +664,33 @@ pub fn child_stderr() -> std::process::Stdio {
 /// silently swallowed in `--silent --parallel` mode. Routes through the
 /// saved real-stderr fd when silent mode is active, fd 2 otherwise.
 ///
-/// Issues a single `write` syscall with `<line>\n` so the kernel's
-/// `PIPE_BUF` (= 4096 on Linux) atomicity keeps lines from concurrent
-/// pump tasks intact without explicit locking.
+/// `write_all` of a pre-built `<line>\n` buffer issues a single short
+/// write to the kernel; on TTYs and pipes the kernel's `PIPE_BUF`
+/// (= 4096+ on every supported unix) atomicity keeps lines from
+/// concurrent pump tasks intact without explicit locking. The dup
+/// happens per line so we don't share a long-lived `File` handle that
+/// would need its own lock — a duplicate `write` syscall pair is
+/// cheaper than an `Arc<Mutex<File>>` and correct under concurrency.
 #[cfg(unix)]
 pub fn write_line_to_real_stderr(line: &str) {
+    use std::io::Write;
     let saved = SAVED_STDERR_FD.load(std::sync::atomic::Ordering::SeqCst);
     let fd = if saved >= 0 { saved } else { 2 };
+    // SAFETY: `fd` is either the saved real-stderr fd (kept live by
+    // `SilentStderrGuard` for the duration of main) or fd 2 (always
+    // open). `BorrowedFd` only borrows; ownership stays with the
+    // saved-fd / std-stream side and `try_clone_to_owned` issues a
+    // `dup` so dropping the resulting `File` does not close fd 2 or
+    // the saved fd.
+    let borrowed = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) };
+    let Ok(owned) = borrowed.try_clone_to_owned() else {
+        return;
+    };
+    let mut file = std::fs::File::from(owned);
     let mut buf = String::with_capacity(line.len() + 1);
     buf.push_str(line);
     buf.push('\n');
-    // SAFETY: `fd` is either the saved real-stderr fd (kept live by
-    // `SilentStderrGuard` for the duration of main) or fd 2 (always
-    // open). A short / failed write is best-effort; the prior
-    // `eprintln!` swallowed errors the same way.
-    unsafe {
-        libc::write(fd, buf.as_ptr().cast(), buf.len());
-    }
+    let _ = file.write_all(buf.as_bytes());
 }
 
 #[cfg(not(unix))]

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -656,6 +656,38 @@ pub fn child_stderr() -> std::process::Stdio {
     std::process::Stdio::inherit()
 }
 
+/// Write `line` plus a newline to the parent's real stderr. Used by
+/// the recursive-run output multiplexer, which pipes child stderr
+/// through aube and re-emits each line with a `<package>: ` prefix —
+/// `eprintln!` writes to fd 2, which `SilentStderrGuard` has redirected
+/// to `/dev/null` under `--silent`, so child stderr would otherwise be
+/// silently swallowed in `--silent --parallel` mode. Routes through the
+/// saved real-stderr fd when silent mode is active, fd 2 otherwise.
+///
+/// Issues a single `write` syscall with `<line>\n` so the kernel's
+/// `PIPE_BUF` (= 4096 on Linux) atomicity keeps lines from concurrent
+/// pump tasks intact without explicit locking.
+#[cfg(unix)]
+pub fn write_line_to_real_stderr(line: &str) {
+    let saved = SAVED_STDERR_FD.load(std::sync::atomic::Ordering::SeqCst);
+    let fd = if saved >= 0 { saved } else { 2 };
+    let mut buf = String::with_capacity(line.len() + 1);
+    buf.push_str(line);
+    buf.push('\n');
+    // SAFETY: `fd` is either the saved real-stderr fd (kept live by
+    // `SilentStderrGuard` for the duration of main) or fd 2 (always
+    // open). A short / failed write is best-effort; the prior
+    // `eprintln!` swallowed errors the same way.
+    unsafe {
+        libc::write(fd, buf.as_ptr().cast(), buf.len());
+    }
+}
+
+#[cfg(not(unix))]
+pub fn write_line_to_real_stderr(line: &str) {
+    eprintln!("{line}");
+}
+
 /// Run a single npm-style script line through `sh -c` with the usual
 /// environment (`$PATH` extended with `node_modules/.bin`, `INIT_CWD`,
 /// `npm_lifecycle_event`, `npm_package_name`, `npm_package_version`).

--- a/crates/aube-workspace/Cargo.toml
+++ b/crates/aube-workspace/Cargo.toml
@@ -14,10 +14,12 @@ include = ["src/**/*.rs"]
 # `#[diagnostic(code(ERR_AUBE_X))]` below uses code names as macro
 # tokens, not symbol references — cargo-machete correctly sees no
 # usage. Same situation as aube-scripts and aube-store.
+aube-codes = { workspace = true }
 aube-manifest = { workspace = true }
 glob = { workspace = true }
 miette = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -6,6 +6,7 @@
 //! dependencies.
 
 pub mod selector;
+pub mod topo;
 
 use std::path::{Path, PathBuf};
 

--- a/crates/aube-workspace/src/topo.rs
+++ b/crates/aube-workspace/src/topo.rs
@@ -112,6 +112,45 @@ pub fn topological_sort(packages: Vec<SelectedPackage>) -> Vec<SelectedPackage> 
         .collect()
 }
 
+/// For each package in `packages`, the indices of *other* packages in
+/// the same slice it depends on (intra-set edges only). Returned shape:
+/// `out[i]` is the list of prerequisite indices for `packages[i]`.
+///
+/// Used by the bounded-parallel paths to wait for a dependent's
+/// workspace deps to finish before claiming its concurrency slot. The
+/// edge definition matches [`topological_sort`] exactly so a `--sort`
+/// run and a `--workspace-concurrency=N` run see the same intra-workspace
+/// dep graph.
+pub fn compute_prereq_indices(packages: &[SelectedPackage]) -> Vec<Vec<usize>> {
+    let by_name: BTreeMap<&str, usize> = packages
+        .iter()
+        .enumerate()
+        .filter_map(|(i, p)| p.name.as_deref().map(|n| (n, i)))
+        .collect();
+    packages
+        .iter()
+        .enumerate()
+        .map(|(i, pkg)| {
+            let m = &pkg.manifest;
+            let mut prereqs: BTreeSet<usize> = BTreeSet::new();
+            for dep in m
+                .dependencies
+                .keys()
+                .chain(m.dev_dependencies.keys())
+                .chain(m.optional_dependencies.keys())
+                .chain(m.peer_dependencies.keys())
+            {
+                if let Some(&j) = by_name.get(dep.as_str())
+                    && j != i
+                {
+                    prereqs.insert(j);
+                }
+            }
+            prereqs.into_iter().collect()
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -207,5 +246,32 @@ mod tests {
         assert!(topological_sort(vec![]).is_empty());
         let single = topological_sort(vec![pkg("only", &[])]);
         assert_eq!(names(&single), vec!["only"]);
+    }
+
+    #[test]
+    fn compute_prereq_indices_returns_intra_set_dep_indices() {
+        // app depends on lib + external; lib depends on core; core has none.
+        // Index 0 = app, 1 = lib, 2 = core. External deps don't appear.
+        let pkgs = vec![
+            pkg("app", &["lib", "lodash"]),
+            pkg("lib", &["core"]),
+            pkg("core", &[]),
+        ];
+        let prereqs = compute_prereq_indices(&pkgs);
+        assert_eq!(prereqs[0], vec![1]); // app -> lib
+        assert_eq!(prereqs[1], vec![2]); // lib -> core
+        assert!(prereqs[2].is_empty()); // core has no intra-set deps
+    }
+
+    #[test]
+    fn compute_prereq_indices_dedupes_when_same_dep_in_multiple_sections() {
+        // A package can list the same name in dependencies AND
+        // peerDependencies; we want one prereq edge, not two.
+        let mut a = pkg("a", &["b"]);
+        a.manifest
+            .peer_dependencies
+            .insert("b".to_string(), "*".to_string());
+        let prereqs = compute_prereq_indices(&[a, pkg("b", &[])]);
+        assert_eq!(prereqs[0], vec![1]);
     }
 }

--- a/crates/aube-workspace/src/topo.rs
+++ b/crates/aube-workspace/src/topo.rs
@@ -118,16 +118,17 @@ pub fn topological_sort(packages: Vec<SelectedPackage>) -> Vec<SelectedPackage> 
 ///
 /// Used by the bounded-parallel paths to wait for a dependent's
 /// workspace deps to finish before claiming its concurrency slot. The
-/// edge definition matches [`topological_sort`] exactly so a `--sort`
-/// run and a `--workspace-concurrency=N` run see the same intra-workspace
-/// dep graph.
+/// edge definition matches [`topological_sort`] for non-cyclic inputs;
+/// when the dep graph contains a cycle, back-edges are dropped so the
+/// returned graph is acyclic. Without that, a parallel run on a cycle
+/// would wedge tasks waiting on each other's `watch::Sender` forever.
 pub fn compute_prereq_indices(packages: &[SelectedPackage]) -> Vec<Vec<usize>> {
     let by_name: BTreeMap<&str, usize> = packages
         .iter()
         .enumerate()
         .filter_map(|(i, p)| p.name.as_deref().map(|n| (n, i)))
         .collect();
-    packages
+    let raw: Vec<Vec<usize>> = packages
         .iter()
         .enumerate()
         .map(|(i, pkg)| {
@@ -148,7 +149,68 @@ pub fn compute_prereq_indices(packages: &[SelectedPackage]) -> Vec<Vec<usize>> {
             }
             prereqs.into_iter().collect()
         })
-        .collect()
+        .collect();
+
+    // DFS each component; an edge u → v where v is on the current
+    // recursion stack (Gray) is a cycle back-edge and gets dropped.
+    // Iterative to avoid blowing the stack on deep workspace graphs.
+    let n = packages.len();
+    let mut state = vec![NodeState::White; n];
+    let mut out: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for start in 0..n {
+        if state[start] != NodeState::White {
+            continue;
+        }
+        let mut stack: Vec<(usize, usize)> = vec![(start, 0)];
+        state[start] = NodeState::Gray;
+        while let Some(&mut (u, ref mut i)) = stack.last_mut() {
+            if let Some(&v) = raw[u].get(*i) {
+                *i += 1;
+                match state[v] {
+                    NodeState::White => {
+                        out[u].push(v);
+                        state[v] = NodeState::Gray;
+                        stack.push((v, 0));
+                    }
+                    NodeState::Black => out[u].push(v),
+                    NodeState::Gray => {} // back-edge: drop
+                }
+            } else {
+                state[u] = NodeState::Black;
+                stack.pop();
+            }
+        }
+    }
+    for edges in &mut out {
+        edges.sort_unstable();
+    }
+    out
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum NodeState {
+    White,
+    Gray,
+    Black,
+}
+
+/// Transpose a prereq adjacency: if `prereqs[i]` lists `j` (i waits on
+/// j), the result has `out[j]` listing `i` (j waits on i). Used by the
+/// bounded-parallel path under `--reverse` so dependents finish before
+/// their deps — the teardown semantics pnpm advertises. Without this,
+/// reversing the slice alone leaves the barrier still enforcing
+/// forward dep order.
+pub fn transpose_prereqs(prereqs: &[Vec<usize>]) -> Vec<Vec<usize>> {
+    let mut out: Vec<Vec<usize>> = vec![Vec::new(); prereqs.len()];
+    for (i, deps) in prereqs.iter().enumerate() {
+        for &j in deps {
+            out[j].push(i);
+        }
+    }
+    for edges in &mut out {
+        edges.sort_unstable();
+    }
+    out
 }
 
 #[cfg(test)]
@@ -273,5 +335,51 @@ mod tests {
             .insert("b".to_string(), "*".to_string());
         let prereqs = compute_prereq_indices(&[a, pkg("b", &[])]);
         assert_eq!(prereqs[0], vec![1]);
+    }
+
+    #[test]
+    fn compute_prereq_indices_breaks_cycles() {
+        // a → b → a forms a cycle. Without cycle-breaking, a parallel
+        // run hangs forever waiting on each other's barrier. Exactly
+        // one of the two edges must be dropped (DFS visits index 0
+        // first, so the b → a back-edge is the one removed).
+        let pkgs = vec![pkg("a", &["b"]), pkg("b", &["a"])];
+        let prereqs = compute_prereq_indices(&pkgs);
+        let total_edges: usize = prereqs.iter().map(Vec::len).sum();
+        assert_eq!(total_edges, 1, "cycle back-edge must be dropped");
+    }
+
+    #[test]
+    fn compute_prereq_indices_breaks_three_node_cycle() {
+        // a → b → c → a. Two edges remain after cycle-breaking, no
+        // node waits on a node already on its own DFS stack.
+        let pkgs = vec![pkg("a", &["b"]), pkg("b", &["c"]), pkg("c", &["a"])];
+        let prereqs = compute_prereq_indices(&pkgs);
+        let total_edges: usize = prereqs.iter().map(Vec::len).sum();
+        assert_eq!(total_edges, 2);
+    }
+
+    #[test]
+    fn transpose_prereqs_swaps_edge_direction() {
+        // Forward chain: app → lib → core (i.e. prereqs[0]=[1], [1]=[2]).
+        // Transposed: core → lib → app  (out[2]=[1], out[1]=[0]).
+        let forward = vec![vec![1], vec![2], vec![]];
+        let reversed = transpose_prereqs(&forward);
+        assert_eq!(reversed[0], Vec::<usize>::new());
+        assert_eq!(reversed[1], vec![0]);
+        assert_eq!(reversed[2], vec![1]);
+    }
+
+    #[test]
+    fn transpose_prereqs_handles_diamond() {
+        // app(0) depends on left(1) and right(2); both depend on shared(3).
+        // Forward: [0]=[1,2], [1]=[3], [2]=[3], [3]=[].
+        // Transposed (teardown order): [3]=[1,2], [1]=[0], [2]=[0], [0]=[].
+        let forward = vec![vec![1, 2], vec![3], vec![3], vec![]];
+        let reversed = transpose_prereqs(&forward);
+        assert_eq!(reversed[0], Vec::<usize>::new());
+        assert_eq!(reversed[1], vec![0]);
+        assert_eq!(reversed[2], vec![0]);
+        assert_eq!(reversed[3], vec![1, 2]);
     }
 }

--- a/crates/aube-workspace/src/topo.rs
+++ b/crates/aube-workspace/src/topo.rs
@@ -1,0 +1,211 @@
+//! Topological sort of selected workspace packages by intra-workspace deps.
+//!
+//! Used by `aube run -r` and `aube exec -r` so that scripts in
+//! dependency packages run before their dependents (e.g. `build` in a
+//! shared library before `build` in an app that consumes it).
+//!
+//! Edges considered: a package `A` depends on `B` when one of `A`'s
+//! `dependencies`, `devDependencies`, `optionalDependencies`, or
+//! `peerDependencies` names a workspace sibling whose
+//! `package.json#name` matches. Dep specifiers are not inspected — any
+//! reference to a sibling name pulls in the edge, matching pnpm.
+//!
+//! Edges are restricted to packages within the matched set. A package
+//! that depends on an unselected workspace sibling has the dep ignored;
+//! pnpm uses the same projection so `aube run -r --filter=foo build`
+//! orders the matched subset without dragging unselected packages in.
+//!
+//! Cycles fall back to insertion (workspace-listing) order for the
+//! cyclic remnant after the acyclic prefix completes. A
+//! [`WARN_AUBE_WORKSPACE_TOPO_CYCLE`] warning is emitted with the
+//! involved package names.
+
+use crate::selector::SelectedPackage;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+/// Topologically sort `packages` so that workspace deps come before
+/// their dependents. Stable: among nodes with equal in-degree, the
+/// original input order is preserved.
+///
+/// Cycle handling: nodes that participate in a cycle (or sit
+/// downstream of one) are appended in their original order after the
+/// acyclic prefix, with a tracing warning identifying them. The total
+/// length of the output always equals `packages.len()`.
+pub fn topological_sort(packages: Vec<SelectedPackage>) -> Vec<SelectedPackage> {
+    if packages.len() < 2 {
+        return packages;
+    }
+
+    let by_name: BTreeMap<&str, usize> = packages
+        .iter()
+        .enumerate()
+        .filter_map(|(i, p)| p.name.as_deref().map(|n| (n, i)))
+        .collect();
+
+    let mut in_degree = vec![0_usize; packages.len()];
+    // adj[i] = indices of packages that depend on i (so once i is
+    // emitted, those become candidates to emit next).
+    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); packages.len()];
+
+    for (i, pkg) in packages.iter().enumerate() {
+        let m = &pkg.manifest;
+        let dep_names: BTreeSet<&str> = m
+            .dependencies
+            .keys()
+            .chain(m.dev_dependencies.keys())
+            .chain(m.optional_dependencies.keys())
+            .chain(m.peer_dependencies.keys())
+            .map(String::as_str)
+            .collect();
+        for dep in dep_names {
+            let Some(&j) = by_name.get(dep) else {
+                continue;
+            };
+            if i == j {
+                continue;
+            }
+            adj[j].push(i);
+            in_degree[i] += 1;
+        }
+    }
+
+    // Kahn's algorithm. The initial queue is the acyclic-leaves set in
+    // input order; subsequent decrements preserve insertion order
+    // because adj[j] was built in input order.
+    let mut queue: VecDeque<usize> = (0..packages.len()).filter(|&i| in_degree[i] == 0).collect();
+    let mut order: Vec<usize> = Vec::with_capacity(packages.len());
+    let mut emitted = vec![false; packages.len()];
+    while let Some(i) = queue.pop_front() {
+        order.push(i);
+        emitted[i] = true;
+        for &k in &adj[i] {
+            in_degree[k] -= 1;
+            if in_degree[k] == 0 {
+                queue.push_back(k);
+            }
+        }
+    }
+
+    if order.len() < packages.len() {
+        let cycle_names: Vec<&str> = packages
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !emitted[*i])
+            .map(|(_, p)| p.name.as_deref().unwrap_or("<unnamed>"))
+            .collect();
+        tracing::warn!(
+            code = aube_codes::warnings::WARN_AUBE_WORKSPACE_TOPO_CYCLE,
+            packages = cycle_names.join(", "),
+            "workspace dependency cycle detected; running cycle members in listing order",
+        );
+        for (i, &done) in emitted.iter().enumerate() {
+            if !done {
+                order.push(i);
+            }
+        }
+    }
+
+    let mut slots: Vec<Option<SelectedPackage>> = packages.into_iter().map(Some).collect();
+    order
+        .into_iter()
+        .map(|i| slots[i].take().expect("each index is visited exactly once"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aube_manifest::PackageJson;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    fn pkg(name: &str, deps: &[&str]) -> SelectedPackage {
+        let manifest = PackageJson {
+            name: Some(name.to_string()),
+            dependencies: deps
+                .iter()
+                .map(|d| ((*d).to_string(), "*".to_string()))
+                .collect::<BTreeMap<_, _>>(),
+            ..PackageJson::default()
+        };
+        SelectedPackage {
+            name: Some(name.to_string()),
+            version: None,
+            private: false,
+            dir: PathBuf::from(name),
+            manifest,
+        }
+    }
+
+    fn names(out: &[SelectedPackage]) -> Vec<&str> {
+        out.iter().map(|p| p.name.as_deref().unwrap()).collect()
+    }
+
+    #[test]
+    fn linear_chain_runs_leaves_first() {
+        // app depends on lib; lib depends on core. Order: core, lib, app.
+        let out = topological_sort(vec![
+            pkg("app", &["lib"]),
+            pkg("lib", &["core"]),
+            pkg("core", &[]),
+        ]);
+        assert_eq!(names(&out), vec!["core", "lib", "app"]);
+    }
+
+    #[test]
+    fn diamond_preserves_input_order_among_independent_nodes() {
+        // app depends on left + right; both depend on shared.
+        // Output: shared first, then left/right in input order, then app.
+        let out = topological_sort(vec![
+            pkg("app", &["left", "right"]),
+            pkg("left", &["shared"]),
+            pkg("right", &["shared"]),
+            pkg("shared", &[]),
+        ]);
+        assert_eq!(names(&out), vec!["shared", "left", "right", "app"]);
+    }
+
+    #[test]
+    fn unrelated_packages_keep_input_order() {
+        let out = topological_sort(vec![pkg("a", &[]), pkg("b", &[]), pkg("c", &[])]);
+        assert_eq!(names(&out), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn ignores_external_deps() {
+        // `lodash` is not in the workspace, so it doesn't contribute
+        // an edge and `a` is treated as a leaf.
+        let out = topological_sort(vec![pkg("a", &["lodash"]), pkg("b", &["a"])]);
+        assert_eq!(names(&out), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn cycle_falls_back_to_input_order_for_cycle_members() {
+        // a → b → a forms a cycle. c is independent. Output: c first
+        // (acyclic prefix), then a, b in input order.
+        let out = topological_sort(vec![pkg("a", &["b"]), pkg("b", &["a"]), pkg("c", &[])]);
+        assert_eq!(names(&out), vec!["c", "a", "b"]);
+    }
+
+    #[test]
+    fn dev_and_peer_deps_count_as_edges() {
+        let mut a = pkg("a", &[]);
+        a.manifest
+            .dev_dependencies
+            .insert("b".to_string(), "*".to_string());
+        a.manifest
+            .peer_dependencies
+            .insert("c".to_string(), "*".to_string());
+        let out = topological_sort(vec![a, pkg("b", &[]), pkg("c", &[])]);
+        // b and c are leaves and come before a; among themselves they
+        // keep input order.
+        assert_eq!(names(&out), vec!["b", "c", "a"]);
+    }
+
+    #[test]
+    fn empty_and_single_inputs_are_passthrough() {
+        assert!(topological_sort(vec![]).is_empty());
+        let single = topological_sort(vec![pkg("only", &[])]);
+        assert_eq!(names(&single), vec!["only"]);
+    }
+}

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -176,6 +176,16 @@ async fn run_filtered_parallel(
         }
     }
 
+    // Topo barrier: same dep-before-dependent contract as
+    // `run_filtered_parallel` in run.rs. `aube exec -r make` over a
+    // chain of workspace packages needs every dep's `make` to finish
+    // before the dependent's `make` reads its outputs. See that
+    // function's doc for the watch-channel rationale.
+    let prereqs = aube_workspace::topo::compute_prereq_indices(&matched);
+    let completion: Vec<tokio::sync::watch::Sender<bool>> = (0..matched.len())
+        .map(|_| tokio::sync::watch::channel(false).0)
+        .collect();
+
     let sem = Arc::new(Semaphore::new(concurrency));
     let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
         Vec::with_capacity(matched.len());
@@ -190,6 +200,11 @@ async fn run_filtered_parallel(
         } else {
             super::run_output::OutputMode::prefix(pkg.name.as_deref(), index)
         };
+        let prereq_rxs: Vec<tokio::sync::watch::Receiver<bool>> = prereqs[index]
+            .iter()
+            .map(|&j| completion[j].subscribe())
+            .collect();
+        let done_tx = completion[index].clone();
         let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
         let dir = pkg.dir.clone();
         let bin = bin.to_string();
@@ -197,11 +212,21 @@ async fn run_filtered_parallel(
         let sem = Arc::clone(&sem);
         task_names.push(name);
         tasks.push(tokio::spawn(async move {
+            for mut rx in prereq_rxs {
+                while !*rx.borrow_and_update() {
+                    if rx.changed().await.is_err() {
+                        break;
+                    }
+                }
+            }
             let _permit = sem
                 .acquire_owned()
                 .await
                 .map_err(|e| miette!("workspace concurrency semaphore closed: {e}"))?;
-            exec_bin_status(&dir, &bin_path, &bin, &args, shell_mode, &output_mode).await
+            let result =
+                exec_bin_status(&dir, &bin_path, &bin, &args, shell_mode, &output_mode).await;
+            let _ = done_tx.send(true);
+            result
         }));
     }
 

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -19,9 +19,10 @@ pub struct ExecArgs {
     /// Skip auto-install check
     #[arg(long)]
     pub no_install: bool,
-    /// Disable topological sorting.
+    /// Disable topological sorting (default is on).
     ///
-    /// Parsed for pnpm compatibility.
+    /// Without this, recursive execs visit packages in a deps-first
+    /// order. Pass this to fall back to raw workspace-listing order.
     #[arg(long, overrides_with = "sort")]
     pub no_sort: bool,
     /// Run recursive workspace executions concurrently.
@@ -37,27 +38,28 @@ pub struct ExecArgs {
     /// Parsed for pnpm compatibility.
     #[arg(long)]
     pub reporter_hide_prefix: bool,
-    /// Resume recursive execution from a package name.
+    /// Resume recursive execution starting at this package name.
     ///
-    /// Parsed for pnpm compatibility.
+    /// Packages before the named one in the post-sort, post-reverse
+    /// order are skipped. Errors if the name isn't in the matched set.
     #[arg(long, value_name = "PACKAGE")]
     pub resume_from: Option<String>,
-    /// Run recursive packages in reverse order.
-    ///
-    /// Parsed for pnpm compatibility.
+    /// Reverse the recursive execution order (after topo sort).
     #[arg(long)]
     pub reverse: bool,
     /// Run the command through `sh -c`.
     #[arg(short = 'c', long)]
     pub shell_mode: bool,
-    /// Sort recursive packages topologically.
+    /// Sort recursive packages topologically (this is the default).
     ///
-    /// Parsed for pnpm compatibility.
+    /// Pass to override an earlier `--no-sort` on the same invocation.
     #[arg(long, overrides_with = "no_sort")]
     pub sort: bool,
-    /// Recursive workspace concurrency.
+    /// Cap the number of recursive packages running at once.
     ///
-    /// Parsed for pnpm compatibility.
+    /// Setting this implicitly enables parallel mode at width `N`.
+    /// `0` means "use the available CPU count". Without this flag,
+    /// `--parallel` stays unbounded.
     #[arg(long, value_name = "N")]
     pub workspace_concurrency: Option<usize>,
     #[command(flatten)]
@@ -81,14 +83,14 @@ pub async fn run(
         no_install,
         parallel,
         no_bail: _,
-        no_sort: _,
+        no_sort,
         report_summary: _,
         reporter_hide_prefix: _,
-        resume_from: _,
-        reverse: _,
+        resume_from,
+        reverse,
         shell_mode,
         sort: _,
-        workspace_concurrency: _,
+        workspace_concurrency,
         lockfile: _,
         network: _,
         virtual_store: _,
@@ -98,7 +100,15 @@ pub async fn run(
     ensure_installed(no_install).await?;
 
     if !filter.is_empty() {
-        return run_filtered(&cwd, &bin, &args, shell_mode, parallel, &filter).await;
+        // Same defaulting rule as `aube run`: sort=on unless `--no-sort`
+        // was explicitly passed.
+        let recursive = super::run::RecursiveOpts {
+            sort: !no_sort,
+            reverse,
+            resume_from,
+            workspace_concurrency,
+        };
+        return run_filtered(&cwd, &bin, &args, shell_mode, parallel, &filter, recursive).await;
     }
 
     let bin_path = super::project_modules_dir(&cwd).join(".bin").join(&bin);
@@ -112,72 +122,94 @@ async fn run_filtered(
     shell_mode: bool,
     parallel: bool,
     filter: &aube_workspace::selector::EffectiveFilter,
+    recursive: super::run::RecursiveOpts,
 ) -> miette::Result<()> {
     let (_root, matched) = super::select_workspace_packages(cwd, filter, "exec")?;
-    if parallel {
-        if !shell_mode {
-            for pkg in &matched {
-                let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
-                if !bin_path.exists() {
-                    let name = pkg
-                        .name
-                        .as_deref()
-                        .unwrap_or_else(|| pkg.dir.to_str().unwrap_or("<unknown>"));
-                    return Err(miette!(
-                        "binary not found in {name}: {bin}\nTry running `aube install` first, or check that the package providing '{bin}' is in its dependencies."
-                    ));
-                }
-            }
-        }
+    let matched = super::run::order_matched_packages(matched, &recursive)?;
 
-        let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
-            Vec::with_capacity(matched.len());
-        let mut task_names = Vec::with_capacity(matched.len());
-        for pkg in matched {
-            let name = pkg
-                .name
-                .clone()
-                .unwrap_or_else(|| pkg.dir.display().to_string());
-            let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
-            let dir = pkg.dir.clone();
-            let bin = bin.to_string();
-            let args = args.to_vec();
-            task_names.push(name);
-            tasks.push(tokio::spawn(async move {
-                exec_bin_status(&dir, &bin_path, &bin, &args, shell_mode).await
-            }));
-        }
-
-        let mut first_err: Option<miette::Report> = None;
-        let mut first_exit: Option<i32> = None;
-        for (task, name) in tasks.into_iter().zip(task_names) {
-            match task.await {
-                Ok(Ok(status)) => {
-                    if !status.success() && first_exit.is_none() {
-                        let code = aube_scripts::exit_code_from_status(status);
-                        first_exit = Some(code);
-                        first_err =
-                            Some(miette!("aube exec: `{bin}` failed in {name} (exit {code})"));
-                    }
-                }
-                Ok(Err(e)) if first_err.is_none() => first_err = Some(e),
-                Ok(Err(_)) => {}
-                Err(e) if first_err.is_none() => first_err = Some(miette!("task panicked: {e}")),
-                Err(_) => {}
-            }
-        }
-        if let Some(code) = first_exit {
-            std::process::exit(code);
-        }
-        if let Some(e) = first_err {
-            return Err(e);
-        }
-        return Ok(());
+    let concurrency = super::run::effective_concurrency(parallel, recursive.workspace_concurrency);
+    if concurrency > 1 {
+        return run_filtered_parallel(bin, args, shell_mode, matched, concurrency).await;
     }
 
     for pkg in matched {
         let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
         exec_bin(&pkg.dir, &bin_path, bin, args, shell_mode).await?;
+    }
+    Ok(())
+}
+
+async fn run_filtered_parallel(
+    bin: &str,
+    args: &[String],
+    shell_mode: bool,
+    matched: Vec<aube_workspace::selector::SelectedPackage>,
+    concurrency: usize,
+) -> miette::Result<()> {
+    use std::sync::Arc;
+    use tokio::sync::Semaphore;
+
+    if !shell_mode {
+        for pkg in &matched {
+            let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
+            if !bin_path.exists() {
+                let name = pkg
+                    .name
+                    .as_deref()
+                    .unwrap_or_else(|| pkg.dir.to_str().unwrap_or("<unknown>"));
+                return Err(miette!(
+                    "binary not found in {name}: {bin}\nTry running `aube install` first, or check that the package providing '{bin}' is in its dependencies."
+                ));
+            }
+        }
+    }
+
+    let sem = Arc::new(Semaphore::new(concurrency));
+    let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
+        Vec::with_capacity(matched.len());
+    let mut task_names = Vec::with_capacity(matched.len());
+    for pkg in matched {
+        let name = pkg
+            .name
+            .clone()
+            .unwrap_or_else(|| pkg.dir.display().to_string());
+        let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
+        let dir = pkg.dir.clone();
+        let bin = bin.to_string();
+        let args = args.to_vec();
+        let sem = Arc::clone(&sem);
+        task_names.push(name);
+        tasks.push(tokio::spawn(async move {
+            let _permit = sem
+                .acquire_owned()
+                .await
+                .map_err(|e| miette!("workspace concurrency semaphore closed: {e}"))?;
+            exec_bin_status(&dir, &bin_path, &bin, &args, shell_mode).await
+        }));
+    }
+
+    let mut first_err: Option<miette::Report> = None;
+    let mut first_exit: Option<i32> = None;
+    for (task, name) in tasks.into_iter().zip(task_names) {
+        match task.await {
+            Ok(Ok(status)) => {
+                if !status.success() && first_exit.is_none() {
+                    let code = aube_scripts::exit_code_from_status(status);
+                    first_exit = Some(code);
+                    first_err = Some(miette!("aube exec: `{bin}` failed in {name} (exit {code})"));
+                }
+            }
+            Ok(Err(e)) if first_err.is_none() => first_err = Some(e),
+            Ok(Err(_)) => {}
+            Err(e) if first_err.is_none() => first_err = Some(miette!("task panicked: {e}")),
+            Err(_) => {}
+        }
+    }
+    if let Some(code) = first_exit {
+        std::process::exit(code);
+    }
+    if let Some(e) = first_err {
+        return Err(e);
     }
     Ok(())
 }

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -33,9 +33,11 @@ pub struct ExecArgs {
     /// Parsed for pnpm compatibility.
     #[arg(long)]
     pub report_summary: bool,
-    /// Hide package prefixes in recursive reporter output.
+    /// Hide the `<package>: ` label on parallel-exec output lines.
     ///
-    /// Parsed for pnpm compatibility.
+    /// Lines are still piped (clean line breaks even with concurrent
+    /// children) but the source package isn't named on each line.
+    /// Sequential execs ignore this flag.
     #[arg(long)]
     pub reporter_hide_prefix: bool,
     /// Resume recursive execution starting at this package name.
@@ -85,7 +87,7 @@ pub async fn run(
         no_bail: _,
         no_sort,
         report_summary: _,
-        reporter_hide_prefix: _,
+        reporter_hide_prefix,
         resume_from,
         reverse,
         shell_mode,
@@ -107,6 +109,7 @@ pub async fn run(
             reverse,
             resume_from,
             workspace_concurrency,
+            reporter_hide_prefix,
         };
         return run_filtered(&cwd, &bin, &args, shell_mode, parallel, &filter, recursive).await;
     }
@@ -129,7 +132,15 @@ async fn run_filtered(
 
     let concurrency = super::run::effective_concurrency(parallel, recursive.workspace_concurrency);
     if concurrency > 1 {
-        return run_filtered_parallel(bin, args, shell_mode, matched, concurrency).await;
+        return run_filtered_parallel(
+            bin,
+            args,
+            shell_mode,
+            matched,
+            concurrency,
+            recursive.reporter_hide_prefix,
+        )
+        .await;
     }
 
     for pkg in matched {
@@ -145,6 +156,7 @@ async fn run_filtered_parallel(
     shell_mode: bool,
     matched: Vec<aube_workspace::selector::SelectedPackage>,
     concurrency: usize,
+    reporter_hide_prefix: bool,
 ) -> miette::Result<()> {
     use std::sync::Arc;
     use tokio::sync::Semaphore;
@@ -168,11 +180,16 @@ async fn run_filtered_parallel(
     let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
         Vec::with_capacity(matched.len());
     let mut task_names = Vec::with_capacity(matched.len());
-    for pkg in matched {
+    for (index, pkg) in matched.into_iter().enumerate() {
         let name = pkg
             .name
             .clone()
             .unwrap_or_else(|| pkg.dir.display().to_string());
+        let output_mode = if reporter_hide_prefix {
+            super::run_output::OutputMode::NoPrefix
+        } else {
+            super::run_output::OutputMode::prefix(pkg.name.as_deref(), index)
+        };
         let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
         let dir = pkg.dir.clone();
         let bin = bin.to_string();
@@ -184,7 +201,7 @@ async fn run_filtered_parallel(
                 .acquire_owned()
                 .await
                 .map_err(|e| miette!("workspace concurrency semaphore closed: {e}"))?;
-            exec_bin_status(&dir, &bin_path, &bin, &args, shell_mode).await
+            exec_bin_status(&dir, &bin_path, &bin, &args, shell_mode, &output_mode).await
         }));
     }
 
@@ -277,10 +294,12 @@ pub(crate) async fn exec_bin_status(
     bin: &str,
     args: &[String],
     shell_mode: bool,
+    output_mode: &super::run_output::OutputMode,
 ) -> miette::Result<std::process::ExitStatus> {
-    exec_bin_status_with_node_args(cwd, bin_path, bin, args, &[], shell_mode).await
+    exec_bin_status_with_node_args(cwd, bin_path, bin, args, &[], shell_mode, output_mode).await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn exec_bin_status_with_node_args(
     cwd: &Path,
     bin_path: &Path,
@@ -288,6 +307,7 @@ pub(crate) async fn exec_bin_status_with_node_args(
     args: &[String],
     node_args: &[String],
     shell_mode: bool,
+    output_mode: &super::run_output::OutputMode,
 ) -> miette::Result<std::process::ExitStatus> {
     if !shell_mode && !bin_path.exists() {
         return Err(miette!(
@@ -315,11 +335,8 @@ pub(crate) async fn exec_bin_status_with_node_args(
     };
     command
         .current_dir(cwd)
-        .stderr(aube_scripts::child_stderr())
-        .status()
-        .await
-        .into_diagnostic()
-        .wrap_err("failed to execute binary")
+        .stderr(aube_scripts::child_stderr());
+    super::run_output::run_command(command, output_mode).await
 }
 
 fn node_bin_command(

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -139,6 +139,7 @@ async fn run_filtered(
             matched,
             concurrency,
             recursive.reporter_hide_prefix,
+            recursive.reverse,
         )
         .await;
     }
@@ -150,6 +151,7 @@ async fn run_filtered(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_filtered_parallel(
     bin: &str,
     args: &[String],
@@ -157,6 +159,7 @@ async fn run_filtered_parallel(
     matched: Vec<aube_workspace::selector::SelectedPackage>,
     concurrency: usize,
     reporter_hide_prefix: bool,
+    reverse: bool,
 ) -> miette::Result<()> {
     use std::sync::Arc;
     use tokio::sync::Semaphore;
@@ -177,19 +180,28 @@ async fn run_filtered_parallel(
     }
 
     // Topo barrier: same dep-before-dependent contract as
-    // `run_filtered_parallel` in run.rs. `aube exec -r make` over a
-    // chain of workspace packages needs every dep's `make` to finish
-    // before the dependent's `make` reads its outputs. See that
-    // function's doc for the watch-channel rationale.
+    // `run_filtered_parallel` in run.rs — see that function's doc for
+    // the watch-channel rationale, cycle handling, and reverse-mode
+    // transposition.
     let prereqs = aube_workspace::topo::compute_prereq_indices(&matched);
-    let completion: Vec<tokio::sync::watch::Sender<bool>> = (0..matched.len())
+    let prereqs = if reverse {
+        aube_workspace::topo::transpose_prereqs(&prereqs)
+    } else {
+        prereqs
+    };
+    let senders: Vec<tokio::sync::watch::Sender<bool>> = (0..matched.len())
         .map(|_| tokio::sync::watch::channel(false).0)
+        .collect();
+    let prereq_rxs_per_task: Vec<Vec<tokio::sync::watch::Receiver<bool>>> = (0..matched.len())
+        .map(|i| prereqs[i].iter().map(|&j| senders[j].subscribe()).collect())
         .collect();
 
     let sem = Arc::new(Semaphore::new(concurrency));
     let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
         Vec::with_capacity(matched.len());
     let mut task_names = Vec::with_capacity(matched.len());
+    let mut senders_iter = senders.into_iter();
+    let mut prereq_rxs_iter = prereq_rxs_per_task.into_iter();
     for (index, pkg) in matched.into_iter().enumerate() {
         let name = pkg
             .name
@@ -200,11 +212,8 @@ async fn run_filtered_parallel(
         } else {
             super::run_output::OutputMode::prefix(pkg.name.as_deref(), index)
         };
-        let prereq_rxs: Vec<tokio::sync::watch::Receiver<bool>> = prereqs[index]
-            .iter()
-            .map(|&j| completion[j].subscribe())
-            .collect();
-        let done_tx = completion[index].clone();
+        let prereq_rxs = prereq_rxs_iter.next().expect("one rx vec per package");
+        let done_tx = senders_iter.next().expect("one sender per package");
         let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
         let dir = pkg.dir.clone();
         let bin = bin.to_string();

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -130,8 +130,9 @@ async fn run_filtered(
     let (_root, matched) = super::select_workspace_packages(cwd, filter, "exec")?;
     let matched = super::run::order_matched_packages(matched, &recursive)?;
 
-    let concurrency = super::run::effective_concurrency(parallel, recursive.workspace_concurrency);
-    if concurrency > 1 {
+    if let Some(concurrency) =
+        super::run::effective_concurrency(parallel, recursive.workspace_concurrency)
+    {
         return run_filtered_parallel(
             bin,
             args,
@@ -367,9 +368,7 @@ pub(crate) async fn exec_bin_status_with_node_args(
         cmd.args(args);
         cmd
     };
-    command
-        .current_dir(cwd)
-        .stderr(aube_scripts::child_stderr());
+    command.current_dir(cwd);
     super::run_output::run_command(command, output_mode).await
 }
 

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -52,6 +52,7 @@ pub mod remove;
 pub mod restart;
 pub mod root;
 pub mod run;
+pub mod run_output;
 pub mod sbom;
 pub mod store;
 pub mod undeprecate;

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -472,8 +472,7 @@ async fn run_script_filtered(
     // re-check the same lockfile N times.
     ensure_installed(no_install).await?;
 
-    let concurrency = effective_concurrency(parallel, recursive.workspace_concurrency);
-    if concurrency > 1 {
+    if let Some(concurrency) = effective_concurrency(parallel, recursive.workspace_concurrency) {
         return run_filtered_parallel(
             script,
             args,
@@ -562,32 +561,42 @@ pub(crate) fn order_matched_packages(
     Ok(matched)
 }
 
-/// Map `--parallel` + `--workspace-concurrency` to a single concurrency
-/// cap. `1` means "use the sequential path" (bail-on-first behavior);
-/// any value `> 1` takes the bounded-parallel path. `--parallel` alone
-/// resolves to [`tokio::sync::Semaphore::MAX_PERMITS`] (= `usize::MAX >> 3`),
-/// which is effectively unbounded for any real workspace and avoids
-/// the runtime panic `Semaphore::new(usize::MAX)` triggers on its
-/// internal `MAX_PERMITS` invariant. Any user-supplied cap is also
-/// clamped to that ceiling.
-pub(crate) fn effective_concurrency(parallel: bool, workspace_concurrency: Option<usize>) -> usize {
+/// Map `--parallel` + `--workspace-concurrency` to a parallel-mode
+/// decision: `None` is the default sequential path (no flags, inherit
+/// stdio, bail on first failure); `Some(n)` takes the bounded-parallel
+/// path (piped/prefixed output, all-tasks-finish, semaphore-capped
+/// fanout) at width `n`. `Some(1)` is intentional pnpm parity — an
+/// explicit `--workspace-concurrency=1` opts into parallel-path
+/// semantics with width 1, even though no two tasks ever run at once.
+///
+/// `--parallel` alone resolves to [`tokio::sync::Semaphore::MAX_PERMITS`]
+/// (= `usize::MAX >> 3`), which is effectively unbounded for any real
+/// workspace and avoids the runtime panic `Semaphore::new(usize::MAX)`
+/// triggers on its internal `MAX_PERMITS` invariant. Any user-supplied
+/// cap is also clamped to that ceiling.
+pub(crate) fn effective_concurrency(
+    parallel: bool,
+    workspace_concurrency: Option<usize>,
+) -> Option<usize> {
     match (parallel, workspace_concurrency) {
         // pnpm: `workspace-concurrency=0` means "use available CPUs".
         // `available_parallelism` is documented to never return 0 — but
         // saturate to `1` defensively so a future change to that contract
         // can't silently turn into "sequential" via underflow.
-        (_, Some(0)) => std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1)
-            .max(1),
-        (_, Some(n)) => n.min(tokio::sync::Semaphore::MAX_PERMITS),
+        (_, Some(0)) => Some(
+            std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1)
+                .max(1),
+        ),
+        (_, Some(n)) => Some(n.min(tokio::sync::Semaphore::MAX_PERMITS)),
         // `--parallel` with no explicit cap preserves the historical
         // unbounded fanout. Power users on a 200-package workspace who
         // upgrade to a version with default-bounded parallel would be
         // surprised by an apparent slowdown; keep the explicit
         // unbounded request honored.
-        (true, None) => tokio::sync::Semaphore::MAX_PERMITS,
-        (false, None) => 1,
+        (true, None) => Some(tokio::sync::Semaphore::MAX_PERMITS),
+        (false, None) => None,
     }
 }
 
@@ -1097,7 +1106,7 @@ mod tests {
 
     #[test]
     fn no_parallel_no_concurrency_is_sequential() {
-        assert_eq!(effective_concurrency(false, None), 1);
+        assert_eq!(effective_concurrency(false, None), None);
     }
 
     #[test]
@@ -1110,7 +1119,7 @@ mod tests {
         // crashing on construction.
         assert_eq!(
             effective_concurrency(true, None),
-            tokio::sync::Semaphore::MAX_PERMITS
+            Some(tokio::sync::Semaphore::MAX_PERMITS)
         );
     }
 
@@ -1120,25 +1129,36 @@ mod tests {
         // otherwise hit the same Semaphore panic. The cap clamps it.
         assert_eq!(
             effective_concurrency(true, Some(usize::MAX)),
-            tokio::sync::Semaphore::MAX_PERMITS
+            Some(tokio::sync::Semaphore::MAX_PERMITS)
         );
     }
 
     #[test]
     fn concurrency_overrides_unbounded_parallel() {
-        assert_eq!(effective_concurrency(true, Some(4)), 4);
+        assert_eq!(effective_concurrency(true, Some(4)), Some(4));
     }
 
     #[test]
     fn concurrency_alone_implies_parallel() {
         // pnpm parity: setting a concurrency cap parallelizes by
         // itself, no separate `--parallel` needed.
-        assert_eq!(effective_concurrency(false, Some(3)), 3);
+        assert_eq!(effective_concurrency(false, Some(3)), Some(3));
+    }
+
+    #[test]
+    fn concurrency_one_explicit_takes_parallel_path() {
+        // pnpm parity: `--workspace-concurrency=1` is documented as
+        // "implicitly enables parallel mode at width N". Width 1 means
+        // tasks serialize, but the user still gets piped/prefixed
+        // output and all-tasks-finish semantics rather than the
+        // sequential default's inherited stdio + bail-on-first.
+        assert_eq!(effective_concurrency(false, Some(1)), Some(1));
+        assert_eq!(effective_concurrency(true, Some(1)), Some(1));
     }
 
     #[test]
     fn concurrency_zero_picks_cpu_count() {
-        let n = effective_concurrency(false, Some(0));
+        let n = effective_concurrency(false, Some(0)).expect("Some on explicit cap");
         assert!(n >= 1, "available_parallelism floor is 1");
     }
 

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -484,6 +484,7 @@ async fn run_script_filtered(
             matched,
             concurrency,
             recursive.reporter_hide_prefix,
+            recursive.reverse,
         )
         .await;
     }
@@ -617,6 +618,7 @@ async fn run_filtered_parallel(
     matched: Vec<aube_workspace::selector::SelectedPackage>,
     concurrency: usize,
     reporter_hide_prefix: bool,
+    reverse: bool,
 ) -> miette::Result<()> {
     use std::sync::Arc;
     use tokio::sync::Semaphore;
@@ -649,23 +651,37 @@ async fn run_filtered_parallel(
 
     // Compute prereqs against the post-`if_present` filtered set so a
     // dependent doesn't deadlock waiting on a sibling that was skipped
-    // because it had no matching script.
+    // because it had no matching script. Transpose under `--reverse`
+    // so dependents wait for their dependents (teardown order); just
+    // reversing the slice without flipping the edges is a no-op for
+    // any dep-linked workspace.
     let runnable_pkgs: Vec<aube_workspace::selector::SelectedPackage> =
         runnable.iter().map(|(p, _)| p.clone()).collect();
     let prereqs = aube_workspace::topo::compute_prereq_indices(&runnable_pkgs);
-    // One sender per package; dependents subscribe via `subscribe()`
-    // before spawning so the receiver exists when the prereq's task
-    // calls `send`. The initial receiver is dropped immediately —
-    // packages with no dependents have no subscribers, and `send` on
-    // a no-receiver channel is a benign Err we ignore.
-    let completion: Vec<tokio::sync::watch::Sender<bool>> = (0..runnable.len())
+    let prereqs = if reverse {
+        aube_workspace::topo::transpose_prereqs(&prereqs)
+    } else {
+        prereqs
+    };
+    // One sender per package. Dependents subscribe before we move the
+    // sender into its task. Sender is moved (not cloned) so that when
+    // a task panics before signaling, its sender is the only one and
+    // the channel closes — `rx.changed()` returns Err and dependents
+    // unblock instead of hanging. Cloning would keep the channel alive
+    // via the original copy and make the panic-recovery path unreachable.
+    let senders: Vec<tokio::sync::watch::Sender<bool>> = (0..runnable.len())
         .map(|_| tokio::sync::watch::channel(false).0)
+        .collect();
+    let prereq_rxs_per_task: Vec<Vec<tokio::sync::watch::Receiver<bool>>> = (0..runnable.len())
+        .map(|i| prereqs[i].iter().map(|&j| senders[j].subscribe()).collect())
         .collect();
 
     let sem = Arc::new(Semaphore::new(concurrency));
     let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
         Vec::with_capacity(runnable.len());
     let mut task_names: Vec<String> = Vec::with_capacity(runnable.len());
+    let mut senders_iter = senders.into_iter();
+    let mut prereq_rxs_iter = prereq_rxs_per_task.into_iter();
     for (index, (pkg, bin_path)) in runnable.into_iter().enumerate() {
         let name = pkg
             .name
@@ -679,11 +695,8 @@ async fn run_filtered_parallel(
         } else {
             super::run_output::OutputMode::prefix(pkg.name.as_deref(), index)
         };
-        let prereq_rxs: Vec<tokio::sync::watch::Receiver<bool>> = prereqs[index]
-            .iter()
-            .map(|&j| completion[j].subscribe())
-            .collect();
-        let done_tx = completion[index].clone();
+        let prereq_rxs = prereq_rxs_iter.next().expect("one rx vec per package");
+        let done_tx = senders_iter.next().expect("one sender per package");
         let script = script.to_string();
         let args = args.to_vec();
         let node_args = node_args.to_vec();
@@ -700,8 +713,9 @@ async fn run_filtered_parallel(
             // wired) and degrades to "dependent runs against possibly
             // stale dep state" — same as pnpm. A `changed()` Err means
             // the prereq's sender was dropped without sending (panic
-            // or aborted JoinHandle); break to avoid deadlocking and
-            // let the script itself decide if its dep state is fatal.
+            // or aborted JoinHandle); break so dependents unblock
+            // instead of hanging — only reachable because each task
+            // *owns* (not clones) its sender.
             for mut rx in prereq_rxs {
                 while !*rx.borrow_and_update() {
                     if rx.changed().await.is_err() {

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -44,10 +44,12 @@ pub struct RunArgs {
     pub no_sort: bool,
     /// Run the script in every matched workspace package concurrently.
     ///
-    /// Unbounded parallelism. Pair with a filter (`-r` / `-F`) —
-    /// single-package runs ignore it. First non-zero exit fails the
-    /// whole run, but siblings are allowed to finish so their output
-    /// isn't truncated.
+    /// Unbounded parallelism. Pair with `--workspace-concurrency=N` to
+    /// cap the worker count. Single-package runs ignore this flag.
+    /// First non-zero exit fails the whole run, but siblings are
+    /// allowed to finish so their output isn't truncated. Child
+    /// stdio is piped and lines are emitted with a `<package>: `
+    /// prefix; pass `--reporter-hide-prefix` to drop the labels.
     #[arg(long)]
     pub parallel: bool,
     /// Write a recursive run summary file.
@@ -55,9 +57,12 @@ pub struct RunArgs {
     /// Parsed for pnpm compatibility.
     #[arg(long)]
     pub report_summary: bool,
-    /// Hide package prefixes in recursive reporter output.
+    /// Hide the `<package>: ` label on parallel-run output lines.
     ///
-    /// Parsed for pnpm compatibility.
+    /// Lines are still piped through aube (so the line breaks are
+    /// clean even when many packages run at once), but the source
+    /// package isn't named on each line. Sequential runs ignore this
+    /// flag.
     #[arg(long)]
     pub reporter_hide_prefix: bool,
     /// Resume recursive execution starting at this package name.
@@ -140,7 +145,7 @@ pub async fn run(
         parallel,
         no_bail: _,
         report_summary: _,
-        reporter_hide_prefix: _,
+        reporter_hide_prefix,
         resume_from,
         reverse,
         silent,
@@ -166,6 +171,7 @@ pub async fn run(
         reverse,
         resume_from,
         workspace_concurrency,
+        reporter_hide_prefix,
     };
     run_script_with(
         &script, &args, &node_args, no_install, if_present, parallel, silent, &filter, recursive,
@@ -194,6 +200,10 @@ pub(crate) struct RecursiveOpts {
     /// where setting workspace-concurrency parallelizes by itself).
     /// `Some(0)` means "use available CPU count".
     pub workspace_concurrency: Option<usize>,
+    /// When set, parallel runs pipe child stdio but emit lines without
+    /// a `<package>: ` prefix. Matches pnpm's `--reporter-hide-prefix`.
+    /// Sequential runs ignore this — they always inherit stdio.
+    pub reporter_hide_prefix: bool,
 }
 
 impl Default for RecursiveOpts {
@@ -203,6 +213,7 @@ impl Default for RecursiveOpts {
             reverse: false,
             resume_from: None,
             workspace_concurrency: None,
+            reporter_hide_prefix: false,
         }
     }
 }
@@ -472,6 +483,7 @@ async fn run_script_filtered(
             enable_pre_post_scripts,
             matched,
             concurrency,
+            recursive.reporter_hide_prefix,
         )
         .await;
     }
@@ -576,7 +588,9 @@ pub(crate) fn effective_concurrency(parallel: bool, workspace_concurrency: Optio
 /// every package up front (no orphaned children if a script-name lookup
 /// errors mid-spawn), let all started tasks finish so output isn't
 /// truncated by an early bail, and report the first non-zero exit's
-/// code through `std::process::exit`.
+/// code through `std::process::exit`. Output mode per task: prefixed
+/// (`<pkg>: <line>`, color-rotated) by default; unprefixed but still
+/// piped under `--reporter-hide-prefix`.
 #[allow(clippy::too_many_arguments)]
 async fn run_filtered_parallel(
     script: &str,
@@ -587,6 +601,7 @@ async fn run_filtered_parallel(
     enable_pre_post_scripts: bool,
     matched: Vec<aube_workspace::selector::SelectedPackage>,
     concurrency: usize,
+    reporter_hide_prefix: bool,
 ) -> miette::Result<()> {
     use std::sync::Arc;
     use tokio::sync::Semaphore;
@@ -621,7 +636,7 @@ async fn run_filtered_parallel(
     let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
         Vec::with_capacity(runnable.len());
     let mut task_names: Vec<String> = Vec::with_capacity(runnable.len());
-    for (pkg, bin_path) in runnable {
+    for (index, (pkg, bin_path)) in runnable.into_iter().enumerate() {
         let name = pkg
             .name
             .clone()
@@ -629,6 +644,11 @@ async fn run_filtered_parallel(
         if !silent {
             tracing::info!("aube run: {name} -> {script} (parallel)");
         }
+        let output_mode = if reporter_hide_prefix {
+            super::run_output::OutputMode::NoPrefix
+        } else {
+            super::run_output::OutputMode::prefix(pkg.name.as_deref(), index)
+        };
         let script = script.to_string();
         let args = args.to_vec();
         let node_args = node_args.to_vec();
@@ -648,7 +668,13 @@ async fn run_filtered_parallel(
                 .map_err(|e| miette!("workspace concurrency semaphore closed: {e}"))?;
             if let Some(bin_path) = bin_path {
                 super::exec::exec_bin_status_with_node_args(
-                    &dir, &bin_path, &script, &args, &node_args, false,
+                    &dir,
+                    &bin_path,
+                    &script,
+                    &args,
+                    &node_args,
+                    false,
+                    &output_mode,
                 )
                 .await
             } else {
@@ -659,6 +685,7 @@ async fn run_filtered_parallel(
                     &args,
                     &node_args,
                     enable_pre_post_scripts,
+                    &output_mode,
                 )
                 .await
             }
@@ -910,8 +937,9 @@ pub(crate) async fn exec_script_status(
     manifest: &PackageJson,
     script: &str,
     args: &[String],
+    output_mode: &super::run_output::OutputMode,
 ) -> miette::Result<std::process::ExitStatus> {
-    exec_script_status_with_node_args(cwd, manifest, script, args, &[]).await
+    exec_script_status_with_node_args(cwd, manifest, script, args, &[], output_mode).await
 }
 
 pub(crate) async fn exec_script_status_chain(
@@ -921,24 +949,27 @@ pub(crate) async fn exec_script_status_chain(
     args: &[String],
     node_args: &[String],
     enable_pre_post_scripts: bool,
+    output_mode: &super::run_output::OutputMode,
 ) -> miette::Result<std::process::ExitStatus> {
     if enable_pre_post_scripts {
         let pre = format!("pre{script}");
         if manifest.scripts.contains_key(&pre) {
-            let status = exec_script_status(cwd, manifest, &pre, &[]).await?;
+            let status = exec_script_status(cwd, manifest, &pre, &[], output_mode).await?;
             if !status.success() {
                 return Ok(status);
             }
         }
     }
-    let status = exec_script_status_with_node_args(cwd, manifest, script, args, node_args).await?;
+    let status =
+        exec_script_status_with_node_args(cwd, manifest, script, args, node_args, output_mode)
+            .await?;
     if !status.success() {
         return Ok(status);
     }
     if enable_pre_post_scripts {
         let post = format!("post{script}");
         if manifest.scripts.contains_key(&post) {
-            return exec_script_status(cwd, manifest, &post, &[]).await;
+            return exec_script_status(cwd, manifest, &post, &[], output_mode).await;
         }
     }
     Ok(status)
@@ -950,17 +981,14 @@ async fn exec_script_status_with_node_args(
     script: &str,
     args: &[String],
     node_args: &[String],
+    output_mode: &super::run_output::OutputMode,
 ) -> miette::Result<std::process::ExitStatus> {
     let cmd = manifest
         .scripts
         .get(script)
         .ok_or_else(|| miette!("script not found: {script}"))?;
-    build_script_command(cwd, manifest, script, cmd, args, node_args)
-        .await?
-        .status()
-        .await
-        .into_diagnostic()
-        .wrap_err("failed to execute script")
+    let command = build_script_command(cwd, manifest, script, cmd, args, node_args).await?;
+    super::run_output::run_command(command, output_mode).await
 }
 
 #[cfg(test)]
@@ -1034,7 +1062,7 @@ mod tests {
             sort: true,
             reverse: true,
             resume_from: Some("lib".to_string()),
-            workspace_concurrency: None,
+            ..RecursiveOpts::default()
         };
         let out = order_matched_packages(
             vec![
@@ -1052,9 +1080,8 @@ mod tests {
     fn order_matched_resume_from_unknown_package_errors() {
         let opts = RecursiveOpts {
             sort: false,
-            reverse: false,
             resume_from: Some("nonexistent".to_string()),
-            workspace_concurrency: None,
+            ..RecursiveOpts::default()
         };
         let err = order_matched_packages(vec![pkg("a", &[])], &opts).unwrap_err();
         assert!(err.to_string().contains("nonexistent"));
@@ -1064,9 +1091,7 @@ mod tests {
     fn order_matched_no_sort_preserves_input_order() {
         let opts = RecursiveOpts {
             sort: false,
-            reverse: false,
-            resume_from: None,
-            workspace_concurrency: None,
+            ..RecursiveOpts::default()
         };
         // Without sort, an app-before-lib input stays that way even
         // though app depends on lib.

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -34,9 +34,12 @@ pub struct RunArgs {
     /// Skip auto-install check
     #[arg(long)]
     pub no_install: bool,
-    /// Disable topological sorting.
+    /// Disable topological sorting (default is on).
     ///
-    /// Parsed for pnpm compatibility.
+    /// Without this, recursive runs visit packages in a deps-first
+    /// order so a `build` script in a shared library finishes before a
+    /// dependent app's `build` starts. Pass this to fall back to the
+    /// raw workspace-listing order.
     #[arg(long, overrides_with = "sort")]
     pub no_sort: bool,
     /// Run the script in every matched workspace package concurrently.
@@ -57,19 +60,22 @@ pub struct RunArgs {
     /// Parsed for pnpm compatibility.
     #[arg(long)]
     pub reporter_hide_prefix: bool,
-    /// Resume recursive execution from a package name.
+    /// Resume recursive execution starting at this package name.
     ///
-    /// Parsed for pnpm compatibility.
+    /// After the topo sort and `--reverse` are applied, packages
+    /// before the named one in the resulting order are skipped. Errors
+    /// if the name isn't in the matched workspace set.
     #[arg(long, value_name = "PACKAGE")]
     pub resume_from: Option<String>,
-    /// Run recursive packages in reverse order.
+    /// Reverse the recursive execution order (after topo sort).
     ///
-    /// Parsed for pnpm compatibility.
+    /// Useful for teardown-style scripts where dependents must shut
+    /// down before their deps.
     #[arg(long)]
     pub reverse: bool,
-    /// Sort recursive packages topologically.
+    /// Sort recursive packages topologically (this is the default).
     ///
-    /// Parsed for pnpm compatibility.
+    /// Pass to override an earlier `--no-sort` on the same invocation.
     #[arg(long, overrides_with = "no_sort")]
     pub sort: bool,
     /// Suppress aube's wrapper output while still showing script
@@ -80,9 +86,11 @@ pub struct RunArgs {
     /// in clap's dispatch.
     #[arg(short = 's')]
     pub silent: bool,
-    /// Recursive workspace concurrency.
+    /// Cap the number of recursive packages running at once.
     ///
-    /// Parsed for pnpm compatibility.
+    /// Setting this implicitly enables parallel mode at width `N`.
+    /// `0` means "use the available CPU count". Without this flag,
+    /// `--parallel` stays unbounded.
     #[arg(long, value_name = "N")]
     pub workspace_concurrency: Option<usize>,
     #[command(flatten)]
@@ -125,7 +133,7 @@ pub async fn run(
         script,
         args,
         no_install,
-        no_sort: _,
+        no_sort,
         if_present,
         inspect,
         inspect_brk,
@@ -133,11 +141,11 @@ pub async fn run(
         no_bail: _,
         report_summary: _,
         reporter_hide_prefix: _,
-        resume_from: _,
-        reverse: _,
+        resume_from,
+        reverse,
         silent,
         sort: _,
-        workspace_concurrency: _,
+        workspace_concurrency,
         lockfile: _,
         network: _,
         virtual_store: _,
@@ -148,10 +156,55 @@ pub async fn run(
         None => prompt_for_script()?,
     };
     let node_args = node_args_from_run_flags(inspect, inspect_brk);
+    let recursive = RecursiveOpts {
+        // pnpm parity: topo sort is on by default. `--sort` and
+        // `--no-sort` use clap `overrides_with`, so only one can land
+        // as `true`; default-false on both means "use the default",
+        // which is sort=on. We invert `no_sort` rather than reading
+        // `sort` so the absence of both flags maps to the default.
+        sort: !no_sort,
+        reverse,
+        resume_from,
+        workspace_concurrency,
+    };
     run_script_with(
-        &script, &args, &node_args, no_install, if_present, parallel, silent, &filter,
+        &script, &args, &node_args, no_install, if_present, parallel, silent, &filter, recursive,
     )
     .await
+}
+
+/// Recursive-run knobs surfaced by `RunArgs` / `ExecArgs`. Only relevant
+/// when a workspace filter is non-empty (sequential/single-package runs
+/// ignore them entirely). Bundled into one struct so `run_script_with`
+/// doesn't grow yet another arm of positional args.
+#[derive(Debug, Clone)]
+pub(crate) struct RecursiveOpts {
+    /// Topologically sort matched packages so deps run before dependents.
+    /// Default `true` to match pnpm.
+    pub sort: bool,
+    /// Reverse the (post-sort) execution order. Useful for teardown
+    /// scripts where dependents must shut down before their deps.
+    pub reverse: bool,
+    /// Skip ordered packages until this package name appears, then run
+    /// from there onward. Errors if the name isn't in the matched set.
+    pub resume_from: Option<String>,
+    /// Cap on concurrent package executions. `None` means
+    /// "unbounded under `--parallel`, sequential otherwise"; `Some(n)`
+    /// implicitly enables parallel mode at width `n` (matching pnpm,
+    /// where setting workspace-concurrency parallelizes by itself).
+    /// `Some(0)` means "use available CPU count".
+    pub workspace_concurrency: Option<usize>,
+}
+
+impl Default for RecursiveOpts {
+    fn default() -> Self {
+        Self {
+            sort: true,
+            reverse: false,
+            resume_from: None,
+            workspace_concurrency: None,
+        }
+    }
 }
 
 fn node_args_from_run_flags(inspect: Option<String>, inspect_brk: Option<String>) -> Vec<String> {
@@ -265,6 +318,7 @@ pub(crate) async fn run_script(
         false,
         silent,
         filter,
+        RecursiveOpts::default(),
     )
     .await
 }
@@ -279,6 +333,7 @@ pub(crate) async fn run_script_with(
     parallel: bool,
     silent: bool,
     filter: &aube_workspace::selector::EffectiveFilter,
+    recursive: RecursiveOpts,
 ) -> miette::Result<()> {
     let initial_cwd = crate::dirs::cwd()?;
     // Walk upward to the nearest `package.json` so `aube run` from a
@@ -319,6 +374,7 @@ pub(crate) async fn run_script_with(
             silent,
             filter,
             enable_pre_post_scripts,
+            recursive,
         )
         .await;
     }
@@ -363,11 +419,19 @@ pub(crate) async fn run_script_with(
     .await
 }
 
-/// Fan out a script over workspace packages matched by `filter`. Runs
-/// sequentially — packages are visited in directory-discovery order, each
-/// gets its own `ensure_installed` check, and the first non-zero exit
-/// aborts the fanout. Parallel execution is a deliberate follow-up: it
-/// requires output multiplexing that collides with the progress UI.
+/// Fan out a script over workspace packages matched by `filter`.
+///
+/// Ordering: matched packages are sorted topologically by intra-workspace
+/// deps (deps before dependents) when `recursive.sort` is true (default).
+/// `--reverse` flips that order; `--resume-from <name>` skips ahead to
+/// the named package in the post-sort, post-reverse list.
+///
+/// Concurrency: sequential by default (bail on first non-zero exit).
+/// `--parallel` spawns all packages at once and lets siblings finish
+/// before reporting the first failure (preserves output integrity).
+/// `--workspace-concurrency=N` caps that fanout to N workers and
+/// implicitly enables parallel mode if `--parallel` wasn't passed.
+/// `N = 0` means "use available CPU count".
 #[allow(clippy::too_many_arguments)]
 async fn run_script_filtered(
     cwd: &Path,
@@ -380,6 +444,7 @@ async fn run_script_filtered(
     silent: bool,
     filter: &aube_workspace::selector::EffectiveFilter,
     enable_pre_post_scripts: bool,
+    recursive: RecursiveOpts,
 ) -> miette::Result<()> {
     // `cwd` is the nearest ancestor with a `package.json`, which in a
     // monorepo subpackage is the child — not the workspace root. The
@@ -388,115 +453,27 @@ async fn run_script_filtered(
     // subpackage.
     let (_root, matched) = super::select_workspace_packages(cwd, filter, "run")?;
 
+    let matched = order_matched_packages(matched, &recursive)?;
+
     // Install once at the workspace root before fanning out — the
     // isolated linker already materializes every workspace package's
     // deps in a single pass, so per-package reinstalls would just
     // re-check the same lockfile N times.
     ensure_installed(no_install).await?;
 
-    if parallel {
-        // Unbounded parallel fanout. Spawn every matched package at
-        // once and let them all finish so the slowest task's output
-        // isn't clipped by an earlier failure. Use `exec_script_status`
-        // — `exec_script` calls `std::process::exit` on a non-zero
-        // exit, which would kill sibling tasks mid-run and make the
-        // collection loop below unreachable.
-        //
-        // Validate every package *before* spawning anything: an
-        // `Err` return after some handles already exist would drop
-        // them, and tokio does not cancel detached tasks — the
-        // orphaned shell children (`sh -c` on Unix, `cmd.exe /D /S
-        // /C` on Windows) would keep running until
-        // `std::process::exit` tore them down, which can corrupt
-        // partial artifacts mid-write.
-        let runnable: Vec<_> = matched
-            .into_iter()
-            .filter_map(|pkg| {
-                if pkg.manifest.scripts.contains_key(script) {
-                    Some(Ok((pkg, None)))
-                } else {
-                    let bin_path = super::project_modules_dir(&pkg.dir)
-                        .join(".bin")
-                        .join(script);
-                    if bin_path.exists() {
-                        return Some(Ok((pkg, Some(bin_path))));
-                    }
-                    if if_present {
-                        return None;
-                    }
-                    let name = pkg
-                        .name
-                        .clone()
-                        .unwrap_or_else(|| pkg.dir.display().to_string());
-                    Some(Err(miette!(
-                        "aube run: package {name} has no `{script}` script"
-                    )))
-                }
-            })
-            .collect::<miette::Result<Vec<_>>>()?;
-
-        let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
-            Vec::with_capacity(runnable.len());
-        let mut task_names: Vec<String> = Vec::with_capacity(runnable.len());
-        for (pkg, bin_path) in runnable {
-            let name = pkg
-                .name
-                .clone()
-                .unwrap_or_else(|| pkg.dir.display().to_string());
-            if !silent {
-                tracing::info!("aube run: {name} -> {script} (parallel)");
-            }
-            let script = script.to_string();
-            let args = args.to_vec();
-            let node_args = node_args.to_vec();
-            let dir = pkg.dir.clone();
-            let manifest = pkg.manifest.clone();
-            task_names.push(name);
-            tasks.push(tokio::spawn(async move {
-                if let Some(bin_path) = bin_path {
-                    super::exec::exec_bin_status_with_node_args(
-                        &dir, &bin_path, &script, &args, &node_args, false,
-                    )
-                    .await
-                } else {
-                    exec_script_status_chain(
-                        &dir,
-                        &manifest,
-                        &script,
-                        &args,
-                        &node_args,
-                        enable_pre_post_scripts,
-                    )
-                    .await
-                }
-            }));
-        }
-        let mut first_err: Option<miette::Report> = None;
-        let mut first_exit: Option<i32> = None;
-        for (t, name) in tasks.into_iter().zip(task_names) {
-            match t.await {
-                Ok(Ok(status)) => {
-                    if !status.success() && first_exit.is_none() {
-                        let code = aube_scripts::exit_code_from_status(status);
-                        first_exit = Some(code);
-                        first_err = Some(miette!(
-                            "aube run: `{script}` failed in {name} (exit {code})"
-                        ));
-                    }
-                }
-                Ok(Err(e)) if first_err.is_none() => first_err = Some(e),
-                Ok(Err(_)) => {}
-                Err(e) if first_err.is_none() => first_err = Some(miette!("task panicked: {e}")),
-                Err(_) => {}
-            }
-        }
-        if let Some(code) = first_exit {
-            std::process::exit(code);
-        }
-        if let Some(e) = first_err {
-            return Err(e);
-        }
-        return Ok(());
+    let concurrency = effective_concurrency(parallel, recursive.workspace_concurrency);
+    if concurrency > 1 {
+        return run_filtered_parallel(
+            script,
+            args,
+            node_args,
+            if_present,
+            silent,
+            enable_pre_post_scripts,
+            matched,
+            concurrency,
+        )
+        .await;
     }
 
     for pkg in &matched {
@@ -535,6 +512,182 @@ async fn run_script_filtered(
             enable_pre_post_scripts,
         )
         .await?;
+    }
+    Ok(())
+}
+
+/// Apply topo sort, reverse, and resume-from to a matched-package list.
+/// Pulled out so `aube exec -r` can share the exact same ordering rules
+/// — divergence between run and exec would surprise pnpm-muscle-memory
+/// users on the same monorepo.
+pub(crate) fn order_matched_packages(
+    mut matched: Vec<aube_workspace::selector::SelectedPackage>,
+    recursive: &RecursiveOpts,
+) -> miette::Result<Vec<aube_workspace::selector::SelectedPackage>> {
+    if recursive.sort {
+        matched = aube_workspace::topo::topological_sort(matched);
+    }
+    if recursive.reverse {
+        matched.reverse();
+    }
+    if let Some(name) = recursive.resume_from.as_deref() {
+        let idx = matched
+            .iter()
+            .position(|p| p.name.as_deref() == Some(name))
+            .ok_or_else(|| {
+                miette!(
+                    "aube run: --resume-from package `{name}` is not in the \
+                     matched workspace set"
+                )
+            })?;
+        matched.drain(..idx);
+    }
+    Ok(matched)
+}
+
+/// Map `--parallel` + `--workspace-concurrency` to a single concurrency
+/// cap. `1` means "use the sequential path" (bail-on-first behavior);
+/// any value `> 1` takes the bounded-parallel path. `usize::MAX` is the
+/// previous unbounded `--parallel` behavior.
+pub(crate) fn effective_concurrency(parallel: bool, workspace_concurrency: Option<usize>) -> usize {
+    match (parallel, workspace_concurrency) {
+        // pnpm: `workspace-concurrency=0` means "use available CPUs".
+        // `available_parallelism` is documented to never return 0 — but
+        // saturate to `1` defensively so a future change to that contract
+        // can't silently turn into "sequential" via underflow.
+        (_, Some(0)) => std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+            .max(1),
+        (_, Some(n)) => n,
+        // `--parallel` with no explicit cap preserves the historical
+        // unbounded fanout. Power users on a 200-package workspace who
+        // upgrade to a version with default-bounded parallel would be
+        // surprised by an apparent slowdown; keep the explicit
+        // unbounded request honored.
+        (true, None) => usize::MAX,
+        (false, None) => 1,
+    }
+}
+
+/// Bounded parallel fanout. Spawns a task per matched package and uses
+/// a [`tokio::sync::Semaphore`] to keep at most `concurrency` running at
+/// any moment. Mirrors the original parallel branch's behavior: validate
+/// every package up front (no orphaned children if a script-name lookup
+/// errors mid-spawn), let all started tasks finish so output isn't
+/// truncated by an early bail, and report the first non-zero exit's
+/// code through `std::process::exit`.
+#[allow(clippy::too_many_arguments)]
+async fn run_filtered_parallel(
+    script: &str,
+    args: &[String],
+    node_args: &[String],
+    if_present: bool,
+    silent: bool,
+    enable_pre_post_scripts: bool,
+    matched: Vec<aube_workspace::selector::SelectedPackage>,
+    concurrency: usize,
+) -> miette::Result<()> {
+    use std::sync::Arc;
+    use tokio::sync::Semaphore;
+
+    let runnable: Vec<_> = matched
+        .into_iter()
+        .filter_map(|pkg| {
+            if pkg.manifest.scripts.contains_key(script) {
+                Some(Ok((pkg, None)))
+            } else {
+                let bin_path = super::project_modules_dir(&pkg.dir)
+                    .join(".bin")
+                    .join(script);
+                if bin_path.exists() {
+                    return Some(Ok((pkg, Some(bin_path))));
+                }
+                if if_present {
+                    return None;
+                }
+                let name = pkg
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| pkg.dir.display().to_string());
+                Some(Err(miette!(
+                    "aube run: package {name} has no `{script}` script"
+                )))
+            }
+        })
+        .collect::<miette::Result<Vec<_>>>()?;
+
+    let sem = Arc::new(Semaphore::new(concurrency));
+    let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
+        Vec::with_capacity(runnable.len());
+    let mut task_names: Vec<String> = Vec::with_capacity(runnable.len());
+    for (pkg, bin_path) in runnable {
+        let name = pkg
+            .name
+            .clone()
+            .unwrap_or_else(|| pkg.dir.display().to_string());
+        if !silent {
+            tracing::info!("aube run: {name} -> {script} (parallel)");
+        }
+        let script = script.to_string();
+        let args = args.to_vec();
+        let node_args = node_args.to_vec();
+        let dir = pkg.dir.clone();
+        let manifest = pkg.manifest.clone();
+        let sem = Arc::clone(&sem);
+        task_names.push(name);
+        tasks.push(tokio::spawn(async move {
+            // The semaphore close path is unreachable — `sem` is held
+            // here via `Arc` and never closed — so `acquire_owned`
+            // failing would mean a logic bug. Surface as a miette
+            // error rather than panic so a future refactor that
+            // adds explicit closing surfaces gracefully.
+            let _permit = sem
+                .acquire_owned()
+                .await
+                .map_err(|e| miette!("workspace concurrency semaphore closed: {e}"))?;
+            if let Some(bin_path) = bin_path {
+                super::exec::exec_bin_status_with_node_args(
+                    &dir, &bin_path, &script, &args, &node_args, false,
+                )
+                .await
+            } else {
+                exec_script_status_chain(
+                    &dir,
+                    &manifest,
+                    &script,
+                    &args,
+                    &node_args,
+                    enable_pre_post_scripts,
+                )
+                .await
+            }
+        }));
+    }
+    let mut first_err: Option<miette::Report> = None;
+    let mut first_exit: Option<i32> = None;
+    for (t, name) in tasks.into_iter().zip(task_names) {
+        match t.await {
+            Ok(Ok(status)) => {
+                if !status.success() && first_exit.is_none() {
+                    let code = aube_scripts::exit_code_from_status(status);
+                    first_exit = Some(code);
+                    first_err = Some(miette!(
+                        "aube run: `{script}` failed in {name} (exit {code})"
+                    ));
+                }
+            }
+            Ok(Err(e)) if first_err.is_none() => first_err = Some(e),
+            Ok(Err(_)) => {}
+            Err(e) if first_err.is_none() => first_err = Some(miette!("task panicked: {e}")),
+            Err(_) => {}
+        }
+    }
+    if let Some(code) = first_exit {
+        std::process::exit(code);
+    }
+    if let Some(e) = first_err {
+        return Err(e);
     }
     Ok(())
 }
@@ -812,7 +965,115 @@ async fn exec_script_status_with_node_args(
 
 #[cfg(test)]
 mod tests {
-    use super::{inject_node_args, node_args_from_run_flags};
+    use super::{
+        RecursiveOpts, effective_concurrency, inject_node_args, node_args_from_run_flags,
+        order_matched_packages,
+    };
+    use aube_manifest::PackageJson;
+    use aube_workspace::selector::SelectedPackage;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    fn pkg(name: &str, deps: &[&str]) -> SelectedPackage {
+        let manifest = PackageJson {
+            name: Some(name.to_string()),
+            dependencies: deps
+                .iter()
+                .map(|d| ((*d).to_string(), "*".to_string()))
+                .collect::<BTreeMap<_, _>>(),
+            ..PackageJson::default()
+        };
+        SelectedPackage {
+            name: Some(name.to_string()),
+            version: None,
+            private: false,
+            dir: PathBuf::from(name),
+            manifest,
+        }
+    }
+
+    fn order_names(out: &[SelectedPackage]) -> Vec<&str> {
+        out.iter().map(|p| p.name.as_deref().unwrap()).collect()
+    }
+
+    #[test]
+    fn no_parallel_no_concurrency_is_sequential() {
+        assert_eq!(effective_concurrency(false, None), 1);
+    }
+
+    #[test]
+    fn parallel_alone_stays_unbounded() {
+        // Backward compat: existing scripts that pass `--parallel`
+        // expect the historical unbounded fanout.
+        assert_eq!(effective_concurrency(true, None), usize::MAX);
+    }
+
+    #[test]
+    fn concurrency_overrides_unbounded_parallel() {
+        assert_eq!(effective_concurrency(true, Some(4)), 4);
+    }
+
+    #[test]
+    fn concurrency_alone_implies_parallel() {
+        // pnpm parity: setting a concurrency cap parallelizes by
+        // itself, no separate `--parallel` needed.
+        assert_eq!(effective_concurrency(false, Some(3)), 3);
+    }
+
+    #[test]
+    fn concurrency_zero_picks_cpu_count() {
+        let n = effective_concurrency(false, Some(0));
+        assert!(n >= 1, "available_parallelism floor is 1");
+    }
+
+    #[test]
+    fn order_matched_applies_topo_then_reverse_then_resume() {
+        // app -> lib -> core. With sort+reverse, the natural order is
+        // [app, lib, core]; --resume-from=lib drops `app`.
+        let opts = RecursiveOpts {
+            sort: true,
+            reverse: true,
+            resume_from: Some("lib".to_string()),
+            workspace_concurrency: None,
+        };
+        let out = order_matched_packages(
+            vec![
+                pkg("app", &["lib"]),
+                pkg("lib", &["core"]),
+                pkg("core", &[]),
+            ],
+            &opts,
+        )
+        .unwrap();
+        assert_eq!(order_names(&out), vec!["lib", "core"]);
+    }
+
+    #[test]
+    fn order_matched_resume_from_unknown_package_errors() {
+        let opts = RecursiveOpts {
+            sort: false,
+            reverse: false,
+            resume_from: Some("nonexistent".to_string()),
+            workspace_concurrency: None,
+        };
+        let err = order_matched_packages(vec![pkg("a", &[])], &opts).unwrap_err();
+        assert!(err.to_string().contains("nonexistent"));
+    }
+
+    #[test]
+    fn order_matched_no_sort_preserves_input_order() {
+        let opts = RecursiveOpts {
+            sort: false,
+            reverse: false,
+            resume_from: None,
+            workspace_concurrency: None,
+        };
+        // Without sort, an app-before-lib input stays that way even
+        // though app depends on lib.
+        let out =
+            order_matched_packages(vec![pkg("app", &["lib"]), pkg("lib", &[])], &opts).unwrap();
+        assert_eq!(order_names(&out), vec!["app", "lib"]);
+    }
 
     #[test]
     fn node_args_from_flags_supports_optional_values() {

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -543,13 +543,17 @@ pub(crate) fn order_matched_packages(
         matched.reverse();
     }
     if let Some(name) = recursive.resume_from.as_deref() {
+        // Used by both `aube run -r` and `aube exec -r`, so the
+        // message intentionally doesn't name a specific subcommand.
+        // Miette already prefixes the diagnostic chain with the
+        // command context.
         let idx = matched
             .iter()
             .position(|p| p.name.as_deref() == Some(name))
             .ok_or_else(|| {
                 miette!(
-                    "aube run: --resume-from package `{name}` is not in the \
-                     matched workspace set"
+                    "--resume-from package `{name}` is not in the matched \
+                     workspace set"
                 )
             })?;
         matched.drain(..idx);
@@ -559,8 +563,12 @@ pub(crate) fn order_matched_packages(
 
 /// Map `--parallel` + `--workspace-concurrency` to a single concurrency
 /// cap. `1` means "use the sequential path" (bail-on-first behavior);
-/// any value `> 1` takes the bounded-parallel path. `usize::MAX` is the
-/// previous unbounded `--parallel` behavior.
+/// any value `> 1` takes the bounded-parallel path. `--parallel` alone
+/// resolves to [`tokio::sync::Semaphore::MAX_PERMITS`] (= `usize::MAX >> 3`),
+/// which is effectively unbounded for any real workspace and avoids
+/// the runtime panic `Semaphore::new(usize::MAX)` triggers on its
+/// internal `MAX_PERMITS` invariant. Any user-supplied cap is also
+/// clamped to that ceiling.
 pub(crate) fn effective_concurrency(parallel: bool, workspace_concurrency: Option<usize>) -> usize {
     match (parallel, workspace_concurrency) {
         // pnpm: `workspace-concurrency=0` means "use available CPUs".
@@ -571,26 +579,33 @@ pub(crate) fn effective_concurrency(parallel: bool, workspace_concurrency: Optio
             .map(|n| n.get())
             .unwrap_or(1)
             .max(1),
-        (_, Some(n)) => n,
+        (_, Some(n)) => n.min(tokio::sync::Semaphore::MAX_PERMITS),
         // `--parallel` with no explicit cap preserves the historical
         // unbounded fanout. Power users on a 200-package workspace who
         // upgrade to a version with default-bounded parallel would be
         // surprised by an apparent slowdown; keep the explicit
         // unbounded request honored.
-        (true, None) => usize::MAX,
+        (true, None) => tokio::sync::Semaphore::MAX_PERMITS,
         (false, None) => 1,
     }
 }
 
-/// Bounded parallel fanout. Spawns a task per matched package and uses
-/// a [`tokio::sync::Semaphore`] to keep at most `concurrency` running at
-/// any moment. Mirrors the original parallel branch's behavior: validate
-/// every package up front (no orphaned children if a script-name lookup
-/// errors mid-spawn), let all started tasks finish so output isn't
-/// truncated by an early bail, and report the first non-zero exit's
-/// code through `std::process::exit`. Output mode per task: prefixed
-/// (`<pkg>: <line>`, color-rotated) by default; unprefixed but still
-/// piped under `--reporter-hide-prefix`.
+/// Bounded parallel fanout with topo-aware ordering.
+///
+/// Each task waits for every intra-workspace dep to finish (success or
+/// failure) before claiming a [`tokio::sync::Semaphore`] permit. With
+/// `concurrency = N`, that gives at most `N` running at once *and* the
+/// dep-before-dependent invariant — without it, a chain `core → lib → app`
+/// at `--workspace-concurrency=2` would let `app` start while `lib` is
+/// still running once `core` released its slot.
+///
+/// Other guarantees preserved from the previous implementation:
+/// validate every package up front (no orphaned children if a
+/// script-name lookup errors mid-spawn), let every started task finish
+/// so output isn't truncated by an early bail, and report the first
+/// non-zero exit's code through `std::process::exit`. Output mode per
+/// task: prefixed (`<pkg>: <line>`, color-rotated) by default;
+/// unprefixed but still piped under `--reporter-hide-prefix`.
 #[allow(clippy::too_many_arguments)]
 async fn run_filtered_parallel(
     script: &str,
@@ -632,6 +647,21 @@ async fn run_filtered_parallel(
         })
         .collect::<miette::Result<Vec<_>>>()?;
 
+    // Compute prereqs against the post-`if_present` filtered set so a
+    // dependent doesn't deadlock waiting on a sibling that was skipped
+    // because it had no matching script.
+    let runnable_pkgs: Vec<aube_workspace::selector::SelectedPackage> =
+        runnable.iter().map(|(p, _)| p.clone()).collect();
+    let prereqs = aube_workspace::topo::compute_prereq_indices(&runnable_pkgs);
+    // One sender per package; dependents subscribe via `subscribe()`
+    // before spawning so the receiver exists when the prereq's task
+    // calls `send`. The initial receiver is dropped immediately —
+    // packages with no dependents have no subscribers, and `send` on
+    // a no-receiver channel is a benign Err we ignore.
+    let completion: Vec<tokio::sync::watch::Sender<bool>> = (0..runnable.len())
+        .map(|_| tokio::sync::watch::channel(false).0)
+        .collect();
+
     let sem = Arc::new(Semaphore::new(concurrency));
     let mut tasks: Vec<tokio::task::JoinHandle<miette::Result<std::process::ExitStatus>>> =
         Vec::with_capacity(runnable.len());
@@ -649,6 +679,11 @@ async fn run_filtered_parallel(
         } else {
             super::run_output::OutputMode::prefix(pkg.name.as_deref(), index)
         };
+        let prereq_rxs: Vec<tokio::sync::watch::Receiver<bool>> = prereqs[index]
+            .iter()
+            .map(|&j| completion[j].subscribe())
+            .collect();
+        let done_tx = completion[index].clone();
         let script = script.to_string();
         let args = args.to_vec();
         let node_args = node_args.to_vec();
@@ -657,6 +692,23 @@ async fn run_filtered_parallel(
         let sem = Arc::clone(&sem);
         task_names.push(name);
         tasks.push(tokio::spawn(async move {
+            // Topo barrier: hold off until every workspace dep has
+            // signaled `true` (= finished, regardless of outcome).
+            // pnpm's default `--no-bail=false` aborts the whole run on
+            // first failure anyway, so the "wait for failed dep too"
+            // case only fires under `--no-bail` (parsed but not yet
+            // wired) and degrades to "dependent runs against possibly
+            // stale dep state" — same as pnpm. A `changed()` Err means
+            // the prereq's sender was dropped without sending (panic
+            // or aborted JoinHandle); break to avoid deadlocking and
+            // let the script itself decide if its dep state is fatal.
+            for mut rx in prereq_rxs {
+                while !*rx.borrow_and_update() {
+                    if rx.changed().await.is_err() {
+                        break;
+                    }
+                }
+            }
             // The semaphore close path is unreachable — `sem` is held
             // here via `Arc` and never closed — so `acquire_owned`
             // failing would mean a logic bug. Surface as a miette
@@ -666,7 +718,7 @@ async fn run_filtered_parallel(
                 .acquire_owned()
                 .await
                 .map_err(|e| miette!("workspace concurrency semaphore closed: {e}"))?;
-            if let Some(bin_path) = bin_path {
+            let result = if let Some(bin_path) = bin_path {
                 super::exec::exec_bin_status_with_node_args(
                     &dir,
                     &bin_path,
@@ -688,7 +740,12 @@ async fn run_filtered_parallel(
                     &output_mode,
                 )
                 .await
-            }
+            };
+            // Always signal completion so dependents don't hang on a
+            // `changed()` that never fires. `send` on a watch with no
+            // subscribers returns Err, which we deliberately ignore.
+            let _ = done_tx.send(true);
+            result
         }));
     }
     let mut first_err: Option<miette::Report> = None;
@@ -1030,10 +1087,27 @@ mod tests {
     }
 
     #[test]
-    fn parallel_alone_stays_unbounded() {
+    fn parallel_alone_uses_semaphore_max_permits() {
         // Backward compat: existing scripts that pass `--parallel`
-        // expect the historical unbounded fanout.
-        assert_eq!(effective_concurrency(true, None), usize::MAX);
+        // expect effectively unbounded fanout. Use tokio's own
+        // `MAX_PERMITS` constant — `Semaphore::new(usize::MAX)` panics
+        // because tokio reserves the high bits internally, so this is
+        // the largest value we can hand to `Semaphore::new` without
+        // crashing on construction.
+        assert_eq!(
+            effective_concurrency(true, None),
+            tokio::sync::Semaphore::MAX_PERMITS
+        );
+    }
+
+    #[test]
+    fn explicit_concurrency_above_max_permits_is_clamped() {
+        // A user passing `--workspace-concurrency=usize::MAX` would
+        // otherwise hit the same Semaphore panic. The cap clamps it.
+        assert_eq!(
+            effective_concurrency(true, Some(usize::MAX)),
+            tokio::sync::Semaphore::MAX_PERMITS
+        );
     }
 
     #[test]

--- a/crates/aube/src/commands/run_output.rs
+++ b/crates/aube/src/commands/run_output.rs
@@ -100,9 +100,16 @@ pub(crate) async fn run_command(
         .take()
         .expect("stderr was piped above; take() must succeed");
 
-    let line_prefix = format_line_prefix(mode);
-    let stdout_pump = tokio::spawn(pump_lines(stdout, line_prefix.clone(), false));
-    let stderr_pump = tokio::spawn(pump_lines(stderr, line_prefix, true));
+    // Compute color gating per stream — stdout and stderr can have
+    // different TTY/redirection state (e.g. `aube run -r --parallel
+    // build 2>errors.log` keeps stdout on a TTY while stderr is a
+    // file). Using a single prefix would either color a non-TTY file
+    // or skip color on a real TTY for one of the streams.
+    let no_color = std::env::var_os("NO_COLOR").is_some();
+    let stdout_prefix = format_line_prefix(mode, std::io::stdout().is_terminal() && !no_color);
+    let stderr_prefix = format_line_prefix(mode, std::io::stderr().is_terminal() && !no_color);
+    let stdout_pump = tokio::spawn(pump_lines(stdout, stdout_prefix, false));
+    let stderr_pump = tokio::spawn(pump_lines(stderr, stderr_prefix, true));
 
     let status = child
         .wait()
@@ -127,12 +134,14 @@ pub(crate) async fn run_command(
 }
 
 /// Build the per-line prefix string up front so we don't re-format it
-/// on every line. Empty for [`OutputMode::NoPrefix`].
-fn format_line_prefix(mode: &OutputMode) -> String {
+/// on every line. Empty for [`OutputMode::NoPrefix`]. `color` is taken
+/// as a parameter rather than queried inside so callers can gate it
+/// per stream (stdout and stderr can have independent TTY state).
+fn format_line_prefix(mode: &OutputMode, color: bool) -> String {
     match mode {
         OutputMode::NoPrefix => String::new(),
         OutputMode::Prefix { name, color_index } => {
-            if std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+            if color {
                 let code = PALETTE[*color_index];
                 format!("\x1b[{code}m{name}\x1b[0m: ")
             } else {
@@ -230,30 +239,30 @@ mod tests {
     }
 
     #[test]
-    fn format_line_prefix_skips_color_when_no_color_env_set() {
-        // We can't easily flip `is_terminal()` in a test, but
-        // `NO_COLOR` is the gate that doesn't require a real TTY.
-        // Set it and observe that the formatted prefix stays plain.
-        // Use a guard to restore state even if the assertion fails.
-        struct EnvGuard {
-            had_value: Option<std::ffi::OsString>,
-        }
-        impl Drop for EnvGuard {
-            fn drop(&mut self) {
-                match self.had_value.take() {
-                    Some(v) => unsafe { std::env::set_var("NO_COLOR", v) },
-                    None => unsafe { std::env::remove_var("NO_COLOR") },
-                }
-            }
-        }
-        let _guard = EnvGuard {
-            had_value: std::env::var_os("NO_COLOR"),
-        };
-        unsafe { std::env::set_var("NO_COLOR", "1") };
-        let p = format_line_prefix(&OutputMode::Prefix {
-            name: "demo".to_string(),
-            color_index: 0,
-        });
+    fn format_line_prefix_skips_color_when_disabled() {
+        // The TTY/NO_COLOR resolution lives in the caller (per-stream),
+        // so the formatter only needs to react to a `color` flag. Pass
+        // `false` directly — no need to mutate process-global env state
+        // and race other tests on the same harness.
+        let p = format_line_prefix(
+            &OutputMode::Prefix {
+                name: "demo".to_string(),
+                color_index: 0,
+            },
+            false,
+        );
         assert_eq!(p, "demo: ");
+    }
+
+    #[test]
+    fn format_line_prefix_emits_ansi_when_color_enabled() {
+        let p = format_line_prefix(
+            &OutputMode::Prefix {
+                name: "demo".to_string(),
+                color_index: 0,
+            },
+            true,
+        );
+        assert_eq!(p, "\x1b[31mdemo\x1b[0m: ");
     }
 }

--- a/crates/aube/src/commands/run_output.rs
+++ b/crates/aube/src/commands/run_output.rs
@@ -1,0 +1,259 @@
+//! Per-package output prefixing for parallel recursive runs.
+//!
+//! `aube run -r --parallel` and `aube exec -r --parallel` (or any mode
+//! with `--workspace-concurrency`) need to keep the stdout/stderr from
+//! N concurrent child processes legible. The default mode here pipes
+//! both streams from each child, reads them line-by-line, and emits
+//! every line as `<pkg>: <line>` with a per-package ANSI color so the
+//! source of each line is unambiguous in a mixed-up scrollback.
+//!
+//! ## Trade-offs
+//!
+//! Piping child stdio loses TTY autodetection in the child, so most
+//! tools (tsc, vite, next, vitest, etc.) stop emitting their own ANSI
+//! colors. We deliberately do **not** set `FORCE_COLOR=1` to compensate:
+//! that env var is a sledgehammer that overrides legitimate
+//! `NO_COLOR` / CI heuristics in the child and produces broken output
+//! for tools whose `FORCE_COLOR` handling is incomplete. Users who want
+//! the child's native colors should run the recursive script
+//! sequentially (no `--parallel`, no `--workspace-concurrency`), where
+//! we keep stdio inherited and pnpm-style topo ordering still applies.
+//!
+//! ## Modes
+//!
+//! - [`OutputMode::Prefix`] — pipe + per-line `<name>: ` prefix in a
+//!   per-package color. The default for parallel runs.
+//! - [`OutputMode::NoPrefix`] — pipe but emit lines without the label.
+//!   Triggered by `--reporter-hide-prefix` for pnpm parity. Useful when
+//!   the user wants line-buffered (so it can be redirected without
+//!   torn writes) but doesn't care which package each line came from.
+//!
+//! Sequential (`aube run -r`, no `--parallel` / `--workspace-concurrency`)
+//! does not go through this module — those paths inherit stdio
+//! directly via `Command::status` so child color autodetection still
+//! works. Multiplexing only kicks in once the user opts into parallel
+//! and is paying for the loss of color anyway.
+
+use miette::{IntoDiagnostic, WrapErr, miette};
+use std::io::IsTerminal;
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::process::Command;
+
+/// 6 ANSI foreground colors rotated round-robin per package. SGR
+/// reset (`\x1b[0m`) is emitted after every prefix so a child line
+/// that itself contains escape codes can't bleed the package color
+/// onto subsequent lines.
+const PALETTE: &[u8] = &[31, 32, 33, 34, 35, 36];
+
+#[derive(Debug, Clone)]
+pub(crate) enum OutputMode {
+    /// Pipe child stdio and prepend `<name>: ` to every line, colored
+    /// from [`PALETTE`] when the parent stdout is a TTY.
+    Prefix { name: String, color_index: usize },
+    /// Pipe child stdio but emit lines as-is (no name prefix). Matches
+    /// pnpm's `--reporter-hide-prefix` semantics.
+    NoPrefix,
+}
+
+impl OutputMode {
+    /// Build a `Prefix` mode for the given package name and index in
+    /// the matched-package list. Falls back to `NoPrefix` if the
+    /// package has no name (degenerate manifest with `name` unset),
+    /// since a colored empty prefix is just confusing noise.
+    pub(crate) fn prefix(name: Option<&str>, index: usize) -> Self {
+        match name {
+            Some(n) => Self::Prefix {
+                name: n.to_string(),
+                color_index: index % PALETTE.len(),
+            },
+            None => Self::NoPrefix,
+        }
+    }
+}
+
+/// Run `cmd` to completion, piping its stdout/stderr through line
+/// pumps that prepend `mode`'s prefix to every line. Both `Prefix` and
+/// `NoPrefix` modes pipe; the only difference is the formatted prefix
+/// string. `wait()` runs concurrently with the pump tasks so we don't
+/// drop output if the child exits before the pipes drain.
+pub(crate) async fn run_command(
+    mut cmd: Command,
+    mode: &OutputMode,
+) -> miette::Result<std::process::ExitStatus> {
+    cmd.stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = cmd
+        .spawn()
+        .into_diagnostic()
+        .wrap_err("failed to spawn child process")?;
+    // `.expect` is sound here: we just set both streams to `piped()`
+    // above, so `take()` on either is guaranteed to return `Some`.
+    // Surfacing this as `unwrap_or_else` -> miette would only ever
+    // fire on a future stdio refactor that bypassed the lines above,
+    // and that's exactly the sort of bug we want to crash loudly on.
+    let stdout = child
+        .stdout
+        .take()
+        .expect("stdout was piped above; take() must succeed");
+    let stderr = child
+        .stderr
+        .take()
+        .expect("stderr was piped above; take() must succeed");
+
+    let line_prefix = format_line_prefix(mode);
+    let stdout_pump = tokio::spawn(pump_lines(stdout, line_prefix.clone(), false));
+    let stderr_pump = tokio::spawn(pump_lines(stderr, line_prefix, true));
+
+    let status = child
+        .wait()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to wait on child process")?;
+
+    // Pumps will see EOF once the child closes its pipe ends on exit
+    // and finish on their own. JoinHandle errors here can only be a
+    // panic in the pump (genuinely unexpected) or a cancellation
+    // (we never cancel them). Surface so a future refactor can't
+    // silently swallow a pump panic.
+    stdout_pump
+        .await
+        .map_err(|e| miette!("stdout pump task failed: {e}"))?
+        .map_err(|e| miette!("stdout pump io error: {e}"))?;
+    stderr_pump
+        .await
+        .map_err(|e| miette!("stderr pump task failed: {e}"))?
+        .map_err(|e| miette!("stderr pump io error: {e}"))?;
+    Ok(status)
+}
+
+/// Build the per-line prefix string up front so we don't re-format it
+/// on every line. Empty for [`OutputMode::NoPrefix`].
+fn format_line_prefix(mode: &OutputMode) -> String {
+    match mode {
+        OutputMode::NoPrefix => String::new(),
+        OutputMode::Prefix { name, color_index } => {
+            if std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+                let code = PALETTE[*color_index];
+                format!("\x1b[{code}m{name}\x1b[0m: ")
+            } else {
+                format!("{name}: ")
+            }
+        }
+    }
+}
+
+/// Drain `reader` line-by-line, emitting each line through `print!` /
+/// `eprint!` with `prefix` prepended. `is_stderr` selects which stream
+/// to write to so child stderr stays distinguishable for callers
+/// piping aube's own stderr separately.
+///
+/// Uses `read_line` (UTF-8) rather than `read_until(b'\n')` because
+/// npm-style script output is always text. A child that emits invalid
+/// UTF-8 surfaces an io error here, which propagates as a pump
+/// failure — visible noise rather than silently dropped output.
+async fn pump_lines<R>(reader: R, prefix: String, is_stderr: bool) -> std::io::Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut reader = BufReader::new(reader);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Ok(());
+        }
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        if is_stderr {
+            eprintln!("{prefix}{trimmed}");
+        } else {
+            println!("{prefix}{trimmed}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exercise the full pipe + pump path: a child that writes a known
+    /// sequence of lines to both stdout and stderr should produce a
+    /// successful `ExitStatus` with the pumps draining cleanly.
+    #[tokio::test]
+    async fn run_command_with_prefix_drains_both_streams() {
+        // `printf` over `sh -c` is portable enough across the unix
+        // CI matrices we care about; aube already tests this way in
+        // bats. Skip on Windows — the script invocation differs and
+        // the multiplexer is unix-tested via real run/exec usage.
+        if cfg!(windows) {
+            return;
+        }
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.arg("-c").arg("echo out1; echo err1 1>&2; echo out2");
+        let mode = OutputMode::Prefix {
+            name: "demo".to_string(),
+            color_index: 0,
+        };
+        let status = run_command(cmd, &mode).await.unwrap();
+        assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn run_command_no_prefix_mode_still_pipes() {
+        // `NoPrefix` mode pipes the same way `Prefix` does — only the
+        // formatted prefix is empty. A child that exits cleanly with
+        // no output should still produce a successful status.
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.arg("-c").arg("true");
+        let status = run_command(cmd, &OutputMode::NoPrefix).await.unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    fn prefix_color_rotates_modulo_palette() {
+        // Same package name at indices 0 and PALETTE.len() should
+        // pick the same color slot — round-robin without overflow.
+        let a = OutputMode::prefix(Some("foo"), 0);
+        let b = OutputMode::prefix(Some("foo"), PALETTE.len());
+        match (a, b) {
+            (
+                OutputMode::Prefix { color_index: i, .. },
+                OutputMode::Prefix { color_index: j, .. },
+            ) => assert_eq!(i, j),
+            _ => panic!("named pkg should produce Prefix mode"),
+        }
+    }
+
+    #[test]
+    fn unnamed_pkg_falls_back_to_noprefix() {
+        assert!(matches!(OutputMode::prefix(None, 3), OutputMode::NoPrefix));
+    }
+
+    #[test]
+    fn format_line_prefix_skips_color_when_no_color_env_set() {
+        // We can't easily flip `is_terminal()` in a test, but
+        // `NO_COLOR` is the gate that doesn't require a real TTY.
+        // Set it and observe that the formatted prefix stays plain.
+        // Use a guard to restore state even if the assertion fails.
+        struct EnvGuard {
+            had_value: Option<std::ffi::OsString>,
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match self.had_value.take() {
+                    Some(v) => unsafe { std::env::set_var("NO_COLOR", v) },
+                    None => unsafe { std::env::remove_var("NO_COLOR") },
+                }
+            }
+        }
+        let _guard = EnvGuard {
+            had_value: std::env::var_os("NO_COLOR"),
+        };
+        unsafe { std::env::set_var("NO_COLOR", "1") };
+        let p = format_line_prefix(&OutputMode::Prefix {
+            name: "demo".to_string(),
+            color_index: 0,
+        });
+        assert_eq!(p, "demo: ");
+    }
+}

--- a/crates/aube/src/commands/run_output.rs
+++ b/crates/aube/src/commands/run_output.rs
@@ -151,10 +151,13 @@ fn format_line_prefix(mode: &OutputMode, color: bool) -> String {
     }
 }
 
-/// Drain `reader` line-by-line, emitting each line through `print!` /
-/// `eprint!` with `prefix` prepended. `is_stderr` selects which stream
-/// to write to so child stderr stays distinguishable for callers
-/// piping aube's own stderr separately.
+/// Drain `reader` line-by-line, emitting each line with `prefix`
+/// prepended. `is_stderr` selects the destination stream so child
+/// stderr stays distinguishable for callers piping aube's own stderr
+/// separately. Stderr lines route through `aube_scripts` so the
+/// `SilentStderrGuard`'s saved real-stderr fd is honored — under
+/// `--silent` aube redirects fd 2 to `/dev/null`, and `eprintln!` would
+/// silently drop child stderr in `--silent --parallel` mode.
 ///
 /// Uses `read_line` (UTF-8) rather than `read_until(b'\n')` because
 /// npm-style script output is always text. A child that emits invalid
@@ -174,7 +177,7 @@ where
         }
         let trimmed = line.trim_end_matches(['\n', '\r']);
         if is_stderr {
-            eprintln!("{prefix}{trimmed}");
+            aube_scripts::write_line_to_real_stderr(&format!("{prefix}{trimmed}"));
         } else {
             println!("{prefix}{trimmed}");
         }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3485,9 +3485,9 @@
           {
             "name": "reporter-hide-prefix",
             "usage": "--reporter-hide-prefix",
-            "help": "Hide package prefixes in recursive reporter output",
-            "help_long": "Hide package prefixes in recursive reporter output.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Hide package prefixes in recursive reporter output",
+            "help": "Hide the `<package>: ` label on parallel-exec output lines",
+            "help_long": "Hide the `<package>: ` label on parallel-exec output lines.\n\nLines are still piped (clean line breaks even with concurrent children) but the source package isn't named on each line. Sequential execs ignore this flag.",
+            "help_first_line": "Hide the `<package>: ` label on parallel-exec output lines",
             "short": [],
             "long": [
               "reporter-hide-prefix"
@@ -8435,7 +8435,7 @@
             "name": "parallel",
             "usage": "--parallel",
             "help": "Run the script in every matched workspace package concurrently",
-            "help_long": "Run the script in every matched workspace package concurrently.\n\nUnbounded parallelism. Pair with a filter (`-r` / `-F`) — single-package runs ignore it. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated.",
+            "help_long": "Run the script in every matched workspace package concurrently.\n\nUnbounded parallelism. Pair with `--workspace-concurrency=N` to cap the worker count. Single-package runs ignore this flag. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated. Child stdio is piped and lines are emitted with a `<package>: ` prefix; pass `--reporter-hide-prefix` to drop the labels.",
             "help_first_line": "Run the script in every matched workspace package concurrently",
             "short": [],
             "long": [
@@ -8460,9 +8460,9 @@
           {
             "name": "reporter-hide-prefix",
             "usage": "--reporter-hide-prefix",
-            "help": "Hide package prefixes in recursive reporter output",
-            "help_long": "Hide package prefixes in recursive reporter output.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Hide package prefixes in recursive reporter output",
+            "help": "Hide the `<package>: ` label on parallel-run output lines",
+            "help_long": "Hide the `<package>: ` label on parallel-run output lines.\n\nLines are still piped through aube (so the line breaks are clean even when many packages run at once), but the source package isn't named on each line. Sequential runs ignore this flag.",
+            "help_first_line": "Hide the `<package>: ` label on parallel-run output lines",
             "short": [],
             "long": [
               "reporter-hide-prefix"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3447,9 +3447,9 @@
           {
             "name": "no-sort",
             "usage": "--no-sort",
-            "help": "Disable topological sorting",
-            "help_long": "Disable topological sorting.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Disable topological sorting",
+            "help": "Disable topological sorting (default is on)",
+            "help_long": "Disable topological sorting (default is on).\n\nWithout this, recursive execs visit packages in a deps-first order. Pass this to fall back to raw workspace-listing order.",
+            "help_first_line": "Disable topological sorting (default is on)",
             "short": [],
             "long": [
               "no-sort"
@@ -3498,9 +3498,9 @@
           {
             "name": "resume-from",
             "usage": "--resume-from <PACKAGE>",
-            "help": "Resume recursive execution from a package name",
-            "help_long": "Resume recursive execution from a package name.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Resume recursive execution from a package name",
+            "help": "Resume recursive execution starting at this package name",
+            "help_long": "Resume recursive execution starting at this package name.\n\nPackages before the named one in the post-sort, post-reverse order are skipped. Errors if the name isn't in the matched set.",
+            "help_first_line": "Resume recursive execution starting at this package name",
             "short": [],
             "long": [
               "resume-from"
@@ -3518,9 +3518,8 @@
           {
             "name": "reverse",
             "usage": "--reverse",
-            "help": "Run recursive packages in reverse order",
-            "help_long": "Run recursive packages in reverse order.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Run recursive packages in reverse order",
+            "help": "Reverse the recursive execution order (after topo sort)",
+            "help_first_line": "Reverse the recursive execution order (after topo sort)",
             "short": [],
             "long": [
               "reverse"
@@ -3545,9 +3544,9 @@
           {
             "name": "sort",
             "usage": "--sort",
-            "help": "Sort recursive packages topologically",
-            "help_long": "Sort recursive packages topologically.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Sort recursive packages topologically",
+            "help": "Sort recursive packages topologically (this is the default)",
+            "help_long": "Sort recursive packages topologically (this is the default).\n\nPass to override an earlier `--no-sort` on the same invocation.",
+            "help_first_line": "Sort recursive packages topologically (this is the default)",
             "short": [],
             "long": [
               "sort"
@@ -3558,9 +3557,9 @@
           {
             "name": "workspace-concurrency",
             "usage": "--workspace-concurrency <N>",
-            "help": "Recursive workspace concurrency",
-            "help_long": "Recursive workspace concurrency.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Recursive workspace concurrency",
+            "help": "Cap the number of recursive packages running at once",
+            "help_long": "Cap the number of recursive packages running at once.\n\nSetting this implicitly enables parallel mode at width `N`. `0` means \"use the available CPU count\". Without this flag, `--parallel` stays unbounded.",
+            "help_first_line": "Cap the number of recursive packages running at once",
             "short": [],
             "long": [
               "workspace-concurrency"
@@ -8422,9 +8421,9 @@
           {
             "name": "no-sort",
             "usage": "--no-sort",
-            "help": "Disable topological sorting",
-            "help_long": "Disable topological sorting.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Disable topological sorting",
+            "help": "Disable topological sorting (default is on)",
+            "help_long": "Disable topological sorting (default is on).\n\nWithout this, recursive runs visit packages in a deps-first order so a `build` script in a shared library finishes before a dependent app's `build` starts. Pass this to fall back to the raw workspace-listing order.",
+            "help_first_line": "Disable topological sorting (default is on)",
             "short": [],
             "long": [
               "no-sort"
@@ -8474,9 +8473,9 @@
           {
             "name": "resume-from",
             "usage": "--resume-from <PACKAGE>",
-            "help": "Resume recursive execution from a package name",
-            "help_long": "Resume recursive execution from a package name.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Resume recursive execution from a package name",
+            "help": "Resume recursive execution starting at this package name",
+            "help_long": "Resume recursive execution starting at this package name.\n\nAfter the topo sort and `--reverse` are applied, packages before the named one in the resulting order are skipped. Errors if the name isn't in the matched workspace set.",
+            "help_first_line": "Resume recursive execution starting at this package name",
             "short": [],
             "long": [
               "resume-from"
@@ -8494,9 +8493,9 @@
           {
             "name": "reverse",
             "usage": "--reverse",
-            "help": "Run recursive packages in reverse order",
-            "help_long": "Run recursive packages in reverse order.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Run recursive packages in reverse order",
+            "help": "Reverse the recursive execution order (after topo sort)",
+            "help_long": "Reverse the recursive execution order (after topo sort).\n\nUseful for teardown-style scripts where dependents must shut down before their deps.",
+            "help_first_line": "Reverse the recursive execution order (after topo sort)",
             "short": [],
             "long": [
               "reverse"
@@ -8507,9 +8506,9 @@
           {
             "name": "sort",
             "usage": "--sort",
-            "help": "Sort recursive packages topologically",
-            "help_long": "Sort recursive packages topologically.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Sort recursive packages topologically",
+            "help": "Sort recursive packages topologically (this is the default)",
+            "help_long": "Sort recursive packages topologically (this is the default).\n\nPass to override an earlier `--no-sort` on the same invocation.",
+            "help_first_line": "Sort recursive packages topologically (this is the default)",
             "short": [],
             "long": [
               "sort"
@@ -8533,9 +8532,9 @@
           {
             "name": "workspace-concurrency",
             "usage": "--workspace-concurrency <N>",
-            "help": "Recursive workspace concurrency",
-            "help_long": "Recursive workspace concurrency.\n\nParsed for pnpm compatibility.",
-            "help_first_line": "Recursive workspace concurrency",
+            "help": "Cap the number of recursive packages running at once",
+            "help_long": "Cap the number of recursive packages running at once.\n\nSetting this implicitly enables parallel mode at width `N`. `0` means \"use the available CPU count\". Without this flag, `--parallel` stays unbounded.",
+            "help_first_line": "Cap the number of recursive packages running at once",
             "short": [],
             "long": [
               "workspace-concurrency"

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -46,9 +46,9 @@ Parsed for pnpm compatibility.
 
 ### `--reporter-hide-prefix`
 
-Hide package prefixes in recursive reporter output.
+Hide the `<package>: ` label on parallel-exec output lines.
 
-Parsed for pnpm compatibility.
+Lines are still piped (clean line breaks even with concurrent children) but the source package isn't named on each line. Sequential execs ignore this flag.
 
 ### `--resume-from <PACKAGE>`
 

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -30,9 +30,9 @@ Skip auto-install check
 
 ### `--no-sort`
 
-Disable topological sorting.
+Disable topological sorting (default is on).
 
-Parsed for pnpm compatibility.
+Without this, recursive execs visit packages in a deps-first order. Pass this to fall back to raw workspace-listing order.
 
 ### `--parallel`
 
@@ -52,15 +52,13 @@ Parsed for pnpm compatibility.
 
 ### `--resume-from <PACKAGE>`
 
-Resume recursive execution from a package name.
+Resume recursive execution starting at this package name.
 
-Parsed for pnpm compatibility.
+Packages before the named one in the post-sort, post-reverse order are skipped. Errors if the name isn't in the matched set.
 
 ### `--reverse`
 
-Run recursive packages in reverse order.
-
-Parsed for pnpm compatibility.
+Reverse the recursive execution order (after topo sort)
 
 ### `-c --shell-mode`
 
@@ -68,15 +66,15 @@ Run the command through `sh -c`
 
 ### `--sort`
 
-Sort recursive packages topologically.
+Sort recursive packages topologically (this is the default).
 
-Parsed for pnpm compatibility.
+Pass to override an earlier `--no-sort` on the same invocation.
 
 ### `--workspace-concurrency <N>`
 
-Recursive workspace concurrency.
+Cap the number of recursive packages running at once.
 
-Parsed for pnpm compatibility.
+Setting this implicitly enables parallel mode at width `N`. `0` means "use the available CPU count". Without this flag, `--parallel` stays unbounded.
 
 ### `--frozen-lockfile`
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -51,7 +51,7 @@ Without this, recursive runs visit packages in a deps-first order so a `build` s
 
 Run the script in every matched workspace package concurrently.
 
-Unbounded parallelism. Pair with a filter (`-r` / `-F`) — single-package runs ignore it. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated.
+Unbounded parallelism. Pair with `--workspace-concurrency=N` to cap the worker count. Single-package runs ignore this flag. First non-zero exit fails the whole run, but siblings are allowed to finish so their output isn't truncated. Child stdio is piped and lines are emitted with a `<package>: ` prefix; pass `--reporter-hide-prefix` to drop the labels.
 
 ### `--report-summary`
 
@@ -61,9 +61,9 @@ Parsed for pnpm compatibility.
 
 ### `--reporter-hide-prefix`
 
-Hide package prefixes in recursive reporter output.
+Hide the `<package>: ` label on parallel-run output lines.
 
-Parsed for pnpm compatibility.
+Lines are still piped through aube (so the line breaks are clean even when many packages run at once), but the source package isn't named on each line. Sequential runs ignore this flag.
 
 ### `--resume-from <PACKAGE>`
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -43,9 +43,9 @@ Skip auto-install check
 
 ### `--no-sort`
 
-Disable topological sorting.
+Disable topological sorting (default is on).
 
-Parsed for pnpm compatibility.
+Without this, recursive runs visit packages in a deps-first order so a `build` script in a shared library finishes before a dependent app's `build` starts. Pass this to fall back to the raw workspace-listing order.
 
 ### `--parallel`
 
@@ -67,21 +67,21 @@ Parsed for pnpm compatibility.
 
 ### `--resume-from <PACKAGE>`
 
-Resume recursive execution from a package name.
+Resume recursive execution starting at this package name.
 
-Parsed for pnpm compatibility.
+After the topo sort and `--reverse` are applied, packages before the named one in the resulting order are skipped. Errors if the name isn't in the matched workspace set.
 
 ### `--reverse`
 
-Run recursive packages in reverse order.
+Reverse the recursive execution order (after topo sort).
 
-Parsed for pnpm compatibility.
+Useful for teardown-style scripts where dependents must shut down before their deps.
 
 ### `--sort`
 
-Sort recursive packages topologically.
+Sort recursive packages topologically (this is the default).
 
-Parsed for pnpm compatibility.
+Pass to override an earlier `--no-sort` on the same invocation.
 
 ### `-s`
 
@@ -91,9 +91,9 @@ Short alias for the global `--silent` flag; long form is intentionally omitted t
 
 ### `--workspace-concurrency <N>`
 
-Recursive workspace concurrency.
+Cap the number of recursive packages running at once.
 
-Parsed for pnpm compatibility.
+Setting this implicitly enables parallel mode at width `N`. `0` means "use the available CPU count". Without this flag, `--parallel` stays unbounded.
 
 ### `--frozen-lockfile`
 

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -607,6 +607,12 @@
       "category": "Progress UI",
       "description": "Install progress numerator exceeded the resolved-package denominator. Display clamps to total; the warning surfaces the bookkeeping mismatch so the underlying race can be diagnosed.",
       "exit_code": null
+    },
+    {
+      "name": "WARN_AUBE_WORKSPACE_TOPO_CYCLE",
+      "category": "Workspace recursion",
+      "description": "Topological sort of `aube run -r` / `aube exec -r` selected packages found a dependency cycle. Cycle members run in workspace-listing order after the rest of the topo-sorted set.",
+      "exit_code": null
     }
   ],
   "categories": {
@@ -633,7 +639,8 @@
       "Registry TLS / proxy",
       "Resolver",
       "Lockfile",
-      "Progress UI"
+      "Progress UI",
+      "Workspace recursion"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Closes the `aube run -r` / `aube exec -r` no-op flags and the parallel output legibility gap, all in one PR.

### Wired flags (previously parsed-but-ignored)
- **`--sort` / `--no-sort`** (default sort=on, pnpm parity): topo-sort matched packages by intra-workspace deps so deps run before dependents. New `aube_workspace::topo` module — Kahn's algorithm with stable insertion-order tiebreaks. Cycles fall back to listing order with `WARN_AUBE_WORKSPACE_TOPO_CYCLE` naming the cycle members.
- **`--reverse`**: flips the post-sort order (teardown-style).
- **`--resume-from <PACKAGE>`**: skips ahead to the named package; errors if not in matched set.
- **`--workspace-concurrency=N`**: caps parallel fanout via `tokio::sync::Semaphore`. Setting `N` implicitly enables parallel; `N=0` uses CPU count. Bare `--parallel` stays effectively unbounded — capped at `Semaphore::MAX_PERMITS` to dodge tokio's runtime panic on `usize::MAX`.
- **`--reporter-hide-prefix`**: switches parallel-run output from `<pkg>: <line>` to plain piped lines.

### Topo correctness in bounded-parallel
A semaphore alone caps simultaneous tasks but doesn't enforce dep-completion-before-dependent-start. Added a per-package `tokio::sync::watch::Sender<bool>` completion signal: each task subscribes to its prereqs' channels before spawning and awaits their `true` signal before claiming a permit. Dependents wait for "finished" (success or failure) so the barrier never deadlocks on a panicked sibling. New `aube_workspace::topo::compute_prereq_indices` helper is shared between `run` and `exec` parallel paths.

### Output multiplexer for parallel
New `commands/run_output` module pipes child stdout/stderr from each parallel task and emits each line as `<pkg>: <line>` with a per-package ANSI color (rotated from a six-color palette). `--reporter-hide-prefix` drops the label but keeps the line buffering; sequential runs still inherit stdio directly so child color autodetection keeps working there.

**Color trade-off**: piping kills child TTY autodetection, so most tools stop emitting color. We deliberately do **not** set `FORCE_COLOR=1` to compensate — that would override legitimate `NO_COLOR` / CI heuristics in the child and produce broken output for tools whose `FORCE_COLOR` handling is incomplete. Users who need child-native colors should run sequentially.

### Shared between run and exec
`RecursiveOpts`, `order_matched_packages`, `effective_concurrency`, and `compute_prereq_indices` are shared so the two subcommands can't drift on ordering / concurrency / dep-graph rules.

### Deferred to follow-up PRs
- `--no-bail` (orthogonal: changes parallel/sequential failure semantics)
- `--report-summary` (needs a stable JSON schema)
- KeepOrder-style buffered output mode (mise's `--output=keep-order` analogue) — a real win once the multiplexer is in place but a meaningful expansion of state

### Test plan
- [x] `cargo test --workspace` — green; new tests: 9 in `aube_workspace::topo` (chains, diamonds, cycles, dev/peer edges, prereq-index, dedup), 8 in `aube::run` dispatcher (concurrency policy, ordering, semaphore clamp), 5 in `aube::run_output` (pipe + pump path, NoPrefix mode, color rotation, NO_COLOR honoring, unnamed-pkg fallback)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo run -p aube-codes --bin generate-error-codes-docs` — `WARN_AUBE_WORKSPACE_TOPO_CYCLE` flows into `docs/error-codes.data.json`
- [x] Bats `aube exec --parallel fans out across workspace packages` (was panicking on `Semaphore::new(usize::MAX)`)
- [ ] Real-monorepo smoke: `aube run -r --workspace-concurrency=4 build` should cap at 4 workers, in topo order, with prefixed colored output
- [ ] Smoke `aube run -r --resume-from=lib build` after a mid-run failure recovers from the right package

*This PR was generated by Claude.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core behavior of `aube run -r`/`aube exec -r` by enabling default topo ordering, reverse/resume semantics, and new bounded-parallel execution with output piping, which could affect monorepo script ordering and failure modes under concurrency.
> 
> **Overview**
> **Finishes wiring recursive workspace execution controls for `aube run -r` and `aube exec -r`.** Recursive runs now *default to topologically sorting* matched packages by intra-workspace deps, support `--reverse` and `--resume-from`, and share a single ordering/concurrency implementation via `RecursiveOpts`.
> 
> **Adds bounded parallelism and a parallel output multiplexer.** `--workspace-concurrency` now caps parallel fanout (and implies parallel mode), enforcing dep-completion barriers even under concurrency; parallel runs pipe child stdio and emit line-buffered output with per-package `<pkg>: ` prefixes (optionally hidden via `--reporter-hide-prefix`).
> 
> **Adds cycle handling + diagnostics.** New `aube_workspace::topo` implements stable topo sort and prereq graph helpers with cycle fallback and emits `WARN_AUBE_WORKSPACE_TOPO_CYCLE`; CLI/docs/help text are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56572603a40df10c5d55e0201e984a492b96930f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->