### PR TITLE
feat(config): scope-split settings precedence; project config.toml support

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -319,7 +319,7 @@ cmd config help="Read and write settings in `.npmrc`" {
         alias rm remove unset
         flag --local help="Shortcut for `--location project`"
         flag --location help="Which config location to act on" default=user {
-            long_help "Which config location to act on.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml`; registry/auth and unknown keys use `~/.npmrc`."
+            long_help "Which config location to act on.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml` (user) or `<cwd>/.config/aube/config.toml` (project); registry/auth and unknown keys use `~/.npmrc` or `<cwd>/.npmrc` respectively."
             arg <LOCATION> {
                 choices user project global
             }
@@ -367,7 +367,7 @@ cmd config help="Read and write settings in `.npmrc`" {
     cmd set help="Write a key=value pair to aube config or the selected `.npmrc` file" {
         flag --local help="Shortcut for `--location project`"
         flag --location help="Which config location to write to" default=user {
-            long_help "Which config location to write to.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml`; registry/auth and unknown keys use `~/.npmrc`."
+            long_help "Which config location to write to.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml` (user) or `<cwd>/.config/aube/config.toml` (project); registry/auth and unknown keys use `~/.npmrc` or `<cwd>/.npmrc` respectively."
             arg <LOCATION> {
                 choices user project global
             }
@@ -1597,7 +1597,7 @@ cmd search hide=#true help="Search the registry for packages (not implemented â€
 cmd set hide=#true help="Alias for `config set` (hidden; prefer `config set`)" {
     flag --local help="Shortcut for `--location project`"
     flag --location help="Which config location to write to" default=user {
-        long_help "Which config location to write to.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml`; registry/auth and unknown keys use `~/.npmrc`."
+        long_help "Which config location to write to.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml` (user) or `<cwd>/.config/aube/config.toml` (project); registry/auth and unknown keys use `~/.npmrc` or `<cwd>/.npmrc` respectively."
         arg <LOCATION> {
             choices user project global
         }

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -571,9 +571,10 @@ impl Default for FetchPolicy {
 
 impl FetchPolicy {
     /// Resolve every field from a settings [`ResolveCtx`]. Walks the
-    /// full cli > env > aubeConfig > npmrc > workspaceYaml precedence
-    /// chain via the generated accessors, so env-var overrides like
-    /// `NPM_CONFIG_FETCH_TIMEOUT` Just Work without bespoke parsing.
+    /// full cli > env > {project,user} aubeConfig/npmrc > workspaceYaml
+    /// precedence chain via the generated accessors, so env-var
+    /// overrides like `NPM_CONFIG_FETCH_TIMEOUT` Just Work without
+    /// bespoke parsing.
     pub fn from_ctx(ctx: &aube_settings::ResolveCtx<'_>) -> Self {
         Self {
             timeout_ms: aube_settings::resolved::fetch_timeout(ctx),
@@ -697,6 +698,58 @@ fn translate_npm_config_env(name: &str, value: &str) -> Option<(String, String)>
 /// looks up each setting's declared `sources.npmrc` keys. That keeps the
 /// registry of "which keys map to which setting" in `settings.toml`
 /// instead of scattering it through a hand-rolled parser.
+/// Scope-split view of [`load_npmrc_entries`]. Returns user-scope
+/// entries (user `~/.npmrc` + pnpm `auth.ini`) and project-scope entries
+/// (project `<cwd>/.npmrc` + `npmrcAuthFile`) as separate slices so the
+/// settings resolver can apply the locality principle (project beats
+/// user) while interleaving aube's own config sources.
+///
+/// Concatenating `user` and `project` (in that order) yields the same
+/// list as [`load_npmrc_entries`].
+pub fn load_npmrc_entries_split(project_dir: &Path) -> SplitNpmrcEntries {
+    use std::sync::{Mutex, OnceLock};
+    type CacheMap = std::collections::HashMap<PathBuf, SplitNpmrcEntries>;
+    static CACHE: OnceLock<Mutex<CacheMap>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    if let Ok(map) = cache.lock()
+        && let Some(hit) = map.get(project_dir)
+    {
+        return hit.clone();
+    }
+    let xdg = aube_util::env::xdg_config_home();
+    let home = home_dir();
+    let user_rc_override = std::env::var("NPM_CONFIG_USERCONFIG")
+        .ok()
+        .or_else(|| std::env::var("npm_config_userconfig").ok())
+        .and_then(|raw| expand_userconfig_path(&raw, home.as_deref()));
+    let tagged = load_npmrc_entries_tagged_with_home(
+        home.as_deref(),
+        xdg.as_deref(),
+        project_dir,
+        user_rc_override.as_deref(),
+    );
+    let mut split = SplitNpmrcEntries::default();
+    for (src, k, v) in tagged {
+        match src {
+            NpmrcSource::User | NpmrcSource::PnpmAuth => split.user.push((k, v)),
+            NpmrcSource::Project | NpmrcSource::NpmrcAuthFile => split.project.push((k, v)),
+            // Env-derived entries (npm_config_*) aren't loaded by the
+            // tagged file walker, so this arm is unreachable here.
+            NpmrcSource::Env => continue,
+        }
+    }
+    if let Ok(mut map) = cache.lock() {
+        map.insert(project_dir.to_path_buf(), split.clone());
+    }
+    split
+}
+
+#[derive(Default, Clone)]
+pub struct SplitNpmrcEntries {
+    pub user: Vec<(String, String)>,
+    pub project: Vec<(String, String)>,
+}
+
 pub fn load_npmrc_entries(project_dir: &Path) -> Vec<(String, String)> {
     // Process-wide memoization keyed by project_dir. `.npmrc` files are
     // not expected to change mid-install, and callers on the hot path

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -571,8 +571,8 @@ impl Default for FetchPolicy {
 
 impl FetchPolicy {
     /// Resolve every field from a settings [`ResolveCtx`]. Walks the
-    /// full cli > env > npmrc > workspaceYaml precedence chain via the
-    /// generated accessors, so env-var overrides like
+    /// full cli > env > aubeConfig > npmrc > workspaceYaml precedence
+    /// chain via the generated accessors, so env-var overrides like
     /// `NPM_CONFIG_FETCH_TIMEOUT` Just Work without bespoke parsing.
     pub fn from_ctx(ctx: &aube_settings::ResolveCtx<'_>) -> Self {
         Self {

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -688,16 +688,6 @@ fn translate_npm_config_env(name: &str, value: &str) -> Option<(String, String)>
     Some((npmrc_key.to_string(), value.to_string()))
 }
 
-/// Load raw `.npmrc` key/value pairs from the same file precedence as
-/// [`NpmConfig::load`]: user-level (`~/.npmrc`) first, then project-level
-/// (`<cwd>/.npmrc`). Returned in encounter order — a later duplicate key
-/// overrides an earlier one, matching npm's own precedence rules.
-///
-/// Callers that want typed, per-setting values should consume this via
-/// `aube_cli::settings_values`, which walks `settings_meta::SETTINGS` and
-/// looks up each setting's declared `sources.npmrc` keys. That keeps the
-/// registry of "which keys map to which setting" in `settings.toml`
-/// instead of scattering it through a hand-rolled parser.
 /// Scope-split view of [`load_npmrc_entries`]. Returns user-scope
 /// entries (user `~/.npmrc` + pnpm `auth.ini`) and project-scope entries
 /// (project `<cwd>/.npmrc` + `npmrcAuthFile`) as separate slices so the
@@ -750,6 +740,16 @@ pub struct SplitNpmrcEntries {
     pub project: Vec<(String, String)>,
 }
 
+/// Load raw `.npmrc` key/value pairs from the same file precedence as
+/// [`NpmConfig::load`]: user-level (`~/.npmrc`) first, then project-level
+/// (`<cwd>/.npmrc`). Returned in encounter order — a later duplicate key
+/// overrides an earlier one, matching npm's own precedence rules.
+///
+/// Callers that want typed, per-setting values should consume this via
+/// `aube_cli::settings_values`, which walks `settings_meta::SETTINGS` and
+/// looks up each setting's declared `sources.npmrc` keys. That keeps the
+/// registry of "which keys map to which setting" in `settings.toml`
+/// instead of scattering it through a hand-rolled parser.
 pub fn load_npmrc_entries(project_dir: &Path) -> Vec<(String, String)> {
     // Process-wide memoization keyed by project_dir. `.npmrc` files are
     // not expected to change mid-install, and callers on the hot path

--- a/crates/aube-settings/build.rs
+++ b/crates/aube-settings/build.rs
@@ -48,7 +48,7 @@ struct SettingDef {
     /// (project + user, project first) and `"aubeConfig"` (project +
     /// user, project first). Unspecified sources are appended in the
     /// default order (`["projectAubeConfig", "projectNpmrc",
-    /// "userAubeConfig", "userNpmrc", "workspaceYaml"]`) so a partial
+    /// "workspaceYaml", "userAubeConfig", "userNpmrc"]`) so a partial
     /// override still falls back on every source. Settings that pnpm v11 reads
     /// primarily from `pnpm-workspace.yaml` (e.g.
     /// `minimumReleaseAge`) override this to
@@ -261,7 +261,7 @@ fn generate_resolved_accessors(settings: &BTreeMap<String, SettingDef>) -> Strin
 
         // Emit source lookups in the declared precedence order. The
         // default order is `[projectAubeConfig, projectNpmrc,
-        // userAubeConfig, userNpmrc, workspaceYaml]`; a setting whose
+        // workspaceYaml, userAubeConfig, userNpmrc]`; a setting whose
         // `precedence` field names only one source gets the rest
         // appended after it. Unknown source names panic loudly at
         // build time — cheaper to catch a typo here than in a user
@@ -546,12 +546,17 @@ fn resolve_precedence(declared: &[String]) -> Vec<String> {
     // The default file order encodes two principles: scope locality
     // (project > user) and aube authority within a scope (aubeConfig >
     // npmrc).
+    // `workspaceYaml` lives at the project root (`pnpm-workspace.yaml`
+    // / `aube-workspace.yaml`), so it's project-scope and outranks
+    // every user-scope source. Within project scope, aube's own
+    // `config.toml` and project `.npmrc` keep their lead — workspace
+    // yaml sits at the bottom of project-scope but above user-scope.
     let file_default = [
         "projectAubeConfig",
         "projectNpmrc",
+        "workspaceYaml",
         "userAubeConfig",
         "userNpmrc",
-        "workspaceYaml",
     ];
     let mut files: Vec<String> = Vec::with_capacity(file_default.len());
     for src in declared {

--- a/crates/aube-settings/build.rs
+++ b/crates/aube-settings/build.rs
@@ -42,9 +42,13 @@ struct SettingDef {
     #[serde(default, rename = "typedAccessorUnused")]
     typed_accessor_unused: bool,
     /// Source precedence for the generated accessor, high-to-low.
-    /// Valid entries: `"npmrc"`, `"aubeConfig"`, `"workspaceYaml"`.
-    /// Unspecified sources are appended in the default order
-    /// (`["aubeConfig", "npmrc", "workspaceYaml"]`) so a partial
+    /// Valid entries: scope-qualified leaves `"projectAubeConfig"`,
+    /// `"projectNpmrc"`, `"userAubeConfig"`, `"userNpmrc"`,
+    /// `"workspaceYaml"`, plus the convenience aliases `"npmrc"`
+    /// (project + user, project first) and `"aubeConfig"` (project +
+    /// user, project first). Unspecified sources are appended in the
+    /// default order (`["projectAubeConfig", "projectNpmrc",
+    /// "userAubeConfig", "userNpmrc", "workspaceYaml"]`) so a partial
     /// override still falls back on every source. Settings that pnpm v11 reads
     /// primarily from `pnpm-workspace.yaml` (e.g.
     /// `minimumReleaseAge`) override this to
@@ -256,7 +260,8 @@ fn generate_resolved_accessors(settings: &BTreeMap<String, SettingDef>) -> Strin
         };
 
         // Emit source lookups in the declared precedence order. The
-        // default order is `[aubeConfig, npmrc, workspaceYaml]`; a setting whose
+        // default order is `[projectAubeConfig, projectNpmrc,
+        // userAubeConfig, userNpmrc, workspaceYaml]`; a setting whose
         // `precedence` field names only one source gets the rest
         // appended after it. Unknown source names panic loudly at
         // build time — cheaper to catch a typo here than in a user
@@ -282,8 +287,10 @@ fn generate_resolved_accessors(settings: &BTreeMap<String, SettingDef>) -> Strin
             let (call, arg) = match src.as_str() {
                 "cli" => (cli_call, "ctx.cli"),
                 "env" => (env_call, "ctx.env"),
-                "npmrc" => (npmrc_call, "ctx.npmrc"),
-                "aubeConfig" => (npmrc_call, "ctx.aube_config"),
+                "projectAubeConfig" => (npmrc_call, "ctx.project_aube_config"),
+                "projectNpmrc" => (npmrc_call, "ctx.project_npmrc"),
+                "userAubeConfig" => (npmrc_call, "ctx.user_aube_config"),
+                "userNpmrc" => (npmrc_call, "ctx.user_npmrc"),
                 "workspaceYaml" => (ws_call, "ctx.workspace_yaml"),
                 other => panic!("{name}: unknown source `{other}` in precedence"),
             };
@@ -533,16 +540,36 @@ fn pascal_case(name: &str) -> String {
 fn resolve_precedence(declared: &[String]) -> Vec<String> {
     // CLI and env are always highest-precedence, in that order. The
     // per-setting `precedence` override only reorders the file-based
-    // sources (`npmrc`, `aubeConfig`, `workspaceYaml`). Anyone who declares `cli`
-    // or `env` in their precedence list gets it silently dropped
-    // below because it's already pinned on top.
-    let file_default = ["aubeConfig", "npmrc", "workspaceYaml"];
+    // sources. Anyone who declares `cli` or `env` in their precedence
+    // list gets it silently dropped because it's already pinned on top.
+    //
+    // The default file order encodes two principles: scope locality
+    // (project > user) and aube authority within a scope (aubeConfig >
+    // npmrc).
+    let file_default = [
+        "projectAubeConfig",
+        "projectNpmrc",
+        "userAubeConfig",
+        "userNpmrc",
+        "workspaceYaml",
+    ];
     let mut files: Vec<String> = Vec::with_capacity(file_default.len());
     for src in declared {
-        match src.as_str() {
+        // Convenience aliases: bare `npmrc` / `aubeConfig` expand to
+        // their project+user pair (project first). Older
+        // `settings.toml` overrides that predate the scope split can
+        // keep using the short names.
+        let expansion: &[&str] = match src.as_str() {
             "cli" | "env" => continue,
-            _ if !files.contains(src) => files.push(src.clone()),
-            _ => {}
+            "npmrc" => &["projectNpmrc", "userNpmrc"],
+            "aubeConfig" => &["projectAubeConfig", "userAubeConfig"],
+            other => &[other],
+        };
+        for name in expansion {
+            let name = (*name).to_string();
+            if !files.contains(&name) {
+                files.push(name);
+            }
         }
     }
     for src in file_default {

--- a/crates/aube-settings/build.rs
+++ b/crates/aube-settings/build.rs
@@ -44,7 +44,7 @@ struct SettingDef {
     /// Source precedence for the generated accessor, high-to-low.
     /// Valid entries: `"npmrc"`, `"aubeConfig"`, `"workspaceYaml"`.
     /// Unspecified sources are appended in the default order
-    /// (`["npmrc", "aubeConfig", "workspaceYaml"]`) so a partial
+    /// (`["aubeConfig", "npmrc", "workspaceYaml"]`) so a partial
     /// override still falls back on every source. Settings that pnpm v11 reads
     /// primarily from `pnpm-workspace.yaml` (e.g.
     /// `minimumReleaseAge`) override this to
@@ -148,7 +148,8 @@ fn generate_resolved_accessors(settings: &BTreeMap<String, SettingDef>) -> Strin
          // One typed accessor per supported scalar setting (`bool`,\n\
          // `string`, `path`, `url`, `int`, `list<string>`, and\n\
          // enum-style string unions). The accessor walks sources in\n\
-         // precedence order (cli/env first, then npmrc / workspace.yaml).\n\
+         // precedence order (cli/env first, then aube config.toml /\n\
+         // npmrc / workspace.yaml).\n\
          // Settings with parseable concrete defaults return `T`; settings\n\
          // whose default is undefined or contextual return `Option<T>`.\n\n",
     );
@@ -255,7 +256,7 @@ fn generate_resolved_accessors(settings: &BTreeMap<String, SettingDef>) -> Strin
         };
 
         // Emit source lookups in the declared precedence order. The
-        // default order is `[npmrc, aubeConfig, workspaceYaml]`; a setting whose
+        // default order is `[aubeConfig, npmrc, workspaceYaml]`; a setting whose
         // `precedence` field names only one source gets the rest
         // appended after it. Unknown source names panic loudly at
         // build time — cheaper to catch a typo here than in a user
@@ -535,7 +536,7 @@ fn resolve_precedence(declared: &[String]) -> Vec<String> {
     // sources (`npmrc`, `aubeConfig`, `workspaceYaml`). Anyone who declares `cli`
     // or `env` in their precedence list gets it silently dropped
     // below because it's already pinned on top.
-    let file_default = ["npmrc", "aubeConfig", "workspaceYaml"];
+    let file_default = ["aubeConfig", "npmrc", "workspaceYaml"];
     let mut files: Vec<String> = Vec::with_capacity(file_default.len());
     for src in declared {
         match src.as_str() {

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -51,14 +51,28 @@ fn global_cli_overrides() -> &'static [(String, String)] {
 /// accessors in [`resolved`]. Each field is a borrowed view so
 /// callers can reuse the same owned values across many lookups
 /// without cloning.
+///
+/// File-source fields are split by scope (user vs project) so the
+/// resolver can apply the locality principle — project-scope entries
+/// outrank user-scope entries, and within a scope aube's own config
+/// outranks `.npmrc`. See the module-level docs for the full chain.
 pub struct ResolveCtx<'a> {
-    /// Merged `.npmrc` entries (user-scope first, project-scope last),
-    /// as returned by `aube_registry::config::load_npmrc_entries`.
-    pub npmrc: &'a [(String, String)],
-    /// Entries from aube's user config file (`config.toml`). Keys use
-    /// canonical setting names, with npmrc aliases accepted for manual
-    /// edits.
-    pub aube_config: &'a [(String, String)],
+    /// Project-scope aube config (`<cwd>/.config/aube/config.toml`).
+    /// Highest-precedence file source by default — a project may pin
+    /// settings here as an alternative to committing them into the
+    /// project `.npmrc` shared with npm/pnpm/yarn.
+    pub project_aube_config: &'a [(String, String)],
+    /// Project-scope `.npmrc` (`<cwd>/.npmrc`) plus any
+    /// `npmrcAuthFile` it points at, in load order.
+    pub project_npmrc: &'a [(String, String)],
+    /// User-scope aube config (`~/.config/aube/config.toml`). Aube's
+    /// authoritative store for user-level settings written via
+    /// `aube config set` — outranks `~/.npmrc` so leftover entries in
+    /// a shared `.npmrc` don't silently shadow what aube wrote.
+    pub user_aube_config: &'a [(String, String)],
+    /// User-scope `.npmrc` (`~/.npmrc` or `NPM_CONFIG_USERCONFIG`) plus
+    /// pnpm's global `auth.ini`, in load order.
+    pub user_npmrc: &'a [(String, String)],
     /// Raw top-level map from `pnpm-workspace.yaml` /
     /// `aube-workspace.yaml`, as returned by
     /// `aube_manifest::workspace::load_raw`.
@@ -77,16 +91,23 @@ pub struct ResolveCtx<'a> {
 }
 
 impl<'a> ResolveCtx<'a> {
-    /// Construct a context that only sees file-based sources.
-    /// Convenience for tests and call sites that haven't wired env/cli
-    /// through yet.
+    /// Construct a context that only sees the merged-`.npmrc` and
+    /// workspace-yaml file sources. Convenience for tests and call
+    /// sites that don't need scope splitting or env/cli plumbing.
+    ///
+    /// The supplied `.npmrc` slice is treated as project-scope so its
+    /// values win over the (empty) user-scope sources — matching
+    /// the install-time precedence callers used to rely on before the
+    /// split.
     pub fn files_only(
         npmrc: &'a [(String, String)],
         workspace_yaml: &'a std::collections::BTreeMap<String, yaml_serde::Value>,
     ) -> Self {
         Self {
-            npmrc,
-            aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: npmrc,
+            user_aube_config: &[],
+            user_npmrc: &[],
             workspace_yaml,
             env: &[],
             cli: &[],
@@ -130,17 +151,36 @@ pub fn process_env() -> &'static [(String, String)] {
 /// returns `bool`, `store_dir` returns `Option<String>`, and
 /// calling either on the wrong type is a compile error.
 ///
-/// Precedence is `cli > env > aubeConfig > npmrc > workspaceYaml`. Aube's
-/// own user config (`~/.config/aube/config.toml`) wins over `~/.npmrc` so
-/// that `aube config set` is authoritative — values aube writes are not
-/// silently shadowed by leftover entries in a shared `.npmrc` that other
-/// tools (npm, pnpm, yarn) also read. The per-setting `precedence`
-/// override in `settings.toml` reorders the file-based sources
-/// (`aubeConfig`, `npmrc`, `workspaceYaml`) but cannot demote `cli` or
-/// `env` off the top — CLI flags and environment variables always win.
-/// Settings with concrete parseable defaults return the defaulted value
-/// directly; settings whose default is undefined or contextual still
-/// return `Option<T>`.
+/// Default precedence, high-to-low:
+///
+/// ```text
+/// cli > env
+///     > project_aube_config (<cwd>/.config/aube/config.toml)
+///     > project_npmrc       (<cwd>/.npmrc + npmrcAuthFile)
+///     > user_aube_config    (~/.config/aube/config.toml)
+///     > user_npmrc          (~/.npmrc + pnpm auth.ini)
+///     > workspace_yaml      (pnpm-workspace.yaml / aube-workspace.yaml)
+/// ```
+///
+/// Two principles drive the file-source ordering:
+///
+/// - **Scope locality**: project-scope entries beat user-scope entries.
+/// - **Aube authority**: within a scope, aube's own config file beats
+///   `.npmrc`. Values aube writes via `aube config set` are not
+///   silently shadowed by leftover entries in a `.npmrc` that other
+///   tools (npm, pnpm, yarn) also read.
+///
+/// The per-setting `precedence` override in `settings.toml` reorders
+/// the file-based sources but cannot demote `cli` or `env` off the
+/// top — CLI flags and environment variables always win. Bare names
+/// `npmrc` and `aubeConfig` in a `precedence` list expand to their
+/// project+user pair (project first); use the scope-qualified names
+/// `projectNpmrc`/`userNpmrc`/`projectAubeConfig`/`userAubeConfig` for
+/// fine-grained control.
+///
+/// Settings with concrete parseable defaults return the defaulted
+/// value directly; settings whose default is undefined or contextual
+/// still return `Option<T>`.
 pub mod resolved {
     use super::ResolveCtx;
     include!(concat!(env!("OUT_DIR"), "/settings_resolved.rs"));
@@ -151,11 +191,10 @@ pub mod resolved {
 /// earlier one). Returns `None` if the metadata entry doesn't exist,
 /// the setting isn't a bool, or no source key was found in `entries`.
 ///
-/// `entries` is the raw merged key/value list from
-/// `aube_registry::config::load_npmrc_entries`. Precedence is already
-/// baked in by the time entries reach this function: project `.npmrc`
-/// appears after user `.npmrc`, so iterating from the end gives
-/// last-write-wins behavior.
+/// `entries` is one of the per-scope slices from
+/// [`crate::ResolveCtx`] (e.g. `project_npmrc` or `user_npmrc`).
+/// Within a single scope, iterating from the end gives last-write-wins
+/// over duplicate keys.
 pub(crate) fn bool_from_npmrc(setting: &str, entries: &[(String, String)]) -> Option<bool> {
     let meta = meta::find(setting)?;
     if meta.type_ != "bool" {
@@ -895,8 +934,8 @@ mod tests {
 
     #[test]
     fn cli_beats_env_beats_npmrc_beats_workspace_yaml() {
-        // Precedence order is cli > env > aubeConfig > npmrc >
-        // workspaceYaml. This test hits the cli/env/npmrc/ws layers by
+        // CLI and env always win over file sources. This test hits
+        // every layer (cli, env, project npmrc, workspace yaml) by
         // setting a unique value at each and asserting the generated
         // accessor returns the CLI value.
         let npmrc = entries(&[("auto-install-peers", "false")]);
@@ -907,8 +946,10 @@ mod tests {
         )];
         let cli = vec![("auto-install-peers".to_string(), "true".to_string())];
         let ctx = ResolveCtx {
-            npmrc: &npmrc,
-            aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &npmrc,
+            user_aube_config: &[],
+            user_npmrc: &[],
             workspace_yaml: &ws,
             env: &env,
             cli: &cli,
@@ -926,8 +967,10 @@ mod tests {
             "true".to_string(),
         )];
         let ctx = ResolveCtx {
-            npmrc: &npmrc,
-            aube_config: &aube_config,
+            project_aube_config: &aube_config,
+            project_npmrc: &npmrc,
+            user_aube_config: &aube_config,
+            user_npmrc: &npmrc,
             workspace_yaml: &ws,
             env: &env,
             cli: &[],
@@ -942,12 +985,13 @@ mod tests {
         // the tail, the effective order is workspaceYaml > npmrc >
         // aubeConfig — workspace YAML wins when present, and
         // `config.toml` is consulted only as a last resort.
-        let npmrc = Vec::new();
         let aube_config = entries(&[("minimumReleaseAge", "2880")]);
         let ws = raw_yaml("minimumReleaseAge: 1440\n");
         let ctx = ResolveCtx {
-            npmrc: &npmrc,
-            aube_config: &aube_config,
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &aube_config,
+            user_npmrc: &[],
             workspace_yaml: &ws,
             env: &[],
             cli: &[],
@@ -956,8 +1000,10 @@ mod tests {
 
         let ws = BTreeMap::new();
         let ctx = ResolveCtx {
-            npmrc: &npmrc,
-            aube_config: &aube_config,
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &aube_config,
+            user_npmrc: &[],
             workspace_yaml: &ws,
             env: &[],
             cli: &[],
@@ -966,26 +1012,74 @@ mod tests {
     }
 
     #[test]
-    fn aube_config_wins_over_npmrc_by_default() {
-        // Default file precedence is `[aubeConfig, npmrc, workspaceYaml]`
-        // so values aube wrote to `~/.config/aube/config.toml` via
-        // `aube config set` are authoritative — a leftover entry in
-        // `~/.npmrc` (which other tools like npm/pnpm/yarn also read)
-        // does not silently shadow them. `autoInstallPeers` has no
-        // per-setting precedence override, so it follows the default.
-        let npmrc = entries(&[("auto-install-peers", "false")]);
-        let aube_config = entries(&[("autoInstallPeers", "true")]);
+    fn user_aube_config_wins_over_user_npmrc_by_default() {
+        // Within user-scope, `~/.config/aube/config.toml` outranks
+        // `~/.npmrc` so values aube wrote via `aube config set` are
+        // authoritative — a leftover entry in `~/.npmrc` (which other
+        // tools like npm/pnpm/yarn also read) does not silently shadow
+        // them. `autoInstallPeers` has no per-setting precedence
+        // override, so it follows the default.
+        let user_npmrc = entries(&[("auto-install-peers", "false")]);
+        let user_aube_config = entries(&[("autoInstallPeers", "true")]);
         let ws = BTreeMap::new();
         let ctx = ResolveCtx {
-            npmrc: &npmrc,
-            aube_config: &aube_config,
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &user_aube_config,
+            user_npmrc: &user_npmrc,
             workspace_yaml: &ws,
             env: &[],
             cli: &[],
         };
         assert!(
             resolved::auto_install_peers(&ctx),
-            "aube_config=true should win over npmrc=false"
+            "user aube_config=true should win over user npmrc=false"
+        );
+    }
+
+    #[test]
+    fn project_npmrc_wins_over_user_aube_config_by_default() {
+        // Locality principle: a project `.npmrc` outranks user-scope
+        // `~/.config/aube/config.toml`. A repo-specific override should
+        // not be silently shadowed by a user-level aube preference.
+        let project_npmrc = entries(&[("auto-install-peers", "false")]);
+        let user_aube_config = entries(&[("autoInstallPeers", "true")]);
+        let ws = BTreeMap::new();
+        let ctx = ResolveCtx {
+            project_aube_config: &[],
+            project_npmrc: &project_npmrc,
+            user_aube_config: &user_aube_config,
+            user_npmrc: &[],
+            workspace_yaml: &ws,
+            env: &[],
+            cli: &[],
+        };
+        assert!(
+            !resolved::auto_install_peers(&ctx),
+            "project npmrc=false should win over user aube_config=true"
+        );
+    }
+
+    #[test]
+    fn project_aube_config_wins_over_project_npmrc_by_default() {
+        // Within project-scope, `<cwd>/.config/aube/config.toml`
+        // outranks `<cwd>/.npmrc` — same authority principle as the
+        // user-scope pair.
+        let project_npmrc = entries(&[("auto-install-peers", "false")]);
+        let project_aube_config = entries(&[("autoInstallPeers", "true")]);
+        let ws = BTreeMap::new();
+        let ctx = ResolveCtx {
+            project_aube_config: &project_aube_config,
+            project_npmrc: &project_npmrc,
+            user_aube_config: &[],
+            user_npmrc: &[],
+            workspace_yaml: &ws,
+            env: &[],
+            cli: &[],
+        };
+        assert!(
+            resolved::auto_install_peers(&ctx),
+            "project aube_config=true should win over project npmrc=false"
         );
     }
 

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -130,13 +130,17 @@ pub fn process_env() -> &'static [(String, String)] {
 /// returns `bool`, `store_dir` returns `Option<String>`, and
 /// calling either on the wrong type is a compile error.
 ///
-/// Precedence is `cli > env > npmrc > aubeConfig > workspaceYaml`. The
-/// per-setting `precedence` override in `settings.toml` reorders the
-/// file-based sources (`npmrc`, `aubeConfig`, `workspaceYaml`) but cannot demote
-/// `cli` or `env` off the top — CLI flags and environment variables
-/// always win. Settings with concrete parseable defaults return the
-/// defaulted value directly; settings whose default is undefined or
-/// contextual still return `Option<T>`.
+/// Precedence is `cli > env > aubeConfig > npmrc > workspaceYaml`. Aube's
+/// own user config (`~/.config/aube/config.toml`) wins over `~/.npmrc` so
+/// that `aube config set` is authoritative — values aube writes are not
+/// silently shadowed by leftover entries in a shared `.npmrc` that other
+/// tools (npm, pnpm, yarn) also read. The per-setting `precedence`
+/// override in `settings.toml` reorders the file-based sources
+/// (`aubeConfig`, `npmrc`, `workspaceYaml`) but cannot demote `cli` or
+/// `env` off the top — CLI flags and environment variables always win.
+/// Settings with concrete parseable defaults return the defaulted value
+/// directly; settings whose default is undefined or contextual still
+/// return `Option<T>`.
 pub mod resolved {
     use super::ResolveCtx;
     include!(concat!(env!("OUT_DIR"), "/settings_resolved.rs"));
@@ -891,9 +895,10 @@ mod tests {
 
     #[test]
     fn cli_beats_env_beats_npmrc_beats_workspace_yaml() {
-        // Precedence order is cli > env > npmrc > workspaceYaml. This
-        // test hits every layer by setting a unique value at each and
-        // asserting the generated accessor returns the CLI value.
+        // Precedence order is cli > env > aubeConfig > npmrc >
+        // workspaceYaml. This test hits the cli/env/npmrc/ws layers by
+        // setting a unique value at each and asserting the generated
+        // accessor returns the CLI value.
         let npmrc = entries(&[("auto-install-peers", "false")]);
         let ws = raw_yaml("autoInstallPeers: false\n");
         let env = vec![(
@@ -931,7 +936,12 @@ mod tests {
     }
 
     #[test]
-    fn generated_accessor_reads_aube_config_between_npmrc_and_workspace_yaml() {
+    fn minimum_release_age_honors_per_setting_precedence_override() {
+        // `minimumReleaseAge` overrides the default file precedence to
+        // `["workspaceYaml", "npmrc"]`. With `aubeConfig` appended at
+        // the tail, the effective order is workspaceYaml > npmrc >
+        // aubeConfig — workspace YAML wins when present, and
+        // `config.toml` is consulted only as a last resort.
         let npmrc = Vec::new();
         let aube_config = entries(&[("minimumReleaseAge", "2880")]);
         let ws = raw_yaml("minimumReleaseAge: 1440\n");
@@ -953,6 +963,30 @@ mod tests {
             cli: &[],
         };
         assert_eq!(resolved::minimum_release_age(&ctx), 2880);
+    }
+
+    #[test]
+    fn aube_config_wins_over_npmrc_by_default() {
+        // Default file precedence is `[aubeConfig, npmrc, workspaceYaml]`
+        // so values aube wrote to `~/.config/aube/config.toml` via
+        // `aube config set` are authoritative — a leftover entry in
+        // `~/.npmrc` (which other tools like npm/pnpm/yarn also read)
+        // does not silently shadow them. `autoInstallPeers` has no
+        // per-setting precedence override, so it follows the default.
+        let npmrc = entries(&[("auto-install-peers", "false")]);
+        let aube_config = entries(&[("autoInstallPeers", "true")]);
+        let ws = BTreeMap::new();
+        let ctx = ResolveCtx {
+            npmrc: &npmrc,
+            aube_config: &aube_config,
+            workspace_yaml: &ws,
+            env: &[],
+            cli: &[],
+        };
+        assert!(
+            resolved::auto_install_peers(&ctx),
+            "aube_config=true should win over npmrc=false"
+        );
     }
 
     #[test]

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -157,14 +157,16 @@ pub fn process_env() -> &'static [(String, String)] {
 /// cli > env
 ///     > project_aube_config (<cwd>/.config/aube/config.toml)
 ///     > project_npmrc       (<cwd>/.npmrc + npmrcAuthFile)
+///     > workspace_yaml      (pnpm-workspace.yaml / aube-workspace.yaml)
 ///     > user_aube_config    (~/.config/aube/config.toml)
 ///     > user_npmrc          (~/.npmrc + pnpm auth.ini)
-///     > workspace_yaml      (pnpm-workspace.yaml / aube-workspace.yaml)
 /// ```
 ///
 /// Two principles drive the file-source ordering:
 ///
 /// - **Scope locality**: project-scope entries beat user-scope entries.
+///   `workspace_yaml` lives at the project root, so it ranks above
+///   every user-scope source.
 /// - **Aube authority**: within a scope, aube's own config file beats
 ///   `.npmrc`. Values aube writes via `aube config set` are not
 ///   silently shadowed by leftover entries in a `.npmrc` that other
@@ -1080,6 +1082,32 @@ mod tests {
         assert!(
             resolved::auto_install_peers(&ctx),
             "project aube_config=true should win over project npmrc=false"
+        );
+    }
+
+    #[test]
+    fn workspace_yaml_wins_over_user_sources_by_default() {
+        // `pnpm-workspace.yaml` / `aube-workspace.yaml` live at the
+        // project root, so by the scope-locality principle they must
+        // outrank both user `.npmrc` and user `config.toml`. Without
+        // this, project-scope writes routed to the workspace yaml
+        // would be silently shadowed by anything the user has at
+        // `~/.config/aube/config.toml` or `~/.npmrc`.
+        let user_npmrc = entries(&[("auto-install-peers", "true")]);
+        let user_aube_config = entries(&[("autoInstallPeers", "true")]);
+        let ws = raw_yaml("autoInstallPeers: false\n");
+        let ctx = ResolveCtx {
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &user_aube_config,
+            user_npmrc: &user_npmrc,
+            workspace_yaml: &ws,
+            env: &[],
+            cli: &[],
+        };
+        assert!(
+            !resolved::auto_install_peers(&ctx),
+            "workspace yaml should win over user-scope sources"
         );
     }
 

--- a/crates/aube/src/commands/config/aube_config.rs
+++ b/crates/aube/src/commands/config/aube_config.rs
@@ -79,11 +79,28 @@ pub(crate) fn user_aube_config_path() -> miette::Result<PathBuf> {
     Ok(home.join(".config").join("aube").join("config.toml"))
 }
 
+/// Project-scope aube config path: `<project>/.config/aube/config.toml`.
+/// Mirrors the XDG layout used at user-scope so the same file name and
+/// folder shape applies everywhere. Project-scope is an alternative to
+/// committing aube-specific settings into a project `.npmrc` shared
+/// with npm/pnpm/yarn.
+pub(crate) fn project_aube_config_path(project_dir: &Path) -> PathBuf {
+    project_dir.join(".config").join("aube").join("config.toml")
+}
+
 pub(crate) fn load_user_entries() -> Vec<(String, String)> {
     let Ok(path) = user_aube_config_path() else {
         return Vec::new();
     };
-    match AubeConfigEdit::load(&path) {
+    load_entries_at(&path)
+}
+
+pub(crate) fn load_project_entries(project_dir: &Path) -> Vec<(String, String)> {
+    load_entries_at(&project_aube_config_path(project_dir))
+}
+
+fn load_entries_at(path: &Path) -> Vec<(String, String)> {
+    match AubeConfigEdit::load(path) {
         Ok(edit) => edit.entries(),
         Err(err) => {
             tracing::warn!("failed to load aube config at {}: {err}", path.display());

--- a/crates/aube/src/commands/config/aube_config.rs
+++ b/crates/aube/src/commands/config/aube_config.rs
@@ -1,6 +1,7 @@
 use super::{literal_aliases, setting_for_key, settings_meta};
 use miette::{Context, IntoDiagnostic, miette};
 use std::path::{Path, PathBuf};
+use yaml_serde::Value as YamlValue;
 
 pub(super) struct AubeConfigEdit {
     table: toml::map::Map<String, toml::Value>,
@@ -112,6 +113,89 @@ fn load_entries_at(path: &Path) -> Vec<(String, String)> {
 pub(super) fn is_aube_config_key(key: &str) -> Option<&'static settings_meta::SettingMeta> {
     let meta = setting_for_key(key)?;
     is_aube_config_setting(meta).then_some(meta)
+}
+
+/// Pick the workspace-yaml key to write under for this setting, or
+/// `None` if the setting has no top-level workspace-yaml source.
+/// Nested keys (e.g. `updateConfig.ignoreDependencies`) are skipped —
+/// they require sub-mapping edits beyond the scope of a generic
+/// `config set`.
+pub(super) fn preferred_workspace_yaml_key(
+    meta: &settings_meta::SettingMeta,
+) -> Option<&'static str> {
+    meta.workspace_yaml_keys
+        .iter()
+        .copied()
+        .find(|k| !k.contains('.'))
+}
+
+/// Write `raw` to `key` in the workspace yaml at `path`, preserving
+/// surrounding comments and unrelated keys via
+/// [`aube_manifest::workspace::edit_workspace_yaml`].
+pub(super) fn set_workspace_yaml_value(
+    path: &Path,
+    meta: &settings_meta::SettingMeta,
+    key: &str,
+    raw: &str,
+) -> miette::Result<()> {
+    let value = raw_to_yaml_value(meta, raw)?;
+    aube_manifest::workspace::edit_workspace_yaml(path, |map| {
+        map.insert(YamlValue::String(key.to_string()), value);
+        Ok(())
+    })
+    .map_err(|e| miette!("failed to write {}: {e}", path.display()))?;
+    Ok(())
+}
+
+/// Remove every alias of `meta` from the workspace yaml at `path`.
+/// Returns `true` if at least one key was found and removed.
+pub(super) fn remove_workspace_yaml_aliases(
+    path: &Path,
+    meta: &settings_meta::SettingMeta,
+) -> miette::Result<bool> {
+    let aliases: Vec<&'static str> = meta
+        .workspace_yaml_keys
+        .iter()
+        .copied()
+        .filter(|k| !k.contains('.'))
+        .collect();
+    if aliases.is_empty() {
+        return Ok(false);
+    }
+    let mut removed = false;
+    aube_manifest::workspace::edit_workspace_yaml(path, |map| {
+        for alias in &aliases {
+            if map
+                .shift_remove(YamlValue::String((*alias).to_string()))
+                .is_some()
+            {
+                removed = true;
+            }
+        }
+        Ok(())
+    })
+    .map_err(|e| miette!("failed to write {}: {e}", path.display()))?;
+    Ok(removed)
+}
+
+fn raw_to_yaml_value(meta: &settings_meta::SettingMeta, raw: &str) -> miette::Result<YamlValue> {
+    match meta.type_ {
+        "bool" => aube_settings::parse_bool(raw)
+            .map(YamlValue::Bool)
+            .ok_or_else(|| miette!("{} expects a boolean value", meta.name)),
+        "int" => raw
+            .trim()
+            .parse::<i64>()
+            .map(|n| YamlValue::Number(n.into()))
+            .map_err(|_| miette!("{} expects an integer value", meta.name)),
+        "list<string>" => Ok(YamlValue::Sequence(
+            parse_string_list(raw)
+                .into_iter()
+                .map(YamlValue::String)
+                .collect(),
+        )),
+        _ => Ok(YamlValue::String(raw.to_string())),
+    }
 }
 
 fn is_aube_config_setting(meta: &settings_meta::SettingMeta) -> bool {

--- a/crates/aube/src/commands/config/delete.rs
+++ b/crates/aube/src/commands/config/delete.rs
@@ -6,8 +6,19 @@ pub type DeleteArgs = KeyArgs;
 
 pub fn run(args: DeleteArgs) -> miette::Result<()> {
     let aliases = resolve_aliases(&args.key);
-    if aube_config::is_aube_config_key(&args.key).is_some() {
+    if let Some(meta) = aube_config::is_aube_config_key(&args.key) {
         let location = args.effective_location();
+        // Mirror `set --location project`: if the value lives in an
+        // existing workspace yaml, remove it from there.
+        if matches!(location, Location::Project)
+            && let Some(yaml_path) = aube_manifest::workspace::workspace_yaml_existing(
+                &crate::dirs::project_root_or_cwd()?,
+            )
+            && aube_config::remove_workspace_yaml_aliases(&yaml_path, meta)?
+        {
+            eprintln!("deleted {} ({})", args.key, yaml_path.display());
+            return Ok(());
+        }
         let path = match location {
             Location::User | Location::Global => aube_config::user_aube_config_path()?,
             Location::Project => {

--- a/crates/aube/src/commands/config/delete.rs
+++ b/crates/aube/src/commands/config/delete.rs
@@ -5,10 +5,13 @@ pub type DeleteArgs = KeyArgs;
 
 pub fn run(args: DeleteArgs) -> miette::Result<()> {
     let aliases = resolve_aliases(&args.key);
-    if matches!(args.effective_location(), Location::User | Location::Global)
-        && aube_config::is_aube_config_key(&args.key).is_some()
-    {
-        let path = aube_config::user_aube_config_path()?;
+    if aube_config::is_aube_config_key(&args.key).is_some() {
+        let path = match args.effective_location() {
+            Location::User | Location::Global => aube_config::user_aube_config_path()?,
+            Location::Project => {
+                aube_config::project_aube_config_path(&crate::dirs::project_root_or_cwd()?)
+            }
+        };
         let mut edit = aube_config::AubeConfigEdit::load(&path)?;
         if !edit.remove_aliases(&aliases) {
             return Err(miette!("{} not set in {}", args.key, path.display()));

--- a/crates/aube/src/commands/config/delete.rs
+++ b/crates/aube/src/commands/config/delete.rs
@@ -1,6 +1,5 @@
-use super::{KeyArgs, Location, NpmrcEdit, aube_config, resolve_aliases, user_npmrc_path};
+use super::{KeyArgs, Location, NpmrcEdit, aube_config, resolve_aliases};
 use miette::miette;
-use std::path::PathBuf;
 
 pub type DeleteArgs = KeyArgs;
 
@@ -10,41 +9,12 @@ pub fn run(args: DeleteArgs) -> miette::Result<()> {
         && aube_config::is_aube_config_key(&args.key).is_some()
     {
         let path = aube_config::user_aube_config_path()?;
-        let mut removed_paths: Vec<PathBuf> = Vec::new();
-        let mut removed = false;
         let mut edit = aube_config::AubeConfigEdit::load(&path)?;
-        if edit.remove_aliases(&aliases) {
-            edit.save(&path)?;
-            removed = true;
-            removed_paths.push(path.clone());
+        if !edit.remove_aliases(&aliases) {
+            return Err(miette!("{} not set in {}", args.key, path.display()));
         }
-        if let Ok(npmrc_path) = user_npmrc_path()
-            && npmrc_path.exists()
-        {
-            let mut edit = NpmrcEdit::load(&npmrc_path)?;
-            let mut npmrc_removed = false;
-            for alias in &aliases {
-                npmrc_removed |= edit.remove(alias);
-            }
-            if npmrc_removed {
-                removed = true;
-                edit.save(&npmrc_path)?;
-                removed_paths.push(npmrc_path);
-            }
-        }
-        if !removed {
-            return Err(miette!(
-                "{} not set in {} or user .npmrc",
-                args.key,
-                path.display()
-            ));
-        }
-        let paths = removed_paths
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        eprintln!("deleted {} ({})", args.key, paths);
+        edit.save(&path)?;
+        eprintln!("deleted {} ({})", args.key, path.display());
         return Ok(());
     }
 

--- a/crates/aube/src/commands/config/delete.rs
+++ b/crates/aube/src/commands/config/delete.rs
@@ -1,6 +1,6 @@
 use super::{KeyArgs, Location, NpmrcEdit, aube_config, resolve_aliases};
 use miette::miette;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub type DeleteArgs = KeyArgs;
 
@@ -8,29 +8,48 @@ pub fn run(args: DeleteArgs) -> miette::Result<()> {
     let aliases = resolve_aliases(&args.key);
     if let Some(meta) = aube_config::is_aube_config_key(&args.key) {
         let location = args.effective_location();
-        // Mirror `set --location project`: if the value lives in an
-        // existing workspace yaml, remove it from there.
+        let mut removed_paths: Vec<PathBuf> = Vec::new();
+
+        // Project-scope deletes also sweep the workspace yaml. We must
+        // not short-circuit after a successful yaml removal — a setting
+        // can exist in both files (e.g. written to `config.toml` first,
+        // overridden in yaml later), and leaving the `config.toml`
+        // copy behind would silently restore the deleted value.
         if matches!(location, Location::Project)
             && let Some(yaml_path) = aube_manifest::workspace::workspace_yaml_existing(
                 &crate::dirs::project_root_or_cwd()?,
             )
             && aube_config::remove_workspace_yaml_aliases(&yaml_path, meta)?
         {
-            eprintln!("deleted {} ({})", args.key, yaml_path.display());
-            return Ok(());
+            removed_paths.push(yaml_path);
         }
-        let path = match location {
+
+        let config_path = match location {
             Location::User | Location::Global => aube_config::user_aube_config_path()?,
             Location::Project => {
                 aube_config::project_aube_config_path(&crate::dirs::project_root_or_cwd()?)
             }
         };
-        let mut edit = aube_config::AubeConfigEdit::load(&path)?;
-        if !edit.remove_aliases(&aliases) {
-            return Err(missing_aube_key_error(&args.key, &aliases, &path, location));
+        let mut edit = aube_config::AubeConfigEdit::load(&config_path)?;
+        if edit.remove_aliases(&aliases) {
+            edit.save(&config_path)?;
+            removed_paths.push(config_path.clone());
         }
-        edit.save(&path)?;
-        eprintln!("deleted {} ({})", args.key, path.display());
+
+        if removed_paths.is_empty() {
+            return Err(missing_aube_key_error(
+                &args.key,
+                &aliases,
+                &config_path,
+                location,
+            ));
+        }
+        let joined = removed_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        eprintln!("deleted {} ({})", args.key, joined);
         return Ok(());
     }
 

--- a/crates/aube/src/commands/config/delete.rs
+++ b/crates/aube/src/commands/config/delete.rs
@@ -1,12 +1,14 @@
 use super::{KeyArgs, Location, NpmrcEdit, aube_config, resolve_aliases};
 use miette::miette;
+use std::path::Path;
 
 pub type DeleteArgs = KeyArgs;
 
 pub fn run(args: DeleteArgs) -> miette::Result<()> {
     let aliases = resolve_aliases(&args.key);
     if aube_config::is_aube_config_key(&args.key).is_some() {
-        let path = match args.effective_location() {
+        let location = args.effective_location();
+        let path = match location {
             Location::User | Location::Global => aube_config::user_aube_config_path()?,
             Location::Project => {
                 aube_config::project_aube_config_path(&crate::dirs::project_root_or_cwd()?)
@@ -14,7 +16,7 @@ pub fn run(args: DeleteArgs) -> miette::Result<()> {
         };
         let mut edit = aube_config::AubeConfigEdit::load(&path)?;
         if !edit.remove_aliases(&aliases) {
-            return Err(miette!("{} not set in {}", args.key, path.display()));
+            return Err(missing_aube_key_error(&args.key, &aliases, &path, location));
         }
         edit.save(&path)?;
         eprintln!("deleted {} ({})", args.key, path.display());
@@ -38,4 +40,34 @@ pub fn run(args: DeleteArgs) -> miette::Result<()> {
     edit.save(&path)?;
     eprintln!("deleted {} ({})", args.key, path.display());
     Ok(())
+}
+
+/// Build the error when an aube-known key isn't in the expected
+/// `config.toml`. Surfaces a stale `.npmrc` entry (typically left by an
+/// older aube that wrote aube-owned keys there) so the user knows where
+/// the value is actually coming from. aube intentionally doesn't modify
+/// `.npmrc` for aube-known keys — it's shared with npm/pnpm/yarn — so
+/// the message tells the user to clear the line themselves.
+fn missing_aube_key_error(
+    key: &str,
+    aliases: &[String],
+    config_path: &Path,
+    location: Location,
+) -> miette::Report {
+    if let Ok(npmrc_path) = location.path()
+        && npmrc_path.exists()
+        && let Ok(edit) = NpmrcEdit::load(&npmrc_path)
+        && edit.entries().iter().any(|(k, _)| aliases.contains(k))
+    {
+        return miette!(
+            "{key} is not set in {} but a stale entry exists in {}.\n\
+             aube no longer modifies `.npmrc` for known settings (it's shared with \
+             npm/pnpm/yarn) — edit that file directly to remove it, or run \
+             `aube config set {key} <value>` to override it from {}.",
+            config_path.display(),
+            npmrc_path.display(),
+            config_path.display(),
+        );
+    }
+    miette!("{key} not set in {}", config_path.display())
 }

--- a/crates/aube/src/commands/config/get.rs
+++ b/crates/aube/src/commands/config/get.rs
@@ -53,8 +53,10 @@ pub fn run(args: GetArgs) -> miette::Result<()> {
             entries
         }
         ListLocation::Project => {
-            // Project-scope aube config outranks project `.npmrc`.
-            let mut entries = read_single(&cwd.join(".npmrc"))?;
+            // Project-scope precedence (low → high): workspace yaml,
+            // project `.npmrc`, project `config.toml`.
+            let mut entries = super::read_workspace_yaml_flat(&cwd);
+            entries.extend(read_single(&cwd.join(".npmrc"))?);
             entries.extend(super::aube_config::load_project_entries(&cwd));
             entries
         }

--- a/crates/aube/src/commands/config/get.rs
+++ b/crates/aube/src/commands/config/get.rs
@@ -45,8 +45,11 @@ pub fn run(args: GetArgs) -> miette::Result<()> {
     let entries: Vec<(String, String)> = match args.effective_location() {
         ListLocation::Merged => read_merged(&cwd)?,
         ListLocation::User | ListLocation::Global => {
-            let mut entries = super::aube_config::load_user_entries();
-            entries.extend(read_single(&user_npmrc_path()?)?);
+            // `aube_config` outranks `~/.npmrc`, so emit it last — the
+            // reversed-iteration lookup below returns the first match,
+            // i.e. the highest-precedence source for the requested key.
+            let mut entries = read_single(&user_npmrc_path()?)?;
+            entries.extend(super::aube_config::load_user_entries());
             entries
         }
         ListLocation::Project => read_single(&cwd.join(".npmrc"))?,

--- a/crates/aube/src/commands/config/get.rs
+++ b/crates/aube/src/commands/config/get.rs
@@ -52,7 +52,12 @@ pub fn run(args: GetArgs) -> miette::Result<()> {
             entries.extend(super::aube_config::load_user_entries());
             entries
         }
-        ListLocation::Project => read_single(&cwd.join(".npmrc"))?,
+        ListLocation::Project => {
+            // Project-scope aube config outranks project `.npmrc`.
+            let mut entries = read_single(&cwd.join(".npmrc"))?;
+            entries.extend(super::aube_config::load_project_entries(&cwd));
+            entries
+        }
     };
 
     for (k, v) in entries.iter().rev() {

--- a/crates/aube/src/commands/config/list.rs
+++ b/crates/aube/src/commands/config/list.rs
@@ -84,9 +84,10 @@ pub fn run(args: ListArgs) -> miette::Result<()> {
             entries
         }
         ListLocation::Project => {
-            // Project-scope aube config outranks project `.npmrc`, same
-            // authority principle as the user-scope pair.
-            let mut entries = read_single(&cwd.join(".npmrc"))?;
+            // Project-scope precedence (low → high): workspace yaml,
+            // project `.npmrc`, project `config.toml`.
+            let mut entries = super::read_workspace_yaml_flat(&cwd);
+            entries.extend(read_single(&cwd.join(".npmrc"))?);
             entries.extend(super::aube_config::load_project_entries(&cwd));
             entries
         }

--- a/crates/aube/src/commands/config/list.rs
+++ b/crates/aube/src/commands/config/list.rs
@@ -77,8 +77,10 @@ pub fn run(args: ListArgs) -> miette::Result<()> {
     let entries: Vec<(String, String)> = match location {
         ListLocation::Merged => read_merged(&cwd)?,
         ListLocation::User | ListLocation::Global => {
-            let mut entries = super::aube_config::load_user_entries();
-            entries.extend(read_single(&user_npmrc_path()?)?);
+            // `aube_config` outranks `~/.npmrc`, so emit it last — the
+            // dedup loop below uses last-write-wins via `BTreeMap::insert`.
+            let mut entries = read_single(&user_npmrc_path()?)?;
+            entries.extend(super::aube_config::load_user_entries());
             entries
         }
         ListLocation::Project => read_single(&cwd.join(".npmrc"))?,

--- a/crates/aube/src/commands/config/list.rs
+++ b/crates/aube/src/commands/config/list.rs
@@ -83,7 +83,13 @@ pub fn run(args: ListArgs) -> miette::Result<()> {
             entries.extend(super::aube_config::load_user_entries());
             entries
         }
-        ListLocation::Project => read_single(&cwd.join(".npmrc"))?,
+        ListLocation::Project => {
+            // Project-scope aube config outranks project `.npmrc`, same
+            // authority principle as the user-scope pair.
+            let mut entries = read_single(&cwd.join(".npmrc"))?;
+            entries.extend(super::aube_config::load_project_entries(&cwd));
+            entries
+        }
     };
 
     let mut seen: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();

--- a/crates/aube/src/commands/config/mod.rs
+++ b/crates/aube/src/commands/config/mod.rs
@@ -276,18 +276,20 @@ fn search_text_matches(haystack: &str, term: &str) -> bool {
 /// Walk every config source in low-to-high precedence order so a later
 /// duplicate wins. Mirrors the chain the install pipeline applies via
 /// [`aube_settings::resolved`]:
-/// `workspaceYaml < userNpmrc < userAubeConfig < projectNpmrc <
-/// projectAubeConfig`. Per-setting `precedence` overrides in
-/// `settings.toml` can reorder file sources (e.g. `minimumReleaseAge`
-/// puts `workspaceYaml` first); `aube config get` shows the
-/// default-precedence view, which is accurate for the common cases.
+/// `userNpmrc < userAubeConfig < workspaceYaml < projectNpmrc <
+/// projectAubeConfig`. `workspaceYaml` sits above user-scope sources
+/// because it lives at the project root (scope locality). Per-setting
+/// `precedence` overrides in `settings.toml` can reorder file sources
+/// (e.g. `minimumReleaseAge` puts `workspaceYaml` first); `aube config
+/// get` shows the default-precedence view, which is accurate for the
+/// common cases.
 pub(super) fn read_merged(cwd: &Path) -> miette::Result<Vec<(String, String)>> {
     let mut out = Vec::new();
-    out.extend(read_workspace_yaml_flat(cwd));
     if let Ok(user) = user_npmrc_path() {
         out.extend(read_single(&user)?);
     }
     out.extend(aube_config::load_user_entries());
+    out.extend(read_workspace_yaml_flat(cwd));
     out.extend(read_single(&cwd.join(".npmrc"))?);
     out.extend(aube_config::load_project_entries(cwd));
     Ok(out)

--- a/crates/aube/src/commands/config/mod.rs
+++ b/crates/aube/src/commands/config/mod.rs
@@ -70,8 +70,9 @@ pub(crate) struct KeyArgs {
     /// Which config location to act on.
     ///
     /// Defaults to `user`. Known aube settings use
-    /// `~/.config/aube/config.toml`; registry/auth and unknown keys
-    /// use `~/.npmrc`.
+    /// `~/.config/aube/config.toml` (user) or
+    /// `<cwd>/.config/aube/config.toml` (project); registry/auth and
+    /// unknown keys use `~/.npmrc` or `<cwd>/.npmrc` respectively.
     #[arg(long, value_enum, default_value_t = Location::User)]
     pub location: Location,
 }
@@ -110,7 +111,10 @@ pub(crate) enum ListLocation {
     Global,
 }
 
-pub(crate) use aube_config::load_user_entries as load_user_aube_config_entries;
+pub(crate) use aube_config::{
+    load_project_entries as load_project_aube_config_entries,
+    load_user_entries as load_user_aube_config_entries,
+};
 pub(crate) use get_cmd::GetArgs;
 pub(crate) use set_cmd::SetArgs;
 
@@ -269,18 +273,18 @@ fn search_text_matches(haystack: &str, term: &str) -> bool {
         .any(|word| word.starts_with(term))
 }
 
-/// Read `~/.npmrc`, then `<cwd>/.npmrc`, then aube's user `config.toml`
-/// and return every entry in file order so a later duplicate wins.
-/// Order mirrors the precedence the install pipeline applies via
-/// [`aube_settings::resolved`]: `aubeConfig` beats `npmrc`, and project
-/// `.npmrc` beats user `.npmrc`.
+/// Walk every config source in low-to-high precedence order so a later
+/// duplicate wins. Mirrors the chain the install pipeline applies via
+/// [`aube_settings::resolved`]:
+/// `userNpmrc < userAubeConfig < projectNpmrc < projectAubeConfig`.
 pub(super) fn read_merged(cwd: &Path) -> miette::Result<Vec<(String, String)>> {
     let mut out = Vec::new();
     if let Ok(user) = user_npmrc_path() {
         out.extend(read_single(&user)?);
     }
-    out.extend(read_single(&cwd.join(".npmrc"))?);
     out.extend(aube_config::load_user_entries());
+    out.extend(read_single(&cwd.join(".npmrc"))?);
+    out.extend(aube_config::load_project_entries(cwd));
     Ok(out)
 }
 

--- a/crates/aube/src/commands/config/mod.rs
+++ b/crates/aube/src/commands/config/mod.rs
@@ -269,15 +269,18 @@ fn search_text_matches(haystack: &str, term: &str) -> bool {
         .any(|word| word.starts_with(term))
 }
 
-/// Read aube's user config, `~/.npmrc`, then `<cwd>/.npmrc` and return
-/// every entry in file order so a later duplicate wins.
+/// Read `~/.npmrc`, then `<cwd>/.npmrc`, then aube's user `config.toml`
+/// and return every entry in file order so a later duplicate wins.
+/// Order mirrors the precedence the install pipeline applies via
+/// [`aube_settings::resolved`]: `aubeConfig` beats `npmrc`, and project
+/// `.npmrc` beats user `.npmrc`.
 pub(super) fn read_merged(cwd: &Path) -> miette::Result<Vec<(String, String)>> {
     let mut out = Vec::new();
-    out.extend(aube_config::load_user_entries());
     if let Ok(user) = user_npmrc_path() {
         out.extend(read_single(&user)?);
     }
     out.extend(read_single(&cwd.join(".npmrc"))?);
+    out.extend(aube_config::load_user_entries());
     Ok(out)
 }
 

--- a/crates/aube/src/commands/config/mod.rs
+++ b/crates/aube/src/commands/config/mod.rs
@@ -276,9 +276,14 @@ fn search_text_matches(haystack: &str, term: &str) -> bool {
 /// Walk every config source in low-to-high precedence order so a later
 /// duplicate wins. Mirrors the chain the install pipeline applies via
 /// [`aube_settings::resolved`]:
-/// `userNpmrc < userAubeConfig < projectNpmrc < projectAubeConfig`.
+/// `workspaceYaml < userNpmrc < userAubeConfig < projectNpmrc <
+/// projectAubeConfig`. Per-setting `precedence` overrides in
+/// `settings.toml` can reorder file sources (e.g. `minimumReleaseAge`
+/// puts `workspaceYaml` first); `aube config get` shows the
+/// default-precedence view, which is accurate for the common cases.
 pub(super) fn read_merged(cwd: &Path) -> miette::Result<Vec<(String, String)>> {
     let mut out = Vec::new();
+    out.extend(read_workspace_yaml_flat(cwd));
     if let Ok(user) = user_npmrc_path() {
         out.extend(read_single(&user)?);
     }
@@ -286,6 +291,34 @@ pub(super) fn read_merged(cwd: &Path) -> miette::Result<Vec<(String, String)>> {
     out.extend(read_single(&cwd.join(".npmrc"))?);
     out.extend(aube_config::load_project_entries(cwd));
     Ok(out)
+}
+
+/// Surface flat scalar entries from the project's workspace yaml so
+/// `aube config get/list` can report values aube actually reads from
+/// there (`autoInstallPeers`, `nodeLinker`, `minimumReleaseAge`, …).
+/// Nested mappings (`updateConfig.ignoreDependencies`, `catalog`,
+/// `allowBuilds`) are skipped — they don't round-trip through a simple
+/// `(key, raw)` view and aren't what `config get <bare-key>` asks for.
+pub(super) fn read_workspace_yaml_flat(cwd: &Path) -> Vec<(String, String)> {
+    let Ok(map) = aube_manifest::workspace::load_raw(cwd) else {
+        return Vec::new();
+    };
+    map.iter()
+        .filter_map(|(k, v)| yaml_scalar_string(v).map(|raw| (k.clone(), raw)))
+        .collect()
+}
+
+fn yaml_scalar_string(value: &yaml_serde::Value) -> Option<String> {
+    match value {
+        yaml_serde::Value::String(s) => Some(s.clone()),
+        yaml_serde::Value::Number(n) => Some(n.to_string()),
+        yaml_serde::Value::Bool(b) => Some(b.to_string()),
+        yaml_serde::Value::Sequence(items) => {
+            let parts: Vec<String> = items.iter().filter_map(yaml_scalar_string).collect();
+            (!parts.is_empty()).then(|| parts.join(","))
+        }
+        _ => None,
+    }
 }
 
 pub(super) fn read_single(path: &std::path::Path) -> miette::Result<Vec<(String, String)>> {

--- a/crates/aube/src/commands/config/set.rs
+++ b/crates/aube/src/commands/config/set.rs
@@ -44,28 +44,18 @@ pub(super) fn set_value(
     report: bool,
 ) -> miette::Result<()> {
     if let Some(meta) = aube_config::is_aube_config_key(key) {
-        // Project-scope writes prefer an existing workspace yaml so we
-        // don't proliferate config files. Settings with no workspace
-        // yaml source fall back to project `config.toml`. User-scope
-        // writes always land in `~/.config/aube/config.toml`.
-        if matches!(location, Location::Project)
-            && let Some(yaml_path) = aube_manifest::workspace::workspace_yaml_existing(
-                &crate::dirs::project_root_or_cwd()?,
-            )
+        let path = aube_config_target(location, meta)?;
+        if path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("yaml"))
             && let Some(yaml_key) = aube_config::preferred_workspace_yaml_key(meta)
         {
-            aube_config::set_workspace_yaml_value(&yaml_path, meta, yaml_key, value)?;
+            aube_config::set_workspace_yaml_value(&path, meta, yaml_key, value)?;
             if report {
-                eprintln!("set {}={} ({})", yaml_key, value, yaml_path.display());
+                eprintln!("set {}={} ({})", yaml_key, value, path.display());
             }
             return Ok(());
         }
-        let path = match location {
-            Location::User | Location::Global => aube_config::user_aube_config_path()?,
-            Location::Project => {
-                aube_config::project_aube_config_path(&crate::dirs::project_root_or_cwd()?)
-            }
-        };
         let mut edit = aube_config::AubeConfigEdit::load(&path)?;
         edit.set(meta, value)?;
         edit.save(&path)?;
@@ -90,6 +80,32 @@ pub(super) fn set_value(
         eprintln!("set {}={} ({})", write_key, value, path.display());
     }
     Ok(())
+}
+
+/// Decide where to write an aube-known setting for the given location.
+/// Project-scope writes prefer an existing workspace yaml when no
+/// project `config.toml` has been adopted yet — keeps the per-project
+/// config story in a single file. Once `config.toml` exists, all
+/// project writes go there (otherwise a yaml write would be silently
+/// shadowed by the higher-precedence `config.toml` entry on read).
+fn aube_config_target(
+    location: Location,
+    meta: &aube_settings::meta::SettingMeta,
+) -> miette::Result<std::path::PathBuf> {
+    match location {
+        Location::User | Location::Global => aube_config::user_aube_config_path(),
+        Location::Project => {
+            let cwd = crate::dirs::project_root_or_cwd()?;
+            let config_path = aube_config::project_aube_config_path(&cwd);
+            if !config_path.exists()
+                && aube_config::preferred_workspace_yaml_key(meta).is_some()
+                && let Some(yaml_path) = aube_manifest::workspace::workspace_yaml_existing(&cwd)
+            {
+                return Ok(yaml_path);
+            }
+            Ok(config_path)
+        }
+    }
 }
 
 pub(super) fn preferred_write_key(input: &str, aliases: &[String]) -> String {

--- a/crates/aube/src/commands/config/set.rs
+++ b/crates/aube/src/commands/config/set.rs
@@ -1,4 +1,4 @@
-use super::{Location, NpmrcEdit, aube_config, resolve_aliases, user_npmrc_path};
+use super::{Location, NpmrcEdit, aube_config, resolve_aliases};
 use clap::Args;
 
 #[derive(Debug, Args)]
@@ -49,7 +49,6 @@ pub(super) fn set_value(
         let mut edit = aube_config::AubeConfigEdit::load(&path)?;
         edit.set(meta, value)?;
         edit.save(&path)?;
-        remove_stale_user_npmrc_aliases(key)?;
         if report {
             eprintln!("set {}={} ({})", meta.name, value, path.display());
         }
@@ -69,24 +68,6 @@ pub(super) fn set_value(
     edit.save(&path)?;
     if report {
         eprintln!("set {}={} ({})", write_key, value, path.display());
-    }
-    Ok(())
-}
-
-fn remove_stale_user_npmrc_aliases(key: &str) -> miette::Result<()> {
-    let Ok(path) = user_npmrc_path() else {
-        return Ok(());
-    };
-    if !path.exists() {
-        return Ok(());
-    }
-    let mut edit = NpmrcEdit::load(&path)?;
-    let mut removed = false;
-    for alias in resolve_aliases(key) {
-        removed |= edit.remove(&alias);
-    }
-    if removed {
-        edit.save(&path)?;
     }
     Ok(())
 }

--- a/crates/aube/src/commands/config/set.rs
+++ b/crates/aube/src/commands/config/set.rs
@@ -16,8 +16,9 @@ pub struct SetArgs {
     /// Which config location to write to.
     ///
     /// Defaults to `user`. Known aube settings use
-    /// `~/.config/aube/config.toml`; registry/auth and unknown keys
-    /// use `~/.npmrc`.
+    /// `~/.config/aube/config.toml` (user) or
+    /// `<cwd>/.config/aube/config.toml` (project); registry/auth and
+    /// unknown keys use `~/.npmrc` or `<cwd>/.npmrc` respectively.
     #[arg(long, value_enum, default_value_t = Location::User)]
     pub location: Location,
 }
@@ -42,10 +43,13 @@ pub(super) fn set_value(
     location: Location,
     report: bool,
 ) -> miette::Result<()> {
-    if matches!(location, Location::User | Location::Global)
-        && let Some(meta) = aube_config::is_aube_config_key(key)
-    {
-        let path = aube_config::user_aube_config_path()?;
+    if let Some(meta) = aube_config::is_aube_config_key(key) {
+        let path = match location {
+            Location::User | Location::Global => aube_config::user_aube_config_path()?,
+            Location::Project => {
+                aube_config::project_aube_config_path(&crate::dirs::project_root_or_cwd()?)
+            }
+        };
         let mut edit = aube_config::AubeConfigEdit::load(&path)?;
         edit.set(meta, value)?;
         edit.save(&path)?;

--- a/crates/aube/src/commands/config/set.rs
+++ b/crates/aube/src/commands/config/set.rs
@@ -44,6 +44,22 @@ pub(super) fn set_value(
     report: bool,
 ) -> miette::Result<()> {
     if let Some(meta) = aube_config::is_aube_config_key(key) {
+        // Project-scope writes prefer an existing workspace yaml so we
+        // don't proliferate config files. Settings with no workspace
+        // yaml source fall back to project `config.toml`. User-scope
+        // writes always land in `~/.config/aube/config.toml`.
+        if matches!(location, Location::Project)
+            && let Some(yaml_path) = aube_manifest::workspace::workspace_yaml_existing(
+                &crate::dirs::project_root_or_cwd()?,
+            )
+            && let Some(yaml_key) = aube_config::preferred_workspace_yaml_key(meta)
+        {
+            aube_config::set_workspace_yaml_value(&yaml_path, meta, yaml_key, value)?;
+            if report {
+                eprintln!("set {}={} ({})", yaml_key, value, yaml_path.display());
+            }
+            return Ok(());
+        }
         let path = match location {
             Location::User | Location::Global => aube_config::user_aube_config_path()?,
             Location::Project => {

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -115,17 +115,10 @@ pub async fn run(
     // (including the raw map) when any unrelated typed field
     // mismatches (e.g. `shamefullyHoist: "maybe"`). That would
     // silently drop `deployAllFiles: true`.
-    let npmrc_entries = aube_registry::config::load_npmrc_entries(&source_root);
-    let aube_config_entries = crate::commands::config::load_user_aube_config_entries();
+    let files = crate::commands::FileSources::load(&source_root);
     let raw_workspace = aube_manifest::workspace::load_raw(&source_root).unwrap_or_default();
     let env = aube_settings::values::process_env();
-    let settings_ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc_entries,
-        aube_config: &aube_config_entries,
-        workspace_yaml: &raw_workspace,
-        env,
-        cli: &[],
-    };
+    let settings_ctx = files.ctx(&raw_workspace, env, &[]);
     let deploy_all_files = aube_settings::resolved::deploy_all_files(&settings_ctx);
 
     // Discover catalog entries from the source workspace before any

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -510,12 +510,13 @@ mod tests {
     #[test]
     fn dlx_install_disables_global_virtual_store() {
         let opts = dlx_install_options();
-        let empty_npmrc = Vec::new();
         let empty_workspace = std::collections::BTreeMap::new();
         let empty_env = Vec::new();
         let ctx = aube_settings::ResolveCtx {
-            npmrc: &empty_npmrc,
-            aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &[],
+            user_npmrc: &[],
             workspace_yaml: &empty_workspace,
             env: &empty_env,
             cli: &opts.cli_flags,

--- a/crates/aube/src/commands/fetch.rs
+++ b/crates/aube/src/commands/fetch.rs
@@ -126,19 +126,12 @@ pub async fn run(args: FetchArgs) -> miette::Result<()> {
     // `fetch_packages`, so callers that invoke `aube fetch` from
     // inside a project pick up that project's configuration without
     // any extra CLI plumbing.
-    let npmrc_entries = aube_registry::config::load_npmrc_entries(&cwd);
-    let aube_config_entries = crate::commands::config::load_user_aube_config_entries();
+    let files = crate::commands::FileSources::load(&cwd);
     let raw_workspace = aube_manifest::workspace::load_both(&cwd)
         .map(|(_, raw)| raw)
         .unwrap_or_default();
     let env = aube_settings::values::process_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc_entries,
-        aube_config: &aube_config_entries,
-        workspace_yaml: &raw_workspace,
-        env,
-        cli: &[],
-    };
+    let ctx = files.ctx(&raw_workspace, env, &[]);
     let git_shallow_hosts = aube_settings::resolved::git_shallow_hosts(&ctx);
     let (_indices, cached, fetched) = install::fetch_packages(
         &filtered,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -886,19 +886,12 @@ pub(super) async fn fetch_packages(
     // honest: the lockfile install path and the standalone fetch
     // path share the same hardcoded fallback behavior when no
     // setting is configured.
-    let npmrc_entries = aube_registry::config::load_npmrc_entries(&cwd);
-    let aube_config_entries = crate::commands::config::load_user_aube_config_entries();
+    let files = crate::commands::FileSources::load(&cwd);
     let raw_workspace = aube_manifest::workspace::load_both(&cwd)
         .map(|(_, raw)| raw)
         .unwrap_or_default();
     let env = aube_settings::values::process_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc_entries,
-        aube_config: &aube_config_entries,
-        workspace_yaml: &raw_workspace,
-        env,
-        cli: &[],
-    };
+    let ctx = files.ctx(&raw_workspace, env, &[]);
     let network_concurrency = resolve_network_concurrency(&ctx);
     let verify_integrity = resolve_verify_store_integrity(&ctx);
     let strict_integrity = settings::resolve_strict_store_integrity(&ctx);
@@ -2111,8 +2104,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // resolving the dep graph. Also load `.npmrc` entries once so
     // the same borrow feeds both the resolve-time settings and the
     // later engine-check settings.
-    let npmrc_entries = aube_registry::config::load_npmrc_entries(&cwd);
-    let aube_config_entries = crate::commands::config::load_user_aube_config_entries();
+    let files = crate::commands::FileSources::load(&cwd);
     let (ws_config_shared, raw_workspace) = aube_manifest::workspace::load_both(&cwd)
         .into_diagnostic()
         .wrap_err("failed to load workspace config")?;
@@ -2122,13 +2114,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // workspace's catalog. See `discover_catalogs` for the precedence
     // order.
     let workspace_catalogs = super::discover_catalogs(&cwd)?;
-    let settings_ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc_entries,
-        aube_config: &aube_config_entries,
-        workspace_yaml: &raw_workspace,
-        env: &opts.env_snapshot,
-        cli: &opts.cli_flags,
-    };
+    let settings_ctx = files.ctx(&raw_workspace, &opts.env_snapshot, &opts.cli_flags);
     super::configure_script_settings(&settings_ctx);
 
     // `--lockfile-dir` / `lockfileDir`: relocate `aube-lock.yaml` to a

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -37,12 +37,12 @@ fn resolve_resolution_mode(ctx: &aube_settings::ResolveCtx<'_>) -> aube_resolver
         })
         .or_else(|| aube_settings::values::string_from_npmrc("resolutionMode", ctx.project_npmrc))
         .or_else(|| {
+            aube_settings::values::string_from_workspace_yaml("resolutionMode", ctx.workspace_yaml)
+        })
+        .or_else(|| {
             aube_settings::values::string_from_npmrc("resolutionMode", ctx.user_aube_config)
         })
-        .or_else(|| aube_settings::values::string_from_npmrc("resolutionMode", ctx.user_npmrc))
-        .or_else(|| {
-            aube_settings::values::string_from_workspace_yaml("resolutionMode", ctx.workspace_yaml)
-        });
+        .or_else(|| aube_settings::values::string_from_npmrc("resolutionMode", ctx.user_npmrc));
     if let Some(raw) = raw
         && let Some(m) = parse_resolution_mode(&raw)
     {
@@ -458,18 +458,22 @@ fn merge_json_object_setting(
 ) {
     // Walk file sources in low-to-high precedence order so later
     // `.extend` calls overwrite earlier ones for shared keys.
+    // `workspace_yaml` sits between user-scope and project-scope —
+    // it's project-scope locality.
+    if let Some(value) = object_setting_from_npmrc(setting, ctx.user_npmrc) {
+        out.extend(value);
+    }
+    if let Some(value) = object_setting_from_npmrc(setting, ctx.user_aube_config) {
+        out.extend(value);
+    }
     if let Some(value) = object_setting_from_workspace_yaml(setting, ctx.workspace_yaml) {
         out.extend(value);
     }
-    for entries in [
-        ctx.user_npmrc,
-        ctx.user_aube_config,
-        ctx.project_npmrc,
-        ctx.project_aube_config,
-    ] {
-        if let Some(value) = object_setting_from_npmrc(setting, entries) {
-            out.extend(value);
-        }
+    if let Some(value) = object_setting_from_npmrc(setting, ctx.project_npmrc) {
+        out.extend(value);
+    }
+    if let Some(value) = object_setting_from_npmrc(setting, ctx.project_aube_config) {
+        out.extend(value);
     }
     if let Some(value) = object_setting_from_env(setting, ctx.env) {
         out.extend(value);
@@ -481,18 +485,20 @@ fn merge_string_map_setting(
     setting: &str,
     out: &mut BTreeMap<String, String>,
 ) {
+    if let Some(value) = object_setting_from_npmrc(setting, ctx.user_npmrc) {
+        out.extend(json_string_map(value));
+    }
+    if let Some(value) = object_setting_from_npmrc(setting, ctx.user_aube_config) {
+        out.extend(json_string_map(value));
+    }
     if let Some(value) = object_setting_from_workspace_yaml(setting, ctx.workspace_yaml) {
         out.extend(json_string_map(value));
     }
-    for entries in [
-        ctx.user_npmrc,
-        ctx.user_aube_config,
-        ctx.project_npmrc,
-        ctx.project_aube_config,
-    ] {
-        if let Some(value) = object_setting_from_npmrc(setting, entries) {
-            out.extend(json_string_map(value));
-        }
+    if let Some(value) = object_setting_from_npmrc(setting, ctx.project_npmrc) {
+        out.extend(json_string_map(value));
+    }
+    if let Some(value) = object_setting_from_npmrc(setting, ctx.project_aube_config) {
+        out.extend(json_string_map(value));
     }
     if let Some(value) = object_setting_from_env(setting, ctx.env) {
         out.extend(json_string_map(value));

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -32,7 +32,14 @@ fn resolve_resolution_mode(ctx: &aube_settings::ResolveCtx<'_>) -> aube_resolver
     // the generator grows per-setting variant aliases.
     let raw = aube_settings::values::string_from_cli("resolutionMode", ctx.cli)
         .or_else(|| aube_settings::values::string_from_env("resolutionMode", ctx.env))
-        .or_else(|| aube_settings::values::string_from_npmrc("resolutionMode", ctx.npmrc))
+        .or_else(|| {
+            aube_settings::values::string_from_npmrc("resolutionMode", ctx.project_aube_config)
+        })
+        .or_else(|| aube_settings::values::string_from_npmrc("resolutionMode", ctx.project_npmrc))
+        .or_else(|| {
+            aube_settings::values::string_from_npmrc("resolutionMode", ctx.user_aube_config)
+        })
+        .or_else(|| aube_settings::values::string_from_npmrc("resolutionMode", ctx.user_npmrc))
         .or_else(|| {
             aube_settings::values::string_from_workspace_yaml("resolutionMode", ctx.workspace_yaml)
         });
@@ -449,11 +456,20 @@ fn merge_json_object_setting(
     setting: &str,
     out: &mut BTreeMap<String, serde_json::Value>,
 ) {
+    // Walk file sources in low-to-high precedence order so later
+    // `.extend` calls overwrite earlier ones for shared keys.
     if let Some(value) = object_setting_from_workspace_yaml(setting, ctx.workspace_yaml) {
         out.extend(value);
     }
-    if let Some(value) = object_setting_from_npmrc(setting, ctx.npmrc) {
-        out.extend(value);
+    for entries in [
+        ctx.user_npmrc,
+        ctx.user_aube_config,
+        ctx.project_npmrc,
+        ctx.project_aube_config,
+    ] {
+        if let Some(value) = object_setting_from_npmrc(setting, entries) {
+            out.extend(value);
+        }
     }
     if let Some(value) = object_setting_from_env(setting, ctx.env) {
         out.extend(value);
@@ -468,8 +484,15 @@ fn merge_string_map_setting(
     if let Some(value) = object_setting_from_workspace_yaml(setting, ctx.workspace_yaml) {
         out.extend(json_string_map(value));
     }
-    if let Some(value) = object_setting_from_npmrc(setting, ctx.npmrc) {
-        out.extend(json_string_map(value));
+    for entries in [
+        ctx.user_npmrc,
+        ctx.user_aube_config,
+        ctx.project_npmrc,
+        ctx.project_aube_config,
+    ] {
+        if let Some(value) = object_setting_from_npmrc(setting, entries) {
+            out.extend(json_string_map(value));
+        }
     }
     if let Some(value) = object_setting_from_env(setting, ctx.env) {
         out.extend(json_string_map(value));

--- a/crates/aube/src/commands/install_test.rs
+++ b/crates/aube/src/commands/install_test.rs
@@ -33,18 +33,11 @@ pub async fn run(script_args: ScriptArgs) -> miette::Result<()> {
     }
 
     if !no_install {
-        let npmrc = aube_registry::config::load_npmrc_entries(&cwd);
-        let aube_config = crate::commands::config::load_user_aube_config_entries();
+        let files = crate::commands::FileSources::load(&cwd);
         let raw_ws = aube_manifest::workspace::load_raw(&cwd)
             .map_err(|e| miette!("failed to load workspace config: {e}"))?;
         let env = aube_settings::values::capture_env();
-        let ctx = aube_settings::ResolveCtx {
-            npmrc: &npmrc,
-            aube_config: &aube_config,
-            workspace_yaml: &raw_ws,
-            env: &env,
-            cli: &[],
-        };
+        let ctx = files.ctx(&raw_ws, &env, &[]);
         let mode = install::FrozenMode::from_override(
             None,
             aube_settings::resolved::prefer_frozen_lockfile(&ctx),

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -193,21 +193,54 @@ pub(crate) fn configure_script_settings(ctx: &aube_settings::ResolveCtx<'_>) {
 /// lifecycle hooks (pack/publish/version) outside the install path,
 /// which already does this via `configure_script_settings` directly.
 pub(crate) fn configure_script_settings_for_cwd(cwd: &Path) -> miette::Result<()> {
-    let npmrc_entries = aube_registry::config::load_npmrc_entries(cwd);
-    let aube_config_entries = config::load_user_aube_config_entries();
+    let files = FileSources::load(cwd);
     let (_, raw_workspace) = aube_manifest::workspace::load_both(cwd)
         .into_diagnostic()
         .wrap_err("failed to load workspace config")?;
     let env_snapshot = aube_settings::values::capture_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc_entries,
-        aube_config: &aube_config_entries,
-        workspace_yaml: &raw_workspace,
-        env: &env_snapshot,
-        cli: &[],
-    };
+    let ctx = files.ctx(&raw_workspace, &env_snapshot, &[]);
     configure_script_settings(&ctx);
     Ok(())
+}
+
+/// Owned bundle of the four file-source slices that feed a
+/// [`aube_settings::ResolveCtx`]: project + user `.npmrc`, and project +
+/// user `~/.config/aube/config.toml`. Construct once with
+/// `FileSources::load`, borrow into a `ResolveCtx` via `FileSources::ctx`.
+pub(crate) struct FileSources {
+    pub user_npmrc: Vec<(String, String)>,
+    pub project_npmrc: Vec<(String, String)>,
+    pub user_aube_config: Vec<(String, String)>,
+    pub project_aube_config: Vec<(String, String)>,
+}
+
+impl FileSources {
+    pub(crate) fn load(cwd: &Path) -> Self {
+        let npmrc = aube_registry::config::load_npmrc_entries_split(cwd);
+        Self {
+            user_npmrc: npmrc.user,
+            project_npmrc: npmrc.project,
+            user_aube_config: config::load_user_aube_config_entries(),
+            project_aube_config: config::load_project_aube_config_entries(cwd),
+        }
+    }
+
+    pub(crate) fn ctx<'a>(
+        &'a self,
+        workspace_yaml: &'a std::collections::BTreeMap<String, yaml_serde::Value>,
+        env: &'a [(String, String)],
+        cli: &'a [(String, String)],
+    ) -> aube_settings::ResolveCtx<'a> {
+        aube_settings::ResolveCtx {
+            project_aube_config: &self.project_aube_config,
+            project_npmrc: &self.project_npmrc,
+            user_aube_config: &self.user_aube_config,
+            user_npmrc: &self.user_npmrc,
+            workspace_yaml,
+            env,
+            cli,
+        }
+    }
 }
 
 fn non_empty_string(value: String) -> Option<String> {
@@ -258,10 +291,10 @@ pub(crate) fn ensure_registry_auth(
 static LOCK_HELD: AtomicBool = AtomicBool::new(false);
 
 /// Whether the project-level advisory lock is disabled. Resolves the
-/// `aubeNoLock` setting through the full cli > env > aubeConfig >
-/// npmrc > workspace.yaml chain so `.npmrc`, `~/.config/aube/config.toml`,
-/// and `aube-workspace.yaml` entries participate alongside the canonical
-/// `AUBE_NO_LOCK` env var.
+/// `aubeNoLock` setting through the full file-source chain so
+/// `.npmrc`, `~/.config/aube/config.toml`, project
+/// `.config/aube/config.toml`, and `aube-workspace.yaml` entries
+/// participate alongside the canonical `AUBE_NO_LOCK` env var.
 fn aube_no_lock_enabled(cwd: &std::path::Path) -> bool {
     with_settings_ctx(cwd, aube_settings::resolved::aube_no_lock)
 }
@@ -406,29 +439,22 @@ pub(crate) fn with_settings_ctx<T>(
     cwd: &std::path::Path,
     f: impl FnOnce(&aube_settings::ResolveCtx<'_>) -> T,
 ) -> T {
-    let npmrc = aube_registry::config::load_npmrc_entries(cwd);
-    let aube_config = config::load_user_aube_config_entries();
+    let files = FileSources::load(cwd);
     let raw_workspace = aube_manifest::workspace::load_raw(cwd).unwrap_or_default();
     // `process_env()` returns a `&'static` borrow of the once-captured
     // env. Avoids cloning ~200-500 String pairs every time a command
     // builds a ResolveCtx (the typical path hits this 5+ times per
     // `aube run`).
     let env = aube_settings::values::process_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc,
-        aube_config: &aube_config,
-        workspace_yaml: &raw_workspace,
-        env,
-        cli: &[],
-    };
+    let ctx = files.ctx(&raw_workspace, env, &[]);
     f(&ctx)
 }
 
 /// Build a registry client configured from .npmrc files in the project directory.
 ///
 /// Also resolves the `fetch*` settings (timeout + retries + backoff)
-/// from the full cli > env > aubeConfig > npmrc > workspace precedence
-/// chain and threads the resulting [`aube_registry::config::FetchPolicy`] into
+/// from the full settings precedence chain and threads the resulting
+/// [`aube_registry::config::FetchPolicy`] into
 /// the client. The CLI bag comes from [`fetch_cli_overrides`], which
 /// `async_main` populates from the global `--fetch-timeout`,
 /// `--fetch-retries`, and `--fetch-retry-{factor,mintimeout,maxtimeout}`
@@ -519,19 +545,12 @@ pub(crate) fn build_resolver(
 /// deprecate, etc) can opt in without duplicating the ctx-building
 /// boilerplate.
 pub(crate) fn resolve_fetch_policy(cwd: &std::path::Path) -> aube_registry::config::FetchPolicy {
-    let npmrc = aube_registry::config::load_npmrc_entries(cwd);
-    let aube_config = config::load_user_aube_config_entries();
+    let files = FileSources::load(cwd);
     let workspace_yaml = aube_manifest::workspace::load_both(cwd)
         .map(|(_, raw)| raw)
         .unwrap_or_default();
     let env = aube_settings::values::process_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc,
-        aube_config: &aube_config,
-        workspace_yaml: &workspace_yaml,
-        env,
-        cli: fetch_cli_overrides(),
-    };
+    let ctx = files.ctx(&workspace_yaml, env, fetch_cli_overrides());
     aube_registry::config::FetchPolicy::from_ctx(&ctx)
 }
 
@@ -631,10 +650,18 @@ pub(crate) fn resolve_virtual_store_dir(
         let modules_dir = aube_settings::resolved::modules_dir(ctx);
         project_dir.join(modules_dir).join(".aube")
     };
-    let has_explicit_npmrc = ctx
-        .npmrc
-        .iter()
-        .any(|(k, _)| k == "virtualStoreDir" || k == "virtual-store-dir");
+    let has_explicit_npmrc = [
+        ctx.project_aube_config,
+        ctx.project_npmrc,
+        ctx.user_aube_config,
+        ctx.user_npmrc,
+    ]
+    .iter()
+    .any(|entries| {
+        entries
+            .iter()
+            .any(|(k, _)| k == "virtualStoreDir" || k == "virtual-store-dir")
+    });
     let has_explicit_yaml = ctx.workspace_yaml.contains_key("virtualStoreDir");
     // Mirrors the `sources.env` list in settings.toml (`virtualStoreDir`).
     // Keep all three aliases here — dropping `AUBE_VIRTUAL_STORE_DIR`
@@ -672,8 +699,10 @@ mod resolve_virtual_store_dir_tests {
         ws: &'a BTreeMap<String, yaml_serde::Value>,
     ) -> ResolveCtx<'a> {
         ResolveCtx {
-            npmrc: &[],
-            aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &[],
+            user_npmrc: &[],
             workspace_yaml: ws,
             env,
             cli: &[],
@@ -1334,17 +1363,10 @@ enum VerifyDepsBeforeRun {
 }
 
 fn resolve_verify_deps_before_run(cwd: &std::path::Path) -> miette::Result<VerifyDepsBeforeRun> {
-    let npmrc = aube_registry::config::load_npmrc_entries(cwd);
-    let aube_config = config::load_user_aube_config_entries();
+    let files = FileSources::load(cwd);
     let empty_ws = std::collections::BTreeMap::new();
     let env = aube_settings::values::process_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc,
-        aube_config: &aube_config,
-        workspace_yaml: &empty_ws,
-        env,
-        cli: &[],
-    };
+    let ctx = files.ctx(&empty_ws, env, &[]);
     let raw = aube_settings::resolved::verify_deps_before_run(&ctx);
     Ok(match raw.trim().to_ascii_lowercase().as_str() {
         "false" | "0" => VerifyDepsBeforeRun::Skip,

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -258,9 +258,10 @@ pub(crate) fn ensure_registry_auth(
 static LOCK_HELD: AtomicBool = AtomicBool::new(false);
 
 /// Whether the project-level advisory lock is disabled. Resolves the
-/// `aubeNoLock` setting through the full cli > env > npmrc >
-/// workspace.yaml chain so `.npmrc` and `aube-workspace.yaml` entries
-/// participate alongside the canonical `AUBE_NO_LOCK` env var.
+/// `aubeNoLock` setting through the full cli > env > aubeConfig >
+/// npmrc > workspace.yaml chain so `.npmrc`, `~/.config/aube/config.toml`,
+/// and `aube-workspace.yaml` entries participate alongside the canonical
+/// `AUBE_NO_LOCK` env var.
 fn aube_no_lock_enabled(cwd: &std::path::Path) -> bool {
     with_settings_ctx(cwd, aube_settings::resolved::aube_no_lock)
 }
@@ -426,8 +427,8 @@ pub(crate) fn with_settings_ctx<T>(
 /// Build a registry client configured from .npmrc files in the project directory.
 ///
 /// Also resolves the `fetch*` settings (timeout + retries + backoff)
-/// from the full cli > env > npmrc > workspace precedence chain and
-/// threads the resulting [`aube_registry::config::FetchPolicy`] into
+/// from the full cli > env > aubeConfig > npmrc > workspace precedence
+/// chain and threads the resulting [`aube_registry::config::FetchPolicy`] into
 /// the client. The CLI bag comes from [`fetch_cli_overrides`], which
 /// `async_main` populates from the global `--fetch-timeout`,
 /// `--fetch-retries`, and `--fetch-retry-{factor,mintimeout,maxtimeout}`

--- a/crates/aube/src/commands/npm_fallback.rs
+++ b/crates/aube/src/commands/npm_fallback.rs
@@ -23,17 +23,10 @@ pub struct FallbackArgs {
 pub fn run(name: &str, args: &FallbackArgs) -> miette::Result<i32> {
     args.network.install_overrides();
     let cwd = crate::dirs::cwd()?;
-    let npmrc = aube_registry::config::load_npmrc_entries(&cwd);
-    let aube_config = crate::commands::config::load_user_aube_config_entries();
+    let files = crate::commands::FileSources::load(&cwd);
     let empty_ws = std::collections::BTreeMap::new();
     let env = aube_settings::values::process_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc,
-        aube_config: &aube_config,
-        workspace_yaml: &empty_ws,
-        env,
-        cli: &[],
-    };
+    let ctx = files.ctx(&empty_ws, env, &[]);
 
     if let Some(npm_path) = aube_settings::resolved::npm_path(&ctx) {
         let mut cmd = std::process::Command::new(&npm_path);

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -48,19 +48,12 @@ pub async fn run(
 
     let cwd = crate::dirs::project_root()?;
     let manifest = load_manifest(&cwd)?;
-    let npmrc_entries = aube_registry::config::load_npmrc_entries(&cwd);
-    let aube_config_entries = crate::commands::config::load_user_aube_config_entries();
+    let files = crate::commands::FileSources::load(&cwd);
     let (workspace, raw_workspace) = aube_manifest::workspace::load_both(&cwd)
         .into_diagnostic()
         .wrap_err("failed to load workspace config")?;
     let env_snapshot = aube_settings::values::capture_env();
-    let settings_ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc_entries,
-        aube_config: &aube_config_entries,
-        workspace_yaml: &raw_workspace,
-        env: &env_snapshot,
-        cli: &[],
-    };
+    let settings_ctx = files.ctx(&raw_workspace, &env_snapshot, &[]);
     super::configure_script_settings(&settings_ctx);
 
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -806,19 +806,12 @@ pub(crate) fn load_manifest(cwd: &Path) -> miette::Result<PackageJson> {
 }
 
 fn configure_script_settings_for_project(cwd: &Path) -> miette::Result<bool> {
-    let npmrc_entries = aube_registry::config::load_npmrc_entries(cwd);
-    let aube_config_entries = crate::commands::config::load_user_aube_config_entries();
+    let files = crate::commands::FileSources::load(cwd);
     let (_, raw_workspace) = aube_manifest::workspace::load_both(cwd)
         .into_diagnostic()
         .wrap_err("failed to load workspace config")?;
     let env_snapshot = aube_settings::values::capture_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc_entries,
-        aube_config: &aube_config_entries,
-        workspace_yaml: &raw_workspace,
-        env: &env_snapshot,
-        cli: &[],
-    };
+    let ctx = files.ctx(&raw_workspace, &env_snapshot, &[]);
     let enable_pre_post_scripts = aube_settings::resolved::enable_pre_post_scripts(&ctx);
     super::configure_script_settings(&ctx);
     Ok(enable_pre_post_scripts)

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -802,19 +802,12 @@ fn with_update_settings_ctx<T>(
     cwd: &std::path::Path,
     f: impl FnOnce(&aube_settings::ResolveCtx<'_>) -> T,
 ) -> miette::Result<T> {
-    let npmrc_entries = aube_registry::config::load_npmrc_entries(cwd);
-    let aube_config_entries = crate::commands::config::load_user_aube_config_entries();
+    let files = crate::commands::FileSources::load(cwd);
     let (_workspace_config, raw_workspace) = aube_manifest::workspace::load_both(cwd)
         .into_diagnostic()
         .wrap_err("failed to read workspace config")?;
     let env = aube_settings::values::process_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc_entries,
-        aube_config: &aube_config_entries,
-        workspace_yaml: &raw_workspace,
-        env,
-        cli: &[],
-    };
+    let ctx = files.ctx(&raw_workspace, env, &[]);
     Ok(f(&ctx))
 }
 

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -845,18 +845,10 @@ fn inner_main() -> miette::Result<()> {
     if !is_silent {
         let use_stderr_active = cli.use_stderr
             || startup_cwd(&cli).ok().is_some_and(|cwd| {
-                let npmrc = aube_registry::config::load_npmrc_entries(&cwd);
-                let aube_config = commands::config::load_user_aube_config_entries();
+                let files = commands::FileSources::load(&cwd);
                 let ws = std::collections::BTreeMap::new();
                 let env_snap = aube_settings::values::capture_env();
-                let ctx = aube_settings::ResolveCtx {
-                    npmrc: &npmrc,
-                    aube_config: &aube_config,
-                    workspace_yaml: &ws,
-                    env: &env_snap,
-                    cli: &[],
-                };
-                aube_settings::resolved::use_stderr(&ctx)
+                aube_settings::resolved::use_stderr(&files.ctx(&ws, &env_snap, &[]))
             });
         if use_stderr_active {
             // SAFETY: single-threaded `main` — no other threads exist yet.
@@ -1387,20 +1379,20 @@ fn startup_cwd(cli: &Cli) -> miette::Result<PathBuf> {
 
 fn load_startup_settings() -> miette::Result<StartupSettings> {
     let cwd = std::env::current_dir().into_diagnostic()?;
-    let npmrc = aube_registry::config::load_npmrc_entries(&cwd);
-    let aube_config = commands::config::load_user_aube_config_entries();
+    let files = commands::FileSources::load(&cwd);
     let empty_ws = std::collections::BTreeMap::new();
     let env = aube_settings::values::capture_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc,
-        aube_config: &aube_config,
-        workspace_yaml: &empty_ws,
-        env: &env,
-        cli: &[],
-    };
+    let ctx = files.ctx(&empty_ws, &env, &[]);
     Ok(StartupSettings {
         loglevel: aube_settings::values::string_from_env("loglevel", &env)
-            .or_else(|| aube_settings::values::string_from_npmrc("loglevel", &npmrc)),
+            .or_else(|| {
+                aube_settings::values::string_from_npmrc("loglevel", &files.project_aube_config)
+            })
+            .or_else(|| aube_settings::values::string_from_npmrc("loglevel", &files.project_npmrc))
+            .or_else(|| {
+                aube_settings::values::string_from_npmrc("loglevel", &files.user_aube_config)
+            })
+            .or_else(|| aube_settings::values::string_from_npmrc("loglevel", &files.user_npmrc)),
         package_manager_strict: resolve_package_manager_strict(&ctx),
         package_manager_strict_version: aube_settings::resolved::package_manager_strict_version(
             &ctx,
@@ -1826,20 +1818,13 @@ async fn run_install_command(
     // workspace yaml from the workspace root, not the member; without
     // this the two diverged when both roots existed.
     let cwd = crate::dirs::workspace_or_project_root()?;
-    let npmrc = aube_registry::config::load_npmrc_entries(&cwd);
+    let files = commands::FileSources::load(&cwd);
     let raw_ws = aube_manifest::workspace::load_raw(&cwd)
         .into_diagnostic()
         .wrap_err("failed to load workspace config")?;
     let env = aube_settings::values::capture_env();
     let cli_flags = args.to_cli_flag_bag(global_frozen, global_gvs);
-    let aube_config = commands::config::load_user_aube_config_entries();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc,
-        aube_config: &aube_config,
-        workspace_yaml: &raw_ws,
-        env: &env,
-        cli: &cli_flags,
-    };
+    let ctx = files.ctx(&raw_ws, &env, &cli_flags);
     let yaml_prefer_frozen = aube_settings::resolved::prefer_frozen_lockfile(&ctx);
     let mut opts = args.into_options(global_frozen, yaml_prefer_frozen, cli_flags, env);
     opts.workspace_filter = filter;

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -903,17 +903,10 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     // workspace yaml bytes still hashed on top, covers map shaped settings
     // like catalog, overrides, packageExtensions, onlyBuiltDependencies
     // where any change means a real re-resolve.
-    let npmrc = aube_registry::config::load_npmrc_entries(project_dir);
-    let aube_config = crate::commands::config::load_user_aube_config_entries();
+    let files = crate::commands::FileSources::load(project_dir);
     let raw_workspace = aube_manifest::workspace::load_raw(project_dir).unwrap_or_default();
     let env = aube_settings::values::capture_env();
-    let ctx = aube_settings::ResolveCtx {
-        npmrc: &npmrc,
-        aube_config: &aube_config,
-        workspace_yaml: &raw_workspace,
-        env: &env,
-        cli: cli_flags,
-    };
+    let ctx = files.ctx(&raw_workspace, &env, cli_flags);
     let mut hasher = blake3::Hasher::new();
     // node_linker, hoist family, modules_dir, import method. these shape
     // the tree on disk. flip any of them, linker needs to rebuild.

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1451,7 +1451,7 @@
                 "name": "location",
                 "usage": "--location <LOCATION>",
                 "help": "Which config location to act on",
-                "help_long": "Which config location to act on.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml`; registry/auth and unknown keys use `~/.npmrc`.",
+                "help_long": "Which config location to act on.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml` (user) or `<cwd>/.config/aube/config.toml` (project); registry/auth and unknown keys use `~/.npmrc` or `<cwd>/.npmrc` respectively.",
                 "help_first_line": "Which config location to act on",
                 "short": [],
                 "long": [
@@ -1763,7 +1763,7 @@
                 "name": "location",
                 "usage": "--location <LOCATION>",
                 "help": "Which config location to write to",
-                "help_long": "Which config location to write to.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml`; registry/auth and unknown keys use `~/.npmrc`.",
+                "help_long": "Which config location to write to.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml` (user) or `<cwd>/.config/aube/config.toml` (project); registry/auth and unknown keys use `~/.npmrc` or `<cwd>/.npmrc` respectively.",
                 "help_first_line": "Which config location to write to",
                 "short": [],
                 "long": [
@@ -9161,7 +9161,7 @@
             "name": "location",
             "usage": "--location <LOCATION>",
             "help": "Which config location to write to",
-            "help_long": "Which config location to write to.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml`; registry/auth and unknown keys use `~/.npmrc`.",
+            "help_long": "Which config location to write to.\n\nDefaults to `user`. Known aube settings use `~/.config/aube/config.toml` (user) or `<cwd>/.config/aube/config.toml` (project); registry/auth and unknown keys use `~/.npmrc` or `<cwd>/.npmrc` respectively.",
             "help_first_line": "Which config location to write to",
             "short": [],
             "long": [

--- a/docs/cli/config/delete.md
+++ b/docs/cli/config/delete.md
@@ -24,7 +24,7 @@ Shortcut for `--location project`
 
 Which config location to act on.
 
-Defaults to `user`. Known aube settings use `~/.config/aube/config.toml`; registry/auth and unknown keys use `~/.npmrc`.
+Defaults to `user`. Known aube settings use `~/.config/aube/config.toml` (user) or `<cwd>/.config/aube/config.toml` (project); registry/auth and unknown keys use `~/.npmrc` or `<cwd>/.npmrc` respectively.
 
 **Choices:**
 

--- a/docs/cli/config/set.md
+++ b/docs/cli/config/set.md
@@ -25,7 +25,7 @@ Shortcut for `--location project`
 
 Which config location to write to.
 
-Defaults to `user`. Known aube settings use `~/.config/aube/config.toml`; registry/auth and unknown keys use `~/.npmrc`.
+Defaults to `user`. Known aube settings use `~/.config/aube/config.toml` (user) or `<cwd>/.config/aube/config.toml` (project); registry/auth and unknown keys use `~/.npmrc` or `<cwd>/.npmrc` respectively.
 
 **Choices:**
 

--- a/test/config.bats
+++ b/test/config.bats
@@ -218,12 +218,56 @@ teardown() {
 	assert_output --partial "auto-install-peers=false"
 }
 
-@test "config set --location project writes to ./.npmrc" {
+@test "config set --location project writes aube-owned keys to project config.toml" {
+	# Project-scope aube settings land in <cwd>/.config/aube/config.toml,
+	# the same XDG layout used at user-scope. The project `.npmrc` is
+	# left alone so it remains a shared file with npm/pnpm/yarn.
 	run aube config set autoInstallPeers false --location project
+	assert_success
+	assert [ -f ".config/aube/config.toml" ]
+	run cat ".config/aube/config.toml"
+	assert_output --partial "autoInstallPeers = false"
+	# If a project `.npmrc` exists (e.g. for the test registry pin), it
+	# must not contain the aube-owned key.
+	if [ -f "./.npmrc" ]; then
+		run cat "./.npmrc"
+		refute_output --partial "autoInstallPeers"
+	fi
+}
+
+@test "config set --location project writes unknown keys to ./.npmrc" {
+	# Registry/auth-style keys aren't aube-owned settings and continue
+	# to land in project `.npmrc`.
+	run aube config set "//registry.example.com/:_authToken" secret --location project
 	assert_success
 	assert [ -f "./.npmrc" ]
 	run cat "./.npmrc"
-	assert_output --partial "autoInstallPeers=false"
+	assert_output --partial "//registry.example.com/:_authToken=secret"
+}
+
+@test "config get prefers project config.toml over project .npmrc" {
+	# Locality: project beats user; within project, config.toml beats
+	# `.npmrc` for the same reason it does at user-scope.
+	mkdir proj
+	echo "autoInstallPeers=false" >proj/.npmrc
+	mkdir -p "proj/.config/aube"
+	echo "autoInstallPeers = true" >"proj/.config/aube/config.toml"
+	cd proj
+	run aube config get autoInstallPeers
+	assert_success
+	assert_output "true"
+}
+
+@test "config get prefers project npmrc over user config.toml" {
+	# Scope locality: project `.npmrc` outranks user `config.toml`.
+	mkdir proj
+	mkdir -p "$XDG_CONFIG_HOME/aube"
+	echo "autoInstallPeers = true" >"$XDG_CONFIG_HOME/aube/config.toml"
+	echo "autoInstallPeers=false" >proj/.npmrc
+	cd proj
+	run aube config get autoInstallPeers
+	assert_success
+	assert_output "false"
 }
 
 @test "config preserves existing unrelated entries when setting a key" {

--- a/test/config.bats
+++ b/test/config.bats
@@ -273,6 +273,58 @@ teardown() {
 	assert_output "true"
 }
 
+@test "config set --location project writes to existing workspace yaml when one is present" {
+	# When a pnpm-workspace.yaml (or aube-workspace.yaml) already
+	# lives in the project, project-scope aube settings land there
+	# instead of creating a new `.config/aube/config.toml`. Keeps the
+	# project's config story to a single file when possible.
+	echo "packages:" >pnpm-workspace.yaml
+	echo "  - 'apps/*'" >>pnpm-workspace.yaml
+	run aube config set autoInstallPeers false --location project
+	assert_success
+	run cat pnpm-workspace.yaml
+	assert_output --partial "autoInstallPeers: false"
+	# Existing entries are preserved.
+	assert_output --partial "packages:"
+	# No new config.toml created.
+	assert [ ! -f ".config/aube/config.toml" ]
+	# Round-trip through `aube config get`.
+	run aube config get autoInstallPeers
+	assert_success
+	assert_output "false"
+}
+
+@test "config set --location project falls back to config.toml for settings without workspace yaml support" {
+	# `scriptShell` is not a workspace-yaml source per settings.toml,
+	# so the project write lands in `<cwd>/.config/aube/config.toml`
+	# even though a workspace yaml exists.
+	echo "packages:" >pnpm-workspace.yaml
+	echo "  - 'apps/*'" >>pnpm-workspace.yaml
+	run aube config set scriptShell /bin/zsh --location project
+	assert_success
+	assert [ -f ".config/aube/config.toml" ]
+	run cat ".config/aube/config.toml"
+	assert_output --partial 'scriptShell = "/bin/zsh"'
+	run cat pnpm-workspace.yaml
+	refute_output --partial "scriptShell"
+}
+
+@test "config delete --location project removes the key from workspace yaml" {
+	# Symmetric with set: delete removes from the workspace yaml
+	# when the value lives there.
+	cat >pnpm-workspace.yaml <<EOF
+packages:
+  - 'apps/*'
+autoInstallPeers: false
+EOF
+	run aube config delete autoInstallPeers --location project
+	assert_success
+	run cat pnpm-workspace.yaml
+	refute_output --partial "autoInstallPeers"
+	# Unrelated entries are preserved.
+	assert_output --partial "packages:"
+}
+
 @test "config get prefers project npmrc over user config.toml" {
 	# Scope locality: project `.npmrc` outranks user `config.toml`.
 	mkdir proj

--- a/test/config.bats
+++ b/test/config.bats
@@ -135,6 +135,21 @@ teardown() {
 	assert_failure
 }
 
+@test "config delete points at stale ~/.npmrc when an aube-known key lives only there" {
+	# Migration case: an older aube wrote aube-known keys to ~/.npmrc.
+	# After upgrading, `aube config delete <key>` should not silently
+	# touch ~/.npmrc (it's shared with npm/pnpm/yarn) — but the error
+	# must tell the user where the value actually is.
+	echo "autoInstallPeers=false" >"$HOME/.npmrc"
+	run aube config delete autoInstallPeers
+	assert_failure
+	assert_output --partial ".npmrc"
+	assert_output --partial "stale entry"
+	# Confirm the .npmrc line is preserved.
+	run cat "$HOME/.npmrc"
+	assert_output --partial "autoInstallPeers=false"
+}
+
 @test "config list prints merged entries" {
 	# Project dir must be separate from HOME so user vs project .npmrc
 	# don't alias to the same file.

--- a/test/config.bats
+++ b/test/config.bats
@@ -309,6 +309,30 @@ teardown() {
 	refute_output --partial "scriptShell"
 }
 
+@test "config set --location project to workspace yaml beats user-scope settings" {
+	# Project-scope writes routed to workspace yaml must not be
+	# silently shadowed by anything in ~/.npmrc or
+	# ~/.config/aube/config.toml. Scope locality: project beats user,
+	# and `pnpm-workspace.yaml` is project-scope.
+	#
+	# `proj/` is separate from $HOME so user-scope and project-scope
+	# config files don't collide.
+	mkdir proj
+	echo "autoInstallPeers=true" >"$HOME/.npmrc"
+	mkdir -p "$XDG_CONFIG_HOME/aube"
+	echo "autoInstallPeers = true" >"$XDG_CONFIG_HOME/aube/config.toml"
+	echo "packages:" >proj/pnpm-workspace.yaml
+	cd proj
+	run aube config set autoInstallPeers false --location project
+	assert_success
+	run cat pnpm-workspace.yaml
+	assert_output --partial "autoInstallPeers: false"
+	# Round-trip: get returns the project value, not user defaults.
+	run aube config get autoInstallPeers
+	assert_success
+	assert_output "false"
+}
+
 @test "config set --location project stays in config.toml once it exists" {
 	# If a project already adopted `.config/aube/config.toml`, later
 	# `set` calls keep landing there even after a `pnpm-workspace.yaml`

--- a/test/config.bats
+++ b/test/config.bats
@@ -35,17 +35,21 @@ teardown() {
 	assert_output "true"
 }
 
-@test "config get and list prefer user .npmrc over user config.toml" {
+@test "config get and list prefer user config.toml over user .npmrc" {
+	# Aube's own user config wins over ~/.npmrc so values aube wrote
+	# via `aube config set` are authoritative — they are not silently
+	# shadowed by leftover entries in a shared .npmrc that other tools
+	# (npm, pnpm, yarn) also read.
 	mkdir -p "$XDG_CONFIG_HOME/aube"
 	echo "autoInstallPeers = true" >"$XDG_CONFIG_HOME/aube/config.toml"
 	echo "autoInstallPeers=false" >"$HOME/.npmrc"
 	run aube config get autoInstallPeers
 	assert_success
-	assert_output "false"
+	assert_output "true"
 	run aube config list --location user
 	assert_success
-	assert_line "auto-install-peers=false"
-	refute_line "auto-install-peers=true"
+	assert_line "auto-install-peers=true"
+	refute_line "auto-install-peers=false"
 }
 
 @test "config get --location project only reads project .npmrc" {
@@ -99,14 +103,21 @@ teardown() {
 	assert_output "undefined"
 }
 
-@test "config set collapses aliases so a prior spelling doesn't linger" {
+@test "config set for an aube-owned key leaves user .npmrc untouched" {
+	# Discussion #601: `aube config set <known-key>` writes to
+	# `config.toml` and must not edit `~/.npmrc`, which is shared with
+	# npm/pnpm/yarn. The new value still takes effect because
+	# `config.toml` outranks `~/.npmrc` in the resolver.
 	echo "auto-install-peers=false" >"$HOME/.npmrc"
 	run aube config set autoInstallPeers true
 	assert_success
 	run cat "$HOME/.npmrc"
-	refute_output --partial "auto-install-peers=false"
+	assert_output "auto-install-peers=false"
 	run cat "$XDG_CONFIG_HOME/aube/config.toml"
 	assert_output --partial "autoInstallPeers = true"
+	run aube config get autoInstallPeers
+	assert_success
+	assert_output "true"
 }
 
 @test "config delete removes a key" {

--- a/test/config.bats
+++ b/test/config.bats
@@ -309,6 +309,47 @@ teardown() {
 	refute_output --partial "scriptShell"
 }
 
+@test "config set --location project stays in config.toml once it exists" {
+	# If a project already adopted `.config/aube/config.toml`, later
+	# `set` calls keep landing there even after a `pnpm-workspace.yaml`
+	# is added. Writing to yaml would be silently shadowed by the
+	# higher-precedence config.toml entry on read.
+	run aube config set autoInstallPeers false --location project
+	assert_success
+	assert [ -f ".config/aube/config.toml" ]
+	echo "packages:" >pnpm-workspace.yaml
+	run aube config set autoInstallPeers true --location project
+	assert_success
+	run cat ".config/aube/config.toml"
+	assert_output --partial "autoInstallPeers = true"
+	run cat pnpm-workspace.yaml
+	refute_output --partial "autoInstallPeers"
+	# Effective value matches the latest set.
+	run aube config get autoInstallPeers
+	assert_success
+	assert_output "true"
+}
+
+@test "config delete --location project sweeps both workspace yaml and config.toml" {
+	# Regression for the silent-resurrection bug: a setting can end up
+	# in both files (e.g. set into config.toml first, into yaml later
+	# via a manual edit). Delete must clear both — otherwise the
+	# config.toml copy silently reactivates after the yaml removal.
+	mkdir -p ".config/aube"
+	echo "autoInstallPeers = true" >".config/aube/config.toml"
+	cat >pnpm-workspace.yaml <<EOF
+packages:
+  - 'apps/*'
+autoInstallPeers: false
+EOF
+	run aube config delete autoInstallPeers --location project
+	assert_success
+	run cat ".config/aube/config.toml"
+	refute_output --partial "autoInstallPeers"
+	run cat pnpm-workspace.yaml
+	refute_output --partial "autoInstallPeers"
+}
+
 @test "config delete --location project removes the key from workspace yaml" {
 	# Symmetric with set: delete removes from the workspace yaml
 	# when the value lives there.


### PR DESCRIPTION
## Summary

Fixes [#601](https://github.com/endevco/aube/discussions/601). Three coupled changes that establish a principled, locality-preserving settings precedence:

1. **`aube config set/delete` no longer edits `.npmrc`.** For aube-known keys, writes land in `~/.config/aube/config.toml` (user) or the new `<cwd>/.config/aube/config.toml` (project). The shared `.npmrc` is preserved for npm/pnpm/yarn.
2. **`<cwd>/.config/aube/config.toml` is a new project-scope source.** Mirrors the XDG layout used at user-scope. It's an alternative to committing aube-specific settings into a project `.npmrc` that other package managers also read.
3. **Settings precedence is split by scope.** The full default file-source chain, high-to-low:

   ```
   cli > env
       > project_aube_config (<cwd>/.config/aube/config.toml)
       > project_npmrc       (<cwd>/.npmrc + npmrcAuthFile)
       > user_aube_config    (~/.config/aube/config.toml)
       > user_npmrc          (~/.npmrc + pnpm auth.ini)
       > workspace_yaml
   ```

   Two principles: **scope locality** (project beats user) and **aube authority** within a scope (aube's config beats `.npmrc`).

## Implementation

- `ResolveCtx` now exposes `{project,user}_{aube_config,npmrc}` slices instead of merged `npmrc`/`aube_config` fields.
- New `aube_registry::config::load_npmrc_entries_split(cwd)` returns user+project halves; reuses the existing tagged loader internally so no duplicate parsing.
- New `commands::FileSources::load(cwd)` helper consolidates the four-source loading boilerplate that 18 call sites used to inline.
- Per-setting `precedence` overrides in `settings.toml` keep working: bare `npmrc` / `aubeConfig` names expand to their project+user pair (project first); scope-qualified `projectNpmrc` / `userNpmrc` / `projectAubeConfig` / `userAubeConfig` are available for fine-grained control.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --workspace` — 1507 passed, 0 failed
- [x] `mise run test:bats test/config.bats` — 38/38 (4 new tests covering project config.toml + scope locality)
- [x] `mise run test:bats test/minimum_release_age.bats` — 5/5 (per-setting precedence override still wired)
- [x] `mise run test:bats test/settings.bats` — 18/18
- [x] New Rust tests in `values.rs`: `user_aube_config_wins_over_user_npmrc_by_default`, `project_npmrc_wins_over_user_aube_config_by_default`, `project_aube_config_wins_over_project_npmrc_by_default`
- [x] New bats tests: `config set --location project writes aube-owned keys to project config.toml`, `config set --location project writes unknown keys to ./.npmrc`, `config get prefers project config.toml over project .npmrc`, `config get prefers project npmrc over user config.toml`

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes settings-resolution precedence across the CLI and redirects `config set/delete` writes for known keys away from `.npmrc`, which can affect effective configuration in existing projects/users.
> 
> **Overview**
> Reworks settings resolution to **split file-based sources by scope** (project vs user) and apply a new default precedence: `project config.toml` > project `.npmrc` > workspace YAML > user `config.toml` > user `.npmrc` (still under `cli > env`).
> 
> Adds **project-scope aube config** at `<cwd>/.config/aube/config.toml`, updates the settings accessor generator to understand scope-qualified precedence names (with `npmrc`/`aubeConfig` aliases expanding to project+user), and introduces `load_npmrc_entries_split` plus a `FileSources` helper to wire the new `ResolveCtx` through many commands.
> 
> Updates `aube config get/list/set/delete` behavior: known settings now write/delete in `config.toml` (or workspace YAML for supported keys when no project config exists) and no longer modify `.npmrc`, with improved errors for stale `.npmrc` entries; docs and bats/unit tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b8604bbe54cbb677bf1593789b4417004ba5cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->