### PR TITLE
fix(bench): pass --frozen-lockfile to vlt install scenarios

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -432,7 +432,11 @@ cmd_template() {
 		echo "cd {project} && HOME={home} DENO_DIR={cache} {bin} install --frozen --quiet >/dev/null 2>&1"
 		;;
 	gvs-warm:vlt | gvs-cold:vlt | ci-warm:vlt | ci-cold:vlt)
-		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install >/dev/null 2>&1"
+		# vlt's --frozen-lockfile mirrors pnpm/npm/aube semantics: refuse
+		# to re-resolve and error out if vlt-lock.json would change.
+		# Without it vlt would silently treat the install as a fresh
+		# resolve, which is not what the other tools measure here.
+		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install --frozen-lockfile >/dev/null 2>&1"
 		;;
 	gvs-cold:npm | ci-cold:npm)
 		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps >/dev/null 2>&1"
@@ -459,7 +463,7 @@ cmd_template() {
 		echo "cd {project} && HOME={home} DENO_DIR={cache} {bin} install --frozen --quiet >/dev/null 2>&1 && HOME={home} DENO_DIR={cache} {bin} task --quiet test >/dev/null 2>&1"
 		;;
 	install-test:vlt)
-		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install >/dev/null 2>&1 && HOME={home} npm_config_cache={cache} {bin} run test >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install --frozen-lockfile >/dev/null 2>&1 && HOME={home} npm_config_cache={cache} {bin} run test >/dev/null 2>&1"
 		;;
 	add:aube)
 		echo "cd {project} && $AUBE_ENV_GVS_ON {bin} add is-odd >/dev/null 2>&1"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -12098,7 +12098,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.10.1",
+  "version": "1.10.2",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.10.1
+**Version**: 1.10.2
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
## Summary

Lost in the squash-merge of #578 due to a force-push timing race. Every other tool in the benchmark matrix gets pinned to its frozen-install mode (pnpm/npm/aube `--frozen-lockfile`, yarn `--immutable`, bun `--frozen-lockfile`, deno `--frozen`); vlt was the odd one out and would have measured a re-resolving install path, which is not what the scenario advertises.

Adds `--frozen-lockfile` to the four warm/cold install rows (gvs-warm, gvs-cold, ci-warm, ci-cold) plus the install-test variant. The `add` scenario stays without it — that one is supposed to mutate the lockfile.

## Test plan

- [ ] `mise run bench:bump` produces vlt numbers comparable to the other tools' frozen-install paths.
- [ ] vlt run no longer re-resolves on warm/cold install scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts benchmark command flags, affecting measurement behavior but not production code paths.
> 
> **Overview**
> Aligns `vlt` benchmark scenarios with other package managers by adding `--frozen-lockfile` to the `gvs-warm`, `gvs-cold`, `ci-warm`, `ci-cold`, and `install-test` install commands in `benchmarks/bench.sh`.
> 
> This prevents `vlt` runs from silently re-resolving and ensures the benchmarks measure locked installs; the `add` scenario remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d1533e0e7ef65bd649f2e6bb59e206b6596b994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->