### PR TITLE
docs: lead hero with auto-install promise over speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  A drop-in Node.js package manager that keeps <code>node_modules</code> in sync with your lockfile, sandboxes lifecycle scripts by default, and reads whatever lockfile you already have.
+  Aube installs automatically when you run a script. The tightest security defaults of any Node.js package manager - and the only one with a lifecycle-script jail. Drops into existing projects.
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  Aube installs automatically when you run a script. The tightest security defaults of any Node.js package manager - and the only one with a lifecycle-script jail. Drops into existing projects.
+  Aube installs automatically when you run a script. The tightest security defaults of any Node.js package manager - and the only one with a lifecycle-script jail. Drops into existing projects using existing lockfiles.
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 <h1 align="center">aube</h1>
 
 <p align="center">
-  A fast Node.js package manager that drops into existing projects.
+  <strong>Never forget to install.</strong>
+</p>
+
+<p align="center">
+  A drop-in Node.js package manager that keeps <code>node_modules</code> in sync with your lockfile, sandboxes lifecycle scripts by default, and reads whatever lockfile you already have.
 </p>
 
 <p align="center">

--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -209,11 +209,11 @@ watch(progressBarEl, (el, previousEl) => {
     <section class="aube-hero" aria-labelledby="aube-hero-title">
       <div class="aube-hero-copy">
         <p class="aube-pronunciation">aube /ob/ - pronounced "ohb"</p>
-        <h1 id="aube-hero-title">A new dawn <em>for node installs.</em></h1>
+        <h1 id="aube-hero-title">Never forget <em>to install.</em></h1>
         <p class="aube-lede">
-          Never forget to install. Aube keeps <code>node_modules</code> in
-          sync with your lockfile, sandboxes lifecycle scripts by default,
-          and drops into existing projects - no lockfile migration required.
+          Aube installs automatically when you run a script. The tightest
+          security defaults of any package manager - and the only one with
+          a lifecycle-script jail. Drops into existing projects.
         </p>
         <div class="aube-actions" aria-label="Primary links">
           <a class="aube-button aube-button-primary" href="/guide/">

--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -212,8 +212,8 @@ watch(progressBarEl, (el, previousEl) => {
         <h1 id="aube-hero-title">Never forget <em>to install.</em></h1>
         <p class="aube-lede">
           Aube installs automatically when you run a script. The tightest
-          security defaults of any package manager - and the only one with
-          a lifecycle-script jail. Drops into existing projects.
+          security defaults of any Node.js package manager - and the only
+          one with a lifecycle-script jail. Drops into existing projects.
         </p>
         <div class="aube-actions" aria-label="Primary links">
           <a class="aube-button aube-button-primary" href="/guide/">

--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -213,7 +213,8 @@ watch(progressBarEl, (el, previousEl) => {
         <p class="aube-lede">
           Aube installs automatically when you run a script. The tightest
           security defaults of any Node.js package manager - and the only
-          one with a lifecycle-script jail. Drops into existing projects.
+          one with a lifecycle-script jail. Drops into existing projects
+          using existing lockfiles.
         </p>
         <div class="aube-actions" aria-label="Primary links">
           <a class="aube-button aube-button-primary" href="/guide/">

--- a/docs/.vitepress/theme/HomeLanding.vue
+++ b/docs/.vitepress/theme/HomeLanding.vue
@@ -211,8 +211,9 @@ watch(progressBarEl, (el, previousEl) => {
         <p class="aube-pronunciation">aube /ob/ - pronounced "ohb"</p>
         <h1 id="aube-hero-title">A new dawn <em>for node installs.</em></h1>
         <p class="aube-lede">
-          Aube is a fast Node.js package manager that drops into existing
-          JavaScript and TypeScript projects - no lockfile migration required.
+          Never forget to install. Aube keeps <code>node_modules</code> in
+          sync with your lockfile, sandboxes lifecycle scripts by default,
+          and drops into existing projects - no lockfile migration required.
         </p>
         <div class="aube-actions" aria-label="Primary links">
           <a class="aube-button aube-button-primary" href="/guide/">


### PR DESCRIPTION
## Summary

- Replace the "fast Node.js package manager" hero copy in `README.md` and the landing page lede with a tagline-led pitch: **"Never forget to install."**
- Subhead now leads with the three things aube actually fixes day-to-day: auto-syncing `node_modules`, sandboxed lifecycle scripts, and reading whatever lockfile you already have.

## Why

Speed wins are commoditizing across package managers (bun, pnpm, aube are all fast enough that benchmarks aren't the differentiator they were two years ago). The papercut that still hurts every morning is "did you run pnpm install?" in Slack. Lead with the promise the user actually feels — the `## Why Try It` block below still carries the perf bullet for skeptics who scroll.

## Test plan

- [ ] `README.md` renders correctly on github.com/endevco/aube
- [ ] Landing page (`docs/.vitepress/theme/HomeLanding.vue`) builds cleanly via VitePress and the lede wraps without overflowing the hero column at common breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes marketing copy in `README.md` and the VitePress landing hero, with no functional or behavioral code changes.
> 
> **Overview**
> Shifts the primary positioning in `README.md` and the docs landing hero from *speed-first* to an *auto-install* promise, introducing the new tagline **"Never forget to install."**
> 
> Updates the accompanying lede text to highlight automatic installs on script runs, stronger security defaults, and lockfile drop-in compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4080b12b987247f73a3fca3d2924cb7f99ee47ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->