### PR TITLE
ci(release): bump rustc to stable on macOS arm64 PGO when <1.95

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,28 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
+      # rustc 1.94.0 on aarch64-apple-darwin miscompiles the
+      # PGO-instrumented binary — the resulting `aube install` SIGSEGVs
+      # on its first invocation during phase 2 training. Verified
+      # locally on rustc 1.95.0 against the same source tree: full PGO
+      # pipeline completes clean. Bump to latest stable only when the
+      # runner's default rustc is older than 1.95 so we don't pay the
+      # toolchain download on runners that have already moved on.
+      - name: Ensure rustc >= 1.95 on macOS arm64
+        if: matrix.target == 'aarch64-apple-darwin'
+        shell: bash
+        run: |
+          current=$(rustc --version | awk '{print $2}')
+          # `sort -V` puts versions in ascending order; if the lower of
+          # (current, 1.95.0) is not 1.95.0, then current < 1.95.0.
+          if [ "$(printf '%s\n%s\n' "$current" "1.95.0" | sort -V | head -1)" != "1.95.0" ]; then
+            echo "rustc $current is below 1.95.0; upgrading to latest stable"
+            rustup update stable
+            rustup default stable
+            rustc --version
+          else
+            echo "rustc $current already >= 1.95.0; no upgrade needed"
+          fi
       - name: Install rustup llvm-tools-preview
         shell: bash
         run: rustup component add llvm-tools-preview

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,14 +226,20 @@ jobs:
       # pipeline completes clean. Bump to latest stable only when the
       # runner's default rustc is older than 1.95 so we don't pay the
       # toolchain download on runners that have already moved on.
+      # TODO: drop this step once the GH macos-arm64 runner image
+      # ships rustc 1.95+ as the default. Track via this PR.
       - name: Ensure rustc >= 1.95 on macOS arm64
         if: matrix.target == 'aarch64-apple-darwin'
         shell: bash
         run: |
           current=$(rustc --version | awk '{print $2}')
-          # `sort -V` puts versions in ascending order; if the lower of
-          # (current, 1.95.0) is not 1.95.0, then current < 1.95.0.
-          if [ "$(printf '%s\n%s\n' "$current" "1.95.0" | sort -V | head -1)" != "1.95.0" ]; then
+          # Parse "1.94.0" into major / minor. `sort -V` would be the
+          # obvious idiom but isn't portable: GH macOS runners ship
+          # BSD `sort` (no `-V` flag), and under `set -eo pipefail`
+          # the failing pipeline either aborts the step or returns
+          # empty, both of which mis-trigger the upgrade path.
+          IFS=. read -r maj min _ <<<"$current"
+          if [ "$maj" -lt 1 ] || { [ "$maj" -eq 1 ] && [ "$min" -lt 95 ]; }; then
             echo "rustc $current is below 1.95.0; upgrading to latest stable"
             rustup update stable
             rustup default stable


### PR DESCRIPTION
## Summary

The macOS arm64 PGO release job has been SIGSEGV'ing in phase 2 training across v1.10.1, v1.10.2, v1.10.3, and the recent dry-run [25642859664](https://github.com/endevco/aube/actions/runs/25642859664):

\`\`\`
benchmarks/pgo.bash: line 152: 16147 Segmentation fault: 11
  ... LLVM_PROFILE_FILE=... "$INSTRUMENTED_BIN" install --ignore-scripts
```

The instrumented binary crashes on its first \`aube install\` invocation, even on the \`macos-arm64-large\` (12×28) runner — so it's not a fork-pressure / resource-contention problem, and bumping the runner profile didn't help.

## Diagnosis

Reproduced the exact CI environment as closely as possible locally:

| Aspect              | CI            | Local (this box) |
|---------------------|---------------|------------------|
| rustc               | **1.94.0**    | **1.95.0**       |
| target              | aarch64-apple-darwin | aarch64-apple-darwin |
| pipeline            | benchmarks/pgo.bash | benchmarks/pgo.bash |
| Phase 1 instrument  | ✓             | ✓                |
| Phase 2 training    | ❌ SIGSEGV on run 1 | ✓ × 6 (3 cold + 3 warm) |
| Phase 3a merge      | (never reached) | ✓              |
| Phase 3b rebuild    | (never reached) | ✓              |
| Final binary        | —             | 48 MB, runs clean |

Same source tree, same script, same architecture, different rustc — fully reproduces only on 1.94. The bug is a **rustc 1.94 PGO codegen miscompile on aarch64-apple-darwin**, fixed in 1.95.

## Fix

Add a conditional step that runs \`rustup update stable && rustup default stable\` **only** when \`matrix.target == 'aarch64-apple-darwin'\` **and** the runner's default rustc is below 1.95.0:

\`\`\`yaml
- name: Ensure rustc >= 1.95 on macOS arm64
  if: matrix.target == 'aarch64-apple-darwin'
  shell: bash
  run: |
    current=$(rustc --version | awk '{print $2}')
    if [ "$(printf '%s\n%s\n' "$current" "1.95.0" | sort -V | head -1)" != "1.95.0" ]; then
      rustup update stable
      rustup default stable
      rustc --version
    else
      echo "rustc $current already >= 1.95.0; no upgrade needed"
    fi
```

The Linux cross-built PGO targets are unaffected — their toolchain lives inside the cross container image, not on the host. Runners that already ship rustc 1.95+ skip the upgrade.

## Test plan

- [ ] Dispatch \`release.yml\` against this branch with \`dry_run=true\` and confirm the macOS arm64 PGO job no longer SIGSEGVs in phase 2 training.
- [ ] Verify the upgrade step is a no-op on aarch64 Linux / x86_64 Linux PGO jobs (the \`if: matrix.target == 'aarch64-apple-darwin'\` gate).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release workflow for PGO builds on macOS arm64, which can affect release reliability and build time if the toolchain upgrade path misfires. Scope is limited to a single conditional step and target gate.
> 
> **Overview**
> Prevents macOS arm64 PGO release builds from using rustc versions known to miscompile the instrumented binary by adding a guarded workflow step that ensures `rustc >= 1.95` for the `aarch64-apple-darwin` matrix row.
> 
> The new step parses the runner’s `rustc --version` in a portable way (avoiding `sort -V` on BSD) and runs `rustup update stable && rustup default stable` only when the detected version is below `1.95.0`, leaving other targets unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587fa93b7ef74732d34ffaeb3c8f05b461fd1c71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->