### PR TITLE
fix(bench): install yarn 4 via @yarnpkg/cli-dist, not yarn@4

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -12098,7 +12098,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.10.1",
+  "version": "1.10.2",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
   "complete": {},
   "about": "A fast Node.js package manager"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.10.1
+**Version**: 1.10.2
 
 - **Usage**: `aube [FLAGS] <SUBCOMMAND>`
 

--- a/mise.toml
+++ b/mise.toml
@@ -46,7 +46,7 @@ dir = "{{config_root}}"
 env = { BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms" }
 run = [
   "cargo build --release",
-  "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest npm:yarn@4 bun@latest deno@latest npm:vlt@latest node@24 -- bash benchmarks/bench.sh",
+  "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest npm:@yarnpkg/cli-dist@latest bun@latest deno@latest npm:vlt@latest node@24 -- bash benchmarks/bench.sh",
 ]
 
 [tasks."bench:pr"]
@@ -70,7 +70,7 @@ dir = "{{config_root}}"
 env = { RUNS = "10", WARMUP = "3", RESULTS_JSON = "{{config_root}}/benchmarks/results.json", BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms" }
 run = [
   "cargo build --release",
-  "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest npm:yarn@4 bun@latest deno@latest npm:vlt@latest node@24 -- bash benchmarks/bench.sh",
+  "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest npm:@yarnpkg/cli-dist@latest bun@latest deno@latest npm:vlt@latest node@24 -- bash benchmarks/bench.sh",
   "node benchmarks/update-readme.mjs",
 ]
 


### PR DESCRIPTION
## Summary

The bench-refresh run [25641518960](https://github.com/endevco/aube/actions/runs/25641518960/job/75262685098) failed installing benchmark deps:

\`\`\`
npm error code ETARGET
npm error notarget No matching version found for yarn@4.
\`\`\`

Root cause: the \`yarn\` npm package only publishes 1.x and 2.x — \`latest\` is \`1.22.22\` and the \`berry\` dist-tag is \`2.4.3\`. There is no 4.x version on that package, so \`npm install yarn@4\` ETARGETs.

Yarn 4 is published as **\`@yarnpkg/cli-dist\`** (current \`latest\` = 4.14.1). It declares a \`bin\` field for \`yarn\`, so installing it globally puts the yarn 4 CLI on \`PATH\` exactly like the old approach did.

Swap \`npm:yarn@4\` → \`npm:@yarnpkg/cli-dist@latest\` in both \`bench\` and \`bench:bump\` mise tasks. \`bench:pr\` doesn't reference yarn (it only benches aube/bun/pnpm).

## Test plan

- [ ] Re-dispatch \`bench-refresh\` and confirm the install step succeeds.
- [ ] On the next bump, \`yarn --version\` reported in \`benchmarks/results.json\` shows \`4.x\` instead of \`1.22.22\`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates benchmark task tooling to install Yarn 4 from the correct npm package, with no impact on production code paths.
> 
> **Overview**
> Fixes failing benchmark runs by replacing `npm:yarn@4` with `npm:@yarnpkg/cli-dist@latest` in the `mise.toml` `bench` and `bench:bump` tasks so Yarn 4 can be installed successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c3b388a606108e6f4a108c577c80c8a2b012177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->