### PR TITLE
perf(store): direct-write CAS fast path on macOS under exclusive install lock

### DIFF
--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -9,6 +9,8 @@ use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 pub const SHA512_INTEGRITY_PREFIX: &str = "sha512-";
 
@@ -59,6 +61,18 @@ thread_local! {
     static SHA512_HASHER: RefCell<Sha512> = RefCell::new(Sha512::new());
 }
 
+/// Per-shard mutex array used by the non-Linux CAS fast path to
+/// serialize concurrent writers within a single process. Indexed by the
+/// first byte of the file's BLAKE3 hash (matching the on-disk 2-char
+/// shard layout), so two threads writing the same hash always collide;
+/// threads writing different hashes typically don't. The array is
+/// process-global rather than per-`Store` because there is at most one
+/// active store per install, and a static avoids carrying 256 mutexes
+/// in every cheap `Store::clone()` along the fetch pipeline.
+#[cfg(not(target_os = "linux"))]
+static FAST_PATH_SHARD_LOCKS: [std::sync::Mutex<()>; 256] =
+    [const { std::sync::Mutex::new(()) }; 256];
+
 fn blake3_hex(content: &[u8]) -> String {
     B3_HASHER.with(|cell| {
         let mut h = cell.borrow_mut();
@@ -79,6 +93,13 @@ fn blake3_hex(content: &[u8]) -> String {
 pub struct Store {
     root: PathBuf,
     cache_dir: PathBuf,
+    /// When set, `create_cas_file` writes directly to the final
+    /// content-addressed path on non-Linux platforms instead of the
+    /// tempfile-then-rename dance. Caller must guarantee no concurrent
+    /// installer is writing into this store — typically via an exclusive
+    /// file lock taken at install start. Linux is unaffected because the
+    /// O_TMPFILE+linkat path is already atomic-by-construction.
+    fast_path: Arc<AtomicBool>,
 }
 
 /// Metadata about a file stored in the CAS.
@@ -138,7 +159,11 @@ impl Store {
     pub fn default_location() -> Result<Self, Error> {
         let root = dirs::store_dir().ok_or(Error::NoHome)?;
         let cache_dir = dirs::cache_dir().ok_or(Error::NoHome)?;
-        Ok(Self { root, cache_dir })
+        Ok(Self {
+            root,
+            cache_dir,
+            fast_path: Arc::new(AtomicBool::new(false)),
+        })
     }
 
     /// Open the store with an explicit root, keeping the default
@@ -148,7 +173,11 @@ impl Store {
     /// rest of aube expects them.
     pub fn with_root(root: PathBuf) -> Result<Self, Error> {
         let cache_dir = dirs::cache_dir().ok_or(Error::NoHome)?;
-        Ok(Self { root, cache_dir })
+        Ok(Self {
+            root,
+            cache_dir,
+            fast_path: Arc::new(AtomicBool::new(false)),
+        })
     }
 
     /// Open the store at a specific path (cache dir derived from store root).
@@ -156,7 +185,23 @@ impl Store {
     /// should prefer `default_location` or `with_root`.
     pub fn at(root: PathBuf) -> Self {
         let cache_dir = root.parent().unwrap_or(&root).join(CACHE_DIR_NAME);
-        Self { root, cache_dir }
+        Self {
+            root,
+            cache_dir,
+            fast_path: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Enable the direct-write fast path for CAS imports. Bypasses the
+    /// tempfile + persist_noclobber pattern on non-Linux platforms and
+    /// writes straight to the final content-addressed path, saving
+    /// ~80µs/file on APFS. The caller MUST hold an exclusive lock against
+    /// the store for the duration any thread might invoke `import_bytes`;
+    /// otherwise a concurrent installer can observe a partial file and the
+    /// `AlreadyExisted` recovery dance can clobber an in-flight write.
+    /// Linux uses O_TMPFILE+linkat unconditionally and is not affected.
+    pub fn enable_fast_path(&self) {
+        self.fast_path.store(true, Ordering::Release);
     }
 
     pub fn root(&self) -> &Path {
@@ -391,8 +436,13 @@ impl Store {
     /// `NotFound` means a concurrent prune or a missed `ensure_shards_exist`
     /// removed the parent shard; recreate it and retry exactly once before
     /// surfacing.
-    fn create_cas_file(path: &Path, content: Option<&[u8]>) -> Result<CasWriteOutcome, Error> {
+    fn create_cas_file(
+        &self,
+        path: &Path,
+        content: Option<&[u8]>,
+    ) -> Result<CasWriteOutcome, Error> {
         fn do_create_and_write(
+            this: &Store,
             path: &Path,
             content: Option<&[u8]>,
         ) -> Result<CasWriteOutcome, Error> {
@@ -417,6 +467,98 @@ impl Store {
                     }
                 }
 
+                // Non-Linux fast path: direct O_CREAT|O_EXCL at the final
+                // content-addressed path, no tempfile dance. Caller (the
+                // install command) flips `fast_path` on only after
+                // acquiring an exclusive store-level lock against other
+                // aube processes. We additionally serialize writers
+                // *within* this process per shard: two threads importing
+                // the same hash (a CAS-dedupe across packages, 35% of
+                // files on dep-heavy graphs like MUI/CodeMirror) would
+                // otherwise both attempt create_new — the loser sees an
+                // EEXIST against the winner's still-empty fd and the
+                // caller's size-mismatch recovery in `import_bytes` would
+                // unlink the file out from under the still-writing
+                // winner. The shard mutex sequences the open+write so the
+                // loser only observes the file at its final size.
+                //
+                // Crashed-predecessor recovery (the unlink+rewrite path
+                // that the slow path defers to `import_bytes`) runs here
+                // while the mutex is still held, so the caller's recovery
+                // can safely no-op for fast-path writes.
+                //
+                // On APFS the fast path is ~2.25x faster than
+                // tempfile+chmod+persist (~64µs/file vs ~145µs/file in
+                // isolation).
+                #[cfg(not(target_os = "linux"))]
+                if this.fast_path.load(Ordering::Acquire) {
+                    use std::io::Write;
+                    use std::os::unix::fs::OpenOptionsExt;
+
+                    let shard_idx = path
+                        .parent()
+                        .and_then(|p| p.file_name())
+                        .and_then(|s| s.to_str())
+                        .and_then(|s| u8::from_str_radix(s, 16).ok())
+                        .map(|b| b as usize);
+                    let _shard_guard = shard_idx.map(|i| {
+                        // Mutex poisoning is impossible here — the guard
+                        // is dropped at end of scope without us panicking
+                        // inside, so we either return cleanly or propagate
+                        // an `Err` while still releasing the lock. If a
+                        // future caller panics inside, `unwrap_or_else`
+                        // recovers the guard anyway.
+                        FAST_PATH_SHARD_LOCKS[i]
+                            .lock()
+                            .unwrap_or_else(|p| p.into_inner())
+                    });
+
+                    let open_result = std::fs::OpenOptions::new()
+                        .mode(0o644)
+                        .create_new(true)
+                        .write(true)
+                        .open(path);
+                    match open_result {
+                        Ok(mut f) => {
+                            f.write_all(bytes)
+                                .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+                            return Ok(CasWriteOutcome::Created);
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                            // Holding the shard lock, so any in-process
+                            // writer for this hash already finished. If
+                            // the file size matches, it's a genuine
+                            // dedupe. If not, it's a crashed-predecessor
+                            // remnant — unlink and rewrite inline.
+                            if cas_file_matches_len(path, bytes.len() as u64) {
+                                return Ok(CasWriteOutcome::AlreadyExisted);
+                            }
+                            let _ = xx::file::remove_file(path);
+                            match std::fs::OpenOptions::new()
+                                .mode(0o644)
+                                .create_new(true)
+                                .write(true)
+                                .open(path)
+                            {
+                                Ok(mut f) => {
+                                    f.write_all(bytes)
+                                        .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+                                    return Ok(CasWriteOutcome::Created);
+                                }
+                                Err(e) => {
+                                    return Err(Error::Io(path.to_path_buf(), e));
+                                }
+                            }
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                            // Shard dir missing — fall through to the slow
+                            // path; the outer wrapper will create_dir_all
+                            // and retry once.
+                        }
+                        Err(e) => return Err(Error::Io(path.to_path_buf(), e)),
+                    }
+                }
+
                 // Tempfile + persist_noclobber gives atomic crash
                 // semantics: a partial write on `tmp` is dropped by
                 // tempfile's Drop impl, so the final path either
@@ -425,7 +567,10 @@ impl Store {
                 // tried (faster path, ~3 syscalls per file) but
                 // raced with concurrent installs in CI where two
                 // processes saw the same partial file in different
-                // orders and clobbered each other's recovery.
+                // orders and clobbered each other's recovery. The
+                // fast-path branch above re-enables it under an
+                // exclusive store lock.
+                let _ = this; // suppress unused warning on Linux
                 let parent = path.parent().ok_or_else(|| {
                     Error::Io(path.to_path_buf(), std::io::ErrorKind::NotFound.into())
                 })?;
@@ -465,7 +610,7 @@ impl Store {
             }
         }
 
-        match do_create_and_write(path, content) {
+        match do_create_and_write(self, path, content) {
             Ok(outcome) => Ok(outcome),
             Err(Error::Io(_, ref ioe)) if ioe.kind() == std::io::ErrorKind::NotFound => {
                 // Shard dir missing. `ensure_shards_exist` normally
@@ -476,7 +621,7 @@ impl Store {
                     std::fs::create_dir_all(parent)
                         .map_err(|e| Error::Io(parent.to_path_buf(), e))?;
                 }
-                do_create_and_write(path, content)
+                do_create_and_write(self, path, content)
             }
             Err(e) => Err(e),
         }
@@ -518,7 +663,7 @@ impl Store {
         // `content.len()` by construction, no need to re-stat. Only
         // the `AlreadyExisted` branch can produce a torn file (from a
         // crashed predecessor) so the length check runs there only.
-        let outcome = Self::create_cas_file(&store_path, Some(content))?;
+        let outcome = self.create_cas_file(&store_path, Some(content))?;
         // Surface CAS dedup hit/miss to diag so cold vs warm vs partial
         // installs can be classified post-hoc. `cas_hit` fires when an
         // identical-content file already lived in the store; `cas_miss`
@@ -532,11 +677,18 @@ impl Store {
                 format!(r#"{{"size":{}}}"#, content.len())
             });
         }
+        // The non-Linux fast path verifies the file size inline under
+        // its shard mutex before returning `AlreadyExisted`, so this
+        // recovery only needs to run when we took the tempfile path.
+        // Skipping it here also prevents a race where the recovery
+        // unlinks a file that another in-process thread is concurrently
+        // re-creating after observing the same crashed-predecessor.
         if outcome == CasWriteOutcome::AlreadyExisted
+            && !self.fast_path.load(Ordering::Acquire)
             && !cas_file_matches_len(&store_path, content.len() as u64)
         {
             let _ = xx::file::remove_file(&store_path);
-            Self::create_cas_file(&store_path, Some(content))?;
+            self.create_cas_file(&store_path, Some(content))?;
             if !cas_file_matches_len(&store_path, content.len() as u64) {
                 let actual_len = store_path.metadata().map(|metadata| metadata.len()).ok();
                 return Err(Error::Io(
@@ -573,7 +725,7 @@ impl Store {
             // through the `PackageIndex` and the linker. So flipping
             // a marker-absent-to-present for a shared hash is safe.
             let exec_marker = PathBuf::from(format!("{}-exec", store_path.display()));
-            Self::create_cas_file(&exec_marker, None)?;
+            self.create_cas_file(&exec_marker, None)?;
         }
 
         Ok(StoredFile {

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -61,15 +61,21 @@ thread_local! {
     static SHA512_HASHER: RefCell<Sha512> = RefCell::new(Sha512::new());
 }
 
-/// Per-shard mutex array used by the non-Linux CAS fast path to
-/// serialize concurrent writers within a single process. Indexed by the
-/// first byte of the file's BLAKE3 hash (matching the on-disk 2-char
-/// shard layout), so two threads writing the same hash always collide;
-/// threads writing different hashes typically don't. The array is
-/// process-global rather than per-`Store` because there is at most one
-/// active store per install, and a static avoids carrying 256 mutexes
-/// in every cheap `Store::clone()` along the fetch pipeline.
-#[cfg(not(target_os = "linux"))]
+/// Per-shard mutex array used by the macOS CAS fast path to serialize
+/// concurrent writers within a single process. Indexed by the first
+/// byte of the file's BLAKE3 hash (matching the on-disk 2-char shard
+/// layout), so two threads writing the same hash always collide; threads
+/// writing different hashes typically don't. The array is process-global
+/// rather than per-`Store` because there is at most one active store
+/// per install, and a static avoids carrying 256 mutexes in every cheap
+/// `Store::clone()` along the fetch pipeline.
+///
+/// macOS-gated rather than `not(linux)` because the fast-path block
+/// itself uses `OpenOptionsExt::mode`, which only exists on Unix —
+/// Windows would fail to compile under `not(linux)`. Linux already has
+/// `O_TMPFILE + linkat` (atomic-by-construction, faster than either
+/// alternative); Windows keeps the tempfile + persist_noclobber path.
+#[cfg(target_os = "macos")]
 static FAST_PATH_SHARD_LOCKS: [std::sync::Mutex<()>; 256] =
     [const { std::sync::Mutex::new(()) }; 256];
 
@@ -467,7 +473,7 @@ impl Store {
                     }
                 }
 
-                // Non-Linux fast path: direct O_CREAT|O_EXCL at the final
+                // macOS fast path: direct O_CREAT|O_EXCL at the final
                 // content-addressed path, no tempfile dance. Caller (the
                 // install command) flips `fast_path` on only after
                 // acquiring an exclusive store-level lock against other
@@ -489,8 +495,10 @@ impl Store {
                 //
                 // On APFS the fast path is ~2.25x faster than
                 // tempfile+chmod+persist (~64µs/file vs ~145µs/file in
-                // isolation).
-                #[cfg(not(target_os = "linux"))]
+                // isolation). macOS-gated rather than `not(linux)`
+                // because `OpenOptionsExt::mode` is unix-only — Windows
+                // keeps the tempfile path.
+                #[cfg(target_os = "macos")]
                 if this.fast_path.load(Ordering::Acquire) {
                     use std::io::Write;
                     use std::os::unix::fs::OpenOptionsExt;

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -541,6 +541,16 @@ impl Store {
                             .lock()
                             .unwrap_or_else(|p| p.into_inner());
 
+                        // `OpenOptionsExt::mode(0o644)` is masked by the
+                        // process umask, so a non-default umask (e.g.
+                        // 0o077) would give CAS files 0o600. The
+                        // tempfile path uses `fchmod`, which ignores
+                        // umask. Match it with an explicit
+                        // `set_permissions` so the same store can't end
+                        // up with mixed-mode files depending on which
+                        // path wrote each entry.
+                        use std::os::unix::fs::PermissionsExt;
+                        let force_mode = std::fs::Permissions::from_mode(0o644);
                         let open_result = std::fs::OpenOptions::new()
                             .mode(0o644)
                             .create_new(true)
@@ -548,6 +558,8 @@ impl Store {
                             .open(path);
                         match open_result {
                             Ok(mut f) => {
+                                f.set_permissions(force_mode.clone())
+                                    .map_err(|e| Error::Io(path.to_path_buf(), e))?;
                                 f.write_all(bytes)
                                     .map_err(|e| Error::Io(path.to_path_buf(), e))?;
                                 return Ok(CasWriteOutcome::Created);
@@ -569,6 +581,8 @@ impl Store {
                                     .open(path)
                                 {
                                     Ok(mut f) => {
+                                        f.set_permissions(force_mode)
+                                            .map_err(|e| Error::Io(path.to_path_buf(), e))?;
                                         f.write_all(bytes)
                                             .map_err(|e| Error::Io(path.to_path_buf(), e))?;
                                         return Ok(CasWriteOutcome::Created);
@@ -721,24 +735,43 @@ impl Store {
         // length-check substitute, so torn CAS files would be accepted.
         let fast_path_handled_recovery =
             cfg!(target_os = "macos") && self.fast_path.load(Ordering::Acquire);
-        if outcome == CasWriteOutcome::AlreadyExisted
-            && !fast_path_handled_recovery
-            && !cas_file_matches_len(&store_path, content.len() as u64)
-        {
-            let _ = xx::file::remove_file(&store_path);
-            self.create_cas_file(&store_path, Some(content))?;
+        if outcome == CasWriteOutcome::AlreadyExisted && !fast_path_handled_recovery {
+            // A length mismatch from this branch can mean either
+            //   (a) a crashed predecessor left a torn file (the recovery
+            //       case this code was originally written for), or
+            //   (b) on macOS, another *process* is currently writing to
+            //       the same path via the fast path (no atomic publish
+            //       at the final path, so its in-progress fd is visible
+            //       by name to other writers).
+            // Burning the file in case (b) would unlink the active
+            // writer's inode and trigger a cascading recovery race. Wait
+            // briefly (50ms is dozens of typical small-file writes) for
+            // the partial file to settle. If it stays mismatched past
+            // the deadline, treat it as (a) and recover.
             if !cas_file_matches_len(&store_path, content.len() as u64) {
-                let actual_len = store_path.metadata().map(|metadata| metadata.len()).ok();
-                return Err(Error::Io(
-                    store_path.clone(),
-                    std::io::Error::other(format!(
-                        "CAS entry has wrong size after import: expected {} bytes, got {}",
-                        content.len(),
-                        actual_len
-                            .map(|len| format!("{len} bytes"))
-                            .unwrap_or_else(|| "missing file".to_owned())
-                    )),
-                ));
+                let deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
+                while !cas_file_matches_len(&store_path, content.len() as u64)
+                    && std::time::Instant::now() < deadline
+                {
+                    std::thread::sleep(std::time::Duration::from_micros(250));
+                }
+            }
+            if !cas_file_matches_len(&store_path, content.len() as u64) {
+                let _ = xx::file::remove_file(&store_path);
+                self.create_cas_file(&store_path, Some(content))?;
+                if !cas_file_matches_len(&store_path, content.len() as u64) {
+                    let actual_len = store_path.metadata().map(|metadata| metadata.len()).ok();
+                    return Err(Error::Io(
+                        store_path.clone(),
+                        std::io::Error::other(format!(
+                            "CAS entry has wrong size after import: expected {} bytes, got {}",
+                            content.len(),
+                            actual_len
+                                .map(|len| format!("{len} bytes"))
+                                .unwrap_or_else(|| "missing file".to_owned())
+                        )),
+                    ));
+                }
             }
         }
 

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -509,61 +509,74 @@ impl Store {
                         .and_then(|s| s.to_str())
                         .and_then(|s| u8::from_str_radix(s, 16).ok())
                         .map(|b| b as usize);
-                    let _shard_guard = shard_idx.map(|i| {
+                    // Every path produced by `file_path_from_hex` lives
+                    // under a 2-char hex shard, so this is the contract
+                    // every fast-path caller satisfies today. The assert
+                    // pins the invariant; if a future caller hands in a
+                    // non-CAS path, release builds skip the fast path
+                    // (falling through to the safe tempfile branch)
+                    // rather than do an unsynchronized write that could
+                    // race with another thread on the same hash.
+                    debug_assert!(
+                        shard_idx.is_some(),
+                        "fast-path CAS write to path without a valid hex shard parent: {}",
+                        path.display()
+                    );
+                    if let Some(i) = shard_idx {
                         // Mutex poisoning is impossible here — the guard
                         // is dropped at end of scope without us panicking
                         // inside, so we either return cleanly or propagate
                         // an `Err` while still releasing the lock. If a
                         // future caller panics inside, `unwrap_or_else`
                         // recovers the guard anyway.
-                        FAST_PATH_SHARD_LOCKS[i]
+                        let _shard_guard = FAST_PATH_SHARD_LOCKS[i]
                             .lock()
-                            .unwrap_or_else(|p| p.into_inner())
-                    });
+                            .unwrap_or_else(|p| p.into_inner());
 
-                    let open_result = std::fs::OpenOptions::new()
-                        .mode(0o644)
-                        .create_new(true)
-                        .write(true)
-                        .open(path);
-                    match open_result {
-                        Ok(mut f) => {
-                            f.write_all(bytes)
-                                .map_err(|e| Error::Io(path.to_path_buf(), e))?;
-                            return Ok(CasWriteOutcome::Created);
-                        }
-                        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                            // Holding the shard lock, so any in-process
-                            // writer for this hash already finished. If
-                            // the file size matches, it's a genuine
-                            // dedupe. If not, it's a crashed-predecessor
-                            // remnant — unlink and rewrite inline.
-                            if cas_file_matches_len(path, bytes.len() as u64) {
-                                return Ok(CasWriteOutcome::AlreadyExisted);
+                        let open_result = std::fs::OpenOptions::new()
+                            .mode(0o644)
+                            .create_new(true)
+                            .write(true)
+                            .open(path);
+                        match open_result {
+                            Ok(mut f) => {
+                                f.write_all(bytes)
+                                    .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+                                return Ok(CasWriteOutcome::Created);
                             }
-                            let _ = xx::file::remove_file(path);
-                            match std::fs::OpenOptions::new()
-                                .mode(0o644)
-                                .create_new(true)
-                                .write(true)
-                                .open(path)
-                            {
-                                Ok(mut f) => {
-                                    f.write_all(bytes)
-                                        .map_err(|e| Error::Io(path.to_path_buf(), e))?;
-                                    return Ok(CasWriteOutcome::Created);
+                            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                                // Holding the shard lock, so any in-process
+                                // writer for this hash already finished. If
+                                // the file size matches, it's a genuine
+                                // dedupe. If not, it's a crashed-predecessor
+                                // remnant — unlink and rewrite inline.
+                                if cas_file_matches_len(path, bytes.len() as u64) {
+                                    return Ok(CasWriteOutcome::AlreadyExisted);
                                 }
-                                Err(e) => {
-                                    return Err(Error::Io(path.to_path_buf(), e));
+                                let _ = xx::file::remove_file(path);
+                                match std::fs::OpenOptions::new()
+                                    .mode(0o644)
+                                    .create_new(true)
+                                    .write(true)
+                                    .open(path)
+                                {
+                                    Ok(mut f) => {
+                                        f.write_all(bytes)
+                                            .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+                                        return Ok(CasWriteOutcome::Created);
+                                    }
+                                    Err(e) => {
+                                        return Err(Error::Io(path.to_path_buf(), e));
+                                    }
                                 }
                             }
+                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                // Shard dir missing — fall through to the slow
+                                // path; the outer wrapper will create_dir_all
+                                // and retry once.
+                            }
+                            Err(e) => return Err(Error::Io(path.to_path_buf(), e)),
                         }
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                            // Shard dir missing — fall through to the slow
-                            // path; the outer wrapper will create_dir_all
-                            // and retry once.
-                        }
-                        Err(e) => return Err(Error::Io(path.to_path_buf(), e)),
                     }
                 }
 

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -198,14 +198,22 @@ impl Store {
         }
     }
 
-    /// Enable the direct-write fast path for CAS imports. Bypasses the
-    /// tempfile + persist_noclobber pattern on non-Linux platforms and
-    /// writes straight to the final content-addressed path, saving
-    /// ~80µs/file on APFS. The caller MUST hold an exclusive lock against
-    /// the store for the duration any thread might invoke `import_bytes`;
-    /// otherwise a concurrent installer can observe a partial file and the
+    /// Enable the macOS direct-write fast path for CAS imports. Bypasses
+    /// the tempfile + persist_noclobber pattern and writes straight to
+    /// the final content-addressed path, saving ~80µs/file on APFS. The
+    /// caller MUST hold an exclusive lock against the store for the
+    /// duration any thread might invoke `import_bytes`; otherwise a
+    /// concurrent installer can observe a partial file and the
     /// `AlreadyExisted` recovery dance can clobber an in-flight write.
-    /// Linux uses O_TMPFILE+linkat unconditionally and is not affected.
+    ///
+    /// macOS-gated rather than just declared inert on other platforms.
+    /// On Linux the `O_TMPFILE+linkat` path has no inline length-check
+    /// recovery — that recovery only lives inside the macOS fast-path
+    /// branch — so the outer skip in `import_bytes` (also macOS-gated
+    /// via `cfg!`) must never see the flag set on Linux. Removing the
+    /// method on non-macOS platforms makes that mismatch a build error
+    /// rather than a silent acceptance of torn CAS files.
+    #[cfg(target_os = "macos")]
     pub fn enable_fast_path(&self) {
         self.fast_path.store(true, Ordering::Release);
     }
@@ -698,14 +706,23 @@ impl Store {
                 format!(r#"{{"size":{}}}"#, content.len())
             });
         }
-        // The non-Linux fast path verifies the file size inline under
-        // its shard mutex before returning `AlreadyExisted`, so this
+        // The macOS fast path verifies the file size inline under its
+        // shard mutex before returning `AlreadyExisted`, so this
         // recovery only needs to run when we took the tempfile path.
-        // Skipping it here also prevents a race where the recovery
+        // Skipping it there also prevents a race where the recovery
         // unlinks a file that another in-process thread is concurrently
         // re-creating after observing the same crashed-predecessor.
+        //
+        // `cfg!(target_os = "macos")` matches the cfg gate on the only
+        // code path that flips `fast_path` to true (and on the inline
+        // recovery inside `create_cas_file`). Without the cfg!, a future
+        // caller setting the flag on Linux would silently disable this
+        // recovery — the Linux O_TMPFILE branch has no inline
+        // length-check substitute, so torn CAS files would be accepted.
+        let fast_path_handled_recovery =
+            cfg!(target_os = "macos") && self.fast_path.load(Ordering::Acquire);
         if outcome == CasWriteOutcome::AlreadyExisted
-            && !self.fast_path.load(Ordering::Acquire)
+            && !fast_path_handled_recovery
             && !cas_file_matches_len(&store_path, content.len() as u64)
         {
             let _ = xx::file::remove_file(&store_path);

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2970,7 +2970,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     if let Err(e) = store.ensure_shards_exist() {
         tracing::debug!("ensure_shards_exist failed (slow path will cover): {e}");
     }
-    // Non-Linux fast-path gate: take an exclusive `try_lock` on
+    // macOS fast-path gate: take an exclusive `try_lock` on
     // `<store>/v1/.install.lock`. If we get it, no other aube install is
     // running against this store right now, so the CAS write path can
     // skip the tempfile + persist_noclobber dance and write straight to
@@ -2982,8 +2982,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     //
     // Linux is unaffected: `create_cas_file` always uses O_TMPFILE+linkat
     // there, which is already atomic-by-construction and faster than
-    // both options.
-    #[cfg(not(target_os = "linux"))]
+    // both options. Windows keeps the tempfile path; the fast-path branch
+    // in `aube-store` is unix-only (`OpenOptionsExt::mode`), so gating
+    // the lock acquisition on macOS too avoids opening a lock file that
+    // nothing would consult.
+    #[cfg(target_os = "macos")]
     let _store_lock = {
         let lock_dir = store
             .root()

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2970,6 +2970,60 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     if let Err(e) = store.ensure_shards_exist() {
         tracing::debug!("ensure_shards_exist failed (slow path will cover): {e}");
     }
+    // Non-Linux fast-path gate: take an exclusive `try_lock` on
+    // `<store>/v1/.install.lock`. If we get it, no other aube install is
+    // running against this store right now, so the CAS write path can
+    // skip the tempfile + persist_noclobber dance and write straight to
+    // the final content-addressed path (`Store::enable_fast_path`). The
+    // guard is held in `_store_lock` for the rest of this `run` call;
+    // dropping it at function exit releases the lock. Contention falls
+    // back to the safe tempfile path — concurrent installers still
+    // proceed, just at the existing speed.
+    //
+    // Linux is unaffected: `create_cas_file` always uses O_TMPFILE+linkat
+    // there, which is already atomic-by-construction and faster than
+    // both options.
+    #[cfg(not(target_os = "linux"))]
+    let _store_lock = {
+        let lock_dir = store
+            .root()
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| store.root().to_path_buf());
+        let _ = std::fs::create_dir_all(&lock_dir);
+        let lock_path = lock_dir.join(".install.lock");
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+        {
+            Ok(file) => match file.try_lock() {
+                Ok(()) => {
+                    store.enable_fast_path();
+                    tracing::debug!("CAS fast path enabled (exclusive store lock acquired)");
+                    Some(file)
+                }
+                Err(std::fs::TryLockError::WouldBlock) => {
+                    tracing::debug!(
+                        "another aube install is using this store; staying on tempfile path"
+                    );
+                    None
+                }
+                Err(std::fs::TryLockError::Error(e)) => {
+                    tracing::debug!("store lock probe failed ({e}); staying on tempfile path");
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::debug!(
+                    "could not open store lock at {} ({e}); staying on tempfile path",
+                    lock_path.display()
+                );
+                None
+            }
+        }
+    };
 
     // Decide what to do with whatever lockfile is on disk based on FrozenMode + drift.
     // Returns either:


### PR DESCRIPTION
cc @hverlin — thanks for the [public cold-install repro](https://gitlab.com/hverlin/aube-cold-install), which is exactly what made the per-file path tractable to measure.

## Summary

On macOS cold installs against a small-file-heavy graph, `phase:fetch` is dominated by per-file CAS write cost. The existing path on non-Linux is `tempfile::Builder::tempfile_in → write_all → set_permissions(0o644) → persist_noclobber`, ~145 µs/file in isolation on APFS. An `O_CREAT|O_EXCL` direct write to the final content-addressed path is ~64 µs — a **2.25× speedup**, attributable to skipping the rename step itself (not the random-name probe or the chmod).

A direct fast path was vetoed previously because two installers could race on a partially-written final path. This PR makes it safe to enable on macOS by gating it behind an exclusive `try_lock` on `<store>/v1/.install.lock` held for the lifetime of the install. If the lock is uncontended, `Store::enable_fast_path` flips on a flag that lets `create_cas_file` skip the tempfile dance; if contended, the existing tempfile path is used so concurrent installers proceed in parallel at the existing speed.

Within a single process, two `spawn_blocking` workers can still target the same hash (35% of files in the bench graph dedupe across packages). A 256-entry static mutex array, indexed by the same first-byte shard as the on-disk layout, serializes the rare same-hash collisions. Uncontended `Mutex::lock` is ~10 ns on Apple Silicon; expected contention rate is `num_threads / 256`. Crashed-predecessor recovery (unlink + rewrite) runs inline under the shard mutex, so the caller's outer length-check recovery is skipped when the fast path is active.

Linux is untouched: `O_TMPFILE + linkat` already gives atomic publish without the tempfile rename, so the entire fast-path block + install-time lock are gated behind `#[cfg(not(target_os = \"linux\"))]`.

## Bench

Repro: [`gitlab.com/hverlin/aube-cold-install`](https://gitlab.com/hverlin/aube-cold-install) (414 packages, ~76k files, mui/icons + monaco + codemirror + atlaskit + types). Three-run median, this Mac on home network, `/tmp/aube-bench.lock` held.

| | cold (median of 3) | warm | gap vs pnpm |
|---|---|---|---|
| pnpm | 12 s | 7.1 s | — |
| aube **before** | 34 s | 0.27 s | 2.7× |
| aube **after** | **25 s** | 0.24 s | 2.1× |

From `AUBE_DIAG_SUMMARY=1`:

| metric | before | after | change |
|---|---|---|---|
| `import_bytes_write` avg | 3.34 ms/file | **1.94 ms/file** | **−42%** |
| `import_bytes_write` cumulative | 255 s | 148 s | −42% |
| `phase:fetch` wall | 33.9 s | 26.1 s | −23% |
| `blake3_hash` avg | 0.02 ms/file | 0.02 ms/file | unchanged |
| `phase:link` wall | 78 ms | 91 ms | noise |

`link_hardlink` is now the next-biggest line item (~2 ms/file × 76 k); that's a separate investigation (likely in `ensure_in_vstore` mkdir/DashMap overhead).

## Reviewer notes

- The shard-mutex array uses `[const { Mutex::new(()) }; 256]` (inline const, stable 1.79) to satisfy clippy's `declare_interior_mutable_const`.
- The lock file is a long-lived sibling of `files/`, created on demand. It's never written to and never deleted — only `try_lock`'d. Existing aube installs that don't have the lock file will create it on next use.
- `cargo test -p aube-store`: 86/86 pass.
- `cargo clippy -p aube-store --all-targets -- -D warnings`: clean.
- `cargo clippy -p aube --all-targets -- -D warnings`: clean (modulo an unrelated `doc_lazy_continuation` in `progress/ci.rs` that's already in the working tree).
- `cargo fmt --check`: clean.

## Test plan

- [x] `cargo test -p aube-store`
- [x] cold install of the gitlab repro: succeeds, ~25 s (down from ~34 s)
- [x] warm install of same: 0.24 s (unchanged)
- [x] `AUBE_DIAG_SUMMARY=1` shows `import_bytes_write` avg dropped 42%
- [x] `--reporter ndjson` log confirms `CAS fast path enabled (exclusive store lock acquired)` debug message fires
- [ ] CI: cross-platform check (Linux path should be a strict no-op)
- [ ] Manual: run two `aube install` against the same store concurrently; verify second install logs the fallback message and still completes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CAS write/publish path and recovery logic on macOS, introducing new cross-thread/process synchronization that could affect correctness under concurrency or crash recovery. Other platforms are largely gated out, but any bug could corrupt the store and cause install failures until repaired.
> 
> **Overview**
> **macOS installs can now bypass the tempfile+rename CAS import path** when an exclusive store lock is available, writing bytes directly to the final content-addressed path.
> 
> `aube install` attempts to `try_lock` a persistent `.install.lock` next to the store; on success it enables `Store::enable_fast_path()` for the lifetime of the install, and on contention it logs and falls back to the existing safe path.
> 
> In `aube-store`, CAS creation is refactored to be store-instance aware and adds a macOS-only direct-write branch with a 256-way shard mutex to serialize same-hash writes within a process, plus updated size-mismatch recovery (including a short wait before repair) to avoid clobbering in-flight writers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0937b356c41bc5ebe2cd579348d84cf54cc22e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

