### PR TITLE
feat(install): flag deprecated + outdated direct deps in summary

### DIFF
--- a/crates/aube-resolver/src/direct_dep_info.rs
+++ b/crates/aube-resolver/src/direct_dep_info.rs
@@ -12,12 +12,20 @@ use std::collections::HashMap;
 /// render next to a direct-dependency line. Returned only for direct
 /// deps where at least one signal is set — the printer skips the badge
 /// column when [`Resolver::direct_dep_info`]'s map has no entry.
+///
+/// Deprecation is a bare flag (not the message string) by design: the
+/// full per-version `deprecated` text already surfaces via the WARN
+/// pipeline in [`crate::deprecations`][crate-deprecations] above the
+/// summary, so the badge column just signals "this direct dep is one
+/// of the WARN lines you saw" without duplicating the message.
+///
+/// [crate-deprecations]: https://github.com/endevco/aube/blob/main/crates/aube/src/deprecations.rs
 #[derive(Debug, Clone, Default)]
 pub struct DirectDepInfo {
-    /// Deprecation message published for the *resolved* version of this
-    /// direct dep (i.e. the packument's per-version `deprecated` field).
-    /// `None` for healthy versions.
-    pub deprecated: Option<String>,
+    /// True when the packument marks the *resolved* version as
+    /// deprecated. The actual message is intentionally not carried
+    /// here — see the struct docs.
+    pub deprecated: bool,
     /// The registry's `dist-tags.latest` for this package, but only
     /// when it differs from the resolved version. `None` when latest
     /// matches the resolved version, when the registry omits `latest`
@@ -54,13 +62,13 @@ impl Resolver {
                 let deprecated = packument
                     .versions
                     .get(&pkg.version)
-                    .and_then(|v| v.deprecated.clone());
+                    .is_some_and(|v| v.deprecated.is_some());
                 let latest = packument
                     .dist_tags
                     .get("latest")
                     .filter(|l| l.as_str() != pkg.version.as_str())
                     .cloned();
-                if deprecated.is_some() || latest.is_some() {
+                if deprecated || latest.is_some() {
                     out.insert(dep.dep_path.clone(), DirectDepInfo { deprecated, latest });
                 }
             }

--- a/crates/aube-resolver/src/direct_dep_info.rs
+++ b/crates/aube-resolver/src/direct_dep_info.rs
@@ -1,0 +1,70 @@
+//! Per-direct-dep packument facts the install summary printer surfaces
+//! inline with the `+ name@version` listing — currently deprecation
+//! status and the registry `latest` dist-tag when it differs from the
+//! resolved version. The data has to be snapshotted before the resolver
+//! (which owns the packument cache) is dropped at the end of resolution.
+
+use crate::Resolver;
+use aube_lockfile::LockfileGraph;
+use std::collections::HashMap;
+
+/// Subset of packument facts the install summary printer wants to
+/// render next to a direct-dependency line. Returned only for direct
+/// deps where at least one signal is set — the printer skips the badge
+/// column when [`Resolver::direct_dep_info`]'s map has no entry.
+#[derive(Debug, Clone, Default)]
+pub struct DirectDepInfo {
+    /// Deprecation message published for the *resolved* version of this
+    /// direct dep (i.e. the packument's per-version `deprecated` field).
+    /// `None` for healthy versions.
+    pub deprecated: Option<String>,
+    /// The registry's `dist-tags.latest` for this package, but only
+    /// when it differs from the resolved version. `None` when latest
+    /// matches the resolved version, when the registry omits `latest`
+    /// (common on private registries), or when the dep wasn't resolved
+    /// from a packument (git / file / link / remote tarball).
+    pub latest: Option<String>,
+}
+
+impl Resolver {
+    /// Snapshot per-direct-dep packument facts so the install summary
+    /// printer can render them inline after the resolver — and its
+    /// packument cache — is dropped. Keys are `DirectDep::dep_path`;
+    /// importer direct deps don't carry peer-context suffixes, so the
+    /// key matches the `LockfileGraph.packages` entry 1:1.
+    ///
+    /// Skips deps whose packument wasn't fetched (frozen-lockfile reuse,
+    /// non-registry sources) and deps whose registry didn't publish a
+    /// `latest` dist-tag. Returns only entries where at least one signal
+    /// is set so the caller's printer can use `get(dep_path)` as the
+    /// "should I render badges?" check.
+    pub fn direct_dep_info(&self, graph: &LockfileGraph) -> HashMap<String, DirectDepInfo> {
+        let mut out: HashMap<String, DirectDepInfo> = HashMap::new();
+        for deps in graph.importers.values() {
+            for dep in deps {
+                let Some(pkg) = graph.packages.get(&dep.dep_path) else {
+                    continue;
+                };
+                if pkg.local_source.is_some() {
+                    continue;
+                }
+                let Some(packument) = self.cache.get(pkg.registry_name()) else {
+                    continue;
+                };
+                let deprecated = packument
+                    .versions
+                    .get(&pkg.version)
+                    .and_then(|v| v.deprecated.clone());
+                let latest = packument
+                    .dist_tags
+                    .get("latest")
+                    .filter(|l| l.as_str() != pkg.version.as_str())
+                    .cloned();
+                if deprecated.is_some() || latest.is_some() {
+                    out.insert(dep.dep_path.clone(), DirectDepInfo { deprecated, latest });
+                }
+            }
+        }
+        out
+    }
+}

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -1,5 +1,6 @@
 mod builder;
 mod catalog;
+mod direct_dep_info;
 mod error;
 mod local_source;
 pub mod override_rule;
@@ -12,6 +13,7 @@ mod semver_util;
 mod trust;
 mod types;
 
+pub use direct_dep_info::DirectDepInfo;
 pub use error::{AgeGateDetails, CatalogDetails, Error, ExoticSubdepDetails, NoMatchDetails};
 pub use package_ext::is_deprecation_allowed;
 pub use peer_context::{

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -3521,3 +3521,136 @@ fn peer_suffix_propagation_dedupes_nested_self_segments() {
         "propagation must not double-emit a peer name already covered transitively in the self suffix"
     );
 }
+
+// ---------------------------------------------------------------------------
+// direct_dep_info
+// ---------------------------------------------------------------------------
+
+fn direct_dep_info_resolver() -> Resolver {
+    let client = Arc::new(aube_registry::client::RegistryClient::new(
+        "http://127.0.0.1:0",
+    ));
+    Resolver::new(client)
+}
+
+fn direct_dep_info_graph(
+    direct: &[(&str, &str, &str)],
+    packages: &[LockedPackage],
+) -> LockfileGraph {
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        direct
+            .iter()
+            .map(|(name, dep_path, spec)| DirectDep {
+                name: (*name).to_string(),
+                dep_path: (*dep_path).to_string(),
+                dep_type: DepType::Production,
+                specifier: Some((*spec).to_string()),
+            })
+            .collect(),
+    );
+    let mut pkg_map = BTreeMap::new();
+    for pkg in packages {
+        pkg_map.insert(pkg.dep_path.clone(), pkg.clone());
+    }
+    LockfileGraph {
+        importers,
+        packages: pkg_map,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn direct_dep_info_flags_deprecated_resolved_version() {
+    let mut packument = make_packument("foo", &["1.0.0", "1.0.1"], "1.0.1");
+    packument.versions.get_mut("1.0.0").unwrap().deprecated = Some("use 1.0.1 instead".to_string());
+
+    let mut resolver = direct_dep_info_resolver();
+    resolver.cache.insert("foo".to_string(), packument);
+
+    let pkg = mk_locked("foo", "1.0.0", &[], &[]);
+    let graph = direct_dep_info_graph(&[("foo", "foo@1.0.0", "^1")], &[pkg]);
+
+    let info = resolver.direct_dep_info(&graph);
+    let entry = info.get("foo@1.0.0").expect("foo@1.0.0 should have info");
+    assert_eq!(entry.deprecated.as_deref(), Some("use 1.0.1 instead"));
+    assert_eq!(entry.latest.as_deref(), Some("1.0.1"));
+}
+
+#[test]
+fn direct_dep_info_omits_latest_when_already_on_latest() {
+    let packument = make_packument("bar", &["2.0.0"], "2.0.0");
+    let mut resolver = direct_dep_info_resolver();
+    resolver.cache.insert("bar".to_string(), packument);
+
+    let pkg = mk_locked("bar", "2.0.0", &[], &[]);
+    let graph = direct_dep_info_graph(&[("bar", "bar@2.0.0", "^2")], &[pkg]);
+
+    let info = resolver.direct_dep_info(&graph);
+    // No deprecated and latest == current → no entry at all.
+    assert!(
+        !info.contains_key("bar@2.0.0"),
+        "got unexpected entry: {info:?}"
+    );
+}
+
+#[test]
+fn direct_dep_info_skips_local_source_deps() {
+    // file: / link: / git: deps don't have packuments and shouldn't be
+    // probed for "latest" even if a same-name packument happens to be
+    // cached (e.g. a transitive registry sibling). Local-source deps
+    // get no badge.
+    let packument = make_packument("baz", &["9.9.9"], "9.9.9");
+    let mut resolver = direct_dep_info_resolver();
+    resolver.cache.insert("baz".to_string(), packument);
+
+    let mut pkg = mk_locked("baz", "0.0.0", &[], &[]);
+    pkg.local_source = Some(LocalSource::Directory(std::path::PathBuf::from(
+        "./vendor/baz",
+    )));
+    let graph = direct_dep_info_graph(&[("baz", "baz@0.0.0", "file:./vendor/baz")], &[pkg]);
+
+    let info = resolver.direct_dep_info(&graph);
+    assert!(
+        info.is_empty(),
+        "local-source dep should be skipped: {info:?}"
+    );
+}
+
+#[test]
+fn direct_dep_info_uses_registry_name_for_aliased_dep() {
+    // `"h3-v2": "npm:h3@2.0.1-rc.20"` — the manifest alias is `h3-v2`
+    // and the packument lives under the registry name `h3`. The
+    // resolver's cache is keyed by registry name, so direct_dep_info
+    // must follow `LockedPackage::registry_name()` (not `name`) to
+    // find the packument.
+    let mut packument = make_packument("h3", &["2.0.0", "2.0.1"], "2.0.1");
+    packument.versions.get_mut("2.0.0").unwrap().deprecated = Some("rc only".to_string());
+    let mut resolver = direct_dep_info_resolver();
+    resolver.cache.insert("h3".to_string(), packument);
+
+    let mut pkg = mk_locked("h3-v2", "2.0.0", &[], &[]);
+    pkg.alias_of = Some("h3".to_string());
+    pkg.dep_path = "h3-v2@2.0.0".to_string();
+    let graph = direct_dep_info_graph(&[("h3-v2", "h3-v2@2.0.0", "npm:h3@2.0.0")], &[pkg]);
+
+    let info = resolver.direct_dep_info(&graph);
+    let entry = info
+        .get("h3-v2@2.0.0")
+        .expect("aliased entry should resolve via registry_name");
+    assert_eq!(entry.deprecated.as_deref(), Some("rc only"));
+    assert_eq!(entry.latest.as_deref(), Some("2.0.1"));
+}
+
+#[test]
+fn direct_dep_info_empty_when_no_packument_cached() {
+    // Frozen-lockfile reuse: the resolver never fetches packuments, so
+    // direct_dep_info should produce no entries rather than blowing up.
+    let resolver = direct_dep_info_resolver();
+    let pkg = mk_locked("ghost", "1.0.0", &[], &[]);
+    let graph = direct_dep_info_graph(&[("ghost", "ghost@1.0.0", "^1")], &[pkg]);
+
+    let info = resolver.direct_dep_info(&graph);
+    assert!(info.is_empty(), "no packument cached → empty map");
+}

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -3574,7 +3574,7 @@ fn direct_dep_info_flags_deprecated_resolved_version() {
 
     let info = resolver.direct_dep_info(&graph);
     let entry = info.get("foo@1.0.0").expect("foo@1.0.0 should have info");
-    assert_eq!(entry.deprecated.as_deref(), Some("use 1.0.1 instead"));
+    assert!(entry.deprecated, "resolved version is deprecated");
     assert_eq!(entry.latest.as_deref(), Some("1.0.1"));
 }
 
@@ -3639,7 +3639,7 @@ fn direct_dep_info_uses_registry_name_for_aliased_dep() {
     let entry = info
         .get("h3-v2@2.0.0")
         .expect("aliased entry should resolve via registry_name");
-    assert_eq!(entry.deprecated.as_deref(), Some("rc only"));
+    assert!(entry.deprecated, "aliased resolved version is deprecated");
     assert_eq!(entry.latest.as_deref(), Some("2.0.1"));
 }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -5225,21 +5225,21 @@ fn print_direct_dependency_section(
 
 /// Render the trailing badge column for a direct-dep line. Empty string
 /// when there's nothing to flag, otherwise a leading two-space gap and
-/// one or more dim-separated tags (`deprecated`, `latest 2.0.0`).
+/// one or more dim-separated tags (`deprecated`, `latest 2.0.0`). The
+/// caller passes `direct_dep_info.get(dep_path)`, and `direct_dep_info`
+/// only carries entries with at least one signal set — so when `info`
+/// is `Some(...)`, `parts` is guaranteed non-empty.
 fn render_direct_dep_badges(info: Option<&aube_resolver::DirectDepInfo>) -> String {
     use clx::style;
     let Some(info) = info else {
         return String::new();
     };
     let mut parts: Vec<String> = Vec::new();
-    if info.deprecated.is_some() {
+    if info.deprecated {
         parts.push(style::eyellow("deprecated").to_string());
     }
     if let Some(latest) = &info.latest {
         parts.push(style::eyellow(format!("latest {latest}")).to_string());
-    }
-    if parts.is_empty() {
-        return String::new();
     }
     let sep = style::edim(" · ").to_string();
     format!("  {}", parts.join(&sep))

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3078,6 +3078,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         std::sync::Mutex<Vec<crate::deprecations::DeprecationRecord>>,
     > = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
 
+    // Per-direct-dep packument snapshot rendered inline by the install
+    // summary printer (`+ name@version  deprecated · latest …`). Only
+    // populated by the resolve-from-packuments branch — the frozen
+    // lockfile reuse path has no cache to read from, so badges silently
+    // degrade to empty rather than triggering extra network.
+    let mut direct_dep_info: std::collections::HashMap<String, aube_resolver::DirectDepInfo> =
+        std::collections::HashMap::new();
+
     // Captures the prewarm task's `compute_graph_hashes` output so the
     // link phase can reuse it instead of recomputing the same 4-pass
     // BLAKE3 walk over `graph.packages`. Populated by the no-lockfile
@@ -3781,6 +3789,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 return resolve_result.map(|_| unreachable!());
             }
             let mut graph = resolve_result.unwrap();
+            // Snapshot per-direct-dep packument facts before dropping the
+            // resolver — its `cache` field owns the only copy and the
+            // install summary printer runs much later, well after the
+            // channel-closing drop below.
+            direct_dep_info = resolver.direct_dep_info(&graph);
             // Drop the resolver to close the channel, signaling the fetch
             // coordinator to finish, then drain the readPackage stderr
             // forwarders so every `ctx.log` record from resolve flushes
@@ -4913,7 +4926,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // `--reporter=append-only` skip the progress object but still get the
     // dependency summary; silent and ndjson stay machine-clean.
     if !install_is_noop && should_print_human_install_summary() {
-        print_direct_dependency_summary(&graph_for_link, &manifests);
+        print_direct_dependency_summary(&graph_for_link, &manifests, &direct_dep_info);
     }
     if let Some(p) = prog_ref {
         p.print_install_summary(
@@ -5122,6 +5135,7 @@ fn print_already_up_to_date() {
 fn print_direct_dependency_summary(
     graph: &aube_lockfile::LockfileGraph,
     manifests: &[(String, aube_manifest::PackageJson)],
+    direct_dep_info: &std::collections::HashMap<String, aube_resolver::DirectDepInfo>,
 ) {
     use clx::style;
     let importers: Vec<(&String, &Vec<aube_lockfile::DirectDep>)> = graph
@@ -5141,9 +5155,19 @@ fn print_direct_dependency_summary(
             let label = direct_dependency_importer_label(importer, manifests);
             eprintln!("{}{}", style::ebold(&label), style::edim(":"));
         }
-        print_direct_dependency_section(graph, deps, aube_lockfile::DepType::Production);
-        print_direct_dependency_section(graph, deps, aube_lockfile::DepType::Optional);
-        print_direct_dependency_section(graph, deps, aube_lockfile::DepType::Dev);
+        print_direct_dependency_section(
+            graph,
+            deps,
+            aube_lockfile::DepType::Production,
+            direct_dep_info,
+        );
+        print_direct_dependency_section(
+            graph,
+            deps,
+            aube_lockfile::DepType::Optional,
+            direct_dep_info,
+        );
+        print_direct_dependency_section(graph, deps, aube_lockfile::DepType::Dev, direct_dep_info);
     }
     eprintln!();
 }
@@ -5168,6 +5192,7 @@ fn print_direct_dependency_section(
     graph: &aube_lockfile::LockfileGraph,
     deps: &[aube_lockfile::DirectDep],
     dep_type: aube_lockfile::DepType,
+    direct_dep_info: &std::collections::HashMap<String, aube_resolver::DirectDepInfo>,
 ) {
     use clx::style;
     let mut deps: Vec<&aube_lockfile::DirectDep> =
@@ -5187,13 +5212,37 @@ fn print_direct_dependency_section(
             .get_package(&dep.dep_path)
             .map(|pkg| pkg.version.as_str())
             .unwrap_or("?");
+        let badges = render_direct_dep_badges(direct_dep_info.get(&dep.dep_path));
         eprintln!(
-            "{} {}{}",
+            "{} {}{}{}",
             style::egreen("+").bold(),
             dep.name,
             style::edim(format!("@{version}")),
+            badges,
         );
     }
+}
+
+/// Render the trailing badge column for a direct-dep line. Empty string
+/// when there's nothing to flag, otherwise a leading two-space gap and
+/// one or more dim-separated tags (`deprecated`, `latest 2.0.0`).
+fn render_direct_dep_badges(info: Option<&aube_resolver::DirectDepInfo>) -> String {
+    use clx::style;
+    let Some(info) = info else {
+        return String::new();
+    };
+    let mut parts: Vec<String> = Vec::new();
+    if info.deprecated.is_some() {
+        parts.push(style::eyellow("deprecated").to_string());
+    }
+    if let Some(latest) = &info.latest {
+        parts.push(style::eyellow(format!("latest {latest}")).to_string());
+    }
+    if parts.is_empty() {
+        return String::new();
+    }
+    let sep = style::edim(" · ").to_string();
+    format!("  {}", parts.join(&sep))
 }
 
 fn invalidate_changed_aube_entries(


### PR DESCRIPTION
## Summary

The install summary now flags deprecated and outdated direct dependencies inline with the `+ name@version` listing — no extra network, just data the resolver already had in its packument cache.

```
dependencies:
+ left-pad@1.0.0   deprecated · latest 1.3.0
+ lodash@4.17.10   latest 4.18.1
+ react@16.0.0     latest 19.2.6
```

### Design

- `aube-resolver` gains `DirectDepInfo { deprecated, latest }` plus a `Resolver::direct_dep_info(&graph)` snapshot method. It walks the graph's importer direct deps, looks up each in the private packument cache by `LockedPackage::registry_name()` (so npm-aliased deps resolve), and returns only entries with at least one signal set. Local-source deps (git/file/link/remote tarball) are skipped — they have no packument.
- `crates/aube/src/commands/install/mod.rs` snapshots the map *before* `drop(resolver)` (the drop is load-bearing — it closes the resolved-package channel that signals the fetch coordinator to finish, so we can't just defer it) and threads it down to `print_direct_dependency_summary` / `print_direct_dependency_section`.
- `render_direct_dep_badges` joins set signals with a dim middle-dot, yellow `deprecated` and `latest X.Y.Z` tags, two-space gutter after the version.

### Graceful degradation

- **Frozen / lockfile reuse without drift**: no packuments fetched → empty map → no badges. Intentional; we don't want install to pay an extra network round trip for the badge column.
- **Partial drift**: only drifted deps have packuments cached, so only those show badges. Fine.
- **No `latest` dist-tag** (common on private registries): badge omitted, matches the existing `aube outdated` policy.
- **Registry omits per-version `deprecated`**: badge omitted.

### Why this doesn't duplicate the existing deprecation pipeline

`crates/aube/src/deprecations.rs` already collects deprecation messages off the resolved-package stream and emits `WARN deprecated …` lines (gated by the `deprecationWarnings` setting). That pipeline covers transitives and routes through the warning system. The new badges are a *summary* signal next to direct deps only — they share the underlying packument data but serve a different UX. The two can coexist; the WARN line tells you *what* the deprecation says, the badge tells you *which* of your direct deps is affected at a glance.

`latest` is genuinely new — nothing in the install path was reading `dist-tags.latest` before.

## Test plan

- [x] 5 new unit tests in `crates/aube-resolver/src/tests.rs` cover: deprecated detection on the resolved version, latest omitted when current == latest, local-source deps skipped, npm-alias resolves via registry_name, empty map when no packument was fetched
- [x] Existing `cargo test` suite passes (full workspace)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Smoke-tested against npmjs.org with `left-pad@1.0.0` (deprecated + outdated), `lodash@4.17.10` (outdated), `react@16.0.0` (outdated), `lodash@latest` (no badge) — output matches expectation including the noop "Already up to date" path
- [x] Existing bats tests pass (assert with `--partial`, so trailing badge text doesn't break them; test-registry packages have `dist-tags.latest == installed version`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to install summary output, reading already-fetched packument metadata and gracefully degrading to no badges when unavailable.
> 
> **Overview**
> The install summary now annotates direct dependencies inline with **badges** for `deprecated` and for `latest <version>` when the resolved version differs from the registry’s `dist-tags.latest`.
> 
> This introduces `Resolver::direct_dep_info` in `aube-resolver` to snapshot the needed packument facts (skipping local-source deps and cases with no cached packument), threads that snapshot through `aube install`, and renders the badge column via `render_direct_dep_badges`. Unit tests cover deprecated/latest detection, local-source skipping, npm-alias lookup via `registry_name()`, and the empty-map (frozen/lockfile-reuse) behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432ef60fee817f4fbf6448f90391615452f333f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->