### PR TITLE
chore(ci): make sponsor blurb append idempotent regardless of input

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -178,13 +178,18 @@ jobs:
           TAG: ${{ needs.release-plz-release.outputs.tag }}
         run: |
           body="$(gh release view "$TAG" --json body --jq .body)"
-          if grep -Fqx '## 💚 Sponsor aube' <<<"$body"; then
-            echo "Release notes already include the sponsor blurb; leaving them unchanged."
-            exit 0
-          fi
+          # Strip any pre-existing sponsor section (the canonical heading,
+          # the no-emoji variant communique sometimes emits, or a leftover
+          # from a prior workflow run) plus trailing blank lines, then
+          # append the canonical block. Idempotent regardless of input.
+          trimmed="$(printf '%s\n' "$body" | awk '
+            /^## .*Sponsor aube[[:space:]]*$/ { exit }
+            /^[[:space:]]*$/ { blanks++; next }
+            { while (blanks-- > 0) print ""; blanks = 0; print }
+          ')"
 
           {
-            printf '%s\n' "$body"
+            printf '%s\n' "$trimmed"
             cat <<'EOF'
 
           ## 💚 Sponsor aube


### PR DESCRIPTION
## Summary

#488 added a `grep -Fqx '## 💚 Sponsor aube'` exact-line check that skips the append when the canonical heading is already present. That handles re-runs of this workflow, but **not** the failure mode that just bit mise:

- **mise v2026.5.4** shipped two `Sponsor mise` sections — `communique` started including its own `## Sponsor mise` (no heart emoji) in the generated body, the equivalent exact-match check in mise missed it, and the workflow appended the canonical block on top. Fixed in [jdx/mise#9745](https://github.com/jdx/mise/pull/9745) and the v2026.5.4 release notes were edited by hand.

The same drift can happen here. aube's check is `grep -Fqx '## 💚 Sponsor aube'` (fixed-string, full-line), so a `## Sponsor aube` heading from `communique` would not match → duplicate block.

## Fix

Switch to a strip-and-reappend pattern (matches what the same step in `hk`, `fnox`, and `communique` already do): pipe the body through a tiny `awk` filter that drops any `## .*Sponsor aube` heading and everything after it, plus trailing blank lines, then append the canonical block.

Idempotent regardless of whether the body already contains a sponsor section, in which variant, or none at all.

## Test plan

Simulated locally against four shapes — the existing canonical body (re-run case), a body containing `## Sponsor aube` (no emoji, the failure mode), a body with no sponsor section at all, and a body with trailing blank lines. Each produces exactly one `## 💚 Sponsor aube` block with one blank line of separation. `actionlint` is clean on the modified workflow.

- [ ] Next tagged release shows exactly one `## 💚 Sponsor aube` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/endevco/codesmith/aube/pr/551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it alters release-note editing logic and could affect the final GitHub release body formatting if the `awk` trimming behaves unexpectedly.
> 
> **Overview**
> Updates the `release-plz` workflow’s “Append en.dev sponsor blurb” step to be fully idempotent by **stripping any existing `Sponsor aube` section (emoji or non-emoji heading) and trailing blank lines** before re-appending the canonical sponsor block.
> 
> This replaces the prior exact-line `grep` check so re-runs or communique-generated sponsor headings no longer produce duplicate sponsor sections in GitHub release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4de71c47fe0c2e14ac8a7332be8727645c861a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->