### PR TITLE
feat(outdated, update): wire `-w/--workspace-root` to retarget cwd at workspace root

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1181,6 +1181,9 @@ cmd outdated help="Report dependencies whose installed version lags behind the r
     flag --json help="Emit a JSON object keyed by package name instead of the default table"
     flag --long help="Also show deps whose `wanted` version matches the installed version"
     flag "-P --prod --production" help="Show only production dependencies (skip devDependencies)"
+    flag "-w --workspace-root --workspace" help="Operate on the workspace root regardless of cwd" {
+        long_help "Operate on the workspace root regardless of cwd.\n\nMirrors pnpm's `-w/--workspace-root`: from a sub-package, `aube outdated -w` reports the root manifest's deps instead of the sub-package's. No-op when paired with `-r` / `--filter` (those already drive workspace selection from the root)."
+    }
     flag --fetch-retries help="Number of retry attempts for failed registry fetches" {
         long_help "Number of retry attempts for failed registry fetches.\n\nOverrides `fetchRetries` / `fetch-retries` from `.npmrc` / `aube-workspace.yaml` when set. Pair with `--fetch-timeout` to fail fast in scripted test runs."
         arg <N>

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -78,6 +78,14 @@ pub struct OutdatedArgs {
         visible_alias = "production"
     )]
     pub prod: bool,
+    /// Operate on the workspace root regardless of cwd.
+    ///
+    /// Mirrors pnpm's `-w/--workspace-root`: from a sub-package,
+    /// `aube outdated -w` reports the root manifest's deps instead
+    /// of the sub-package's. No-op when paired with `-r` / `--filter`
+    /// (those already drive workspace selection from the root).
+    #[arg(short = 'w', long = "workspace-root", visible_alias = "workspace")]
+    pub workspace_root: bool,
     #[command(flatten)]
     pub network: crate::cli_args::NetworkArgs,
 }
@@ -116,7 +124,7 @@ pub async fn run(
     mut filter: aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<()> {
     args.network.install_overrides();
-    let cwd = crate::dirs::project_root()?;
+    let mut cwd = crate::dirs::project_root()?;
     if !filter.is_empty() {
         // Discussion #602: include the workspace root in `outdated -r`
         // by default. pnpm parity here is strict (root is opt-in via
@@ -125,6 +133,16 @@ pub async fn run(
         // parity concern.
         filter.include_workspace_root = true;
         return run_filtered(&cwd, args, &filter).await;
+    }
+    // `-w/--workspace-root`: retarget the report at the workspace
+    // root manifest, regardless of which sub-package the user ran
+    // from. Mirrors `pnpm -w outdated`. No-op when no workspace root
+    // exists above cwd (single-project install) so the flag is safe
+    // to leave in shell aliases.
+    if args.workspace_root
+        && let Some(root) = crate::dirs::find_workspace_root(&cwd)
+    {
+        cwd = root;
     }
     run_one(&cwd, args, None).await?;
     Ok(())
@@ -347,6 +365,7 @@ impl OutdatedArgs {
             json: self.json,
             long: self.long,
             prod: self.prod,
+            workspace_root: self.workspace_root,
             network: self.network.clone(),
         }
     }

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -116,7 +116,7 @@ pub async fn run(
     args.lockfile.install_overrides();
     args.virtual_store.install_overrides();
     let _ = args.ignore_scripts; // parity no-op: dep scripts already gated by allowBuilds
-    let _ = (args.global, args.workspace);
+    let _ = args.global;
     if let Some(depth) = args.depth.as_deref() {
         // pnpm's `--depth Infinity` is the only useful value; the
         // intermediate ones (`--depth 1`, `--depth 2`) have semantics
@@ -164,7 +164,18 @@ pub async fn run(
     // into a per-key predicate so the same code path serves both.
     let effective_latest = latest || !explicit_latest_keys.is_empty();
     let should_rewrite_key = |key: &str| -> bool { latest || explicit_latest_keys.contains(key) };
-    let cwd = crate::dirs::project_root()?;
+    let mut cwd = crate::dirs::project_root()?;
+    // `-w/--workspace-root`: act on the workspace root manifest
+    // regardless of which sub-package the user ran from. Mirrors
+    // `pnpm -w update`. Falls back to the original project root when
+    // there's no workspace above (single-project install) so the
+    // flag stays safe in shell aliases. Must run before the project
+    // lock is acquired so we lock the right directory.
+    if args.workspace
+        && let Some(root) = crate::dirs::find_workspace_root(&cwd)
+    {
+        cwd = root;
+    }
     let _lock = super::take_project_lock(&cwd)?;
     let manifest_path = cwd.join("package.json");
 
@@ -947,6 +958,15 @@ async fn run_filtered(
             // clear it on the per-pkg clone so the recursive call doesn't
             // re-warn once per matched workspace package.
             per_pkg.depth = None;
+            // `-w` retargets cwd at the workspace root inside `run`. Each
+            // per-package iteration here already retargets via
+            // `retarget_cwd(&pkg.dir)`; if the flag survived the clone,
+            // the inner `run` would re-retarget every iteration to the
+            // workspace root and lock/rewrite the root manifest for every
+            // package, leaving the per-package merge step with nothing to
+            // pick up. `-r` plus `-w` is documented as a no-op precisely
+            // because `-r` already includes the root in its sweep.
+            per_pkg.workspace = false;
             if !args.packages.is_empty() {
                 let manifest_path = pkg.dir.join("package.json");
                 let project_manifest = aube_manifest::PackageJson::from_path(&manifest_path)

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6664,6 +6664,22 @@
             "global": false
           },
           {
+            "name": "workspace-root",
+            "usage": "-w --workspace-root",
+            "help": "Operate on the workspace root regardless of cwd",
+            "help_long": "Operate on the workspace root regardless of cwd.\n\nMirrors pnpm's `-w/--workspace-root`: from a sub-package, `aube outdated -w` reports the root manifest's deps instead of the sub-package's. No-op when paired with `-r` / `--filter` (those already drive workspace selection from the root).",
+            "help_first_line": "Operate on the workspace root regardless of cwd",
+            "short": [
+              "w"
+            ],
+            "long": [
+              "workspace-root",
+              "workspace"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "fetch-retries",
             "usage": "--fetch-retries <N>",
             "help": "Number of retry attempts for failed registry fetches",

--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -29,6 +29,12 @@ Also show deps whose `wanted` version matches the installed version
 
 Show only production dependencies (skip devDependencies)
 
+### `-w --workspace-root`
+
+Operate on the workspace root regardless of cwd.
+
+Mirrors pnpm's `-w/--workspace-root`: from a sub-package, `aube outdated -w` reports the root manifest's deps instead of the sub-package's. No-op when paired with `-r` / `--filter` (those already drive workspace selection from the root).
+
 ### `--fetch-retries <N>`
 
 Number of retry attempts for failed registry fetches.

--- a/test/outdated.bats
+++ b/test/outdated.bats
@@ -179,6 +179,36 @@ EOF
 	assert_output --partial "is-odd"
 }
 
+@test "aube outdated -w retargets at the workspace root from a sub-package" {
+	# Mirrors `pnpm -w outdated`: from a sub-package, `-w` must report
+	# the root manifest's deps (not the sub-package's) regardless of
+	# cwd. Without `-w`, the outdated check resolves the sub-package's
+	# lockfile, which doesn't exist in shared-lockfile workspaces and
+	# would emit "No lockfile found".
+	cat >package.json <<'EOF'
+{"name":"root","version":"0.0.0","private":true,"dependencies":{"is-odd":"0.1.2"}}
+EOF
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - packages/*
+EOF
+	mkdir -p packages/api
+	cat >packages/api/package.json <<'EOF'
+{"name":"api","version":"1.0.0","dependencies":{"is-even":"0.1.0"}}
+EOF
+
+	run aube install
+	assert_success
+
+	cd packages/api
+	run aube outdated -w
+	assert_failure
+	# Root's `is-odd` shows as outdated; the sub-package's `is-even`
+	# must not appear because we're targeting the root manifest.
+	assert_output --partial "is-odd"
+	refute_output --partial "is-even"
+}
+
 @test "aube outdated --filter limits workspace importers" {
 	cat >package.json <<'EOF'
 {"name":"root","version":"0.0.0","private":true}

--- a/test/pnpm_update.bats
+++ b/test/pnpm_update.bats
@@ -1430,3 +1430,73 @@ JSON
 	run grep '"is-even": *"1.0.0"' packages/a/package.json
 	assert_success
 }
+
+@test "aube update -w retargets at the workspace root from a sub-package" {
+	# Mirrors `pnpm -w update`: from a sub-package, `update -w` must
+	# rewrite the root manifest (not the sub-package's). Without `-w`,
+	# the in-package run resolves the sub-package's lockfile / writes
+	# the sub-package's manifest.
+	cat >package.json <<'JSON'
+{"name":"root","version":"0.0.0","private":true,"dependencies":{"is-odd":"0.1.2"}}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	mkdir -p packages/api
+	cat >packages/api/package.json <<'JSON'
+{"name":"api","version":"1.0.0","dependencies":{"is-even":"0.1.0"}}
+JSON
+
+	run aube install
+	assert_success
+
+	cd packages/api
+	run aube update -w --latest
+	assert_success
+
+	# Root manifest's is-odd moved off the 0.1.2 pin (avoid hardcoding
+	# the registry's current `latest` so the test survives future
+	# fixture additions); sub-package's is-even must stay frozen
+	# because we never targeted it.
+	run grep -E '"is-odd": *"[^0]\.' ../../package.json
+	assert_success
+	run grep '"is-even": *"0.1.0"' package.json
+	assert_success
+}
+
+@test "aube update -r -w: -r keeps per-package retargeting (regression)" {
+	# `-w` retargets cwd at the workspace root inside `run`. `-r`
+	# fans out to every workspace package and retargets cwd per
+	# package via `retarget_cwd`; if `-w` survived the inner clone,
+	# every iteration would re-retarget to the workspace root, lock
+	# + rewrite the root manifest in a loop, and the per-package
+	# lockfile merge would have nothing to pick up. `-r` plus `-w`
+	# must be equivalent to plain `-r` (which already includes the
+	# root in its sweep).
+	cat >package.json <<'JSON'
+{"name":"root","version":"0.0.0","private":true,"dependencies":{"is-odd":"0.1.2"}}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	mkdir -p packages/api
+	cat >packages/api/package.json <<'JSON'
+{"name":"api","version":"1.0.0","dependencies":{"is-even":"0.1.0"}}
+JSON
+
+	run aube install
+	assert_success
+
+	run aube update -r -w --latest
+	assert_success
+
+	# Both manifests bumped past their pins — the per-package fanout
+	# updated `api` correctly instead of being clobbered by the
+	# workspace-root retarget on every iteration.
+	run grep -E '"is-odd": *"[^0]\.' package.json
+	assert_success
+	run grep -E '"is-even": *"[^0]\.' packages/api/package.json
+	assert_success
+}


### PR DESCRIPTION
## Summary

Followup to [#610](https://github.com/endevco/aube/pull/610) (which fixed [#602](https://github.com/endevco/aube/discussions/602)). That PR added root-inclusion to `-r` by default but couldn't land a meaningful `-w` flag — the original user request — because root was already implicit. With cwd-retargeting semantics, `-w` does something distinct from `-r`:

```
aube outdated                # from packages/api/: api's deps
aube outdated -w             # from packages/api/: root's deps
aube outdated -r             # both root and every workspace pkg
```

Mirrors `pnpm -w outdated` / `pnpm -w update`: from a sub-package, `-w` acts on the root manifest regardless of where the user ran it from.

## Implementation

- `outdated`: new `workspace_root: bool` flag, reachable via `-w`, `--workspace-root`, or `--workspace`. When set with no `--filter`, `find_workspace_root(cwd)` and override the local `cwd` before the manifest/lockfile load.
- `update`: the pre-existing `workspace: bool` was a parity no-op (discarded with `let _ = ...`). Removed it from the discard, kept the existing `-w` short flag, and applied the same retarget — must happen before `take_project_lock` so the right directory gets locked.

Falls back to the original project root when no workspace exists above (single-project install), so the flag is safe to leave in shell aliases.

## Test plan

- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `mise run test:bats test/outdated.bats test/pnpm_update.bats` — 41 tests, no failures
- [x] New bats coverage:
  - `aube outdated -w retargets at the workspace root from a sub-package`
  - `aube update -w retargets at the workspace root from a sub-package`
- [x] Manual repro: from `packages/api/`, `aube outdated -w` reports root's `is-odd` drift; `aube update -w --latest` rewrites root's `package.json` while leaving `api/package.json` untouched.

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `outdated` and `update` select the working directory/manifest in workspaces, which can affect which `package.json` and lockfile are read/written. Risk is mitigated by explicit flags plus added bats coverage for root/subpackage and `-r` interactions.
> 
> **Overview**
> Adds a new `-w/--workspace-root` flag to `aube outdated` that retargets the report to the workspace root manifest when invoked from a sub-package (and is ignored when `--filter`/`-r` already drive workspace selection).
> 
> Wires the existing `-w` flag in `aube update` to perform the same cwd retargeting **before** acquiring the project lock, and prevents `-w` from leaking into recursive fanout clones so `update -r -w` continues to update per-package manifests.
> 
> Updates generated CLI docs/usage (`aube.usage.kdl`, `docs/cli/commands.json`, `docs/cli/outdated.md`) and adds bats tests covering `outdated -w`, `update -w`, and the `update -r -w` regression case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b869e2e08da943f6040cbc9324048c50491375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->