### PR TITLE
feat(install): show post-install dependency summary

### DIFF
--- a/.rules
+++ b/.rules
@@ -122,9 +122,10 @@ commits:
   types[12]: fix, feat, refactor, chore, docs, style, test, perf, build, ci, revert, security
   scope_optional: true (omit for repo-wide changes like `chore: release v1.2.0`)
   scope_enforcement: advisory — the lint workflow only validates `type`, not `scope`. lists below are the conventional set, but new crates/features can introduce new scopes without a workflow change. release-plz keys off `type` only
-  scopes_crates[10]: cli, resolver, registry, lockfile, store, linker, manifest, scripts, workspace, settings
+  scopes_crates[9]: resolver, registry, lockfile, store, linker, manifest, scripts, workspace, settings
   scopes_features[12]: install, add, publish, dlx, audit, login, logout, deprecate, unpublish, fetch, import, catalog
   scopes_infra[5]: bench, packaging, release, deps, release-plz
+  scope_rule: never use `cli` as a scope. user-visible command behavior belongs to the command/feature scope (`install`, `add`, `dlx`, etc.); cross-command CLI plumbing should use the narrowest affected command scope or omit the scope when truly repo-wide.
   breaking: append `!` after type/scope (e.g. `feat(resolver)!: drop yarn classic`) or include `BREAKING CHANGE:` footer in body. release-plz will cut a major bump
   body_rules: reserve body for breaking changes, security fixes, benchmark tables, non-obvious WHY. wrap 72, use - not *
   pr_numbers: never type (#NN) yourself, GitHub squash-merge appends them automatically
@@ -134,7 +135,7 @@ commits:
     - emoji in commit subject
   trailers_accepted: Co-authored-by (agents + bots are normal aube history, 50+ commits use them)
   examples[7]:
-    - feat(cli): add aubr/aubx multicall shims for run and dlx
+    - feat(dlx): add aubx multicall shim
     - fix(resolver): preserve npm-alias as folder name on fresh resolve
     - refactor(store): swap CAS hash from SHA-512 to BLAKE3
     - feat(lockfile): add yarn berry (v2+) parse + write support

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -4295,14 +4295,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         }
     }
 
-    // Final summary. When linking did real work this is the green
-    // `✓ installed N packages in Xs` line (TTY only; CI mode prints
-    // its own framed `✓` from the heartbeat's stop tick). When
-    // nothing needed linking we emit `Already up to date` in both TTY
-    // and CI modes so cache-only runs still confirm the no-op — text /
-    // silent / ndjson modes stay quiet because prog_ref is None. Emitted
-    // after every post-link lifecycle script has finished so the line
-    // lands as the very last thing on stderr.
+    // Final user-facing output. When linking did real work, print the
+    // direct deps that now exist at the top level before the green
+    // `✓ installed N packages in Xs` line. Text modes such as `-v` and
+    // `--reporter=append-only` skip the progress object but still get the
+    // dependency summary; silent and ndjson stay machine-clean.
+    if !install_is_noop && should_print_human_install_summary() {
+        print_direct_dependency_summary(&graph_for_link, &manifests);
+    }
     if let Some(p) = prog_ref {
         p.print_install_summary(
             stats.packages_linked,
@@ -4505,6 +4505,75 @@ fn print_already_up_to_date() {
     );
     let line = crate::progress::aube_prefix_line(&msg);
     let _ = writeln!(std::io::stderr(), "{line}");
+}
+
+fn print_direct_dependency_summary(
+    graph: &aube_lockfile::LockfileGraph,
+    manifests: &[(String, aube_manifest::PackageJson)],
+) {
+    let importers: Vec<(&String, &Vec<aube_lockfile::DirectDep>)> = graph
+        .importers
+        .iter()
+        .filter(|(_, deps)| !deps.is_empty())
+        .collect();
+    if importers.is_empty() {
+        return;
+    }
+    let show_importer_headers = importers.len() > 1;
+    for (idx, (importer, deps)) in importers.iter().enumerate() {
+        if idx > 0 {
+            eprintln!();
+        }
+        if show_importer_headers {
+            eprintln!("{}:", direct_dependency_importer_label(importer, manifests));
+        }
+        print_direct_dependency_section(graph, deps, aube_lockfile::DepType::Production);
+        print_direct_dependency_section(graph, deps, aube_lockfile::DepType::Optional);
+        print_direct_dependency_section(graph, deps, aube_lockfile::DepType::Dev);
+    }
+    eprintln!();
+}
+
+fn direct_dependency_importer_label(
+    importer: &str,
+    manifests: &[(String, aube_manifest::PackageJson)],
+) -> String {
+    manifests
+        .iter()
+        .find(|(path, _)| path == importer)
+        .and_then(|(_, manifest)| manifest.name.clone())
+        .unwrap_or_else(|| importer.to_string())
+}
+
+fn should_print_human_install_summary() -> bool {
+    let flags = super::global_output_flags();
+    !flags.silent && !flags.ndjson
+}
+
+fn print_direct_dependency_section(
+    graph: &aube_lockfile::LockfileGraph,
+    deps: &[aube_lockfile::DirectDep],
+    dep_type: aube_lockfile::DepType,
+) {
+    let mut deps: Vec<&aube_lockfile::DirectDep> =
+        deps.iter().filter(|dep| dep.dep_type == dep_type).collect();
+    if deps.is_empty() {
+        return;
+    }
+    deps.sort_by(|a, b| a.name.cmp(&b.name));
+    let label = match dep_type {
+        aube_lockfile::DepType::Production => "dependencies",
+        aube_lockfile::DepType::Optional => "optionalDependencies",
+        aube_lockfile::DepType::Dev => "devDependencies",
+    };
+    eprintln!("{label}:");
+    for dep in deps {
+        let version = graph
+            .get_package(&dep.dep_path)
+            .map(|pkg| pkg.version.as_str())
+            .unwrap_or("?");
+        eprintln!("+ {}@{version}", dep.name);
+    }
 }
 
 fn invalidate_changed_aube_entries(

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -96,6 +96,7 @@ static FETCH_CLI_OVERRIDES: OnceLock<Vec<(String, String)>> = OnceLock::new();
 
 #[derive(Copy, Clone, Debug, Default)]
 pub(crate) struct GlobalOutputFlags {
+    pub ndjson: bool,
     pub silent: bool,
 }
 

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -903,6 +903,7 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
     let effective_filter = compute_effective_filter(&cli);
 
     commands::set_global_output_flags(commands::GlobalOutputFlags {
+        ndjson: matches!(cli.reporter, Some(ReporterType::Ndjson)),
         silent: matches!(effective_level, LogLevel::Silent),
     });
 

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -2,24 +2,22 @@
 //!
 //! Two modes live behind one API so call sites in `install::run` stay the same:
 //!
-//! * **TTY** — an animated clx bar: a root row with overall counts plus
-//!   transient child rows for in-flight tarball fetches. Children auto-hide
-//!   on completion via `ProgressJobDoneBehavior::Hide`, so the display stays
-//!   bounded even though the pipeline resolves → fetches → links concurrently.
-//! * **CI** — append-only lines safe for GitHub Actions / plain pipes: a
-//!   single repeating pnpm-style `Progress:` line emitted on a ~2s
-//!   heartbeat, showing `resolved` / `reused` / `downloaded` plus the
-//!   byte total for the downloaded set. The heartbeat only prints when
-//!   something actually advanced, so a fast install stays quiet and a
-//!   slow one shows exactly *why* it's slow (network-bound vs
-//!   linker-bound). No phase noise, no child rows, no redraws.
+//! * **TTY** — an animated clx bar, kept as an internal fallback for callers
+//!   that explicitly opt into an in-place display. It redraws by moving the
+//!   cursor and clearing the previous frame.
+//! * **Append-only** — lines safe for terminals, GitHub Actions, and plain
+//!   pipes: a single repeating pnpm-style `Progress:` line emitted on a ~2s
+//!   heartbeat, showing `resolved` / `reused` / `downloaded` plus the byte
+//!   total for the downloaded set. The heartbeat only prints when something
+//!   actually advanced, so a fast install stays quiet and a slow one shows
+//!   exactly *why* it's slow (network-bound vs linker-bound). No phase noise,
+//!   no child rows, no redraws.
 //!
-//! `try_new` picks the mode: TTY on an interactive stderr, CI on a pipe,
-//! or CI when `is_ci::cached()` detects a known CI environment (Buildkite,
-//! GitHub Actions, etc.) even if stderr looks like a TTY — those systems
-//! allocate a PTY so tools emit colors, but their log capturers strip
-//! cursor-control escapes and each animation frame lands as its own log
-//! line. CI mode's ~2s heartbeat is the right shape for that.
+//! `try_new` picks the append-only mode by default. The clx TTY renderer
+//! clears the previous frame on every redraw; that makes installs look like
+//! the screen is blinking right before the post-install package summary lands.
+//! Set `AUBE_TTY_PROGRESS=1` to use the in-place renderer while it remains
+//! useful for local debugging.
 //! It returns `None` only when clx has been forced into text mode
 //! (`--silent`, `-v`, `--reporter=append-only|ndjson`) — those modes own
 //! their own output and we stay out of the way.
@@ -34,7 +32,7 @@ use clx::progress::{
 use clx::style;
 use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -48,6 +46,15 @@ const TTY_MAX_VISIBLE_FETCH_ROWS: usize = 5;
 fn overflow_fetch_label(count: usize) -> String {
     let word = pluralizer::pluralize("package", count as isize, false);
     format!("{count} more {word}…")
+}
+
+fn env_truthy(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| {
+        !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        )
+    })
 }
 
 /// Build the standard `aube VERSION by en.dev · <msg>` one-line
@@ -83,6 +90,9 @@ pub struct InstallProgress {
 enum Mode {
     Tty {
         root: Arc<ProgressJob>,
+        /// Set after explicit finish so Drop does not later clear the
+        /// terminal rows that the success path intentionally preserved.
+        finished: Arc<AtomicBool>,
         /// Our own mirror of the denominator so `inc_total` can atomically
         /// fetch-add without racing a concurrent reader/writer through clx's
         /// separate `overall_progress()` / `progress_total()` calls.
@@ -159,16 +169,12 @@ impl InstallProgress {
         if clx::progress::output() == ProgressOutput::Text {
             return None;
         }
-        // Prefer CI mode whenever we're in a known CI environment
-        // (`is_ci` checks `CI`, `BUILDKITE`, `GITHUB_ACTIONS`, and friends),
-        // even when stderr looks like a TTY. Most CI runners allocate a
-        // PTY so child processes emit colors, which makes
-        // `is_terminal()` return true — but the log capturer then strips
-        // cursor-control escapes and each animation frame becomes its
-        // own log line, flooding the build log with thousands of
-        // near-duplicate spinner rows. CI mode's 2s heartbeat is the
-        // right shape there.
-        if std::io::stderr().is_terminal() && !is_ci::cached() {
+        // The animated TTY renderer redraws via cursor movement plus
+        // clear-to-end-of-screen. That is fine for a standalone progress bar,
+        // but it looks like a screen wipe when followed by the post-install
+        // dependency summary. Default to append-only progress everywhere and
+        // leave the in-place renderer behind an explicit debugging opt-in.
+        if std::io::stderr().is_terminal() && !is_ci::cached() && env_truthy("AUBE_TTY_PROGRESS") {
             Some(Self::new_tty())
         } else {
             Some(Self::new_ci())
@@ -204,11 +210,12 @@ impl InstallProgress {
             .prop("eta", "")
             .progress_current(0)
             .progress_total(0)
-            .on_done(ProgressJobDoneBehavior::Hide)
+            .on_done(ProgressJobDoneBehavior::Collapse)
             .start();
         Self {
             mode: Mode::Tty {
                 root,
+                finished: Arc::new(AtomicBool::new(false)),
                 total: Arc::new(AtomicUsize::new(0)),
                 reused: Arc::new(AtomicUsize::new(0)),
                 downloaded: Arc::new(AtomicUsize::new(0)),
@@ -671,8 +678,9 @@ impl InstallProgress {
         }
     }
 
-    /// Finalize and clear the progress display. TTY mode leaves no output
-    /// behind. CI mode blocks until the heartbeat thread has actually
+    /// Finalize the progress display. TTY mode leaves the collapsed final
+    /// root row behind so the terminal does not visibly blink/clear right
+    /// before the install summary. CI mode blocks until the heartbeat thread has actually
     /// stopped so no stray tick can appear after this returns, and
     /// optionally writes the final framed `[ ✓ … ]` status line.
     /// Idempotent.
@@ -684,9 +692,10 @@ impl InstallProgress {
     /// want the framed summary to remain the end of CI log output.
     pub fn finish(&self, print_ci_summary: bool) {
         match &self.mode {
-            Mode::Tty { root, .. } => {
+            Mode::Tty { root, finished, .. } => {
                 root.set_status(ProgressStatus::Done);
-                clx::progress::stop_clear();
+                finished.store(true, Ordering::Relaxed);
+                clx::progress::stop();
             }
             Mode::Ci(s) => s.stop(print_ci_summary),
         }
@@ -712,9 +721,8 @@ impl InstallProgress {
     /// **Safety:** must be called *after* [`InstallProgress::finish`]. The
     /// write goes straight to stderr without routing through
     /// `PausingWriter` or `with_terminal_lock`, which is only safe once
-    /// `finish()` has synchronously stopped the render loop via
-    /// `stop_clear()`. A new call site placed before `finish()` would
-    /// silently race the animated display.
+    /// `finish()` has synchronously stopped the render loop. A new call site
+    /// placed before `finish()` would silently race the animated display.
     pub fn print_install_summary(
         &self,
         linked: usize,
@@ -785,8 +793,8 @@ impl Drop for InstallProgress {
     /// — the heartbeat still gets joined so no stray tick escapes.
     fn drop(&mut self) {
         match &self.mode {
-            Mode::Tty { root, .. } => {
-                if Arc::strong_count(root) == 1 {
+            Mode::Tty { root, finished, .. } => {
+                if Arc::strong_count(root) == 1 && !finished.load(Ordering::Relaxed) {
                     root.set_status(ProgressStatus::Done);
                     clx::progress::stop_clear();
                 }

--- a/test/install.bats
+++ b/test/install.bats
@@ -55,6 +55,107 @@ teardown() {
 	refute_output --partial "Already up to date"
 }
 
+@test "aube install prints grouped direct dependencies after real work" {
+	cat >package.json <<'JSON'
+{
+  "name": "install-summary",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-odd": "3.0.1"
+  },
+  "devDependencies": {
+    "kind-of": "6.0.3"
+  },
+  "optionalDependencies": {
+    "is-number": "7.0.0"
+  }
+}
+JSON
+
+	run aube install
+	assert_success
+	assert_output --partial "dependencies:"
+	assert_output --partial "+ is-odd@3.0.1"
+	assert_output --partial "optionalDependencies:"
+	assert_output --partial "+ is-number@7.0.0"
+	assert_output --partial "devDependencies:"
+	assert_output --partial "+ kind-of@6.0.3"
+
+	run aube install
+	assert_success
+	assert_output --partial "Already up to date"
+	refute_output --partial "+ is-odd@3.0.1"
+}
+
+@test "aube install prints direct dependency summary in append-only text mode" {
+	cat >package.json <<'JSON'
+{
+  "name": "install-summary-text",
+  "version": "1.0.0",
+  "dependencies": {
+    "kind-of": "6.0.3"
+  }
+}
+JSON
+
+	run aube --reporter=append-only install
+	assert_success
+	assert_output --partial "dependencies:"
+	assert_output --partial "+ kind-of@6.0.3"
+}
+
+@test "aube install does not print human dependency summary in ndjson mode" {
+	cat >package.json <<'JSON'
+{
+  "name": "install-summary-ndjson",
+  "version": "1.0.0",
+  "dependencies": {
+    "kind-of": "6.0.3"
+  }
+}
+JSON
+
+	run aube --reporter=ndjson install
+	assert_success
+	refute_output --partial "dependencies:"
+	refute_output --partial "+ kind-of@6.0.3"
+}
+
+@test "aube install labels workspace dependency summaries by package name" {
+	cat >package.json <<'JSON'
+{
+  "name": "workspace-root",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "kind-of": "6.0.3"
+  }
+}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	mkdir -p packages/app
+	cat >packages/app/package.json <<'JSON'
+{
+  "name": "workspace-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-number": "7.0.0"
+  }
+}
+JSON
+
+	run aube --reporter=append-only install
+	assert_success
+	assert_output --partial "workspace-root:"
+	assert_output --partial "+ kind-of@6.0.3"
+	assert_output --partial "workspace-app:"
+	assert_output --partial "+ is-number@7.0.0"
+	refute_output --partial ".:"
+}
+
 @test "aube install --dev installs only devDependencies" {
 	cat >package.json <<'JSON'
 {


### PR DESCRIPTION
## Summary

- Add a compact post-install direct dependency summary grouped by dependency type.
- Render entries as `+ package@version` so users can quickly see what was installed.
- Default install progress to the append-only heartbeat path to avoid screen-clearing redraws before the final summary.

## Example

```console
$ aube install
dependencies:
+ is-odd@3.0.1

optionalDependencies:
+ is-number@7.0.0

devDependencies:
+ kind-of@6.0.3

aube 1.8.0 by en.dev · ✓ installed 3 packages in 1.2s
```

No-op reruns stay quiet and keep the existing concise confirmation:

```console
$ aube install
aube 1.8.0 by en.dev · ✓ Already up to date
```

## Validation

- `cargo fmt --check`
- `cargo build`
- `mise run test:bats test/install.bats`
- `cargo clippy --all-targets -- -D warnings`
- PTY smoke check confirmed `clear_screen=0`, `clear_line=0`, and dependency summary output present.

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `aube install` user-facing output and progress rendering defaults, which may affect log parsers and expectations in CI/terminal environments. Behavior is gated for `--silent`/`--reporter=ndjson` and covered by new integration tests, reducing risk.
> 
> **Overview**
> Adds a post-install *direct dependency summary* to `aube install`, grouped by `dependencies`/`optionalDependencies`/`devDependencies` and printed as `+ name@version` (including per-workspace headers when multiple importers exist). The summary is shown only when the install did real work and is suppressed in `--silent` and `--reporter=ndjson` modes.
> 
> Adjusts progress UI behavior to default to the append-only heartbeat renderer even on TTYs, with the animated in-place renderer now behind `AUBE_TTY_PROGRESS=1`, and updates TTY teardown to avoid clearing the terminal right before the final summary. Integration tests in `test/install.bats` assert the new output and mode gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6134aa2220306b4edbff62f01d637eb583c1ee59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

