### PR TITLE
feat(install): fill resolving bar against a real denominator

### DIFF
--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -957,6 +957,8 @@ impl Resolver {
                             },
                         );
                         if let Some(ref tx) = self.resolved_tx {
+                            let pending =
+                                queue.len() + in_flight.len() + deferred_transitives.len();
                             let _ = tx
                                 .send(ResolvedPackage {
                                     dep_path: dep_path.clone(),
@@ -980,6 +982,7 @@ impl Resolver {
                                     libc: aube_lockfile::PlatformList::new(),
                                     deprecated: None,
                                     unpacked_size: None,
+                                    pending,
                                 })
                                 .await;
                         }
@@ -1223,6 +1226,8 @@ impl Resolver {
                             }
 
                             if let Some(ref tx) = self.resolved_tx {
+                                let pending =
+                                    queue.len() + in_flight.len() + deferred_transitives.len();
                                 let _ = tx
                                     .send(ResolvedPackage {
                                         dep_path: dep_path.clone(),
@@ -1258,6 +1263,7 @@ impl Resolver {
                                         // a running download total instead
                                         // when the estimate is unavailable.
                                         unpacked_size: None,
+                                        pending,
                                     })
                                     .await;
                             }
@@ -1781,6 +1787,7 @@ impl Resolver {
                 // for aliased packages where `name` alone (`h3-v2`)
                 // would 404.
                 if let Some(ref tx) = self.resolved_tx {
+                    let pending = queue.len() + in_flight.len() + deferred_transitives.len();
                     let _ = tx
                         .send(ResolvedPackage {
                             dep_path: dep_path.clone(),
@@ -1795,6 +1802,7 @@ impl Resolver {
                             libc: version_meta.libc.iter().cloned().collect(),
                             deprecated: deprecated_msg.clone(),
                             unpacked_size: version_meta.dist.as_ref().and_then(|d| d.unpacked_size),
+                            pending,
                         })
                         .await;
                 }

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -188,6 +188,17 @@ pub struct ResolvedPackage {
     /// when the packument doesn't carry the field (older publishes,
     /// `file:`/`link:` deps, JSR packages without npm metadata).
     pub unpacked_size: Option<u64>,
+    /// Resolver's view of remaining work at the moment this package
+    /// was sent: the size of the BFS queue plus any packument fetches
+    /// still in flight plus transitives deferred behind a time-based
+    /// cutoff. `received_count + pending` is a non-strict lower bound
+    /// on the final resolved-package count, used by the install
+    /// progress UI to render a real bar during the resolving phase
+    /// instead of an empty placeholder. Approximate by construction —
+    /// a packument fetch completing without enqueueing children can
+    /// transiently shrink the frontier, so the install side raises
+    /// the displayed denominator with `fetch_max` semantics.
+    pub pending: usize,
 }
 
 impl ResolvedPackage {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3302,6 +3302,29 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // No lockfile — resolve + fetch tarballs concurrently
             tracing::debug!("No lockfile found, resolving dependencies for {project_name}...");
             if let Some(p) = prog_ref {
+                // Seed the resolving-phase denominator floor from any
+                // existing lockfile on disk. In FrozenMode::Fix /
+                // Prefer we already parsed it into
+                // `existing_for_resolver`; in FrozenMode::No the
+                // pre-parse is skipped (we always re-resolve), so peek
+                // the disk lockfile inline. The cost is one extra
+                // parse on the fresh-resolve path, dwarfed by the
+                // resolve itself — and the resulting estimate lets
+                // the resolving bar show real progress instead of an
+                // empty placeholder.
+                let lockfile_estimate =
+                    existing_for_resolver.map(|g| g.packages.len()).or_else(|| {
+                        parse_lockfile_dir_remapped_with_kind(
+                            &lockfile_dir,
+                            &lockfile_importer_key,
+                            &manifest,
+                        )
+                        .ok()
+                        .map(|(g, _)| g.packages.len())
+                    });
+                if let Some(n) = lockfile_estimate {
+                    p.set_total_floor(n);
+                }
                 p.set_phase("resolving");
             }
             // Resolve node version + build policy up front so the
@@ -3496,6 +3519,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 > = tokio::task::JoinSet::new();
                 let mut indices: BTreeMap<String, aube_store::PackageIndex> = BTreeMap::new();
                 let mut cached_count = 0usize;
+                // Drives the resolving-phase denominator estimate.
+                // `received + pkg.pending` is a non-strict lower bound
+                // on the final resolved-package count; raising it via
+                // `set_total_floor` makes the bar fill as the
+                // BFS-frontier high-water mark grows. Tracked locally
+                // because the resolver's view is per-send, not a
+                // single shared atomic.
+                let mut resolved_received: usize = 0;
 
                 while let Some(pkg) = resolved_rx.recv().await {
                     if let Some(ref msg) = pkg.deprecated {
@@ -3521,8 +3552,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     // overcount on dropped optionals is reconciled by a
                     // single `set_total(graph.packages.len())` after
                     // `filter_graph` runs.
+                    resolved_received += 1;
                     if let Some(p) = fetch_progress.as_ref() {
                         p.inc_total(1);
+                        // Raise the resolving-phase denominator floor
+                        // toward the resolver's current frontier so
+                        // the bar fills against a meaningful target
+                        // instead of an empty placeholder. Stamping
+                        // the frontier on each `ResolvedPackage`
+                        // keeps the protocol shape unchanged.
+                        p.set_total_floor(resolved_received + pkg.pending);
                         if let Some(sz) = pkg.unpacked_size {
                             p.inc_estimated_bytes(&pkg.dep_path, sz);
                         }

--- a/crates/aube/src/progress/ci.rs
+++ b/crates/aube/src/progress/ci.rs
@@ -53,6 +53,17 @@ const CI_BAR_WIDTH: usize = 15;
 pub(super) struct CiState {
     phase: AtomicUsize,
     pub(super) resolved: AtomicUsize,
+    /// Best-effort estimate of the eventual resolved-package count.
+    /// Seeded once from any existing lockfile on disk (re-install,
+    /// `package.json` change, foreign lockfile) and raised by the
+    /// resolver's BFS-frontier signal as new transitives are
+    /// discovered. Only ever increases — `fetch_max` semantics — so
+    /// a transient frontier shrink (a packument fetch completing
+    /// without enqueueing children) can't snap the displayed
+    /// denominator backward. Zero until the first signal lands, in
+    /// which case the resolving-phase bar falls back to the empty-bar
+    /// placeholder.
+    pub(super) target_total: AtomicUsize,
     pub(super) reused: AtomicUsize,
     pub(super) downloaded: AtomicUsize,
     pub(super) downloaded_bytes: AtomicU64,
@@ -130,6 +141,7 @@ impl CiState {
         Self {
             phase: AtomicUsize::new(0),
             resolved: AtomicUsize::new(0),
+            target_total: AtomicUsize::new(0),
             reused: AtomicUsize::new(0),
             downloaded: AtomicUsize::new(0),
             downloaded_bytes: AtomicU64::new(0),
@@ -161,6 +173,7 @@ impl CiState {
         Snap {
             phase: self.phase.load(Ordering::Relaxed),
             resolved: self.resolved.load(Ordering::Relaxed),
+            target_total: self.target_total.load(Ordering::Relaxed),
             reused: self.reused.load(Ordering::Relaxed),
             downloaded: self.downloaded.load(Ordering::Relaxed),
             bytes: self.downloaded_bytes.load(Ordering::Relaxed),
@@ -361,6 +374,11 @@ impl CiState {
 pub(super) struct Snap {
     pub(super) phase: usize,
     pub(super) resolved: usize,
+    /// Best-effort estimate of the final resolved count: lockfile
+    /// peek plus the BFS-frontier high-water mark. `0` means no
+    /// estimate is available yet; render falls back to the pre-floor
+    /// empty bar.
+    pub(super) target_total: usize,
     pub(super) reused: usize,
     pub(super) downloaded: usize,
     pub(super) bytes: u64,

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -43,6 +43,18 @@ use std::time::{Duration, Instant};
 /// once.
 const TTY_MAX_VISIBLE_FETCH_ROWS: usize = 5;
 
+/// Fixed denominator clx's `{{progress_bar}}` is held at in TTY mode.
+/// We don't drive clx's progress_current/progress_total with raw
+/// package counts because the unified-bar formula needs sub-package
+/// precision (resolving fills 20% of the bar, which on a 1230-package
+/// install is < 1 package per cell). Encoding the unified-progress
+/// fraction as `progress_current / TTY_BAR_SCALE` gives clx 10 000
+/// steps to interpolate over — more than enough for the flex-rendered
+/// bar to look smooth at any terminal width. The cur/total label is
+/// owned separately via the `count` prop so the scaled denominator
+/// never leaks into the user-facing text.
+const TTY_BAR_SCALE: usize = 10_000;
+
 fn overflow_fetch_label(count: usize) -> String {
     let word = pluralizer::pluralize("package", count as isize, false);
     format!("{count} more {word}…")
@@ -112,12 +124,12 @@ enum Mode {
         /// Resolving-phase denominator hint. Seeded from any lockfile
         /// on disk before resolution starts and raised by the
         /// resolver's BFS-frontier signal during resolution.
-        /// `fetch_max` semantics keep it from ever shrinking, so a
-        /// transient frontier dip can't snap the displayed total
-        /// backward. Distinct from `total` because the
-        /// post-`filter_graph` `set_total` reset would otherwise
-        /// clobber the resolving-phase estimate at the fetching-phase
-        /// transition.
+        /// `fetch_max` semantics keep it from ever shrinking. Drives
+        /// the resolving-slice fill via the shared
+        /// [`render::unified_progress`] math — the clx
+        /// `{{progress_bar}}` template reads `progress_current` /
+        /// `progress_total`, which `refresh_tty_bar` scales to encode
+        /// the unified-progress fraction.
         target_total: Arc<AtomicUsize>,
         /// Mirror of cumulative reused-package count so the TTY bar can
         /// recompute the live numerator without taking a round-trip
@@ -213,25 +225,32 @@ impl InstallProgress {
             style::edim(crate::version::VERSION.as_str()),
             style::edim("by en.dev"),
         );
-        // Layout: header, animated bar, cur/total, optional bytes
+        // Layout: header, animated bar, count segment, optional bytes
         // segment (running download, with `/ ~estimated` when
         // available), phase-gated rate, ETA. Mirrors the CI-mode
         // label segment-for-segment so both modes show the same
-        // information.
+        // information. `{{count}}` is a custom prop populated by
+        // `refresh_tty_bar` (using the shared
+        // [`render::count_segment`] helper) so the cur/total shape
+        // matches CI exactly — phase-conditional, suppressed-slash
+        // during resolving-without-an-estimate, and so on. The clx
+        // built-in `{{cur}}/{{total}}` is bypassed because
+        // `progress_total` is held at `TTY_BAR_SCALE` to encode the
+        // unified-progress fraction in the bar, which would otherwise
+        // leak into the label as the scaled denominator.
         let root = ProgressJobBuilder::new()
             .body(
-                "{{aube}}{{phase}}  {{progress_bar(flex=true)}} {{cur}}/{{total}}{{bytes}}{{rate}}{{eta}}",
+                "{{aube}}{{phase}}  {{progress_bar(flex=true)}} {{count}}{{bytes}}{{rate}}{{eta}}",
             )
-            .body_text(Some(
-                "{{aube}}{{phase}} {{cur}}/{{total}}{{bytes}}{{rate}}{{eta}}",
-            ))
+            .body_text(Some("{{aube}}{{phase}} {{count}}{{bytes}}{{rate}}{{eta}}"))
             .prop("aube", &header)
             .prop("phase", "")
+            .prop("count", "")
             .prop("bytes", "")
             .prop("rate", "")
             .prop("eta", "")
             .progress_current(0)
-            .progress_total(0)
+            .progress_total(TTY_BAR_SCALE)
             .on_done(ProgressJobDoneBehavior::Collapse)
             .start();
         Self {
@@ -283,6 +302,7 @@ impl InstallProgress {
         match &self.mode {
             Mode::Tty { target_total, .. } => {
                 target_total.fetch_max(n, Ordering::Relaxed);
+                self.refresh_tty_bar();
             }
             Mode::Ci(s) => {
                 s.target_total.fetch_max(n, Ordering::Relaxed);
@@ -305,15 +325,17 @@ impl InstallProgress {
     pub fn set_total(&self, total: usize) {
         match &self.mode {
             Mode::Tty {
-                root,
                 total: t,
                 reused,
                 downloaded,
                 ..
             } => {
                 t.store(total, Ordering::Relaxed);
-                root.progress_total(total);
                 clamp_reused_to(reused, downloaded, total);
+                // Refresh *after* clamping so the bar/count label
+                // pick up the corrected numerator on the same tick
+                // the denominator drops.
+                self.refresh_tty_bar();
                 self.refresh_eta();
             }
             Mode::Ci(s) => {
@@ -326,9 +348,9 @@ impl InstallProgress {
     /// Atomically bump the total (`resolved`) by `n` packages.
     pub fn inc_total(&self, n: usize) {
         match &self.mode {
-            Mode::Tty { root, total, .. } => {
-                let new_total = total.fetch_add(n, Ordering::Relaxed) + n;
-                root.progress_total(new_total);
+            Mode::Tty { total, .. } => {
+                total.fetch_add(n, Ordering::Relaxed);
+                self.refresh_tty_bar();
                 self.refresh_eta();
             }
             Mode::Ci(s) => {
@@ -473,6 +495,12 @@ impl InstallProgress {
                 self.refresh_bytes_segment();
                 self.refresh_rate();
                 self.refresh_eta();
+                // Phase change shifts the unified-progress slice
+                // (resolving → fetching crosses the
+                // `RESOLVE_BAR_WEIGHT` boundary; fetching → linking
+                // locks at 100%), so the bar + count label must
+                // recompute even when no counter advanced this turn.
+                self.refresh_tty_bar();
             }
             Mode::Ci(s) => s.set_phase(phase),
         }
@@ -483,9 +511,9 @@ impl InstallProgress {
     /// `file:` / `link:` source — anything that didn't touch the network.
     pub fn inc_reused(&self, n: usize) {
         match &self.mode {
-            Mode::Tty { root, reused, .. } => {
+            Mode::Tty { reused, .. } => {
                 reused.fetch_add(n, Ordering::Relaxed);
-                root.increment(n);
+                self.refresh_tty_bar();
                 self.refresh_eta();
             }
             Mode::Ci(s) => {
@@ -527,6 +555,31 @@ impl InstallProgress {
     /// TTY-only: rebuild the `bytes` prop from the current downloaded /
     /// estimated counters. Picks shape based on what we know:
     ///   `4.2 MB / ~13.8 MB` when both are available, `4.2 MB` when
+    /// TTY-only: recompute the bar fill + count label from the current
+    /// TTY atomics and push them to clx. Shares the unified-progress
+    /// math with CI mode via [`render::unified_progress`] and the
+    /// count-segment shape via [`render::count_segment`], so a tweak
+    /// to either lands in both renderers. clx's
+    /// `progress_total`/`progress_current` are held at
+    /// `TTY_BAR_SCALE / scaled-progress` to drive the flex-rendered
+    /// bar; the user-facing cur/total label lives in the `count` prop
+    /// so the scaled denominator never leaks into the text.
+    fn refresh_tty_bar(&self) {
+        let Mode::Tty {
+            root,
+            total,
+            target_total,
+            reused,
+            downloaded,
+            phase_num,
+            ..
+        } = &self.mode
+        else {
+            return;
+        };
+        refresh_tty_bar_from_atomics(root, total, target_total, reused, downloaded, phase_num);
+    }
+
     ///   only the running total is, `~13.8 MB` when only the estimate
     ///   is, empty otherwise. CI mode does this inside the heartbeat
     ///   render — no per-call refresh needed there.
@@ -677,9 +730,27 @@ impl InstallProgress {
             Mode::Tty {
                 root,
                 fetch_state,
+                total,
+                target_total,
+                reused,
                 downloaded,
+                phase_num,
                 ..
             } => {
+                let make_row = |child: Arc<ProgressJob>, visible: bool| FetchRow {
+                    inner: FetchRowInner::Tty {
+                        child,
+                        root: Arc::downgrade(root),
+                        fetch_state: Arc::downgrade(fetch_state),
+                        total: Arc::downgrade(total),
+                        target_total: Arc::downgrade(target_total),
+                        reused: Arc::downgrade(reused),
+                        downloaded: Arc::downgrade(downloaded),
+                        phase_num: Arc::downgrade(phase_num),
+                        visible,
+                    },
+                    completed: false,
+                };
                 let mut st = fetch_state.lock().unwrap();
                 if st.visible < TTY_MAX_VISIBLE_FETCH_ROWS {
                     st.visible += 1;
@@ -692,16 +763,7 @@ impl InstallProgress {
                         .on_done(ProgressJobDoneBehavior::Hide)
                         .build();
                     let child = root.add(child);
-                    return FetchRow {
-                        inner: FetchRowInner::Tty {
-                            child,
-                            root: Arc::downgrade(root),
-                            fetch_state: Arc::downgrade(fetch_state),
-                            downloaded: Arc::downgrade(downloaded),
-                            visible: true,
-                        },
-                        completed: false,
-                    };
+                    return make_row(child, true);
                 }
                 // Over the visible-row cap: fold this fetch into the
                 // single "N more packages…" overflow row. Lazily
@@ -721,16 +783,9 @@ impl InstallProgress {
                 } else if let Some(row) = &st.overflow_row {
                     row.prop("label", &overflow_fetch_label(st.overflow));
                 }
-                FetchRow {
-                    inner: FetchRowInner::Tty {
-                        child: st.overflow_row.as_ref().unwrap().clone(),
-                        root: Arc::downgrade(root),
-                        fetch_state: Arc::downgrade(fetch_state),
-                        downloaded: Arc::downgrade(downloaded),
-                        visible: false,
-                    },
-                    completed: false,
-                }
+                let child = st.overflow_row.as_ref().unwrap().clone();
+                drop(st);
+                make_row(child, false)
             }
             Mode::Ci(s) => FetchRow {
                 inner: FetchRowInner::Ci(Arc::downgrade(s)),
@@ -838,6 +893,52 @@ impl InstallProgress {
     }
 }
 
+/// TTY-only bar refresh primitive. Strongly-typed `&AtomicUsize` /
+/// `&ProgressJob` references so both the `InstallProgress`
+/// method (which holds Arcs) and `FetchRow::drop` (which holds
+/// Weaks and upgrades them) can share the math without duplicating
+/// the snapshot/scale/prop-set sequence. Reads the same field set
+/// as `Mode::Tty` and feeds it through `render::unified_progress` /
+/// `render::count_segment`, so a tweak to either lands in both
+/// renderers.
+fn refresh_tty_bar_from_atomics(
+    root: &Arc<ProgressJob>,
+    total: &AtomicUsize,
+    target_total: &AtomicUsize,
+    reused: &AtomicUsize,
+    downloaded: &AtomicUsize,
+    phase_num: &AtomicUsize,
+) {
+    let phase = phase_num.load(Ordering::Relaxed);
+    let resolved = total.load(Ordering::Relaxed);
+    let target = target_total.load(Ordering::Relaxed);
+    let r = reused.load(Ordering::Relaxed);
+    let d = downloaded.load(Ordering::Relaxed);
+    // Reuse the CI-mode `Snap` shape so the shared helpers don't
+    // need a TTY-specific variant. The byte/rate/ETA fields aren't
+    // consulted by `unified_progress` or `count_segment`; their
+    // zero values are inert.
+    let snap = ci::Snap {
+        phase,
+        resolved,
+        target_total: target,
+        reused: r,
+        downloaded: d,
+        bytes: 0,
+        estimated: 0,
+        fetch_elapsed_ms: 0,
+        completed_at_fetch_start: None,
+    };
+    // Same clamp the CI render applies — keeps the numerator from
+    // exceeding the resolved denominator if a deferred-package
+    // catch-up reorders against `set_total`.
+    let completed = (r + d).min(resolved);
+    let progress = render::unified_progress(snap, completed);
+    let scaled = ((progress * TTY_BAR_SCALE as f64).round() as usize).min(TTY_BAR_SCALE);
+    root.progress_current(scaled);
+    root.prop("count", &render::count_segment(snap, completed));
+}
+
 impl Drop for InstallProgress {
     /// Safety net: if `install::run` bails through `?` without reaching
     /// `finish()` (flaky network, lockfile parse error, linker failure, …)
@@ -887,11 +988,17 @@ enum FetchRowInner {
         /// decrement visible/overflow counters and refresh the
         /// overflow row label without pinning it alive.
         fetch_state: Weak<Mutex<FetchState>>,
-        /// Weak ref to the TTY mirror of the downloaded counter so
-        /// drop can bump it without holding the root alive. Mirrors
-        /// CI mode's `downloaded` counter — used by the ETA / clamp
-        /// computations in the bar render.
+        /// Weak refs to every TTY counter the unified-bar refresh
+        /// reads. Bundled here so `FetchRow::drop` can recompute the
+        /// bar fill + count label after bumping `downloaded`, without
+        /// requiring a back-pointer to `InstallProgress` (which is
+        /// not itself reference-counted). Mirrors the field set
+        /// `refresh_tty_bar` reads off `Mode::Tty`.
+        total: Weak<AtomicUsize>,
+        target_total: Weak<AtomicUsize>,
+        reused: Weak<AtomicUsize>,
         downloaded: Weak<AtomicUsize>,
+        phase_num: Weak<AtomicUsize>,
         /// Whether this row occupies one of the `TTY_MAX_VISIBLE_FETCH_ROWS`
         /// visible slots. Overflow rows share a single child job; they
         /// only bump the overflow counter and the label on drop.
@@ -914,26 +1021,49 @@ impl FetchRow {
                 child,
                 root,
                 fetch_state,
+                total,
+                target_total,
+                reused,
                 downloaded,
+                phase_num,
                 visible,
             } => {
-                // Note: this site bumps `downloaded` but doesn't call
-                // `refresh_eta` — the ETA prop is recomputed on every
-                // `inc_downloaded_bytes` event, which fires once per
-                // tarball *before* this drop. The off-by-one (ETA
-                // computed against pre-bump `downloaded`) self-corrects
-                // on the next fetch's bytes; for the very last fetch,
-                // `set_phase("linking")` immediately clears the prop.
-                // Wiring a refresh here would require either bundling
-                // every refresh-related Arc into the FetchRow weak ref
-                // or holding a back-pointer to InstallProgress; the
-                // observable lag is ≤ one fetch worth of time and the
-                // last-fetch case never reaches the user.
-                if let Some(root) = root.upgrade() {
-                    root.increment(1);
-                }
+                // Bump the downloaded counter, then refresh the
+                // unified bar (clx `progress_current` + `count` prop)
+                // by upgrading the weak refs to each TTY atomic.
+                // `refresh_eta` is *not* called here — the ETA prop
+                // is recomputed on every `inc_downloaded_bytes`
+                // event, which fires once per tarball before this
+                // drop. The off-by-one (ETA computed against pre-bump
+                // `downloaded`) self-corrects on the next fetch's
+                // bytes; for the very last fetch, `set_phase("linking")`
+                // immediately clears the prop.
                 if let Some(d) = downloaded.upgrade() {
                     d.fetch_add(1, Ordering::Relaxed);
+                }
+                if let (
+                    Some(root),
+                    Some(total),
+                    Some(target_total),
+                    Some(reused),
+                    Some(downloaded),
+                    Some(phase_num),
+                ) = (
+                    root.upgrade(),
+                    total.upgrade(),
+                    target_total.upgrade(),
+                    reused.upgrade(),
+                    downloaded.upgrade(),
+                    phase_num.upgrade(),
+                ) {
+                    refresh_tty_bar_from_atomics(
+                        &root,
+                        &total,
+                        &target_total,
+                        &reused,
+                        &downloaded,
+                        &phase_num,
+                    );
                 }
                 if *visible {
                     child.set_status(ProgressStatus::Done);

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -109,6 +109,16 @@ enum Mode {
         /// fetch-add without racing a concurrent reader/writer through clx's
         /// separate `overall_progress()` / `progress_total()` calls.
         total: Arc<AtomicUsize>,
+        /// Resolving-phase denominator hint. Seeded from any lockfile
+        /// on disk before resolution starts and raised by the
+        /// resolver's BFS-frontier signal during resolution.
+        /// `fetch_max` semantics keep it from ever shrinking, so a
+        /// transient frontier dip can't snap the displayed total
+        /// backward. Distinct from `total` because the
+        /// post-`filter_graph` `set_total` reset would otherwise
+        /// clobber the resolving-phase estimate at the fetching-phase
+        /// transition.
+        target_total: Arc<AtomicUsize>,
         /// Mirror of cumulative reused-package count so the TTY bar can
         /// recompute the live numerator without taking a round-trip
         /// through clx's progress accessors.
@@ -229,6 +239,7 @@ impl InstallProgress {
                 root,
                 finished: Arc::new(AtomicBool::new(false)),
                 total: Arc::new(AtomicUsize::new(0)),
+                target_total: Arc::new(AtomicUsize::new(0)),
                 reused: Arc::new(AtomicUsize::new(0)),
                 downloaded: Arc::new(AtomicUsize::new(0)),
                 phase_num: Arc::new(AtomicUsize::new(0)),
@@ -257,6 +268,25 @@ impl InstallProgress {
         Self {
             mode: Mode::Ci(state),
             unpacked_sizes: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Raise the resolving-phase denominator floor. Only ever
+    /// increases the displayed total — a smaller `n` is silently
+    /// ignored. Used by the install command to seed the resolving bar
+    /// from any lockfile on disk and to surface the resolver's
+    /// BFS-frontier high-water mark while resolution is in flight,
+    /// so phase 1 renders a real bar instead of the empty-bar
+    /// placeholder. No-op once resolution finishes — phase 2+ reads
+    /// the actual count via `total` (set by [`set_total`]).
+    pub fn set_total_floor(&self, n: usize) {
+        match &self.mode {
+            Mode::Tty { target_total, .. } => {
+                target_total.fetch_max(n, Ordering::Relaxed);
+            }
+            Mode::Ci(s) => {
+                s.target_total.fetch_max(n, Ordering::Relaxed);
+            }
         }
     }
 

--- a/crates/aube/src/progress/render.rs
+++ b/crates/aube/src/progress/render.rs
@@ -60,18 +60,13 @@ const RESOLVE_BAR_WEIGHT: f64 = 0.20;
 /// the phase word in the label is the cue for that final stretch.
 const FETCH_BAR_WEIGHT: f64 = 1.0 - RESOLVE_BAR_WEIGHT;
 
-/// The fixed-width left-aligned bar. Empty portion is dim throughout;
-/// the filled portion takes its color from the current phase (cyan
-/// while fetching, green for linking/done) so the bar visually tracks
-/// the same phase progression that the right-side label spells out
-/// in words. One unified bar across the whole install: resolving
-/// fills the leftmost `RESOLVE_BAR_WEIGHT` slice, fetching extends
-/// from there to the right edge, linking holds at 100%. Without a
-/// resolving-phase estimate the resolving slice stays empty and
-/// fetching fills the full bar — the user-facing fallback when no
-/// lockfile and no BFS-frontier signal are available.
-pub(super) fn bar_only(snap: Snap, width: usize, completed: usize) -> String {
-    let progress: f64 = match snap.phase {
+/// Unified install-progress fraction in [0, 1]. Drives both the
+/// CI-mode bar (rendered here via [`bar_only`]) and the TTY-mode bar
+/// (rendered by clx after the caller scales this to its
+/// `progress_current`/`progress_total` integers). The two modes share
+/// this function so a tweak to the weighting lands in both renderers.
+pub(super) fn unified_progress(snap: Snap, completed: usize) -> f64 {
+    match snap.phase {
         1 if snap.target_total > 0 => {
             let estimate = snap.target_total.max(snap.resolved).max(1) as f64;
             RESOLVE_BAR_WEIGHT * (snap.resolved as f64 / estimate).min(1.0)
@@ -99,7 +94,21 @@ pub(super) fn bar_only(snap: Snap, width: usize, completed: usize) -> String {
         }
         3 => 1.0,
         _ => 0.0,
-    };
+    }
+}
+
+/// The fixed-width left-aligned bar. Empty portion is dim throughout;
+/// the filled portion takes its color from the current phase (cyan
+/// while fetching, green for linking/done) so the bar visually tracks
+/// the same phase progression that the right-side label spells out
+/// in words. One unified bar across the whole install: resolving
+/// fills the leftmost `RESOLVE_BAR_WEIGHT` slice, fetching extends
+/// from there to the right edge, linking holds at 100%. Without a
+/// resolving-phase estimate the resolving slice stays empty and
+/// fetching fills the full bar — the user-facing fallback when no
+/// lockfile and no BFS-frontier signal are available.
+pub(super) fn bar_only(snap: Snap, width: usize, completed: usize) -> String {
+    let progress = unified_progress(snap, completed);
     let filled = ((progress * width as f64).round() as usize).min(width);
     let empty = width - filled;
     let fill = "█".repeat(filled);
@@ -110,6 +119,40 @@ pub(super) fn bar_only(snap: Snap, width: usize, completed: usize) -> String {
         style::egreen(fill).to_string()
     };
     format!("{}{}", styled_fill, style::edim(empty))
+}
+
+/// Just the count segment of the label (`23/142 pkgs`, `1230 pkgs`).
+/// Extracted from [`label_for`] so TTY mode can render the same
+/// phase-conditional shape via the `count` template prop. Width
+/// padding mirrors `label_for`: resolving without an estimate
+/// right-aligns to its own running count; everything else aligns to
+/// the denominator's digit width.
+pub(super) fn count_segment(snap: Snap, completed: usize) -> String {
+    match snap.phase {
+        1 if snap.target_total > snap.resolved => {
+            let cur = pad_count(snap.resolved, snap.target_total);
+            format!(
+                "{}/{} {}",
+                style::ecyan(cur).bold(),
+                style::ecyan(snap.target_total).bold(),
+                style::edim("pkgs"),
+            )
+        }
+        1 => {
+            let count = pad_count(snap.resolved, snap.resolved);
+            format!("{} {}", style::ecyan(count).bold(), style::edim("pkgs"))
+        }
+        2 | 3 => {
+            let cur = pad_count(completed, snap.resolved);
+            format!(
+                "{}/{} {}",
+                style::ecyan(cur).bold(),
+                style::ecyan(snap.resolved).bold(),
+                style::edim("pkgs"),
+            )
+        }
+        _ => String::new(),
+    }
 }
 
 /// Phase-specific label content. Format:
@@ -128,37 +171,15 @@ fn label_for(snap: Snap, completed: usize) -> String {
     let dot = format!(" {} ", style::edim("·"));
     match snap.phase {
         1 => {
-            // Phase 1 numerator: count resolved so far. When we have a
-            // denominator estimate from the lockfile peek or the
-            // BFS-frontier signal, render as `cur/total`; otherwise
-            // fall back to the bare running count.
-            let count_segment = if snap.target_total > snap.resolved {
-                let cur = pad_count(snap.resolved, snap.target_total);
-                format!(
-                    "{}/{} {}",
-                    style::ecyan(cur).bold(),
-                    style::ecyan(snap.target_total).bold(),
-                    style::edim("pkgs"),
-                )
-            } else {
-                let count = pad_count(snap.resolved, snap.resolved);
-                format!("{} {}", style::ecyan(count).bold(), style::edim("pkgs"))
-            };
             let parts = [
-                count_segment,
+                count_segment(snap, completed),
                 style::eyellow("resolving").bold().to_string(),
             ];
             parts.join(&dot)
         }
         2 => {
-            let cur = pad_count(completed, snap.resolved);
             let mut parts = Vec::with_capacity(4);
-            parts.push(format!(
-                "{}/{} {}",
-                style::ecyan(cur).bold(),
-                style::ecyan(snap.resolved).bold(),
-                style::edim("pkgs"),
-            ));
+            parts.push(count_segment(snap, completed));
             // Skip the bytes segment when nothing has landed and no
             // unpackedSize estimate is available — older publishes
             // and the lockfile fast path both miss the field. Pushing
@@ -182,13 +203,7 @@ fn label_for(snap: Snap, completed: usize) -> String {
             // (fully warm cache) — `0 B` would be visual noise. Order
             // is `linking · bytes` so the active phase word reads first
             // and the static byte total trails it.
-            let cur = pad_count(completed, snap.resolved);
-            let mut parts = vec![format!(
-                "{}/{} {}",
-                style::ecyan(cur).bold(),
-                style::ecyan(snap.resolved).bold(),
-                style::edim("pkgs"),
-            )];
+            let mut parts = vec![count_segment(snap, completed)];
             parts.push(style::ecyan("linking").bold().to_string());
             if snap.bytes > 0 {
                 parts.push(style::edim(format_bytes(snap.bytes)).to_string());

--- a/crates/aube/src/progress/render.rs
+++ b/crates/aube/src/progress/render.rs
@@ -46,24 +46,50 @@ pub(super) fn progress_line(snap: Snap, term_width: usize, bar_width: usize) -> 
     format!("{bar} {label}")
 }
 
+/// Share of the install bar assigned to the resolving phase. The
+/// resolver typically accounts for a small fraction of wall time on a
+/// network-bound install; reserving ~20% leaves the dominant 80% for
+/// the fetching/linking stretch. The bar fills 0 → `RESOLVE_BAR_WEIGHT`
+/// during resolving, then continues 1:1 through fetching until it
+/// reaches the right edge.
+const RESOLVE_BAR_WEIGHT: f64 = 0.20;
+/// Share of the install bar assigned to fetching. Linking shares the
+/// fetching segment's right edge: by the time the linker runs every
+/// package is already in the CAS (or reflinked via the GVS prewarm
+/// pipeline), so there's no separate "linking" fill to track —
+/// the phase word in the label is the cue for that final stretch.
+const FETCH_BAR_WEIGHT: f64 = 1.0 - RESOLVE_BAR_WEIGHT;
+
 /// The fixed-width left-aligned bar. Empty portion is dim throughout;
 /// the filled portion takes its color from the current phase (cyan
 /// while fetching, green for linking/done) so the bar visually tracks
 /// the same phase progression that the right-side label spells out
-/// in words. Resolving has no fill — phase 1 always renders an empty
-/// bar — so it doesn't need its own arm here.
+/// in words. One unified bar across the whole install: resolving
+/// fills the leftmost `RESOLVE_BAR_WEIGHT` slice, fetching extends
+/// from there to the right edge, linking holds at 100%. Without a
+/// resolving-phase estimate the resolving slice stays empty and
+/// fetching fills the full bar — the user-facing fallback when no
+/// lockfile and no BFS-frontier signal are available.
 pub(super) fn bar_only(snap: Snap, width: usize, completed: usize) -> String {
-    let (numerator, denominator) = if snap.phase == 1 {
-        (0, 1)
-    } else {
-        let denom = snap.resolved.max(1);
-        (completed, denom)
+    let progress: f64 = match snap.phase {
+        1 if snap.target_total > 0 => {
+            let estimate = snap.target_total.max(snap.resolved).max(1) as f64;
+            RESOLVE_BAR_WEIGHT * (snap.resolved as f64 / estimate).min(1.0)
+        }
+        2 => {
+            let total = snap.resolved.max(1) as f64;
+            let fetch_progress = (completed as f64 / total).min(1.0);
+            // Offset by the resolving slice so the bar continues
+            // monotonically from where phase 1 left off. The mild
+            // jump at the boundary (when `target_total` undershoots
+            // or overshoots reality) is bounded by `RESOLVE_BAR_WEIGHT`
+            // and resolves within the first few fetch completions.
+            RESOLVE_BAR_WEIGHT + FETCH_BAR_WEIGHT * fetch_progress
+        }
+        3 => 1.0,
+        _ => 0.0,
     };
-    let filled = numerator
-        .checked_mul(width)
-        .and_then(|v| v.checked_div(denominator))
-        .unwrap_or(0)
-        .min(width);
+    let filled = ((progress * width as f64).round() as usize).min(width);
     let empty = width - filled;
     let fill = "█".repeat(filled);
     let empty = "░".repeat(empty);
@@ -91,9 +117,24 @@ fn label_for(snap: Snap, completed: usize) -> String {
     let dot = format!(" {} ", style::edim("·"));
     match snap.phase {
         1 => {
-            let count = pad_count(snap.resolved, snap.resolved);
+            // Phase 1 numerator: count resolved so far. When we have a
+            // denominator estimate from the lockfile peek or the
+            // BFS-frontier signal, render as `cur/total`; otherwise
+            // fall back to the bare running count.
+            let count_segment = if snap.target_total > snap.resolved {
+                let cur = pad_count(snap.resolved, snap.target_total);
+                format!(
+                    "{}/{} {}",
+                    style::ecyan(cur).bold(),
+                    style::ecyan(snap.target_total).bold(),
+                    style::edim("pkgs"),
+                )
+            } else {
+                let count = pad_count(snap.resolved, snap.resolved);
+                format!("{} {}", style::ecyan(count).bold(), style::edim("pkgs"))
+            };
             let parts = [
-                format!("{} {}", style::ecyan(count).bold(), style::edim("pkgs")),
+                count_segment,
                 style::eyellow("resolving").bold().to_string(),
             ];
             parts.join(&dot)
@@ -292,6 +333,7 @@ mod tests {
         Snap {
             phase,
             resolved,
+            target_total: 0,
             reused: completed,
             downloaded: 0,
             bytes,
@@ -401,6 +443,83 @@ mod tests {
         assert!(line.contains("linking"), "got: {line}");
         assert!(!line.contains("MB/s"), "rate must drop in linking: {line}");
         assert!(!line.contains("ETA"), "eta must drop in linking: {line}");
+    }
+
+    #[test]
+    fn resolving_with_target_total_shows_cur_total_and_filled_bar() {
+        let mut s = snap(1, 500, 0, 0, 0);
+        s.target_total = 1230;
+        let line = strip_ansi(&progress_line(s, 80, 15));
+        assert!(line.contains("500/1230 pkgs"), "got: {line}");
+        assert!(line.contains("resolving"), "got: {line}");
+        // Bar should have at least one filled cell once
+        // target_total > resolved > 0.
+        assert!(line.contains('\u{2588}'), "expected filled fill: {line}");
+        assert!(line.contains('\u{2591}'), "expected empty fill: {line}");
+    }
+
+    #[test]
+    fn resolving_without_target_total_keeps_bare_count() {
+        let line = strip_ansi(&progress_line(snap(1, 500, 0, 0, 0), 80, 15));
+        // No target_total → fall back to original "N pkgs" shape
+        // with an empty bar so we don't fake a denominator.
+        assert!(line.contains("500 pkgs"), "got: {line}");
+        assert!(!line.contains("/"), "no cur/total without estimate: {line}");
+        assert!(
+            !line.contains('\u{2588}'),
+            "no fill without estimate: {line}"
+        );
+    }
+
+    #[test]
+    fn resolving_target_total_undershoot_caps_at_resolve_weight() {
+        // Resolved already exceeded a stale estimate (e.g. lockfile
+        // undershot because the user added a big new subtree). The
+        // bar's resolving slice caps at `RESOLVE_BAR_WEIGHT`; phase 2
+        // takes over for the remaining fill. Label shows the bare
+        // count rather than `cur/total` with cur > total.
+        let mut s = snap(1, 1300, 0, 0, 0);
+        s.target_total = 1230;
+        let line = strip_ansi(&progress_line(s, 80, 15));
+        assert!(line.contains("1300 pkgs"), "got: {line}");
+        // Bar is in resolving phase — at most ~RESOLVE_BAR_WEIGHT (~20%)
+        // of the 15-cell bar can be filled, so the empty portion is
+        // still present.
+        assert!(
+            line.contains('\u{2591}'),
+            "resolving bar must not extend past its slice: {line}"
+        );
+    }
+
+    #[test]
+    fn unified_bar_continues_from_resolve_into_fetch() {
+        // End of resolving with a 1:1 estimate hits the resolve-slice
+        // edge; phase 2 starts at the same fill level and grows from
+        // there, so the bar progresses monotonically across phases.
+        let mut end_resolve = snap(1, 1230, 0, 0, 0);
+        end_resolve.target_total = 1230;
+        let resolve_bar = strip_ansi(&bar_only(end_resolve, 15, 0));
+        let resolve_filled = resolve_bar.matches('\u{2588}').count();
+
+        let start_fetch = snap(2, 1230, 0, 0, 0);
+        let fetch_bar = strip_ansi(&bar_only(start_fetch, 15, 0));
+        let fetch_filled = fetch_bar.matches('\u{2588}').count();
+
+        // Phase 2 at completed=0 starts at exactly the resolving
+        // slice's edge (or one cell higher from rounding), never
+        // backs up.
+        assert!(
+            fetch_filled >= resolve_filled,
+            "fetch start ({fetch_filled}) must not regress below resolve end ({resolve_filled})"
+        );
+        // And fetch end (completed = total) reaches the full width.
+        let end_fetch = snap(2, 1230, 1230, 0, 0);
+        let end_fetch_bar = strip_ansi(&bar_only(end_fetch, 15, 1230));
+        assert_eq!(
+            end_fetch_bar.matches('\u{2588}').count(),
+            15,
+            "got: {end_fetch_bar}"
+        );
     }
 
     #[test]

--- a/crates/aube/src/progress/render.rs
+++ b/crates/aube/src/progress/render.rs
@@ -80,11 +80,22 @@ pub(super) fn bar_only(snap: Snap, width: usize, completed: usize) -> String {
             let total = snap.resolved.max(1) as f64;
             let fetch_progress = (completed as f64 / total).min(1.0);
             // Offset by the resolving slice so the bar continues
-            // monotonically from where phase 1 left off. The mild
-            // jump at the boundary (when `target_total` undershoots
-            // or overshoots reality) is bounded by `RESOLVE_BAR_WEIGHT`
-            // and resolves within the first few fetch completions.
-            RESOLVE_BAR_WEIGHT + FETCH_BAR_WEIGHT * fetch_progress
+            // monotonically from where phase 1 left off — but only
+            // when a resolving estimate was actually in play. Without
+            // one (true first install, no lockfile and no streamed
+            // BFS-frontier signal), phase 1 rendered an empty bar,
+            // and anchoring fetching at 20% would snap the bar
+            // upward at the phase boundary. Fall back to the
+            // pre-PR full-range fill in that case. The mild
+            // boundary jump that survives — when `target_total`
+            // under- or overshoots reality — is bounded by
+            // `RESOLVE_BAR_WEIGHT` and resolves within the first
+            // few fetch completions.
+            if snap.target_total > 0 {
+                RESOLVE_BAR_WEIGHT + FETCH_BAR_WEIGHT * fetch_progress
+            } else {
+                fetch_progress
+            }
         }
         3 => 1.0,
         _ => 0.0,
@@ -492,16 +503,53 @@ mod tests {
     }
 
     #[test]
+    fn fetch_start_without_estimate_does_not_jump_to_resolve_offset() {
+        // No estimate was ever provided (no lockfile, BFS-frontier
+        // signal never raised the floor): resolving rendered empty,
+        // and fetching at completed=0 must also start empty rather
+        // than snap up to RESOLVE_BAR_WEIGHT.
+        let empty_resolve = snap(1, 0, 0, 0, 0);
+        let resolve_bar = strip_ansi(&bar_only(empty_resolve, 15, 0));
+        assert_eq!(
+            resolve_bar.matches('\u{2588}').count(),
+            0,
+            "resolving without estimate must render empty: {resolve_bar}"
+        );
+
+        let fetch_start = snap(2, 142, 0, 0, 0);
+        let fetch_bar = strip_ansi(&bar_only(fetch_start, 15, 0));
+        assert_eq!(
+            fetch_bar.matches('\u{2588}').count(),
+            0,
+            "fetch start without estimate must not snap to RESOLVE_BAR_WEIGHT: {fetch_bar}"
+        );
+
+        // And fetching still fills the full bar by completion, same
+        // as the pre-PR behavior on the no-estimate path.
+        let fetch_end = snap(2, 142, 142, 0, 0);
+        let end_bar = strip_ansi(&bar_only(fetch_end, 15, 142));
+        assert_eq!(
+            end_bar.matches('\u{2588}').count(),
+            15,
+            "fetch end without estimate must fill: {end_bar}"
+        );
+    }
+
+    #[test]
     fn unified_bar_continues_from_resolve_into_fetch() {
         // End of resolving with a 1:1 estimate hits the resolve-slice
         // edge; phase 2 starts at the same fill level and grows from
         // there, so the bar progresses monotonically across phases.
+        // target_total carries forward through the phase change — the
+        // atomic isn't cleared at the boundary — so phase 2 picks up
+        // the offset.
         let mut end_resolve = snap(1, 1230, 0, 0, 0);
         end_resolve.target_total = 1230;
         let resolve_bar = strip_ansi(&bar_only(end_resolve, 15, 0));
         let resolve_filled = resolve_bar.matches('\u{2588}').count();
 
-        let start_fetch = snap(2, 1230, 0, 0, 0);
+        let mut start_fetch = snap(2, 1230, 0, 0, 0);
+        start_fetch.target_total = 1230;
         let fetch_bar = strip_ansi(&bar_only(start_fetch, 15, 0));
         let fetch_filled = fetch_bar.matches('\u{2588}').count();
 
@@ -513,7 +561,8 @@ mod tests {
             "fetch start ({fetch_filled}) must not regress below resolve end ({resolve_filled})"
         );
         // And fetch end (completed = total) reaches the full width.
-        let end_fetch = snap(2, 1230, 1230, 0, 0);
+        let mut end_fetch = snap(2, 1230, 1230, 0, 0);
+        end_fetch.target_total = 1230;
         let end_fetch_bar = strip_ansi(&bar_only(end_fetch, 15, 1230));
         assert_eq!(
             end_fetch_bar.matches('\u{2588}').count(),


### PR DESCRIPTION
## Summary

The resolving phase used to render an empty bar with just a running pkg
count — the BFS resolver discovers transitives as it walks, so we had no
denominator to fill against:

```
░░░░░░░░░░░░░░░ 1237 pkgs · resolving · ETA …
```

Now the bar is one unified fill across the whole install:

- **Resolver side**: each `ResolvedPackage` carries a `pending` field —
  `queue.len() + in_flight.len() + deferred.len()` at send time. That
  plus `received_count` is a non-strict lower bound on the final
  resolved-package count.
- **Install side** seeds a `set_total_floor` from any lockfile already
  on disk (foreign formats included — covers `--no-frozen` too where the
  pre-parse is skipped) and raises it per streamed package using the
  resolver's frontier signal. `fetch_max` semantics keep the displayed
  total from snapping backward when the frontier transiently shrinks.
- **Render** is one unified bar across the install: resolving fills the
  leftmost ~20% slice, fetching extends from there to the right edge,
  linking holds at 100%. Without an estimate (true first install, no
  lockfile) the resolving slice stays empty and fetching fills the full
  bar — original behavior.

Label during resolving switches to `cur/total pkgs` when an estimate is
available, falls back to the bare `N pkgs` count otherwise.

## Test plan

- [x] `cargo build`, `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 12 progress tests (3 new) plus full workspace suite passing
- [ ] Manual smoke: install on a medium fixture, watch bar fill across resolve → fetch → link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to progress reporting and resolver-to-installer telemetry (new `ResolvedPackage.pending` field) with no impact on dependency selection or install correctness beyond UI counters.
> 
> **Overview**
> Adds a best-effort *resolving-phase denominator* so the progress bar can fill during dependency resolution instead of staying empty.
> 
> The resolver now streams a `pending` count on each `ResolvedPackage` (queue + in-flight fetches + deferred transitives), and `install` uses `received + pending` plus an optional on-disk lockfile size peek to raise a monotonic `set_total_floor` estimate.
> 
> Progress rendering is updated to a unified bar: resolving fills an initial ~20% slice when an estimate is available (and switches the label to `cur/total pkgs`), fetching continues from that offset, and linking holds at 100%; TTY mode is refactored to use a scaled denominator and shared `render::unified_progress`/`count_segment` helpers, with new tests covering the new resolving behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ee49bd53163c3f6913da317d72ebb35341cfa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->