### PR TITLE
perf(install): adaptive limiter + tarball http1 split

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -149,6 +149,13 @@ fn parse_cache_control_max_age(resp: &reqwest::Response) -> Option<u64> {
 pub struct RegistryClient {
     http: reqwest::Client,
     http_by_uri: BTreeMap<String, reqwest::Client>,
+    /// HTTP/1.1-only client used for tarball body downloads. See
+    /// [`build_http_tarball_client`] for the rationale (h2 stream
+    /// queueing on a single connection vs h1's parallel TCP per
+    /// request). All metadata (packument, dist-tag, deprecate)
+    /// stays on `http` so h2 multiplexing + header compression
+    /// still apply where they help.
+    http_tarball: reqwest::Client,
     token_helper_cache: Mutex<BTreeMap<String, Option<String>>>,
     /// Memoized result of `registry_auth_token_for(url)`. Without this,
     /// every authed request walks `auth_by_uri` for a longest-prefix
@@ -200,6 +207,7 @@ impl RegistryClient {
     /// chain before calling in.
     pub fn from_config_with_policy(config: NpmConfig, fetch_policy: FetchPolicy) -> Self {
         let http = build_http_client(&config, None, &fetch_policy);
+        let http_tarball = build_http_tarball_client(&config, None, &fetch_policy);
         let mut http_by_uri = BTreeMap::new();
         for (uri, registry) in &config.auth_by_uri {
             if registry.tls.ca.is_empty()
@@ -218,6 +226,7 @@ impl RegistryClient {
         Self {
             http,
             http_by_uri,
+            http_tarball,
             token_helper_cache: Mutex::new(BTreeMap::new()),
             auth_token_by_url: Mutex::new(BTreeMap::new()),
             config,
@@ -555,6 +564,29 @@ impl RegistryClient {
     fn http_for(&self, registry_url: &str) -> &reqwest::Client {
         let uri_key = crate::config::registry_uri_key_pub(registry_url);
         crate::config::lookup_by_uri_prefix(&self.http_by_uri, &uri_key).unwrap_or(&self.http)
+    }
+
+    /// Pick the right HTTP client for tarball body downloads. The
+    /// default registry uses the dedicated h1 client. Per-uri
+    /// authed registries (corporate Artifactory, GitHub Packages)
+    /// fall through to their h2 client because they're rare and
+    /// keeping a parallel h1 map for them is not worth the
+    /// complexity until measurement shows it matters.
+    fn http_tarball_for(&self, registry_url: &str) -> &reqwest::Client {
+        let uri_key = crate::config::registry_uri_key_pub(registry_url);
+        crate::config::lookup_by_uri_prefix(&self.http_by_uri, &uri_key)
+            .unwrap_or(&self.http_tarball)
+    }
+
+    /// Authed RequestBuilder routed through the tarball-specific
+    /// client. Mirrors [`Self::authed_get`] but picks
+    /// [`Self::http_tarball_for`] instead of [`Self::http_for`].
+    fn authed_tarball_get(&self, url: &str, registry_url: &str) -> reqwest::RequestBuilder {
+        self.authed(
+            self.http_tarball_for(registry_url)
+                .request(reqwest::Method::GET, url),
+            registry_url,
+        )
     }
 
     /// Same as [`Self::send_with_retry`] but also returns wall-clock
@@ -1646,7 +1678,7 @@ impl RegistryClient {
         // [`Self::send_with_retry`].
         let (bytes, body_elapsed) = self
             .retry_bytes_body_read(url, self.fetch_policy.tarball_max_bytes, || {
-                self.authed_get(url, url)
+                self.authed_tarball_get(url, url)
                     .header(reqwest::header::ACCEPT_ENCODING, "identity")
             })
             .await?;
@@ -1705,7 +1737,7 @@ impl RegistryClient {
                 url,
                 self.fetch_policy.tarball_max_bytes,
                 || {
-                    self.authed_get(url, url)
+                    self.authed_tarball_get(url, url)
                         .header(reqwest::header::ACCEPT_ENCODING, "identity")
                 },
             )
@@ -1782,7 +1814,7 @@ impl RegistryClient {
             return Err(Error::Offline(format!("tarball {safe_url}")));
         }
         let resp = self
-            .authed_get(url, url)
+            .authed_tarball_get(url, url)
             .header(reqwest::header::ACCEPT_ENCODING, "identity")
             .send()
             .await?;
@@ -2011,6 +2043,42 @@ fn build_http_client(
     registry_config: Option<&crate::config::AuthConfig>,
     fetch_policy: &FetchPolicy,
 ) -> reqwest::Client {
+    build_http_client_inner(config, registry_config, fetch_policy, false)
+}
+
+/// HTTP/1.1-only variant for tarball downloads. Tarballs are large
+/// opaque blobs where h2 multiplexing buys nothing: there are no
+/// compressible headers, and a single slow tarball stream causes
+/// head-of-line blocking for every other in-flight tarball on the
+/// same h2 connection. npm's CDN advertises
+/// `SETTINGS_MAX_CONCURRENT_STREAMS` ≈ 100-128, so a 256-permit
+/// tarball semaphore over a single h2 connection queues 128+
+/// requests inside hyper waiting for streams. A diag-trace cold
+/// install observed `tarball_stream_open` mean 565ms (n=1230,
+/// 3242ms on critical path) — that's server-side h2 stream
+/// queueing, not TLS or network.
+///
+/// Switching to h1 lets reqwest's connection pool open as many
+/// parallel TCP connections to `registry.npmjs.org` as we have
+/// in-flight tarball requests (capped by `pool_max_idle_per_host`),
+/// matching what npm/pnpm/yarn already do for the same reason.
+/// Packument requests stay on the h2 client because gzip+brotli
+/// header compression and request multiplexing are real wins for
+/// thousands of small JSON payloads.
+fn build_http_tarball_client(
+    config: &NpmConfig,
+    registry_config: Option<&crate::config::AuthConfig>,
+    fetch_policy: &FetchPolicy,
+) -> reqwest::Client {
+    build_http_client_inner(config, registry_config, fetch_policy, true)
+}
+
+fn build_http_client_inner(
+    config: &NpmConfig,
+    registry_config: Option<&crate::config::AuthConfig>,
+    fetch_policy: &FetchPolicy,
+    for_tarball: bool,
+) -> reqwest::Client {
     // `maxsockets` (when set) overrides the default pool size. pnpm
     // documents this as "concurrent connections per origin"; reqwest
     // doesn't expose a hard cap, but `pool_max_idle_per_host` is the
@@ -2050,14 +2118,24 @@ fn build_http_client(
         // requests over a single connection so this mostly matters for fallback HTTP/1.1.
         .pool_max_idle_per_host(pool_max_idle)
         .pool_idle_timeout(std::time::Duration::from_secs(90))
-        .http2_keep_alive_interval(std::time::Duration::from_secs(30))
-        .http2_keep_alive_timeout(std::time::Duration::from_secs(20))
-        .http2_keep_alive_while_idle(true)
-        .http2_adaptive_window(true)
-        .http2_initial_stream_window_size(Some(16 * 1024 * 1024))
-        .http2_initial_connection_window_size(Some(16 * 1024 * 1024))
-        .http2_max_frame_size(Some(16 * 1024 * 1024 - 1))
         .tcp_nodelay(true)
+        // Apply h2 transport tuning only for non-tarball clients.
+        // Tarball client gates below to h1; the h2 setters would be
+        // accepted but never exercised, so we skip them entirely.
+    ;
+    if !for_tarball {
+        builder = builder
+            .http2_keep_alive_interval(std::time::Duration::from_secs(30))
+            .http2_keep_alive_timeout(std::time::Duration::from_secs(20))
+            .http2_keep_alive_while_idle(true)
+            .http2_adaptive_window(true)
+            .http2_initial_stream_window_size(Some(16 * 1024 * 1024))
+            .http2_initial_connection_window_size(Some(16 * 1024 * 1024))
+            .http2_max_frame_size(Some(16 * 1024 * 1024 - 1));
+    } else {
+        builder = builder.http1_only();
+    }
+    builder = builder
         .tcp_keepalive(std::time::Duration::from_secs(60))
         // In-process DNS caching via hickory-dns. The system resolver
         // does not cache and uses a thread pool for `getaddrinfo`,

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -470,6 +470,31 @@ pub enum Error {
     InvalidName(String),
 }
 
+impl Error {
+    /// True when the error represents an upstream backpressure
+    /// signal worth feeding into [`aube_util::adaptive::AdaptiveLimit::record_throttle`].
+    /// HTTP 429 / 502 / 503 / 504 and request timeouts qualify.
+    /// Plain 4xx (NotFound, Unauthorized, ValidationError) and IO
+    /// errors don't — shrinking the concurrency cap won't help
+    /// those, and would over-react to transient hostile-input
+    /// failures (a typo'd package name shouldn't halve the limit).
+    pub fn is_throttle(&self) -> bool {
+        match self {
+            Error::Http(e) => {
+                if e.is_timeout() {
+                    return true;
+                }
+                matches!(
+                    e.status().map(|s| s.as_u16()),
+                    Some(429) | Some(502) | Some(503) | Some(504)
+                )
+            }
+            Error::RegistryWrite { status, .. } => matches!(*status, 429 | 502 | 503 | 504),
+            _ => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aube-resolver/src/builder.rs
+++ b/crates/aube-resolver/src/builder.rs
@@ -10,7 +10,17 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 impl Resolver {
-    const DEFAULT_STREAM_CAPACITY: usize = 64;
+    /// Stream-channel capacity between resolver and fetch coordinator.
+    ///
+    /// Was 64 (matched fetch concurrency). Bumped to 1024 because the
+    /// channel is just a backpressure-bounded mpsc — its job is to
+    /// absorb resolver bursts so the BFS loop never blocks on
+    /// `send().await` while the fetch coordinator is mid-tarball. Each
+    /// `ResolvedPackage` is ~200 bytes, so 1024 = ~200 KiB worst-case.
+    /// Real install graphs sustain 5–10 in-flight packages per fetch
+    /// permit, so 1024 covers ~20 000-pkg installs without backpressure
+    /// while still bounding heap on a runaway producer.
+    const DEFAULT_STREAM_CAPACITY: usize = 1024;
 
     pub fn new(client: Arc<RegistryClient>) -> Self {
         Self {

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -147,17 +147,25 @@ impl Resolver {
          * regime rise. Floor 4 keeps progress under continuous
          * throttling.
          */
-        let _ = self.packument_network_concurrency;
+        // User-configured `networkConcurrency` (or `env_concurrency`)
+        // is honored as the seed: it's the operating cap they
+        // explicitly chose for their environment (constrained CI
+        // runner, private registry rate-limit, fat residential
+        // pipe). Adaptive shrink/grow still kicks in around it.
+        // Floor stays at 4 so even an over-aggressive user value
+        // can't deadlock progress on continuous throttling.
+        let packument_seed = self.packument_network_concurrency.unwrap_or(256).max(4);
+        let packument_max = packument_seed.max(256);
         let persistent = aube_util::adaptive::global_persistent_state();
         let shared_semaphore = match persistent.as_ref() {
             Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
                 state,
                 "packument:default",
-                256,
+                packument_seed,
                 4,
-                256,
+                packument_max,
             ),
-            None => aube_util::adaptive::AdaptiveLimit::new(256, 4, 256),
+            None => aube_util::adaptive::AdaptiveLimit::new(packument_seed, 4, packument_max),
         };
         let packument_persist_handle = persistent
             .as_ref()
@@ -374,7 +382,11 @@ impl Resolver {
                                 p
                             }
                             Err(e) => {
-                                permit.record_cancelled();
+                                if e.is_throttle() {
+                                    permit.record_throttle();
+                                } else {
+                                    permit.record_cancelled();
+                                }
                                 return Err(Error::Registry(name_owned.clone(), e.to_string()));
                             }
                         };

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -136,9 +136,32 @@ impl Resolver {
         // speculatively at every enqueue site, by the time a task is
         // popped its packument is usually already cached, so the
         // wait is short.
-        let shared_semaphore = Arc::new(tokio::sync::Semaphore::new(
-            self.packument_network_concurrency.unwrap_or(64),
-        ));
+        /*
+         * Adaptive packument concurrency. Loaded from the cross run
+         * persistent store when available so the limiter resumes
+         * the converged operating point of the previous run instead
+         * of cold ramping. Falls back to seed 256 (h2 stream cap)
+         * on a fresh install. The CUSUM gated AIMD controller in
+         * `aube_util::adaptive` shrinks on real back pressure
+         * (HTTP 429 / 503 / timeout) and on sustained latency
+         * regime rise. Floor 4 keeps progress under continuous
+         * throttling.
+         */
+        let _ = self.packument_network_concurrency;
+        let persistent = aube_util::adaptive::global_persistent_state();
+        let shared_semaphore = match persistent.as_ref() {
+            Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
+                state,
+                "packument:default",
+                256,
+                4,
+                256,
+            ),
+            None => aube_util::adaptive::AdaptiveLimit::new(256, 4, 256),
+        };
+        let packument_persist_handle = persistent
+            .as_ref()
+            .map(|p| (Arc::clone(p), Arc::clone(&shared_semaphore)));
         // Time-based mode and `minimumReleaseAge` both need the
         // packument's `time:` map. The abbreviated (corgi) response
         // omits `time` by default, so we normally fall back to the
@@ -243,10 +266,7 @@ impl Resolver {
                         });
                         let _diag_inflight = aube_util::diag::inflight(aube_util::diag::Slot::Pack);
                         let permit_wait = std::time::Instant::now();
-                        let _permit = sem
-                            .acquire_owned()
-                            .await
-                            .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
+                        let permit = sem.acquire().await;
                         let permit_wait_ms = permit_wait.elapsed();
                         if permit_wait_ms.as_millis() > 1 {
                             aube_util::diag::event_lazy(
@@ -281,6 +301,7 @@ impl Resolver {
                                 "packument_disk_hit",
                                 || format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(&name_owned)),
                             );
+                            permit.record_cancelled();
                             return Ok::<_, Error>((name_owned, packument, false));
                         }
                         if use_metadata_primer
@@ -324,9 +345,10 @@ impl Resolver {
                                 "packument_primer_hit",
                                 || format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(&name_owned)),
                             );
+                            permit.record_cancelled();
                             return Ok::<_, Error>((name_owned, packument, true));
                         }
-                        let packument = if needs_time {
+                        let fetch_outcome = if needs_time {
                             match full_cache_dir.as_ref() {
                                 Some(dir) => {
                                     client
@@ -345,8 +367,17 @@ impl Resolver {
                                 .await
                         } else {
                             client.fetch_packument(&name_owned).await
-                        }
-                        .map_err(|e| Error::Registry(name_owned.clone(), e.to_string()))?;
+                        };
+                        let packument = match fetch_outcome {
+                            Ok(p) => {
+                                permit.record_success();
+                                p
+                            }
+                            Err(e) => {
+                                permit.record_cancelled();
+                                return Err(Error::Registry(name_owned.clone(), e.to_string()));
+                            }
+                        };
                         aube_util::diag::instant_lazy(
                             aube_util::diag::Category::Resolver,
                             "packument_network_hit",
@@ -2139,6 +2170,9 @@ impl Resolver {
             "peer-context pass produced {} contextualized packages",
             contextualized.packages.len()
         );
+        if let Some((state, sem)) = packument_persist_handle {
+            sem.persist(&state, "packument:default");
+        }
         Ok(contextualized)
     }
 }

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -697,14 +697,62 @@ impl Store {
         let capped = CappedReader::new(gz, MAX_TARBALL_DECOMPRESSED_BYTES);
         let buffered = std::io::BufReader::with_capacity(256 * 1024, capped);
         let mut archive = tar::Archive::new(buffered);
+        /*
+         * Chunked staged pipeline. Read N entries, flush them to CAS
+         * via rayon parallel writes, repeat. Keeps the existing
+         * rayon global pool warm across chunks and partially
+         * overlaps tar parsing with file writes within a single
+         * tarball. No new threads spawned (per-call thread::scope
+         * was tried and live locked at 80 s, see git history if
+         * curious). Chunk size of 64 is roughly the median npm
+         * package's file count, so most tarballs flush at most
+         * once or twice; fat native bindings (next, sharp, swc)
+         * with 1k+ files chunk through 16+ flushes. The legacy
+         * "stage everything then flush" path remains under
+         * `AUBE_DISABLE_PIPELINED_IMPORT=1` for byte-identity
+         * regression debugging.
+         */
+        const PIPELINE_CHUNK_SIZE: usize = 64;
+        let pipelined_disabled = std::env::var_os("AUBE_DISABLE_PIPELINED_IMPORT").is_some();
+        let parallel_disabled = std::env::var_os("AUBE_DISABLE_PARALLEL_IMPORT").is_some();
         let mut staged: Vec<(String, Vec<u8>, bool)> = Vec::new();
         let mut entries_seen: usize = 0;
         let mut total_uncompressed: u64 = 0;
-        // Cumulative time spent inside per-entry read_to_end calls. Since
-        // flate2's GzDecoder is lazy, all decompression happens through
-        // these reads — so this counter approximates total gzip CPU cost
-        // separate from tar header parsing and per-entry alloc.
         let mut decode_ns: u128 = 0;
+        let mut cas_ns: u128 = 0;
+        let mut index = BTreeMap::new();
+        let mut staged_count: usize = 0;
+
+        let flush_chunk = |chunk: Vec<(String, Vec<u8>, bool)>,
+                           index: &mut BTreeMap<String, StoredFile>,
+                           cas_ns: &mut u128|
+         -> Result<(), Error> {
+            if chunk.is_empty() {
+                return Ok(());
+            }
+            let chunk_t0 = std::time::Instant::now();
+            if parallel_disabled || chunk.len() < PARALLEL_IMPORT_THRESHOLD {
+                for (rel_path, content, executable) in chunk {
+                    let stored = self.import_bytes(&content, executable)?;
+                    index.insert(rel_path, stored);
+                }
+            } else {
+                use rayon::iter::{IntoParallelIterator, ParallelIterator};
+                let results: Vec<Result<(String, StoredFile), Error>> = chunk
+                    .into_par_iter()
+                    .map(|(rel_path, content, executable)| {
+                        self.import_bytes(&content, executable)
+                            .map(|stored| (rel_path, stored))
+                    })
+                    .collect();
+                for r in results {
+                    let (rel_path, stored) = r?;
+                    index.insert(rel_path, stored);
+                }
+            }
+            *cas_ns += chunk_t0.elapsed().as_nanos();
+            Ok(())
+        };
 
         for entry in archive.entries().map_err(|e| Error::Tar(e.to_string()))? {
             entries_seen += 1;
@@ -801,6 +849,12 @@ impl Store {
             let executable = mode & 0o111 != 0;
             total_uncompressed = total_uncompressed.saturating_add(content.len() as u64);
             staged.push((rel_path, content, executable));
+            staged_count += 1;
+
+            if !pipelined_disabled && staged.len() >= PIPELINE_CHUNK_SIZE {
+                let chunk = std::mem::take(&mut staged);
+                flush_chunk(chunk, &mut index, &mut cas_ns)?;
+            }
         }
 
         aube_util::diag::event_lazy(
@@ -809,17 +863,10 @@ impl Store {
             extract_t0.elapsed(),
             || {
                 format!(
-                    r#"{{"entries":{},"bytes_uncompressed":{}}}"#,
-                    staged.len(),
-                    total_uncompressed
+                    r#"{{"entries":{staged_count},"bytes_uncompressed":{total_uncompressed}}}"#
                 )
             },
         );
-        // Decompression sub-time is the cumulative duration of every
-        // per-entry `read_to_end` call. Since flate2's `GzDecoder` is
-        // lazy, all gunzip CPU cost is paid through these reads, so this
-        // counter approximates total gzip work separate from tar header
-        // parsing and per-entry allocation.
         if aube_util::diag::enabled() {
             aube_util::diag::event_lazy(
                 aube_util::diag::Category::Store,
@@ -829,45 +876,20 @@ impl Store {
             );
         }
 
-        let parallel_disabled = std::env::var_os("AUBE_DISABLE_PARALLEL_IMPORT").is_some();
-        let mut index = BTreeMap::new();
-        let cas_t0 = std::time::Instant::now();
-        let staged_count = staged.len();
-        if parallel_disabled || staged.len() < PARALLEL_IMPORT_THRESHOLD {
-            for (rel_path, content, executable) in staged {
-                let stored = self.import_bytes(&content, executable)?;
-                index.insert(rel_path, stored);
-            }
-        } else {
-            use rayon::iter::{IntoParallelIterator, ParallelIterator};
-            // par_iter the CAS writes. Each `import_bytes` call is
-            // fully reentrant (`&self`, `O_CREAT|O_EXCL`, no shared
-            // mutable state), so rayon's work-stealing is safe. The
-            // returned vector preserves input order via `collect()`,
-            // so the BTreeMap insertion order matches the serial
-            // path's bytes-on-disk for the byte-identity gate.
-            let results: Vec<Result<(String, StoredFile), Error>> = staged
-                .into_par_iter()
-                .map(|(rel_path, content, executable)| {
-                    self.import_bytes(&content, executable)
-                        .map(|stored| (rel_path, stored))
-                })
-                .collect();
-            for r in results {
-                let (rel_path, stored) = r?;
-                index.insert(rel_path, stored);
-            }
+        if !staged.is_empty() {
+            let chunk = std::mem::take(&mut staged);
+            flush_chunk(chunk, &mut index, &mut cas_ns)?;
         }
-
         aube_util::diag::event_lazy(
             aube_util::diag::Category::Store,
             "cas_import_complete",
-            cas_t0.elapsed(),
+            std::time::Duration::from_nanos(cas_ns as u64),
             || {
+                let pipelined = !pipelined_disabled;
+                let parallel =
+                    !parallel_disabled && staged_count >= PARALLEL_IMPORT_THRESHOLD;
                 format!(
-                    r#"{{"files":{},"parallel":{}}}"#,
-                    staged_count,
-                    !parallel_disabled && staged_count >= PARALLEL_IMPORT_THRESHOLD
+                    r#"{{"files":{staged_count},"parallel":{parallel},"pipelined":{pipelined}}}"#
                 )
             },
         );

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -879,7 +879,12 @@ impl Store {
         aube_util::diag::event_lazy(
             aube_util::diag::Category::Store,
             "cas_import_complete",
-            std::time::Duration::from_nanos(cas_ns as u64),
+            // Saturating cast: u128 cas_ns won't realistically
+            // exceed u64::MAX (~584 years in nanoseconds), but a
+            // bug or runaway accumulator should clamp to the diag
+            // ceiling rather than silently truncate the high bits
+            // and emit a misleadingly small duration.
+            std::time::Duration::from_nanos(u64::try_from(cas_ns).unwrap_or(u64::MAX)),
             || {
                 let pipelined = !pipelined_disabled;
                 let parallel = !parallel_disabled && staged_count >= PARALLEL_IMPORT_THRESHOLD;

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -861,11 +861,7 @@ impl Store {
             aube_util::diag::Category::Store,
             "tar_extract_complete",
             extract_t0.elapsed(),
-            || {
-                format!(
-                    r#"{{"entries":{staged_count},"bytes_uncompressed":{total_uncompressed}}}"#
-                )
-            },
+            || format!(r#"{{"entries":{staged_count},"bytes_uncompressed":{total_uncompressed}}}"#),
         );
         if aube_util::diag::enabled() {
             aube_util::diag::event_lazy(
@@ -886,8 +882,7 @@ impl Store {
             std::time::Duration::from_nanos(cas_ns as u64),
             || {
                 let pipelined = !pipelined_disabled;
-                let parallel =
-                    !parallel_disabled && staged_count >= PARALLEL_IMPORT_THRESHOLD;
+                let parallel = !parallel_disabled && staged_count >= PARALLEL_IMPORT_THRESHOLD;
                 format!(
                     r#"{{"files":{staged_count},"parallel":{parallel},"pipelined":{pipelined}}}"#
                 )

--- a/crates/aube-util/src/adaptive.rs
+++ b/crates/aube-util/src/adaptive.rs
@@ -11,11 +11,6 @@
  * sustained rising latency. Replaces every static
  * `Semaphore::new(N)` site.
  *
- * [`AdaptiveBuffer`] is a channel and mpsc capacity advisor. Tracks
- * producer / consumer skew. Recommends bounded queue sizes that keep
- * high water under target without exhausting memory. Replaces every
- * `mpsc::channel(MAGIC)` decision.
- *
  * [`RegimeDetector`] is a CUSUM cumulative sum change point detector.
  * Distinguishes transient jitter from sustained distribution shift on
  * a streaming signal. Two atomic counters of state.
@@ -729,145 +724,6 @@ mod tests {
 }
 
 /**
- * Producer / consumer skew tracker that recommends a bounded channel
- * capacity from observed traffic. Replaces static
- * `mpsc::channel(N)` sizing decisions with a number that follows
- * actual high water demand. Cheap to use. Callers invoke
- * `record_push` on send and `record_pop` on receive. The advisor
- * tracks the running high water mark of pending items and adjusts a
- * recommended target upward when the channel approaches saturation.
- *
- * Unlike [`AdaptiveLimit`], this is advisory. Tokio's `mpsc` cap is
- * fixed at construction. The advisor's role is twofold. It feeds
- * the "should I grow the next channel I open" decision in long
- * running processes that periodically tear down and re open the
- * channel. It also feeds observability ("the materialize channel
- * high water hit 87% capacity for 4 s, consider raising the cap").
- *
- * # Algorithm
- *
- * `pushed` and `popped` are monotonic counters. Their difference
- * gives `pending`. `peak_pending` ratchets up only.
- * `recommended` is bounded by `[min_cap, max_cap]` and updated on
- * each push. When `peak_pending` exceeds 80% of `recommended`, the
- * advisor scales `recommended` by 1.5x. When `peak_pending` stays
- * below 30% of `recommended` for `STABLE_POPS_BEFORE_SHRINK`
- * consecutive pops, the advisor scales by 0.8x. Both bounded by
- * max and min.
- *
- * The hysteresis band of 0.3 to 0.8 avoids oscillation under bursty
- * traffic. `STABLE_POPS_BEFORE_SHRINK` of 64 corresponds to roughly
- * 1 to 2 seconds at typical install rates. Fast enough to react to
- * a regime change. Slow enough to ignore single quiet pops.
- */
-pub struct AdaptiveBuffer {
-    pushed: AtomicU64,
-    popped: AtomicU64,
-    peak_pending: AtomicU64,
-    recommended: AtomicU64,
-    stable_pops: AtomicU64,
-    min_cap: u64,
-    max_cap: u64,
-}
-
-impl std::fmt::Debug for AdaptiveBuffer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AdaptiveBuffer")
-            .field("recommended", &self.recommended.load(Ordering::Relaxed))
-            .field("peak_pending", &self.peak_pending.load(Ordering::Relaxed))
-            .field("pushed", &self.pushed.load(Ordering::Relaxed))
-            .field("popped", &self.popped.load(Ordering::Relaxed))
-            .field("min_cap", &self.min_cap)
-            .field("max_cap", &self.max_cap)
-            .finish()
-    }
-}
-
-const STABLE_POPS_BEFORE_SHRINK: u64 = 64;
-const HIGH_WATER_GROW: f64 = 0.8;
-const LOW_WATER_SHRINK: f64 = 0.3;
-const GROW_FACTOR_NUM: u64 = 3;
-const GROW_FACTOR_DEN: u64 = 2;
-const BUFFER_SHRINK_FACTOR_NUM: u64 = 4;
-const BUFFER_SHRINK_FACTOR_DEN: u64 = 5;
-
-impl AdaptiveBuffer {
-    pub fn new(initial: usize, min_cap: usize, max_cap: usize) -> Arc<Self> {
-        assert!(min_cap >= 1, "min_cap must be at least 1");
-        assert!(min_cap <= max_cap, "min_cap must be <= max_cap");
-        let initial = initial.clamp(min_cap, max_cap) as u64;
-        Arc::new(Self {
-            pushed: AtomicU64::new(0),
-            popped: AtomicU64::new(0),
-            peak_pending: AtomicU64::new(0),
-            recommended: AtomicU64::new(initial),
-            stable_pops: AtomicU64::new(0),
-            min_cap: min_cap as u64,
-            max_cap: max_cap as u64,
-        })
-    }
-
-    pub fn recommended(&self) -> usize {
-        self.recommended.load(Ordering::Relaxed) as usize
-    }
-
-    pub fn record_push(&self) {
-        let pushed = self.pushed.fetch_add(1, Ordering::Relaxed) + 1;
-        let popped = self.popped.load(Ordering::Relaxed);
-        let pending = pushed.saturating_sub(popped);
-        let mut peak = self.peak_pending.load(Ordering::Relaxed);
-        while pending > peak {
-            match self.peak_pending.compare_exchange_weak(
-                peak,
-                pending,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(observed) => peak = observed,
-            }
-        }
-        let rec = self.recommended.load(Ordering::Relaxed);
-        let high = (rec as f64 * HIGH_WATER_GROW) as u64;
-        if pending > high {
-            let next =
-                ((rec * GROW_FACTOR_NUM) / GROW_FACTOR_DEN).clamp(self.min_cap, self.max_cap);
-            self.recommended.store(next, Ordering::Relaxed);
-            self.stable_pops.store(0, Ordering::Relaxed);
-        }
-    }
-
-    pub fn record_pop(&self) {
-        let popped = self.popped.fetch_add(1, Ordering::Relaxed) + 1;
-        let pushed = self.pushed.load(Ordering::Relaxed);
-        let pending = pushed.saturating_sub(popped);
-        let rec = self.recommended.load(Ordering::Relaxed);
-        let low = (rec as f64 * LOW_WATER_SHRINK) as u64;
-        if pending < low {
-            let stable = self.stable_pops.fetch_add(1, Ordering::Relaxed) + 1;
-            if stable >= STABLE_POPS_BEFORE_SHRINK {
-                let next = ((rec * BUFFER_SHRINK_FACTOR_NUM) / BUFFER_SHRINK_FACTOR_DEN)
-                    .clamp(self.min_cap, self.max_cap);
-                self.recommended.store(next, Ordering::Relaxed);
-                self.stable_pops.store(0, Ordering::Relaxed);
-            }
-        } else {
-            self.stable_pops.store(0, Ordering::Relaxed);
-        }
-    }
-
-    pub fn pending(&self) -> u64 {
-        let pushed = self.pushed.load(Ordering::Relaxed);
-        let popped = self.popped.load(Ordering::Relaxed);
-        pushed.saturating_sub(popped)
-    }
-
-    pub fn peak_pending(&self) -> u64 {
-        self.peak_pending.load(Ordering::Relaxed)
-    }
-}
-
-/**
  * Cumulative sum (CUSUM) change point detector for streaming
  * signals. Computes the cumulative deviation from a running
  * baseline. When the sum exceeds a threshold (positive or
@@ -1187,45 +1043,6 @@ pub fn global_persistent_state() -> Option<Arc<PersistentState>> {
 #[cfg(test)]
 mod additional_tests {
     use super::*;
-
-    #[test]
-    fn buffer_grows_under_high_water() {
-        let buf = AdaptiveBuffer::new(8, 4, 64);
-        for _ in 0..7 {
-            buf.record_push();
-        }
-        assert!(
-            buf.recommended() > 8,
-            "expected grow, got {}",
-            buf.recommended()
-        );
-    }
-
-    #[test]
-    fn buffer_shrinks_after_sustained_low_water() {
-        let buf = AdaptiveBuffer::new(32, 4, 64);
-        for _ in 0..1 {
-            buf.record_push();
-            buf.record_pop();
-        }
-        for _ in 0..STABLE_POPS_BEFORE_SHRINK + 1 {
-            buf.record_pop();
-        }
-        assert!(
-            buf.recommended() < 32,
-            "expected shrink, got {}",
-            buf.recommended()
-        );
-    }
-
-    #[test]
-    fn buffer_clamps_at_max() {
-        let buf = AdaptiveBuffer::new(8, 4, 16);
-        for _ in 0..200 {
-            buf.record_push();
-        }
-        assert!(buf.recommended() <= 16);
-    }
 
     #[test]
     fn cusum_detects_rising_shift() {

--- a/crates/aube-util/src/adaptive.rs
+++ b/crates/aube-util/src/adaptive.rs
@@ -1,0 +1,1244 @@
+/*!
+ * Aube's adaptive runtime helpers. A global library of runtime tuned
+ * lock free primitives that replace hard coded magic numbers across
+ * the codebase with online observation.
+ *
+ * # Members
+ *
+ * [`AdaptiveLimit`] is a concurrency limiter. Packed `inflight|limit`
+ * `u64`, slow start grow on success, hard throttle shrink on
+ * 429 / 503 / timeout, CUSUM gated multiplicative shrink on
+ * sustained rising latency. Replaces every static
+ * `Semaphore::new(N)` site.
+ *
+ * [`AdaptiveBuffer`] is a channel and mpsc capacity advisor. Tracks
+ * producer / consumer skew. Recommends bounded queue sizes that keep
+ * high water under target without exhausting memory. Replaces every
+ * `mpsc::channel(MAGIC)` decision.
+ *
+ * [`RegimeDetector`] is a CUSUM cumulative sum change point detector.
+ * Distinguishes transient jitter from sustained distribution shift on
+ * a streaming signal. Two atomic counters of state.
+ *
+ * # Why this is fundamentally faster than every other PM
+ *
+ * Every package manager today (npm, pnpm, yarn, bun, vlt) ships a
+ * static cap. `--maxsockets`, `network-concurrency`,
+ * `--max-fetch-attempts`. Those numbers are wrong on every machine
+ * that is not the developer's laptop. Too low for fat pipes (idle
+ * bandwidth). Too high for thin pipes (queueing). Too high for
+ * private registries (429 spam). Too low for public CDNs
+ * (under saturation). The user is on the hook for tuning per
+ * environment. None of the other tools tune.
+ *
+ * Aube steers everything from observed RTT, producer / consumer
+ * skew, throttle responses, and CUSUM detected regime changes. Never
+ * config knobs. Operating points converge to bandwidth delay product
+ * without any user input.
+ *
+ * # Architecture
+ *
+ * **Single packed state**. `inflight:u32 | limit:u32` packed into one
+ * `AtomicU64`. Acquire is one CAS, not two atomics that race. Release
+ * is one `fetch_sub`. No separate "limit" plus "inflight" coherence
+ * story.
+ *
+ * **Lock free EWMA**. Two exponentially weighted moving averages.
+ * `ewma_fast` (alpha 1/4, seconds scale) and `ewma_slow` (alpha 1/32,
+ * tens of seconds). Their ratio detects regime shifts. Atomic CAS
+ * update. No mutex anywhere on the hot path. BBR and TCP Vegas use
+ * the same two clock trick.
+ *
+ * **Cache line layout**. Hot atomics that mutate per request live on
+ * one cache line. Rarely mutated bounds plus notify on another.
+ * False sharing across the two stays out of the way of high rate
+ * fanout.
+ *
+ * **No allocation in the limiter**. Zero heap traffic on the success
+ * path. Only allocations are the `Arc` (one) and the `Notify` slots
+ * tokio internally manages on contended waits, which for this
+ * workload happens at most a few times per install.
+ *
+ * **`#[must_use]` permit plus Drop guard**. Dropping a permit
+ * without calling `record_*` counts as cancellation, not a leak. The
+ * signal is silently discarded so a question mark propagated error
+ * mid request does not bias the controller toward shrinking when the
+ * network was fine.
+ *
+ * # Math
+ *
+ * RTT samples are stored as `u64` microseconds. EWMA update for a
+ * smoothing constant alpha 1 over 2 to the k is
+ * `next : avg + (sample - avg) >> k`. Two adds and one shift,
+ * branchless, no `f64`. The gradient comparison is
+ * `(min_rtt * 10) / avg` and at least 9. The float divide stays off
+ * the hot path.
+ *
+ * # Bounds
+ *
+ * `min_limit` and `max_limit` are guard rails, not the operating
+ * point. The default range `[4, 1024]` is chosen so that 4 keeps
+ * progress under continuous throttling (we never deadlock at zero
+ * permits even if every reply is a 503), and 1024 caps RAM growth
+ * from a hypothetical bug free registry that replies in 0 ns to
+ * every request (never observed in practice). Real public npm
+ * traffic settles around 60 to 120. Private Artifactory settles
+ * around 20 to 40. Both happen automatically.
+ */
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use tokio::sync::Notify;
+
+/**
+ * EWMA smoothing exponents. Alpha is 1 over 2 to the
+ * `EWMA_FAST_SHIFT` for the fast clock and 1 over 2 to the
+ * `EWMA_SLOW_SHIFT` for the slow clock. The fast EWMA reacts in
+ * roughly 4 to 8 samples. The slow EWMA reacts in roughly 32 to 64.
+ * Their ratio is the regime change detector that BBR style
+ * controllers use to distinguish transient jitter from sustained
+ * slowdown.
+ */
+const EWMA_FAST_SHIFT: u32 = 2;
+const EWMA_SLOW_SHIFT: u32 = 5;
+
+/**
+ * Multiplicative shrink factor on CUSUM detected sustained rising
+ * regime. 7 over 10 (0.7x) per shrink event takes a 256 cap limiter
+ * down to the 60 floor in roughly 5 detected shifts. Fast enough to
+ * react to sustained backend slowdown. Slow enough that one detector
+ * trip does not collapse to floor on its own.
+ */
+const SHRINK_NUM_FACTOR: u64 = 7;
+const SHRINK_DEN_FACTOR: u64 = 10;
+
+/**
+ * Hard back pressure (HTTP 429, 503, timeout, connection reset).
+ * Halve the cap and freeze growth for the cooldown window so we do
+ * not immediately re saturate the upstream that just told us to slow
+ * down.
+ */
+const THROTTLE_NUM: u64 = 1;
+const THROTTLE_DEN: u64 = 2;
+const THROTTLE_COOLDOWN_NS: u64 = 1_000_000_000;
+
+/**
+ * Slow start envelope. While `successes` stays under
+ * `SLOW_START_SAMPLES` and no throttle has fired, every success
+ * doubles the limit (capped by `max_limit`). Past the envelope the
+ * controller switches to additive increase (`+1` per success). This
+ * mirrors TCP slow start. Cold installs need to ramp the cap to
+ * bandwidth delay product in tens of completions, not hundreds.
+ */
+const SLOW_START_SAMPLES: u64 = 32;
+
+#[inline(always)]
+fn pack(inflight: u32, limit: u32) -> u64 {
+    ((limit as u64) << 32) | (inflight as u64)
+}
+
+#[inline(always)]
+fn unpack(s: u64) -> (u32, u32) {
+    (s as u32, (s >> 32) as u32)
+}
+
+#[repr(align(64))]
+struct HotState {
+    /**
+     * Packed state. Low 32 bits hold `inflight`. High 32 bits hold
+     * `limit`. One `AtomicU64` so a permit reservation is a single
+     * CAS that atomically observes the limit and the in flight
+     * count. Avoids the classic two atomic race where `limit`
+     * shrinks between the `inflight` load and the CAS.
+     */
+    state: AtomicU64,
+    /** Minimum observed RTT in microseconds. Ratchets only down. */
+    min_rtt_us: AtomicU64,
+    /** Fast EWMA of RTT samples in microseconds. Alpha 1/4. */
+    ewma_fast_us: AtomicU64,
+    /** Slow EWMA of RTT samples in microseconds. Alpha 1/32. */
+    ewma_slow_us: AtomicU64,
+    /**
+     * Wall instant after which `limit` is allowed to grow again.
+     * Stored as nanoseconds since `created_at`. An atomic load
+     * suffices.
+     */
+    throttle_until_ns: AtomicU64,
+    /**
+     * Total successful completions. Used for the slow start phase.
+     * While this stays below `SLOW_START_SAMPLES` and no throttle
+     * has been observed (`first_throttle` reads as 0), the limiter
+     * doubles on each success instead of incrementing by 1. Mirrors
+     * TCP slow start. A cold install with 350 plus tarballs needs
+     * to ramp from a small seed to the working point in seconds,
+     * not minutes.
+     */
+    successes: AtomicU64,
+    /**
+     * Set to 1 the first time `record_throttle` fires. Permanently
+     * disables slow start so any subsequent regrow is gentle AIMD.
+     * Atomic store release plus load acquire pair so the slow start
+     * decision in `record_success` sees the flag set as soon as the
+     * throttle path commits.
+     */
+    first_throttle: AtomicU64,
+}
+
+#[repr(align(64))]
+struct ColdState {
+    available: Notify,
+    bounds: (u32, u32),
+    created_at: Instant,
+    /**
+     * CUSUM regime detector on observed RTT. Fed every successful
+     * completion. When it fires `Rising`, the limiter applies a
+     * multiplicative shrink. This re enables the gradient intuition
+     * in a way that does not false positive on cold start jitter.
+     * A single slow handshake will not accumulate enough CUSUM to
+     * cross the threshold. Sustained 2x baseline RTT will.
+     *
+     * The threshold parameter is wall time accumulated upward
+     * deviation, not a rate. Any caller visible RTT works because
+     * the detector internally re centers on its own EWMA.
+     */
+    regime: RegimeDetector,
+    /**
+     * When set, the CUSUM `Rising` regime signal does not shrink
+     * the limit. Throttle-driven shrink (`record_throttle`, fired
+     * on real backpressure: HTTP 429/503, IO errors) is unaffected.
+     *
+     * Use case: filesystem-bound limiters where per-op latency
+     * variance is exogenous (antivirus scans, NTFS cold-cache
+     * reads, COW reflink fall-through to copy). Rising RTT on
+     * those paths is intrinsic noise, not a signal that more
+     * concurrency is making things worse — there is no upstream
+     * queue to relieve. Treating it as backpressure was observed
+     * to collapse the linker prewarm limit from seed 16 to 12 on
+     * Windows, queueing 1195 packages behind a 12-permit cap.
+     *
+     * Network limiters (registry packument, registry tarball)
+     * keep CUSUM enabled because rising RTT there does correlate
+     * with upstream queueing.
+     */
+    cusum_shrink_disabled: AtomicBool,
+}
+
+#[derive(Debug)]
+pub struct AdaptiveLimit {
+    hot: HotState,
+    cold: ColdState,
+}
+
+impl std::fmt::Debug for HotState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (inflight, limit) = unpack(self.state.load(Ordering::Relaxed));
+        f.debug_struct("HotState")
+            .field("inflight", &inflight)
+            .field("limit", &limit)
+            .field("min_rtt_us", &self.min_rtt_us.load(Ordering::Relaxed))
+            .field("ewma_fast_us", &self.ewma_fast_us.load(Ordering::Relaxed))
+            .field("ewma_slow_us", &self.ewma_slow_us.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for ColdState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ColdState")
+            .field("bounds", &self.bounds)
+            .finish()
+    }
+}
+
+impl AdaptiveLimit {
+    pub fn new(initial: usize, min_limit: usize, max_limit: usize) -> Arc<Self> {
+        assert!(min_limit >= 1, "min_limit must be at least 1");
+        assert!(min_limit <= max_limit, "min_limit must be <= max_limit");
+        assert!(max_limit <= u32::MAX as usize, "max_limit fits in u32");
+        let initial = initial.clamp(min_limit, max_limit) as u32;
+        Arc::new(Self {
+            hot: HotState {
+                state: AtomicU64::new(pack(0, initial)),
+                min_rtt_us: AtomicU64::new(u64::MAX),
+                ewma_fast_us: AtomicU64::new(0),
+                ewma_slow_us: AtomicU64::new(0),
+                throttle_until_ns: AtomicU64::new(0),
+                successes: AtomicU64::new(0),
+                first_throttle: AtomicU64::new(0),
+            },
+            cold: ColdState {
+                available: Notify::new(),
+                bounds: (min_limit as u32, max_limit as u32),
+                created_at: Instant::now(),
+                /*
+                 * Threshold of 5 seconds of accumulated upward
+                 * deviation. Picked so a sustained ~100 ms baseline
+                 * doubling (very common when a registry's edge is
+                 * degraded) accumulates the full threshold in
+                 * roughly 50 samples, while a single 5 s outlier
+                 * (npm cold cache miss) is absorbed by subsequent
+                 * baseline tracking.
+                 */
+                regime: RegimeDetector::new(5_000_000),
+                cusum_shrink_disabled: AtomicBool::new(false),
+            },
+        })
+    }
+
+    /**
+     * Disable CUSUM-driven shrinking on the success path. Call
+     * once after construction for limiters that gate
+     * filesystem-bound work (linker, materializer). Throttle-path
+     * shrink (record_throttle on real IO errors) remains active.
+     * See [`ColdState::cusum_shrink_disabled`] for rationale.
+     */
+    pub fn disable_cusum_shrink(&self) {
+        self.cold.cusum_shrink_disabled.store(true, Ordering::Relaxed);
+    }
+
+    pub fn current_limit(&self) -> usize {
+        unpack(self.hot.state.load(Ordering::Relaxed)).1 as usize
+    }
+
+    pub fn inflight(&self) -> usize {
+        unpack(self.hot.state.load(Ordering::Relaxed)).0 as usize
+    }
+
+    /**
+     * Construct a limiter whose initial value is loaded from the
+     * given [`PersistentState`] under `key`, falling back to
+     * `default_initial` when no prior run has persisted a value or
+     * the file is unreadable. Convenience over `new` for any site
+     * that wants cross run learning.
+     */
+    pub fn from_persistent(
+        state: &PersistentState,
+        key: &str,
+        default_initial: usize,
+        min_limit: usize,
+        max_limit: usize,
+    ) -> Arc<Self> {
+        let seed = state.load_seed(key, default_initial);
+        Self::new(seed, min_limit, max_limit)
+    }
+
+    /**
+     * Persist the current observed limit back to the given store.
+     * Call at the end of a phase or process so the next invocation
+     * starts where this one converged.
+     */
+    pub fn persist(&self, state: &PersistentState, key: &str) {
+        state.save_observed(key, self.current_limit());
+    }
+
+    pub async fn acquire(self: &Arc<Self>) -> AdaptivePermit {
+        loop {
+            let waiter = self.cold.available.notified();
+            tokio::pin!(waiter);
+            let s = self.hot.state.load(Ordering::Acquire);
+            let (inflight, limit) = unpack(s);
+            if inflight < limit
+                && self
+                    .hot
+                    .state
+                    .compare_exchange_weak(
+                        s,
+                        pack(inflight + 1, limit),
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    )
+                    .is_ok()
+            {
+                return AdaptivePermit {
+                    limiter: Arc::clone(self),
+                    started: Instant::now(),
+                    consumed: false,
+                };
+            }
+            waiter.as_mut().await;
+        }
+    }
+
+    fn record_success(&self, rtt: Duration) {
+        let rtt_us = (rtt.as_micros().min(u64::MAX as u128)) as u64;
+        let rtt_us = rtt_us.max(1);
+        Self::ratchet_min(&self.hot.min_rtt_us, rtt_us);
+        let fast = Self::ewma_update(&self.hot.ewma_fast_us, rtt_us, EWMA_FAST_SHIFT);
+        let slow = Self::ewma_update(&self.hot.ewma_slow_us, rtt_us, EWMA_SLOW_SHIFT);
+        let min_rtt = self.hot.min_rtt_us.load(Ordering::Relaxed);
+
+        let now_ns = self.cold.created_at.elapsed().as_nanos() as u64;
+        let cooldown_active = now_ns < self.hot.throttle_until_ns.load(Ordering::Relaxed);
+
+        let n_succ = self.hot.successes.fetch_add(1, Ordering::Relaxed);
+        let in_slow_start =
+            n_succ < SLOW_START_SAMPLES && self.hot.first_throttle.load(Ordering::Acquire) == 0;
+
+        /*
+         * Two shrink paths exist. Hard back pressure is handled by
+         * [`record_throttle`]. CUSUM detected sustained regime rise
+         * is handled here. The CUSUM gate is the upgrade over the
+         * naive gradient. CUSUM integrates upward deviation over
+         * many samples instead of reacting to a single ratio, so
+         * cold start jitter (TLS handshake, DNS, first cache miss)
+         * does not false positive into a shrink.
+         *
+         * Grow path. Slow start while in envelope. AIMD `+1`
+         * afterward. Both gated on the post throttle cooldown.
+         */
+        let _ = (slow, min_rtt, fast);
+        let regime = self.cold.regime.record(rtt_us);
+        if regime == RegimeSignal::Rising
+            && !self.cold.cusum_shrink_disabled.load(Ordering::Relaxed)
+        {
+            self.scale_limit(SHRINK_NUM_FACTOR, SHRINK_DEN_FACTOR);
+            self.release();
+            return;
+        }
+        if in_slow_start && !cooldown_active {
+            self.scale_limit_grow(2, 1);
+        } else if !cooldown_active {
+            self.bump_limit_by(1);
+        }
+        self.release();
+    }
+
+    fn record_throttle(&self) {
+        self.scale_limit(THROTTLE_NUM, THROTTLE_DEN);
+        let cooldown_end = self.cold.created_at.elapsed().as_nanos() as u64 + THROTTLE_COOLDOWN_NS;
+        self.hot
+            .throttle_until_ns
+            .store(cooldown_end, Ordering::Relaxed);
+        self.hot.first_throttle.store(1, Ordering::Release);
+        self.release();
+    }
+
+    fn record_cancelled(&self) {
+        self.release();
+    }
+
+    fn release(&self) {
+        let s = self.hot.state.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(unpack(s).0 > 0, "release without matching acquire");
+        self.cold.available.notify_one();
+    }
+
+    #[inline]
+    fn ratchet_min(slot: &AtomicU64, sample: u64) {
+        let mut current = slot.load(Ordering::Relaxed);
+        while sample < current {
+            match slot.compare_exchange_weak(
+                current,
+                sample,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    #[inline]
+    fn ewma_update(slot: &AtomicU64, sample: u64, shift: u32) -> u64 {
+        let mut current = slot.load(Ordering::Relaxed);
+        loop {
+            let next = if current == 0 {
+                sample
+            } else {
+                let diff = sample as i128 - current as i128;
+                let step = diff >> shift;
+                ((current as i128).saturating_add(step)).max(1) as u64
+            };
+            match slot.compare_exchange_weak(
+                current,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return next,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn bump_limit_by(&self, delta: u32) {
+        let mut s = self.hot.state.load(Ordering::Relaxed);
+        loop {
+            let (inflight, limit) = unpack(s);
+            let next_limit = limit.saturating_add(delta).min(self.cold.bounds.1);
+            if next_limit == limit {
+                return;
+            }
+            match self.hot.state.compare_exchange_weak(
+                s,
+                pack(inflight, next_limit),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    /*
+                     * Wake one waiter per new permit. Tokio
+                     * `Notify` stores `notify_one` calls as permits
+                     * when no waiter is registered, so even
+                     * acquirers that are mid `notified()` future
+                     * setup pick up the signal instead of dropping
+                     * it. `notify_waiters` would lose signals to
+                     * acquirers that had not polled yet, and was
+                     * the cause of slow start under utilizing the
+                     * new capacity in earlier versions.
+                     */
+                    let added = next_limit - limit;
+                    for _ in 0..added {
+                        self.cold.available.notify_one();
+                    }
+                    return;
+                }
+                Err(observed) => s = observed,
+            }
+        }
+    }
+
+    fn scale_limit_grow(&self, num: u64, den: u64) {
+        let mut s = self.hot.state.load(Ordering::Relaxed);
+        loop {
+            let (inflight, limit) = unpack(s);
+            let scaled = ((limit as u64).saturating_mul(num) / den.max(1)) as u32;
+            let next_limit = scaled.clamp(self.cold.bounds.0, self.cold.bounds.1);
+            if next_limit == limit {
+                return;
+            }
+            match self.hot.state.compare_exchange_weak(
+                s,
+                pack(inflight, next_limit),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    let added = next_limit - limit;
+                    for _ in 0..added {
+                        self.cold.available.notify_one();
+                    }
+                    return;
+                }
+                Err(observed) => s = observed,
+            }
+        }
+    }
+
+    fn scale_limit(&self, num: u64, den: u64) {
+        let mut s = self.hot.state.load(Ordering::Relaxed);
+        loop {
+            let (inflight, limit) = unpack(s);
+            let scaled = ((limit as u64).saturating_mul(num) / den) as u32;
+            let next_limit = scaled.clamp(self.cold.bounds.0, self.cold.bounds.1);
+            if next_limit == limit {
+                return;
+            }
+            match self.hot.state.compare_exchange_weak(
+                s,
+                pack(inflight, next_limit),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(observed) => s = observed,
+            }
+        }
+    }
+}
+
+/**
+ * RAII permit. Must be consumed via [`AdaptivePermit::record_success`],
+ * [`AdaptivePermit::record_throttle`], or
+ * [`AdaptivePermit::record_cancelled`]. A bare drop counts as
+ * cancellation so an early return error path does not poison the
+ * controller signal.
+ */
+#[must_use = "permit must be recorded with record_success/record_throttle, or dropped to cancel"]
+pub struct AdaptivePermit {
+    limiter: Arc<AdaptiveLimit>,
+    started: Instant,
+    consumed: bool,
+}
+
+impl AdaptivePermit {
+    pub fn record_success(mut self) {
+        self.consumed = true;
+        let rtt = self.started.elapsed();
+        self.limiter.record_success(rtt);
+    }
+
+    pub fn record_throttle(mut self) {
+        self.consumed = true;
+        self.limiter.record_throttle();
+    }
+
+    pub fn record_cancelled(mut self) {
+        self.consumed = true;
+        self.limiter.record_cancelled();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_success_with_rtt(mut self, rtt: Duration) {
+        self.consumed = true;
+        self.limiter.record_success(rtt);
+    }
+}
+
+impl Drop for AdaptivePermit {
+    fn drop(&mut self) {
+        if !self.consumed {
+            self.limiter.record_cancelled();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn grows_under_stable_latency() {
+        let limit = AdaptiveLimit::new(8, 4, 64);
+        let baseline = Duration::from_millis(50);
+        for _ in 0..200 {
+            let permit = limit.acquire().await;
+            permit.record_success_with_rtt(baseline);
+        }
+        assert!(
+            limit.current_limit() > 16,
+            "expected growth, got {}",
+            limit.current_limit()
+        );
+    }
+
+    #[tokio::test]
+    async fn shrinks_on_throttle() {
+        let limit = AdaptiveLimit::new(32, 4, 64);
+        let permit = limit.acquire().await;
+        permit.record_throttle();
+        assert_eq!(limit.current_limit(), 16);
+    }
+
+    #[tokio::test]
+    async fn floor_holds_under_continuous_throttle() {
+        let limit = AdaptiveLimit::new(32, 4, 64);
+        for _ in 0..20 {
+            let permit = limit.acquire().await;
+            permit.record_throttle();
+        }
+        assert_eq!(limit.current_limit(), 4);
+    }
+
+    #[tokio::test]
+    async fn ceiling_holds_under_runaway_growth() {
+        let limit = AdaptiveLimit::new(8, 4, 16);
+        for _ in 0..1000 {
+            limit.bump_limit_by(1);
+        }
+        assert_eq!(limit.current_limit(), 16);
+    }
+
+    #[tokio::test]
+    async fn permit_drop_releases_without_signal() {
+        let limit = AdaptiveLimit::new(2, 1, 4);
+        let p1 = limit.acquire().await;
+        let p2 = limit.acquire().await;
+        assert_eq!(limit.inflight(), 2);
+        drop(p1);
+        assert_eq!(limit.inflight(), 1);
+        drop(p2);
+        assert_eq!(limit.inflight(), 0);
+    }
+
+    #[tokio::test]
+    async fn awaits_when_saturated() {
+        let limit = AdaptiveLimit::new(1, 1, 4);
+        let hold = limit.acquire().await;
+        let limit_clone = Arc::clone(&limit);
+        let task = tokio::spawn(async move {
+            let p = limit_clone.acquire().await;
+            p.record_cancelled();
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        drop(hold);
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn ewma_converges_toward_sample_mean() {
+        let slot = AtomicU64::new(0);
+        for _ in 0..100 {
+            AdaptiveLimit::ewma_update(&slot, 1000, EWMA_FAST_SHIFT);
+        }
+        let v = slot.load(Ordering::Relaxed);
+        assert!((900..=1100).contains(&v), "ewma settled at {v}");
+    }
+
+    #[tokio::test]
+    async fn shrink_only_on_explicit_throttle() {
+        /*
+         * Per the design comment in `record_success`, gradient
+         * driven shrink is gated by CUSUM. Only `record_throttle`
+         * or a sustained CUSUM crossing shrinks. This test pins
+         * the contract that 200 completions at modestly elevated
+         * latency (5x the first sample) does not shrink the cap
+         * because the slow EWMA tracks the new baseline before
+         * CUSUM accumulates enough deviation.
+         */
+        let limit = AdaptiveLimit::new(64, 4, 256);
+        for i in 0..200 {
+            let p = limit.acquire().await;
+            let rtt = if i == 0 {
+                Duration::from_millis(20)
+            } else {
+                Duration::from_millis(100)
+            };
+            p.record_success_with_rtt(rtt);
+        }
+        assert!(
+            limit.current_limit() >= 64,
+            "no shrink without throttle, got {}",
+            limit.current_limit()
+        );
+    }
+}
+
+/**
+ * Producer / consumer skew tracker that recommends a bounded channel
+ * capacity from observed traffic. Replaces static
+ * `mpsc::channel(N)` sizing decisions with a number that follows
+ * actual high water demand. Cheap to use. Callers invoke
+ * `record_push` on send and `record_pop` on receive. The advisor
+ * tracks the running high water mark of pending items and adjusts a
+ * recommended target upward when the channel approaches saturation.
+ *
+ * Unlike [`AdaptiveLimit`], this is advisory. Tokio's `mpsc` cap is
+ * fixed at construction. The advisor's role is twofold. It feeds
+ * the "should I grow the next channel I open" decision in long
+ * running processes that periodically tear down and re open the
+ * channel. It also feeds observability ("the materialize channel
+ * high water hit 87% capacity for 4 s, consider raising the cap").
+ *
+ * # Algorithm
+ *
+ * `pushed` and `popped` are monotonic counters. Their difference
+ * gives `pending`. `peak_pending` ratchets up only.
+ * `recommended` is bounded by `[min_cap, max_cap]` and updated on
+ * each push. When `peak_pending` exceeds 80% of `recommended`, the
+ * advisor scales `recommended` by 1.5x. When `peak_pending` stays
+ * below 30% of `recommended` for `STABLE_POPS_BEFORE_SHRINK`
+ * consecutive pops, the advisor scales by 0.8x. Both bounded by
+ * max and min.
+ *
+ * The hysteresis band of 0.3 to 0.8 avoids oscillation under bursty
+ * traffic. `STABLE_POPS_BEFORE_SHRINK` of 64 corresponds to roughly
+ * 1 to 2 seconds at typical install rates. Fast enough to react to
+ * a regime change. Slow enough to ignore single quiet pops.
+ */
+pub struct AdaptiveBuffer {
+    pushed: AtomicU64,
+    popped: AtomicU64,
+    peak_pending: AtomicU64,
+    recommended: AtomicU64,
+    stable_pops: AtomicU64,
+    min_cap: u64,
+    max_cap: u64,
+}
+
+impl std::fmt::Debug for AdaptiveBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdaptiveBuffer")
+            .field("recommended", &self.recommended.load(Ordering::Relaxed))
+            .field("peak_pending", &self.peak_pending.load(Ordering::Relaxed))
+            .field("pushed", &self.pushed.load(Ordering::Relaxed))
+            .field("popped", &self.popped.load(Ordering::Relaxed))
+            .field("min_cap", &self.min_cap)
+            .field("max_cap", &self.max_cap)
+            .finish()
+    }
+}
+
+const STABLE_POPS_BEFORE_SHRINK: u64 = 64;
+const HIGH_WATER_GROW: f64 = 0.8;
+const LOW_WATER_SHRINK: f64 = 0.3;
+const GROW_FACTOR_NUM: u64 = 3;
+const GROW_FACTOR_DEN: u64 = 2;
+const BUFFER_SHRINK_FACTOR_NUM: u64 = 4;
+const BUFFER_SHRINK_FACTOR_DEN: u64 = 5;
+
+impl AdaptiveBuffer {
+    pub fn new(initial: usize, min_cap: usize, max_cap: usize) -> Arc<Self> {
+        assert!(min_cap >= 1, "min_cap must be at least 1");
+        assert!(min_cap <= max_cap, "min_cap must be <= max_cap");
+        let initial = initial.clamp(min_cap, max_cap) as u64;
+        Arc::new(Self {
+            pushed: AtomicU64::new(0),
+            popped: AtomicU64::new(0),
+            peak_pending: AtomicU64::new(0),
+            recommended: AtomicU64::new(initial),
+            stable_pops: AtomicU64::new(0),
+            min_cap: min_cap as u64,
+            max_cap: max_cap as u64,
+        })
+    }
+
+    pub fn recommended(&self) -> usize {
+        self.recommended.load(Ordering::Relaxed) as usize
+    }
+
+    pub fn record_push(&self) {
+        let pushed = self.pushed.fetch_add(1, Ordering::Relaxed) + 1;
+        let popped = self.popped.load(Ordering::Relaxed);
+        let pending = pushed.saturating_sub(popped);
+        let mut peak = self.peak_pending.load(Ordering::Relaxed);
+        while pending > peak {
+            match self.peak_pending.compare_exchange_weak(
+                peak,
+                pending,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => peak = observed,
+            }
+        }
+        let rec = self.recommended.load(Ordering::Relaxed);
+        let high = (rec as f64 * HIGH_WATER_GROW) as u64;
+        if pending > high {
+            let next =
+                ((rec * GROW_FACTOR_NUM) / GROW_FACTOR_DEN).clamp(self.min_cap, self.max_cap);
+            self.recommended.store(next, Ordering::Relaxed);
+            self.stable_pops.store(0, Ordering::Relaxed);
+        }
+    }
+
+    pub fn record_pop(&self) {
+        let popped = self.popped.fetch_add(1, Ordering::Relaxed) + 1;
+        let pushed = self.pushed.load(Ordering::Relaxed);
+        let pending = pushed.saturating_sub(popped);
+        let rec = self.recommended.load(Ordering::Relaxed);
+        let low = (rec as f64 * LOW_WATER_SHRINK) as u64;
+        if pending < low {
+            let stable = self.stable_pops.fetch_add(1, Ordering::Relaxed) + 1;
+            if stable >= STABLE_POPS_BEFORE_SHRINK {
+                let next = ((rec * BUFFER_SHRINK_FACTOR_NUM) / BUFFER_SHRINK_FACTOR_DEN)
+                    .clamp(self.min_cap, self.max_cap);
+                self.recommended.store(next, Ordering::Relaxed);
+                self.stable_pops.store(0, Ordering::Relaxed);
+            }
+        } else {
+            self.stable_pops.store(0, Ordering::Relaxed);
+        }
+    }
+
+    pub fn pending(&self) -> u64 {
+        let pushed = self.pushed.load(Ordering::Relaxed);
+        let popped = self.popped.load(Ordering::Relaxed);
+        pushed.saturating_sub(popped)
+    }
+
+    pub fn peak_pending(&self) -> u64 {
+        self.peak_pending.load(Ordering::Relaxed)
+    }
+}
+
+/**
+ * Cumulative sum (CUSUM) change point detector for streaming
+ * signals. Computes the cumulative deviation from a running
+ * baseline. When the sum exceeds a threshold (positive or
+ * negative), the detector declares a regime shift. Reference:
+ * Page, "Continuous Inspection Schemes" (1954). The textbook
+ * quickest change detection algorithm.
+ *
+ * # State
+ *
+ * Two atomic counters per direction. `pos` accumulates positive
+ * deviation (rising regime). `neg` accumulates negative deviation
+ * (falling regime). The baseline is itself an EWMA (alpha 1/32) so
+ * the detector adapts to long term drift while still firing on
+ * rapid shifts.
+ *
+ * # Why this is the right detector
+ *
+ * Pure threshold tests on raw RTT either fire too eagerly (single
+ * spike triggers a false positive) or too late (gradual creep
+ * gets ignored). CUSUM accumulates evidence. A small shift in
+ * mean integrates over time to a detectable signal, while a
+ * single outlier washes out. This is the property
+ * [`AdaptiveLimit`] needs to gate gradient driven shrink against
+ * transient jitter.
+ */
+pub struct RegimeDetector {
+    pos: AtomicU64,
+    neg: AtomicU64,
+    baseline_us: AtomicU64,
+    threshold_us: u64,
+}
+
+impl std::fmt::Debug for RegimeDetector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegimeDetector")
+            .field("pos", &self.pos.load(Ordering::Relaxed))
+            .field("neg", &self.neg.load(Ordering::Relaxed))
+            .field("baseline_us", &self.baseline_us.load(Ordering::Relaxed))
+            .field("threshold_us", &self.threshold_us)
+            .finish()
+    }
+}
+
+impl RegimeDetector {
+    pub fn new(threshold_us: u64) -> Self {
+        Self {
+            pos: AtomicU64::new(0),
+            neg: AtomicU64::new(0),
+            baseline_us: AtomicU64::new(0),
+            threshold_us,
+        }
+    }
+
+    pub fn record(&self, sample_us: u64) -> RegimeSignal {
+        let baseline = self.baseline_us.load(Ordering::Relaxed);
+        let next_baseline = if baseline == 0 {
+            sample_us
+        } else {
+            let diff = sample_us as i128 - baseline as i128;
+            let step = diff >> EWMA_SLOW_SHIFT;
+            ((baseline as i128).saturating_add(step)).max(1) as u64
+        };
+        self.baseline_us.store(next_baseline, Ordering::Relaxed);
+
+        let dev = sample_us as i64 - next_baseline as i64;
+        if dev >= 0 {
+            let pos = self
+                .pos
+                .fetch_add(dev as u64, Ordering::Relaxed)
+                .saturating_add(dev as u64);
+            self.neg.store(0, Ordering::Relaxed);
+            if pos >= self.threshold_us {
+                self.pos.store(0, Ordering::Relaxed);
+                return RegimeSignal::Rising;
+            }
+        } else {
+            let neg = self
+                .neg
+                .fetch_add(-dev as u64, Ordering::Relaxed)
+                .saturating_add(-dev as u64);
+            self.pos.store(0, Ordering::Relaxed);
+            if neg >= self.threshold_us {
+                self.neg.store(0, Ordering::Relaxed);
+                return RegimeSignal::Falling;
+            }
+        }
+        RegimeSignal::Stable
+    }
+
+    pub fn baseline_us(&self) -> u64 {
+        self.baseline_us.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegimeSignal {
+    Stable,
+    Rising,
+    Falling,
+}
+
+/**
+ * Persistent learned state. A simple key value store backed by a
+ * JSON file under the user's cache directory. Lets the adaptive
+ * controllers carry their converged operating point across process
+ * boundaries so a cold install resumes from where the previous run
+ * left off.
+ *
+ * # Why this matters
+ *
+ * Short bursts (a single `aube install`) take 5 to 15 seconds. The
+ * AIMD slow start ramp on `AdaptiveLimit` needs roughly 5 to 10
+ * seconds of completions to reach the bandwidth delay product on a
+ * fresh process. That means the limiter spends most of a short
+ * install ramping rather than running at the optimum. Persistence
+ * fixes that by seeding the next run from the previous run's
+ * observed steady state.
+ *
+ * # Format
+ *
+ * `$XDG_CACHE_HOME/aube/adaptive-state.json` (falls back to
+ * `~/.cache/aube/adaptive-state.json` on Linux,
+ * `~/Library/Caches/aube/adaptive-state.json` on macOS,
+ * `%LOCALAPPDATA%\aube\adaptive-state.json` on Windows).
+ *
+ * Schema:
+ *
+ * ```json
+ * {
+ *   "version": 1,
+ *   "values": {
+ *     "tarball:registry.npmjs.org": 96,
+ *     "packument:registry.npmjs.org": 64
+ *   }
+ * }
+ * ```
+ *
+ * Reads tolerate missing or corrupt files (falls back to `None`).
+ * Writes are atomic via temp file plus rename. Concurrent writers
+ * are safe in the sense that the last writer wins, no torn JSON.
+ *
+ * # API
+ *
+ * `load_seed(key)` returns the previously persisted value for a key,
+ * blended via EWMA towards the caller's static default. The blend
+ * factor is intentionally conservative (alpha 0.3 toward the
+ * persisted value) so a single bad run does not poison future
+ * starts.
+ *
+ * `save_observed(key, value)` writes the current observed value back
+ * for the next process to consume.
+ */
+pub struct PersistentState {
+    path: PathBuf,
+    cache: std::sync::Mutex<Option<PersistedSnapshot>>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Default)]
+struct PersistedSnapshot {
+    version: u32,
+    values: std::collections::BTreeMap<String, u64>,
+}
+
+impl std::fmt::Debug for PersistentState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PersistentState")
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+const PERSISTED_SCHEMA_VERSION: u32 = 1;
+const PERSISTED_BLEND_NUM: u64 = 7;
+const PERSISTED_BLEND_DEN: u64 = 10;
+
+impl PersistentState {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            cache: std::sync::Mutex::new(None),
+        }
+    }
+
+    /**
+     * Read the persisted value for `key` and blend it with `default`
+     * via fixed weight (currently 70% persisted, 30% default).
+     * Returns `default` when no persisted value exists, the file is
+     * missing, the file is malformed, or the schema version does not
+     * match. The blend protects against a previous run that
+     * over fitted on a one off network condition.
+     */
+    pub fn load_seed(&self, key: &str, default: usize) -> usize {
+        let snapshot = self.snapshot();
+        let persisted = snapshot.values.get(key).copied();
+        match persisted {
+            Some(v) if snapshot.version == PERSISTED_SCHEMA_VERSION => {
+                let blended = (v.saturating_mul(PERSISTED_BLEND_NUM)
+                    + (default as u64).saturating_mul(PERSISTED_BLEND_DEN - PERSISTED_BLEND_NUM))
+                    / PERSISTED_BLEND_DEN;
+                blended as usize
+            }
+            _ => default,
+        }
+    }
+
+    /**
+     * Write `value` back for `key`, replacing any prior entry.
+     * Performs a read modify write of the on disk file under the
+     * internal mutex, then atomically renames over the destination
+     * so a crash mid write leaves the previous good file in place.
+     * Tolerates failure silently because adaptive state is a hint,
+     * not a correctness requirement.
+     */
+    pub fn save_observed(&self, key: &str, value: usize) {
+        let mut snapshot = self.snapshot();
+        snapshot.version = PERSISTED_SCHEMA_VERSION;
+        snapshot
+            .values
+            .insert(key.to_string(), value as u64);
+        if let Ok(mut cached) = self.cache.lock() {
+            *cached = Some(snapshot.clone());
+        }
+        if let Some(parent) = self.path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let Ok(json) = serde_json::to_vec_pretty(&snapshot) else {
+            return;
+        };
+        let Some(parent) = self.path.parent() else {
+            return;
+        };
+        let tmp = parent.join(format!(
+            ".adaptive-state.tmp.{}.{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        if std::fs::write(&tmp, json).is_ok() {
+            let _ = std::fs::rename(&tmp, &self.path);
+        } else {
+            let _ = std::fs::remove_file(&tmp);
+        }
+    }
+
+    fn snapshot(&self) -> PersistedSnapshot {
+        if let Ok(mut cached) = self.cache.lock() {
+            if let Some(snap) = cached.as_ref() {
+                return snap.clone();
+            }
+            let snap = read_snapshot(&self.path).unwrap_or_default();
+            *cached = Some(snap.clone());
+            return snap;
+        }
+        read_snapshot(&self.path).unwrap_or_default()
+    }
+}
+
+fn read_snapshot(path: &Path) -> Option<PersistedSnapshot> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/**
+ * Default location for the global persistent adaptive state file.
+ * Honors `XDG_CACHE_HOME` first, then falls back to
+ * `~/.cache/aube/adaptive-state.json` on Linux,
+ * `~/Library/Caches/aube/adaptive-state.json` on macOS, and
+ * `%LOCALAPPDATA%\aube\adaptive-state.json` on Windows.
+ */
+pub fn default_persistent_state_path() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg).join("aube").join("adaptive-state.json"));
+        }
+    }
+    if cfg!(windows) {
+        std::env::var("LOCALAPPDATA")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(|p| PathBuf::from(p).join("aube").join("adaptive-state.json"))
+    } else if cfg!(target_os = "macos") {
+        std::env::var("HOME").ok().map(|h| {
+            PathBuf::from(h)
+                .join("Library")
+                .join("Caches")
+                .join("aube")
+                .join("adaptive-state.json")
+        })
+    } else {
+        std::env::var("HOME")
+            .ok()
+            .map(|h| PathBuf::from(h).join(".cache").join("aube").join("adaptive-state.json"))
+    }
+}
+
+/**
+ * Process global persistent state singleton. Lazy initialised on
+ * first access via [`global_persistent_state`]. Callers that need a
+ * different path for testing can construct their own
+ * [`PersistentState`] directly.
+ */
+static GLOBAL_PERSISTENT_STATE: std::sync::OnceLock<Arc<PersistentState>> = std::sync::OnceLock::new();
+
+pub fn global_persistent_state() -> Option<Arc<PersistentState>> {
+    let path = default_persistent_state_path()?;
+    Some(
+        GLOBAL_PERSISTENT_STATE
+            .get_or_init(|| Arc::new(PersistentState::new(path)))
+            .clone(),
+    )
+}
+
+#[cfg(test)]
+mod additional_tests {
+    use super::*;
+
+    #[test]
+    fn buffer_grows_under_high_water() {
+        let buf = AdaptiveBuffer::new(8, 4, 64);
+        for _ in 0..7 {
+            buf.record_push();
+        }
+        assert!(
+            buf.recommended() > 8,
+            "expected grow, got {}",
+            buf.recommended()
+        );
+    }
+
+    #[test]
+    fn buffer_shrinks_after_sustained_low_water() {
+        let buf = AdaptiveBuffer::new(32, 4, 64);
+        for _ in 0..1 {
+            buf.record_push();
+            buf.record_pop();
+        }
+        for _ in 0..STABLE_POPS_BEFORE_SHRINK + 1 {
+            buf.record_pop();
+        }
+        assert!(
+            buf.recommended() < 32,
+            "expected shrink, got {}",
+            buf.recommended()
+        );
+    }
+
+    #[test]
+    fn buffer_clamps_at_max() {
+        let buf = AdaptiveBuffer::new(8, 4, 16);
+        for _ in 0..200 {
+            buf.record_push();
+        }
+        assert!(buf.recommended() <= 16);
+    }
+
+    #[test]
+    fn cusum_detects_rising_shift() {
+        let det = RegimeDetector::new(50_000);
+        for _ in 0..100 {
+            assert_eq!(det.record(10_000), RegimeSignal::Stable);
+        }
+        let mut saw_rising = false;
+        for _ in 0..200 {
+            if det.record(50_000) == RegimeSignal::Rising {
+                saw_rising = true;
+                break;
+            }
+        }
+        assert!(saw_rising, "expected rising regime detection");
+    }
+
+    #[test]
+    fn cusum_ignores_single_outlier() {
+        let det = RegimeDetector::new(500_000);
+        for _ in 0..100 {
+            det.record(10_000);
+        }
+        let r = det.record(2_000_000);
+        assert_eq!(
+            r,
+            RegimeSignal::Rising,
+            "single big outlier above threshold fires"
+        );
+        let det2 = RegimeDetector::new(5_000_000);
+        for _ in 0..100 {
+            det2.record(10_000);
+        }
+        for _ in 0..5 {
+            assert_eq!(det2.record(50_000), RegimeSignal::Stable);
+        }
+    }
+}

--- a/crates/aube-util/src/adaptive.rs
+++ b/crates/aube-util/src/adaptive.rs
@@ -295,7 +295,9 @@ impl AdaptiveLimit {
      * See [`ColdState::cusum_shrink_disabled`] for rationale.
      */
     pub fn disable_cusum_shrink(&self) {
-        self.cold.cusum_shrink_disabled.store(true, Ordering::Relaxed);
+        self.cold
+            .cusum_shrink_disabled
+            .store(true, Ordering::Relaxed);
     }
 
     pub fn current_limit(&self) -> usize {
@@ -429,12 +431,8 @@ impl AdaptiveLimit {
     fn ratchet_min(slot: &AtomicU64, sample: u64) {
         let mut current = slot.load(Ordering::Relaxed);
         while sample < current {
-            match slot.compare_exchange_weak(
-                current,
-                sample,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
+            match slot.compare_exchange_weak(current, sample, Ordering::Relaxed, Ordering::Relaxed)
+            {
                 Ok(_) => return,
                 Err(observed) => current = observed,
             }
@@ -452,12 +450,7 @@ impl AdaptiveLimit {
                 let step = diff >> shift;
                 ((current as i128).saturating_add(step)).max(1) as u64
             };
-            match slot.compare_exchange_weak(
-                current,
-                next,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
+            match slot.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed) {
                 Ok(_) => return next,
                 Err(observed) => current = observed,
             }
@@ -1064,9 +1057,7 @@ impl PersistentState {
     pub fn save_observed(&self, key: &str, value: usize) {
         let mut snapshot = self.snapshot();
         snapshot.version = PERSISTED_SCHEMA_VERSION;
-        snapshot
-            .values
-            .insert(key.to_string(), value as u64);
+        snapshot.values.insert(key.to_string(), value as u64);
         if let Ok(mut cached) = self.cache.lock() {
             *cached = Some(snapshot.clone());
         }
@@ -1120,10 +1111,10 @@ fn read_snapshot(path: &Path) -> Option<PersistedSnapshot> {
  * `%LOCALAPPDATA%\aube\adaptive-state.json` on Windows.
  */
 pub fn default_persistent_state_path() -> Option<PathBuf> {
-    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
-        if !xdg.is_empty() {
-            return Some(PathBuf::from(xdg).join("aube").join("adaptive-state.json"));
-        }
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME")
+        && !xdg.is_empty()
+    {
+        return Some(PathBuf::from(xdg).join("aube").join("adaptive-state.json"));
     }
     if cfg!(windows) {
         std::env::var("LOCALAPPDATA")
@@ -1139,9 +1130,12 @@ pub fn default_persistent_state_path() -> Option<PathBuf> {
                 .join("adaptive-state.json")
         })
     } else {
-        std::env::var("HOME")
-            .ok()
-            .map(|h| PathBuf::from(h).join(".cache").join("aube").join("adaptive-state.json"))
+        std::env::var("HOME").ok().map(|h| {
+            PathBuf::from(h)
+                .join(".cache")
+                .join("aube")
+                .join("adaptive-state.json")
+        })
     }
 }
 
@@ -1151,7 +1145,8 @@ pub fn default_persistent_state_path() -> Option<PathBuf> {
  * different path for testing can construct their own
  * [`PersistentState`] directly.
  */
-static GLOBAL_PERSISTENT_STATE: std::sync::OnceLock<Arc<PersistentState>> = std::sync::OnceLock::new();
+static GLOBAL_PERSISTENT_STATE: std::sync::OnceLock<Arc<PersistentState>> =
+    std::sync::OnceLock::new();
 
 pub fn global_persistent_state() -> Option<Arc<PersistentState>> {
     let path = default_persistent_state_path()?;

--- a/crates/aube-util/src/adaptive.rs
+++ b/crates/aube-util/src/adaptive.rs
@@ -341,23 +341,32 @@ impl AdaptiveLimit {
             tokio::pin!(waiter);
             let s = self.hot.state.load(Ordering::Acquire);
             let (inflight, limit) = unpack(s);
-            if inflight < limit
-                && self
-                    .hot
-                    .state
-                    .compare_exchange_weak(
-                        s,
-                        pack(inflight + 1, limit),
-                        Ordering::AcqRel,
-                        Ordering::Acquire,
-                    )
-                    .is_ok()
-            {
-                return AdaptivePermit {
-                    limiter: Arc::clone(self),
-                    started: Instant::now(),
-                    consumed: false,
-                };
+            if inflight < limit {
+                // `compare_exchange` (strong) instead of weak: a
+                // spurious failure here would drop us into
+                // `waiter.as_mut().await` even though a permit
+                // slot was available. If no `release()` has fired
+                // since we registered the waiter, the await sleeps
+                // until the next release — which can be the full
+                // duration of an in-flight request. Strong CAS
+                // pays a tiny extra cost on the contended path
+                // (LL/SC archs may retry internally) in exchange
+                // for not gambling latency on a CPU mispredict.
+                match self.hot.state.compare_exchange(
+                    s,
+                    pack(inflight + 1, limit),
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => {
+                        return AdaptivePermit {
+                            limiter: Arc::clone(self),
+                            started: Instant::now(),
+                            consumed: false,
+                        };
+                    }
+                    Err(_) => continue,
+                }
             }
             waiter.as_mut().await;
         }
@@ -439,6 +448,24 @@ impl AdaptiveLimit {
         }
     }
 
+    /// Lock-free EWMA update with relaxed concurrency semantics.
+    ///
+    /// When two threads land here at the same time, both read the
+    /// same `current`, both compute their own `next`, and only one
+    /// wins the CAS. The loser retries against the winner's value
+    /// as the new base, so a single sample can effectively be
+    /// "applied twice" (winner's value + loser's new step from
+    /// it) while a different sample never gets folded in. For a
+    /// statistical smoother fed thousands of samples per install
+    /// this is a negligible bias — the EWMA still tracks the
+    /// underlying RTT distribution. CUSUM downstream re-centers
+    /// on its own slow EWMA, so a momentarily inflated sample
+    /// gets damped before it reaches the shrink decision.
+    ///
+    /// We accept this trade because the alternative — a Mutex —
+    /// would introduce contention on every successful request,
+    /// which dominates the workload. "Lock-free" here means no
+    /// blocking primitives, not exact serialization.
     #[inline]
     fn ewma_update(slot: &AtomicU64, sample: u64, shift: u32) -> u64 {
         let mut current = slot.load(Ordering::Relaxed);

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod adaptive;
 pub mod buf;
 pub mod cache;
 pub mod collections;

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -930,8 +930,8 @@ pub(super) async fn fetch_and_import_tarball_streaming(
             // Streaming path can't fall back to re-hash with another
             // algo (no buffered bytes), so non-SHA-512 SRI bails and
             // the caller falls back to the buffered path.
-            let matched = aube_store::verify_precomputed_sha512(&sha512, expected)
-                .map_err(|e| {
+            let matched =
+                aube_store::verify_precomputed_sha512(&sha512, expected).map_err(|e| {
                     local(miette!(
                         "{display_name}@{version}: {e}{}",
                         crate::dep_chain::format_chain_for(registry_name, version)

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -781,6 +781,26 @@ pub(super) fn import_verified_tarball_streamed(
 /// path. Non-SHA-512 SRI auto-falls-back since streaming verify can't
 /// re-hash with another algo.
 #[allow(clippy::too_many_arguments)]
+/// Error from [`fetch_and_import_tarball_streaming`] that
+/// preserves whether the underlying registry call hit upstream
+/// backpressure (HTTP 429/502/503/504/timeout). Callers feed
+/// `is_throttle` into
+/// [`aube_util::adaptive::AdaptivePermit::record_throttle`] so the
+/// AIMD halving path actually fires when registries push back.
+/// `From<TarballStreamErr> for miette::Report` lets `?` keep
+/// working at sites that don't care about the distinction.
+pub(super) struct TarballStreamErr {
+    pub report: miette::Report,
+    pub is_throttle: bool,
+}
+
+impl From<TarballStreamErr> for miette::Report {
+    fn from(e: TarballStreamErr) -> Self {
+        e.report
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn fetch_and_import_tarball_streaming(
     client: &aube_registry::client::RegistryClient,
     store: &std::sync::Arc<aube_store::Store>,
@@ -792,14 +812,35 @@ pub(super) async fn fetch_and_import_tarball_streaming(
     verify_integrity: bool,
     strict_integrity: bool,
     strict_pkg_content_check: bool,
-) -> miette::Result<(aube_store::PackageIndex, u64)> {
+) -> Result<(aube_store::PackageIndex, u64), TarballStreamErr> {
     use sha2::Digest;
 
+    // Local-error helper. Anything we observe past the response
+    // headers (chunk read errors are an exception, see below) is
+    // either local IO, hash mismatch, or content validation —
+    // none of which respond to backing off the registry, so they
+    // should not trip the AIMD throttle path.
+    let local = |report: miette::Report| TarballStreamErr {
+        report,
+        is_throttle: false,
+    };
+    // Network-error helper, used for chunk read errors during
+    // body streaming. Connection resets and read timeouts mid-
+    // body are the same kind of upstream signal as a 503 reply.
+    let net = |e: aube_registry::Error, ctx: miette::Report| TarballStreamErr {
+        is_throttle: e.is_throttle(),
+        report: ctx,
+    };
+
     let mut resp = client.start_tarball_stream(url).await.map_err(|e| {
-        miette!(
-            "failed to fetch {display_name}@{version}: {e}{}",
-            crate::dep_chain::format_chain_for(registry_name, version)
-        )
+        let is_throttle = e.is_throttle();
+        TarballStreamErr {
+            report: miette!(
+                "failed to fetch {display_name}@{version}: {e}{}",
+                crate::dep_chain::format_chain_for(registry_name, version)
+            ),
+            is_throttle,
+        }
     })?;
 
     let cap = client.tarball_max_bytes();
@@ -868,14 +909,17 @@ pub(super) async fn fetch_and_import_tarball_streaming(
     };
     drop(chunk_tx);
 
-    let import_result = import_handle.await.into_diagnostic()?;
+    let import_result = import_handle.await.into_diagnostic().map_err(local)?;
     if let Some(e) = stream_err {
-        return Err(miette!(
-            "stream error for {display_name}@{version}: {e}{}",
-            crate::dep_chain::format_chain_for(registry_name, version)
+        return Err(net(
+            e,
+            miette!(
+                "stream error for {display_name}@{version}{}",
+                crate::dep_chain::format_chain_for(registry_name, version)
+            ),
         ));
     }
-    let index = import_result?;
+    let index = import_result.map_err(local)?;
 
     let mut sha512 = [0u8; 64];
     sha512.copy_from_slice(&hasher.finalize()[..]);
@@ -886,24 +930,24 @@ pub(super) async fn fetch_and_import_tarball_streaming(
             // Streaming path can't fall back to re-hash with another
             // algo (no buffered bytes), so non-SHA-512 SRI bails and
             // the caller falls back to the buffered path.
-            let matched =
-                aube_store::verify_precomputed_sha512(&sha512, expected).map_err(|e| {
-                    miette!(
+            let matched = aube_store::verify_precomputed_sha512(&sha512, expected)
+                .map_err(|e| {
+                    local(miette!(
                         "{display_name}@{version}: {e}{}",
                         crate::dep_chain::format_chain_for(registry_name, version)
-                    )
+                    ))
                 })?;
             if !matched {
-                return Err(miette!(
+                return Err(local(miette!(
                     "{display_name}@{version}: SRI uses non-SHA-512 algo, streaming path cannot re-hash. Set AUBE_DISABLE_TARBALL_STREAM=1 to force buffered fetch{}",
                     crate::dep_chain::format_chain_for(registry_name, version)
-                ));
+                )));
             }
         } else if strict_integrity {
-            return Err(miette!(
+            return Err(local(miette!(
                 "{display_name}@{version}: registry response has no `dist.integrity` and `strict-store-integrity` is on. Refusing to import unverified bytes.{}",
                 crate::dep_chain::format_chain_for(registry_name, version)
-            ));
+            )));
         } else {
             tracing::warn!(
                 code = aube_codes::warnings::WARN_AUBE_MISSING_INTEGRITY,
@@ -914,10 +958,10 @@ pub(super) async fn fetch_and_import_tarball_streaming(
 
     if strict_pkg_content_check {
         aube_store::validate_pkg_content(&index, registry_name, version).map_err(|e| {
-            miette!(
+            local(miette!(
                 "{display_name}@{version}: {e}{}",
                 crate::dep_chain::format_chain_for(registry_name, version)
-            )
+            ))
         })?;
     }
 

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -911,10 +911,16 @@ pub(super) async fn fetch_and_import_tarball_streaming(
 
     let import_result = import_handle.await.into_diagnostic().map_err(local)?;
     if let Some(e) = stream_err {
+        // Stash the Display rendering before `net` consumes `e`
+        // for `is_throttle()` — the user-facing diagnostic must
+        // still name the underlying cause (timeout, status 503,
+        // connection reset). Dropping it would leave triage with
+        // a bare "stream error for foo@1.2.3".
+        let cause = e.to_string();
         return Err(net(
             e,
             miette!(
-                "stream error for {display_name}@{version}{}",
+                "stream error for {display_name}@{version}: {cause}{}",
                 crate::dep_chain::format_chain_for(registry_name, version)
             ),
         ));

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1153,11 +1153,11 @@ pub(super) async fn run_gvs_prewarm_materializer(
         Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
             state,
             "linker_prewarm:default",
-            permit_seed.max(16).min(48),
+            permit_seed.clamp(16, 48),
             8,
             64,
         ),
-        None => aube_util::adaptive::AdaptiveLimit::new(permit_seed.max(16).min(48), 8, 64),
+        None => aube_util::adaptive::AdaptiveLimit::new(permit_seed.clamp(16, 48), 8, 64),
     };
     sem.disable_cusum_shrink();
     let linker_sem_for_persist = std::sync::Arc::clone(&sem);
@@ -1314,11 +1314,11 @@ async fn run_aube_dir_materializer(
         Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
             state,
             "linker_per_project:default",
-            permit_seed.max(16).min(48),
+            permit_seed.clamp(16, 48),
             8,
             64,
         ),
-        None => aube_util::adaptive::AdaptiveLimit::new(permit_seed.max(16).min(48), 8, 64),
+        None => aube_util::adaptive::AdaptiveLimit::new(permit_seed.clamp(16, 48), 8, 64),
     };
     sem.disable_cusum_shrink();
     let perproj_sem_for_persist = std::sync::Arc::clone(&sem);
@@ -1692,11 +1692,11 @@ where
             Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
                 state,
                 "tarball:default",
-                sem_seed.max(64).min(128),
+                sem_seed.clamp(64, 128),
                 4,
                 256,
             ),
-            None => aube_util::adaptive::AdaptiveLimit::new(sem_seed.max(64).min(128), 4, 256),
+            None => aube_util::adaptive::AdaptiveLimit::new(sem_seed.clamp(64, 128), 4, 256),
         };
         if let Some(state) = lockfile_persistent.clone() {
             lockfile_persist_handle = Some((state, std::sync::Arc::clone(&semaphore)));

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -944,10 +944,11 @@ pub(super) struct GvsPrewarmInputs {
     pub use_global_virtual_store_override: Option<bool>,
 }
 
-/// Backpressure on the (canonical_key, PackageIndex) channel that
-/// feeds the GVS-prewarm materializer. 2048 ~= 2x big-monorepo
-/// median so backpressure only fires under genuine producer/consumer
-/// skew (slow FS, Defender).
+/// Default initial capacity for the (canonical_key, PackageIndex)
+/// channel that feeds the GVS-prewarm materializer. Used as the seed
+/// when no persisted observation exists. Real cap is sized via
+/// [`aube_util::adaptive::AdaptiveBuffer`] which carries the
+/// converged value across process boundaries.
 pub(super) const MATERIALIZE_CHANNEL_CAPACITY: usize = 2048;
 
 pub(super) type MaterializeChannel = (
@@ -962,14 +963,32 @@ pub(super) type MaterializeJoinHandle = tokio::task::JoinHandle<
     )>,
 >;
 
-/// New (tx, rx) sized to MATERIALIZE_CHANNEL_CAPACITY. Both fetch
-/// branches need to hold tx for streaming and rx for the consumer
-/// task spawned later, so the channel creation is split from the
-/// task spawn.
+/**
+ * Construct the materialize channel sized from the cross run learned
+ * recommendation if available, otherwise from
+ * [`MATERIALIZE_CHANNEL_CAPACITY`]. Tokio's `mpsc::channel` cap is
+ * fixed at construction so the only knob we can turn here is the
+ * initial size for this process. The advisor returned here lets the
+ * fetch path call `record_push` and the materializer call
+ * `record_pop` so the next process learns from the high water mark.
+ * Bounds 256 to 16384 cap RAM and floor progress.
+ */
+pub(super) fn materialize_channel_with_advisor()
+-> (MaterializeChannel, std::sync::Arc<aube_util::adaptive::AdaptiveBuffer>) {
+    let persistent = aube_util::adaptive::global_persistent_state();
+    let cap = persistent
+        .as_ref()
+        .map(|state| state.load_seed("materialize_channel:default", MATERIALIZE_CHANNEL_CAPACITY))
+        .unwrap_or(MATERIALIZE_CHANNEL_CAPACITY)
+        .clamp(256, 16384);
+    let (tx, rx) = tokio::sync::mpsc::channel(cap);
+    aube_util::diag::register_channel("materialize", &tx, cap);
+    let advisor = aube_util::adaptive::AdaptiveBuffer::new(cap, 256, 16384);
+    ((tx, rx), advisor)
+}
+
 pub(super) fn materialize_channel() -> MaterializeChannel {
-    let (tx, rx) = tokio::sync::mpsc::channel(MATERIALIZE_CHANNEL_CAPACITY);
-    aube_util::diag::register_channel("materialize", &tx, MATERIALIZE_CHANNEL_CAPACITY);
-    (tx, rx)
+    materialize_channel_with_advisor().0
 }
 
 /// Spawn the GVS-prewarm consumer with the given inputs and rx.
@@ -1108,8 +1127,39 @@ pub(super) async fn run_gvs_prewarm_materializer(
     }
     let linker = std::sync::Arc::new(linker);
 
-    let permits = link_concurrency.unwrap_or_else(aube_linker::default_linker_parallelism);
-    let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(permits));
+    /*
+     * Adaptive linker parallelism. The signal is the same as the
+     * network limiter for ceiling/throttle behavior, but with
+     * CUSUM-driven shrink disabled. Per-package
+     * `ensure_in_virtual_store` wall on storage-bound workloads
+     * has high intrinsic variance (Defender scans, NTFS
+     * cold-cache, COW reflink fall-through to copy) that has no
+     * upstream queue to relieve — treating rising RTT as
+     * backpressure was observed to collapse the limit from seed
+     * 16 down to 12 on Windows, queueing 1195 packages behind a
+     * 12-permit cap (mean 2456ms permit_wait).
+     *
+     * `record_throttle` shrink remains active for real IO errors.
+     * `link_concurrency` setting is a *seed* (when set); default
+     * seed clamps `default_linker_parallelism()` into [16, 48].
+     * Floor 8 prevents pathological collapse under throttle
+     * cascades; ceiling 64 caps concurrent open file descriptors.
+     */
+    let permit_seed = link_concurrency.unwrap_or_else(aube_linker::default_linker_parallelism);
+    let linker_persistent = aube_util::adaptive::global_persistent_state();
+    let sem = match linker_persistent.as_ref() {
+        Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
+            state,
+            "linker_prewarm:default",
+            permit_seed.max(16).min(48),
+            8,
+            64,
+        ),
+        None => aube_util::adaptive::AdaptiveLimit::new(permit_seed.max(16).min(48), 8, 64),
+    };
+    sem.disable_cusum_shrink();
+    let linker_sem_for_persist = std::sync::Arc::clone(&sem);
+    let linker_persistent_for_save = linker_persistent.clone();
     let mut in_flight: Vec<tokio::task::JoinHandle<miette::Result<aube_linker::LinkStats>>> =
         Vec::new();
     let mut rx = materialize_rx;
@@ -1147,7 +1197,7 @@ pub(super) async fn run_gvs_prewarm_materializer(
                         });
                 let _diag_pkg_inflight = aube_util::diag::inflight(aube_util::diag::Slot::Imp);
                 let permit_wait = std::time::Instant::now();
-                let _permit = sem.acquire().await.unwrap();
+                let permit = sem.acquire().await;
                 let permit_wait_ms = permit_wait.elapsed();
                 if permit_wait_ms.as_millis() > 1 {
                     aube_util::diag::event_lazy(
@@ -1158,7 +1208,7 @@ pub(super) async fn run_gvs_prewarm_materializer(
                     );
                 }
                 let dep_path_for_err = dep_path.clone();
-                tokio::task::spawn_blocking(move || -> miette::Result<_> {
+                let outcome = tokio::task::spawn_blocking(move || -> miette::Result<_> {
                     let _diag_blk = aube_util::diag::Span::new(
                         aube_util::diag::Category::Materialize,
                         "package_blocking",
@@ -1176,7 +1226,12 @@ pub(super) async fn run_gvs_prewarm_materializer(
                     Ok(stats)
                 })
                 .await
-                .into_diagnostic()?
+                .into_diagnostic()?;
+                match &outcome {
+                    Ok(_) => permit.record_success(),
+                    Err(_) => permit.record_cancelled(),
+                }
+                outcome
             }));
         }
     }
@@ -1186,6 +1241,9 @@ pub(super) async fn run_gvs_prewarm_materializer(
         total.packages_linked += s.packages_linked;
         total.packages_cached += s.packages_cached;
         total.files_linked += s.files_linked;
+    }
+    if let Some(state) = linker_persistent_for_save.as_ref() {
+        linker_sem_for_persist.persist(state, "linker_prewarm:default");
     }
     Ok((total, Some(graph_hashes_arc)))
 }
@@ -1236,8 +1294,33 @@ async fn run_aube_dir_materializer(
     }
 
     let linker = std::sync::Arc::new(linker);
-    let permits = link_concurrency.unwrap_or_else(aube_linker::default_linker_parallelism);
-    let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(permits));
+    /*
+     * Adaptive per-project materialize parallelism. Same gradient
+     * controller as the prewarm path, with CUSUM-driven shrink
+     * disabled for the same reason: per-package `ensure_in_aube_dir`
+     * wall is filesystem-bound (Defender, NTFS cold-cache, COW
+     * fall-through) and rising RTT here is intrinsic noise rather
+     * than upstream backpressure. `record_throttle` shrink remains
+     * active for real IO errors. Floor 8 prevents pathological
+     * collapse under throttle cascades; persisted under
+     * `linker_per_project:default` so the next process resumes
+     * the converged operating point.
+     */
+    let permit_seed = link_concurrency.unwrap_or_else(aube_linker::default_linker_parallelism);
+    let perproj_persistent = aube_util::adaptive::global_persistent_state();
+    let sem = match perproj_persistent.as_ref() {
+        Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
+            state,
+            "linker_per_project:default",
+            permit_seed.max(16).min(48),
+            8,
+            64,
+        ),
+        None => aube_util::adaptive::AdaptiveLimit::new(permit_seed.max(16).min(48), 8, 64),
+    };
+    sem.disable_cusum_shrink();
+    let perproj_sem_for_persist = std::sync::Arc::clone(&sem);
+    let perproj_persistent_for_save = perproj_persistent.clone();
     // JoinSet aborts in-flight tasks if we early-return on error,
     // so a failed materialize doesn't leave orphan tasks racing
     // disk writes against the install driver's cleanup.
@@ -1276,12 +1359,9 @@ async fn run_aube_dir_materializer(
             let aube_dir = aube_dir.clone();
             let nested_link_targets = nested_link_targets.clone();
             in_flight.spawn(async move {
-                let _permit = sem
-                    .acquire()
-                    .await
-                    .map_err(|e| miette!("materializer semaphore closed: {e}"))?;
+                let permit = sem.acquire().await;
                 let dep_path_for_err = dep_path.clone();
-                tokio::task::spawn_blocking(move || -> miette::Result<_> {
+                let outcome = tokio::task::spawn_blocking(move || -> miette::Result<_> {
                     let mut stats = aube_linker::LinkStats::default();
                     linker
                         .ensure_in_aube_dir(
@@ -1296,7 +1376,12 @@ async fn run_aube_dir_materializer(
                     Ok(stats)
                 })
                 .await
-                .into_diagnostic()?
+                .into_diagnostic()?;
+                match &outcome {
+                    Ok(_) => permit.record_success(),
+                    Err(_) => permit.record_cancelled(),
+                }
+                outcome
             });
         }
     }
@@ -1305,6 +1390,9 @@ async fn run_aube_dir_materializer(
         total.packages_linked += s.packages_linked;
         total.packages_cached += s.packages_cached;
         total.files_linked += s.files_linked;
+    }
+    if let Some(state) = perproj_persistent_for_save.as_ref() {
+        perproj_sem_for_persist.persist(state, "linker_per_project:default");
     }
     Ok((total, None))
 }
@@ -1571,6 +1659,11 @@ where
     }
     let fetch_count = to_fetch.len();
 
+    let mut lockfile_persist_handle: Option<(
+        std::sync::Arc<aube_util::adaptive::PersistentState>,
+        std::sync::Arc<aube_util::adaptive::AdaptiveLimit>,
+    )> = None;
+
     if !to_fetch.is_empty() {
         // Only build the reqwest+TLS client now that we know we
         // actually need to fetch tarballs. On a warm no-op install
@@ -1582,21 +1675,30 @@ where
             Some(c) => c,
             None => (client_builder.take().unwrap())(),
         };
-        // Cap concurrent tarball downloads. Linux handles 128 well;
-        // APFS gets syscall-bound above the mid-20s, so macOS uses a
-        // lower default unless the user explicitly overrides it.
-        // 128 is deliberately above
-        // typical HTTP/1.1 per-origin limits (6–8) — reqwest upgrades
-        // to HTTP/2 when the server advertises it, multiplexing all
-        // streams over a single TCP connection, and falls back to
-        // HTTP/1.1 keep-alive otherwise (where reqwest pools
-        // connections internally). 256 went further in isolated
-        // tests but triggered registry-side rate-limiting variance
-        // against real npmjs; 128 is the stable sweet spot and still
-        // shaves ~300 ms off the medium benchmark's cold-fetch wall
-        // time vs the previous 64.
-        let sem_permits = network_concurrency.unwrap_or_else(default_lockfile_network_concurrency);
-        let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(sem_permits));
+        /*
+         * Adaptive concurrency on the lockfile driven fetch path
+         * (frozen / fetch / ci / matched lockfile). Same gradient
+         * controller as the streaming resolver fetch path.
+         * `networkConcurrency` setting acts as the seed when set.
+         * Cross run persisted under `tarball:default` so this path
+         * shares its converged operating point with the streaming
+         * tarball path.
+         */
+        let sem_seed = network_concurrency.unwrap_or_else(default_lockfile_network_concurrency);
+        let lockfile_persistent = aube_util::adaptive::global_persistent_state();
+        let semaphore = match lockfile_persistent.as_ref() {
+            Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
+                state,
+                "tarball:default",
+                sem_seed.max(64).min(128),
+                4,
+                256,
+            ),
+            None => aube_util::adaptive::AdaptiveLimit::new(sem_seed.max(64).min(128), 4, 256),
+        };
+        if let Some(state) = lockfile_persistent.clone() {
+            lockfile_persist_handle = Some((state, std::sync::Arc::clone(&semaphore)));
+        }
         // Hoist env-driven flags out of the per-tarball closure so
         // the libc lock fires once instead of N times on a 1000-pkg
         // install.
@@ -1621,7 +1723,7 @@ where
             handles.spawn(async move {
                 let _row = row;
                 let task_start = std::time::Instant::now();
-                let permit = sem.acquire().await.unwrap();
+                let permit = sem.acquire().await;
                 let wait_time = task_start.elapsed();
                 // Aliased entries (`"h3-v2": "npm:h3@..."`) carry the
                 // resolved tarball URL verbatim from the lockfile so
@@ -1643,7 +1745,7 @@ where
                         .as_deref()
                         .is_none_or(|s| s.starts_with("sha512-"));
                 if stream_eligible {
-                    let (index, bytes_len) = crate::commands::install::lifecycle::fetch_and_import_tarball_streaming(
+                    let streamed = crate::commands::install::lifecycle::fetch_and_import_tarball_streaming(
                         &client,
                         &store,
                         &url,
@@ -1655,7 +1757,17 @@ where
                         strict_integrity,
                         strict_pkg_content_check,
                     )
-                    .await?;
+                    .await;
+                    let (index, bytes_len) = match streamed {
+                        Ok(v) => {
+                            permit.record_success();
+                            v
+                        }
+                        Err(e) => {
+                            permit.record_cancelled();
+                            return Err(e);
+                        }
+                    };
                     let dl_time = dl_start.elapsed();
                     if let Some(p) = bytes_progress.as_ref() {
                         p.inc_downloaded_bytes(bytes_len);
@@ -1666,7 +1778,6 @@ where
                         dl_time,
                         bytes_len
                     );
-                    drop(permit);
                     return Ok::<_, miette::Report>((dep_path, index));
                 }
 
@@ -1675,25 +1786,34 @@ where
                 // skips its hash pass and compares directly.
                 // AUBE_DISABLE_STREAMING_SHA512=1 reverts to the
                 // buffered-then-hash path.
-                let (bytes, streamed_digest) = if streaming_sha512_enabled {
-                    let (bytes, digest) = client
+                let fetch_outcome = if streaming_sha512_enabled {
+                    client
                         .fetch_tarball_bytes_streaming_sha512(&url)
                         .await
+                        .map(|(b, d)| (b, Some(d)))
                         .map_err(|e| {
                             miette!(
                                 "failed to fetch {display_name}@{version}: {e}{}",
                                 crate::dep_chain::format_chain_for(&display_name, &version)
                             )
-                        })?;
-                    (bytes, Some(digest))
+                        })
                 } else {
-                    let bytes = client.fetch_tarball_bytes(&url).await.map_err(|e| {
+                    client.fetch_tarball_bytes(&url).await.map(|b| (b, None)).map_err(|e| {
                         miette!(
                             "failed to fetch {display_name}@{version}: {e}{}",
                             crate::dep_chain::format_chain_for(&display_name, &version)
                         )
-                    })?;
-                    (bytes, None)
+                    })
+                };
+                let (bytes, streamed_digest) = match fetch_outcome {
+                    Ok(v) => {
+                        permit.record_success();
+                        v
+                    }
+                    Err(e) => {
+                        permit.record_cancelled();
+                        return Err(e);
+                    }
                 };
                 let dl_time = dl_start.elapsed();
 
@@ -1738,7 +1858,6 @@ where
                     bytes_len,
                     import_time
                 );
-                drop(permit);
 
                 Ok::<_, miette::Report>((dep_path, index))
             });
@@ -1776,6 +1895,10 @@ where
 
     // Without explicit drop, consumer's rx.recv() loop hangs.
     drop(materialize_tx);
+
+    if let Some((state, sem)) = lockfile_persist_handle {
+        sem.persist(&state, "tarball:default");
+    }
 
     Ok((indices, cached_count, fetch_count))
 }
@@ -3160,8 +3283,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let fetch_network_concurrency = env_concurrency
                 .or(network_concurrency_setting)
                 .unwrap_or_else(default_streaming_network_concurrency);
+            // Channel capacity is decoupled from fetch concurrency: the
+            // mpsc just buffers ResolvedPackage handoffs so the BFS
+            // never blocks on send() while the fetch coordinator is
+            // mid-tarball. Sized to absorb deep-tree bursts without
+            // backpressure on graphs into the tens of thousands of
+            // packages; fetch parallelism is still gated by
+            // `fetch_network_concurrency` downstream.
+            let stream_capacity = fetch_network_concurrency.saturating_mul(16).max(1024);
             let (resolver, mut resolved_rx) =
-                aube_resolver::Resolver::with_stream_capacity(client, fetch_network_concurrency);
+                aube_resolver::Resolver::with_stream_capacity(client, stream_capacity);
             let pnpmfile_paths = if opts.ignore_pnpmfile {
                 Vec::new()
             } else {
@@ -3249,18 +3380,44 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             };
             // Each imported (dep_path, index) feeds the GVS-prewarm
             // materializer running concurrently with the rest of fetch.
-            // Bounded(2048) caps RSS on huge graphs when the
-            // materializer falls behind on a slow FS (Windows Defender,
-            // network share). Backpressure only triggers under real
-            // producer/consumer skew.
+            /*
+             * Materialize channel sized from the cross run learned
+             * recommendation when available, falling back to the
+             * static default. Tokio mpsc cap is fixed at
+             * construction so the only knob we can turn here is
+             * the initial size for this process. Bounds 256 to
+             * 16384 cap RAM and floor progress.
+             */
             let (materialize_tx, materialize_rx) = materialize_channel();
             // Clone the shared deprecations accumulator into the
             // spawned task. The install command reads it back after
             // `filter_graph` prunes the post-resolve graph.
             let fetch_deprecations_tx = deprecations.clone();
             let fetch_handle = tokio::spawn(async move {
-                let semaphore =
-                    std::sync::Arc::new(tokio::sync::Semaphore::new(fetch_network_concurrency));
+                /*
+                 * Adaptive tarball concurrency. Loaded from the
+                 * cross run persistent store when available so the
+                 * limiter starts where a previous run converged
+                 * instead of cold ramping from the ceiling. Falls
+                 * back to seed 256 (h2 stream cap) on first ever
+                 * run. Floor 4 keeps progress under continuous
+                 * 429 / 503. Persisted back at end of fetch phase
+                 * so the next invocation benefits.
+                 */
+                let persistent = aube_util::adaptive::global_persistent_state();
+                let semaphore = match persistent.as_ref() {
+                    Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
+                        state,
+                        "tarball:default",
+                        256,
+                        4,
+                        256,
+                    ),
+                    None => aube_util::adaptive::AdaptiveLimit::new(256, 4, 256),
+                };
+                let semaphore_for_persist = std::sync::Arc::clone(&semaphore);
+                let persistent_for_save = persistent.clone();
+                let _ = fetch_network_concurrency;
                 // Hoist env-driven flags out of the per-tarball loop.
                 let streaming_sha512_enabled =
                     std::env::var_os("AUBE_DISABLE_STREAMING_SHA512").is_none();
@@ -3423,7 +3580,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                                 aube_util::diag::jstr(&pkg.name), aube_util::diag::jstr(&pkg.version)));
                         let _diag_tar_inflight = aube_util::diag::inflight(aube_util::diag::Slot::Tar);
                         let permit_wait = std::time::Instant::now();
-                        let permit = sem.acquire().await.unwrap();
+                        let permit = sem.acquire().await;
                         let permit_wait_ms = permit_wait.elapsed();
                         let pkg_id_for_diag = format!("{}@{}", pkg.name, pkg.version);
                         if permit_wait_ms.as_millis() > 1 {
@@ -3455,7 +3612,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                                 .is_none_or(|s| s.starts_with("sha512-"));
                         aube_util::diag::instant_lazy(aube_util::diag::Category::Fetch, "tarball_path", || format!(r#"{{"streaming":{},"name":{}}}"#, stream_eligible, aube_util::diag::jstr(&pkg.name)));
                         if stream_eligible {
-                            let (index, bytes_len) = crate::commands::install::lifecycle::fetch_and_import_tarball_streaming(
+                            let streamed = crate::commands::install::lifecycle::fetch_and_import_tarball_streaming(
                                 &client,
                                 &store,
                                 &url,
@@ -3467,18 +3624,28 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                                 fetch_strict_integrity,
                                 fetch_strict_pkg_content_check,
                             )
-                            .await?;
+                            .await;
+                            let (index, bytes_len) = match streamed {
+                                Ok(v) => {
+                                    permit.record_success();
+                                    v
+                                }
+                                Err(e) => {
+                                    permit.record_cancelled();
+                                    return Err(e);
+                                }
+                            };
                             if let Some(p) = bytes_progress.as_ref() {
                                 p.inc_downloaded_bytes(bytes_len);
                             }
-                            drop(permit);
                             return Ok::<_, miette::Report>((dep_path, index));
                         }
 
-                        let (bytes, streamed_digest) = if streaming_sha512_enabled {
-                            let (bytes, digest) = client
+                        let fetch_outcome = if streaming_sha512_enabled {
+                            client
                                 .fetch_tarball_bytes_streaming_sha512(&url)
                                 .await
+                                .map(|(b, d)| (b, Some(d)))
                                 .map_err(|e| {
                                     miette!(
                                         "failed to fetch {}@{}: {e}{}",
@@ -3486,27 +3653,30 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                                         pkg.version,
                                         crate::dep_chain::format_chain_for(&pkg.name, &pkg.version)
                                     )
-                                })?;
-                            (bytes, Some(digest))
+                                })
                         } else {
-                            let bytes = client.fetch_tarball_bytes(&url).await.map_err(|e| {
+                            client.fetch_tarball_bytes(&url).await.map(|b| (b, None)).map_err(|e| {
                                 miette!(
                                     "failed to fetch {}@{}: {e}{}",
                                     pkg.name,
                                     pkg.version,
                                     crate::dep_chain::format_chain_for(&pkg.name, &pkg.version)
                                 )
-                            })?;
-                            (bytes, None)
+                            })
+                        };
+                        let (bytes, streamed_digest) = match fetch_outcome {
+                            Ok(v) => {
+                                permit.record_success();
+                                v
+                            }
+                            Err(e) => {
+                                permit.record_cancelled();
+                                return Err(e);
+                            }
                         };
                         if let Some(p) = bytes_progress.as_ref() {
                             p.inc_downloaded_bytes(bytes.len() as u64);
                         }
-
-                        // Release download permit before CPU-bound
-                        // import. Without this drop, --network-concurrency
-                        // would cap downloads AND extractions at N.
-                        drop(permit);
 
                         let (index, _) = run_import_on_blocking(
                             store,
@@ -3541,6 +3711,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 // materializer consumer sees the channel close and
                 // exits its receive loop.
                 drop(materialize_tx);
+                if let Some(state) = persistent_for_save.as_ref() {
+                    semaphore_for_persist.persist(state, "tarball:default");
+                }
                 Ok::<_, miette::Report>((indices, cached_count, fetch_count))
             });
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1766,8 +1766,12 @@ where
                             v
                         }
                         Err(e) => {
-                            permit.record_cancelled();
-                            return Err(e);
+                            if e.is_throttle {
+                                permit.record_throttle();
+                            } else {
+                                permit.record_cancelled();
+                            }
+                            return Err(e.into());
                         }
                     };
                     let dl_time = dl_start.elapsed();
@@ -1794,16 +1798,24 @@ where
                         .await
                         .map(|(b, d)| (b, Some(d)))
                         .map_err(|e| {
-                            miette!(
-                                "failed to fetch {display_name}@{version}: {e}{}",
-                                crate::dep_chain::format_chain_for(&display_name, &version)
+                            let throttled = e.is_throttle();
+                            (
+                                miette!(
+                                    "failed to fetch {display_name}@{version}: {e}{}",
+                                    crate::dep_chain::format_chain_for(&display_name, &version)
+                                ),
+                                throttled,
                             )
                         })
                 } else {
                     client.fetch_tarball_bytes(&url).await.map(|b| (b, None)).map_err(|e| {
-                        miette!(
-                            "failed to fetch {display_name}@{version}: {e}{}",
-                            crate::dep_chain::format_chain_for(&display_name, &version)
+                        let throttled = e.is_throttle();
+                        (
+                            miette!(
+                                "failed to fetch {display_name}@{version}: {e}{}",
+                                crate::dep_chain::format_chain_for(&display_name, &version)
+                            ),
+                            throttled,
                         )
                     })
                 };
@@ -1812,9 +1824,13 @@ where
                         permit.record_success();
                         v
                     }
-                    Err(e) => {
-                        permit.record_cancelled();
-                        return Err(e);
+                    Err((report, throttled)) => {
+                        if throttled {
+                            permit.record_throttle();
+                        } else {
+                            permit.record_cancelled();
+                        }
+                        return Err(report);
                     }
                 };
                 let dl_time = dl_start.elapsed();
@@ -3406,20 +3422,26 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                  * 429 / 503. Persisted back at end of fetch phase
                  * so the next invocation benefits.
                  */
+                // Honor user-configured `networkConcurrency` (or
+                // `AUBE_NETWORK_CONCURRENCY` env override) as the
+                // seed. Adaptive grow/shrink still operate around
+                // it. Floor 4 keeps progress under continuous
+                // throttling regardless of seed.
+                let tarball_seed = fetch_network_concurrency.max(4);
+                let tarball_max = tarball_seed.max(256);
                 let persistent = aube_util::adaptive::global_persistent_state();
                 let semaphore = match persistent.as_ref() {
                     Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
                         state,
                         "tarball:default",
-                        256,
+                        tarball_seed,
                         4,
-                        256,
+                        tarball_max,
                     ),
-                    None => aube_util::adaptive::AdaptiveLimit::new(256, 4, 256),
+                    None => aube_util::adaptive::AdaptiveLimit::new(tarball_seed, 4, tarball_max),
                 };
                 let semaphore_for_persist = std::sync::Arc::clone(&semaphore);
                 let persistent_for_save = persistent.clone();
-                let _ = fetch_network_concurrency;
                 // Hoist env-driven flags out of the per-tarball loop.
                 let streaming_sha512_enabled =
                     std::env::var_os("AUBE_DISABLE_STREAMING_SHA512").is_none();
@@ -3633,8 +3655,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                                     v
                                 }
                                 Err(e) => {
-                                    permit.record_cancelled();
-                                    return Err(e);
+                                    if e.is_throttle {
+                                        permit.record_throttle();
+                                    } else {
+                                        permit.record_cancelled();
+                                    }
+                                    return Err(e.into());
                                 }
                             };
                             if let Some(p) = bytes_progress.as_ref() {
@@ -3649,20 +3675,28 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                                 .await
                                 .map(|(b, d)| (b, Some(d)))
                                 .map_err(|e| {
+                                    let throttled = e.is_throttle();
+                                    (
+                                        miette!(
+                                            "failed to fetch {}@{}: {e}{}",
+                                            pkg.name,
+                                            pkg.version,
+                                            crate::dep_chain::format_chain_for(&pkg.name, &pkg.version)
+                                        ),
+                                        throttled,
+                                    )
+                                })
+                        } else {
+                            client.fetch_tarball_bytes(&url).await.map(|b| (b, None)).map_err(|e| {
+                                let throttled = e.is_throttle();
+                                (
                                     miette!(
                                         "failed to fetch {}@{}: {e}{}",
                                         pkg.name,
                                         pkg.version,
                                         crate::dep_chain::format_chain_for(&pkg.name, &pkg.version)
-                                    )
-                                })
-                        } else {
-                            client.fetch_tarball_bytes(&url).await.map(|b| (b, None)).map_err(|e| {
-                                miette!(
-                                    "failed to fetch {}@{}: {e}{}",
-                                    pkg.name,
-                                    pkg.version,
-                                    crate::dep_chain::format_chain_for(&pkg.name, &pkg.version)
+                                    ),
+                                    throttled,
                                 )
                             })
                         };
@@ -3671,9 +3705,13 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                                 permit.record_success();
                                 v
                             }
-                            Err(e) => {
-                                permit.record_cancelled();
-                                return Err(e);
+                            Err((report, throttled)) => {
+                                if throttled {
+                                    permit.record_throttle();
+                                } else {
+                                    permit.record_cancelled();
+                                }
+                                return Err(report);
                             }
                         };
                         if let Some(p) = bytes_progress.as_ref() {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -973,8 +973,10 @@ pub(super) type MaterializeJoinHandle = tokio::task::JoinHandle<
  * `record_pop` so the next process learns from the high water mark.
  * Bounds 256 to 16384 cap RAM and floor progress.
  */
-pub(super) fn materialize_channel_with_advisor()
--> (MaterializeChannel, std::sync::Arc<aube_util::adaptive::AdaptiveBuffer>) {
+pub(super) fn materialize_channel_with_advisor() -> (
+    MaterializeChannel,
+    std::sync::Arc<aube_util::adaptive::AdaptiveBuffer>,
+) {
     let persistent = aube_util::adaptive::global_persistent_state();
     let cap = persistent
         .as_ref()

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -944,11 +944,17 @@ pub(super) struct GvsPrewarmInputs {
     pub use_global_virtual_store_override: Option<bool>,
 }
 
-/// Default initial capacity for the (canonical_key, PackageIndex)
-/// channel that feeds the GVS-prewarm materializer. Used as the seed
-/// when no persisted observation exists. Real cap is sized via
-/// [`aube_util::adaptive::AdaptiveBuffer`] which carries the
-/// converged value across process boundaries.
+/// Initial capacity for the (canonical_key, PackageIndex) channel
+/// that feeds the GVS-prewarm materializer. Bounded so RSS on a
+/// huge graph stays sane while a slow filesystem (Defender,
+/// network share) backs up the materializer; backpressure only
+/// kicks in under real producer/consumer skew.
+///
+/// Tokio mpsc capacity is fixed at construction, so a bigger
+/// learned-from-prior-run value couldn't be applied to the
+/// current channel anyway. A static cap keeps the construction
+/// path obvious without dragging cross-run telemetry through the
+/// hot send/recv loops for marginal gain.
 pub(super) const MATERIALIZE_CHANNEL_CAPACITY: usize = 2048;
 
 pub(super) type MaterializeChannel = (
@@ -963,34 +969,10 @@ pub(super) type MaterializeJoinHandle = tokio::task::JoinHandle<
     )>,
 >;
 
-/**
- * Construct the materialize channel sized from the cross run learned
- * recommendation if available, otherwise from
- * [`MATERIALIZE_CHANNEL_CAPACITY`]. Tokio's `mpsc::channel` cap is
- * fixed at construction so the only knob we can turn here is the
- * initial size for this process. The advisor returned here lets the
- * fetch path call `record_push` and the materializer call
- * `record_pop` so the next process learns from the high water mark.
- * Bounds 256 to 16384 cap RAM and floor progress.
- */
-pub(super) fn materialize_channel_with_advisor() -> (
-    MaterializeChannel,
-    std::sync::Arc<aube_util::adaptive::AdaptiveBuffer>,
-) {
-    let persistent = aube_util::adaptive::global_persistent_state();
-    let cap = persistent
-        .as_ref()
-        .map(|state| state.load_seed("materialize_channel:default", MATERIALIZE_CHANNEL_CAPACITY))
-        .unwrap_or(MATERIALIZE_CHANNEL_CAPACITY)
-        .clamp(256, 16384);
-    let (tx, rx) = tokio::sync::mpsc::channel(cap);
-    aube_util::diag::register_channel("materialize", &tx, cap);
-    let advisor = aube_util::adaptive::AdaptiveBuffer::new(cap, 256, 16384);
-    ((tx, rx), advisor)
-}
-
 pub(super) fn materialize_channel() -> MaterializeChannel {
-    materialize_channel_with_advisor().0
+    let (tx, rx) = tokio::sync::mpsc::channel(MATERIALIZE_CHANNEL_CAPACITY);
+    aube_util::diag::register_channel("materialize", &tx, MATERIALIZE_CHANNEL_CAPACITY);
+    (tx, rx)
 }
 
 /// Spawn the GVS-prewarm consumer with the given inputs and rx.

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -860,12 +860,22 @@ fn inner_main() -> miette::Result<()> {
         }
     }
 
-    // High-core boxes don't need 64-128 worker threads for an I/O
-    // pipeline. Default worker_threads = num_cpus and
-    // max_blocking_threads = 512 are both wasteful. Cap workers at 8
-    // (install semaphore already gates network), blocking at 64
-    // (covers tarball decode plus linker fan-out on a 16-core box).
-    // AUBE_TOKIO_WORKERS / AUBE_TOKIO_BLOCKING for benchmarking.
+    /*
+     * High core boxes don't need 64-128 worker threads for an I/O
+     * pipeline. Default worker_threads = num_cpus and
+     * max_blocking_threads = 512 are both wasteful. Cap workers at
+     * 8 (install semaphore already gates network).
+     *
+     * Blocking pool sits at 128, raised from 64 after diag traces
+     * showed AdaptiveLimit running 100+ concurrent tarball imports
+     * (each holding a blocking slot for gzip + tar + CAS write)
+     * while the linker is also fanning out hardlinks on the same
+     * pool. 64 was saturating, queueing late tarballs behind
+     * earlier finishers. 128 covers worst case fat tarball
+     * pipeline plus linker plus side effects.
+     *
+     * AUBE_TOKIO_WORKERS / AUBE_TOKIO_BLOCKING for benchmarking.
+     */
     let parse_env = |key: &str, default: usize| -> usize {
         std::env::var(key)
             .ok()
@@ -877,7 +887,7 @@ fn inner_main() -> miette::Result<()> {
         .map(|n| n.get())
         .unwrap_or(4);
     let workers = parse_env("AUBE_TOKIO_WORKERS", cpu_count.min(8));
-    let blocking = parse_env("AUBE_TOKIO_BLOCKING", 64);
+    let blocking = parse_env("AUBE_TOKIO_BLOCKING", 128);
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(workers)
         .max_blocking_threads(blocking)


### PR DESCRIPTION
## Changed

### install: adaptive concurrency limiter for hot paths
- new `aube_util::adaptive` module: `AdaptiveLimit` (packed inflight|limit `AtomicU64`, slow-start grow, AIMD bump, CUSUM-gated shrink), `AdaptiveBuffer` (channel high-water advisor), `RegimeDetector` (CUSUM change-point), `PersistentState` (cross-run JSON store under XDG cache)
- wired at every dynamic concurrency site that was previously `Semaphore::new(MAGIC)`:
  - resolver packument fetch (`crates/aube-resolver/src/resolve.rs`)
  - install streaming tarball fetch + lockfile-driven tarball fetch (`crates/aube/src/commands/install/mod.rs`)
  - GVS-prewarm materializer + per-project materializer (same file)
- packument-resolver→fetch-coordinator stream channel capacity bumped from 64 to 1024 to absorb resolver bursts without blocking BFS on `send().await`

### install: skip CUSUM shrink on filesystem-bound limiters
- `AdaptiveLimit::disable_cusum_shrink()` opts a limiter out of CUSUM-driven `Rising` shrinks while keeping `record_throttle` shrink for real IO errors
- applied to both linker materializer sites (`linker_prewarm:default`, `linker_per_project:default`)
- rationale: per-package `ensure_in_virtual_store` wall on Windows NTFS+Defender / cold-cache reads / COW reflink fall-through has high intrinsic variance with no upstream queue to relieve. Treating jitter as backpressure was collapsing the limit toward floor and queueing packages behind too few permits
- floor raised 2 → 8 to bound any throttle cascade
- network limiters (registry packument, registry tarball) keep CUSUM enabled because rising RTT there does correlate with upstream queueing

### registry: separate http1 client for tarball downloads
- new `http_tarball: reqwest::Client` field on `RegistryClient`, built via `build_http_tarball_client` with `.http1_only()` and no h2 transport tuning
- `start_tarball_stream`, `fetch_tarball_bytes`, `fetch_tarball_bytes_streaming_sha512` route through the tarball client via new `authed_tarball_get` + `http_tarball_for` helpers
- packument requests stay on the h2 client so gzip/brotli/zstd header compression and stream multiplexing keep working for thousands of small JSON payloads
- per-uri authed registries (Artifactory etc.) fall back to their existing h2 client until measurement justifies a parallel h1 map

## Removed

- unused `OnlineQuantile` (P² streaming quantile estimator) — never wired into a production code path
- unused `hedged()` request racer — never called

## Notes

- 127 registry tests pass. 13 adaptive unit tests pass (down from 15 after `OnlineQuantile` removal)
- packument fetch path keeps h2 + abbreviated metadata + ETag revalidation
- adaptive state persists under `\$XDG_CACHE_HOME/aube/adaptive-state.json` (or platform equivalent) so converged operating points carry across runs