### PR TITLE
fix(install): run peer-context pass on bun.lock imports

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3204,7 +3204,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // would double-suffix every key.
             if matches!(
                 kind,
-                aube_lockfile::LockfileKind::Npm | aube_lockfile::LockfileKind::NpmShrinkwrap
+                aube_lockfile::LockfileKind::Npm
+                    | aube_lockfile::LockfileKind::NpmShrinkwrap
+                    | aube_lockfile::LockfileKind::Bun
             ) {
                 let peer_pass_start = std::time::Instant::now();
                 let pkgs_before = graph.packages.len();

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3186,8 +3186,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 &supported_architectures,
                 &ignored_optional_deps,
             );
-            // npm/yarn(v1)/bun lockfiles serialize a flat, pre-hoisted
-            // tree with no peer context — they rely on Node's upward
+            // npm/bun lockfiles serialize a flat, pre-hoisted tree
+            // with no peer context — they rely on Node's upward
             // `node_modules/` walk to find peer deps, which the
             // isolated virtual store breaks. Fresh resolves flow
             // through `Resolver::resolve_workspace`, which runs
@@ -3202,6 +3202,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // peer-context suffixes and peer edges merged into
             // `dependencies`, so we skip them — re-running the pass
             // would double-suffix every key.
+            //
+            // Yarn v1 has the same flat shape but is intentionally
+            // omitted: real-world `yarn.lock` files don't record
+            // `peerDependencies` per entry (yarn 1.22 emits them
+            // only on the workspace root), so running the pass would
+            // be a no-op. Making yarn v1 imports peer-correct needs
+            // a packument fetch on the import path to graft peer
+            // ranges back onto each `LockedPackage` — a deeper
+            // change than this match arm.
             if matches!(
                 kind,
                 aube_lockfile::LockfileKind::Npm

--- a/fixtures/import-bun-peer/bun.lock
+++ b/fixtures/import-bun-peer/bun.lock
@@ -1,0 +1,18 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "import-bun-peer-test",
+      "dependencies": {
+        "fdir": "6.5.0",
+        "picomatch": "4.0.4",
+      },
+    },
+  },
+  "packages": {
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+  }
+}

--- a/fixtures/import-bun-peer/package.json
+++ b/fixtures/import-bun-peer/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "import-bun-peer-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "fdir": "6.5.0",
+    "picomatch": "4.0.4"
+  }
+}

--- a/test/import.bats
+++ b/test/import.bats
@@ -94,6 +94,27 @@ teardown() {
 	assert_dir_exists "node_modules/@sindresorhus/is"
 }
 
+@test "aube install applies peer-context suffixes when importing from bun.lock" {
+	# Regression for the bun.lock importer skipping
+	# `apply_peer_contexts`. Without the pass, `fdir` lands in the
+	# virtual store as `fdir@6.5.0/` with no peer-qualified sibling
+	# link, so any consumer that runs from inside the isolated dir
+	# can't find `picomatch` and falls through to whatever copy is
+	# hoisted in `.aube/node_modules/`.
+	cp "$PROJECT_ROOT/fixtures/import-bun-peer/package.json" .
+	cp "$PROJECT_ROOT/fixtures/import-bun-peer/bun.lock" .
+
+	run aube install
+	assert_success
+
+	# Peer-qualified virtual-store directory now exists.
+	run sh -c 'ls node_modules/.aube/ | grep "^fdir@6.5.0_picomatch@4.0.4"'
+	assert_success
+
+	# And the sibling peer link is wired inside that directory.
+	assert_link_exists "node_modules/.aube/$(ls node_modules/.aube/ | grep '^fdir@6.5.0_picomatch@4.0.4')/node_modules/picomatch"
+}
+
 @test "aube install smoke installs messy bun.lock fixture and doesn't change lockfile" {
 	cp -R "$PROJECT_ROOT/fixtures/import-bun-messy/." .
 	cp bun.lock bun.lock.before

--- a/test/import.bats
+++ b/test/import.bats
@@ -107,12 +107,16 @@ teardown() {
 	run aube install
 	assert_success
 
-	# Peer-qualified virtual-store directory now exists.
-	run sh -c 'ls node_modules/.aube/ | grep "^fdir@6.5.0_picomatch@4.0.4"'
-	assert_success
+	# Resolve the peer-qualified virtual-store directory via a glob
+	# so the test fails loudly if zero or multiple entries match
+	# (rather than papering over the breakage with a literal
+	# newline embedded in the assert_link_exists path).
+	local matches=(node_modules/.aube/fdir@6.5.0_picomatch@4.0.4*)
+	[ "${#matches[@]}" -eq 1 ] || fail "expected exactly one peer-qualified fdir dir, got: ${matches[*]}"
+	[ -d "${matches[0]}" ] || fail "peer-qualified fdir dir missing: ${matches[0]}"
 
 	# And the sibling peer link is wired inside that directory.
-	assert_link_exists "node_modules/.aube/$(ls node_modules/.aube/ | grep '^fdir@6.5.0_picomatch@4.0.4')/node_modules/picomatch"
+	assert_link_exists "${matches[0]}/node_modules/picomatch"
 }
 
 @test "aube install smoke installs messy bun.lock fixture and doesn't change lockfile" {


### PR DESCRIPTION
## Summary
- Includes `LockfileKind::Bun` in the `apply_peer_contexts` branch of `commands::install::run` so peer-dependent packages imported from a `bun.lock` get peer-qualified dep_paths (and sibling peer links) in the virtual store.
- Without the pass, the plugin landed at `.aube/<pkg>@<ver>/` with no `vite` sibling and walked up to whatever copy was hoisted in `.aube/node_modules/`, picking an unrelated workspace's `vite` in a mixed-version workspace.
- The companion comment already named npm/yarn(v1)/bun as the formats that need this pass; the match arm just hadn't caught up.

Repro from [discussion #345](https://github.com/endevco/aube/discussions/345#discussioncomment-16884697):
- `bun install` materializes `bun.lock`, then `aube install` imports it.
- Before: `@cloudflare/vite-plugin@1.17.1` (no peer suffix), Cloudflare/react-router code falls through to docs workspace's `vite@5.4.21` and dies at `Class extends value undefined is not a constructor or null`.
- After: `@cloudflare+vite-plugin@1.17.1_vite@8.0.10_esbuild@0.27.3_` with sibling `vite -> vite@8.0.10`, all consumers resolve `vite@8.0.10`, postinstall succeeds.

Yarn v1 has the same shape (the comment calls it out) and isn't fixed here — keeping the change scoped to the format the user reported. Happy to follow up.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p aube-lockfile -p aube-resolver`
- [x] `mise run test:bats test/import.bats` (includes the new fixture/test)
- [x] End-to-end on the user's repro: `aube install` succeeds, `aube run postinstall` succeeds, `inspect-links.cjs` reports `vite@8.0.10` for `cloudflarePlugin` and `reactRouterDev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time lockfile import behavior for `bun.lock`, which can alter virtual-store paths and peer dependency linking; risk is moderate because it affects dependency resolution correctness during installs.
> 
> **Overview**
> Ensures `aube install` runs the peer hoisting/contexting pass when reusing a `bun.lock`, so peer-dependent packages get peer-qualified virtual-store paths and correct sibling peer links (matching the npm lockfile import behavior).
> 
> Adds a regression fixture and Bats test that imports a `bun.lock` with a peer dependency and asserts the peer-suffixed directory is created and contains the expected peer symlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3694916a751ed402dec9683b50ad57b547f826d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->