### PR TITLE
fix(config): preserve symlinked ~/.config/aube/config.toml on write

### DIFF
--- a/crates/aube/src/commands/config/aube_config.rs
+++ b/crates/aube/src/commands/config/aube_config.rs
@@ -1,4 +1,5 @@
 use super::{literal_aliases, setting_for_key, settings_meta};
+use crate::commands::npmrc::symlink_target_or_self;
 use miette::{Context, IntoDiagnostic, miette};
 use std::path::{Path, PathBuf};
 
@@ -63,9 +64,14 @@ impl AubeConfigEdit {
         let out = toml::to_string_pretty(&self.table)
             .into_diagnostic()
             .wrap_err("failed to serialize aube config")?;
-        aube_util::fs_atomic::atomic_write(path, out.as_bytes())
+        // Follow symlinks so a user-managed `~/.config/aube/config.toml`
+        // pointing at e.g. a dotfiles repo keeps its symlink intact;
+        // atomic_write renames a sibling temp over the path, which
+        // would otherwise replace the symlink with a regular file.
+        let write_path = symlink_target_or_self(path).into_diagnostic()?;
+        aube_util::fs_atomic::atomic_write(&write_path, out.as_bytes())
             .into_diagnostic()
-            .wrap_err_with(|| format!("failed to write {}", path.display()))
+            .wrap_err_with(|| format!("failed to write {}", write_path.display()))
     }
 }
 
@@ -175,5 +181,30 @@ mod tests {
             edit.entries(),
             vec![("minimumReleaseAge".to_string(), "2880".to_string())]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_preserves_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real-config.toml");
+        let link = dir.path().join("config.toml");
+        std::fs::write(&real, "minimumReleaseAge = 1\n").unwrap();
+        std::os::unix::fs::symlink("real-config.toml", &link).unwrap();
+
+        let meta = settings_meta::find("minimumReleaseAge").unwrap();
+        let mut edit = AubeConfigEdit::load(&link).unwrap();
+        edit.set(meta, "2880").unwrap();
+        edit.save(&link).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "save replaced the symlink instead of following it"
+        );
+        let written = std::fs::read_to_string(&real).unwrap();
+        assert!(written.contains("minimumReleaseAge = 2880"));
     }
 }

--- a/crates/aube/src/commands/npmrc.rs
+++ b/crates/aube/src/commands/npmrc.rs
@@ -149,7 +149,7 @@ impl NpmrcEdit {
     }
 }
 
-fn symlink_target_or_self(path: &Path) -> std::io::Result<PathBuf> {
+pub(crate) fn symlink_target_or_self(path: &Path) -> std::io::Result<PathBuf> {
     let Ok(meta) = std::fs::symlink_metadata(path) else {
         return Ok(path.to_path_buf());
     };


### PR DESCRIPTION
## Summary

- `aube config set/delete` wrote into a sibling temp file and renamed it over the path, which replaced a symlinked `~/.config/aube/config.toml` with a regular file
- Resolve the symlink target before calling `atomic_write`, mirroring the fix [#517](https://github.com/endevco/aube/pull/517) shipped for `~/.npmrc`
- Expose `symlink_target_or_self` as `pub(crate)` in `npmrc.rs` so `aube_config.rs` can reuse it without duplicating

Closes [#603](https://github.com/endevco/aube/discussions/603).

## Test plan

- [x] `cargo test -p aube commands::config::aube_config` — new `save_preserves_symlink` test passes
- [x] `cargo test -p aube commands::npmrc::tests::save_preserves_symlink` — existing npmrc symlink test still passes
- [x] `cargo clippy -p aube --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly changes the write path resolution for `aube config` saves and adds a Unix-only regression test; behavior for non-symlink paths should remain unchanged.
> 
> **Overview**
> `aube config` writes now preserve a symlinked `~/.config/aube/config.toml` by resolving `path` to its symlink target before calling `atomic_write`, avoiding replacing the symlink with a regular file during rename-based atomic saves.
> 
> The existing `npmrc` helper `symlink_target_or_self` is made `pub(crate)` for reuse, and a Unix-only test is added to assert symlink preservation and correct content updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99215e360f5f1d95bb5aa0b4d3942470a2e4b324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->