### PR TITLE
fix(bench): pin yarn enableImmutableInstalls=false in bench warm

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -236,6 +236,12 @@ for i in "${!TOOLS[@]}"; do
 			printf "enableGlobalCache: false\n"
 			printf "enableTelemetry: false\n"
 			printf "enableScripts: false\n"
+			# Yarn 4 auto-enables immutable installs when it detects
+			# `CI=true`, which makes the warm step refuse to create
+			# the initial lockfile (YN0028) and crashes bench-refresh.
+			# Pin the flag off so the warm install can populate the
+			# lockfile + cache + store the same way it does locally.
+			printf "enableImmutableInstalls: false\n"
 		} >"$dir/.yarnrc.yml"
 	fi
 


### PR DESCRIPTION
## Summary

The daily `bench-refresh` cron has been failing on the yarn warm step:

```
Populating store and cache for yarn...
Yarn 4.14.1
YN0028: The lockfile would have been created by this install, which is explicitly forbidden.
Failed with errors in 0s 10ms
```

Yarn 4 auto-enables `enableImmutableInstalls` when it detects `CI=true`, then refuses to create the initial `yarn.lock` during the bench warm install. Locally there is no `CI` env var, so this only ever surfaced in GitHub Actions — which is exactly where the cron runs.

`benchmarks/bench.sh` already pins `nodeLinker`, `cacheFolder`, `enableGlobalCache`, `enableTelemetry`, `enableScripts` in the generated `.yarnrc.yml`. Add `enableImmutableInstalls: false` to the same block so the warm step matches local behavior.

Failing run for reference: https://github.com/endevco/aube/actions/runs/25642167176/job/75264364692

## Test plan

- [x] `shellcheck benchmarks/bench.sh` passes
- [ ] Next scheduled `bench-refresh` run (or `workflow_dispatch`) completes the yarn warm step instead of dying at YN0028

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small benchmark-script config change that only affects Yarn’s warm-install behavior in CI to avoid lockfile-creation failures.
> 
> **Overview**
> Fixes `bench-refresh` failures for Yarn 4 in CI by updating the generated `.yarnrc.yml` to set `enableImmutableInstalls: false` during the warm populate step, allowing Yarn to create the initial `yarn.lock` and fill caches/stores before the benchmark matrix runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2faff51e0e76c0f2b85769d54e1509a44918f7d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->