### PR TITLE
fix(lockfile): recognize file: resolved field in npm package-lock

### DIFF
--- a/crates/aube-lockfile/src/npm.rs
+++ b/crates/aube-lockfile/src/npm.rs
@@ -391,10 +391,9 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             let version = entry.version.clone().ok_or_else(|| {
                 Error::parse(path, format!("package '{install_name}' has no version"))
             })?;
-            let local_source = entry
-                .resolved
-                .as_deref()
-                .and_then(local_git_source_from_resolved);
+            let local_source = entry.resolved.as_deref().and_then(|r| {
+                local_git_source_from_resolved(r).or_else(|| local_file_source_from_resolved(r))
+            });
             let dep_path = local_source.as_ref().map_or_else(
                 || format!("{install_name}@{version}"),
                 |l| l.dep_path(&install_name),
@@ -730,6 +729,29 @@ fn local_git_source_from_resolved(resolved: &str) -> Option<LocalSource> {
         resolved,
         subpath,
     }))
+}
+
+/// Convert a `file:<path>` value in a non-`link:true` entry's
+/// `resolved` field to the matching local source. npm writes this
+/// shape for `npm install file:../foo-1.0.0.tgz` (local tarballs)
+/// and for some directory deps that pre-date the modern `link: true`
+/// emission. Without recognizing it, the entry parses as a plain
+/// registry package; lockfile-reuse then matches by name+version and
+/// the fetcher 404s on the literal package name.
+///
+/// Tarball vs. Directory is decided purely by the `.tgz`/`.tar.gz`
+/// suffix: the lockfile path is authoritative, and we don't have the
+/// project root here to stat the target. False classification is
+/// recoverable on the next install — `LocalSource::parse` from the
+/// manifest re-runs the FS-aware check.
+fn local_file_source_from_resolved(resolved: &str) -> Option<LocalSource> {
+    let rest = resolved.strip_prefix("file:")?;
+    let path = PathBuf::from(rest);
+    if LocalSource::path_looks_like_tarball(&path) {
+        Some(LocalSource::Tarball(path))
+    } else {
+        Some(LocalSource::Directory(path))
+    }
 }
 
 fn npm_resolved_field(pkg: &LockedPackage) -> Option<String> {
@@ -1756,6 +1778,77 @@ mod tests {
 
         let body = std::fs::read_to_string(out.path()).unwrap();
         assert!(!body.contains("\"node_modules/local-dir\""));
+    }
+
+    #[test]
+    fn test_parse_file_resolved_without_link() {
+        // npm writes `resolved: "file:..."` without `link: true` for
+        // local tarball deps (`npm install file:../foo-1.0.0.tgz`) and
+        // for some directory deps. Both shapes must surface as a
+        // LocalSource so the resolver dispatches the local-source
+        // branch and doesn't fall through to a registry fetch.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "dependencies": {
+                        "tar-dep": "file:../utils/tar-dep-1.0.0.tgz",
+                        "dir-dep": "file:../utils"
+                    }
+                },
+                "node_modules/tar-dep": {
+                    "version": "1.0.0",
+                    "resolved": "file:../utils/tar-dep-1.0.0.tgz",
+                    "integrity": "sha512-aaa"
+                },
+                "node_modules/dir-dep": {
+                    "version": "1.0.0",
+                    "resolved": "file:../utils"
+                }
+            }
+        }"#;
+        std::fs::write(tmp.path(), content).unwrap();
+
+        let graph = parse(tmp.path()).unwrap();
+
+        let tar_pkg = graph
+            .packages
+            .values()
+            .find(|p| p.name == "tar-dep")
+            .expect("tar-dep entry");
+        assert!(
+            matches!(&tar_pkg.local_source, Some(LocalSource::Tarball(p)) if p == Path::new("../utils/tar-dep-1.0.0.tgz")),
+            "expected Tarball source, got {:?}",
+            tar_pkg.local_source,
+        );
+        assert!(
+            tar_pkg.dep_path.starts_with("tar-dep@file+"),
+            "tarball dep_path should be local-source-keyed, got {}",
+            tar_pkg.dep_path,
+        );
+
+        let dir_pkg = graph
+            .packages
+            .values()
+            .find(|p| p.name == "dir-dep")
+            .expect("dir-dep entry");
+        assert!(
+            matches!(&dir_pkg.local_source, Some(LocalSource::Directory(p)) if p == Path::new("../utils")),
+            "expected Directory source, got {:?}",
+            dir_pkg.local_source,
+        );
+        assert!(
+            dir_pkg.dep_path.starts_with("dir-dep@file+"),
+            "directory dep_path should be local-source-keyed, got {}",
+            dir_pkg.dep_path,
+        );
+
+        let root = graph.importers.get(".").unwrap();
+        let tar_direct = root.iter().find(|d| d.name == "tar-dep").unwrap();
+        assert_eq!(tar_direct.dep_path, tar_pkg.dep_path);
+        let dir_direct = root.iter().find(|d| d.name == "dir-dep").unwrap();
+        assert_eq!(dir_direct.dep_path, dir_pkg.dep_path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- npm writes `resolved: "file:<path>"` (no `link: true`) for local tarball deps (`npm install file:../foo-1.0.0.tgz`) and for some directory deps. Aube's npm parser only recognized git URLs in `resolved`, so these entries lost their `local_source`. Lockfile-reuse then matched name+version and the fetcher 404'd against `registry.npmjs.org/<literal-name>`.
- Extends `crates/aube-lockfile/src/npm.rs` to chain a `file:` detector after the git one — `.tgz`/`.tar.gz` → `LocalSource::Tarball`, otherwise `LocalSource::Directory`.
- Reported by a user who hit it with a monorepo where the main web project depends on a sibling utilities project; their workaround was to delete `package-lock.json`, which pushed the resolver onto the manifest path that already handles `file:` correctly.

## Repro (pre-fix)
```sh
mkdir -p web utils && cd utils
echo '{"name":"@company/utils","version":"1.0.0"}' > package.json
npm pack
cd ../web
echo '{"name":"web","version":"0.0.1","dependencies":{"@company/utils":"file:../utils/company-utils-1.0.0.tgz"}}' > package.json
npm install --package-lock-only --ignore-scripts
aube install
# × failed to fetch @company/utils@1.0.0: HTTP 404 ... registry.npmjs.org/@company/utils/-/utils-1.0.0.tgz
```

## Test plan
- [x] New unit test `test_parse_file_resolved_without_link` covers both tarball and directory shapes
- [x] `cargo test` (all 16 crates, 0 failures)
- [x] `cargo fmt --check`
- [x] Manual repro: tarball + directory shapes both install correctly post-fix; node_modules symlink resolves into `.aube/<name>@file+<hash>/...`
- [x] Existing `test_write_skips_non_git_local_sources` still passes — write side intentionally omits non-git local sources, that's pre-existing and unchanged

## Notes
- Tarball-vs-Directory is decided purely by suffix because the parser doesn't have the project root for a filesystem check; misclassification is recoverable on the next install (the manifest path's `LocalSource::parse` is FS-aware).
- Write-side support for emitting `resolved: "file:..."` for non-git local sources is a separate, pre-existing limitation (`npm_resolved_field` only handles git). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/endevco/codesmith/aube/pr/553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm lockfile parsing to treat `resolved: "file:..."` entries as local tarball/directory sources, which can affect dependency identity and install behavior for projects using local deps. Scope is small and covered by a new unit test, but it touches lockfile resolution logic.
> 
> **Overview**
> Fixes npm `package-lock.json` parsing so non-`link:true` entries with `resolved: "file:..."` are recognized as local sources (tarball vs directory) instead of falling back to registry packages.
> 
> Adds `local_file_source_from_resolved` and chains it after the existing git `resolved` detection, ensuring `dep_path` and direct deps are keyed off the local source; includes a new unit test covering both tarball and directory `file:` shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 426ee8f225c85d9b00fb4da404fb36dcf0070994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->