### PR TITLE
ci(release): bump linux PGO runners to amd64-large

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,11 +169,11 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+            runner: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
             build-tool: cross
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+            runner: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
             build-tool: cross
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
## Summary

- v1.10.1 release run [25640949943](https://github.com/endevco/aube/actions/runs/25640949943) OOM-killed (exit 137) the x86_64 Linux PGO jobs at [benchmarks/pgo.bash:97](benchmarks/pgo.bash#L97) — the phase-1 instrumented build of \`aube\` (fat LTO + \`codegen-units=1\` + \`-Cprofile-generate\`).
- Bumps both Linux PGO matrix entries to \`namespace-profile-endev-linux-amd64-large\` (32 GB) so the link step has headroom for the IR bloat \`-Cprofile-generate\` stacks on top of fat LTO. The base profile (8 GB) is too small.
- Single-file change in [release.yml:172,176](.github/workflows/release.yml#L172). macOS arm64 PGO and the non-PGO Windows/aarch64 matrix entries are unchanged.

## Why \`-large\`, not \`-xlarge\`

Peak RSS for a fat-LTO link of \`aube\` (~150 deps, including sigstore/tera/ratatui) is normally 8–16 GB; \`-Cprofile-generate\` adds ~1.5–2× IR bloat, so we expect ~12–20 GB peak. 32 GB has comfortable headroom; 64 GB would be paying for slack we don't need. If a future dep growth pushes us over, we can escalate to xlarge (and add it to [.github/actionlint.yaml](.github/actionlint.yaml) at that point).

## Cache

The \`aube-rust-linux\` cache-tag override is already shared between the base and \`-large\` profiles (used by the bench jobs), so the cargo cache is reused across regular CI, bench, and the PGO release jobs with no extra setup.

## Test plan

- [ ] Cut a dispatch run of \`release\` workflow (or wait for next release-plz tag) and confirm both \`upload-assets-pgo\` Linux jobs finish.
- [ ] Spot-check archive sizes match prior PGO builds (no profile data difference; only the runner changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the GitHub Actions runner size for two Linux PGO matrix entries, with no code or build logic modifications.
> 
> **Overview**
> **Release CI now uses larger Linux runners for PGO builds.** The `upload-assets-pgo` job’s x86_64 GNU and musl matrix entries switch from `namespace-profile-endev-linux-amd64` to `namespace-profile-endev-linux-amd64-large` to prevent OOM failures during the instrumented PGO link step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562313753f9f6fed75f44ec33b0c3f0987520579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->