### PR TITLE
security: harden install + publish surface against malicious inputs

### DIFF
--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -57,7 +57,11 @@ jobs:
             exit 1
           fi
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            if [[ -n "$INPUT_CHROOTS" && ! "$INPUT_CHROOTS" =~ ^[a-z0-9][a-z0-9\ \-]*$ ]]; then
+            # COPR chroot names look like `fedora-rawhide-x86_64` or
+            # `epel-10-aarch64` — lowercase letters, digits, hyphens,
+            # underscores, and spaces between entries. Underscore is
+            # required for the `x86_64` arch suffix.
+            if [[ -n "$INPUT_CHROOTS" && ! "$INPUT_CHROOTS" =~ ^[a-z0-9][a-z0-9\ _\-]*$ ]]; then
               echo "::error::Refusing to build: chroots '$INPUT_CHROOTS' contains unexpected characters"
               exit 1
             fi

--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -30,8 +30,10 @@ jobs:
           dnf update -y
           # copr-cli comes from Fedora's own packages — Fedora 38+
           # enforces PEP 668 and blocks `pip install` into the system
-          # Python.
-          dnf install -y rpm-build rpmdevtools copr-cli git rust cargo gcc openssl-devel pkgconf-pkg-config tar gzip
+          # Python. `gh` is needed by the validate-inputs step below; it
+          # runs inside this `fedora:45` container, where the host
+          # runner's pre-installed `gh` isn't visible.
+          dnf install -y rpm-build rpmdevtools copr-cli git rust cargo gcc openssl-devel pkgconf-pkg-config tar gzip gh
           rpmdev-setuptree
 
       - name: Validate workflow inputs

--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -34,31 +34,72 @@ jobs:
           dnf install -y rpm-build rpmdevtools copr-cli git rust cargo gcc openssl-devel pkgconf-pkg-config tar gzip
           rpmdev-setuptree
 
+      - name: Validate workflow inputs
+        # Inputs from workflow_dispatch are attacker-controllable; reject
+        # anything that doesn't match the expected release-tag and chroot
+        # shapes before we let those values reach a shell or the COPR API.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_CHROOTS: ${{ inputs.chroots }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="$RELEASE_TAG"
+          else
+            TAG="$INPUT_TAG"
+          fi
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$ ]]; then
+            echo "::error::Refusing to build: tag '$TAG' does not match vMAJOR.MINOR.PATCH[-prerelease]"
+            exit 1
+          fi
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [[ -n "$INPUT_CHROOTS" && ! "$INPUT_CHROOTS" =~ ^[a-z0-9][a-z0-9\ \-]*$ ]]; then
+              echo "::error::Refusing to build: chroots '$INPUT_CHROOTS' contains unexpected characters"
+              exit 1
+            fi
+            # Tag must point at a commit reachable from main so a manual
+            # dispatch can't sign packages from unreviewed history.
+            STATUS=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${TAG}" --jq '.status' 2>/dev/null || echo "missing")
+            if [ "$STATUS" != "identical" ] && [ "$STATUS" != "behind" ]; then
+              echo "::error::Tag '$TAG' is not reachable from main (compare status: $STATUS)"
+              exit 1
+            fi
+          fi
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.event_name == 'release' && github.ref || inputs.tag }}
+          ref: refs/tags/${{ env.TAG }}
           fetch-depth: 0
 
       - name: Set up environment variables
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_CHROOTS: ${{ inputs.chroots }}
+          MAINTAINER_NAME_VAR: ${{ vars.COPR_MAINTAINER_NAME }}
+          MAINTAINER_EMAIL_VAR: ${{ vars.COPR_MAINTAINER_EMAIL }}
+          COPR_OWNER_VAR: ${{ vars.COPR_OWNER }}
+          COPR_PROJECT_VAR: ${{ vars.COPR_PROJECT }}
         run: |
-          TAG="${{ github.event_name == 'release' && github.ref_name || inputs.tag }}"
           VERSION="${TAG#v}"
 
-          if [ "${{ github.event_name }}" = "release" ]; then
+          if [ "$EVENT_NAME" = "release" ]; then
             CHROOTS="fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64"
           else
-            CHROOTS="${{ inputs.chroots }}"
+            CHROOTS="$INPUT_CHROOTS"
           fi
 
           {
             echo "VERSION=${VERSION}"
             echo "CHROOTS=${CHROOTS}"
             echo "PACKAGE_NAME=${PACKAGE_NAME}"
-            echo "MAINTAINER_NAME=${{ vars.COPR_MAINTAINER_NAME || 'aube Release Bot' }}"
-            echo "MAINTAINER_EMAIL=${{ vars.COPR_MAINTAINER_EMAIL || 'noreply@aube.en.dev' }}"
-            echo "COPR_OWNER=${{ vars.COPR_OWNER || 'jdxcode' }}"
-            echo "COPR_PROJECT=${{ vars.COPR_PROJECT || 'aube' }}"
+            echo "MAINTAINER_NAME=${MAINTAINER_NAME_VAR:-aube Release Bot}"
+            echo "MAINTAINER_EMAIL=${MAINTAINER_EMAIL_VAR:-noreply@aube.en.dev}"
+            echo "COPR_OWNER=${COPR_OWNER_VAR:-jdxcode}"
+            echo "COPR_PROJECT=${COPR_PROJECT_VAR:-aube}"
             echo "BUILD_PROFILE=release"
           } >> "$GITHUB_ENV"
 

--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -174,9 +174,13 @@ jobs:
           done
 
       - name: Configure Git
+        # `MAINTAINER_NAME`/`MAINTAINER_EMAIL` were already exported via
+        # $GITHUB_ENV; read them from the process env rather than letting
+        # GitHub Actions splice the literal value into the shell source,
+        # so a tampered `vars.PPA_MAINTAINER_*` can't reach `bash -c`.
         run: |
-          git config --global user.name "${{ env.MAINTAINER_NAME }}"
-          git config --global user.email "${{ env.MAINTAINER_EMAIL }}"
+          git config --global user.name "$MAINTAINER_NAME"
+          git config --global user.email "$MAINTAINER_EMAIL"
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6

--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -38,25 +38,76 @@ jobs:
     timeout-minutes: 45
 
     steps:
+      - name: Validate workflow inputs
+        # The dispatch path eventually signs packages with AUBE_GPG_KEY and
+        # uploads them to Launchpad; gate every attacker-controllable input
+        # on a strict regex before it reaches the shell, and require the
+        # tag to be reachable from main so unreviewed history can't ship.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_DISTRIBUTIONS: ${{ inputs.distributions }}
+          INPUT_BUILD_REVISION: ${{ inputs.build_revision }}
+          INPUT_VERSION_SUFFIX: ${{ inputs.version_suffix }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="$RELEASE_TAG"
+          else
+            TAG="$INPUT_TAG"
+          fi
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$ ]]; then
+            echo "::error::Refusing to build: tag '$TAG' does not match vMAJOR.MINOR.PATCH[-prerelease]"
+            exit 1
+          fi
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [[ -n "$INPUT_DISTRIBUTIONS" && ! "$INPUT_DISTRIBUTIONS" =~ ^[a-z][a-z0-9\ \-]*$ ]]; then
+              echo "::error::Refusing to build: distributions '$INPUT_DISTRIBUTIONS' contains unexpected characters"
+              exit 1
+            fi
+            if [[ -n "$INPUT_BUILD_REVISION" && ! "$INPUT_BUILD_REVISION" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::Refusing to build: build_revision '$INPUT_BUILD_REVISION' is not a positive integer"
+              exit 1
+            fi
+            if [[ -n "$INPUT_VERSION_SUFFIX" && ! "$INPUT_VERSION_SUFFIX" =~ ^[A-Za-z0-9.+-]+$ ]]; then
+              echo "::error::Refusing to build: version_suffix '$INPUT_VERSION_SUFFIX' contains unexpected characters"
+              exit 1
+            fi
+            STATUS=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${TAG}" --jq '.status' 2>/dev/null || echo "missing")
+            if [ "$STATUS" != "identical" ] && [ "$STATUS" != "behind" ]; then
+              echo "::error::Tag '$TAG' is not reachable from main (compare status: $STATUS)"
+              exit 1
+            fi
+          fi
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.event_name == 'release' && github.ref || inputs.tag }}
+          ref: refs/tags/${{ env.TAG }}
           fetch-depth: 0
 
       - name: Set up environment variables
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_DISTRIBUTIONS: ${{ inputs.distributions }}
+          INPUT_BUILD_REVISION: ${{ inputs.build_revision }}
+          INPUT_VERSION_SUFFIX: ${{ inputs.version_suffix }}
+          MAINTAINER_NAME_VAR: ${{ vars.PPA_MAINTAINER_NAME }}
+          MAINTAINER_EMAIL_VAR: ${{ vars.PPA_MAINTAINER_EMAIL }}
+          PPA_NAME_VAR: ${{ vars.PPA_NAME }}
         run: |
-          TAG="${{ github.event_name == 'release' && github.ref_name || inputs.tag }}"
           VERSION="${TAG#v}"
 
-          if [ "${{ github.event_name }}" = "release" ]; then
+          if [ "$EVENT_NAME" = "release" ]; then
             DISTRIBUTIONS="resolute"
             BUILD_REVISION="1"
             VERSION_SUFFIX=""
           else
-            DISTRIBUTIONS="${{ inputs.distributions }}"
-            BUILD_REVISION="${{ inputs.build_revision || '1' }}"
-            VERSION_SUFFIX="${{ inputs.version_suffix }}"
+            DISTRIBUTIONS="$INPUT_DISTRIBUTIONS"
+            BUILD_REVISION="${INPUT_BUILD_REVISION:-1}"
+            VERSION_SUFFIX="$INPUT_VERSION_SUFFIX"
           fi
 
           # Deb version: SemVer `-` prerelease separators collate as
@@ -72,9 +123,9 @@ jobs:
             echo "DISTRIBUTIONS=${DISTRIBUTIONS}"
             echo "BUILD_REVISION=${BUILD_REVISION}"
             echo "PACKAGE_NAME=aube"
-            echo "MAINTAINER_NAME=${{ vars.PPA_MAINTAINER_NAME || 'aube Release Bot' }}"
-            echo "MAINTAINER_EMAIL=${{ vars.PPA_MAINTAINER_EMAIL || 'noreply@aube.en.dev' }}"
-            echo "PPA_NAME=${{ vars.PPA_NAME || 'ppa:jdxcode/aube' }}"
+            echo "MAINTAINER_NAME=${MAINTAINER_NAME_VAR:-aube Release Bot}"
+            echo "MAINTAINER_EMAIL=${MAINTAINER_EMAIL_VAR:-noreply@aube.en.dev}"
+            echo "PPA_NAME=${PPA_NAME_VAR:-ppa:jdxcode/aube}"
             echo "BUILD_PROFILE=release"
           } >> "$GITHUB_ENV"
 

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -30,13 +30,30 @@ jobs:
       - name: Resolve tag
         id: tag
         env:
+          EVENT_NAME: ${{ github.event_name }}
           EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${EVENT_TAG:-$INPUT_TAG}"
           if [ -z "$TAG" ]; then
             echo "::error::no tag from release event or workflow_dispatch input"
             exit 1
+          fi
+          # Strict format check before the tag reaches any privileged step.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$ ]]; then
+            echo "::error::Refusing to publish: tag '$TAG' does not match vMAJOR.MINOR.PATCH[-prerelease]"
+            exit 1
+          fi
+          # Manual dispatch: require the tag to point at a commit reachable
+          # from main so an attacker with tag-create + dispatch can't push
+          # an unreviewed formula to the tap under AUBE_GH_TOKEN.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            STATUS=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${TAG}" --jq '.status' 2>/dev/null || echo "missing")
+            if [ "$STATUS" != "identical" ] && [ "$STATUS" != "behind" ]; then
+              echo "::error::Tag '$TAG' is not reachable from main (compare status: $STATUS)"
+              exit 1
+            fi
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -48,13 +48,31 @@ jobs:
       - name: Resolve tag
         id: tag
         env:
+          EVENT_NAME: ${{ github.event_name }}
           EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${EVENT_TAG:-$INPUT_TAG}"
           if [ -z "$TAG" ]; then
             echo "::error::no tag from release event or workflow_dispatch input"
             exit 1
+          fi
+          # Strict format check before the tag controls the checkout ref.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$ ]]; then
+            echo "::error::Refusing to publish: tag '$TAG' does not match vMAJOR.MINOR.PATCH[-prerelease]"
+            exit 1
+          fi
+          # Manual dispatch path: id-token: write on this workflow means npm
+          # Trusted Publishing will accept whatever the checked-out tag's
+          # publish.mjs does. Require the tag to be reachable from main so
+          # an unreviewed ref can't push an @endevco/aube* package.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            STATUS=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${TAG}" --jq '.status' 2>/dev/null || echo "missing")
+            if [ "$STATUS" != "identical" ] && [ "$STATUS" != "behind" ]; then
+              echo "::error::Tag '$TAG' is not reachable from main (compare status: $STATUS)"
+              exit 1
+            fi
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,32 @@ env:
   AUBE_REQUIRE_PRIMER: "1"
 
 jobs:
+  validate-inputs:
+    # inputs.ref is dry-run-only by contract: it lets us rebuild a branch
+    # without an associated release tag. Honoring it for real uploads
+    # would let a dispatcher build arbitrary code under the release tag's
+    # name with contents/id-token/attestations write — fail fast.
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Reject ref override on real release
+        env:
+          REF: ${{ inputs.ref }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          if [ -n "$REF" ] && [ "$DRY_RUN" != "true" ]; then
+            echo "::error::inputs.ref override is only allowed when inputs.dry_run is true"
+            exit 1
+          fi
+
   generate-primer:
+    needs: validate-inputs
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
+          ref: ${{ inputs.ref != '' && fromJSON(inputs.dry_run || 'false') && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           submodules: recursive
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -94,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
+          ref: ${{ inputs.ref != '' && fromJSON(inputs.dry_run || 'false') && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           submodules: recursive
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -122,7 +141,7 @@ jobs:
           archive: aube-$tag-$target
           target: ${{ matrix.target }}
           build-tool: ${{ matrix.build-tool }}
-          ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
+          ref: ${{ inputs.ref != '' && fromJSON(inputs.dry_run || 'false') && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           token: ${{ secrets.AUBE_GH_TOKEN }}
           codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           codesign_prefix: dev.jdx.
@@ -136,7 +155,7 @@ jobs:
           archive: aube-$tag-$target
           target: ${{ matrix.target }}
           build-tool: ${{ matrix.build-tool }}
-          ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
+          ref: ${{ inputs.ref != '' && fromJSON(inputs.dry_run || 'false') && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           token: ${{ secrets.AUBE_GH_TOKEN }}
           dry-run: ${{ fromJSON(inputs.dry_run || 'false') }}
       - name: Resolve uploaded archive
@@ -239,7 +258,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ inputs.ref != '' && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
+          ref: ${{ inputs.ref != '' && fromJSON(inputs.dry_run || 'false') && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
           submodules: recursive
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/npm/installArchSpecificPackage.js
+++ b/npm/installArchSpecificPackage.js
@@ -85,17 +85,33 @@ function linkSubpkgBins(subpkgName, platform) {
     var binDir = path.resolve(__dirname, 'bin');
     try { fs.mkdirSync(binDir); } catch (e) { if (e.code !== 'EEXIST') throw e; }
 
+    // Realpath the platform package dir once so the containment compares
+    // happen in symlink-resolved space (the package itself can be
+    // pnpm-style symlinked, which is fine — what we care about is whether
+    // its `bin/*` entries escape the realpath of that directory).
+    var subpkgRealDir = fs.realpathSync(subpkgDir);
+
     var subpkgBin = subpkg.bin || {};
     ALLOWED_BINS.forEach(function(name) {
         var srcRel = subpkgBin[name];
         if (typeof srcRel !== 'string') return;
 
         var src = path.resolve(subpkgDir, srcRel);
-        // Reject bin values whose path escapes the platform package — a
-        // hostile package could otherwise point us at arbitrary files on
-        // disk via "../../etc/..." style traversal.
+        // String-only containment first: rejects `../` traversal before
+        // we ever touch the filesystem.
         if (!isContained(subpkgDir, src)) {
             throw new Error('platform package bin "' + name + '" escapes its package directory');
+        }
+        // Then realpath the source so a symlink inside the package can't
+        // smuggle in an arbitrary on-disk file (e.g. `bin/aube -> ~/.ssh/id_rsa`).
+        // The subsequent hardlink/copy follows symlinks, so a bare string
+        // check would let `fs.copyFileSync` read straight through.
+        var srcReal;
+        try { srcReal = fs.realpathSync(src); } catch (e) {
+            throw new Error('platform package bin "' + name + '" cannot be resolved: ' + (e && e.message ? e.message : e));
+        }
+        if (!isContained(subpkgRealDir, srcReal)) {
+            throw new Error('platform package bin "' + name + '" resolves outside its package directory');
         }
 
         var destBasename = platform === 'win32' ? name + '.exe' : name;
@@ -110,10 +126,11 @@ function linkSubpkgBins(subpkgName, platform) {
         try {
             // Hardlink is cheapest (same inode, no extra disk). On some
             // filesystems (cross-device, restricted sandboxes) hardlink
-            // fails — fall through to a copy.
-            fs.linkSync(src, dest);
+            // fails — fall through to a copy. Use the realpath so we
+            // never link/copy through a symlink that bypassed the check.
+            fs.linkSync(srcReal, dest);
         } catch (e) {
-            fs.copyFileSync(src, dest);
+            fs.copyFileSync(srcReal, dest);
         }
         if (platform !== 'win32') {
             try { fs.chmodSync(dest, 0o755); } catch (_) {}

--- a/npm/installArchSpecificPackage.js
+++ b/npm/installArchSpecificPackage.js
@@ -38,7 +38,10 @@ function main() {
     var subpkgName = '@endevco/aube-' + platform + '-' + arch + suffix;
 
     var npmCmd = platform === 'win32' ? 'npm.cmd' : 'npm';
-    var args = ['install', '--no-save', '--no-package-lock', subpkgName + '@' + version];
+    // --ignore-scripts: platform packages are passive binary carriers;
+    // a compromised mirror/registry must not get RCE via lifecycle hooks
+    // when the user installs the trusted root @endevco/aube.
+    var args = ['install', '--no-save', '--no-package-lock', '--ignore-scripts', subpkgName + '@' + version];
 
     var cp = spawn(npmCmd, args, { stdio: 'inherit', shell: true });
     cp.on('close', function(code, signal) {
@@ -64,6 +67,16 @@ function main() {
     });
 }
 
+// Only these names are ever produced by aube's own build pipeline; ignore
+// any other keys the platform package's bin map might carry so a hostile
+// or malformed sub-package can't smuggle in extra files.
+var ALLOWED_BINS = ['aube', 'aubr', 'aubx'];
+
+function isContained(parent, child) {
+    var rel = path.relative(parent, child);
+    return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
 function linkSubpkgBins(subpkgName, platform) {
     var subpkgJsonPath = require.resolve(subpkgName + '/package.json');
     var subpkg = JSON.parse(fs.readFileSync(subpkgJsonPath, 'utf8'));
@@ -72,11 +85,26 @@ function linkSubpkgBins(subpkgName, platform) {
     var binDir = path.resolve(__dirname, 'bin');
     try { fs.mkdirSync(binDir); } catch (e) { if (e.code !== 'EEXIST') throw e; }
 
-    Object.keys(subpkg.bin).forEach(function(name) {
-        var srcRel = subpkg.bin[name];
+    var subpkgBin = subpkg.bin || {};
+    ALLOWED_BINS.forEach(function(name) {
+        var srcRel = subpkgBin[name];
+        if (typeof srcRel !== 'string') return;
+
         var src = path.resolve(subpkgDir, srcRel);
+        // Reject bin values whose path escapes the platform package — a
+        // hostile package could otherwise point us at arbitrary files on
+        // disk via "../../etc/..." style traversal.
+        if (!isContained(subpkgDir, src)) {
+            throw new Error('platform package bin "' + name + '" escapes its package directory');
+        }
+
         var destBasename = platform === 'win32' ? name + '.exe' : name;
         var dest = path.resolve(binDir, destBasename);
+        // destBasename comes from our static allowlist, but guard anyway so
+        // a future change to ALLOWED_BINS can't silently regress.
+        if (!isContained(binDir, dest)) {
+            throw new Error('refusing to write outside bin dir: ' + destBasename);
+        }
 
         try { fs.unlinkSync(dest); } catch (e) { if (e.code !== 'ENOENT') throw e; }
         try {
@@ -91,6 +119,9 @@ function linkSubpkgBins(subpkgName, platform) {
             try { fs.chmodSync(dest, 0o755); } catch (_) {}
         } else {
             var shim = path.resolve(binDir, name);
+            if (!isContained(binDir, shim)) {
+                throw new Error('refusing to write outside bin dir: ' + name);
+            }
             try { fs.unlinkSync(shim); } catch (e) { if (e.code !== 'ENOENT') throw e; }
             fs.writeFileSync(shim, '#!' + dest.replace(/\\/g, '/') + '\n');
         }


### PR DESCRIPTION
## Summary

Addresses findings from a vulnerability scan against the install/publish surface. One CRITICAL (lifecycle-script RCE during preinstall) and seven HIGH issues across the publish workflows and the npm bin-linking helper.

## What changed

**`npm/installArchSpecificPackage.js`**
- Add `--ignore-scripts` to the nested `npm install` of the platform package. A compromised registry/mirror could otherwise execute lifecycle scripts during install of the trusted root `@endevco/aube`, since the platform packages are passive binary carriers.
- Restrict bin linking to a static allowlist (`aube`, `aubr`, `aubx`) and verify resolved paths stay inside the platform package and `./bin` respectively, blocking traversal via crafted bin names/values.

**`.github/workflows/copr-publish.yml` and `ppa-publish.yml`**
- Route `workflow_dispatch` inputs through `env:` blocks instead of inlining `${{ inputs.* }}` into `run:` scripts.
- Validate each input (`tag`, `chroots`, `distributions`, `build_revision`, `version_suffix`) against a strict regex before it reaches the shell, `dput`, or the COPR API. Closes a command-injection vector that could persist code through `$GITHUB_ENV` before the GPG/COPR secrets were attached.
- Require dispatched tags to be reachable from `main` via `gh api compare`.

**`.github/workflows/publish-homebrew.yml` and `publish-npm.yml`**
- Validate the tag format and require its commit to be reachable from `main`, so a user with tag-create + dispatch can't push an unreviewed Homebrew formula or publish an `@endevco/aube*` package under npm Trusted Publishing.

**`.github/workflows/release.yml`**
- New `validate-inputs` job fails fast when `inputs.ref` is set without `inputs.dry_run`.
- All five `ref:` expressions tightened so `inputs.ref` is only honored when `inputs.dry_run` is true. Prevents a dispatcher from producing signed/attested release artifacts from an arbitrary branch under the official release tag.

## Why

The dispatch entrypoints carry significant blast radius (signed PPA / COPR packages, npm Trusted Publishing OIDC, Homebrew tap push, GH release attestations). The pre-existing pattern of interpolating `${{ inputs.* }}` directly into shell scripts and honoring arbitrary refs/tags meant a privileged dispatcher (or anyone who could craft a tag) could route around the normal `main`-reviewed release pipeline. These changes don't change the happy path for `release-plz`-driven releases; they just narrow the manual-dispatch surface.

## Test plan

- [ ] Trigger `copr-publish` and `ppa-publish` via `workflow_dispatch` with a valid release tag and confirm they still build/sign packages
- [ ] Manually dispatch each publish workflow with a malformed tag (e.g. `v1.0.0; whoami`) and confirm the validate step rejects it
- [ ] Dispatch `release.yml` with `dry_run=false` and a non-empty `ref` and confirm the `validate-inputs` job fails
- [ ] Dispatch `release.yml` with `dry_run=true` and an explicit branch ref and confirm it still builds correctly
- [ ] Locally run `node --check npm/installArchSpecificPackage.js` and exercise the preinstall against the published `@endevco/aube-<platform>` packages to confirm bin linking still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release/publish workflow gating and npm install-time behavior, which could block legitimate releases or break binary linking if the new validations/containment checks are too strict.
> 
> **Overview**
> **Hardens the release/publish surface against malicious `workflow_dispatch` inputs and unreviewed tags.** COPR/PPA/Homebrew/npm workflows now validate tag/input formats, require dispatched tags to be reachable from `main` via `gh api compare`, and avoid inlining attacker-controlled values into shell scripts (plus install `gh` in the COPR container).
> 
> **Tightens release workflow ref handling.** `release.yml` adds a `validate-inputs` job and only honors `inputs.ref` when `inputs.dry_run` is true, preventing ref overrides from affecting real signed/attested uploads.
> 
> **Reduces npm install-time RCE and path traversal risk.** `npm/installArchSpecificPackage.js` adds `--ignore-scripts` to the nested install and restricts bin linking to an allowlist with directory containment + `realpath` checks before hardlink/copy into `./bin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc8687772a31a3bf1a23de7c553ab51e7bc091c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->