### PR TITLE
ci(release): add native linux-arm64 PGO, bump macos-arm64 PGO to -large

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,11 +3,15 @@ self-hosted-runner:
     - namespace-profile-endev-linux-amd64
     - namespace-profile-endev-linux-amd64-large
     - namespace-profile-endev-linux-arm64
+    - namespace-profile-endev-linux-arm64-large
     - namespace-profile-endev-macos-arm64
     # Namespace lets you append `;overrides.cache-tag=NAME` to a profile
     # to share a cache volume across multiple profiles. Both the base
     # and `-large` Linux profiles point at the same `aube-rust-linux`
     # tag so the rust cache is shared between regular CI and the bench
-    # jobs that run on `-large`.
+    # jobs that run on `-large`. arm64 has its own cache tag — the
+    # rust target dir is arch-specific, so sharing with amd64 would
+    # thrash.
     - namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     - namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
+    - namespace-profile-endev-linux-arm64-large;overrides.cache-tag=aube-rust-linux-arm64

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - namespace-profile-endev-linux-arm64
     - namespace-profile-endev-linux-arm64-large
     - namespace-profile-endev-macos-arm64
+    - namespace-profile-endev-macos-arm64-large
     # Namespace lets you append `;overrides.cache-tag=NAME` to a profile
     # to share a cache volume across multiple profiles. Both the base
     # and `-large` Linux profiles point at the same `aube-rust-linux`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,11 @@ jobs:
           name: metadata-primer
           path: crates/aube-resolver/data/primer-top${{ env.AUBE_PRIMER_TOP }}-v${{ env.AUBE_PRIMER_VERSION_CAP }}.rkyv.json
 
-  # Non-PGO targets: aarch64 Linux (cross-compiled, can't easily train
-  # under QEMU) and Windows (untested PGO toolchain). Built via taiki-e
-  # straight from the release profile.
+  # Non-PGO targets: aarch64 musl Linux (cross-compiled, no native musl
+  # runner), Windows (untested PGO toolchain), and macOS arm64 (the PGO
+  # instrumented binary segfaults during training on macOS arm64 — see
+  # the v1.10.1 release run; revisit once we can reproduce locally).
+  # Built via taiki-e straight from the release profile.
   upload-assets:
     needs: generate-primer
     runs-on: ${{ matrix.runner }}
@@ -69,14 +71,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
-            build-tool: cross
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
             build-tool: cross
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+            build-tool: cargo
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             runner: windows-latest
@@ -150,15 +152,19 @@ jobs:
         with:
           subject-path: ${{ steps.archive.outputs.path }}
 
-  # PGO-optimized targets: x86_64 Linux GNU/musl + macOS arm64 (the three
-  # native-built artifacts that cover the bulk of downloads). Each builds
+  # PGO-optimized targets: x86_64 Linux GNU/musl (cross-built on amd64)
+  # plus native aarch64 Linux GNU (the bulk of downloads). Each builds
   # via benchmarks/pgo.bash — instrument under release-pgo, train against
-  # the hermetic Verdaccio registry, rebuild with -Cprofile-use. Linux
-  # targets keep build-tool=cross so the resulting binary preserves the
-  # current glibc baseline; the cross-built instrumented binary runs on
-  # the host for training (cross's older glibc is forward-compatible
-  # with the runner's). Cross.toml passes RUSTFLAGS through to the
-  # container so phase 1 / 3b RUSTFLAGS reach cargo inside cross.
+  # the hermetic Verdaccio registry, rebuild with -Cprofile-use. The
+  # x86_64 Linux targets use build-tool=cross so the resulting binary
+  # preserves the current glibc baseline; the cross-built instrumented
+  # binary runs on the host for training (cross's older glibc is
+  # forward-compatible with the runner's). Cross.toml passes RUSTFLAGS
+  # through to the container so phase 1 / 3b RUSTFLAGS reach cargo
+  # inside cross. The aarch64 Linux row runs natively on
+  # `namespace-profile-endev-linux-arm64-large` (32 GB) so the same
+  # fat-LTO + profile-generate headroom argument from
+  # acdf415 applies, and we don't need QEMU to train.
   upload-assets-pgo:
     needs: generate-primer
     runs-on: ${{ matrix.runner }}
@@ -175,9 +181,9 @@ jobs:
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
             build-tool: cross
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            runner: namespace-profile-endev-linux-arm64-large;overrides.cache-tag=aube-rust-linux-arm64
             build-tool: cargo
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,8 @@ jobs:
           path: crates/aube-resolver/data/primer-top${{ env.AUBE_PRIMER_TOP }}-v${{ env.AUBE_PRIMER_VERSION_CAP }}.rkyv.json
 
   # Non-PGO targets: aarch64 musl Linux (cross-compiled, no native musl
-  # runner), Windows (untested PGO toolchain), and macOS arm64 (the PGO
-  # instrumented binary segfaults during training on macOS arm64 — see
-  # the v1.10.1 release run; revisit once we can reproduce locally).
-  # Built via taiki-e straight from the release profile.
+  # runner) and Windows (untested PGO toolchain). Built via taiki-e
+  # straight from the release profile.
   upload-assets:
     needs: generate-primer
     runs-on: ${{ matrix.runner }}
@@ -75,10 +73,6 @@ jobs:
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
             build-tool: cross
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
-            build-tool: cargo
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             runner: windows-latest
@@ -153,7 +147,7 @@ jobs:
           subject-path: ${{ steps.archive.outputs.path }}
 
   # PGO-optimized targets: x86_64 Linux GNU/musl (cross-built on amd64)
-  # plus native aarch64 Linux GNU (the bulk of downloads). Each builds
+  # plus native aarch64 Linux GNU and native macOS arm64. Each builds
   # via benchmarks/pgo.bash — instrument under release-pgo, train against
   # the hermetic Verdaccio registry, rebuild with -Cprofile-use. The
   # x86_64 Linux targets use build-tool=cross so the resulting binary
@@ -164,7 +158,12 @@ jobs:
   # inside cross. The aarch64 Linux row runs natively on
   # `namespace-profile-endev-linux-arm64-large` (32 GB) so the same
   # fat-LTO + profile-generate headroom argument from
-  # acdf415 applies, and we don't need QEMU to train.
+  # acdf415 applies, and we don't need QEMU to train. macOS arm64 is
+  # on the `-large` (12×28) variant because the previous instrumented
+  # binary segfaulted during training on the 6×14 base profile — fork
+  # pressure from `aube install` may have been racing under resource
+  # contention. Revisit moving back to base if `-large` proves stable
+  # across a few release cycles.
   upload-assets-pgo:
     needs: generate-primer
     runs-on: ${{ matrix.runner }}
@@ -184,6 +183,10 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-arm64-large;overrides.cache-tag=aube-rust-linux-arm64
+            build-tool: cargo
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            runner: namespace-profile-endev-macos-arm64-large
             build-tool: cargo
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -12098,7 +12098,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.10.1",
+  "version": "1.10.2",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.10.1
+**Version**: 1.10.2
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
## Summary

The macOS arm64 PGO job has been segfaulting (exit 139, SIGSEGV) in the instrumented training step on v1.10.1 — the instrumented `aube` binary crashes during `aube install --ignore-scripts` against the hermetic Verdaccio. See [job 75261461680](https://github.com/endevco/aube/actions/runs/25640949943/job/75261461680).

Three changes here:

1. **Bump macOS arm64 PGO to `namespace-profile-endev-macos-arm64-large`** (12 vCPU / 28 GB, up from 6 / 14). The previous segfault might just be resource-contention under fork pressure during `aube install` — try the bigger box before dropping macOS arm64 from PGO entirely.
2. **Add a native `aarch64-unknown-linux-gnu` row to `upload-assets-pgo`** using a new `namespace-profile-endev-linux-arm64-large` runner. Native arm64 means we don't have to figure out QEMU for the training step, and we get PGO on the busiest arm64 target.
3. **Register the new runner labels** (`linux-arm64-large` + `macos-arm64-large` + an `aube-rust-linux-arm64` cache-tag variant) in [`.github/actionlint.yaml`](.github/actionlint.yaml). arm64 gets its own cache tag — the rust target dir is arch-specific, so sharing with the `aube-rust-linux` (amd64) cache would thrash.

## Why `-large` and not the base profile

Same reasoning as [#577](https://github.com/endevco/aube/pull/577): fat-LTO link of `aube` (~150 deps) is normally 8-16 GB; `-Cprofile-generate` adds ~1.5-2x IR bloat → expect 12-20 GB peak. The base linux profile (8 GB) OOMed on amd64, and there's no reason arm64 would be different. For macOS arm64 the previous failure was a runtime segfault, not OOM — but 28 GB removes paging/contention as a variable, which is the cheap first thing to rule out.

## Net matrix change

**Before:**
- `upload-assets`: aarch64-linux-gnu (cross), aarch64-linux-musl (cross), x86_64-windows, aarch64-windows
- `upload-assets-pgo`: x86_64-linux-gnu (cross, large), x86_64-linux-musl (cross, large), aarch64-apple-darwin (base macos-arm64) ⛔ segfaulting

**After:**
- `upload-assets`: aarch64-linux-musl (cross), x86_64-windows, aarch64-windows
- `upload-assets-pgo`: x86_64-linux-gnu (cross, large), x86_64-linux-musl (cross, large), **aarch64-linux-gnu** (native arm64-large) ✨, **aarch64-apple-darwin** (macos-arm64-**large**) ✨

## Test plan

- [ ] Dispatch the `release` workflow against v1.10.2 (or the next tag release-plz cuts) and confirm all four PGO rows finish.
- [ ] Spot-check arm64 + macOS archive sizes vs the prior cross-compiled non-PGO arm64 / segfailing macOS builds.
- [ ] If macOS arm64 PGO still segfaults on `-large`, open a follow-up to drop it back to non-PGO and investigate locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release build matrix and runner/cache configuration, which could affect produced artifacts and release pipeline stability. Risk is limited to CI/release behavior (no runtime code changes) but impacts critical distribution paths.
> 
> **Overview**
> **Release CI now shifts PGO coverage toward native arm64.** The `release.yml` workflow drops the non-PGO `aarch64-unknown-linux-gnu` asset, adds a new **PGO** `aarch64-unknown-linux-gnu` job running on `namespace-profile-endev-linux-arm64-large` with an arm64-specific Rust cache tag, and moves macOS arm64 PGO to `namespace-profile-endev-macos-arm64-large`.
> 
> **Runner metadata is updated accordingly.** `.github/actionlint.yaml` registers the new `*-large` runner labels and documents/separates the arm64 cache tag. Generated CLI docs are bumped from version `1.10.1` to `1.10.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c450474ba0d078dec6fd9b4def6d08b20ecb4b1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->