### PR TITLE
ci(release): try GitHub-hosted macos-arm64 runner for PGO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,17 @@ jobs:
             build-tool: cargo
           - target: aarch64-apple-darwin
             os: macos-latest
-            runner: namespace-profile-endev-macos-arm64-large
+            # Trying GitHub's own Apple Silicon runner (12 vCPU / 30 GB)
+            # — the namespace `macos-arm64-large` image segfaulted the
+            # PGO-instrumented binary on both rustc 1.94 and 1.95. #589
+            # was supposed to rule out a 1.94 codegen bug; the upgrade
+            # fired but training still SIGSEGV'd, so the toolchain isn't
+            # it. Switch to GH's hosted runner to test whether the
+            # crash is something image- or hardware-specific to the
+            # namespace fleet (older Apple silicon, custom kernel/Xcode
+            # bundle, sandbox differences) before dropping macOS arm64
+            # from the PGO matrix entirely.
+            runner: macos-latest-large
             build-tool: cargo
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,17 +205,16 @@ jobs:
             build-tool: cargo
           - target: aarch64-apple-darwin
             os: macos-latest
-            # Trying GitHub's own Apple Silicon runner (12 vCPU / 30 GB)
-            # — the namespace `macos-arm64-large` image segfaulted the
-            # PGO-instrumented binary on both rustc 1.94 and 1.95. #589
-            # was supposed to rule out a 1.94 codegen bug; the upgrade
-            # fired but training still SIGSEGV'd, so the toolchain isn't
-            # it. Switch to GH's hosted runner to test whether the
-            # crash is something image- or hardware-specific to the
-            # namespace fleet (older Apple silicon, custom kernel/Xcode
-            # bundle, sandbox differences) before dropping macOS arm64
-            # from the PGO matrix entirely.
-            runner: macos-latest-large
+            # Trying GitHub's standard Apple Silicon runner — the
+            # namespace `macos-arm64-large` image segfaulted the
+            # PGO-instrumented binary on both rustc 1.94 and 1.95
+            # (#589's rustup bump fired but training still SIGSEGV'd,
+            # so the toolchain isn't the variable). Switch to GH's
+            # hosted runner to test whether the crash is image- or
+            # hardware-specific to the namespace fleet (older Apple
+            # silicon, custom kernel/Xcode bundle, sandbox quirks)
+            # before dropping macOS arm64 from the PGO matrix entirely.
+            runner: macos-latest
             build-tool: cargo
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,10 @@ jobs:
   upload-assets-pgo:
     needs: generate-primer
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 75
+    # 180 to cover macos-latest (3 vCPU) which needs ~80 min for two
+    # fat-LTO compiles. Linux PGO on -large runners completes in well
+    # under 75, so the extra headroom is dead slack for them.
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,13 @@ jobs:
           else
             echo "rustc $current already >= 1.95.0; no upgrade needed"
           fi
+          # GH macos-latest-large defaults to an x86_64-apple-darwin
+          # host rustc (Rosetta) — `--target=aarch64-apple-darwin`
+          # from pgo.bash then triggers a cross-compile that needs the
+          # arm64 std lib explicitly installed. Idempotent on namespace
+          # runners where the target is already present.
+          rustup target add aarch64-apple-darwin
+          rustup show
       - name: Install rustup llvm-tools-preview
         shell: bash
         run: rustup component add llvm-tools-preview


### PR DESCRIPTION
## Summary

The namespace \`macos-arm64-large\` runner has SIGSEGV'd the PGO-instrumented \`aube install\` binary across **both** rustc 1.94 and rustc 1.95 — see [dry-run 25644281405](https://github.com/endevco/aube/actions/runs/25644281405) where [#589](https://github.com/endevco/aube/pull/589)'s rustup bump fired correctly (log shows \`1.94.1 → 1.95.0\`) yet training still segfaulted on first \`aube install\`. So the toolchain isn't the variable.

Working theory: something image- or hardware-specific to the namespace fleet. Older Apple silicon generation, custom Xcode/kernel bundle, or sandbox quirks could all explain why my local box (Apple M4 / macOS 26 / rustc 1.95.0) runs the same source clean while namespace's runner segfaults.

This PR swaps the \`aarch64-apple-darwin\` PGO matrix entry to GitHub's hosted \`macos-latest-large\` (12 vCPU / 30 GB Apple Silicon, same class as namespace's). Two outcomes either way:

- **Crash gone** → bug was in namespace's image; we stay on GH-hosted for this target.
- **Crash reproduces** → bug is in our PGO + mimalloc + whatever Apple silicon generation GH hosts, and we drop macOS arm64 from PGO entirely.

## Test plan

Dispatch dry-run against this branch directly (no merge needed):

\`\`\`sh
gh workflow run release.yml \\
  --ref claude/macos-gh-runner \\
  -f tag=dryrun-macos-gh \\
  -f ref=claude/macos-gh-runner \\
  -f dry_run=true
\`\`\`

Watch \`upload-assets-pgo (aarch64-apple-darwin)\`. If it produces an archive, merge this. If it segfaults, abandon and follow up with a drop-from-PGO PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts the release workflow’s PGO build environment and timeouts, which can impact macOS arm64 artifact correctness and overall release job reliability/duration.
> 
> **Overview**
> Moves the `aarch64-apple-darwin` entry in the `upload-assets-pgo` matrix from the namespace macOS runner to GitHub’s `macos-latest` runner to isolate recurring PGO training SIGSEGVs.
> 
> Increases `upload-assets-pgo` `timeout-minutes` to `180` and adds a macOS-arm64-specific rust toolchain step to install the `aarch64-apple-darwin` target (plus `rustup show`) to handle Rosetta/x86_64 host toolchains on GitHub runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7bd8fe91fdc6f84bf871840b4ffe8d349d9d15c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->