### PR TITLE
feat(update): add --lockfile-only flag

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1884,6 +1884,9 @@ cmd update help="Update dependencies" {
     flag --ignore-scripts help="Skip lifecycle scripts" {
         long_help "Skip lifecycle scripts.\n\nAccepted for pnpm parity — dep scripts are already gated by `allowBuilds`, so the flag is currently a no-op, but scripts that wrap `pnpm update --ignore-scripts` keep working without complaint."
     }
+    flag --lockfile-only help="Refresh the lockfile without populating `node_modules`" {
+        long_help "Refresh the lockfile without populating `node_modules`.\n\nRe-resolves the full graph (direct + transitive) and writes `aube-lock.yaml`, then skips the linker so `node_modules` is left untouched. Mirrors `npm update --package-lock-only`."
+    }
     flag --no-optional help="Skip optionalDependencies"
     flag --no-save help="Refresh the lockfile without rewriting `package.json` ranges" {
         long_help "Refresh the lockfile without rewriting `package.json` ranges.\n\nPair with `--latest` to pull a newer resolved version into the lockfile while leaving the manifest's caret/tilde ranges untouched. Without `--latest` this flag is a no-op (plain `update` already doesn't touch the manifest). Mirrors `pnpm update --no-save`."

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -74,6 +74,13 @@ pub struct UpdateArgs {
     /// complaint.
     #[arg(long)]
     pub ignore_scripts: bool,
+    /// Refresh the lockfile without populating `node_modules`.
+    ///
+    /// Re-resolves the full graph (direct + transitive) and writes
+    /// `aube-lock.yaml`, then skips the linker so `node_modules` is
+    /// left untouched. Mirrors `npm update --package-lock-only`.
+    #[arg(long, conflicts_with = "frozen_lockfile")]
+    pub lockfile_only: bool,
     /// Skip optionalDependencies.
     #[arg(long)]
     pub no_optional: bool,
@@ -663,6 +670,11 @@ pub async fn run(
     chained.ignore_pnpmfile = args.ignore_pnpmfile;
     chained.pnpmfile = args.pnpmfile.clone();
     chained.global_pnpmfile = args.global_pnpmfile.clone();
+    // `--lockfile-only`: lockfile is already written above; tell the
+    // chained install to skip linking `node_modules` so the on-disk
+    // tree stays as-is. Mirrors `aube install --lockfile-only` and
+    // closes the gap with `npm update --package-lock-only`.
+    chained.lockfile_only = args.lockfile_only;
     install::run(chained).await?;
 
     Ok(())

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -10871,6 +10871,19 @@
             "global": false
           },
           {
+            "name": "lockfile-only",
+            "usage": "--lockfile-only",
+            "help": "Refresh the lockfile without populating `node_modules`",
+            "help_long": "Refresh the lockfile without populating `node_modules`.\n\nRe-resolves the full graph (direct + transitive) and writes `aube-lock.yaml`, then skips the linker so `node_modules` is left untouched. Mirrors `npm update --package-lock-only`.",
+            "help_first_line": "Refresh the lockfile without populating `node_modules`",
+            "short": [],
+            "long": [
+              "lockfile-only"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "no-optional",
             "usage": "--no-optional",
             "help": "Skip optionalDependencies",

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -71,6 +71,12 @@ Skip lifecycle scripts.
 
 Accepted for pnpm parity — dep scripts are already gated by `allowBuilds`, so the flag is currently a no-op, but scripts that wrap `pnpm update --ignore-scripts` keep working without complaint.
 
+### `--lockfile-only`
+
+Refresh the lockfile without populating `node_modules`.
+
+Re-resolves the full graph (direct + transitive) and writes `aube-lock.yaml`, then skips the linker so `node_modules` is left untouched. Mirrors `npm update --package-lock-only`.
+
 ### `--no-optional`
 
 Skip optionalDependencies

--- a/test/update.bats
+++ b/test/update.bats
@@ -251,3 +251,40 @@ EOF
 	run grep -c 'is-odd@3' aube-lock.yaml
 	assert_success
 }
+
+@test "aube update --lockfile-only: refreshes lockfile without populating node_modules" {
+	_setup_outdated_project
+
+	run aube update --lockfile-only is-odd
+	assert_success
+
+	# Lockfile picks up a newer is-odd than the seeded 0.1.2 pin.
+	run grep 'is-odd@3' aube-lock.yaml
+	assert_success
+
+	# node_modules is not materialized.
+	assert [ ! -e node_modules ]
+}
+
+@test "aube update --lockfile-only --latest: bumps direct deps without linking" {
+	_setup_outdated_project
+
+	run aube update --lockfile-only --latest is-odd
+	assert_success
+
+	# package.json gets the manifest rewrite (--latest flag).
+	run grep '"is-odd"' package.json
+	assert_success
+	refute_output --partial '>=0.1.0'
+
+	# Lockfile is fresh, but no node_modules.
+	run grep 'is-odd@3' aube-lock.yaml
+	assert_success
+	assert [ ! -e node_modules ]
+}
+
+@test "aube update --lockfile-only conflicts with --frozen-lockfile" {
+	_setup_outdated_project
+	run aube update --lockfile-only --frozen-lockfile
+	assert_failure
+}


### PR DESCRIPTION
## Summary
- Adds `--lockfile-only` to `aube update`. Re-resolves the full graph (direct + transitive) and writes `aube-lock.yaml`, then skips the linker so `node_modules` stays untouched.
- Closes the gap with `npm update --package-lock-only` and matches the existing `aube install --lockfile-only` semantics.
- Composes with `--latest` (manifest rewrite still happens), `--no-save`, recursive (`-r`), and the existing pnpmfile flags.

Requested in [discussion #345](https://github.com/endevco/aube/discussions/345#discussioncomment-16863301).

## Test plan
- [x] `cargo build -p aube`
- [x] `cargo clippy -p aube --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p aube --bins` (446 passed)
- [x] `mise run test:bats test/update.bats` (16/16 passing, 3 new)
  - refreshes lockfile without populating node_modules
  - `--lockfile-only --latest` bumps direct deps without linking
  - `--lockfile-only --frozen-lockfile` is rejected by clap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive CLI flag that only changes behavior when explicitly enabled, with coverage ensuring `node_modules` is not linked and flag conflicts are enforced.
> 
> **Overview**
> Adds `aube update --lockfile-only` to refresh `aube-lock.yaml` while intentionally skipping `node_modules` linking, mirroring `npm update --package-lock-only`.
> 
> Wires the flag through the chained post-update `install` call (so the lockfile refresh doesn’t later materialize `node_modules`) and adds bats tests covering lockfile-only behavior, composition with `--latest`, and the `--frozen-lockfile` conflict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829f514164053a16e24f6a6e336f4efea06e3d5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->