### PR TITLE
fix(release): set LLVM_PROFILE_FILE so cross-built PGO writes profraw

### DIFF
--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -124,6 +124,19 @@ AUBE_BIN="$INSTRUMENTED_BIN" hermetic_start
 # uplink path. Drop those before the real training runs land.
 rm -f "$PGO_PROFRAW_DIR"/*.profraw
 
+# Force the instrumented binary to write profraw to a host path we
+# control, regardless of what `-Cprofile-generate=<dir>` baked in at
+# compile time. With AUBE_PGO_BUILD_TOOL=cross the rustc compile runs
+# inside a container where the project may be mounted under a path
+# that differs from the host (cross's default MOUNT_FINDER puts the
+# workspace at `/project`). The host path embedded in the binary then
+# doesn't resolve at runtime, profraw goes nowhere, and llvm-profdata
+# silently produces no merged output. Setting LLVM_PROFILE_FILE at
+# runtime sidesteps the path-translation question entirely. %m
+# disambiguates per module signature; %p per process — together they
+# keep the 6 training runs from colliding on the same file.
+PROFRAW_PATTERN="$PGO_PROFRAW_DIR/aube-%m-%p.profraw"
+
 # 3 cold + 3 warm. Cold runs each get a fresh dir so the resolver,
 # registry, store, and linker hot paths all run end-to-end. Warm runs
 # reuse the last cold dir so the frozen-lockfile fast path is also
@@ -136,13 +149,13 @@ cold_run() {
 	printf 'registry=%s\n' "$BENCH_REGISTRY_URL" >"$run_dir/.npmrc"
 	printf 'registry=%s\n' "$BENCH_REGISTRY_URL" >"$run_dir/home/.npmrc"
 	echo "  train: cold install ($i)"
-	(cd "$run_dir" && HOME="$run_dir/home" "$INSTRUMENTED_BIN" install --ignore-scripts >/dev/null)
+	(cd "$run_dir" && HOME="$run_dir/home" LLVM_PROFILE_FILE="$PROFRAW_PATTERN" "$INSTRUMENTED_BIN" install --ignore-scripts >/dev/null)
 }
 
 warm_run() {
 	local run_dir=$1 i=$2
 	echo "  train: warm install ($i)"
-	(cd "$run_dir" && HOME="$run_dir/home" "$INSTRUMENTED_BIN" install --ignore-scripts >/dev/null)
+	(cd "$run_dir" && HOME="$run_dir/home" LLVM_PROFILE_FILE="$PROFRAW_PATTERN" "$INSTRUMENTED_BIN" install --ignore-scripts >/dev/null)
 }
 
 for i in 1 2 3; do
@@ -153,6 +166,19 @@ for i in 1 2 3; do
 done
 
 hermetic_stop
+
+# Sanity check: confirm training actually wrote profraw. Without
+# LLVM_PROFILE_FILE this silently produced zero files on cross-built
+# targets — llvm-profdata then merged nothing and phase 3b failed with
+# "file ... merged.profdata does not exist". Fail loudly here instead.
+profraw_count=$(find "$PGO_PROFRAW_DIR" -maxdepth 1 -name '*.profraw' -type f | wc -l | tr -d ' ')
+if [ "$profraw_count" -eq 0 ]; then
+	echo "ERROR: no .profraw files written to $PGO_PROFRAW_DIR after training" >&2
+	echo "  Training ran but the instrumented binary did not record profile data." >&2
+	echo "  Check LLVM_PROFILE_FILE handling and the cross host/container mount." >&2
+	exit 1
+fi
+echo ">>> $profraw_count .profraw files collected"
 
 # ---------- Phase 3a: merge ----------
 echo ">>> [3/3] Merging profile data"


### PR DESCRIPTION
## Summary

The x86_64-linux-{gnu,musl} PGO release jobs have been failing on v1.10.1, v1.10.2, and v1.10.3 — see [job 75264599337](https://github.com/endevco/aube/actions/runs/25642154864/job/75264599337) — with:

\`\`\`
error: file \`target/pgo-data/merged.profdata\` passed to \`-C profile-use\` does not exist
\`\`\`

**Root cause**: phase 1 of \`benchmarks/pgo.bash\` compiles the instrumented binary inside the \`cross\` container. cross's default MOUNT_FINDER mounts the workspace under a path that does not match the host (typically \`/project\`). The \`-Cprofile-generate=<host-path>\` baked into the binary at compile time therefore does not resolve when the binary runs on the host — profraw writes silently go nowhere, llvm-profdata merges nothing, phase 3b has no profdata to consume.

This bug has been latent since [#572](https://github.com/endevco/aube/pull/572) (where the PGO pipeline first landed). It hasn't shipped a successful PGO Linux release yet — v1.10.0 was non-PGO, v1.10.1 / 1.10.2 / 1.10.3 all hit this.

## Fix

- Set \`LLVM_PROFILE_FILE\` on every training invocation. This overrides whatever \`-Cprofile-generate\` path was baked in, so the host/container mount mismatch becomes irrelevant. Use \`%m-%p\` placeholders so the six training runs (3 cold + 3 warm) don't collide on a single file.
- Add a post-training sanity check that fails loudly if zero \`.profraw\` files materialized. The silent zero is what hid this across three releases — \`llvm-profdata merge\` with an empty input dir exits 0 without writing the output file.

## Test plan

- [ ] Cut a v1.10.4 release (or workflow-dispatch \`release\` against an existing tag) and confirm \`upload-assets-pgo (x86_64-unknown-linux-{gnu,musl})\` both succeed and attach archives.
- [ ] If a future change to Cross.toml or cross itself regresses path translation, the new \`profraw_count == 0\` check stops the script with an actionable error instead of pushing the failure into the opaque rustc invocation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the PGO release build script and changes how profiling artifacts are generated; mistakes would break Linux PGO releases but do not affect runtime behavior of shipped binaries beyond optimization quality.
> 
> **Overview**
> Fixes cross-built PGO training so profile data is reliably written and merged by exporting `LLVM_PROFILE_FILE` (with `%m/%p` to avoid collisions) for each training run.
> 
> Adds a post-training sanity check that fails early if zero `.profraw` files were produced, preventing later stages from failing with a missing `merged.profdata`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7dc261cb39176965802e74e8cddda10969814a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->