### PR TITLE
ci(release): add dry-run mode to release.yml for branch-level testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
           token: ${{ secrets.AUBE_GH_TOKEN }}
           codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           codesign_prefix: dev.jdx.
-          dry-run: ${{ inputs.dry_run == true }}
+          dry-run: ${{ fromJSON(inputs.dry_run || 'false') }}
       - name: Upload binary (non-macOS)
         id: upload-non-macos
         if: ${{ !startsWith(matrix.os, 'macos') }}
@@ -138,7 +138,7 @@ jobs:
           build-tool: ${{ matrix.build-tool }}
           ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           token: ${{ secrets.AUBE_GH_TOKEN }}
-          dry-run: ${{ inputs.dry_run == true }}
+          dry-run: ${{ fromJSON(inputs.dry_run || 'false') }}
       - name: Resolve uploaded archive
         id: archive
         shell: bash
@@ -154,13 +154,13 @@ jobs:
           fi
           echo "path=$archive" >> "$GITHUB_OUTPUT"
       - name: Upload archive as workflow artifact (dry run)
-        if: ${{ inputs.dry_run == true }}
+        if: ${{ fromJSON(inputs.dry_run || 'false') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: aube-${{ inputs.tag }}-${{ matrix.target }}
           path: ${{ steps.archive.outputs.path }}
       - name: Attest release archive
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ !fromJSON(inputs.dry_run || 'false') }}
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: ${{ steps.archive.outputs.path }}
@@ -264,7 +264,7 @@ jobs:
           tar -czf "$archive" -C "target/${TARGET}/release-pgo" aube aubr aubx
           echo "path=$archive" >> "$GITHUB_OUTPUT"
       - name: Upload archive to release
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ !fromJSON(inputs.dry_run || 'false') }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
@@ -272,13 +272,13 @@ jobs:
           ARCHIVE: ${{ steps.archive.outputs.path }}
         run: gh release upload "$TAG" "$ARCHIVE" --clobber
       - name: Upload archive as workflow artifact (dry run)
-        if: ${{ inputs.dry_run == true }}
+        if: ${{ fromJSON(inputs.dry_run || 'false') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: aube-${{ inputs.tag }}-${{ matrix.target }}
           path: ${{ steps.archive.outputs.path }}
       - name: Attest release archive
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ !fromJSON(inputs.dry_run || 'false') }}
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: ${{ steps.archive.outputs.path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,19 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to attach binaries to (e.g. v1.0.0)"
+        description: "Tag (or archive-name label, for dry runs) — e.g. v1.0.0 or dryrun"
         required: true
         type: string
+      ref:
+        description: "Branch or sha to build. Empty = use refs/tags/<tag>. Only honored in dry-run."
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Build everything but skip the GitHub release upload. Uses ref instead of refs/tags/<tag> when set."
+        required: false
+        type: boolean
+        default: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -41,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: refs/tags/${{ inputs.tag }}
+          ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           submodules: recursive
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -84,7 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: refs/tags/${{ inputs.tag }}
+          ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           submodules: recursive
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -112,10 +122,11 @@ jobs:
           archive: aube-$tag-$target
           target: ${{ matrix.target }}
           build-tool: ${{ matrix.build-tool }}
-          ref: refs/tags/${{ inputs.tag }}
+          ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           token: ${{ secrets.AUBE_GH_TOKEN }}
           codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           codesign_prefix: dev.jdx.
+          dry-run: ${{ inputs.dry_run == true }}
       - name: Upload binary (non-macOS)
         id: upload-non-macos
         if: ${{ !startsWith(matrix.os, 'macos') }}
@@ -125,8 +136,9 @@ jobs:
           archive: aube-$tag-$target
           target: ${{ matrix.target }}
           build-tool: ${{ matrix.build-tool }}
-          ref: refs/tags/${{ inputs.tag }}
+          ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           token: ${{ secrets.AUBE_GH_TOKEN }}
+          dry-run: ${{ inputs.dry_run == true }}
       - name: Resolve uploaded archive
         id: archive
         shell: bash
@@ -141,7 +153,14 @@ jobs:
             exit 1
           fi
           echo "path=$archive" >> "$GITHUB_OUTPUT"
+      - name: Upload archive as workflow artifact (dry run)
+        if: ${{ inputs.dry_run == true }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aube-${{ inputs.tag }}-${{ matrix.target }}
+          path: ${{ steps.archive.outputs.path }}
       - name: Attest release archive
+        if: ${{ inputs.dry_run != true }}
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: ${{ steps.archive.outputs.path }}
@@ -191,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: refs/tags/${{ inputs.tag }}
+          ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           submodules: recursive
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -245,13 +264,21 @@ jobs:
           tar -czf "$archive" -C "target/${TARGET}/release-pgo" aube aubr aubx
           echo "path=$archive" >> "$GITHUB_OUTPUT"
       - name: Upload archive to release
+        if: ${{ inputs.dry_run != true }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
           TAG: ${{ inputs.tag }}
           ARCHIVE: ${{ steps.archive.outputs.path }}
         run: gh release upload "$TAG" "$ARCHIVE" --clobber
+      - name: Upload archive as workflow artifact (dry run)
+        if: ${{ inputs.dry_run == true }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aube-${{ inputs.tag }}-${{ matrix.target }}
+          path: ${{ steps.archive.outputs.path }}
       - name: Attest release archive
+        if: ${{ inputs.dry_run != true }}
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: ${{ steps.archive.outputs.path }}


### PR DESCRIPTION
## Summary

Adds two new \`workflow_dispatch\` inputs to [release.yml](.github/workflows/release.yml):

- **\`ref\`** — branch or sha to build instead of \`refs/tags/<tag>\`. Empty falls back to the tag, so the existing release-plz call path is unchanged.
- **\`dry_run\`** — when true, the binary-build matrix runs end-to-end (instrument, train, link, cross matrix, codesign, archive) but skips the actual GitHub-release upload and the build-provenance attestation. The archive is uploaded as a **workflow artifact** so the dispatcher can pull the binary down and poke at it.

\`workflow_call\` is untouched. release-plz keeps passing \`tag\` only; \`dry_run\` defaults to \`false\` for that path.

## Why

The LLVM_PROFILE_FILE bug in [#585](https://github.com/endevco/aube/pull/585) escaped three releases (v1.10.1, v1.10.2, v1.10.3) because the binary-build matrix can only be exercised at release time. With this in place:

\`\`\`
gh workflow run release.yml \\
  --ref claude/pgo-profile-file \\
  -f tag=dryrun-pgo \\
  -f ref=claude/pgo-profile-file \\
  -f dry_run=true
\`\`\`

…runs the exact same matrix the real release runs, against the branch's code, without tagging or publishing anything.

## Mechanics

- \`actions/checkout\` and \`taiki-e/upload-rust-binary-action\` both get \`ref: \${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}\` — so when \`ref\` is empty, they fall back to the existing tag-based path.
- \`taiki-e/upload-rust-binary-action\` gains \`dry-run: \${{ inputs.dry_run == true }}\`. The action then builds and archives but does not upload to a release.
- The PGO matrix's hand-rolled \`gh release upload\` step gets gated on \`inputs.dry_run != true\`.
- An \`actions/upload-artifact\` step lands the archive on the workflow run when dry-running, so \`gh run download\` can fetch it.
- \`actions/attest-build-provenance\` skips in dry-run — no real release to attest.

## Test plan

- [ ] Merge this.
- [ ] Re-dispatch \`release.yml\` against [#585](https://github.com/endevco/aube/pull/585)'s branch with \`dry_run=true\` and confirm both x86_64 Linux PGO jobs succeed (they fail on main today).
- [ ] Confirm release-plz's next post-merge release run is unaffected (workflow_call inputs unchanged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release automation path; while behavior is gated behind `workflow_dispatch` inputs and defaults preserve the tag-based flow, mistakes could still disrupt publishing or attestations during real releases.
> 
> **Overview**
> Adds `workflow_dispatch` support for **dry-run releases** by introducing new inputs `ref` (build from a branch/SHA instead of `refs/tags/<tag>`) and `dry_run` (skip publishing).
> 
> When `dry_run` is enabled, build jobs still produce archives but **do not upload to GitHub Releases** and **skip provenance attestation**; instead the resulting archives are uploaded as workflow artifacts for download/testing. The existing tag-based path remains the default via a fallback `ref` expression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5761fd1e64c01305fa20516bc055e9d85d8322f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->