### PR TITLE
fix(install): probe link strategy against the actual destination dir

### DIFF
--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -228,37 +228,71 @@ fn resolve_jail_grant_path(project_dir: &std::path::Path, raw: &str) -> std::pat
 /// override, `.npmrc` / `pnpm-workspace.yaml`, or filesystem detection.
 /// Shared by the prewarm-GVS materializer (which needs the strategy
 /// before the full linker is built) and the link phase proper.
+///
+/// `planned_gvs` tells the probe where the linker will actually write
+/// files: when GVS is on, materialization targets the GVS dir (always
+/// on the cache-store FS), and `node_modules/.aube/<dep_path>` is a
+/// cross-FS-tolerant symlink. When GVS is off, materialization writes
+/// straight into the project's `.aube/<dep_path>`. Probing the
+/// destination the writes will hit avoids the cross-FS Copy verdict
+/// that would otherwise mis-fire on an install where the project
+/// lives on a different volume than the store but the GVS layer
+/// already absorbs the FS boundary as a symlink.
 pub(super) fn resolve_link_strategy(
     cwd: &std::path::Path,
     ctx: &aube_settings::ResolveCtx<'_>,
+    planned_gvs: bool,
 ) -> miette::Result<aube_linker::LinkStrategy> {
     let package_import_method_cli =
         aube_settings::values::string_from_cli("packageImportMethod", ctx.cli);
     // Shared probe used by both the CLI and resolved-setting paths
-    // below. Probe across store dir and project dir. Single-dir probe
-    // reports reflink but real link ops across a mount boundary hit
-    // EXDEV and silently fall back to per-file copy. Catches the
-    // cross-FS case at probe time without requiring node_modules to
-    // exist yet.
+    // below. The destination passed to `detect_strategy_cross` is the
+    // dir the linker will materialize files into:
+    //   * GVS enabled → `<store>/virtual-store/` (same FS as store →
+    //     hardlink works even when the *project* is on another mount;
+    //     the cross-FS hop is absorbed by the symlink from
+    //     `node_modules/.aube/<dep_path>`).
+    //   * GVS disabled → the project's `.aube/<dep_path>` lives on
+    //     the project FS, so probe against `cwd` to catch the cross-
+    //     FS case before every file `fs::copy` silently falls back.
     let auto_probe = || {
         let store_dir = super::super::open_store(cwd)
             .map(|s| s.root().to_path_buf())
             .ok();
+        let gvs_dir = planned_gvs
+            .then(|| {
+                super::super::open_store(cwd)
+                    .map(|s| s.virtual_store_dir())
+                    .ok()
+            })
+            .flatten();
+        // Probe against the GVS dir when GVS is on; that dir won't
+        // exist yet on a cold install, so make sure its parent
+        // chain is present before the probe writes its test file.
+        if let Some(gvs) = gvs_dir.as_deref() {
+            let _ = std::fs::create_dir_all(gvs);
+        }
+        let probe_dst = gvs_dir.as_deref().unwrap_or(cwd);
         let strategy = match store_dir.as_deref() {
-            Some(sd) => aube_linker::Linker::detect_strategy_cross(sd, cwd),
-            None => aube_linker::Linker::detect_strategy(cwd),
+            Some(sd) => aube_linker::Linker::detect_strategy_cross(sd, probe_dst),
+            None => aube_linker::Linker::detect_strategy(probe_dst),
         };
-        // Cross-volume install hits Copy fallback because hardlink
-        // and reflink can't cross device boundaries. aube still
-        // outperforms other PMs in this regime, so just log at debug
-        // for diagnosis without spamming WARN at every invocation.
+        // With GVS off, a cross-volume install hits Copy fallback
+        // because hardlink and reflink can't cross device boundaries.
+        // aube still outperforms other PMs in this regime, so just log
+        // at debug for diagnosis without spamming WARN at every
+        // invocation. With GVS on, the probe targets the GVS dir
+        // (always same FS as the store), so Copy here means the *cache
+        // store* itself is on a different volume than the chosen GVS
+        // dir — a real misconfiguration the user should hear about.
         if matches!(strategy, aube_linker::LinkStrategy::Copy)
             && let Some(sd) = store_dir.as_deref()
-            && aube_util::fs::cross_volume(sd, cwd)
+            && aube_util::fs::cross_volume(sd, probe_dst)
         {
             tracing::debug!(
                 store = %sd.display(),
                 project = %cwd.display(),
+                probe_dst = %probe_dst.display(),
                 "cross-volume install, using per-file copy. set `storeDir` to a path on the project volume for hardlink fast path."
             );
         }

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -256,45 +256,55 @@ pub(super) fn resolve_link_strategy(
     //     the project FS, so probe against `cwd` to catch the cross-
     //     FS case before every file `fs::copy` silently falls back.
     let auto_probe = || {
-        let store_dir = super::super::open_store(cwd)
-            .map(|s| s.root().to_path_buf())
-            .ok();
+        // Open the store once and derive both paths from the same
+        // handle. `open_store` performs lockfile + IO work; a second
+        // call to fetch `virtual_store_dir` would repeat that on the
+        // hot path of every `auto`-mode install.
+        let store = super::super::open_store(cwd).ok();
+        let store_dir = store.as_ref().map(|s| s.root().to_path_buf());
+        // Probe against the GVS dir when GVS is on. The GVS dir won't
+        // exist yet on a cold install, so create it before the probe
+        // writes its test file. If creation fails (permission, ENOSPC,
+        // …) `gvs_dir` falls back to `None` so the probe targets `cwd`
+        // — better to under-probe than to probe a non-existent dir and
+        // get a spurious `Copy` verdict.
         let gvs_dir = planned_gvs
-            .then(|| {
-                super::super::open_store(cwd)
-                    .map(|s| s.virtual_store_dir())
-                    .ok()
-            })
-            .flatten();
-        // Probe against the GVS dir when GVS is on; that dir won't
-        // exist yet on a cold install, so make sure its parent
-        // chain is present before the probe writes its test file.
-        if let Some(gvs) = gvs_dir.as_deref() {
-            let _ = std::fs::create_dir_all(gvs);
-        }
+            .then(|| store.as_ref().map(|s| s.virtual_store_dir()))
+            .flatten()
+            .filter(|gvs| std::fs::create_dir_all(gvs).is_ok());
         let probe_dst = gvs_dir.as_deref().unwrap_or(cwd);
         let strategy = match store_dir.as_deref() {
             Some(sd) => aube_linker::Linker::detect_strategy_cross(sd, probe_dst),
             None => aube_linker::Linker::detect_strategy(probe_dst),
         };
-        // With GVS off, a cross-volume install hits Copy fallback
-        // because hardlink and reflink can't cross device boundaries.
-        // aube still outperforms other PMs in this regime, so just log
-        // at debug for diagnosis without spamming WARN at every
-        // invocation. With GVS on, the probe targets the GVS dir
-        // (always same FS as the store), so Copy here means the *cache
-        // store* itself is on a different volume than the chosen GVS
-        // dir — a real misconfiguration the user should hear about.
+        // Two distinct cross-volume regimes, two different messages.
+        // With GVS on, the probe targets the GVS dir (always same FS
+        // as the store in a sane setup), so Copy here means the user
+        // pointed `storeDir` and `XDG_CACHE_HOME` at different volumes
+        // — a real misconfiguration that costs per-file copies. Warn.
+        // With GVS off, the probe targets `cwd`; a cross-volume verdict
+        // there is the documented "project lives on an external mount"
+        // regime where aube still outperforms other PMs, so log at
+        // debug to keep the warning out of normal install output.
         if matches!(strategy, aube_linker::LinkStrategy::Copy)
             && let Some(sd) = store_dir.as_deref()
             && aube_util::fs::cross_volume(sd, probe_dst)
         {
-            tracing::debug!(
-                store = %sd.display(),
-                project = %cwd.display(),
-                probe_dst = %probe_dst.display(),
-                "cross-volume install, using per-file copy. set `storeDir` to a path on the project volume for hardlink fast path."
-            );
+            if gvs_dir.is_some() {
+                tracing::warn!(
+                    store = %sd.display(),
+                    gvs_dir = %probe_dst.display(),
+                    "global virtual store dir is on a different volume than `storeDir`; \
+                     install will fall back to per-file copy. Move `XDG_CACHE_HOME` \
+                     (or `storeDir`) so both live on the same volume."
+                );
+            } else {
+                tracing::debug!(
+                    store = %sd.display(),
+                    project = %cwd.display(),
+                    "cross-volume install, using per-file copy. set `storeDir` to a path on the project volume for hardlink fast path."
+                );
+            }
         }
         strategy
     };

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3205,7 +3205,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 aube_settings::resolved::node_version(&settings_ctx).as_deref(),
             );
             let lock_build_policy = std::sync::Arc::new(build_policy.clone());
-            let lock_strategy = resolve_link_strategy(&cwd, &settings_ctx)?;
+            let lock_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
             let (lock_patches, lock_patch_hashes) = crate::patches::load_patches_for_linker(&cwd)?;
             let (lock_materialize_tx, lock_materialize_rx) = materialize_channel();
             let lock_prewarm_inputs = GvsPrewarmInputs {
@@ -3848,7 +3848,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // the per-project .aube/<dep_path> symlink.
             let materialize_phase_start = std::time::Instant::now();
             let materialize_graph_arc = std::sync::Arc::new(graph.clone());
-            let materialize_strategy = resolve_link_strategy(&cwd, &settings_ctx)?;
+            let materialize_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
             let (materialize_patches, materialize_patch_hashes) =
                 crate::patches::load_patches_for_linker(&cwd)?;
             let materialize_inputs = GvsPrewarmInputs {
@@ -4231,7 +4231,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // diagnostic). Settings-file values flow through the generated typed
     // accessor, which collapses unknown values to `None` so they behave
     // like an absent setting.
-    let strategy = resolve_link_strategy(&cwd, &settings_ctx)?;
+    let strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
     if let Some(p) = prog_ref {
         p.set_phase("linking");
     }


### PR DESCRIPTION
## Summary

`resolve_link_strategy`'s `auto` probe always called `Linker::detect_strategy_cross(store_dir, cwd)`. But when GVS is enabled (the default outside CI) the linker materializes files into `<store>/virtual-store/<subdir>` — same FS as the store — and `node_modules/.aube/<dep_path>` is a plain symlink that doesn't care about FS boundaries.

On a cross-FS install (project on `/mnt/external`, store on `/home`), the probe saw the cross-volume boundary against `cwd`, returned `Copy`, and the linker did per-file `fs::copy` for writes that would have happily hardlinked (`/home → /home`). The cross-FS hop was already absorbed by the symlink; the probe just didn't know.

Pass `planned_gvs` through to the probe so it targets the dir the writes will actually hit:

- **GVS on** → probe `(store_dir, gvs_dir)`. Both on the cache-store FS in practice, so the probe returns `Hardlink` and materialization runs as a clean hardlink chain. The cross-FS hop stays a free symlink.
- **GVS off** (CI, explicit disable, GVS-incompatible workspace) → probe `(store_dir, cwd)` as today. Materialization writes straight into the project's `.aube/<dep_path>`, so the cross-FS Copy verdict is correct.

`planned_gvs` is already computed at install/mod.rs:2907; the three `resolve_link_strategy` call sites in install/mod.rs (lock-fast-path, fresh-resolve, link-phase) all have it in scope.

Probing the GVS dir requires the dir to exist (the probe writes a test file); a `create_dir_all(gvs)` is added before the probe — idempotent, and we'd create the dir during materialization anyway.

Edge case: `XDG_CACHE_HOME` on a different volume than `XDG_DATA_HOME`. The probe would say `Hardlink` and the in-loop EXDEV fallback in `link_file_fresh` would still degrade to `fs::copy` correctly. Same safety net as today.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` passes
- [ ] Manual cross-FS smoke: project on a non-`$HOME` volume, run `aube install`, confirm per-file `fs::copy` is gone (visible via `diag` linker events — `link_hardlink` should dominate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)