### PR TITLE
feat(release): PGO for x86_64 Linux + macOS arm64 release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,9 @@ jobs:
           name: metadata-primer
           path: crates/aube-resolver/data/primer-top${{ env.AUBE_PRIMER_TOP }}-v${{ env.AUBE_PRIMER_VERSION_CAP }}.rkyv.json
 
+  # Non-PGO targets: aarch64 Linux (cross-compiled, can't easily train
+  # under QEMU) and Windows (untested PGO toolchain). Built via taiki-e
+  # straight from the release profile.
   upload-assets:
     needs: generate-primer
     runs-on: ${{ matrix.runner }}
@@ -66,19 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
-            build-tool: cargo
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
-            build-tool: cross
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
-            build-tool: cross
-          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
             build-tool: cross
@@ -154,6 +145,103 @@ jobs:
             exit 1
           fi
           echo "path=$archive" >> "$GITHUB_OUTPUT"
+      - name: Attest release archive
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: ${{ steps.archive.outputs.path }}
+
+  # PGO-optimized targets: x86_64 Linux GNU/musl + macOS arm64 (the three
+  # native-built artifacts that cover the bulk of downloads). Each builds
+  # via benchmarks/pgo.bash — instrument under release-pgo, train against
+  # the hermetic Verdaccio registry, rebuild with -Cprofile-use. Linux
+  # targets keep build-tool=cross so the resulting binary preserves the
+  # current glibc baseline; the cross-built instrumented binary runs on
+  # the host for training (cross's older glibc is forward-compatible
+  # with the runner's). Cross.toml passes RUSTFLAGS through to the
+  # container so phase 1 / 3b RUSTFLAGS reach cargo inside cross.
+  upload-assets-pgo:
+    needs: generate-primer
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+            build-tool: cross
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+            build-tool: cross
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+            build-tool: cargo
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          submodules: recursive
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: metadata-primer
+          path: crates/aube-resolver/data
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+      - name: Install rustup llvm-tools-preview
+        shell: bash
+        run: rustup component add llvm-tools-preview
+      - name: Install cross
+        if: ${{ matrix.build-tool == 'cross' }}
+        shell: bash
+        run: cargo install cross --locked
+      - name: Install verdaccio
+        shell: bash
+        run: npm install --global verdaccio@6
+      - name: Import codesign certs
+        if: startsWith(matrix.os, 'macos')
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
+      - name: PGO build (instrument + train + optimize)
+        shell: bash
+        env:
+          AUBE_PGO_NO_LOCK: "1"
+          AUBE_PGO_BUILD_TOOL: ${{ matrix.build-tool }}
+          AUBE_PGO_TARGET: ${{ matrix.target }}
+        run: bash benchmarks/pgo.bash
+      - name: Codesign macOS binaries
+        if: startsWith(matrix.os, 'macos')
+        shell: bash
+        env:
+          IDENTITY: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
+          BIN_DIR: target/${{ matrix.target }}/release-pgo
+        run: |
+          for bin in aube aubr aubx; do
+            codesign --sign "$IDENTITY" --options runtime --timestamp \
+              --prefix dev.jdx. "$BIN_DIR/$bin"
+          done
+      - name: Archive PGO binaries
+        id: archive
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          archive="aube-${TAG}-${TARGET}.tar.gz"
+          tar -czf "$archive" -C "target/${TARGET}/release-pgo" aube aubr aubx
+          echo "path=$archive" >> "$GITHUB_OUTPUT"
+      - name: Upload archive to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          ARCHIVE: ${{ steps.archive.outputs.path }}
+        run: gh release upload "$TAG" "$ARCHIVE" --clobber
       - name: Attest release archive
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,9 +198,9 @@ jobs:
         if: ${{ matrix.build-tool == 'cross' }}
         shell: bash
         run: cargo install cross --locked
-      - name: Install verdaccio
-        shell: bash
-        run: npm install --global verdaccio@6
+      # verdaccio is installed lazily by hermetic.bash's
+      # _hermetic_ensure_verdaccio (called from pgo.bash via hermetic_start),
+      # so no explicit install step is needed here.
       - name: Import codesign certs
         if: startsWith(matrix.os, 'macos')
         uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3

--- a/.rules
+++ b/.rules
@@ -91,6 +91,7 @@ error_codes:
 
 commands:
   build: cargo build
+  build_pgo: mise run build:pgo (instrument -> train on hermetic registry -> optimize; outputs target/release-pgo/aube; holds /tmp/aube-bench.lock; needs `rustup component add llvm-tools-preview`)
   test_unit: cargo test
   clippy: cargo clippy --all-targets -- -D warnings
   fmt_check: cargo fmt --check
@@ -106,10 +107,11 @@ release_profile:
 when_to_use_release:
   default: debug. `cargo build` / `cargo clippy` already produce the `target/debug/aube` binary that bats and local smoke tests exercise
   bats_binary: test/test_helper/common_setup.bash prepends `target/debug` to PATH. never `cargo build --release` to debug a bats failure — rebuild debug, which is already warm from clippy
-  allowed_release_uses[3]:
+  allowed_release_uses[4]:
     - profiling (samply, flamegraph, hyperfine) — optimizer-off numbers are meaningless
     - reproducing a perf bug only observable in release
     - benchmarks (mise run bench* always builds release via its own manifest)
+    - PGO build (mise run build:pgo uses release-pgo profile + hermetic-registry training; portable binary, no -Ctarget-cpu=native, see benchmarks/pgo.bash)
   forbidden[3]:
     - rebuilding release "just to be safe" during iterative debug (1+ min cost vs 5s incremental debug)
     - shipping release-only asserts that don't exist in debug — keep invariants consistent across profiles

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,4 +3,10 @@ passthrough = [
     "AUBE_PRIMER_TOP",
     "AUBE_PRIMER_VERSION_CAP",
     "AUBE_REQUIRE_PRIMER",
+    # PGO: pgo.bash sets RUSTFLAGS for -Cprofile-generate (phase 1) and
+    # -Cprofile-use (phase 3b). CARGO_PROFILE_RELEASE_LTO=fat is set when
+    # the final build is delegated to a downstream step that uses the
+    # `release` profile; we override LTO to match `release-pgo`.
+    "RUSTFLAGS",
+    "CARGO_PROFILE_RELEASE_LTO",
 ]

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -117,6 +117,13 @@ trap cleanup EXIT
 
 AUBE_BIN="$INSTRUMENTED_BIN" hermetic_start
 
+# hermetic_start runs _hermetic_warm on the first invocation against a
+# given cache dir, which executes the instrumented binary against npmjs
+# uplink. In CI that warm step fires every run (no persisted cache) and
+# would otherwise contribute non-representative profraw covering the
+# uplink path. Drop those before the real training runs land.
+rm -f "$PGO_PROFRAW_DIR"/*.profraw
+
 # 3 cold + 3 warm. Cold runs each get a fresh dir so the resolver,
 # registry, store, and linker hot paths all run end-to-end. Warm runs
 # reuse the last cold dir so the frozen-lockfile fast path is also
@@ -167,5 +174,9 @@ echo ">>> Rebuilding with -Cprofile-use"
 RUSTFLAGS="-Cprofile-use=$PGO_MERGED -Cllvm-args=-pgo-warn-missing-function" \
 	"$PGO_BUILD_TOOL" build --profile="$PGO_PROFILE" $target_arg -p aube
 
-echo ">>> PGO build complete: $INSTRUMENTED_BIN"
-ls -lh "$INSTRUMENTED_BIN"
+# Phase 3b wrote to the same path as phase 1, so the file at
+# $INSTRUMENTED_BIN is now the PGO-optimized build, not the instrumented
+# one. Alias for clarity in the success log.
+PGO_FINAL_BIN="$INSTRUMENTED_BIN"
+echo ">>> PGO build complete: $PGO_FINAL_BIN"
+ls -lh "$PGO_FINAL_BIN"

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Profile-Guided Optimization build for aube.
+#
+# Three-phase rustc PGO flow:
+#
+#   1. Build aube with -Cprofile-generate (instrumented binary).
+#   2. Train against the hermetic Verdaccio registry — a mix of cold
+#      and warm installs of fixture.package.json — so the profile
+#      covers the resolver / registry / store / linker hot paths and
+#      the frozen-lockfile fast path.
+#   3. Merge .profraw via llvm-profdata, recompile with -Cprofile-use.
+#
+# Local default: target/release-pgo/aube using profile=release-pgo.
+#
+# Holds /tmp/aube-bench.lock for the entire run because the hermetic
+# registry (port 4874), throttle proxy (port 4875), and warmed cache
+# (~/.cache/aube-bench/registry) are shared across worktrees,
+# terminals, and agents.
+#
+# CI hooks (env vars):
+#   AUBE_PGO_NO_LOCK=1          skip /tmp/aube-bench.lock acquisition
+#                               (also auto-skipped if `flock` is missing,
+#                               e.g. on macOS).
+#   AUBE_PGO_PROFILE=<profile>  cargo profile for both phases (default:
+#                               release-pgo). Set to `release` in CI when
+#                               the final build is delegated to another
+#                               step.
+#   AUBE_PGO_TARGET=<triple>    cross-compilation target (default: host).
+#                               Output lands at target/<triple>/<profile>/.
+#   AUBE_PGO_BUILD_TOOL=<tool>  `cargo` (default) or `cross`. cross is
+#                               used in CI for Linux GNU/musl targets so
+#                               the resulting binary keeps cross's older
+#                               glibc baseline. Cross.toml passes RUSTFLAGS
+#                               through to the container.
+#   AUBE_PGO_SKIP_FINAL_BUILD=1 stop after merging .profraw. Use when the
+#                               final optimized build is delegated to a
+#                               separate step (e.g. taiki-e action) that
+#                               picks up RUSTFLAGS+CARGO_PROFILE_RELEASE_LTO
+#                               from the environment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PGO_DATA_DIR="$REPO_ROOT/target/pgo-data"
+PGO_PROFRAW_DIR="$PGO_DATA_DIR/profraw"
+PGO_MERGED="$PGO_DATA_DIR/merged.profdata"
+
+PGO_PROFILE="${AUBE_PGO_PROFILE:-release-pgo}"
+PGO_TARGET="${AUBE_PGO_TARGET:-}"
+PGO_BUILD_TOOL="${AUBE_PGO_BUILD_TOOL:-cargo}"
+
+# target_arg stays unquoted at expansion sites: empty string disappears,
+# "--target=foo" expands to one arg. Avoids bash 3.2 (macOS) array+set -u
+# unbound-variable issues with "${arr[@]}".
+target_arg=""
+target_dir_part=""
+if [ -n "$PGO_TARGET" ]; then
+	target_arg="--target=$PGO_TARGET"
+	target_dir_part="$PGO_TARGET/"
+fi
+
+# Default to the same throttled hermetic registry the rest of aube's
+# bench harness uses, so PGO numbers and bench numbers stay comparable.
+export BENCH_HERMETIC="${BENCH_HERMETIC:-1}"
+export BENCH_BANDWIDTH="${BENCH_BANDWIDTH:-500mbit}"
+export BENCH_LATENCY="${BENCH_LATENCY:-50ms}"
+
+if [ -z "${AUBE_PGO_NO_LOCK:-}" ] && command -v flock >/dev/null 2>&1; then
+	echo ">>> Acquiring /tmp/aube-bench.lock (30 min timeout)"
+	exec 9>/tmp/aube-bench.lock
+	if ! flock -w 1800 9; then
+		echo "ERROR: failed to acquire /tmp/aube-bench.lock after 30 min" >&2
+		exit 1
+	fi
+	echo ">>> Lock acquired"
+else
+	echo ">>> Skipping /tmp/aube-bench.lock (AUBE_PGO_NO_LOCK or flock missing)"
+fi
+
+RUSTC_HOST="$(rustc -vV | sed -n 's|^host: ||p')"
+RUSTC_SYSROOT="$(rustc --print sysroot)"
+LLVM_PROFDATA="$RUSTC_SYSROOT/lib/rustlib/$RUSTC_HOST/bin/llvm-profdata"
+if [ ! -x "$LLVM_PROFDATA" ]; then
+	echo "ERROR: llvm-profdata not found at $LLVM_PROFDATA" >&2
+	echo "  Install with: rustup component add llvm-tools-preview" >&2
+	exit 1
+fi
+
+mkdir -p "$PGO_PROFRAW_DIR"
+rm -f "$PGO_PROFRAW_DIR"/*.profraw "$PGO_MERGED"
+
+# ---------- Phase 1: instrumented build ----------
+echo ">>> [1/3] Building instrumented binary ($PGO_BUILD_TOOL, profile=$PGO_PROFILE${PGO_TARGET:+, target=$PGO_TARGET})"
+# shellcheck disable=SC2086 # intentional word-splitting on $target_arg
+RUSTFLAGS="-Cprofile-generate=$PGO_PROFRAW_DIR" \
+	"$PGO_BUILD_TOOL" build --profile="$PGO_PROFILE" $target_arg -p aube
+
+INSTRUMENTED_BIN="$REPO_ROOT/target/${target_dir_part}${PGO_PROFILE}/aube"
+if [ ! -x "$INSTRUMENTED_BIN" ]; then
+	echo "ERROR: instrumented binary missing at $INSTRUMENTED_BIN" >&2
+	exit 1
+fi
+
+# ---------- Phase 2: training ----------
+echo ">>> [2/3] Training against hermetic registry"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/hermetic.bash"
+
+train_dir="$(mktemp -d "${TMPDIR:-/tmp}/aube-pgo-train.XXXXXX")"
+cleanup() {
+	hermetic_stop || true
+	rm -rf "$train_dir"
+}
+trap cleanup EXIT
+
+AUBE_BIN="$INSTRUMENTED_BIN" hermetic_start
+
+# 3 cold + 3 warm. Cold runs each get a fresh dir so the resolver,
+# registry, store, and linker hot paths all run end-to-end. Warm runs
+# reuse the last cold dir so the frozen-lockfile fast path is also
+# represented in the profile.
+cold_run() {
+	local i=$1
+	local run_dir="$train_dir/cold.$i"
+	mkdir -p "$run_dir/home"
+	cp "$SCRIPT_DIR/fixture.package.json" "$run_dir/package.json"
+	printf 'registry=%s\n' "$BENCH_REGISTRY_URL" >"$run_dir/.npmrc"
+	printf 'registry=%s\n' "$BENCH_REGISTRY_URL" >"$run_dir/home/.npmrc"
+	echo "  train: cold install ($i)"
+	(cd "$run_dir" && HOME="$run_dir/home" "$INSTRUMENTED_BIN" install --ignore-scripts >/dev/null)
+}
+
+warm_run() {
+	local run_dir=$1 i=$2
+	echo "  train: warm install ($i)"
+	(cd "$run_dir" && HOME="$run_dir/home" "$INSTRUMENTED_BIN" install --ignore-scripts >/dev/null)
+}
+
+for i in 1 2 3; do
+	cold_run "$i"
+done
+for i in 1 2 3; do
+	warm_run "$train_dir/cold.3" "$i"
+done
+
+hermetic_stop
+
+# ---------- Phase 3a: merge ----------
+echo ">>> [3/3] Merging profile data"
+"$LLVM_PROFDATA" merge -o "$PGO_MERGED" "$PGO_PROFRAW_DIR"
+
+if [ -n "${AUBE_PGO_SKIP_FINAL_BUILD:-}" ]; then
+	echo ">>> Skipping final optimized build (AUBE_PGO_SKIP_FINAL_BUILD=1)"
+	echo ">>> Profile ready at: $PGO_MERGED"
+	exit 0
+fi
+
+# ---------- Phase 3b: optimize ----------
+echo ">>> Rebuilding with -Cprofile-use"
+
+# -Cllvm-args=-pgo-warn-missing-function: informational only —
+# functions the training run didn't exercise stay un-PGO'd, which is
+# fine, but the warning surfaces unexpectedly cold paths.
+# shellcheck disable=SC2086 # intentional word-splitting on $target_arg
+RUSTFLAGS="-Cprofile-use=$PGO_MERGED -Cllvm-args=-pgo-warn-missing-function" \
+	"$PGO_BUILD_TOOL" build --profile="$PGO_PROFILE" $target_arg -p aube
+
+echo ">>> PGO build complete: $INSTRUMENTED_BIN"
+ls -lh "$INSTRUMENTED_BIN"

--- a/mise.toml
+++ b/mise.toml
@@ -74,6 +74,10 @@ run = [
   "node benchmarks/update-readme.mjs",
 ]
 
+[tasks."build:pgo"]
+dir = "{{config_root}}"
+run = "bash benchmarks/pgo.bash"
+
 [tasks.render]
 depends = ["build"]
 run = [


### PR DESCRIPTION
## Summary

- Wire `benchmarks/pgo.bash` into the release pipeline for three of seven targets: x86_64 Linux GNU, x86_64 Linux musl, aarch64 macOS. aarch64 Linux (training under QEMU is impractical) and Windows (untested PGO toolchain) stay on the existing `taiki-e/upload-rust-binary-action` flow.
- `pgo.bash` gains five CI hooks (`AUBE_PGO_NO_LOCK`, `AUBE_PGO_PROFILE`, `AUBE_PGO_TARGET`, `AUBE_PGO_BUILD_TOOL`, `AUBE_PGO_SKIP_FINAL_BUILD`); local invocation behavior is unchanged. flock now auto-skips when `flock` is missing (macOS).
- New `upload-assets-pgo` job: setup-node + verdaccio + llvm-tools-preview → `pgo.bash` (cross for Linux, cargo for macOS) → codesign on macOS → tar.gz → `gh release upload --clobber` → attest. Existing `upload-assets` keeps the four non-PGO targets unchanged.

## Numbers

Local A/B on the sonic-rs tip (commit 2245810), 5 cold installs of `benchmarks/fixture.package.json` against the throttled hermetic registry (500mbit / 50ms latency), `--ignore-scripts`, fresh state per run:

| metric    | release  | release-pgo | delta              |
| ---       | ---      | ---         | ---                |
| wall      | 7.333 s  | **7.117 s** | **−216 ms (−3.0%)** |
| user CPU  | 6.772 s  | **5.923 s** | **−849 ms (−12.5%)** |
| system CPU| 7.206 s  | 7.333 s     | +127 ms (noise)    |

PGO is 1.03 ± 0.01× faster than release on cold install. The user-CPU delta (−12.5%) is much larger than the wall delta because cold install is network/syscall-bound — warm install / frozen fast path is CPU-bound and should see a bigger wall win, but that A/B is out of scope for this PR.

## Why these specific architectural choices

- **Linux PGO targets keep `build-tool: cross`**, not native cargo. Switching to native would shift the glibc baseline from cross's ~2.27 to the runner's 2.35+ and break users on older distros. The cross-built instrumented binary runs on the host for training (newer glibc is forward-compatible with the older one cross targets), then cross does the optimized build. `Cross.toml` passes `RUSTFLAGS` + `CARGO_PROFILE_RELEASE_LTO` through so phase 1 / 3b `RUSTFLAGS` reach cargo inside the container.
- **PGO-targets use a separate job** (`upload-assets-pgo`) rather than conditional steps in `upload-assets`. The PGO flow replaces taiki-e's build/codesign/upload entirely, so conditional steps would have left half the original job unused on each matrix entry.
- **macOS codesign step replicates `taiki-e/upload-rust-binary-action`'s behavior**: `codesign --sign "Developer ID Application: …" --options runtime --timestamp --prefix dev.jdx.` per bin.
- **BOLT deferred.** Linux-only (4 of 7 targets get nothing), modest expected wins on aube's network-bound cold install workload (1–3% on top of PGO), adds reproducibility risk by stacking optimizers. Worth revisiting after a warm-install A/B confirms PGO leaves CPU on the table.

## Caveats

- **CI flow has not been runtime-tested.** First exercise will be the next release. Suggested: trigger `upload-assets-pgo` via `workflow_dispatch` against a throwaway test tag before relying on it for a real release.
- **macOS codesign step replicates taiki-e's behavior but is not byte-equivalent.** Verify with `codesign --verify -v aube` on the produced macOS arm64 artifact.
- **Per-job CI time goes up by ~7–10 min** (instrumented build + ~1 min training + optimized build). The three PGO jobs run in parallel against the existing matrix, so wall-clock release time depends on the slowest target.
- **`cargo install cross --locked` on each Linux PGO run** is ~1–2 min uncached. If it gets noisy, swap for a cached install action.

## Test plan

- [x] Local PGO build on sonic-rs tip works (`mise run build:pgo`)
- [x] Local A/B vs plain release shows the numbers above
- [x] `bash -n` + shellcheck + shfmt clean on `benchmarks/pgo.bash`
- [x] `actionlint` clean on `.github/workflows/release.yml`
- [ ] **Manual `workflow_dispatch` against a test tag** to validate the CI flow before next release
- [ ] **Verify codesign + notarization on the macOS arm64 artifact** from the test run
- [ ] **Verify Linux artifacts run on a glibc-2.27 baseline** (Ubuntu 18.04 container)

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it restructures the release GitHub Actions workflow and changes how the most-downloaded artifacts are built, signed, packaged, and uploaded, which could break releases if the new PGO flow or tooling behaves differently in CI.
> 
> **Overview**
> Adds a new PGO build path for the primary release artifacts (**x86_64 Linux GNU/musl** and **macOS arm64**) by introducing an `upload-assets-pgo` job that runs a full instrument→train→optimize cycle and then manually packages, uploads (via `gh release upload`), and attests the resulting archives.
> 
> Moves those three targets out of the existing `taiki-e/upload-rust-binary-action` matrix, leaving `upload-assets` to handle only the non-PGO targets (aarch64 Linux + Windows).
> 
> Introduces `benchmarks/pgo.bash` (three-phase rustc PGO using the hermetic Verdaccio training workload), wires it into dev tooling via `mise run build:pgo`, and updates `Cross.toml` to pass through `RUSTFLAGS`/`CARGO_PROFILE_RELEASE_LTO` needed for cross-container PGO builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c5226572c01ce8875e3a1604ec9bc2a2bc962b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->