### PR TITLE
chore(ci): assert mise run render produces no diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,14 @@ jobs:
       - run: cargo-machete
       - run: cargo msrv --manifest-path crates/aube/Cargo.toml verify --output-format minimal
       - run: mise run render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff
+            exit 1
+          fi
       - run: mise run docs:build
 
   # BATS integration shards. Linux runs 4 shards (matches Buildkite),


### PR DESCRIPTION
Adds a `git status --porcelain` check after `mise run render` in CI so contributors are reminded to run it locally and commit the result.

Follows up the autofix.ci workflow removal in #629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds an extra post-render check; main impact is potentially failing builds if rendering is non-deterministic or contributors forget to commit generated output.
> 
> **Overview**
> Adds a CI guardrail in `.github/workflows/ci.yml` to **fail the `test-linux` job if `mise run render` leaves the repo dirty**.
> 
> After rendering, CI now checks `git status --porcelain` and, on changes, prints `git status`/`git diff` and exits non-zero so generated artifacts must be committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 504dc935091518813dbeec5237a28a6a9a51db1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->