### PR TITLE
ci: remove caching from publishing workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -35,9 +35,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.AUBE_GH_TOKEN }}
           submodules: recursive
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
-        with:
-          cache: rust
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
@@ -234,9 +231,6 @@ jobs:
       # of silently re-resolving `"latest"` pins and rewriting mise.lock.
       # release-plz refuses to run against a dirty tree, and intentional
       # lockfile bumps should land via their own PR.
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
-        with:
-          cache: rust
       - uses: jdx/mise-action@b287efda3dc5f4f3c328507653b6617da783ff84 # v4
         env:
           MISE_LOCKED: "1"


### PR DESCRIPTION
## Summary
- Strips cache actions (`nscloud-cache-action`, `Swatinem/rust-cache`, `actions/cache`) from release / release-plz / publishing workflows.
- These workflows have elevated permissions (write tokens, signing keys, registry credentials). Even with Namespace's protected-branches setting and GHA's ref-scoped cache enforcement, the simplest defense for the publishing surface is to not depend on any cache at all — builds re-run from clean each time.
- For mise's `release-plz.yml`, also removes the now-pointless sccache install/configure since it had no persistent backing store without the nscloud cache.

## Test plan
- [ ] Releases still build successfully (cold cache; expect slower but functional).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release/publish GitHub Actions workflow by removing the Rust cache step; low functional complexity, but it touches the publishing pipeline that uses elevated tokens so any CI misconfiguration could block releases.
> 
> **Overview**
> Removes the `namespacelabs/nscloud-cache-action` Rust caching step from `.github/workflows/release-plz.yml` for both the `release-plz release` and `release-plz PR` jobs, forcing publishing-related runs to build from a cold state.
> 
> No release logic is otherwise changed; the workflow still checks out, runs `release-plz`, and (for PRs) uses `mise`/`release-plz` as before, just without cached artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d119473370784d33dcb24f4593656b699af23c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->