### PR TITLE
perf(release): apply BOLT post-link rewrite to x86_64 Linux PGO builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,26 +287,30 @@ jobs:
         if: ${{ matrix.build-tool == 'cross' }}
         shell: bash
         run: cargo install cross --locked
-      # BOLT (post-link layout optimizer) runs after PGO phase 3b on the
-      # x86_64 Linux rows. perf is the LBR sampler that feeds perf2bolt;
-      # linux-tools-generic pulls the binary that matches the running
-      # kernel. perf_event_paranoid is bumped down so the cycles:u
-      # event with branch-stack sampling can fire — Namespace runners
-      # default to 4 which would otherwise produce an empty perf.data
-      # and a confusing perf2bolt error.
+      # BOLT (post-link layout optimizer) runs after PGO phase 3b on
+      # the Linux PGO rows. We pull it from apt.llvm.org rather than
+      # Ubuntu's archive because the noble `llvm-bolt`/`bolt-18`
+      # packages are amd64-only; apt.llvm.org publishes the same
+      # source for both amd64 and arm64. pgo.bash phase 4 uses BOLT's
+      # instrumentation mode, so no `perf` install or
+      # `kernel.perf_event_paranoid` tweaks are needed.
       - name: Install BOLT toolchain
         if: ${{ matrix.bolt }}
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm-bolt linux-tools-common linux-tools-generic
-          if ! command -v llvm-bolt >/dev/null; then
-            echo "/usr/lib/llvm-18/bin" >> "$GITHUB_PATH"
-            export PATH=/usr/lib/llvm-18/bin:$PATH
-          fi
-          llvm-bolt --version | head -2
-          perf2bolt --version 2>&1 | head -2 || true
-          sudo sysctl -w kernel.perf_event_paranoid=1 || true
+          sudo apt-get install -y --no-install-recommends wget gnupg ca-certificates
+          sudo install -d -m 0755 /etc/apt/keyrings
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+          codename=$(. /etc/os-release && echo "$VERSION_CODENAME")
+          echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-18 main" \
+            | sudo tee /etc/apt/sources.list.d/llvm-toolchain-18.list
+          sudo apt-get update
+          sudo apt-get install -y bolt-18
+          echo "/usr/lib/llvm-18/bin" >> "$GITHUB_PATH"
+          /usr/lib/llvm-18/bin/llvm-bolt --version | head -2
+          /usr/lib/llvm-18/bin/merge-fdata --help | head -2 || true
       # verdaccio is installed lazily by hermetic.bash's
       # _hermetic_ensure_verdaccio (called from pgo.bash via hermetic_start),
       # so no explicit install step is needed here.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,16 +194,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # BOLT runs against every Linux PGO target. Local bench on
-          # Zen 4 (x86_64) shows -2.7% wall / -18% L1-icache misses /
-          # -4.4% branch misses on the user-mode "frozen lockfile"
+          # BOLT runs against the glibc Linux PGO targets. Local bench
+          # on Zen 4 (x86_64) shows -2.7% wall / -18% L1-icache misses
+          # / -4.4% branch misses on the user-mode "frozen lockfile"
           # fast path (z=-6.45 on wall, n=20). The canonical install
           # benchmarks don't move statistically because system-call
           # time dominates real installs — codegen wins exist but get
-          # buried under syscall jitter. aarch64-linux uses the same
-          # perf-LBR-driven flow; the host's branch sampling support
-          # is checked at runtime in pgo.bash phase 4 and fails loud
-          # if absent. macOS BOLT support is not in tree.
+          # buried under syscall jitter.
+          #
+          # musl is skipped because BOLT's instrumentation runtime
+          # (libbolt_rt_instr.a) assumes glibc semantics for _exit /
+          # TLS and SIGSEGVs at startup against musl libc. Confirmed
+          # empirically in dry-run 25688552218. macOS BOLT support is
+          # not in tree.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
@@ -213,7 +216,7 @@ jobs:
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
             build-tool: cross
-            bolt: true
+            bolt: false
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-arm64-large;overrides.cache-tag=aube-rust-linux-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,15 +194,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # BOLT runs against the x86_64 Linux PGO targets only. Local
-          # bench on Zen 4 shows -2.7% wall / -18% L1-icache misses /
+          # BOLT runs against every Linux PGO target. Local bench on
+          # Zen 4 (x86_64) shows -2.7% wall / -18% L1-icache misses /
           # -4.4% branch misses on the user-mode "frozen lockfile"
           # fast path (z=-6.45 on wall, n=20). The canonical install
           # benchmarks don't move statistically because system-call
           # time dominates real installs — codegen wins exist but get
-          # buried under syscall jitter. aarch64-linux is skipped
-          # pending validation on an aarch64 host; macOS BOLT support
-          # is not in tree.
+          # buried under syscall jitter. aarch64-linux uses the same
+          # perf-LBR-driven flow; the host's branch sampling support
+          # is checked at runtime in pgo.bash phase 4 and fails loud
+          # if absent. macOS BOLT support is not in tree.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
@@ -217,7 +218,7 @@ jobs:
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-arm64-large;overrides.cache-tag=aube-rust-linux-arm64
             build-tool: cargo
-            bolt: false
+            bolt: true
           - target: aarch64-apple-darwin
             os: macos-latest
             # Trying GitHub's standard Apple Silicon runner — the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,18 +194,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # BOLT runs against the x86_64 Linux PGO targets only. Local
+          # bench on Zen 4 shows -2.7% wall / -18% L1-icache misses /
+          # -4.4% branch misses on the user-mode "frozen lockfile"
+          # fast path (z=-6.45 on wall, n=20). The canonical install
+          # benchmarks don't move statistically because system-call
+          # time dominates real installs — codegen wins exist but get
+          # buried under syscall jitter. aarch64-linux is skipped
+          # pending validation on an aarch64 host; macOS BOLT support
+          # is not in tree.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
             build-tool: cross
+            bolt: true
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
             build-tool: cross
+            bolt: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-arm64-large;overrides.cache-tag=aube-rust-linux-arm64
             build-tool: cargo
+            bolt: false
           - target: aarch64-apple-darwin
             os: macos-latest
             # Trying GitHub's standard Apple Silicon runner — the
@@ -219,6 +231,7 @@ jobs:
             # before dropping macOS arm64 from the PGO matrix entirely.
             runner: macos-latest
             build-tool: cargo
+            bolt: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -273,6 +286,26 @@ jobs:
         if: ${{ matrix.build-tool == 'cross' }}
         shell: bash
         run: cargo install cross --locked
+      # BOLT (post-link layout optimizer) runs after PGO phase 3b on the
+      # x86_64 Linux rows. perf is the LBR sampler that feeds perf2bolt;
+      # linux-tools-generic pulls the binary that matches the running
+      # kernel. perf_event_paranoid is bumped down so the cycles:u
+      # event with branch-stack sampling can fire — Namespace runners
+      # default to 4 which would otherwise produce an empty perf.data
+      # and a confusing perf2bolt error.
+      - name: Install BOLT toolchain
+        if: ${{ matrix.bolt }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-bolt linux-tools-common linux-tools-generic
+          if ! command -v llvm-bolt >/dev/null; then
+            echo "/usr/lib/llvm-18/bin" >> "$GITHUB_PATH"
+            export PATH=/usr/lib/llvm-18/bin:$PATH
+          fi
+          llvm-bolt --version | head -2
+          perf2bolt --version 2>&1 | head -2 || true
+          sudo sysctl -w kernel.perf_event_paranoid=1 || true
       # verdaccio is installed lazily by hermetic.bash's
       # _hermetic_ensure_verdaccio (called from pgo.bash via hermetic_start),
       # so no explicit install step is needed here.
@@ -288,6 +321,7 @@ jobs:
           AUBE_PGO_NO_LOCK: "1"
           AUBE_PGO_BUILD_TOOL: ${{ matrix.build-tool }}
           AUBE_PGO_TARGET: ${{ matrix.target }}
+          AUBE_PGO_BOLT: ${{ matrix.bolt && '1' || '' }}
         run: bash benchmarks/pgo.bash
       - name: Codesign macOS binaries
         if: startsWith(matrix.os, 'macos')

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -52,7 +52,9 @@
 #                               from the environment.
 #   AUBE_PGO_BOLT=1             append a BOLT post-link rewrite pass
 #                               after phase 3b. Requires `llvm-bolt`
-#                               and `merge-fdata` on PATH. Linux-only;
+#                               and `merge-fdata` from a `bolt-NN`
+#                               package — either on PATH or installed
+#                               at /usr/lib/llvm-NN/bin/. Linux-only;
 #                               BOLT's macOS support is not in tree.
 #                               Uses BOLT's instrumentation mode (no
 #                               `perf` needed), which works without
@@ -94,11 +96,22 @@ if [ -n "$PGO_BOLT" ]; then
 		echo "  Install via apt.llvm.org: bolt-18 (or newer)" >&2
 		exit 1
 	fi
-	if ! command -v merge-fdata >/dev/null 2>&1; then
-		echo "ERROR: AUBE_PGO_BOLT=1 but merge-fdata is not on PATH" >&2
+	# Resolve `merge-fdata` next to `llvm-bolt` so a versioned
+	# bolt-18 install works without its directory being on PATH
+	# (e.g. local runs without the workflow's GITHUB_PATH append).
+	# Fall back to PATH only if no sibling exists.
+	bolt_bindir=$(dirname "$LLVM_BOLT")
+	if [ -x "$bolt_bindir/merge-fdata" ]; then
+		MERGE_FDATA="$bolt_bindir/merge-fdata"
+	else
+		MERGE_FDATA=$(command -v merge-fdata || true)
+	fi
+	if [ -z "$MERGE_FDATA" ]; then
+		echo "ERROR: AUBE_PGO_BOLT=1 but merge-fdata is not installed" >&2
+		echo "  Expected next to llvm-bolt at $bolt_bindir/merge-fdata" >&2
 		exit 1
 	fi
-	echo ">>> BOLT toolchain: $LLVM_BOLT"
+	echo ">>> BOLT toolchain: $LLVM_BOLT ($MERGE_FDATA)"
 fi
 
 # target_arg stays unquoted at expansion sites: empty string disappears,
@@ -360,7 +373,7 @@ fi
 echo ">>> ${#fdata_files[@]} fdata files collected"
 
 echo ">>> [4c/4] Merging fdata"
-merge-fdata "${fdata_files[@]}" -o "$BOLT_FDATA"
+"$MERGE_FDATA" "${fdata_files[@]}" -o "$BOLT_FDATA"
 
 # llvm-bolt flags:
 #   reorder-blocks=ext-tsp     — extended TSP block layout, the

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Profile-Guided Optimization build for aube.
+# Profile-Guided Optimization build for aube, with optional BOLT
+# post-link rewrite.
 #
-# Three-phase rustc PGO flow:
+# Three-phase rustc PGO flow, plus an optional BOLT step:
 #
 #   1. Build aube with -Cprofile-generate (instrumented binary).
 #   2. Train against the hermetic Verdaccio registry — a mix of cold
@@ -9,6 +10,13 @@
 #      covers the resolver / registry / store / linker hot paths and
 #      the frozen-lockfile fast path.
 #   3. Merge .profraw via llvm-profdata, recompile with -Cprofile-use.
+#   4. (AUBE_PGO_BOLT=1) re-link phase 3b with `--emit-relocs`, retrain
+#      under `perf record` to capture an LBR-derived branch profile,
+#      then run `llvm-bolt` to reorder blocks + split cold paths.
+#      Layered after PGO because LLVM's PGO and BOLT optimize different
+#      things — PGO drives instruction-level codegen (inlining,
+#      branch weights), BOLT does post-link block/function layout
+#      and cold-path splitting that LLVM can't see at IR time.
 #
 # Local default: target/release-pgo/aube using profile=release-pgo.
 #
@@ -37,6 +45,11 @@
 #                               separate step (e.g. taiki-e action) that
 #                               picks up RUSTFLAGS+CARGO_PROFILE_RELEASE_LTO
 #                               from the environment.
+#   AUBE_PGO_BOLT=1             append a BOLT post-link rewrite pass
+#                               after phase 3b. Requires `llvm-bolt`,
+#                               `perf2bolt`, and `perf` (with branch
+#                               sampling) on the host. Linux-only;
+#                               BOLT's macOS support is not in tree.
 
 set -euo pipefail
 
@@ -49,6 +62,17 @@ PGO_MERGED="$PGO_DATA_DIR/merged.profdata"
 PGO_PROFILE="${AUBE_PGO_PROFILE:-release-pgo}"
 PGO_TARGET="${AUBE_PGO_TARGET:-}"
 PGO_BUILD_TOOL="${AUBE_PGO_BUILD_TOOL:-cargo}"
+PGO_BOLT="${AUBE_PGO_BOLT:-}"
+
+if [ -n "$PGO_BOLT" ]; then
+	for tool in llvm-bolt perf2bolt perf; do
+		if ! command -v "$tool" >/dev/null 2>&1; then
+			echo "ERROR: AUBE_PGO_BOLT=1 but '$tool' is not on PATH" >&2
+			echo "  Install on Debian/Ubuntu: sudo apt install llvm-bolt linux-tools-generic" >&2
+			exit 1
+		fi
+	done
+fi
 
 # target_arg stays unquoted at expansion sites: empty string disappears,
 # "--target=foo" expands to one arg. Avoids bash 3.2 (macOS) array+set -u
@@ -152,30 +176,37 @@ PROFRAW_PATTERN="$PGO_PROFRAW_DIR/aube-%m-%p.profraw"
 # 3 cold + 3 warm. Cold runs each get a fresh dir so the resolver,
 # registry, store, and linker hot paths all run end-to-end. Warm runs
 # reuse the last cold dir so the frozen-lockfile fast path is also
-# represented in the profile.
+# represented in the profile. The binary is parameterized so phase 4
+# (BOLT) can replay the same workload against the PGO-optimized binary
+# under `perf record`.
 cold_run() {
-	local i=$1
-	local run_dir="$train_dir/cold.$i"
+	local bin=$1 i=$2 tag=${3:-cold}
+	local run_dir="$train_dir/$tag.$i"
+	rm -rf "$run_dir"
 	mkdir -p "$run_dir/home"
 	cp "$SCRIPT_DIR/fixture.package.json" "$run_dir/package.json"
 	printf 'registry=%s\n' "$BENCH_REGISTRY_URL" >"$run_dir/.npmrc"
 	printf 'registry=%s\n' "$BENCH_REGISTRY_URL" >"$run_dir/home/.npmrc"
 	echo "  train: cold install ($i)"
-	(cd "$run_dir" && HOME="$run_dir/home" LLVM_PROFILE_FILE="$PROFRAW_PATTERN" "$INSTRUMENTED_BIN" install --ignore-scripts >/dev/null)
+	(cd "$run_dir" && HOME="$run_dir/home" "$bin" install --ignore-scripts >/dev/null)
 }
 
 warm_run() {
-	local run_dir=$1 i=$2
+	local bin=$1 run_dir=$2 i=$3
 	echo "  train: warm install ($i)"
-	(cd "$run_dir" && HOME="$run_dir/home" LLVM_PROFILE_FILE="$PROFRAW_PATTERN" "$INSTRUMENTED_BIN" install --ignore-scripts >/dev/null)
+	(cd "$run_dir" && HOME="$run_dir/home" "$bin" install --ignore-scripts >/dev/null)
 }
 
+# LLVM_PROFILE_FILE only matters for the instrumented binary, so it's
+# exported just around phase 2's training loop.
+export LLVM_PROFILE_FILE="$PROFRAW_PATTERN"
 for i in 1 2 3; do
-	cold_run "$i"
+	cold_run "$INSTRUMENTED_BIN" "$i" cold
 done
 for i in 1 2 3; do
-	warm_run "$train_dir/cold.3" "$i"
+	warm_run "$INSTRUMENTED_BIN" "$train_dir/cold.3" "$i"
 done
+unset LLVM_PROFILE_FILE
 
 hermetic_stop
 
@@ -216,7 +247,7 @@ if [ -n "${AUBE_PGO_SKIP_FINAL_BUILD:-}" ]; then
 fi
 
 # ---------- Phase 3b: optimize ----------
-echo ">>> Rebuilding with -Cprofile-use"
+echo ">>> Rebuilding with -Cprofile-use${PGO_BOLT:+ + --emit-relocs}"
 
 # -Cllvm-args=-pgo-warn-missing-function=false: silence LLVM's per-symbol
 # "no profile data available for function …" notes during phase 3b.
@@ -224,8 +255,18 @@ echo ">>> Rebuilding with -Cprofile-use"
 # code path — and emitting a warning per uncovered symbol drowns the CI
 # build log without surfacing actionable signal. The functions still
 # get compiled, just without PGO data, which is the documented fallback.
+#
+# When AUBE_PGO_BOLT=1, add `--emit-relocs` so the binary keeps its
+# `.rela.text` table after link. BOLT needs the relocations to rewrite
+# branch targets when it moves blocks around; without them it falls
+# back to a much less effective mode that only reorders within
+# functions.
+phase3b_rustflags="-Cprofile-use=$PGO_MERGED -Cllvm-args=-pgo-warn-missing-function=false"
+if [ -n "$PGO_BOLT" ]; then
+	phase3b_rustflags="$phase3b_rustflags -C link-arg=-Wl,--emit-relocs -C link-arg=-Wl,-q"
+fi
 # shellcheck disable=SC2086 # intentional word-splitting on $target_arg
-RUSTFLAGS="-Cprofile-use=$PGO_MERGED -Cllvm-args=-pgo-warn-missing-function=false" \
+RUSTFLAGS="$phase3b_rustflags" \
 	"$PGO_BUILD_TOOL" build --profile="$PGO_PROFILE" $target_arg -p aube
 
 # Phase 3b wrote to the same path as phase 1, so the file at
@@ -233,4 +274,85 @@ RUSTFLAGS="-Cprofile-use=$PGO_MERGED -Cllvm-args=-pgo-warn-missing-function=fals
 # one. Alias for clarity in the success log.
 PGO_FINAL_BIN="$INSTRUMENTED_BIN"
 echo ">>> PGO build complete: $PGO_FINAL_BIN"
+ls -lh "$PGO_FINAL_BIN"
+
+if [ -z "$PGO_BOLT" ]; then
+	exit 0
+fi
+
+# ---------- Phase 4: BOLT post-link rewrite ----------
+echo ">>> [4/4] BOLT post-link rewrite"
+
+BOLT_PERF_DATA="$PGO_DATA_DIR/bolt-perf.data"
+BOLT_FDATA="$PGO_DATA_DIR/aube.fdata"
+rm -f "$BOLT_PERF_DATA" "$BOLT_FDATA"
+
+# Restart hermetic so phase 4 trains against the same registry as
+# phase 2. The optimized binary doesn't emit profraw (no
+# -Cprofile-generate), so no per-process profile pattern is needed —
+# perf record samples cycles + branches across the whole training run.
+AUBE_BIN="$PGO_FINAL_BIN" hermetic_start
+
+# -j any,u captures user-space taken branches via LBR (kernel
+# samples discarded). A successful capture needs
+# `kernel.perf_event_paranoid <= 1` — checked here so the failure
+# is one line of helpful diagnostic instead of an empty perf.data
+# 30 seconds later.
+paranoid=$(cat /proc/sys/kernel/perf_event_paranoid 2>/dev/null || echo 4)
+if [ "$paranoid" -gt 1 ]; then
+	echo "ERROR: kernel.perf_event_paranoid=$paranoid (need <= 1 for BOLT)" >&2
+	echo "  Temporarily: sudo sysctl -w kernel.perf_event_paranoid=1" >&2
+	exit 1
+fi
+
+echo ">>> [4a/4] perf record around training workload"
+perf record -e cycles:u -j any,u -o "$BOLT_PERF_DATA" -- bash -c "
+	set -euo pipefail
+	$(declare -f cold_run warm_run)
+	train_dir='$train_dir'
+	BENCH_REGISTRY_URL='$BENCH_REGISTRY_URL'
+	SCRIPT_DIR='$SCRIPT_DIR'
+	for i in 1 2 3; do cold_run '$PGO_FINAL_BIN' \"\$i\" bolt; done
+	for i in 1 2 3; do warm_run '$PGO_FINAL_BIN' '$train_dir/bolt.3' \"\$i\"; done
+"
+
+hermetic_stop
+
+echo ">>> [4b/4] perf2bolt — converting LBR samples to fdata"
+perf2bolt -p "$BOLT_PERF_DATA" -o "$BOLT_FDATA" "$PGO_FINAL_BIN"
+
+# llvm-bolt flags:
+#   reorder-blocks=ext-tsp     — extended TSP block layout, the
+#                                strongest available; recommended by
+#                                upstream for any non-trivial binary.
+#   reorder-functions=cdsort   — function reordering using the cdsort
+#                                algorithm (call-density sort), the
+#                                current default on LLVM ≥ 17. Hot
+#                                functions cluster together so the
+#                                kernel can map them out of the same
+#                                pages.
+#   split-functions            — split each function into hot/cold so
+#                                the cold parts don't waste i-cache.
+#   split-all-cold             — aggressive: split even functions BOLT
+#                                isn't 100% sure about. Costs a few
+#                                kbytes; pays back in icache.
+#   split-eh                   — split exception-handling paths too;
+#                                aube's hot install path raises ~zero
+#                                so all of those are cold.
+#   use-gnu-stack              — emit a PT_GNU_STACK header; required
+#                                by recent toolchains to keep the
+#                                stack non-executable.
+echo ">>> [4c/4] llvm-bolt — rewriting binary"
+llvm-bolt "$PGO_FINAL_BIN" \
+	-o "$PGO_FINAL_BIN.bolt" \
+	-data="$BOLT_FDATA" \
+	-reorder-blocks=ext-tsp \
+	-reorder-functions=cdsort \
+	-split-functions \
+	-split-all-cold \
+	-split-eh \
+	-use-gnu-stack
+
+mv -f "$PGO_FINAL_BIN.bolt" "$PGO_FINAL_BIN"
+echo ">>> PGO+BOLT build complete: $PGO_FINAL_BIN"
 ls -lh "$PGO_FINAL_BIN"

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -10,13 +10,18 @@
 #      covers the resolver / registry / store / linker hot paths and
 #      the frozen-lockfile fast path.
 #   3. Merge .profraw via llvm-profdata, recompile with -Cprofile-use.
-#   4. (AUBE_PGO_BOLT=1) re-link phase 3b with `--emit-relocs`, retrain
-#      under `perf record` to capture an LBR-derived branch profile,
-#      then run `llvm-bolt` to reorder blocks + split cold paths.
+#   4. (AUBE_PGO_BOLT=1) re-link phase 3b with `--emit-relocs`, build
+#      an instrumented variant via `llvm-bolt --instrument`, replay
+#      the phase 2 training workload to collect per-process fdata,
+#      `merge-fdata` them, then run `llvm-bolt` again to reorder
+#      blocks + split cold paths using the merged profile.
 #      Layered after PGO because LLVM's PGO and BOLT optimize different
 #      things — PGO drives instruction-level codegen (inlining,
 #      branch weights), BOLT does post-link block/function layout
 #      and cold-path splitting that LLVM can't see at IR time.
+#      Instrumentation rather than perf-LBR sampling so the flow
+#      works on aarch64 (no LBR/BRBE dependency) and on hosts where
+#      `kernel.perf_event_paranoid` denies branch-stack sampling.
 #
 # Local default: target/release-pgo/aube using profile=release-pgo.
 #
@@ -199,8 +204,8 @@ PROFRAW_PATTERN="$PGO_PROFRAW_DIR/aube-%m-%p.profraw"
 # registry, store, and linker hot paths all run end-to-end. Warm runs
 # reuse the last cold dir so the frozen-lockfile fast path is also
 # represented in the profile. The binary is parameterized so phase 4
-# (BOLT) can replay the same workload against the PGO-optimized binary
-# under `perf record`.
+# (BOLT) can replay the same workload against the BOLT-instrumented
+# variant of the PGO-optimized binary.
 cold_run() {
 	local bin=$1 i=$2 tag=${3:-cold}
 	local run_dir="$train_dir/$tag.$i"

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -46,10 +46,13 @@
 #                               picks up RUSTFLAGS+CARGO_PROFILE_RELEASE_LTO
 #                               from the environment.
 #   AUBE_PGO_BOLT=1             append a BOLT post-link rewrite pass
-#                               after phase 3b. Requires `llvm-bolt`,
-#                               `perf2bolt`, and `perf` (with branch
-#                               sampling) on the host. Linux-only;
+#                               after phase 3b. Requires `llvm-bolt`
+#                               and `merge-fdata` on PATH. Linux-only;
 #                               BOLT's macOS support is not in tree.
+#                               Uses BOLT's instrumentation mode (no
+#                               `perf` needed), which works without
+#                               LBR/BRBE branch sampling and without
+#                               privileged kernel knobs.
 
 set -euo pipefail
 
@@ -65,13 +68,32 @@ PGO_BUILD_TOOL="${AUBE_PGO_BUILD_TOOL:-cargo}"
 PGO_BOLT="${AUBE_PGO_BOLT:-}"
 
 if [ -n "$PGO_BOLT" ]; then
-	for tool in llvm-bolt perf2bolt perf; do
-		if ! command -v "$tool" >/dev/null 2>&1; then
-			echo "ERROR: AUBE_PGO_BOLT=1 but '$tool' is not on PATH" >&2
-			echo "  Install on Debian/Ubuntu: sudo apt install llvm-bolt linux-tools-generic" >&2
-			exit 1
+	# Prefer `/usr/lib/llvm-NN/bin/llvm-bolt` over the unversioned
+	# `/usr/bin/llvm-bolt`. BOLT derives its runtime-lib search dir
+	# from `dirname(dirname(argv[0]))/lib`, so the versioned path
+	# resolves to `/usr/lib/llvm-NN/lib/libbolt_rt_instr.a` (where
+	# Debian/Ubuntu actually ship the static archive). The
+	# unversioned path looks in `/usr/lib/` and fails.
+	LLVM_BOLT=""
+	for candidate in /usr/lib/llvm-18/bin/llvm-bolt /usr/lib/llvm-19/bin/llvm-bolt /usr/lib/llvm-20/bin/llvm-bolt; do
+		if [ -x "$candidate" ]; then
+			LLVM_BOLT="$candidate"
+			break
 		fi
 	done
+	if [ -z "$LLVM_BOLT" ]; then
+		LLVM_BOLT=$(command -v llvm-bolt || true)
+	fi
+	if [ -z "$LLVM_BOLT" ]; then
+		echo "ERROR: AUBE_PGO_BOLT=1 but llvm-bolt is not installed" >&2
+		echo "  Install via apt.llvm.org: bolt-18 (or newer)" >&2
+		exit 1
+	fi
+	if ! command -v merge-fdata >/dev/null 2>&1; then
+		echo "ERROR: AUBE_PGO_BOLT=1 but merge-fdata is not on PATH" >&2
+		exit 1
+	fi
+	echo ">>> BOLT toolchain: $LLVM_BOLT"
 fi
 
 # target_arg stays unquoted at expansion sites: empty string disappears,
@@ -280,70 +302,77 @@ if [ -z "$PGO_BOLT" ]; then
 	exit 0
 fi
 
-# ---------- Phase 4: BOLT post-link rewrite ----------
-echo ">>> [4/4] BOLT post-link rewrite"
+# ---------- Phase 4: BOLT post-link rewrite (instrumentation mode) ----------
+# Why instrumentation rather than the more common `perf record + perf2bolt`
+# LBR flow:
+#   - `perf record -j any,u` needs `kernel.perf_event_paranoid <= 1` —
+#     the Namespace runners we use for PGO default to 2 and don't
+#     honor `sudo sysctl -w` from a workflow step.
+#   - aarch64 hosts without ARM v9.2 BRBE can't do LBR sampling at all,
+#     so the perf flow would silently miss profile data on the
+#     aarch64-linux PGO row even if paranoid were 0.
+# Instrumentation sidesteps both: BOLT injects counters into the binary,
+# the instrumented binary writes one fdata file per process at exit,
+# and `merge-fdata` rolls them up into a single profile. Slower training
+# (instrumented binary is ~5× slower than native) but the workload is
+# small enough that the wall cost is well under a minute.
+echo ">>> [4/4] BOLT post-link rewrite (instrumentation mode)"
 
-BOLT_PERF_DATA="$PGO_DATA_DIR/bolt-perf.data"
+BOLT_INSTR_BIN="$PGO_DATA_DIR/aube.instr"
+BOLT_FDATA_PREFIX="$PGO_DATA_DIR/bolt"
 BOLT_FDATA="$PGO_DATA_DIR/aube.fdata"
-rm -f "$BOLT_PERF_DATA" "$BOLT_FDATA"
+rm -f "$BOLT_INSTR_BIN" "$BOLT_FDATA"
+find "$PGO_DATA_DIR" -maxdepth 1 -name 'bolt.*.fdata' -delete 2>/dev/null || true
 
-# Restart hermetic so phase 4 trains against the same registry as
-# phase 2. The optimized binary doesn't emit profraw (no
-# -Cprofile-generate), so no per-process profile pattern is needed —
-# perf record samples cycles + branches across the whole training run.
-AUBE_BIN="$PGO_FINAL_BIN" hermetic_start
+echo ">>> [4a/4] Building instrumented binary"
+"$LLVM_BOLT" "$PGO_FINAL_BIN" \
+	--instrument \
+	--instrumentation-file="$BOLT_FDATA_PREFIX" \
+	--instrumentation-file-append-pid \
+	-o "$BOLT_INSTR_BIN"
 
-# -j any,u captures user-space taken branches via LBR (kernel
-# samples discarded). A successful capture needs
-# `kernel.perf_event_paranoid <= 1` — checked here so the failure
-# is one line of helpful diagnostic instead of an empty perf.data
-# 30 seconds later.
-paranoid=$(cat /proc/sys/kernel/perf_event_paranoid 2>/dev/null || echo 4)
-if [ "$paranoid" -gt 1 ]; then
-	echo "ERROR: kernel.perf_event_paranoid=$paranoid (need <= 1 for BOLT)" >&2
-	echo "  Temporarily: sudo sysctl -w kernel.perf_event_paranoid=1" >&2
-	exit 1
-fi
+# Replay the same 3 cold + 3 warm training workload as phase 2, this
+# time against the instrumented PGO binary. Each invocation writes
+# bolt.<pid>.fdata on exit. The hermetic registry was stopped at end
+# of phase 2; restart it here.
+AUBE_BIN="$BOLT_INSTR_BIN" hermetic_start
 
-echo ">>> [4a/4] perf record around training workload"
-perf record -e cycles:u -j any,u -o "$BOLT_PERF_DATA" -- bash -c "
-	set -euo pipefail
-	$(declare -f cold_run warm_run)
-	train_dir='$train_dir'
-	BENCH_REGISTRY_URL='$BENCH_REGISTRY_URL'
-	SCRIPT_DIR='$SCRIPT_DIR'
-	for i in 1 2 3; do cold_run '$PGO_FINAL_BIN' \"\$i\" bolt; done
-	for i in 1 2 3; do warm_run '$PGO_FINAL_BIN' '$train_dir/bolt.3' \"\$i\"; done
-"
+echo ">>> [4b/4] Training instrumented binary"
+for i in 1 2 3; do cold_run "$BOLT_INSTR_BIN" "$i" bolt; done
+for i in 1 2 3; do warm_run "$BOLT_INSTR_BIN" "$train_dir/bolt.3" "$i"; done
 
 hermetic_stop
 
-echo ">>> [4b/4] perf2bolt — converting LBR samples to fdata"
-perf2bolt -p "$BOLT_PERF_DATA" -o "$BOLT_FDATA" "$PGO_FINAL_BIN"
+# Sanity check: instrumentation writes on `_exit`. If the binary
+# crashed mid-run, no fdata. Without this we'd fall through to
+# llvm-bolt with an empty profile.
+fdata_files=("$PGO_DATA_DIR"/bolt.*.fdata)
+if [ ! -e "${fdata_files[0]}" ]; then
+	echo "ERROR: no bolt.*.fdata files written to $PGO_DATA_DIR" >&2
+	echo "  Instrumented binary may have crashed before exit." >&2
+	exit 1
+fi
+echo ">>> ${#fdata_files[@]} fdata files collected"
+
+echo ">>> [4c/4] Merging fdata"
+merge-fdata "${fdata_files[@]}" -o "$BOLT_FDATA"
 
 # llvm-bolt flags:
 #   reorder-blocks=ext-tsp     — extended TSP block layout, the
-#                                strongest available; recommended by
-#                                upstream for any non-trivial binary.
-#   reorder-functions=cdsort   — function reordering using the cdsort
-#                                algorithm (call-density sort), the
-#                                current default on LLVM ≥ 17. Hot
-#                                functions cluster together so the
-#                                kernel can map them out of the same
-#                                pages.
+#                                strongest available.
+#   reorder-functions=cdsort   — call-density sort. Hot functions
+#                                cluster so the kernel maps them
+#                                out of the same pages.
 #   split-functions            — split each function into hot/cold so
 #                                the cold parts don't waste i-cache.
-#   split-all-cold             — aggressive: split even functions BOLT
-#                                isn't 100% sure about. Costs a few
-#                                kbytes; pays back in icache.
-#   split-eh                   — split exception-handling paths too;
-#                                aube's hot install path raises ~zero
-#                                so all of those are cold.
-#   use-gnu-stack              — emit a PT_GNU_STACK header; required
-#                                by recent toolchains to keep the
-#                                stack non-executable.
-echo ">>> [4c/4] llvm-bolt — rewriting binary"
-llvm-bolt "$PGO_FINAL_BIN" \
+#   split-all-cold             — aggressive: split even functions
+#                                BOLT isn't 100% sure about.
+#   split-eh                   — split exception-handling paths;
+#                                aube's hot install path raises ~zero.
+#   use-gnu-stack              — emit a PT_GNU_STACK header so the
+#                                kernel keeps the stack non-executable.
+echo ">>> [4d/4] Rewriting binary"
+"$LLVM_BOLT" "$PGO_FINAL_BIN" \
 	-o "$PGO_FINAL_BIN.bolt" \
 	-data="$BOLT_FDATA" \
 	-reorder-blocks=ext-tsp \


### PR DESCRIPTION
## Summary
- Adds optional BOLT phase 4 to `benchmarks/pgo.bash` (gated on `AUBE_PGO_BOLT=1`)
- Enables it for `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` PGO targets in `release.yml`
- Uses BOLT's **instrumentation mode** (no `perf`, no LBR/BRBE), so the same flow works on x86_64 and aarch64
- Installs `bolt-18` from `apt.llvm.org` (Ubuntu noble's archive package is amd64-only)

## What BOLT does on top of PGO
PGO drives LLVM's instruction-level codegen (inlining, branch weights, function granularity). BOLT rewrites the linked binary to do post-link block layout (`ext-tsp`), function reordering (`cdsort`), and hot/cold splitting LLVM can't see at IR time. They optimize different layers, so stacking is additive.

## Why instrumentation rather than perf-LBR
Instrumentation mode (this PR) injects counters into the binary, the instrumented binary writes one fdata file per process, and `merge-fdata` rolls them up. The `perf record + perf2bolt` flow was tried first and failed in CI because (1) Namespace runners default to `kernel.perf_event_paranoid=2` and ignore `sudo sysctl -w` from workflow steps, denying LBR branch sampling; and (2) aarch64 hosts can't use Intel LBR at all.

Side effect of instrumentation: richer profile. Local measurement shows **3415 functions profiled (16.3%)** vs 1261 (6.0%) with LBR. The dry-run (25688552218) confirmed identical numbers on both archs in CI: x86_64-gnu 3379 functions (16.2%) / 1784 reordered, aarch64-gnu 3382 (16.4%) / 1701 reordered.

## Measurement
Local Zen 4 (Ryzen 9 7950X3D), n=20 `perf stat` runs of `aube install` on an already-installed project (pure user-mode work). PGO vs PGO+BOLT:

| counter | PGO | PGO+BOLT | Δ |
|---|---|---|---|
| wall | 8.112 ± 0.122 ms | 7.890 ± 0.094 ms | **-2.74% (z=-6.45)** |
| cycles:u | 8.54M ± 1.53% | 8.38M ± 1.41% | -1.82% (z=-3.94) |
| branch-misses:u | 64,993 | 62,115 | -4.4% |
| L1-icache-load-misses | 25,677 | 21,061 | **-18.0%** |
| iTLB-load-misses | 9,434 | 9,306 | -1.4% |

## What this doesn't move
The canonical hyperfine install benchmarks (gvs-warm, ci-warm, ci-cold) — both the existing fixture and the vlt-benchmarks large fixture (109 direct deps, 1410 transitive) — **do not move statistically**. All deltas within combined σ, |t| < 1.5. Real installs spend ~80% of wall time in system calls; BOLT only affects user-mode codegen, and the gains get buried under syscall jitter.

## Pipeline cost
- `pgo.bash` grows ~100 lines (new phase 4 + helper refactor); shellcheck clean
- `release.yml` grows ~25 lines (toolchain install step + matrix `bolt` flag)
- Extra ~1–2 min per affected target on release (build instrumented binary + replay training + merge + rewrite)
- Final binary roughly same size (BOLT split-cold section vs strip — net wash after `strip = "debuginfo"`)
- New apt source: `apt.llvm.org/<codename>/ llvm-toolchain-<codename>-18 main`; new build dep `bolt-18`

## What's not in this PR
- **`x86_64-unknown-linux-musl`** — BOLT's instrumentation runtime (`libbolt_rt_instr.a`) is built against glibc and pre-main SIGSEGVs at startup under musl's static libc (init_array / `_exit` / TLS semantics differ). Confirmed empirically in dry-run 25688552218. The musl target's audience cares about static binaries, where instrumenting at link time is invasive anyway; revisit if/when LLVM upstream ships a musl-compatible BOLT runtime.
- `aarch64-apple-darwin` — BOLT macOS support isn't in upstream LLVM yet.
- Larger CI training fixture — out of scope; PGO + BOLT train on the same bench fixture as today.

## Test plan
- [x] Local: `AUBE_PGO_BOLT=1 bash benchmarks/pgo.bash` produces a working binary, verified `aube --version` and `aube --help`
- [x] `actionlint` + `shellcheck` + `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean
- [x] CI dry-run #1 (25686331454): identified the perf-LBR failure modes, pivoted to instrumentation
- [x] CI dry-run #2 (25688552218): **x86_64-gnu ✓, aarch64-gnu ✓**, musl excluded based on this run's failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release build pipeline and produced binaries by adding a new BOLT rewrite phase and new apt.llvm.org dependency, which could affect build reliability and artifact correctness on Linux PGO targets.
> 
> **Overview**
> Adds an **optional BOLT “phase 4”** to `benchmarks/pgo.bash` (gated by `AUBE_PGO_BOLT=1`) that relinks the PGO-optimized binary with `--emit-relocs`, instruments it with `llvm-bolt`, replays the existing training workload to collect/merge `fdata`, then rewrites the final binary with block/function reordering and hot/cold splitting.
> 
> Updates the `release.yml` PGO matrix with a per-target `bolt` flag, installs `bolt-18` from `apt.llvm.org` when enabled, and turns BOLT on for `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` while explicitly keeping it off for musl and macOS rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f0b510d54a43069facefc1cb3176bb2111df01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->