### PR TITLE
feat(deploy): accept --offline and --prefer-offline

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -453,6 +453,10 @@ cmd deploy help="Deploy a workspace package into a target directory with deps in
     flag --no-prod help="Deploy every dependency kind (production + dev + optional)" {
         long_help "Deploy every dependency kind (production + dev + optional).\n\nOpts out of the implicit `--prod` deploy default. Useful when a deployed package needs its devDependencies at runtime (test harnesses, build-step deploys). Combine with `--no-optional` to drop optionals while keeping prod + dev. Mutually exclusive with `--prod` and `--dev`."
     }
+    flag --offline help="Fail if any metadata or tarball isn't already in the local cache" {
+        long_help "Fail if any metadata or tarball isn't already in the local cache.\n\nNever hits the network. Useful in multi-stage Dockerfiles where an earlier `aube install` already populated the store: deploy then reproduces a prod-only tree without re-fetching anything."
+    }
+    flag --prefer-offline help="Prefer cached metadata over revalidation; only hit the network on a miss"
     flag --frozen-lockfile help="Error if the lockfile drifts from package.json"
     flag --no-frozen-lockfile help="Always re-resolve, even if the lockfile is up to date"
     flag --prefer-frozen-lockfile help="Use the lockfile when fresh, re-resolve when stale"

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -83,6 +83,16 @@ pub struct DeployArgs {
     /// `--prod` and `--dev`.
     #[arg(long, conflicts_with_all = ["prod", "dev"])]
     pub no_prod: bool,
+    /// Fail if any metadata or tarball isn't already in the local cache.
+    ///
+    /// Never hits the network. Useful in multi-stage Dockerfiles where
+    /// an earlier `aube install` already populated the store: deploy
+    /// then reproduces a prod-only tree without re-fetching anything.
+    #[arg(long, conflicts_with = "prefer_offline")]
+    pub offline: bool,
+    /// Prefer cached metadata over revalidation; only hit the network on a miss.
+    #[arg(long, conflicts_with = "offline")]
+    pub prefer_offline: bool,
     #[command(flatten)]
     pub lockfile: crate::cli_args::LockfileArgs,
     #[command(flatten)]
@@ -278,6 +288,13 @@ pub async fn run(
         } else {
             FrozenMode::No
         };
+        let network_mode = if args.offline {
+            aube_registry::NetworkMode::Offline
+        } else if args.prefer_offline {
+            aube_registry::NetworkMode::PreferOffline
+        } else {
+            aube_registry::NetworkMode::Online
+        };
         let opts = InstallOptions {
             project_dir: Some(s.target.clone()),
             mode,
@@ -289,7 +306,7 @@ pub async fn run(
             lockfile_only: false,
             merge_git_branch_lockfiles: false,
             dangerously_allow_all_builds: false,
-            network_mode: aube_registry::NetworkMode::Online,
+            network_mode,
             minimum_release_age_override: None,
             strict_no_lockfile: false,
             force: false,
@@ -1350,6 +1367,8 @@ mod tests {
             no_optional: false,
             prod: false,
             no_prod: false,
+            offline: false,
+            prefer_offline: false,
             lockfile: crate::cli_args::LockfileArgs::default(),
             network: crate::cli_args::NetworkArgs::default(),
             virtual_store: crate::cli_args::VirtualStoreArgs::default(),

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2335,6 +2335,31 @@
             "global": false
           },
           {
+            "name": "offline",
+            "usage": "--offline",
+            "help": "Fail if any metadata or tarball isn't already in the local cache",
+            "help_long": "Fail if any metadata or tarball isn't already in the local cache.\n\nNever hits the network. Useful in multi-stage Dockerfiles where an earlier `aube install` already populated the store: deploy then reproduces a prod-only tree without re-fetching anything.",
+            "help_first_line": "Fail if any metadata or tarball isn't already in the local cache",
+            "short": [],
+            "long": [
+              "offline"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "prefer-offline",
+            "usage": "--prefer-offline",
+            "help": "Prefer cached metadata over revalidation; only hit the network on a miss",
+            "help_first_line": "Prefer cached metadata over revalidation; only hit the network on a miss",
+            "short": [],
+            "long": [
+              "prefer-offline"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "frozen-lockfile",
             "usage": "--frozen-lockfile",
             "help": "Error if the lockfile drifts from package.json",

--- a/docs/cli/deploy.md
+++ b/docs/cli/deploy.md
@@ -37,6 +37,16 @@ Deploy every dependency kind (production + dev + optional).
 
 Opts out of the implicit `--prod` deploy default. Useful when a deployed package needs its devDependencies at runtime (test harnesses, build-step deploys). Combine with `--no-optional` to drop optionals while keeping prod + dev. Mutually exclusive with `--prod` and `--dev`.
 
+### `--offline`
+
+Fail if any metadata or tarball isn't already in the local cache.
+
+Never hits the network. Useful in multi-stage Dockerfiles where an earlier `aube install` already populated the store: deploy then reproduces a prod-only tree without re-fetching anything.
+
+### `--prefer-offline`
+
+Prefer cached metadata over revalidation; only hit the network on a miss
+
 ### `--frozen-lockfile`
 
 Error if the lockfile drifts from package.json

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -152,7 +152,9 @@ _setup_workspace_fixture() {
 
 	run aube deploy --filter @test/lib ./out
 	assert_failure
-	assert_output --partial "not empty"
+	# miette wraps the rendered error at ~80 cols; "not empty" can split
+	# once the temp-dir path grows a digit, so match "is not" instead.
+	assert_output --partial "is not"
 }
 
 @test "aube deploy: glob filter fans out across every match" {
@@ -186,7 +188,9 @@ _setup_workspace_fixture() {
 
 	run aube deploy --filter "@test/*" ./out
 	assert_failure
-	assert_output --partial "not empty"
+	# miette wraps the rendered error at ~80 cols; "not empty" can split
+	# once the temp-dir path grows a digit, so match "is not" instead.
+	assert_output --partial "is not"
 }
 
 # Narrow @test/lib's publish surface to just package.json + index.js so

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -92,6 +92,35 @@ _setup_workspace_fixture() {
 	assert_dir_exists out/node_modules/@test/lib
 }
 
+@test "aube deploy: --offline reuses the store warmed by an earlier install" {
+	_setup_workspace_fixture
+
+	# Mirrors the multi-stage Dockerfile pattern: an earlier
+	# `aube install` populates ~/.local/share/aube/store + the packument
+	# cache, then `aube deploy --offline` reproduces a prod-only tree
+	# without touching the network.
+	run aube install
+	assert_success
+
+	# Force the registry URL to a host that doesn't resolve. If deploy
+	# secretly hits the network despite --offline, the install pass
+	# fails with a DNS error and this assertion catches it.
+	echo "registry=http://aube-deploy-offline.invalid/" >.npmrc
+
+	run aube deploy --filter @test/lib --offline ./out
+	assert_success
+	assert_output --partial "deployed @test/lib@1.0.0"
+	assert_dir_exists out/node_modules/is-odd
+}
+
+@test "aube deploy: --offline and --prefer-offline conflict" {
+	_setup_workspace_fixture
+
+	run aube deploy --filter @test/lib --offline --prefer-offline ./out
+	assert_failure
+	assert_output --partial "cannot be used with"
+}
+
 @test "aube deploy: errors when --filter does not match a workspace package" {
 	_setup_workspace_fixture
 


### PR DESCRIPTION
## Summary

- Forward `--offline` / `--prefer-offline` from `aube deploy` into the install pass it runs in the target.
- Previously deploy hardcoded `NetworkMode::Online`, so the install always revalidated packuments even when the store + cache were already warmed by an earlier `aube install` in the same Dockerfile.
- Mirrors the flags `aube install` already exposes, so the multi-stage Docker pattern (`RUN aube install --frozen-lockfile` → `RUN aube deploy --prod --frozen-lockfile --offline /app`) now skips the registry round-trip entirely.

Refs: https://github.com/endevco/aube/discussions/598

## Test plan

- [x] `cargo build -p aube` clean
- [x] `cargo clippy -p aube --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p aube --bin aube commands::deploy::tests` — 29 passed
- [x] New bats coverage: warmed-cache `--offline` succeeds against a bogus registry, and `--offline --prefer-offline` is rejected as a conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `aube deploy` to optionally avoid or reduce registry/network access during its internal install, which can affect deployment behavior when caches are cold or stale. Scope is limited to deploy’s install options and is covered by new bats tests and CLI docs updates.
> 
> **Overview**
> `aube deploy` now accepts `--offline` and `--prefer-offline` and forwards them into the target-directory install by setting `InstallOptions.network_mode` instead of hardcoding online behavior.
> 
> CLI docs/help are updated to describe the new flags, and new bats coverage verifies `--offline` succeeds with a warmed cache against an unreachable registry and that `--offline` and `--prefer-offline` are rejected as conflicting options (plus more robust error substring matching for non-empty target tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bd9d14dd2394913b7872771bf4f63720e44a05e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->