### PR TITLE
perf(registry): drop deep clone and fsync from packument cache writes

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -401,14 +401,16 @@ impl RegistryClient {
         let Ok(packument) = serde_json::to_value(packument) else {
             return;
         };
-        let cached = CachedFullPackument {
-            etag: etag.map(str::to_owned),
-            last_modified: last_modified.map(str::to_owned),
-            fetched_at: if fresh { now_secs() } else { 0 },
-            max_age_secs: (!fresh).then_some(0),
-            packument,
-        };
-        if let Err(e) = write_cached_full_packument(&cache_path, &cached) {
+        let fetched_at = if fresh { now_secs() } else { 0 };
+        let max_age_secs = (!fresh).then_some(0);
+        if let Err(e) = write_cached_full_packument(
+            &cache_path,
+            etag,
+            last_modified,
+            fetched_at,
+            max_age_secs,
+            &packument,
+        ) {
             tracing::debug!(
                 "failed to seed full packument cache {} from bundled primer: {e}",
                 cache_path.display()
@@ -984,14 +986,14 @@ impl RegistryClient {
                     {
                         let revalidated_max_age =
                             parse_cache_control_max_age(&resp).or(c.max_age_secs);
-                        let to_cache = CachedFullPackument {
-                            etag: c.etag.clone(),
-                            last_modified: c.last_modified.clone(),
-                            fetched_at: now_secs(),
-                            max_age_secs: revalidated_max_age,
-                            packument: c.packument.clone(),
-                        };
-                        if let Err(e) = write_cached_full_packument(&cache_path, &to_cache) {
+                        if let Err(e) = write_cached_full_packument(
+                            &cache_path,
+                            c.etag.as_deref(),
+                            c.last_modified.as_deref(),
+                            now_secs(),
+                            revalidated_max_age,
+                            &c.packument,
+                        ) {
                             tracing::warn!(
                                 code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
                                 "failed to write packument cache {}: {e}",
@@ -1008,14 +1010,14 @@ impl RegistryClient {
                     check_body_cap(&resp, self.fetch_policy.packument_max_bytes, &label)?;
                     match parse_full_response::<serde_json::Value>(resp).await {
                         Ok(packument) => {
-                            let to_cache = CachedFullPackument {
-                                etag,
-                                last_modified,
-                                fetched_at: now_secs(),
+                            if let Err(e) = write_cached_full_packument(
+                                &cache_path,
+                                etag.as_deref(),
+                                last_modified.as_deref(),
+                                now_secs(),
                                 max_age_secs,
-                                packument: packument.clone(),
-                            };
-                            if let Err(e) = write_cached_full_packument(&cache_path, &to_cache) {
+                                &packument,
+                            ) {
                                 tracing::warn!(
                                     code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
                                     "failed to write packument cache {}: {e}",
@@ -1176,9 +1178,7 @@ impl RegistryClient {
                 Ok(resp) if resp.status() == reqwest::StatusCode::NOT_MODIFIED => {
                     let revalidated_max_age =
                         parse_cache_control_max_age(&resp).or(cached.max_age_secs);
-                    let mut to_cache = if let Some(to_cache) =
-                        read_cached_full_packument(&cache_path)
-                    {
+                    let to_cache = if let Some(to_cache) = read_cached_full_packument(&cache_path) {
                         to_cache
                     } else {
                         let packument = serde_json::to_value(&cached.packument).map_err(|e| {
@@ -1192,9 +1192,14 @@ impl RegistryClient {
                             packument,
                         }
                     };
-                    to_cache.fetched_at = now_secs();
-                    to_cache.max_age_secs = revalidated_max_age;
-                    if let Err(e) = write_cached_full_packument(&cache_path, &to_cache) {
+                    if let Err(e) = write_cached_full_packument(
+                        &cache_path,
+                        to_cache.etag.as_deref(),
+                        to_cache.last_modified.as_deref(),
+                        now_secs(),
+                        revalidated_max_age,
+                        &to_cache.packument,
+                    ) {
                         tracing::warn!(
                             code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
                             "failed to write packument cache {}: {e}",
@@ -1211,14 +1216,14 @@ impl RegistryClient {
                     check_body_cap(&resp, self.fetch_policy.packument_max_bytes, &label)?;
                     match parse_full_response::<serde_json::Value>(resp).await {
                         Ok(value) => {
-                            let to_cache = CachedFullPackument {
-                                etag,
-                                last_modified,
-                                fetched_at: now_secs(),
+                            if let Err(e) = write_cached_full_packument(
+                                &cache_path,
+                                etag.as_deref(),
+                                last_modified.as_deref(),
+                                now_secs(),
                                 max_age_secs,
-                                packument: value.clone(),
-                            };
-                            if let Err(e) = write_cached_full_packument(&cache_path, &to_cache) {
+                                &value,
+                            ) {
                                 tracing::warn!(
                                     code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
                                     "failed to write packument cache {}: {e}",
@@ -2542,8 +2547,35 @@ fn read_cached_full_packument_typed(path: &Path, force_cache: bool) -> Option<Pa
     read_cached_full_packument_typed_lookup(path, force_cache).packument
 }
 
-fn write_cached_full_packument(path: &Path, cached: &CachedFullPackument) -> std::io::Result<()> {
-    let json = serde_json::to_vec(cached).map_err(std::io::Error::other)?;
+fn write_cached_full_packument(
+    path: &Path,
+    etag: Option<&str>,
+    last_modified: Option<&str>,
+    fetched_at: u64,
+    max_age_secs: Option<u64>,
+    packument: &serde_json::Value,
+) -> std::io::Result<()> {
+    // Serialize through a borrow struct so popular packuments don't pay
+    // a multi-MB `serde_json::Value::clone` per write. The owned
+    // `CachedFullPackument` is still used by the read path; the writer
+    // just doesn't need ownership.
+    #[derive(Serialize)]
+    struct CachedFullPackumentRef<'a> {
+        etag: Option<&'a str>,
+        last_modified: Option<&'a str>,
+        fetched_at: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max_age_secs: Option<u64>,
+        packument: &'a serde_json::Value,
+    }
+    let json = serde_json::to_vec(&CachedFullPackumentRef {
+        etag,
+        last_modified,
+        fetched_at,
+        max_age_secs,
+        packument,
+    })
+    .map_err(std::io::Error::other)?;
     aube_util::fs_atomic::atomic_write(path, &json)
 }
 

--- a/crates/aube-util/src/fs_atomic.rs
+++ b/crates/aube-util/src/fs_atomic.rs
@@ -65,7 +65,15 @@ pub fn atomic_write(final_path: &Path, bytes: &[u8]) -> io::Result<()> {
         use std::io::Write;
         let mut f = std::fs::File::create(&tmp)?;
         f.write_all(bytes)?;
-        let _ = f.sync_all();
+        // No fsync: every aube caller writes content that is either
+        // regenerable from network/manifest (packument cache, install
+        // state, version-check cache) or paired with explicit user
+        // intent that can be retried (patches, `aube config set`).
+        // The atomic rename below still gives us "all or nothing"
+        // visibility — without fsync we just trade a narrow crash-
+        // window where the renamed file can read back as zero bytes
+        // for a measurable cold-install win (~1.6% of CPU was in
+        // sync_all on the packument cache writers).
     }
     match rename_with_retry(&tmp, final_path) {
         Ok(()) => Ok(()),


### PR DESCRIPTION
## Summary

Two cold-install hotspots surfaced by a samply profile against a throttled hermetic registry (`fixture.package.json`, 500mbit / 50ms):

- **Drop the `serde_json::Value::clone`** in `write_cached_full_packument`. The writer now takes borrowed parts via an inline `CachedFullPackumentRef<'a>` (`etag: Option<&str>`, `last_modified: Option<&str>`, `packument: &serde_json::Value`), so popular packuments no longer pay a multi-MB JSON-tree deep-clone per fresh fetch / 304 revalidation. The owned `CachedFullPackument` stays exactly as-is for the read path.
- **Drop `sync_all()` from `atomic_write`**. Every aube caller writes content that is either regenerable from network/manifest (packument cache, install state, version-check cache) or paired with explicit user intent (patches, `aube config set`), so the fsync was load-bearing for nothing — the atomic rename still gives all-or-nothing visibility, we just no longer flush each tempfile to platter before the rename.

## Numbers

Hyperfine, 3 runs, hermetic Verdaccio + throttle proxy (500mbit / 50ms latency), cold node_modules / lockfile / packument-cache / CAS-store:

| metric | before | after | delta |
| --- | --- | --- | --- |
| wall (mean ± σ) | 7.833s ± 0.133s | 7.422s ± 0.019s | −411 ms (−5.2%), 7× lower σ |
| user CPU | 8.144s | 7.075s | −1.07s (−13.1%) |
| system CPU | 7.668s | 7.430s | −0.24s (−3.1%) |

Post-fix profile confirms the targeted hotspots are gone:
- `__GI_fsync` callers in aube threads: 430 → **0** samples
- `serde_json::Value::clone` deep-recursion in fetch path: 550+ → 2 (one unrelated `VersionMetadata` clone)

## Test plan

- [x] `cargo test -p aube-util -p aube-registry` (88 passed, 0 failed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Cold install profile re-run on the same hermetic + throttled setup
- [ ] CI

*This PR was generated by Claude.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: removing `sync_all()` weakens durability guarantees (crash/power-loss could yield empty/partial cache files), and refactoring cache-write signatures touches multiple write paths, though the data is regenerable.
> 
> **Overview**
> Speeds up full packument caching by refactoring `write_cached_full_packument` to serialize from borrowed fields (`&serde_json::Value`, `Option<&str>`) instead of constructing/cloning an owned `CachedFullPackument` per write.
> 
> Improves install performance by removing `sync_all()` from `aube_util::fs_atomic::atomic_write`, relying on atomic rename for visibility while accepting reduced crash-safety for cache-like writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b436db35897c0a237d2926d1fdaaaaf24298085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->