### PR TITLE
fix(bench): pin yarn enableImmutableInstalls=false in warm step

### DIFF
--- a/benchmarks/hermetic.bash
+++ b/benchmarks/hermetic.bash
@@ -209,6 +209,13 @@ _hermetic_warm() {
 				printf 'cacheFolder: "%s/yarn-cache"\n' "$pm_dir/home"
 				printf 'npmRegistryServer: "%s"\n' "$reg"
 				printf 'unsafeHttpWhitelist:\n  - 127.0.0.1\n  - localhost\n'
+				# Yarn 4 auto-enables immutable installs when `CI=true`,
+				# refusing to create the initial `yarn.lock` and failing
+				# the warm step with YN0028. Without this the warm cache
+				# misses transitive tarballs (e.g. node-gyp), and later
+				# bench steps that ask for them 404 against Verdaccio.
+				# Sibling fix for the bench.sh-side yarnrc in PR #594.
+				printf 'enableImmutableInstalls: false\n'
 			} >"$pm_dir/.yarnrc.yml"
 		fi
 		if ! (cd "$pm_dir" && HOME="$pm_dir/home" \


### PR DESCRIPTION
## Summary

Follow-up to #594. That PR fixed the Yarn 4 + `CI=true` immutable-install trap in `benchmarks/bench.sh`'s generated `.yarnrc.yml`, but the warm-cache step in `benchmarks/hermetic.bash` generates a parallel `.yarnrc.yml` for the *same purpose* and was missed.

Cascade in the latest `bench-refresh` cron:

1. Warm step's `yarn install` against Verdaccio fails with `YN0028: The lockfile would have been created by this install, which is explicitly forbidden.` because yarn auto-enabled immutable mode on `CI=true`.
2. Warm cache exits with a `WARN: warm with yarn failed (continuing)` and never populates yarn's transitive tarballs (`node-gyp`, etc.).
3. Downstream bench step's `yarn install` against the same Verdaccio re-resolves those packages and 404s: `YN0035: node-gyp@npm:latest: Package not found`.
4. `bench:bump` task exits non-zero.

Add `enableImmutableInstalls: false` to the warm step's `.yarnrc.yml` so it matches the bench.sh-side flag set.

Failing run: https://github.com/endevco/aube/actions/runs/25658644681/job/75313299011

## Test plan

- [x] `shellcheck benchmarks/hermetic.bash` passes
- [ ] Next scheduled `bench-refresh` (or `workflow_dispatch`) completes the yarn warm step instead of dying with YN0028, and the downstream bench step finds node-gyp in cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: benchmark-only change that adjusts Yarn warm-cache configuration to avoid CI-specific install failures, without impacting production code paths.
> 
> **Overview**
> Fixes the hermetic benchmark warm-cache step for Yarn 4 under `CI=true` by writing `enableImmutableInstalls: false` into the generated `.yarnrc.yml`.
> 
> This prevents the warm `yarn install` from failing before it can create `yarn.lock`, improving cache completeness so later offline/verdaccio-backed benchmark installs don’t hit 404s for transitive tarballs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a77da311d3e7fa3f6e2a994f8ba201e9faa378b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->