### PR TITLE
fix(bench): use uplink during populate to fill warm cache holes

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -271,6 +271,15 @@ cp "$SCRIPT_DIR/fixture.package.json" "$BENCH_DIR/original-package.json"
 # populated before the scenario matrix runs. Everything is hermetic
 # (isolated HOME / cache / store), so this is safe to run in parallel
 # in the future but we keep it serial for clear console output.
+#
+# Bracket the populate loop with uplink-enabled Verdaccio so any
+# package the warm step missed (e.g. when a PM's resolution diverges
+# between the warm fixture and the bench fixture) gets fetched from
+# npmjs and cached locally. The cold config is restored afterwards so
+# the timed scenarios remain hermetic.
+if [ "${BENCH_HERMETIC:-0}" = "1" ]; then
+	hermetic_use_warm_uplink
+fi
 
 for i in "${!TOOLS[@]}"; do
 	tool="${TOOLS[$i]}"
@@ -346,6 +355,10 @@ for i in "${!TOOLS[@]}"; do
 	fi
 	cp "$dir/$lockfile_name" "$BENCH_DIR/saved-lockfile-$tool"
 done
+
+if [ "${BENCH_HERMETIC:-0}" = "1" ]; then
+	hermetic_use_no_uplink
+fi
 
 # ── Helper ─────────────────────────────────────────────────────────────────
 #

--- a/benchmarks/hermetic.bash
+++ b/benchmarks/hermetic.bash
@@ -317,3 +317,23 @@ hermetic_stop() {
 	_hermetic_stop_proxy
 	_hermetic_stop_verdaccio
 }
+
+# Swap Verdaccio to the warm (uplink-enabled) config. Used by bench.sh
+# to bracket the per-tool populate step so any package the warm pass
+# missed gets pulled from npmjs and cached locally — without this,
+# subtle resolution differences (e.g. deno's warm fixture includes
+# `is-odd` while the bench fixture does not) leave 404-holes that
+# crash the cold-config populate. The throttle proxy stays up; client
+# requests resume against the restarted Verdaccio on the same port.
+hermetic_use_warm_uplink() {
+	_hermetic_stop_verdaccio
+	_hermetic_start_verdaccio "$HERMETIC_CONFIG_WARM"
+}
+
+# Swap Verdaccio back to the cold (no-uplink) config. Called after
+# the populate step so the timed benchmark scenarios run against a
+# fully hermetic registry — no npmjs jitter in the numbers.
+hermetic_use_no_uplink() {
+	_hermetic_stop_verdaccio
+	_hermetic_start_verdaccio "$HERMETIC_CONFIG_COLD"
+}


### PR DESCRIPTION
## Summary

The `bench-refresh` workflow [run 25696558355](https://github.com/endevco/aube/actions/runs/25696558355/job/75446208460) crashed during `Populating store and cache for deno...` with:

```
error: npm package '@humanwhocodes/config-array' does not exist.
[bench:bump] ERROR task failed
```

### Root cause

The hermetic Verdaccio runs with `config.yaml` (no uplink) once `hermetic_start` completes. The earlier warm pass uses `config.warm.yaml` (uplink → npmjs) and is supposed to materialize every tarball each PM will later ask for. But the warm fixture has `is-odd` injected (so the bench-time `add is-odd` scenario can resolve offline) while `bench.sh`'s per-tool populate uses the pristine fixture — so deno's two resolutions diverge slightly, and the warm pass doesn't fetch `@humanwhocodes/config-array`. When the cold-config populate then asks for it, Verdaccio answers 404 and the run dies.

### Fix

Swap Verdaccio to the warm (uplink-enabled) config for the populate loop in `bench.sh`, then swap back to cold before the timed scenarios start. Populate becomes self-healing for any cache hole the warm pass missed; timed scenarios stay fully hermetic so the numbers don't pick up npmjs jitter.

Two new public functions in `benchmarks/hermetic.bash` — `hermetic_use_warm_uplink` / `hermetic_use_no_uplink` — wrap the existing private `_hermetic_stop_verdaccio` + `_hermetic_start_verdaccio` pair. The throttle proxy stays up across the swap.

## Test plan

- [ ] Re-trigger `bench-refresh` via `workflow_dispatch` and confirm deno's populate completes (the run also exercises the other six PMs, so a regression in the swap would surface broadly)
- [ ] Spot-check that the timed scenarios' aube numbers in the resulting `benchmarks/results.json` don't drift outside the usual run-to-run noise — the cold-config swap-back should keep the registry hermetic during timing
- [ ] Confirm `verdaccio.log` shows no uplink fetches after the populate step (file lives under `~/.cache/aube-bench/registry/` on the runner)

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to benchmark harness scripting, but they do alter hermetic registry lifecycle and could affect benchmark repeatability if the swap-back fails.
> 
> **Overview**
> Makes hermetic benchmark runs more robust by temporarily restarting Verdaccio with the *uplink-enabled* config during the per-tool populate loop, so any missing tarballs can be fetched from npmjs and cached.
> 
> Adds `hermetic_use_warm_uplink` and `hermetic_use_no_uplink` helpers in `benchmarks/hermetic.bash` and uses them in `benchmarks/bench.sh` to bracket populate, then restores the no-uplink config before timed scenarios to keep measurements fully hermetic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660e02b3dac17001f104ac9137717b0456616723. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->