### PR TITLE
fix(install): surface materializer error instead of generic channel-closed message

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -984,6 +984,26 @@ pub(super) fn spawn_gvs_prewarm(
     tokio::spawn(run_gvs_prewarm_materializer(inputs, rx))
 }
 
+/// When the fetch task fails the surfaced error is often just
+/// "materializer task exited before fetch finished" — a symptom of the
+/// materializer dying first (its `rx` was dropped, fetch's `tx.send`
+/// returned Err). Await the materializer (don't abort) so its actual
+/// error wins. If the materializer succeeded the fetch error was the
+/// real one and stays put.
+async fn prefer_materializer_error(
+    materialize_handle: MaterializeJoinHandle,
+    fetch_err: miette::Report,
+) -> miette::Report {
+    match materialize_handle.await {
+        Ok(Ok(_)) => fetch_err,
+        Ok(Err(mat_err)) => mat_err,
+        Err(join_err) => Err::<(), _>(join_err)
+            .into_diagnostic()
+            .err()
+            .map_or(fetch_err, |r| r.wrap_err("materializer task panicked")),
+    }
+}
+
 // Consumes (canonical_key, index) from rx as tarballs land in the CAS,
 // reflinks each into the global virtual store. Returns aggregate
 // LinkStats plus computed graph hashes so the caller's link phase
@@ -3248,12 +3268,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 resolve_git_shallow_hosts(&settings_ctx),
             )
             .await;
-            // Drop alone detaches. Abort kills the task on fetch err.
+            // Don't abort the materializer on fetch err: the failing
+            // fetch task drops its `tx`, so the materializer's `rx`
+            // closes and it exits naturally. Awaiting first lets a real
+            // materializer error (the likely root cause of a generic
+            // "materializer task exited..." fetch err) surface instead.
             let (indices, cached, fetched) = match fetch_result {
                 Ok(t) => t,
                 Err(e) => {
-                    lock_materialize_handle.abort();
-                    return Err(e);
+                    return Err(prefer_materializer_error(lock_materialize_handle, e).await);
                 }
             };
             // Materializer stats roll into link via GVS-already-linked
@@ -3879,11 +3902,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let _diag_fetch_wait =
                 aube_util::diag::Span::new(aube_util::diag::Category::Install, "phase_fetch_await");
             let fetch_phase_start = std::time::Instant::now();
+            // Don't abort the materializer on fetch err: the failing
+            // fetch task drops its `tx`, so the materializer's `rx`
+            // closes and it exits naturally. Awaiting first lets a real
+            // materializer error (the likely root cause of a generic
+            // "materializer task exited..." fetch err) surface instead.
             let fetch_result = match fetch_handle.await.into_diagnostic()? {
                 Ok(v) => v,
                 Err(e) => {
-                    materialize_handle.abort();
-                    return Err(e);
+                    return Err(prefer_materializer_error(materialize_handle, e).await);
                 }
             };
             let (canonical_indices, mut cached, mut fetched) = fetch_result;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -999,8 +999,8 @@ async fn prefer_materializer_error(
         Ok(Err(mat_err)) => mat_err,
         Err(join_err) => Err::<(), _>(join_err)
             .into_diagnostic()
-            .err()
-            .map_or(fetch_err, |r| r.wrap_err("materializer task panicked")),
+            .unwrap_err()
+            .wrap_err("materializer task panicked"),
     }
 }
 
@@ -3894,19 +3894,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             );
             let materialize_handle = spawn_gvs_prewarm(materialize_inputs, materialize_rx);
 
-            // Wait for all fetches to complete. If fetch fails we have
-            // to abort the materializer explicitly: dropping a
-            // `JoinHandle` only detaches the task, so otherwise the
-            // install would return an error while the materializer
-            // kept reflinking packages into the GVS in the background.
+            // On fetch err, await the materializer (don't abort): the
+            // failing fetch task drops its `tx`, so the materializer's
+            // `rx` closes and it exits naturally. Awaiting first lets a
+            // real materializer error (the likely root cause of a
+            // generic "materializer task exited..." fetch err) surface
+            // instead.
             let _diag_fetch_wait =
                 aube_util::diag::Span::new(aube_util::diag::Category::Install, "phase_fetch_await");
             let fetch_phase_start = std::time::Instant::now();
-            // Don't abort the materializer on fetch err: the failing
-            // fetch task drops its `tx`, so the materializer's `rx`
-            // closes and it exits naturally. Awaiting first lets a real
-            // materializer error (the likely root cause of a generic
-            // "materializer task exited..." fetch err) surface instead.
             let fetch_result = match fetch_handle.await.into_diagnostic()? {
                 Ok(v) => v,
                 Err(e) => {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -987,21 +987,27 @@ pub(super) fn spawn_gvs_prewarm(
 /// When the fetch task fails the surfaced error is often just
 /// "materializer task exited before fetch finished" — a symptom of the
 /// materializer dying first (its `rx` was dropped, fetch's `tx.send`
-/// returned Err). Await the materializer (don't abort) so its actual
-/// error wins. If the materializer succeeded the fetch error was the
-/// real one and stays put.
-async fn prefer_materializer_error(
+/// returned Err). Await the materializer (don't abort) so its real
+/// error joins the chain. The returned report shows both errors:
+///
+/// * top message = how the pipeline aborted (the fetch error)
+/// * source chain = why the materializer task failed (root cause)
+///
+/// If the materializer succeeded the fetch error was the real one and
+/// is returned unchanged.
+async fn combine_install_pipeline_errors(
     materialize_handle: MaterializeJoinHandle,
     fetch_err: miette::Report,
 ) -> miette::Report {
-    match materialize_handle.await {
-        Ok(Ok(_)) => fetch_err,
-        Ok(Err(mat_err)) => mat_err,
+    let mat_err = match materialize_handle.await {
+        Ok(Ok(_)) => return fetch_err,
+        Ok(Err(err)) => err,
         Err(join_err) => Err::<(), _>(join_err)
             .into_diagnostic()
             .unwrap_err()
             .wrap_err("materializer task panicked"),
-    }
+    };
+    mat_err.wrap_err(format!("install aborted: {fetch_err}"))
 }
 
 // Consumes (canonical_key, index) from rx as tarballs land in the CAS,
@@ -3276,7 +3282,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let (indices, cached, fetched) = match fetch_result {
                 Ok(t) => t,
                 Err(e) => {
-                    return Err(prefer_materializer_error(lock_materialize_handle, e).await);
+                    return Err(combine_install_pipeline_errors(lock_materialize_handle, e).await);
                 }
             };
             // Materializer stats roll into link via GVS-already-linked
@@ -3906,7 +3912,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let fetch_result = match fetch_handle.await.into_diagnostic()? {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(prefer_materializer_error(materialize_handle, e).await);
+                    return Err(combine_install_pipeline_errors(materialize_handle, e).await);
                 }
             };
             let (canonical_indices, mut cached, mut fetched) = fetch_result;
@@ -5752,6 +5758,67 @@ mod critical_path_tests {
                 "lodash",
                 "@types/node"
             ]
+        );
+    }
+}
+
+#[cfg(test)]
+mod combine_pipeline_errors_tests {
+    use super::combine_install_pipeline_errors;
+    use miette::miette;
+
+    fn fmt_chain(report: &miette::Report) -> String {
+        let mut out = report.to_string();
+        let mut src = report.source();
+        while let Some(e) = src {
+            out.push_str(" :: ");
+            out.push_str(&e.to_string());
+            src = e.source();
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn returns_fetch_err_when_materializer_succeeded() {
+        let handle = tokio::spawn(async {
+            Ok((
+                aube_linker::LinkStats::default(),
+                None::<std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>>,
+            ))
+        });
+        let fetch_err = miette!("network down: timed out fetching foo@1.0");
+        let combined = combine_install_pipeline_errors(handle, fetch_err).await;
+        assert!(
+            combined.to_string().contains("network down"),
+            "got: {}",
+            combined
+        );
+    }
+
+    #[tokio::test]
+    async fn nests_both_errors_when_materializer_failed() {
+        let handle = tokio::spawn(async {
+            Err::<
+                (
+                    aube_linker::LinkStats,
+                    Option<std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>>,
+                ),
+                _,
+            >(miette!("materialize foo@1.0: permission denied"))
+        });
+        // The fetch task surfaces the channel-closed symptom.
+        let fetch_err = miette!("materializer task exited before fetch finished");
+        let combined = combine_install_pipeline_errors(handle, fetch_err).await;
+        let chain = fmt_chain(&combined);
+        // Both errors visible: fetch's symptom on top, materializer's
+        // root cause in the chain below.
+        assert!(
+            chain.contains("materializer task exited before fetch finished"),
+            "fetch err missing from chain: {chain}"
+        );
+        assert!(
+            chain.contains("permission denied"),
+            "materializer err missing from chain: {chain}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- When fetch fails with the generic "materializer task exited before fetch finished" message, await the materializer (don't abort) so its real error surfaces — that's the actual root cause whenever the materializer died first and caused fetch's `tx.send` to err on a closed channel.
- Applied to both fetch error paths in [crates/aube/src/commands/install/mod.rs](crates/aube/src/commands/install/mod.rs): the lockfile branch and the fresh-resolve branch.
- Adds a small private helper `prefer_materializer_error` that picks the more informative error: if the materializer returned Ok, the fetch error was the real one and stays put; if the materializer errored, that wins; if it panicked, surface the join error wrapped.

This is a diagnostics-only change — it doesn't fix any underlying install bug, but it stops swallowing materializer errors. Once it lands, reporters hitting the symptom (e.g. https://github.com/endevco/aube/discussions/597) will see the actual `ensure_in_aube_dir` / `ensure_in_virtual_store` failure that triggered the cascade.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p aube --bins` — 456 passed
- [ ] Discussion #597 reporter to confirm the next failure now surfaces the underlying linker error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error-path handling and diagnostics during install, primarily affecting how concurrent fetch/materialize task failures are reported.
> 
> **Overview**
> Improves install failure diagnostics by awaiting the GVS prewarm materializer when the fetch phase errors, instead of aborting it, so the materializer’s underlying failure (or panic) is included in the returned `miette` error chain rather than a generic channel-closed symptom.
> 
> Introduces `combine_install_pipeline_errors` and applies it to both the lockfile fast-path and fresh-resolve fetch error paths, plus adds tokio tests to verify the combined error behavior when the materializer succeeds vs fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dbd4d0092f4aed339491b6508e5df999cb7ef0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->