### PR TITLE
fix(registry): retry initial request in start_tarball_stream

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -1789,12 +1789,16 @@ impl RegistryClient {
 
     /// Start a streaming tarball fetch. Returns the live reqwest
     /// Response so the caller can pull `chunk()` futures and pipe them
-    /// through gz+tar+CAS without buffering the full body. Caller must
-    /// enforce the body cap and retries (we skip retry here because
-    /// once chunks have started flowing into the importer, restarting
-    /// the request would require unwinding partial CAS writes).
-    /// Caller should fall back to fetch_tarball_bytes_streaming_sha512
-    /// on error if a retried buffered fetch is desired.
+    /// through gz+tar+CAS without buffering the full body.
+    ///
+    /// Retries the *initial* request on transient failures (5xx, 429,
+    /// connection errors) using `fetch_policy.retries` attempts with
+    /// exponential backoff. Once chunks start flowing the caller owns
+    /// stream-level errors — restarting mid-body would require
+    /// unwinding partial CAS writes — so the caller should fall back
+    /// to `fetch_tarball_bytes_streaming_sha512` (which retries the
+    /// full body cleanly via a buffered fetch) if a mid-stream error
+    /// needs another attempt.
     pub async fn start_tarball_stream(&self, url: &str) -> Result<reqwest::Response, Error> {
         let _diag =
             aube_util::diag::Span::new(aube_util::diag::Category::Registry, "tarball_stream_open")
@@ -1818,14 +1822,66 @@ impl RegistryClient {
         if self.network_mode == NetworkMode::Offline {
             return Err(Error::Offline(format!("tarball {safe_url}")));
         }
-        let resp = self
-            .authed_tarball_get(url, url)
-            .header(reqwest::header::ACCEPT_ENCODING, "identity")
-            .send()
-            .await?;
-        let resp = resp.error_for_status()?;
-        check_body_cap(&resp, self.fetch_policy.tarball_max_bytes, "tarball")?;
-        Ok(resp)
+
+        let label = format!("tarball {safe_url}");
+        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        let mut timeout_retries: u32 = 0;
+        for attempt in 0..max_attempts {
+            let is_last = attempt + 1 >= max_attempts;
+            let result = self
+                .authed_tarball_get(url, url)
+                .header(reqwest::header::ACCEPT_ENCODING, "identity")
+                .send()
+                .await;
+            match result {
+                Ok(resp) if is_retriable_status(resp.status()) && !is_last => {
+                    let wait = retry_after_from(&resp)
+                        .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        status = resp.status().as_u16(),
+                        label = label.as_str(),
+                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
+                        "retrying HTTP request after transient failure",
+                    );
+                    drop(resp);
+                    tokio::time::sleep(wait).await;
+                }
+                Ok(resp) => {
+                    let resp = resp.error_for_status()?;
+                    check_body_cap(&resp, self.fetch_policy.tarball_max_bytes, "tarball")?;
+                    return Ok(resp);
+                }
+                Err(err) if !is_last => {
+                    if err.is_timeout() {
+                        if timeout_retries >= TIMEOUT_RETRY_CAP {
+                            return Err(Error::Http(err));
+                        }
+                        timeout_retries += 1;
+                    }
+                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        error = %err,
+                        label = label.as_str(),
+                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSPORT,
+                        "retrying HTTP request after transport error",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Err(err) => return Err(Error::Http(err)),
+            }
+        }
+        // FetchPolicy::retries is `u32`, so `max_attempts =
+        // retries + 1` is always ≥ 1 and the loop runs at least once;
+        // every path inside the loop either returns or continues. An
+        // exit past this point is a structural bug, not a runtime
+        // input the caller can provoke.
+        unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
     }
 
     /// Tarball body cap, surfaced so the streaming caller can enforce
@@ -2986,6 +3042,47 @@ mod retry_tests {
             .await
             .expect("tarball fetch should succeed");
         assert_eq!(&bytes[..], b"tgz bytes");
+    }
+
+    #[tokio::test]
+    async fn start_tarball_stream_retries_on_503_then_succeeds() {
+        // Streaming tarball fetch used to skip retry entirely — a single
+        // 503/connect-time hiccup from the registry would propagate
+        // straight back to the caller. The initial-request retry covers
+        // 5xx + transport errors before any chunks have streamed, while
+        // still leaving mid-stream errors to the caller (which falls
+        // back to the buffered fetch_tarball_bytes_streaming_sha512 path).
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pkg.tgz"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/pkg.tgz"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"tgz bytes".to_vec()))
+            .mount(&server)
+            .await;
+
+        let policy = FetchPolicy {
+            timeout_ms: 5_000,
+            retries: 2,
+            retry_factor: 1,
+            retry_min_timeout_ms: 1,
+            retry_max_timeout_ms: 1,
+            ..FetchPolicy::default()
+        };
+        let client = client_with(&server, policy);
+        let url = format!("{}/pkg.tgz", server.uri());
+        let resp = client
+            .start_tarball_stream(&url)
+            .await
+            .expect("retry recovery");
+        assert_eq!(resp.status(), 200);
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 3, "expected 3 attempts (2 retries)");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The default install hot path uses streaming tarball fetch via [`fetch_and_import_tarball_streaming`](crates/aube/src/commands/install/lifecycle.rs:804) → [`start_tarball_stream`](crates/aube-registry/src/client.rs:1798). That function used to skip retry entirely:

> "we skip retry here because once chunks have started flowing into the importer, restarting the request would require unwinding partial CAS writes"

The reasoning is right for **mid-stream** errors — partial CAS writes are real. But it also leaked into **pre-response** failures. A 503, 429, connection refused, or connection reset *before any chunk has flowed* propagated straight back to the caller with no recovery. The buffered path (`fetch_tarball_bytes` / `_streaming_sha512`) retries the same kind of failure up to `fetchRetries` times; the streaming path didn't, for no good reason.

Caught this on a macOS-latest PGO dry-run ([run 25644830509](https://github.com/endevco/aube/actions/runs/25644830509/job/75271726951)): Verdaccio / throttle-proxy hiccupped, reqwest returned `error sending request for url`, and the install bailed without a single retry log line.

## Fix

Wrap the initial `.send().await` in `start_tarball_stream` in the same retry shape used by `retry_bytes_body_read_streaming_sha512`:

- Retry on `is_retriable_status` (5xx + 429), honoring `Retry-After`.
- Retry on transport `Err(reqwest::Error)`, bounded by `TIMEOUT_RETRY_CAP` for timeouts.
- Emit the existing `WARN_AUBE_HTTP_RETRY_TRANSIENT` / `_TRANSPORT` logs so users see retry activity.
- Once `error_for_status` + `check_body_cap` pass, return immediately — at that point chunks start flowing and the mid-stream-restart hazard kicks in.

The doc comment now spells out the retry boundary explicitly: initial request = retried; mid-stream = caller falls back to the buffered streaming fetcher.

## Test

New unittest `start_tarball_stream_retries_on_503_then_succeeds` covers 503 → 503 → 200 against `start_tarball_stream`, mirroring the existing `retries_on_503_then_succeeds` for `fetch_packument`. Full crate test suite: 128 passing, 0 failing.

## Affected paths

- Every `aube install` against an sha512-prefixed lockfile entry — i.e. the modern default. (Path is gated on `AUBE_DISABLE_TARBALL_STREAM=1`; that env-var-disabled fallback already uses `fetch_tarball_bytes` which retries.)
- Resilience to transient registry / mirror / proxy hiccups during cold installs in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tarball streaming fetch behavior to perform retry/backoff on initial request failures, which can alter install latency and request volume under transient registry errors.
> 
> **Overview**
> Improves resilience of streaming tarball downloads by adding retry/backoff around the initial `start_tarball_stream` request for transient HTTP statuses (5xx/429, honoring `Retry-After`) and transport errors (with the existing timeout retry cap), while still leaving mid-stream failures to the caller.
> 
> Updates the method docs to clarify the retry boundary and adds a wiremock test covering `503 → 503 → 200` recovery and expected attempt count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29c872f8117cf4d525b80149597af56f031a4dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->