### PR TITLE
fix(add): forward --allow-build to global installs

### DIFF
--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -698,7 +698,7 @@ pub async fn run(
     }
 
     if global {
-        return run_global(packages, lockfile, network, virtual_store).await;
+        return run_global(packages, allow_build, lockfile, network, virtual_store).await;
     }
 
     // `--workspace` / `-w`: redirect the add at the workspace root
@@ -2040,6 +2040,7 @@ async fn run_filtered(
 /// keeps.
 async fn run_global(
     packages: &[String],
+    allow_build: Vec<String>,
     lockfile: crate::cli_args::LockfileArgs,
     network: crate::cli_args::NetworkArgs,
     virtual_store: crate::cli_args::VirtualStoreArgs,
@@ -2090,6 +2091,7 @@ async fn run_global(
         .collect();
     let result = run_global_inner(
         packages,
+        allow_build,
         &layout,
         &install_dir,
         lockfile,
@@ -2127,6 +2129,7 @@ async fn run_global(
 
 async fn run_global_inner(
     packages: &[String],
+    allow_build: Vec<String>,
     layout: &super::global::GlobalLayout,
     install_dir: &std::path::Path,
     lockfile: crate::cli_args::LockfileArgs,
@@ -2197,7 +2200,16 @@ async fn run_global_inner(
         workspace: false,
         save_catalog: false,
         save_catalog_name: None,
-        allow_build: Vec::new(),
+        // Forward `--allow-build=<pkg>` flags from the outer invocation:
+        // the inner `run()` writes them to the throwaway install dir's
+        // `package.json#aube.allowBuilds` (no workspace yaml exists
+        // there) before lifecycle scripts run, matching pnpm's
+        // `pnpm add -g --allow-build=<pkg>` behavior. Without this the
+        // outer flag is silently dropped — under `strictDepBuilds=true`
+        // the install then errors with "must be reviewed before
+        // install" even when the user explicitly approved the dep
+        // (see Discussion #617).
+        allow_build,
         // Propagate the outer caller's flag groups through so the inner
         // run()'s `install_overrides()` calls reset the global slots to the
         // same values rather than wiping them — `set_registry_override`

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -179,6 +179,29 @@ teardown() {
 	assert_file_exists "$install_dir/aube-builds-marker.txt"
 }
 
+@test "aube add -g --allow-build=<pkg> pre-approves a global dep's build scripts" {
+	# Regression for Discussion #617: outer `--allow-build` was dropped
+	# at the `run_global_inner` boundary (synthetic AddArgs hardcoded
+	# `allow_build: Vec::new()`), so under `strictDepBuilds=true` the
+	# install errored with "must be reviewed before install" even when
+	# the user explicitly approved the dep on the CLI.
+	AUBE_STRICT_DEP_BUILDS=true run aube add -g \
+		--allow-build=aube-test-builds-marker \
+		aube-test-builds-marker@1.0.0
+	assert_success
+	refute_output --partial "must be reviewed before install"
+	refute_output --partial "ignored build scripts"
+
+	pkg_dir="$AUBE_HOME/global-aube"
+	install_dir="$(find "$pkg_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+	# Build actually ran — the marker dep's postinstall writes the file.
+	assert_file_exists "$install_dir/aube-builds-marker.txt"
+	# Approval landed in the throwaway install dir's package.json under
+	# the `aube` namespace (no workspace yaml exists there).
+	run grep -q '"aube-test-builds-marker": true' "$install_dir/package.json"
+	assert_success
+}
+
 @test "aube remove -g on a missing package errors" {
 	run aube remove -g nonexistent-pkg
 	assert_failure


### PR DESCRIPTION
## Summary

- `aube add --global` built a synthetic `AddArgs` with `allow_build: Vec::new()`, silently dropping the outer flag. Under `strictDepBuilds=true` the install then errored with "must be reviewed before install" even when the user explicitly approved the dep on the CLI.
- Plumb `allow_build` through `run_global` / `run_global_inner` so the inner `run()` writes approvals into the throwaway install dir's `package.json#aube.allowBuilds` before lifecycle scripts run. No workspace yaml exists in that throwaway dir, so the writer falls through to the `aube.allowBuilds` namespace in `package.json` — the same shape `aube approve-builds -g` already produces (covered by the existing `aube approve-builds -g --all` test).
- Added a bats regression in `test/global_install.bats` that runs under `AUBE_STRICT_DEP_BUILDS=true` and asserts the build actually fires (the marker dep's `postinstall` writes `aube-builds-marker.txt`).

Closes https://github.com/endevco/aube/discussions/617.

## Test plan

- [x] `cargo build -p aube`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p aube --bin aube` (473 passed)
- [x] `mise run test:bats test/global_install.bats` (14/14 passed, including the new regression)

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global install argument plumbing for lifecycle-script approvals; a bug here could unintentionally allow/deny dependency build scripts during `aube add -g` under `strictDepBuilds`.
> 
> **Overview**
> Fixes `aube add -g` to **preserve and forward** any `--allow-build=<pkg>` flags into the inner synthetic `AddArgs`, so global installs correctly pre-approve dependency lifecycle scripts instead of dropping the approval.
> 
> Adds a Bats regression test covering `AUBE_STRICT_DEP_BUILDS=true` to ensure `aube add -g --allow-build=...` both succeeds without review errors and actually runs the approved package’s build (marker file is created and approval is written to the global install `package.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d532e950bdb2185ee24eaf3d7707580e3e0589e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->