### PR TITLE
docs: add global virtual store page

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2599,7 +2599,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                  enableGlobalVirtualStore false --location project` — or set \
                  `disableGlobalVirtualStoreForPackages=[]` to opt out of this \
                  auto-detection entirely. \
-                 Details: https://aube.en.dev/package-manager/node-modules#global-virtual-store"
+                 Details: https://aube.en.dev/package-manager/global-virtual-store"
             );
             Some(false)
         } else {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -108,6 +108,7 @@ export default defineConfig({
           { text: "Workspaces", link: "/package-manager/workspaces" },
           { text: "Lockfiles", link: "/package-manager/lockfiles" },
           { text: "node_modules layout", link: "/package-manager/node-modules" },
+          { text: "Global virtual store", link: "/package-manager/global-virtual-store" },
           { text: "Lifecycle scripts", link: "/package-manager/lifecycle-scripts" },
           { text: "Jailed builds", link: "/package-manager/jailed-builds" },
           { text: "Configuration", link: "/package-manager/configuration" },

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -11,8 +11,11 @@ to time each scenario under identical conditions.
 
 ::: tip Methodology
 Every scenario assumes a committed lockfile is present. The main axis is
-how warm the tool's cache/store is before the command runs; the CI rows
-also disable aube's global virtual store for CI parity. *Warm* clears
+how warm the tool's cache/store is before the command runs; the local
+install rows use each tool's default install model, which means aube's
+[global virtual store](/package-manager/global-virtual-store) is enabled
+and pnpm's comparable feature is left at pnpm's default of off. The CI
+rows disable aube's global virtual store for CI parity. *Warm* clears
 `node_modules` but keeps each tool's store/cache populated; *cold* wipes
 the store and cache too. The fixture, scripts, and raw
 hyperfine output live at
@@ -35,10 +38,13 @@ defaults.
 
 ## Why it's faster
 
-aube uses the same on-disk model as pnpm — a global content-addressable
-store plus an isolated symlink layout — but the install pipeline is
-written in a faster, natively-threaded language instead of JavaScript.
-Same layout, quicker engine.
+aube starts from pnpm's isolated symlink model — a global
+content-addressable store plus a per-project virtual store — and enables a
+[global virtual store](/package-manager/global-virtual-store) by default
+for local installs. pnpm supports a similar global virtual store, but
+leaves it off by default, so the main benchmark rows compare the tools as
+users get them out of the box. The CI rows turn aube's global virtual
+store off and measure the shared per-project model.
 
 ## Scenarios
 

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -1,0 +1,151 @@
+# Global virtual store
+
+aube's global virtual store reuses fully materialized package directories across
+projects. It is enabled by default for local installs and disabled under CI.
+
+This is separate from the global content store:
+
+- The **global content store** (`$XDG_DATA_HOME/aube/store/v1/files/`) stores
+  package files by BLAKE3 hash. Every install uses it.
+- The **global virtual store**
+  (`$XDG_CACHE_HOME/aube/virtual-store/`, defaulting to
+  `~/.cache/aube/virtual-store/`) stores package directory trees keyed by
+  dependency graph. Project `node_modules` entries symlink into it.
+
+## Default behavior
+
+Without the global virtual store, each project gets its own virtual store under
+`node_modules/.aube/`. Package files are still deduplicated through the global
+content store, but the directory tree is rebuilt for each checkout.
+
+```text
+project-a/
+  node_modules/
+    react -> .aube/react@18.2.0/node_modules/react
+    .aube/
+      react@18.2.0/
+        node_modules/
+          react/       # files imported from the content store
+
+project-b/
+  node_modules/
+    react -> .aube/react@18.2.0/node_modules/react
+    .aube/
+      react@18.2.0/
+        node_modules/
+          react/       # same file content, separate directory tree
+```
+
+## With the global virtual store
+
+With the global virtual store enabled, aube builds the package tree once in the
+shared cache. Each project points directly at that shared tree:
+
+```text
+project-a/
+  node_modules/
+    react -> $XDG_CACHE_HOME/aube/virtual-store/react@18.2.0/<graph-hash>/node_modules/react
+
+project-b/
+  node_modules/
+    react -> $XDG_CACHE_HOME/aube/virtual-store/react@18.2.0/<graph-hash>/node_modules/react
+```
+
+The global virtual store still imports package files from the global content
+store. The win is that aube avoids rebuilding the same package directory tree in
+every checkout.
+
+## Package identity
+
+Entries are keyed by the resolved dependency graph, not just by package name and
+version. Two projects can share `react@18.2.0` when the surrounding dependency
+graph matches. If peer dependencies or transitive dependencies differ, aube
+creates a separate entry with a different graph hash.
+
+That keeps Node's resolution semantics intact: sharing only happens when the
+materialized package tree is safe to reuse.
+
+## Compared with pnpm
+
+pnpm has a similar
+[global virtual store](https://pnpm.io/global-virtual-store), but project
+installs leave it disabled by default. aube enables the global virtual store by
+default for local installs, then turns it off automatically under CI and for
+known symlink-sensitive toolchains.
+
+## When it helps
+
+The global virtual store is most useful on developer machines:
+
+- multiple worktrees or checkouts of the same repo
+- repeated fresh installs after deleting `node_modules`
+- several projects using the same package versions
+- one-off `aubx` and script workflows that benefit from warm local state
+
+It is usually less useful in CI. CI jobs often start without a warm
+`$XDG_CACHE_HOME/aube/virtual-store/`, so aube disables the global virtual store
+under CI and materializes packages per project instead.
+
+## Configuration
+
+Set the project default in `.npmrc`:
+
+```ini
+enableGlobalVirtualStore=true
+```
+
+or:
+
+```ini
+enableGlobalVirtualStore=false
+```
+
+Override a single command with:
+
+```sh
+aube install --enable-global-virtual-store
+aube install --disable-global-virtual-store
+```
+
+## Limitations
+
+Some tools canonicalize `node_modules/<pkg>` symlinks to their real path and
+then walk upward looking for project files, app roots, or hoisted dependencies.
+When the real path is in `$XDG_CACHE_HOME/aube/virtual-store/`, that walk has
+escaped the project and the tool can fail.
+
+aube automatically falls back to per-project materialization when an importer
+depends on a package with a known global-virtual-store incompatibility. The
+default trigger list is:
+
+- `next`
+- `nuxt`
+- `vite`
+- `vitepress`
+- `parcel`
+
+When that happens, install still succeeds and aube prints a warning. Repeat
+installs of that project just won't share materialized package directories
+across projects.
+
+To add a package to the trigger list, append entries to
+`disableGlobalVirtualStoreForPackages` in `.npmrc`:
+
+```ini
+disableGlobalVirtualStoreForPackages[]=my-tool
+```
+
+To silence the warning while keeping the fallback, set:
+
+```ini
+enableGlobalVirtualStore=false
+```
+
+To opt out of the compatibility heuristic entirely, set:
+
+```ini
+disableGlobalVirtualStoreForPackages=[]
+```
+
+Only use that when you know the project's tools tolerate symlinks that point
+outside the project.

--- a/docs/package-manager/node-modules.md
+++ b/docs/package-manager/node-modules.md
@@ -46,56 +46,11 @@ hardlinks, or copies depending on filesystem support and
 
 ## Global virtual store
 
-aube has two "stores":
-
-- The **global content store** (`$XDG_DATA_HOME/aube/store/v1/files/`) holds
-  package *files* deduplicated by BLAKE3 hash. Every install reads from it.
-- The **global virtual store** (`~/.cache/aube/virtual-store/`) holds
-  materialized package *directories* keyed by dependency-graph hash.
-  `node_modules/.aube/<pkg>` is an absolute symlink into this shared location,
-  so repeat installs across projects reuse the same tree instead of
-  re-materializing it.
-
-The global virtual store is on by default outside CI and off under CI (where a
-warm cache is rarely available). Override per-project with
-`enableGlobalVirtualStore=true|false` in `.npmrc`, or per-invocation with
-`--enable-global-virtual-store` / `--disable-global-virtual-store`.
-
-### Why aube turns it off for some packages
-
-A few tools resolve modules by canonicalizing every `node_modules/<pkg>`
-symlink to its real path, then walking up the directory tree looking for
-configs, app-router roots, or hoisted deps. When `<pkg>` points into the
-global virtual store, the walk escapes the project and fails with errors
-like `Symlink ... is invalid, it points out of the filesystem root`.
-
-When any importer depends on a known-incompatible package, aube falls back
-to per-project materialization under `node_modules/.aube/` and prints a
-one-line warning:
-
-```text
-`next` isn't compatible with aube's global virtual store — installing
-per-project instead. Install still succeeds; repeat installs of this
-project just won't share materialized packages across projects.
-```
-
-- **How to fix it properly.** The package itself would need to stop
-  canonicalizing through symlinks (pnpm users hit the same class of issue).
-  That's an upstream change in the tool — please file it with the package
-  maintainers, not with aube.
-- **How to silence the warning.** Add `enableGlobalVirtualStore=false` to
-  `.npmrc`. The per-project fallback stays on; the warning just goes away.
-- **How to opt out of the heuristic entirely** (at your own risk — expect
-  the errors above): set `disableGlobalVirtualStoreForPackages=[]` in
-  `.npmrc`.
-
-The default trigger list is `next`, `nuxt`, `vite`, `vitepress`, `parcel` —
-the tools with concrete, reproducible walk-up failures. Add names to
-`disableGlobalVirtualStoreForPackages` if you hit the same class of error
-with another package.
+The [global virtual store](/package-manager/global-virtual-store) reuses
+materialized package directories across projects. It is on by default outside
+CI and off under CI.
 
 ## Coexistence with pnpm
 
 aube does not reuse `node_modules/.pnpm/` or `~/.pnpm-store/`. If a pnpm-built
 tree already exists, aube installs alongside it in `node_modules/.aube/`.
-

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,7 +21,7 @@ Symptoms that usually point here:
 - `ERR_INVALID_PACKAGE_TARGET` or exports-resolution failures for a
   package that resolves fine under pnpm/npm
 
-See [Global virtual store](/package-manager/node-modules#global-virtual-store)
+See [Global virtual store](/package-manager/global-virtual-store)
 for what this changes.
 
 ## A package is missing from `node_modules`


### PR DESCRIPTION
## Summary

Adds a standalone Global virtual store documentation page that explains the content store vs virtual store split, default local and CI behavior, package identity, pnpm comparison, configuration, and known symlink-sensitive limitations.

Updates the benchmark page, node_modules overview, troubleshooting page, and install warning URL to point at the new standalone page.

## Validation

- `npm run docs:build`

*This PR was generated by Codex.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/endevco/codesmith/aube/pr/550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily documentation restructuring plus a warning-message URL update; no behavior changes beyond pointing users to a new docs page.
> 
> **Overview**
> Adds a standalone **`Global virtual store`** documentation page describing the feature, defaults (local vs CI), configuration knobs, and symlink-sensitive limitations.
> 
> Updates existing docs to link to the new page: adds it to the VitePress sidebar, revises benchmarks wording to reflect default GVS behavior, trims the `node_modules` page to a short link-out, and repoints troubleshooting and the install-time incompatibility warning’s *Details* URL to `/package-manager/global-virtual-store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0880a9ab8d3282e737fbcad04ee8957d07f4837a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->