### PR TITLE
fix(install): inherit build approvals for git prepare

### DIFF
--- a/crates/aube-scripts/src/policy.rs
+++ b/crates/aube-scripts/src/policy.rs
@@ -231,6 +231,24 @@ impl BuildPolicy {
     pub fn has_any_allow_rule(&self) -> bool {
         self.allow_all || !self.allowed.is_empty() || !self.allowed_wildcards.is_empty()
     }
+
+    /// Merge another resolved policy into this one. Denies from either
+    /// policy still win at decision time.
+    pub fn merge(&mut self, other: &Self) {
+        self.allow_all |= other.allow_all;
+        self.allowed.extend(other.allowed.iter().cloned());
+        self.denied.extend(other.denied.iter().cloned());
+        merge_unique(&mut self.allowed_wildcards, &other.allowed_wildcards);
+        merge_unique(&mut self.denied_wildcards, &other.denied_wildcards);
+    }
+}
+
+fn merge_unique(target: &mut Vec<String>, source: &[String]) {
+    for value in source {
+        if !target.iter().any(|existing| existing == value) {
+            target.push(value.clone());
+        }
+    }
 }
 
 /// True when a package-pattern entry matches `(name, version)`.
@@ -548,6 +566,23 @@ mod tests {
         let (p, errs) = BuildPolicy::from_config(&map, &[], &never_built, false);
         assert!(errs.is_empty());
         assert_eq!(p.decide("esbuild", "0.19.0"), AllowDecision::Deny);
+    }
+
+    #[test]
+    fn merge_deduplicates_wildcards() {
+        let mut p = policy(&[("@babel/*", true), ("*-internal", false)]);
+        let other = policy(&[
+            ("@babel/*", true),
+            ("@types/*", true),
+            ("*-internal", false),
+        ]);
+        p.merge(&other);
+        p.merge(&other);
+
+        assert_eq!(p.allowed_wildcards, vec!["@babel/*", "@types/*"]);
+        assert_eq!(p.denied_wildcards, vec!["*-internal"]);
+        assert_eq!(p.decide("@types/node", "1.0.0"), AllowDecision::Allow);
+        assert_eq!(p.decide("pkg-internal", "1.0.0"), AllowDecision::Deny);
     }
 
     #[test]

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -80,6 +80,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         cli_flags: Vec::new(),
         env_snapshot: aube_settings::values::capture_env(),
         git_prepare_depth: 0,
+        inherited_build_policy: None,
         workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
         skip_root_lifecycle: false,
     };

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -287,6 +287,7 @@ pub async fn run(
             cli_flags: Vec::new(),
             env_snapshot: aube_settings::values::capture_env(),
             git_prepare_depth: 0,
+            inherited_build_policy: None,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
             skip_root_lifecycle: false,
         };

--- a/crates/aube/src/commands/install/git_prepare.rs
+++ b/crates/aube/src/commands/install/git_prepare.rs
@@ -96,6 +96,7 @@ pub(super) async fn run_git_dep_prepare(
     spec: &str,
     ignore_scripts: bool,
     depth: u32,
+    inherited_build_policy: Option<std::sync::Arc<aube_scripts::BuildPolicy>>,
 ) -> miette::Result<()> {
     if depth >= GIT_PREPARE_MAX_DEPTH {
         return Err(miette!(
@@ -106,6 +107,7 @@ pub(super) async fn run_git_dep_prepare(
     opts.project_dir = Some(clone_dir.to_path_buf());
     opts.ignore_scripts = ignore_scripts;
     opts.git_prepare_depth = depth + 1;
+    opts.inherited_build_policy = inherited_build_policy;
     // Override the chained-call default: this nested install's "root" IS
     // the git dep itself, and running its `prepare` (plus
     // pre/post-install) is the entire point of git-dep preparation.

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -224,28 +224,6 @@ fn resolve_jail_grant_path(project_dir: &std::path::Path, raw: &str) -> std::pat
     }
 }
 
-/// Resolve the prewarm-shared bits used by both the lockfile and
-/// no-lockfile materializer setup paths: node engine version (for
-/// graph-hash domain split) plus the build-policy decision oracle
-/// (for graph-hash patch fold). Hoisted so both branches compute
-/// identical hashes and link-step-1 fast-paths through pkg_nm_dir.exists().
-/// `_policy_warnings` is dropped because the link phase calls
-/// `build_policy_from_sources` again and re-emits warnings (idempotent).
-pub(super) fn resolve_prewarm_shared(
-    settings_ctx: &aube_settings::ResolveCtx<'_>,
-    manifest: &aube_manifest::PackageJson,
-    workspace_config: &aube_manifest::WorkspaceConfig,
-    dangerously_allow_all_builds: bool,
-) -> (Option<String>, std::sync::Arc<aube_scripts::BuildPolicy>) {
-    let node_version = {
-        let override_ = aube_settings::resolved::node_version(settings_ctx);
-        crate::engines::resolve_node_version(override_.as_deref())
-    };
-    let (policy, _warnings) =
-        build_policy_from_sources(manifest, workspace_config, dangerously_allow_all_builds);
-    (node_version, std::sync::Arc::new(policy))
-}
-
 /// Resolve the link strategy (reflink / hardlink / copy) from CLI
 /// override, `.npmrc` / `pnpm-workspace.yaml`, or filesystem detection.
 /// Shared by the prewarm-GVS materializer (which needs the strategy

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -29,8 +29,8 @@ pub(crate) use lifecycle::{
     run_dep_lifecycle_scripts,
 };
 use lifecycle::{
-    resolve_link_strategy, resolve_prewarm_shared, run_import_on_blocking, run_root_lifecycle,
-    unreviewed_dep_builds, validate_required_scripts,
+    resolve_link_strategy, run_import_on_blocking, run_root_lifecycle, unreviewed_dep_builds,
+    validate_required_scripts,
 };
 pub(crate) use settings::PeerDependencyRules;
 pub(crate) use settings::{resolve_dependency_policy, resolve_force_metadata_primer};
@@ -330,6 +330,7 @@ impl InstallArgs {
             cli_flags,
             env_snapshot,
             git_prepare_depth: 0,
+            inherited_build_policy: None,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
             // Argumentless `aube install` runs root lifecycle hooks; the
             // chained-call constructor (`with_mode`) is where commands
@@ -421,6 +422,11 @@ pub struct InstallOptions {
     /// Current git dependency prepare nesting depth. Kept in options so
     /// in-process prepare installs do not need cascading environment vars.
     pub git_prepare_depth: u32,
+    /// Dependency build policy inherited by an in-process nested install.
+    /// Used for git dependency `prepare`: the nested install runs in a
+    /// scratch clone, but dependency build approval belongs to the outer
+    /// project that requested the git package.
+    pub inherited_build_policy: Option<std::sync::Arc<aube_scripts::BuildPolicy>>,
     /// Global `--filter` / `--filter-prod` selectors. Resolution and
     /// lockfile writing still happen at the workspace root; these
     /// selectors narrow only the graph passed to the linker. Prod-only
@@ -523,6 +529,7 @@ impl InstallOptions {
             cli_flags: Vec::new(),
             env_snapshot: aube_settings::values::capture_env(),
             git_prepare_depth: 0,
+            inherited_build_policy: None,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
             // pnpm parity: every chained-call site (add / remove / update
             // / dedupe / dlx / patch / ensure_installed / git prepare)
@@ -554,6 +561,7 @@ pub(super) async fn import_local_source(
     client: Option<&std::sync::Arc<aube_registry::client::RegistryClient>>,
     ignore_scripts: bool,
     git_prepare_depth: u32,
+    inherited_build_policy: Option<std::sync::Arc<aube_scripts::BuildPolicy>>,
     git_shallow_hosts: &[String],
     pkg_name: &str,
     pkg_version: &str,
@@ -766,8 +774,14 @@ pub(super) async fn import_local_source(
                 // `ScratchDir` removes the copy on drop, including
                 // on the error path.
                 let scratch = prepare_scratch_copy(&pkg_root, &spec)?;
-                run_git_dep_prepare(scratch.path(), &spec, ignore_scripts, git_prepare_depth)
-                    .await?;
+                run_git_dep_prepare(
+                    scratch.path(),
+                    &spec,
+                    ignore_scripts,
+                    git_prepare_depth,
+                    inherited_build_policy,
+                )
+                .await?;
                 let archive = crate::commands::pack::build_archive(scratch.path())
                     .wrap_err_with(|| format!("failed to pack prepared git dep {spec}{chain}"))?;
                 let index = store
@@ -884,6 +898,7 @@ pub(super) async fn fetch_packages(
         strict_integrity,
         strict_pkg_content_check,
         git_prepare_depth,
+        None,
         git_shallow_hosts,
     )
     .await
@@ -1281,6 +1296,7 @@ pub(super) async fn fetch_packages_with_root<F>(
     strict_integrity: bool,
     strict_pkg_content_check: bool,
     git_prepare_depth: u32,
+    inherited_build_policy: Option<std::sync::Arc<aube_scripts::BuildPolicy>>,
     git_shallow_hosts: Vec<String>,
 ) -> miette::Result<(BTreeMap<String, aube_store::PackageIndex>, usize, usize)>
 where
@@ -1417,6 +1433,7 @@ where
             client_slot.as_ref(),
             ignore_scripts,
             git_prepare_depth,
+            inherited_build_policy.clone(),
             &git_shallow_hosts,
             &pkg.name,
             &pkg.version,
@@ -2292,6 +2309,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         } else {
             vec![(".".to_string(), manifest.clone())]
         };
+    let (mut build_policy, policy_warnings) = build_policy_from_manifest_sources(
+        lifecycle_manifests.iter().map(|(_, manifest)| manifest),
+        &ws_config_shared,
+        opts.dangerously_allow_all_builds,
+    );
+    if let Some(inherited) = opts.inherited_build_policy.as_deref() {
+        build_policy.merge(inherited);
+    }
+    let inherited_build_policy_for_git_prepare = Some(std::sync::Arc::new(build_policy.clone()));
 
     // 1b. Project `preinstall` lifecycle hooks.
     //     Workspace installs run the hook for every physical importer
@@ -2944,12 +2970,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let network_mode = opts.network_mode;
             let cwd_for_client = cwd.clone();
 
-            let (lock_node_version, lock_build_policy) = resolve_prewarm_shared(
-                &settings_ctx,
-                &manifest,
-                &ws_config_shared,
-                opts.dangerously_allow_all_builds,
+            let lock_node_version = crate::engines::resolve_node_version(
+                aube_settings::resolved::node_version(&settings_ctx).as_deref(),
             );
+            let lock_build_policy = std::sync::Arc::new(build_policy.clone());
             let lock_strategy = resolve_link_strategy(&cwd, &settings_ctx)?;
             let (lock_patches, lock_patch_hashes) = crate::patches::load_patches_for_linker(&cwd)?;
             let (lock_materialize_tx, lock_materialize_rx) = materialize_channel();
@@ -2989,6 +3013,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 strict_store_integrity_setting,
                 strict_store_pkg_content_check_setting,
                 opts.git_prepare_depth,
+                inherited_build_policy_for_git_prepare.clone(),
                 resolve_git_shallow_hosts(&settings_ctx),
             )
             .await;
@@ -3024,12 +3049,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // await) can compute the same graph hashes the link phase
             // will. Keeping a single source of truth avoids any
             // subdir-name drift between prewarm and link step 1.
-            let (node_version_for_prewarm, build_policy_for_prewarm) = resolve_prewarm_shared(
-                &settings_ctx,
-                &manifest,
-                &ws_config_shared,
-                opts.dangerously_allow_all_builds,
+            let node_version_for_prewarm = crate::engines::resolve_node_version(
+                aube_settings::resolved::node_version(&settings_ctx).as_deref(),
             );
+            let build_policy_for_prewarm = std::sync::Arc::new(build_policy.clone());
             let client =
                 std::sync::Arc::new(make_client(&cwd).with_network_mode(opts.network_mode));
             // Speculative TLS + TCP + HTTP/2 handshake. Fires while the
@@ -3116,6 +3139,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let fetch_local_client = tarball_client.clone();
             let fetch_ignore_scripts = opts.ignore_scripts;
             let fetch_git_prepare_depth = opts.git_prepare_depth;
+            let fetch_inherited_build_policy = inherited_build_policy_for_git_prepare.clone();
             let fetch_verify_integrity = verify_store_integrity_setting;
             let fetch_strict_integrity = strict_store_integrity_setting;
             let fetch_strict_pkg_content_check = strict_store_pkg_content_check_setting;
@@ -3239,6 +3263,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             Some(&fetch_local_client),
                             fetch_ignore_scripts,
                             fetch_git_prepare_depth,
+                            fetch_inherited_build_policy.clone(),
                             &fetch_git_shallow_hosts,
                             &pkg.name,
                             &pkg.version,
@@ -3698,6 +3723,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     strict_store_integrity_setting,
                     strict_store_pkg_content_check_setting,
                     opts.git_prepare_depth,
+                    inherited_build_policy_for_git_prepare.clone(),
                     resolve_git_shallow_hosts(&settings_ctx),
                 )
                 .await?;
@@ -3830,11 +3856,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         virtual_store_dir_max_length,
     )?;
 
-    let (build_policy, policy_warnings) = build_policy_from_manifest_sources(
-        lifecycle_manifests.iter().map(|(_, manifest)| manifest),
-        &ws_config_shared,
-        opts.dangerously_allow_all_builds,
-    );
     // Emit policy-config warnings regardless of `--ignore-scripts`.
     // User wants to know about typos in `allowBuilds` even if scripts
     // will not run, otherwise they reenable scripts later and wonder

--- a/test/git_deps.bats
+++ b/test/git_deps.bats
@@ -102,6 +102,36 @@ EOF
 	(cd "$work" && git rev-parse HEAD)
 }
 
+_make_git_repo_with_prepare_build_dep() {
+	local bare="$1" name="$2" version="$3"
+	local work
+	work="$(temp_make)"
+	(
+		cd "$work" || exit 1
+		git init -q
+		git config commit.gpgsign false
+		cat >package.json <<EOF
+{
+  "name": "$name",
+  "version": "$version",
+  "main": "dist/index.js",
+  "files": ["dist"],
+  "scripts": {
+    "prepare": "mkdir -p dist && printf 'module.exports = true;\\n' > dist/index.js"
+  },
+  "devDependencies": {
+    "aube-test-builds-marker": "^1.0.0"
+  }
+}
+EOF
+		git add -A
+		git commit -q -m "init"
+	)
+	git init -q --bare "$bare"
+	(cd "$work" && git push -q "$bare" HEAD:refs/heads/main)
+	(cd "$work" && git rev-parse HEAD)
+}
+
 @test "aube install handles git+file:// dep" {
 	sha="$(_make_git_repo "$TEST_TEMP_DIR/git-src.git" gitpkg 3.4.5)"
 
@@ -333,6 +363,31 @@ EOF
 	run aube --registry="$AUBE_TEST_REGISTRY" install
 	assert_success
 	assert_file_exists node_modules/gitprepregistry/dist/index.js
+}
+
+@test "git dep prepare nested install inherits top-level allowBuilds" {
+	_make_git_repo_with_prepare_build_dep "$TEST_TEMP_DIR/git-prep-allow-builds.git" gitprepallowbuilds 1.0.0 >/dev/null
+
+	mkdir -p app
+	cd app
+	cat >package.json <<EOF
+{
+  "name": "app",
+  "version": "0.0.0",
+  "dependencies": {
+    "gitprepallowbuilds": "git+file://$TEST_TEMP_DIR/git-prep-allow-builds.git"
+  },
+  "pnpm": {
+    "allowBuilds": {
+      "aube-test-builds-marker": true
+    }
+  }
+}
+EOF
+
+	run env AUBE_STRICT_DEP_BUILDS=true aube --registry="$AUBE_TEST_REGISTRY" install
+	assert_success
+	assert_file_exists node_modules/gitprepallowbuilds/dist/index.js
 }
 
 @test "--ignore-scripts reinstall doesn't inherit prior prepare's build artifacts" {


### PR DESCRIPTION
## Summary

- Thread the resolved dependency build policy into nested git dependency `prepare` installs.
- Merge inherited build approvals with the nested package's own policy so top-level `allowBuilds` entries still apply inside the scratch checkout.
- Add a regression test covering strict dependency build approval for git dependency `prepare`.

## Root Cause

Git dependency `prepare` runs an in-process nested `aube install` rooted at a scratch clone. That nested install rebuilt `BuildPolicy` only from the git package's own config, so reviewed top-level `pnpm.allowBuilds` entries from the consuming project were lost.

## Validation

- `cargo fmt --check`
- `cargo check -q`
- `cargo clippy --all-targets -- -D warnings`
- `mise run test:bats test/git_deps.bats --filter 'inherits top-level allowBuilds'`
- commit hook: cargo fmt, shfmt, shellcheck, per-crate clippy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how dependency lifecycle script approvals are computed for nested git-dependency `prepare` installs, which can affect whether scripts run under strict build policies. While scoped to git prepare, it touches security-sensitive allow/deny logic and install option plumbing.
> 
> **Overview**
> Fixes git dependency `prepare` by **threading the outer project’s resolved `BuildPolicy` into the in-process nested install**, so top-level `pnpm.allowBuilds` approvals still apply when the git repo is prepared from a scratch clone.
> 
> Adds `BuildPolicy::merge` (with wildcard deduping) and introduces a new `InstallOptions.inherited_build_policy` that is passed through fetch/import and `run_git_dep_prepare`, merging inherited approvals with the nested package’s own policy.
> 
> Adds a Bats regression test ensuring strict dep-build enforcement still allows a git dep’s `prepare` to run when the top-level project has approved the needed build dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85d713e4fc6287f4cdef3efd2b36c5c7a1356150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->