### PR TITLE
fix(release): bind-mount pgo-data into cross container for phase 3b

### DIFF
--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -90,6 +90,18 @@ fi
 mkdir -p "$PGO_PROFRAW_DIR"
 rm -f "$PGO_PROFRAW_DIR"/*.profraw "$PGO_MERGED"
 
+# With AUBE_PGO_BUILD_TOOL=cross, rustc runs inside a container that
+# mounts the project at `/project` (not at the host path), so when
+# phase 3b reads `-Cprofile-use=<host-path>` from RUSTFLAGS the file
+# is invisible — rustc bails with "file ... does not exist" even when
+# the merge step wrote it on the host. Bind-mount PGO_DATA_DIR at the
+# same host path inside the container so the existing RUSTFLAGS value
+# resolves. Harmless on the host-side phase 1 build (cross still
+# writes the instrumented binary to target/ via its own bind mount).
+if [ "$PGO_BUILD_TOOL" = "cross" ]; then
+	export CROSS_CONTAINER_OPTS="${CROSS_CONTAINER_OPTS:-} -v $PGO_DATA_DIR:$PGO_DATA_DIR:rw"
+fi
+
 # ---------- Phase 1: instrumented build ----------
 echo ">>> [1/3] Building instrumented binary ($PGO_BUILD_TOOL, profile=$PGO_PROFILE${PGO_TARGET:+, target=$PGO_TARGET})"
 # shellcheck disable=SC2086 # intentional word-splitting on $target_arg
@@ -183,6 +195,19 @@ echo ">>> $profraw_count .profraw files collected"
 # ---------- Phase 3a: merge ----------
 echo ">>> [3/3] Merging profile data"
 "$LLVM_PROFDATA" merge -o "$PGO_MERGED" "$PGO_PROFRAW_DIR"
+
+# Defense in depth: confirm llvm-profdata actually wrote the merged
+# file. A version mismatch between the rustc that instrumented (phase 1
+# inside cross) and the host's llvm-profdata can produce a 0-exit
+# silent no-op. Without this check we'd fall through to phase 3b and
+# see rustc's opaque "file ... does not exist" against a path that
+# really doesn't exist on the host at all.
+if [ ! -f "$PGO_MERGED" ]; then
+	echo "ERROR: $PGO_MERGED was not produced by llvm-profdata merge" >&2
+	echo "  Check that the host's llvm-profdata version matches the rustc that built the instrumented binary." >&2
+	exit 1
+fi
+echo ">>> merged profile written: $(stat -c %s "$PGO_MERGED" 2>/dev/null || stat -f %z "$PGO_MERGED") bytes"
 
 if [ -n "${AUBE_PGO_SKIP_FINAL_BUILD:-}" ]; then
 	echo ">>> Skipping final optimized build (AUBE_PGO_SKIP_FINAL_BUILD=1)"


### PR DESCRIPTION
## Summary

After [#585](https://github.com/endevco/aube/pull/585) landed (LLVM_PROFILE_FILE during training), the dry-run on main ([run 25642859664](https://github.com/endevco/aube/actions/runs/25642859664)) shows the x86_64-linux-{gnu,musl} PGO jobs now correctly produce **6 .profraw files**, merge them, then still fail phase 3b with:

\`\`\`
error: file \`/home/runner/work/aube/aube/target/pgo-data/merged.profdata\`
       passed to \`-C profile-use\` does not exist
\`\`\`

## Root cause

\`cross\` mounts the project at \`/project\` inside its container, not at the host path. The host path embedded in RUSTFLAGS by phase 3b is invisible to rustc inside cross. Phase 1's profile-generate path-bake was sidestepped by setting LLVM_PROFILE_FILE at training-runtime (#585); phase 3b reads its path at compile-runtime *inside* cross, so the path needs to actually resolve in the container.

## Fix

\`\`\`bash
if [ "$PGO_BUILD_TOOL" = "cross" ]; then
    export CROSS_CONTAINER_OPTS="\${CROSS_CONTAINER_OPTS:-} -v $PGO_DATA_DIR:$PGO_DATA_DIR:rw"
fi
\`\`\`

cross passes the option through to docker/podman, the path resolves identically on both sides, and RUSTFLAGS works unchanged.

Also add a defense-in-depth \`test -f "$PGO_MERGED"\` check after \`llvm-profdata merge\`. If a future rustc/llvm-profdata version mismatch makes the merge silently no-op, this fails loudly with an actionable message instead of pushing the failure into rustc's opaque "file ... does not exist" path.

## Test plan

- [ ] Dispatch \`release.yml\` against this branch with \`dry_run=true\` and confirm \`upload-assets-pgo (x86_64-unknown-linux-{gnu,musl})\` both succeed and upload archives as workflow artifacts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the PGO/release build script and `cross` container options; mistakes could break CI artifacts for Linux targets but doesn’t affect runtime application logic.
> 
> **Overview**
> Fixes PGO builds when using `cross` by bind-mounting `target/pgo-data` into the container so phase 3b’s `-Cprofile-use=<host-path>` resolves correctly inside rustc.
> 
> Adds a post-merge verification that `llvm-profdata merge` actually produced `merged.profdata` (and logs its size), failing early with a clearer error instead of surfacing later as rustc “file does not exist”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19cc74cd6db44ce0cd6560020dc7fed0d2173f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->