### PR TITLE
fix(install): co-locate cached indexes with CAS + verified probe self-heal

### DIFF
--- a/.rules
+++ b/.rules
@@ -9,10 +9,10 @@ project:
   error_codes: every error/warning carries a stable ERR_AUBE_*/WARN_AUBE_* identifier from aube-codes crate; bespoke exit codes for a curated subset; see error_codes section below for conventions
 
 layout:
-  global_store: $XDG_DATA_HOME/aube/store/v1/files/ (falls back to ~/.local/share/aube/store/v1/files/)
+  global_store: $XDG_DATA_HOME/aube/store/v1/ (contains files/ for CAS shards + index/ for cached package indexes; falls back to ~/.local/share/aube/store/v1/). `aube store path` prints this v1/ dir, matching `pnpm store path` granularity. The legacy index location at $XDG_CACHE_HOME/aube/index/ is migrated in-place on the first store open after upgrade.
   store_hashing: BLAKE3 content addressed, 2-char sharding
   virtual_store: node_modules/.aube/ (isolated symlink layout)
-  cache_packuments: $XDG_CACHE_HOME/aube/ or ~/.cache/aube/ (linux/mac) or %LOCALAPPDATA%/aube/ (windows)
+  cache_packuments: $XDG_CACHE_HOME/aube/packuments-{v1,full-v1}/ (regenerable from registry; not part of `aube store path`)
   state: node_modules/.aube-state (install freshness hashes)
   scripts_default: skipped for security, allow-builds allowlist opts in (wired via aube-scripts policy + aube approve-builds)
   coexistence: never touches .pnpm/ or ~/.pnpm-store/ or foreign node_modules (by construction, not enforced)

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -2901,14 +2901,14 @@ fn classify_link_error(
 /// next install miss `load_index` instead of looping on the same dead
 /// reference. If the cache write fails (e.g. permission error), warn
 /// loudly so the user knows the auto-recovery didn't take and they need
-/// to wipe `~/.cache/aube/index/` by hand.
+/// to wipe the index dir by hand (run `aube store path` to find it).
 pub(crate) fn invalidate_stale_index_for_package(store: &aube_store::Store, pkg: &LockedPackage) {
     match store.invalidate_cached_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref())
     {
         Ok(true) => debug!("invalidated stale index for {}", pkg.spec_key()),
         Ok(false) => {}
         Err(e) => warn!(
-            "failed to invalidate stale index for {}: {e}; manual recovery: rm -rf ~/.cache/aube/index",
+            "failed to invalidate stale index for {}: {e}; manual recovery: rm -rf \"$(aube store path)/index\"",
             pkg.spec_key()
         ),
     }

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -790,14 +790,8 @@ Path interpretation matches pnpm: `~` expands to the user's home
 directory and a relative path is resolved against the project root,
 not the current working directory. aube appends its own schema suffix
 (`v1`) to the user-supplied directory, so `store-dir=/srv/aube-store`
-stores package content under `/srv/aube-store/v1/files/` and cached
-package indexes under `/srv/aube-store/v1/index/`. `aube store path`
-prints the `v1/` directory itself — a single backup or Docker
-BuildKit cache mount of that path captures both files and indexes,
-matching `pnpm store path` granularity.
-
-Only the on-disk store moves; the packument cache (regenerable from
-the registry) stays at `$XDG_CACHE_HOME/aube`.
+stores package content under `/srv/aube-store/v1/`. Run
+`aube store path` to print the resolved store location.
 """
 sources.cli = []
 sources.env = ["npm_config_store_dir", "NPM_CONFIG_STORE_DIR", "AUBE_STORE_DIR"]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -776,11 +776,11 @@ examples = []
 [storeDir]
 description = "Location where packages are saved on disk (content-addressable store)."
 type = "path"
-default = "$XDG_DATA_HOME/aube/store/v1/files/"
+default = "$XDG_DATA_HOME/aube/store/"
 docs = """
 Defaults to aube's own XDG-compliant store path
-(`$XDG_DATA_HOME/aube/store/v1/files/`, falling back to
-`~/.local/share/aube/store/v1/files/`). aube does not read from or write to
+(`$XDG_DATA_HOME/aube/store/`, falling back to
+`~/.local/share/aube/store/`). aube does not read from or write to
 pnpm's `~/.pnpm-store/`. Set in `.npmrc` or `aube-workspace.yaml` to point at
 a different directory, which is useful for isolating CI runners, putting the
 store on a faster disk, or sharing one store across multiple users on the
@@ -788,12 +788,16 @@ same host.
 
 Path interpretation matches pnpm: `~` expands to the user's home
 directory and a relative path is resolved against the project root,
-not the current working directory. aube appends its own CAS schema suffix
-(`v1/files`) to the user-supplied directory, so `store-dir=/srv/aube-store`
-stores package content under `/srv/aube-store/v1/files`.
+not the current working directory. aube appends its own schema suffix
+(`v1`) to the user-supplied directory, so `store-dir=/srv/aube-store`
+stores package content under `/srv/aube-store/v1/files/` and cached
+package indexes under `/srv/aube-store/v1/index/`. `aube store path`
+prints the `v1/` directory itself — a single backup or Docker
+BuildKit cache mount of that path captures both files and indexes,
+matching `pnpm store path` granularity.
 
-Only the on-disk CAS moves; the packument and virtual-store caches
-stay at `$XDG_CACHE_HOME/aube`.
+Only the on-disk store moves; the packument cache (regenerable from
+the registry) stays at `$XDG_CACHE_HOME/aube`.
 """
 sources.cli = []
 sources.env = ["npm_config_store_dir", "NPM_CONFIG_STORE_DIR", "AUBE_STORE_DIR"]

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -3251,6 +3251,69 @@ mod tests {
     }
 
     #[test]
+    fn load_index_passes_partial_corruption_load_index_verified_catches_it() {
+        // The user's BuildKit failure mode: cached index references
+        // multiple files; the lexicographically-first file's CAS shard
+        // happens to still exist (or never did — `dist.size` is absent
+        // on legacy indexes so the probe defaults to `exists()`), but a
+        // later file's shard is gone. The fast `load_index` returns
+        // Some(stale_index), which then dies inside the linker with
+        // `ERR_AUBE_MISSING_STORE_FILE`. `load_index_verified` stats
+        // every file and drops the index so the fetch path re-imports.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+
+        // Two files, distinct CAS shards. BTreeMap key order puts
+        // "AAA.txt" before "BBB.txt", so the cheap `load_index` probe
+        // checks AAA first.
+        let kept = store.import_bytes(b"present", false).unwrap();
+        let dropped = store.import_bytes(b"missing-soon", false).unwrap();
+        let dropped_path = dropped.store_path.clone();
+        let mut index = BTreeMap::new();
+        index.insert("AAA.txt".to_string(), kept);
+        index.insert("BBB.txt".to_string(), dropped);
+        store
+            .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
+            .unwrap();
+
+        // Remove the SECOND file's CAS shard. The first remains.
+        std::fs::remove_file(&dropped_path).unwrap();
+
+        // Cheap probe accepts the index — the bug class that motivated
+        // the fix.
+        assert!(
+            store
+                .load_index("pkg", "1.0.0", Some(TEST_INTEGRITY))
+                .is_some(),
+            "cheap probe must accept partial corruption (precondition for the fix)"
+        );
+        // Re-save (load_index drops the index when its embedded
+        // `dist.size` check fires on later files for newer indexes).
+        // load_index doesn't actually drop on the cheap path today, but
+        // re-save defensively to keep this test independent of probe
+        // tuning.
+        store
+            .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
+            .unwrap();
+
+        // Verified probe walks every file and rejects the stale index.
+        assert!(
+            store
+                .load_index_verified("pkg", "1.0.0", Some(TEST_INTEGRITY))
+                .is_none(),
+            "verified probe must reject an index whose later files are missing"
+        );
+
+        // Side effect: load_index_verified drops the JSON so the next
+        // fetch re-imports rather than racing on the same dead reference.
+        let path = store.index_path("pkg", "1.0.0", Some(TEST_INTEGRITY));
+        assert!(
+            !path.unwrap().exists(),
+            "verified probe must drop the stale cached index"
+        );
+    }
+
+    #[test]
     fn test_invalidate_cached_index_removes_entry() {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::at(dir.path().join("files"));

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -79,6 +79,28 @@ thread_local! {
 static FAST_PATH_SHARD_LOCKS: [std::sync::Mutex<()>; 256] =
     [const { std::sync::Mutex::new(()) }; 256];
 
+/// Recursively copy `src` into `dst`. Used only by the one-shot
+/// legacy-index migration fallback when `rename` fails (typically
+/// cross-filesystem). Not a hot path; correctness > speed.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&from, &to)?;
+        }
+        // Symlinks and other types are skipped — the index cache only
+        // ever contains regular JSON files (optionally under a single
+        // level of integrity-shard subdirs).
+    }
+    Ok(())
+}
+
 fn blake3_hex(content: &[u8]) -> String {
     B3_HASHER.with(|cell| {
         let mut h = cell.borrow_mut();
@@ -95,6 +117,15 @@ fn blake3_hex(content: &[u8]) -> String {
 /// Files are stored by BLAKE3 hash with two-char hex directory sharding.
 /// (Tarball-level integrity is still SHA-512 because that's the format the
 /// npm registry returns; the per-file CAS key is an internal choice.)
+///
+/// Layout under the store-version directory (`v1/`):
+/// - `v1/files/` — CAS shards, content-addressed by BLAKE3 hex
+/// - `v1/index/` — cached package indexes (kept next to `files/` so a
+///   single backup/mount captures the whole store; matches pnpm's
+///   `~/.pnpm-store/v11/{files,index.db}` grouping)
+///
+/// `cache_dir` ($XDG_CACHE_HOME/aube) still holds genuinely
+/// regenerable caches: the virtual store and packument metadata.
 #[derive(Clone)]
 pub struct Store {
     root: PathBuf,
@@ -165,11 +196,13 @@ impl Store {
     pub fn default_location() -> Result<Self, Error> {
         let root = dirs::store_dir().ok_or(Error::NoHome)?;
         let cache_dir = dirs::cache_dir().ok_or(Error::NoHome)?;
-        Ok(Self {
+        let store = Self {
             root,
             cache_dir,
             fast_path: Arc::new(AtomicBool::new(false)),
-        })
+        };
+        store.migrate_legacy_index_dir();
+        Ok(store)
     }
 
     /// Open the store with an explicit root, keeping the default
@@ -179,11 +212,13 @@ impl Store {
     /// rest of aube expects them.
     pub fn with_root(root: PathBuf) -> Result<Self, Error> {
         let cache_dir = dirs::cache_dir().ok_or(Error::NoHome)?;
-        Ok(Self {
+        let store = Self {
             root,
             cache_dir,
             fast_path: Arc::new(AtomicBool::new(false)),
-        })
+        };
+        store.migrate_legacy_index_dir();
+        Ok(store)
     }
 
     /// Open the store at a specific path (cache dir derived from store root).
@@ -222,10 +257,97 @@ impl Store {
         &self.root
     }
 
-    /// Directory for cached package indices. Public so introspection
-    /// commands (`aube find-hash`) can walk it directly.
+    /// The store-version directory containing `files/` and `index/`.
+    ///
+    /// For the default layout this is `<storeDir>/v1/` (parent of
+    /// `root`, which is the `files/` subdir). Matches the granularity
+    /// of `pnpm store path` — a single cache-mount or backup covering
+    /// this directory captures both the CAS shards and the cached
+    /// package indexes, so they cannot drift apart.
+    ///
+    /// Falls back to `root` itself when `root` has no parent (only
+    /// possible at the filesystem root, which is never a real store).
+    pub fn store_v1_dir(&self) -> PathBuf {
+        self.root
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| self.root.clone())
+    }
+
+    /// Directory for cached package indexes. Lives next to `files/`
+    /// at `<v1_dir>/index/` so the whole store is one mount/backup
+    /// unit. Public so introspection commands (`aube find-hash`,
+    /// `aube store status`, `aube store prune`) can walk it directly.
     pub fn index_dir(&self) -> PathBuf {
+        self.store_v1_dir().join(INDEX_SUBDIR)
+    }
+
+    /// Legacy index location at `$XDG_CACHE_HOME/aube/index/`, where
+    /// aube wrote cached package indexes before they were moved next
+    /// to the CAS files. Used only by [`migrate_legacy_index_dir`]; new
+    /// code should always go through [`index_dir`].
+    fn legacy_index_dir(&self) -> PathBuf {
         self.cache_dir.join(INDEX_SUBDIR)
+    }
+
+    /// One-shot migration from the legacy XDG-cache index location to
+    /// the in-store `v1/index/` directory. Runs at `Store::open`-time.
+    ///
+    /// The legacy location was a footgun under Docker BuildKit cache
+    /// mounts: users would mount the CAS files dir, the indexes would
+    /// silently land on the image layer instead, and the next install
+    /// would hit `MissingStoreFile` on every package whose CAS shards
+    /// the cache mount dropped. Co-locating index with files matches
+    /// pnpm's grouping and removes the drift class entirely.
+    ///
+    /// Best-effort: a same-filesystem rename is one syscall; on
+    /// `EXDEV` (cache dir and store dir on different filesystems, e.g.
+    /// tmpfs cache + persistent data) we fall back to a recursive
+    /// copy + remove. Either failure logs a warning and proceeds —
+    /// the worst-case is re-fetching tarballs on the next install,
+    /// which is what would have happened without the migration anyway.
+    fn migrate_legacy_index_dir(&self) {
+        let legacy = self.legacy_index_dir();
+        let new = self.index_dir();
+        if !legacy.exists() || new.exists() {
+            return;
+        }
+        if let Some(parent) = new.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            warn!(
+                "failed to create {} for index migration: {e}",
+                parent.display()
+            );
+            return;
+        }
+        if std::fs::rename(&legacy, &new).is_ok() {
+            debug!(
+                "migrated cached indexes from {} to {}",
+                legacy.display(),
+                new.display()
+            );
+            return;
+        }
+        // Cross-filesystem rename (cache dir on tmpfs, data dir on a
+        // persistent FS — common in containers) or any other rename
+        // failure: fall back to recursive copy + remove.
+        if let Err(e) = copy_dir_recursive(&legacy, &new) {
+            warn!(
+                "failed to migrate cached indexes from {} to {}: {e}; will be rebuilt on next install",
+                legacy.display(),
+                new.display()
+            );
+            let _ = std::fs::remove_dir_all(&new);
+            return;
+        }
+        if let Err(e) = std::fs::remove_dir_all(&legacy) {
+            warn!(
+                "migrated indexes to {} but failed to remove old {}: {e}",
+                new.display(),
+                legacy.display()
+            );
+        }
     }
 
     /// Directory for the global virtual store (materialized packages).
@@ -2679,6 +2801,109 @@ fn git_commit_matches(actual: &str, requested: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Construct a Store with explicit root + cache_dir, bypassing the
+    /// XDG resolution path. Test-only so the migration test can drive
+    /// `migrate_legacy_index_dir` against a fully isolated layout
+    /// without touching env vars or process-global state.
+    fn store_for_migration_test(root: PathBuf, cache_dir: PathBuf) -> Store {
+        Store {
+            root,
+            cache_dir,
+            fast_path: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    #[test]
+    fn migrate_legacy_index_dir_relocates_files_and_subdirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("data/aube/store/v1/files");
+        let cache_dir = tmp.path().join("cache/aube");
+        std::fs::create_dir_all(&root).unwrap();
+        let legacy_index = cache_dir.join("index");
+        let legacy_shard = legacy_index.join("0123456789abcdef");
+        std::fs::create_dir_all(&legacy_shard).unwrap();
+        std::fs::write(legacy_index.join("foo@1.0.0.json"), b"{\"index\":\"a\"}").unwrap();
+        std::fs::write(legacy_shard.join("bar@2.0.0.json"), b"{\"index\":\"b\"}").unwrap();
+
+        let store = store_for_migration_test(root.clone(), cache_dir.clone());
+        store.migrate_legacy_index_dir();
+
+        let new_index = store.index_dir();
+        assert!(new_index.exists(), "new index dir must exist");
+        assert_eq!(
+            std::fs::read(new_index.join("foo@1.0.0.json")).unwrap(),
+            b"{\"index\":\"a\"}",
+            "integrity-less entry must migrate"
+        );
+        assert_eq!(
+            std::fs::read(new_index.join("0123456789abcdef/bar@2.0.0.json")).unwrap(),
+            b"{\"index\":\"b\"}",
+            "integrity-keyed shard subdir must migrate"
+        );
+        assert!(
+            !legacy_index.exists(),
+            "legacy index dir must be removed after a successful migration"
+        );
+    }
+
+    #[test]
+    fn migrate_legacy_index_dir_is_a_noop_when_new_dir_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("data/aube/store/v1/files");
+        let cache_dir = tmp.path().join("cache/aube");
+        std::fs::create_dir_all(&root).unwrap();
+        let legacy_index = cache_dir.join("index");
+        std::fs::create_dir_all(&legacy_index).unwrap();
+        std::fs::write(legacy_index.join("foo@1.0.0.json"), b"old").unwrap();
+
+        let store = store_for_migration_test(root.clone(), cache_dir.clone());
+        // Pre-existing new-location entry must not be clobbered.
+        std::fs::create_dir_all(store.index_dir()).unwrap();
+        std::fs::write(store.index_dir().join("keep.json"), b"new").unwrap();
+
+        store.migrate_legacy_index_dir();
+
+        assert!(
+            legacy_index.exists(),
+            "legacy dir must stay untouched when new dir already exists"
+        );
+        assert_eq!(
+            std::fs::read(store.index_dir().join("keep.json")).unwrap(),
+            b"new",
+            "existing new-location content must not be overwritten"
+        );
+        assert!(
+            !store.index_dir().join("foo@1.0.0.json").exists(),
+            "no copy must happen — migration only runs when new dir is absent"
+        );
+    }
+
+    #[test]
+    fn migrate_legacy_index_dir_is_a_noop_when_legacy_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("data/aube/store/v1/files");
+        let cache_dir = tmp.path().join("cache/aube");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let store = store_for_migration_test(root, cache_dir);
+        store.migrate_legacy_index_dir();
+
+        assert!(
+            !store.index_dir().exists(),
+            "migration must not create an empty new dir when there's nothing to migrate"
+        );
+    }
+
+    #[test]
+    fn store_v1_dir_is_parent_of_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("data/aube/store/v1/files");
+        let cache_dir = tmp.path().join("cache/aube");
+        let store = store_for_migration_test(root.clone(), cache_dir);
+        assert_eq!(store.store_v1_dir(), root.parent().unwrap());
+        assert_eq!(store.index_dir(), root.parent().unwrap().join("index"));
+    }
 
     #[test]
     fn git_commit_matches_abbreviated_sha() {

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -329,6 +329,12 @@ impl Store {
             );
             return;
         }
+        // Rename lost (cross-FS, or a concurrent process already won
+        // the race). If `legacy` is gone, a concurrent process already
+        // migrated successfully — leave `new` alone.
+        if !legacy.exists() {
+            return;
+        }
         // Cross-filesystem rename (cache dir on tmpfs, data dir on a
         // persistent FS — common in containers) or any other rename
         // failure: fall back to recursive copy + remove.
@@ -338,7 +344,15 @@ impl Store {
                 legacy.display(),
                 new.display()
             );
-            let _ = std::fs::remove_dir_all(&new);
+            // Only roll back `new` if `legacy` is still here — meaning
+            // we own the half-copied content and have a recovery
+            // path (next install re-fetches). If `legacy` is also gone,
+            // a concurrent rename succeeded between our two checks and
+            // `new` holds that process's valid data; removing it would
+            // silently delete the only good copy.
+            if legacy.exists() {
+                let _ = std::fs::remove_dir_all(&new);
+            }
             return;
         }
         if let Err(e) = std::fs::remove_dir_all(&legacy) {

--- a/crates/aube/src/commands/cat_index.rs
+++ b/crates/aube/src/commands/cat_index.rs
@@ -1,7 +1,11 @@
 //! `aube cat-index <pkg@version>` — print the cached package index JSON.
 //!
 //! Prints the index that `aube fetch`/`aube install` writes under
-//! `~/.cache/aube/index/`. Integrity-keyed entries live under
+//! `<store>/v1/index/` (next to the CAS shards in `v1/files/`, so a
+//! single backup/cache-mount captures both). Older aube versions wrote
+//! these under `$XDG_CACHE_HOME/aube/index/`; a one-shot migration on
+//! the first store open after upgrade relocates them. Integrity-keyed
+//! entries live under
 //! `<16 hex>/<name>@<version>.json` (subdirectory keyed by the
 //! tarball's SHA-512 prefix); integrity-less entries live at
 //! `<name>@<version>.json` in the root. The filename alone never

--- a/crates/aube/src/commands/find_hash.rs
+++ b/crates/aube/src/commands/find_hash.rs
@@ -1,7 +1,7 @@
 //! `aube find-hash <hash>` — reverse lookup from a file hash to the
 //! `<name>@<version>` packages whose index references it.
 //!
-//! Walks `~/.cache/aube/index/*.json`, parses each cached `PackageIndex`,
+//! Walks `<store>/v1/index/*.json`, parses each cached `PackageIndex`,
 //! and prints every `<name>@<version>` whose index contains the given
 //! hash along with the relative path the hash lives at. Accepts both
 //! `sha512-<base64>` integrity strings and raw hex CAS digests;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1463,7 +1463,7 @@ where
     // (either as a real directory here in per-project mode, or as a
     // symlink into the global virtual store that itself exists),
     // there's nothing to materialize and the 13–15 KB JSON on disk at
-    // `~/.cache/aube/index/<name>@<ver>.json` would be read for
+    // `<store>/v1/index/<name>@<ver>.json` would be read for
     // nothing. A fresh no-op install against the 1.4k-package medium
     // fixture drops from ~38 ms of parallel index reads to a handful
     // of `stat(2)`s.
@@ -1540,7 +1540,22 @@ where
             // under the same (name, version) — e.g. a github codeload
             // archive vs. the npm-published bytes — can't return the
             // wrong file list.
-            match store.load_index(pkg.registry_name(), &pkg.version, pkg.integrity.as_deref()) {
+            //
+            // `_verified` because the index cache and the CAS shards
+            // live in separate paths until the v1/index/ migration
+            // completes on disk, and external systems can drift them
+            // apart even after (Docker BuildKit cache mounts that
+            // only cover one path, foreign sync tools, partial wipes
+            // mid-install). Stat-per-file is paid only on a cache hit;
+            // a stale index drops here and falls through to `NeedsFetch`,
+            // which re-fetches the tarball cleanly — the alternative is
+            // the materializer dying mid-link with `ERR_AUBE_MISSING_STORE_FILE`,
+            // forcing the user to retry the whole install.
+            match store.load_index_verified(
+                pkg.registry_name(),
+                &pkg.version,
+                pkg.integrity.as_deref(),
+            ) {
                 Some(index) => (dep_path.clone(), pkg, CheckResult::Cached(index)),
                 None => (dep_path.clone(), pkg, CheckResult::NeedsFetch),
             }
@@ -3699,8 +3714,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     // of the cache key so a github-sourced tarball
                     // under the same (name, version) can't return the
                     // registry-cached file list.
+                    //
+                    // `_verified`: see the matching call in
+                    // `fetch_packages_with_root` for the full
+                    // rationale — short version, a stat-per-file cache
+                    // check is cheap, and dropping a stale index
+                    // here re-fetches the tarball cleanly instead of
+                    // letting the materializer die later with
+                    // `ERR_AUBE_MISSING_STORE_FILE`.
                     let pkg_registry_name = pkg.registry_name().to_string();
-                    if let Some(index) = fetch_store.load_index(
+                    if let Some(index) = fetch_store.load_index_verified(
                         &pkg_registry_name,
                         &pkg.version,
                         pkg.integrity.as_deref(),

--- a/crates/aube/src/commands/store.rs
+++ b/crates/aube/src/commands/store.rs
@@ -2,9 +2,13 @@
 //!
 //! Mirrors `pnpm store`:
 //!
-//! - `aube store path` — print the store root (aube-owned by default:
-//!   `$XDG_DATA_HOME/aube/store/v1/files/`, falling back to
-//!   `~/.local/share/aube/store/v1/files/`).
+//! - `aube store path` — print the store-version directory (aube-owned
+//!   by default: `$XDG_DATA_HOME/aube/store/v1/`, falling back to
+//!   `~/.local/share/aube/store/v1/`). This directory contains both
+//!   `files/` (the CAS shards) and `index/` (the cached package
+//!   indexes), so a single backup or Docker BuildKit cache mount of
+//!   this path captures the whole store — matching `pnpm store path`'s
+//!   granularity (which prints e.g. `~/.pnpm-store/v11/`).
 //! - `aube store add <pkg>…` — resolve each spec against the registry, fetch
 //!   the tarball, and import it into the global CAS. Pre-warms the store
 //!   without touching any project's `node_modules/`.
@@ -14,7 +18,7 @@
 //!   independent inodes so the nlink count is always 1 and pruning there
 //!   can't safely tell referenced from unreferenced files; in that case we
 //!   fall back to removing only files that no cached package index in
-//!   `~/.cache/aube/index/` points at.
+//!   `<store>/v1/index/` points at.
 //! - `aube store status` — verify every file referenced by a cached package
 //!   index still exists in the store and its BLAKE3 hash matches. Exits 0
 //!   when everything is consistent, 1 when any corruption is found.
@@ -74,7 +78,7 @@ fn open_store() -> miette::Result<aube_store::Store> {
 
 fn path() -> miette::Result<()> {
     let store = open_store()?;
-    println!("{}", store.root().display());
+    println!("{}", store.store_v1_dir().display());
     Ok(())
 }
 
@@ -154,7 +158,7 @@ async fn add(specs: Vec<String>) -> miette::Result<()> {
 }
 
 /// Collect the set of hex hashes referenced by any cached package index
-/// under `~/.cache/aube/index/`. Integrity-keyed entries live under
+/// under `<store>/v1/index/`. Integrity-keyed entries live under
 /// `<16 hex>/<name>@<version>.json` subdirs; integrity-less entries
 /// live at the root as `<name>@<version>.json`. Walk both. Used as
 /// the "known-referenced" set for `store prune` and `store status`.

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -5,9 +5,8 @@ projects. It is enabled by default for local installs and disabled under CI.
 
 This is separate from the global content store:
 
-- The **global content store** (`$XDG_DATA_HOME/aube/store/v1/`) holds the
-  CAS shards under `files/` and the cached package indexes under `index/`,
-  both addressed by BLAKE3 hash. Every install uses it.
+- The **global content store** (`$XDG_DATA_HOME/aube/store/v1/`) stores
+  package files by BLAKE3 hash. Every install uses it.
 - The **global virtual store**
   (`$XDG_CACHE_HOME/aube/virtual-store/`, defaulting to
   `~/.cache/aube/virtual-store/`) stores package directory trees keyed by

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -5,8 +5,9 @@ projects. It is enabled by default for local installs and disabled under CI.
 
 This is separate from the global content store:
 
-- The **global content store** (`$XDG_DATA_HOME/aube/store/v1/files/`) stores
-  package files by BLAKE3 hash. Every install uses it.
+- The **global content store** (`$XDG_DATA_HOME/aube/store/v1/`) holds the
+  CAS shards under `files/` and the cached package indexes under `index/`,
+  both addressed by BLAKE3 hash. Every install uses it.
 - The **global virtual store**
   (`$XDG_CACHE_HOME/aube/virtual-store/`, defaulting to
   `~/.cache/aube/virtual-store/`) stores package directory trees keyed by

--- a/docs/package-manager/node-modules.md
+++ b/docs/package-manager/node-modules.md
@@ -31,14 +31,20 @@ packages are visible at the top level.
 
 ## Global store
 
-Package files are stored by content hash under:
+Package files and their cached indexes live side-by-side under the
+store-version directory:
 
 ```text
-$XDG_DATA_HOME/aube/store/v1/files/
+$XDG_DATA_HOME/aube/store/v1/
+├── files/   # content-addressed CAS shards (BLAKE3, 2-char sharding)
+└── index/   # cached package indexes (name@version -> files map)
 ```
 
-This defaults to `~/.local/share/aube/store/v1/files/` when
-`$XDG_DATA_HOME` is unset.
+The `v1/` directory is what `aube store path` prints. The defaults
+fall back to `~/.local/share/aube/store/v1/{files,index}/` when
+`$XDG_DATA_HOME` is unset. Co-locating files and index means a single
+backup, snapshot, or Docker BuildKit cache mount of that one path
+captures the whole store — matching `pnpm store path` granularity.
 
 aube imports files from that store into the virtual store with reflinks,
 hardlinks, or copies depending on filesystem support and

--- a/docs/package-manager/node-modules.md
+++ b/docs/package-manager/node-modules.md
@@ -31,20 +31,15 @@ packages are visible at the top level.
 
 ## Global store
 
-Package files and their cached indexes live side-by-side under the
-store-version directory:
+Package files are stored by content hash under:
 
 ```text
 $XDG_DATA_HOME/aube/store/v1/
-├── files/   # content-addressed CAS shards (BLAKE3, 2-char sharding)
-└── index/   # cached package indexes (name@version -> files map)
 ```
 
-The `v1/` directory is what `aube store path` prints. The defaults
-fall back to `~/.local/share/aube/store/v1/{files,index}/` when
-`$XDG_DATA_HOME` is unset. Co-locating files and index means a single
-backup, snapshot, or Docker BuildKit cache mount of that one path
-captures the whole store — matching `pnpm store path` granularity.
+This defaults to `~/.local/share/aube/store/v1/` when
+`$XDG_DATA_HOME` is unset. Run `aube store path` to see the resolved
+location.
 
 aube imports files from that store into the virtual store with reflinks,
 hardlinks, or copies depending on filesystem support and

--- a/docs/pnpm-users.md
+++ b/docs/pnpm-users.md
@@ -46,7 +46,7 @@ and install first only when needed. Use `aubx <pkg>` for one-off tools.
 | --- | --- | --- |
 | Default lockfile (new projects) | `pnpm-lock.yaml` | `aube-lock.yaml` |
 | Virtual store | `node_modules/.pnpm/` | `node_modules/.aube/` |
-| Global content-addressable store | `~/.pnpm-store/` (contains `files/` + `index.db`) | `$XDG_DATA_HOME/aube/store/v1/` (defaulting to `~/.local/share/aube/store/v1/`; contains `files/` + `index/`). `aube store path` prints this directory, matching `pnpm store path` granularity — a single backup or Docker BuildKit cache mount of this path captures both the CAS shards and the cached package indexes. |
+| Global content-addressable store | `~/.pnpm-store/` | `$XDG_DATA_HOME/aube/store/v1/` (defaulting to `~/.local/share/aube/store/v1/`). Run `aube store path` to see the resolved location. |
 | Install state | `node_modules/.modules.yaml` | `node_modules/.aube-state` |
 | Workspace manifest | `pnpm-workspace.yaml` | `aube-workspace.yaml` |
 

--- a/docs/pnpm-users.md
+++ b/docs/pnpm-users.md
@@ -46,7 +46,7 @@ and install first only when needed. Use `aubx <pkg>` for one-off tools.
 | --- | --- | --- |
 | Default lockfile (new projects) | `pnpm-lock.yaml` | `aube-lock.yaml` |
 | Virtual store | `node_modules/.pnpm/` | `node_modules/.aube/` |
-| Global content-addressable store | `~/.pnpm-store/` | `$XDG_DATA_HOME/aube/store/v1/files/` (defaulting to `~/.local/share/aube/store/v1/files/`) |
+| Global content-addressable store | `~/.pnpm-store/` (contains `files/` + `index.db`) | `$XDG_DATA_HOME/aube/store/v1/` (defaulting to `~/.local/share/aube/store/v1/`; contains `files/` + `index/`). `aube store path` prints this directory, matching `pnpm store path` granularity — a single backup or Docker BuildKit cache mount of this path captures both the CAS shards and the cached package indexes. |
 | Install state | `node_modules/.modules.yaml` | `node_modules/.aube-state` |
 | Workspace manifest | `pnpm-workspace.yaml` | `aube-workspace.yaml` |
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -861,14 +861,8 @@ Path interpretation matches pnpm: `~` expands to the user's home
 directory and a relative path is resolved against the project root,
 not the current working directory. aube appends its own schema suffix
 (`v1`) to the user-supplied directory, so `store-dir=/srv/aube-store`
-stores package content under `/srv/aube-store/v1/files/` and cached
-package indexes under `/srv/aube-store/v1/index/`. `aube store path`
-prints the `v1/` directory itself — a single backup or Docker
-BuildKit cache mount of that path captures both files and indexes,
-matching `pnpm store path` granularity.
-
-Only the on-disk store moves; the packument cache (regenerable from
-the registry) stays at `$XDG_CACHE_HOME/aube`.
+stores package content under `/srv/aube-store/v1/`. Run
+`aube store path` to print the resolved store location.
 
 Examples:
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -844,14 +844,14 @@ warning suppresses itself in that case.
 Location where packages are saved on disk (content-addressable store).
 
 - Type: `path`
-- Default: `$XDG_DATA_HOME/aube/store/v1/files/`
+- Default: `$XDG_DATA_HOME/aube/store/`
 - Environment: `npm_config_store_dir`, `NPM_CONFIG_STORE_DIR`, `AUBE_STORE_DIR`
 - .npmrc keys: `store-dir`, `storeDir`
 - Workspace YAML keys: `storeDir`
 
 Defaults to aube's own XDG-compliant store path
-(`$XDG_DATA_HOME/aube/store/v1/files/`, falling back to
-`~/.local/share/aube/store/v1/files/`). aube does not read from or write to
+(`$XDG_DATA_HOME/aube/store/`, falling back to
+`~/.local/share/aube/store/`). aube does not read from or write to
 pnpm's `~/.pnpm-store/`. Set in `.npmrc` or `aube-workspace.yaml` to point at
 a different directory, which is useful for isolating CI runners, putting the
 store on a faster disk, or sharing one store across multiple users on the
@@ -859,12 +859,16 @@ same host.
 
 Path interpretation matches pnpm: `~` expands to the user's home
 directory and a relative path is resolved against the project root,
-not the current working directory. aube appends its own CAS schema suffix
-(`v1/files`) to the user-supplied directory, so `store-dir=/srv/aube-store`
-stores package content under `/srv/aube-store/v1/files`.
+not the current working directory. aube appends its own schema suffix
+(`v1`) to the user-supplied directory, so `store-dir=/srv/aube-store`
+stores package content under `/srv/aube-store/v1/files/` and cached
+package indexes under `/srv/aube-store/v1/index/`. `aube store path`
+prints the `v1/` directory itself — a single backup or Docker
+BuildKit cache mount of that path captures both files and indexes,
+matching `pnpm store path` granularity.
 
-Only the on-disk CAS moves; the packument and virtual-store caches
-stay at `$XDG_CACHE_HOME/aube`.
+Only the on-disk store moves; the packument cache (regenerable from
+the registry) stays at `$XDG_CACHE_HOME/aube`.
 
 Examples:
 

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -76,11 +76,14 @@ teardown() {
 	assert_dir_exists "$aube_store/v1/files"
 
 	# Wipe the store but leave node_modules intact — the case the
-	# `AlreadyLinked` shortcut would have silently broken.
+	# `AlreadyLinked` shortcut would have silently broken. The
+	# `v1/` removal takes the cached package indexes (under `v1/index`)
+	# with it, so `load_index` is forced to fall through to a real
+	# tarball fetch when the store file is missing.
 	rm -rf "$aube_store"
-	# Also clear the per-package index cache so `load_index` is
-	# forced to fall through to a real tarball fetch when the
-	# store file is missing.
+	# Belt-and-suspenders: also clear the legacy XDG-cache index dir
+	# in case the user is on an older aube that hadn't run the
+	# one-shot in-store migration yet.
 	rm -rf "$HOME/.cache/aube/index"
 
 	# `aube fetch` must re-download + repopulate the store, not

--- a/test/install.bats
+++ b/test/install.bats
@@ -1179,3 +1179,57 @@ JSON
 	assert_output --partial "    devDependencies:
       is-odd:"
 }
+
+@test "aube install self-heals when a CAS shard goes missing under a cached index" {
+	# Regression for the BuildKit cache-mount class (endevco/aube#345):
+	# a stale cached package index points at a CAS shard that's been
+	# pruned out from under it (foreign sync tool, partial wipe, a
+	# cache-mount that only covered part of the store, etc.). The fast
+	# `load_index` probe only checks the first file in the index, so
+	# corruption past that point used to slip through and the
+	# materializer would die mid-link with `ERR_AUBE_MISSING_STORE_FILE`.
+	#
+	# The verified probe on the install fetch fast path walks every
+	# file, drops the stale index, and re-fetches the tarball — the
+	# install completes without any user-visible recovery dance.
+	_setup_basic_fixture
+	run aube install
+	assert_success
+
+	store_v1="$(aube store path)"
+	# Pick one cached index, then delete the CAS shard for a NON-first
+	# file inside it. The first file would be caught by the old cheap
+	# probe; this test exercises the gap that the verified probe closes.
+	index="$(find "$store_v1/index" -name '*.json' -print -quit)"
+	assert_file_exists "$index"
+	# Jump to the second `store_path` entry — the index is JSON keyed by
+	# file path, and BTreeMap serialization preserves lexicographic key
+	# order, so entry #2 is reliably past the first-file probe horizon.
+	victim="$(grep -o '"store_path":"[^"]*"' "$index" | sed -n '2p' | sed 's/.*":"//;s/"$//')"
+	assert_file_exists "$victim"
+	rm "$victim"
+
+	# Wipe both node_modules AND the global virtual store. The GVS at
+	# `$XDG_CACHE_HOME/aube/virtual-store/` holds hardlinks back to the
+	# (deleted) CAS path, and `ensure_in_virtual_store` short-circuits
+	# on `pkg_nm_dir.exists()` — leaving the GVS in place would let the
+	# materializer skip the broken package entirely and mask the very
+	# bug this test exists to catch.
+	rm -rf node_modules "$XDG_CACHE_HOME/aube/virtual-store"
+
+	# Without the verified probe, this install would fail with
+	# `ERR_AUBE_MISSING_STORE_FILE` from the GVS prewarm path; with
+	# the fix, the fetch fast path drops the stale index, the tarball
+	# gets re-fetched against the offline Verdaccio, and the install
+	# completes cleanly.
+	run aube install
+	assert_success
+	assert_dir_exists node_modules/.aube
+
+	# The previously-missing shard must be back in the store after the
+	# self-heal. We can't assert the exact path (the re-fetched tarball
+	# may BLAKE3 to a different shard if the tarball/file bytes differ),
+	# but the CAS root must still contain at least one file.
+	shard_count="$(find "$store_v1/files" -type f | wc -l | tr -d ' ')"
+	[ "$shard_count" -gt 0 ]
+}

--- a/test/store.bats
+++ b/test/store.bats
@@ -18,24 +18,27 @@ teardown() {
 	assert_output --partial "add"
 }
 
-@test "aube store path defaults to \$XDG_DATA_HOME/aube/store" {
+@test "aube store path defaults to \$XDG_DATA_HOME/aube/store/v1" {
 	run aube store path
 	assert_success
-	# HOME is isolated to the test temp dir and XDG_DATA_HOME points
-	# inside it, so the resolved store path must match exactly.
-	assert_output "$XDG_DATA_HOME/aube/store/v1/files"
+	# `aube store path` prints the store-version directory containing
+	# both `files/` (CAS) and `index/` (cached indexes), matching the
+	# granularity of `pnpm store path`. HOME is isolated to the test
+	# temp dir and XDG_DATA_HOME points inside it, so the resolved
+	# path must match exactly.
+	assert_output "$XDG_DATA_HOME/aube/store/v1"
 }
 
-@test "aube store path honors store-dir from .npmrc and appends v1/files" {
+@test "aube store path honors store-dir from .npmrc and appends v1" {
 	mkdir -p custom-store
 	echo "store-dir=$PWD/custom-store" >.npmrc
 	run aube store path
 	assert_success
-	# aube appends its own CAS schema suffix (`v1/files`) to the
-	# user-supplied store-dir. The suffix exists so the on-disk layout
-	# is stable across versions of aube and never collides with a pnpm
-	# store rooted at the same path.
-	assert_output "$PWD/custom-store/v1/files"
+	# aube appends its own schema suffix (`v1`) to the user-supplied
+	# store-dir. The suffix exists so the on-disk layout is stable
+	# across versions of aube and never collides with a pnpm store
+	# rooted at the same path.
+	assert_output "$PWD/custom-store/v1"
 }
 
 @test "aube store path honors storeDir from pnpm-workspace.yaml" {
@@ -45,14 +48,14 @@ storeDir: $PWD/ws-store
 EOF
 	run aube store path
 	assert_success
-	assert_output "$PWD/ws-store/v1/files"
+	assert_output "$PWD/ws-store/v1"
 }
 
 @test "aube store path expands ~ in store-dir to \$HOME" {
 	echo 'store-dir=~/custom-home-store' >.npmrc
 	run aube store path
 	assert_success
-	assert_output "$HOME/custom-home-store/v1/files"
+	assert_output "$HOME/custom-home-store/v1"
 }
 
 @test "aube store add fetches a package and subsequent install is warm" {
@@ -63,9 +66,10 @@ EOF
 	assert_output --partial "is-odd@3.0.1"
 
 	# The cached index should exist for the added package. The
-	# on-disk layout is `$HOME/.cache/aube/index/<16 hex>/<name>@<ver>.json`
-	# — find any such file matching the name and version.
-	run bash -c 'compgen -G "$HOME/.cache/aube/index/*/is-odd@3.0.1.json"'
+	# on-disk layout is `$STORE_V1/index/<16 hex>/<name>@<ver>.json`,
+	# where the store-version directory is what `aube store path` prints.
+	store_v1="$(aube store path)"
+	run bash -c "compgen -G \"$store_v1/index/*/is-odd@3.0.1.json\""
 	assert_success
 
 	# Also sanity-check `store status` returns clean after an add.
@@ -86,9 +90,10 @@ EOF
 
 	# Pick one of the files the cached index points at and corrupt it.
 	# Integrity-keyed entries live at
-	# `<index>/<16 hex>/<name>@<ver>.json` — walk two levels to find
-	# the actual file.
-	index="$(find "$HOME/.cache/aube/index" -mindepth 2 -maxdepth 2 -name 'is-odd@3.0.1.json' -print -quit)"
+	# `<store_v1>/index/<16 hex>/<name>@<ver>.json` — walk two levels
+	# to find the actual file.
+	store_v1="$(aube store path)"
+	index="$(find "$store_v1/index" -mindepth 2 -maxdepth 2 -name 'is-odd@3.0.1.json' -print -quit)"
 	assert_file_exists "$index"
 	store_path="$(grep -o '"store_path":"[^"]*"' "$index" | head -n1 | sed 's/.*":"//;s/"$//')"
 	echo "garbage" >"$store_path"
@@ -111,9 +116,10 @@ EOF
 	# Drop the cached index so every file the `add` just wrote becomes
 	# unreferenced. Without this the prune loop would `continue` on every
 	# file and never exercise the deletion branch. Integrity-keyed
-	# files live under `<16 hex>/<name>@<ver>.json` — glob the whole
-	# subdir layout.
-	rm "$HOME/.cache/aube/index"/*/is-odd@3.0.1.json
+	# files live under `<store_v1>/index/<16 hex>/<name>@<ver>.json` —
+	# glob the whole subdir layout.
+	store_v1="$(aube store path)"
+	rm "$store_v1/index"/*/is-odd@3.0.1.json
 
 	run aube store prune
 	assert_success


### PR DESCRIPTION
## Summary

- Move cached package indexes from `$XDG_CACHE_HOME/aube/index/` into the store at `$XDG_DATA_HOME/aube/store/v1/index/`, next to `v1/files/`. `aube store path` now returns the `v1/` directory — same granularity as `pnpm store path`, so a single backup or Docker BuildKit cache mount captures the whole store. Lazy in-place migration on first store open after upgrade (rename fast path, recursive-copy fallback for cross-FS).
- Switch the install fetch fast path from `load_index` to `load_index_verified` so a stale cached index whose CAS shards have drifted out from under it is dropped at fetch classification time and the tarball is re-fetched cleanly — instead of letting the materializer die mid-link with `ERR_AUBE_MISSING_STORE_FILE`.

Together these address the BuildKit cache-mount footgun reported in [discussion #345](https://github.com/endevco/aube/discussions/345#discussioncomment-16892176): the layout change prevents drift by construction, the verified probe is the defensive backstop for any other cause (foreign sync tools, partial cache corruption, etc.).

## Why two layers

| Layer | Behavior | Cost |
| --- | --- | --- |
| Layout (v1/index next to v1/files) | One mount/backup captures both. No drift possible if user follows `aube store path`. | ~0; one-time migration is best-effort. |
| Verified probe at fetch | Walks every file in a cache-hit index, drops stale ones, falls through to NeedsFetch. | Stat-per-file paid only on cache hit; ~30k stats sub-30ms on the medium fixture. |

The marked-breaking commit on the layout change is conservative: `aube store path` output changes from `…/v1/files` to `…/v1`. Scripts that consume it would now mount one level higher, which is the intended behaviour — but it's a visible CLI output change so the commit is `refactor(store)!`.

## Test plan

- [x] `cargo test --workspace --lib` (90 → 91 aube-store unit tests; new ones cover migration relocate / new-exists-noop / legacy-absent-noop / store_v1_dir layout / partial-corruption probe rejection)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `mise run test:bats test/store.bats` (10/10, including updated `aube store path` assertions)
- [x] `mise run test:bats test/fetch.bats` (13/13, including the post-wipe re-fetch path that now uses the verified probe)
- [x] `mise run test:bats test/install.bats` (66 existing + 1 new regression that asserts install self-heals when a non-first CAS shard goes missing under a cached index; confirmed the new test fails when the verified-probe upgrade is reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes on-disk store layout/CLI output (`aube store path`) and adds a best-effort migration plus stricter cache-hit validation that can alter install behavior (more refetching) if bugs occur.
> 
> **Overview**
> **Co-locates cached package indexes with the CAS store** by moving index files from `$XDG_CACHE_HOME/aube/index/` into the store under `<store>/v1/index/` (next to `v1/files/`). `storeDir` defaults/semantics are updated so `aube store path` now prints the `v1/` directory, and `Store` performs a one-shot best-effort migration from the legacy cache location (rename with cross-filesystem copy fallback).
> 
> **Hardens install/fetch against stale indexes** by switching the install fast paths to use `load_index_verified`, dropping cached indexes whose referenced CAS shards are missing so the tarball is re-fetched instead of failing later during materialization. Docs, help text, warnings, and BATS/unit tests are updated to match the new layout and to cover the migration and self-heal regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eeca60e92a365524b38de1be496c285703f1f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->