### PR TITLE
fix(release): skip already-published versions in npm publish

### DIFF
--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -57,6 +57,13 @@ function run(cmd, args, opts = {}) {
     }
 }
 
+// musl gets a `-musl` name suffix; glibc keeps the historical name
+// so existing installers upgrade in place without a rename.
+function platformPkgName(target) {
+    const suffix = target.libc === 'musl' ? '-musl' : '';
+    return `@endevco/aube-${target.os}-${target.cpu}${suffix}`;
+}
+
 // Returns true when <pkg>@<version> is already on the registry, so a
 // re-run after a partial publish (or a re-tag) skips instead of erroring
 // with "cannot publish over the previously published versions".
@@ -65,10 +72,14 @@ function isVersionPublished(pkgName, version) {
         stdio: ['ignore', 'pipe', 'pipe'],
         encoding: 'utf8',
     });
+    // spawn itself failed (e.g. `npm` not on PATH) — surface ENOENT/EACCES
+    // instead of letting it dissolve into "failed: null" downstream.
+    if (result.error) throw result.error;
     if (result.status === 0) return result.stdout.trim() === version;
-    const stderr = result.stderr || '';
-    if (/E404|code E404|not found/i.test(stderr)) return false;
-    throw new Error(`npm view ${pkgName}@${version} failed: ${stderr.trim() || result.status}`);
+    // Match only the canonical npm 404 code; broader patterns like
+    // "not found" would also swallow ENOTFOUND DNS failures.
+    if (/E404/.test(result.stderr || '')) return false;
+    throw new Error(`npm view ${pkgName}@${version} failed: ${(result.stderr || '').trim() || result.status}`);
 }
 
 function assertEnv(name) {
@@ -120,10 +131,8 @@ function extractArchive(archivePath, target, destDir) {
 }
 
 async function buildPlatformPackage(repo, tag, version, target) {
-    // musl gets a `-musl` name suffix; glibc keeps the historical name
-    // so existing installers upgrade in place without a rename.
+    const pkgName = platformPkgName(target);
     const suffix = target.libc === 'musl' ? '-musl' : '';
-    const pkgName = `@endevco/aube-${target.os}-${target.cpu}${suffix}`;
     const stageDir = resolve(stageRoot, `${target.os}-${target.cpu}${suffix}`);
     rmSync(stageDir, { recursive: true, force: true });
     const binDir = resolve(stageDir, 'bin');
@@ -189,8 +198,7 @@ async function main() {
     if (!skipPlatforms) {
         for (const target of TARGETS) {
             console.log(`\n[publish] --- ${target.os}-${target.cpu} (${target.triple}) ---`);
-            const suffix = target.libc === 'musl' ? '-musl' : '';
-            const pkgName = `@endevco/aube-${target.os}-${target.cpu}${suffix}`;
+            const pkgName = platformPkgName(target);
             if (!dryRun && isVersionPublished(pkgName, version)) {
                 console.log(`[publish] ${pkgName}@${version} already published, skipping`);
                 continue;

--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -57,6 +57,20 @@ function run(cmd, args, opts = {}) {
     }
 }
 
+// Returns true when <pkg>@<version> is already on the registry, so a
+// re-run after a partial publish (or a re-tag) skips instead of erroring
+// with "cannot publish over the previously published versions".
+function isVersionPublished(pkgName, version) {
+    const result = spawnSync('npm', ['view', `${pkgName}@${version}`, 'version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf8',
+    });
+    if (result.status === 0) return result.stdout.trim() === version;
+    const stderr = result.stderr || '';
+    if (/E404|code E404|not found/i.test(stderr)) return false;
+    throw new Error(`npm view ${pkgName}@${version} failed: ${stderr.trim() || result.status}`);
+}
+
 function assertEnv(name) {
     const v = process.env[name];
     if (!v) throw new Error(`${name} env var is required`);
@@ -175,9 +189,15 @@ async function main() {
     if (!skipPlatforms) {
         for (const target of TARGETS) {
             console.log(`\n[publish] --- ${target.os}-${target.cpu} (${target.triple}) ---`);
-            const { pkgName, stageDir } = await buildPlatformPackage(repo, tag, version, target);
-            console.log(`[publish] staged ${pkgName} at ${stageDir}`);
-            npmPublish(stageDir, npmTag, dryRun);
+            const suffix = target.libc === 'musl' ? '-musl' : '';
+            const pkgName = `@endevco/aube-${target.os}-${target.cpu}${suffix}`;
+            if (!dryRun && isVersionPublished(pkgName, version)) {
+                console.log(`[publish] ${pkgName}@${version} already published, skipping`);
+                continue;
+            }
+            const built = await buildPlatformPackage(repo, tag, version, target);
+            console.log(`[publish] staged ${built.pkgName} at ${built.stageDir}`);
+            npmPublish(built.stageDir, npmTag, dryRun);
         }
     }
 
@@ -186,6 +206,10 @@ async function main() {
         const rootPkgPath = resolve(npmDir, 'package.json');
         const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf8'));
         rootPkg.version = version;
+        if (!dryRun && isVersionPublished(rootPkg.name, version)) {
+            console.log(`[publish] ${rootPkg.name}@${version} already published, skipping`);
+            return;
+        }
         writeFileSync(rootPkgPath, JSON.stringify(rootPkg, null, 2) + '\n');
         // `npm pack` doesn't follow symlinks, so stage a real README
         // copy next to package.json rather than linking ../README.md.


### PR DESCRIPTION
## Summary
- npm publish job fails with \`You cannot publish over the previously published versions\` when a prior run partially succeeded (e.g. one platform package landed before the workflow died), and there's no way to retry without manual cleanup
- probe each \`<pkg>@<version>\` via \`npm view\` and skip when it's already on the registry, so a re-run completes the remaining targets

Repro: https://github.com/endevco/aube/actions/runs/25635089614/job/75247245845 — \`@endevco/aube-darwin-arm64@1.10.0\` was already published from an earlier attempt, killing the run before any other platform/root package could publish.

## Test plan
- [ ] re-run the failed v1.10.0 publish workflow and confirm \`darwin-arm64\` is reported as already published while the remaining six platform packages + root publish cleanly
- [ ] dry-run path (\`DRY_RUN=1\`) is unaffected — registry probe is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release automation behavior and could unintentionally skip publishes if the registry probe misclassifies errors, though it’s limited to the publish script and avoids broad error swallowing.
> 
> **Overview**
> Makes `npm/scripts/publish.mjs` resilient to partial reruns by probing the registry with `npm view <pkg>@<version>` and **skipping** publishes that already exist (both per-platform packages and the root `@endevco/aube` package).
> 
> Refactors platform package naming into `platformPkgName()` and adds `isVersionPublished()` with tighter error handling (only treating `E404` as “not published” and surfacing spawn failures) so rerunning a failed workflow doesn’t error on already-published versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb6b40f3fd5bd2ac65f5d0d15c00062d9dc4646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->