### PR TITLE
fix(store): take libc::off_t in posix_fallocate wrapper for 32-bit targets

### DIFF
--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1176,8 +1176,14 @@ const MAX_TARBALL_ENTRIES: usize = 64;
 // directly (does not set errno). Caller decides how to handle the
 // error. Existing call site uses `let _ = ...` to ignore EOPNOTSUPP /
 // ENOSYS / EINVAL on filesystems where pre-allocation is a no-op.
+//
+// `len` is `libc::off_t` because that's the type the underlying glibc
+// signature uses, and it varies per target: `i64` on 64-bit Linux and
+// on 32-bit Linux when the libc bindings opt into _FILE_OFFSET_BITS=64,
+// `i32` on 32-bit Linux otherwise (e.g. Debian/Ubuntu's armhf packaging
+// build env). Taking it directly keeps the call-site cast in one place.
 #[cfg(target_os = "linux")]
-fn posix_fallocate(file: &std::fs::File, len: i64) -> std::io::Result<()> {
+fn posix_fallocate(file: &std::fs::File, len: libc::off_t) -> std::io::Result<()> {
     use std::os::fd::AsRawFd;
     if len <= 0 {
         return Ok(());
@@ -1246,7 +1252,7 @@ fn try_o_tmpfile_publish(path: &Path, bytes: &[u8]) -> Result<CasWriteOutcome, O
     // Best-effort fallocate so the kernel allocates contiguous extents
     // up front. Skips ext4 fragmentation churn on the next write.
     // EOPNOTSUPP and ENOSYS are fine, regular write_all handles them.
-    let _ = posix_fallocate(&file, bytes.len() as i64);
+    let _ = posix_fallocate(&file, bytes.len() as libc::off_t);
     file.write_all(bytes)
         .map_err(|e| OTmpfileFallback::Hard(Error::Io(path.to_path_buf(), e)))?;
     // No sync_data: contradicts the no-fsync CAS policy. Crash window


### PR DESCRIPTION
## Summary

Launchpad's Ubuntu Resolute armhf build of v1.10.3 fails to compile [aube-store](crates/aube-store/src/lib.rs) with:

\`\`\`
error[E0308]: mismatched types
    --> crates/aube-store/src/lib.rs:1186:65
     |
1186 |     let r = unsafe { libc::posix_fallocate(file.as_raw_fd(), 0, len) };
     |                                                                ^^^ expected \`i32\`, found \`i64\`
note: function defined here
     |
4121 |     pub fn posix_fallocate(fd: c_int, offset: off_t, len: off_t) -> c_int;
\`\`\`

Build log: [buildlog_ubuntu-resolute-armhf.aube_1.10.3~resolute1_BUILDING.txt.gz](https://launchpadlibrarian.net/860629123/buildlog_ubuntu-resolute-armhf.aube_1.10.3~resolute1_BUILDING.txt.gz).

## Root cause

On 32-bit Linux with the default (non-LFS) libc bindings, \`off_t = i32\`. The wrapper at \`crates/aube-store/src/lib.rs:1180\` was hard-coded to \`len: i64\`, which happens to match \`off_t\` on every 64-bit target (x86_64-linux-gnu, aarch64-linux-gnu, aarch64-linux-musl) but breaks armhf.

## Fix

- Change the wrapper signature to \`fn posix_fallocate(file: &std::fs::File, len: libc::off_t)\`.
- Cast \`bytes.len() as libc::off_t\` at the single call site. The cast resolves per-target: identity on 64-bit Linux (i64 → i64), narrowing to \`i32\` on 32-bit non-LFS armhf.
- Tarballs we write through this O_TMPFILE path are bounded by \`bytes.len()\` (\`usize\`), so the 2 GiB ceiling on 32-bit non-LFS is well above anything we'd realistically push through the CAS.

## Test plan

- [x] \`cargo check -p aube-store\` on x86_64-apple-darwin (host) — passes.
- [ ] Launchpad's next armhf rebuild of aube (or a downstream test against \`armv7-unknown-linux-gnueabihf\`) compiles clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a type/signature adjustment around a best-effort preallocation call, intended to fix 32-bit Linux builds without changing core store semantics.
> 
> **Overview**
> Fixes Linux `posix_fallocate` wrapper typing to be portable on 32-bit targets by changing its `len` parameter to `libc::off_t` and updating the single call site to cast `bytes.len()` to `libc::off_t`.
> 
> Adds clarifying comments explaining why `off_t` varies by target and why the cast is centralized in the wrapper/call site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b954e9111ae9f2f69598cad6d694b9a83bb893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->