### PR TITLE
fix(update): preserve cross-platform optionals and time entries

### DIFF
--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -1704,10 +1704,24 @@ impl Resolver {
                 // (v5.15.1+) and full-packument fetches do include it,
                 // and then we round-trip it into the lockfile just like
                 // pnpm does.
-                if self.should_record_times()
-                    && let Some(t) = picked_publish_time.as_ref()
-                {
-                    resolved_times.insert(dep_path.clone(), t.clone());
+                //
+                // Fall back to the prior lockfile's time when the
+                // packument doesn't carry one — `aube update` filters
+                // direct deps out of `existing.packages` to force a
+                // fresh resolve, so the lockfile-reuse fallback further
+                // up doesn't fire for them. Without this fallback the
+                // resolver-fetched corgi (no time) would silently drop
+                // the dep's `time:` entry on every update, even when
+                // the version didn't change. Reported in discussion
+                // #345 (mrazauskas).
+                if self.should_record_times() {
+                    if let Some(t) = picked_publish_time.as_ref() {
+                        resolved_times.insert(dep_path.clone(), t.clone());
+                    } else if let Some(g) = existing
+                        && let Some(t) = g.times.get(&dep_path)
+                    {
+                        resolved_times.insert(dep_path.clone(), t.clone());
+                    }
                 }
 
                 // Record root dep

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -33,12 +33,11 @@ use lifecycle::{
     validate_required_scripts,
 };
 pub(crate) use settings::PeerDependencyRules;
-pub(crate) use settings::{resolve_dependency_policy, resolve_force_metadata_primer};
+pub(crate) use settings::{ResolverConfigInputs, configure_resolver};
 pub(crate) use side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root};
 
 use settings::{
-    ResolverConfigInputs, check_unmet_peers, configure_resolver,
-    default_lockfile_network_concurrency, default_streaming_network_concurrency,
+    check_unmet_peers, default_lockfile_network_concurrency, default_streaming_network_concurrency,
     detect_aube_dir_gvs_mode, find_gvs_incompatible_trigger, maybe_cleanup_unused_catalogs,
     resolve_dedupe_peer_dependents, resolve_dedupe_peers, resolve_git_shallow_hosts,
     resolve_link_concurrency, resolve_network_concurrency, resolve_peers_from_workspace_root,
@@ -2815,7 +2814,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 settings_ctx: &settings_ctx,
                 workspace_config: &ws_config_shared,
                 workspace_catalogs: &workspace_catalogs,
-                opts: &opts,
+                minimum_release_age_override: opts.minimum_release_age_override,
                 // `lockfile=false` collapses to `None` so the resolver
                 // doesn't waste a fetch widening a lockfile that will
                 // never be written. With lockfiles enabled, a missing
@@ -2824,6 +2823,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 // applies.
                 target_lockfile_kind: lockfile_enabled
                     .then(|| source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube)),
+                cache_full_packuments: true,
             },
             read_package_hook,
         );
@@ -3459,13 +3459,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     settings_ctx: &settings_ctx,
                     workspace_config: &ws_config_shared,
                     workspace_catalogs: &workspace_catalogs,
-                    opts: &opts,
+                    minimum_release_age_override: opts.minimum_release_age_override,
                     // Same disambiguation as the `--lockfile-only` path:
                     // `None` only when no lockfile will be written, so
                     // widening to every common platform doesn't happen
                     // just to be discarded.
                     target_lockfile_kind: lockfile_enabled
                         .then(|| source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube)),
+                    cache_full_packuments: true,
                 },
                 read_package_hook,
             );

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -1,5 +1,5 @@
 use super::super::{packument_cache_dir, packument_full_cache_dir};
-use super::{InstallOptions, version_from_dep_path};
+use super::version_from_dep_path;
 use miette::miette;
 use std::collections::BTreeMap;
 
@@ -614,12 +614,25 @@ fn read_peer_dependencies_meta(
 /// the streaming main path and the `--lockfile-only` short-circuit.
 /// Both paths must produce identical lockfiles, so any new resolver
 /// option should land here rather than only in one branch.
-pub(super) struct ResolverConfigInputs<'a> {
-    pub(super) settings_ctx: &'a aube_settings::ResolveCtx<'a>,
-    pub(super) workspace_config: &'a aube_manifest::workspace::WorkspaceConfig,
-    pub(super) workspace_catalogs:
+///
+/// Also reused by `add`/`remove`/`update`/`dedupe`/`audit` via
+/// `super::build_resolver` so those commands resolve under the same
+/// settings install does — historically those went through a stripped
+/// `Resolver::new + with_dependency_policy` shim that silently dropped
+/// `supportedArchitectures`, `resolutionMode`, `minimumReleaseAge`,
+/// `autoInstallPeers`, overrides, and friends. Concrete fallout:
+/// `aube update` was rewriting the lockfile with host-only optional
+/// deps (collapsing `@biomejs/biome` / `rollup` platform variants) and
+/// dropping `time:` entries for not-updated direct deps.
+pub(crate) struct ResolverConfigInputs<'a> {
+    pub(crate) settings_ctx: &'a aube_settings::ResolveCtx<'a>,
+    pub(crate) workspace_config: &'a aube_manifest::workspace::WorkspaceConfig,
+    pub(crate) workspace_catalogs:
         &'a std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
-    pub(super) opts: &'a InstallOptions,
+    /// CLI-supplied `--minimum-release-age` override in minutes. Only
+    /// `aube install` exposes the flag today; every other caller passes
+    /// `None` and gets the settings-chain value.
+    pub(crate) minimum_release_age_override: Option<u64>,
     /// Lockfile format aube will write on the way out, or `None` when
     /// `lockfile=false` and no lockfile will be written at all. Drives
     /// whether the resolver widens its platform filter to cover every
@@ -631,10 +644,24 @@ pub(super) struct ResolverConfigInputs<'a> {
     /// `None` skips widening entirely — nothing consumes the extra
     /// resolutions. Callers compute this as
     /// `lockfile_enabled.then(|| source_kind_before.unwrap_or(Aube))`.
-    pub(super) target_lockfile_kind: Option<aube_lockfile::LockfileKind>,
+    pub(crate) target_lockfile_kind: Option<aube_lockfile::LockfileKind>,
+    /// When `true`, the resolver caches full (non-corgi) packuments on
+    /// disk so the next install/update can reuse them without a
+    /// round-trip. Install opts in (`true`) to amortize the cost of
+    /// fetching potentially thousands of full packuments. Update /
+    /// add / dedupe / audit (via `super::build_resolver`) opt out
+    /// (`false`) so that re-resolving immediately after a registry
+    /// dist-tag change picks up the new latest instead of serving the
+    /// previous run's cached packument within its `Cache-Control`
+    /// freshness window. The abbreviated cache stays on either way —
+    /// it's keyed off `(name, registry)` and revalidates per request,
+    /// so dist-tag drift is observed there too, but the freshness
+    /// window only matters when `needs_time` routes through the full
+    /// cache.
+    pub(crate) cache_full_packuments: bool,
 }
 
-pub(super) fn configure_resolver(
+pub(crate) fn configure_resolver(
     resolver: aube_resolver::Resolver,
     cwd: &std::path::Path,
     manifest: &aube_manifest::PackageJson,
@@ -645,8 +672,9 @@ pub(super) fn configure_resolver(
         settings_ctx,
         workspace_config,
         workspace_catalogs,
-        opts,
+        minimum_release_age_override,
         target_lockfile_kind,
+        cache_full_packuments,
     } = inputs;
     let auto_install_peers = resolve_auto_install_peers(settings_ctx);
     let exclude_links_from_lockfile = resolve_exclude_links_from_lockfile(settings_ctx);
@@ -726,7 +754,7 @@ pub(super) fn configure_resolver(
     }
     let resolution_mode = resolve_resolution_mode(settings_ctx);
     let minimum_release_age =
-        resolve_minimum_release_age(settings_ctx, opts.minimum_release_age_override);
+        resolve_minimum_release_age(settings_ctx, minimum_release_age_override);
     if let Some(ref mra) = minimum_release_age {
         tracing::debug!(
             "minimumReleaseAge: {} min, {} excluded, strict={}",
@@ -739,8 +767,11 @@ pub(super) fn configure_resolver(
     let packument_concurrency = resolve_network_concurrency(settings_ctx);
     let mut resolver = resolver
         .with_packument_network_concurrency(packument_concurrency)
-        .with_packument_cache(packument_cache_dir())
-        .with_packument_full_cache(packument_full_cache_dir())
+        .with_packument_cache(packument_cache_dir());
+    if cache_full_packuments {
+        resolver = resolver.with_packument_full_cache(packument_full_cache_dir());
+    }
+    let mut resolver = resolver
         .with_auto_install_peers(auto_install_peers)
         .with_peers_suffix_max_length(peers_suffix_max_length)
         .with_exclude_links_from_lockfile(exclude_links_from_lockfile)

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -513,30 +513,68 @@ pub(crate) async fn run_pnpmfile_pre_resolution(
         .wrap_err("pnpmfile preResolution hook failed")
 }
 
-/// Build the standard resolver used by add/remove/update/dedupe: a
-/// shared `RegistryClient` wrapped in `Arc`, the shared packument
-/// cache directory, the given catalog map, and the dependency policy
-/// resolved from `.npmrc` / workspace yaml. Without applying the
-/// policy here `blockExoticSubdeps=false` (and other policy bits)
-/// gets honored by `aube install` but ignored by `aube add` — the
-/// install pipeline runs `configure_resolver` while these commands
-/// re-resolve manifests through this stripped-down builder.
+/// Build the standard resolver used by add/remove/update/dedupe/audit.
+/// Internally routes through install's `configure_resolver` so every
+/// setting `aube install` plumbs — `supportedArchitectures`,
+/// `resolutionMode`, `minimumReleaseAge`, `autoInstallPeers`,
+/// `dedupePeerDependents`, overrides, `ignoredOptionalDependencies`,
+/// peer suffix length, git shallow hosts, network concurrency — lands
+/// here too. Skipping this caused `aube update` to rewrite the
+/// lockfile against host-only `supportedArchitectures` (collapsing
+/// platform-variant optional deps like `@biomejs/biome-*` /
+/// `@rollup/rollup-linux-*`) and to drop `time:` entries for direct
+/// deps reused from the lockfile (the resolver only records times
+/// when `resolutionMode=time-based` / `minimumReleaseAge` is on /
+/// `trustPolicy=no-downgrade`, and none of those were threaded
+/// through here).
+///
+/// Reads `.npmrc` + workspace yaml once via `with_settings_ctx`,
+/// detects the existing lockfile kind so the platform-widening
+/// behaves identically to the install that wrote that lockfile, and
+/// passes `minimum_release_age_override = None` since these commands
+/// don't expose `--minimum-release-age` today.
 pub(crate) fn build_resolver(
     cwd: &std::path::Path,
     manifest: &aube_manifest::PackageJson,
     catalogs: CatalogMap,
 ) -> aube_resolver::Resolver {
-    let (policy, force_metadata_primer) = with_settings_ctx(cwd, |ctx| {
-        (
-            install::resolve_dependency_policy(manifest, ctx),
-            install::resolve_force_metadata_primer(ctx),
-        )
-    });
-    aube_resolver::Resolver::new(std::sync::Arc::new(make_client(cwd)))
+    let (ws_config, raw_workspace) = aube_manifest::workspace::load_both(cwd).unwrap_or_default();
+    let files = FileSources::load(cwd);
+    let env = aube_settings::values::process_env();
+    let ctx = files.ctx(&raw_workspace, env, &[]);
+    // `aube update` and friends always rewrite a lockfile, so pick a
+    // target kind. Detect the existing format to match install's
+    // cross-platform widening rules — a project on `pnpm-lock.yaml`
+    // keeps pnpm's host-only optional set, `aube-lock.yaml` gets the
+    // wide aube default.
+    let target_lockfile_kind = Some(
+        aube_lockfile::detect_existing_lockfile_kind(cwd)
+            .unwrap_or(aube_lockfile::LockfileKind::Aube),
+    );
+    let resolver = aube_resolver::Resolver::new(std::sync::Arc::new(make_client(cwd)))
         .with_packument_cache(packument_cache_dir())
-        .with_catalogs(catalogs)
-        .with_dependency_policy(policy)
-        .with_force_metadata_primer(force_metadata_primer)
+        .with_catalogs(catalogs.clone());
+    install::configure_resolver(
+        resolver,
+        cwd,
+        manifest,
+        install::ResolverConfigInputs {
+            settings_ctx: &ctx,
+            workspace_config: &ws_config,
+            workspace_catalogs: &catalogs,
+            minimum_release_age_override: None,
+            target_lockfile_kind,
+            // Update / add / dedupe / audit deliberately skip the
+            // full-packument disk cache install populates: the cache's
+            // freshness window can outlive a registry dist-tag bump,
+            // and these commands need to observe `latest` exactly as
+            // it stands right now (pnpm_update.bats simulates this by
+            // mutating `dist-tags` between commands). The abbreviated
+            // cache stays on either way.
+            cache_full_packuments: false,
+        },
+        None,
+    )
 }
 
 /// Resolve [`aube_registry::config::FetchPolicy`] from the same

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -551,11 +551,8 @@ pub(crate) fn build_resolver(
         aube_lockfile::detect_existing_lockfile_kind(cwd)
             .unwrap_or(aube_lockfile::LockfileKind::Aube),
     );
-    let resolver = aube_resolver::Resolver::new(std::sync::Arc::new(make_client(cwd)))
-        .with_packument_cache(packument_cache_dir())
-        .with_catalogs(catalogs.clone());
     install::configure_resolver(
-        resolver,
+        aube_resolver::Resolver::new(std::sync::Arc::new(make_client(cwd))),
         cwd,
         manifest,
         install::ResolverConfigInputs {

--- a/test/update.bats
+++ b/test/update.bats
@@ -288,3 +288,121 @@ EOF
 	run aube update --lockfile-only --frozen-lockfile
 	assert_failure
 }
+
+# Regression for discussion #345 (mrazauskas): `aube update` was
+# stripping non-host platform-locked optional deps from the lockfile
+# because `super::build_resolver` constructed a stripped-down resolver
+# that never received `supportedArchitectures` from install's settings
+# pipeline. The bug collapsed packages like `@biomejs/biome` /
+# `rollup` to one platform binary each, breaking cross-platform CI.
+@test "aube update preserves cross-platform optional deps in lockfile" {
+	cat >package.json <<-'JSON'
+		{
+		  "name": "update-cross-platform",
+		  "version": "0.0.0",
+		  "optionalDependencies": {
+		    "aube-test-optional-win32": "1.0.0"
+		  }
+		}
+	JSON
+	run aube install --no-frozen-lockfile
+	assert_success
+	# Sanity: install widens supportedArchitectures and writes the
+	# win32-only optional into the committed lockfile even on
+	# Linux/macOS hosts. Without this baseline the regression test
+	# below has nothing to preserve.
+	run grep -F 'aube-test-optional-win32@1.0.0' aube-lock.yaml
+	assert_success
+
+	# The actual regression: `aube update` should re-resolve under
+	# the same widened platform filter install used, so the optional
+	# entry survives the rewrite.
+	run aube update
+	assert_success
+	run grep -F 'aube-test-optional-win32@1.0.0' aube-lock.yaml
+	assert_success
+}
+
+# Companion regression for discussion #345: `aube update` was dropping
+# `time:` entries for direct deps from the rewritten lockfile because
+# (a) the stripped-down `build_resolver` skipped install-time settings
+# and (b) `aube update`'s `filtered_existing` strips direct deps from
+# `existing.packages` to force a fresh re-resolve, so the lockfile-
+# reuse path's time-carry-forward never fired for them. Transitive
+# deps stayed in `existing.packages` and kept their times — the
+# asymmetry @mrazauskas flagged.
+@test "aube update preserves time: entries for direct deps" {
+	# `^0.1.0` is the only spec that exposes the bug cleanly: `>=0.1.0`
+	# would bump is-odd to 3.0.1 and the resolver would (correctly)
+	# write a fresh `time:` entry for the new version, masking the
+	# regression. With `^0.1.0` the highest in-range version equals
+	# the locked one (0.1.2), so the resolver re-resolves to the
+	# same version and the `time:` entry must round-trip.
+	cat >package.json <<-'JSON'
+		{
+		  "name": "update-time-preserve",
+		  "version": "0.0.0",
+		  "dependencies": {
+		    "is-odd": "^0.1.0"
+		  }
+		}
+	JSON
+	cat >aube-lock.yaml <<-'EOF'
+		lockfileVersion: '9.0'
+
+		settings:
+		  autoInstallPeers: true
+		  excludeLinksFromLockfile: false
+
+		time:
+		  is-odd@0.1.2: '2099-01-02T00:00:00.000Z'
+		  is-number@3.0.0: '2099-01-03T00:00:00.000Z'
+		  kind-of@3.2.2: '2099-01-04T00:00:00.000Z'
+
+		importers:
+		  .:
+		    dependencies:
+		      is-odd:
+		        specifier: ^0.1.0
+		        version: 0.1.2
+
+		packages:
+		  is-number@3.0.0:
+		    resolution: {integrity: sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==}
+		  is-odd@0.1.2:
+		    resolution: {integrity: sha512-Ri7C2K7o5IrUU9UEI8losXJCCD/UtsaIrkR5sxIcFg4xQ9cRJXlWA5DQvTE0yDc0krvSNLsRGXN11UPS6KyfBw==}
+		  kind-of@3.2.2:
+		    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
+
+		snapshots:
+		  is-number@3.0.0:
+		    dependencies:
+		      kind-of: 3.2.2
+		  is-odd@0.1.2:
+		    dependencies:
+		      is-number: 3.0.0
+		  kind-of@3.2.2: {}
+	EOF
+
+	run aube update
+	assert_success
+
+	# Every locked dep — direct AND transitive — must keep a `time:`
+	# entry after the rewrite. We can't pin the timestamp value
+	# because the resolver may have refreshed it from the packument
+	# during re-resolve, but the entry MUST be present. The
+	# pre-fix bug dropped the is-odd line entirely while leaving the
+	# transitive entries intact.
+	#
+	# The character after the colon-space distinguishes a `time:`
+	# block entry (`  is-odd@0.1.2: <ISO>` — pnpm-style writers may
+	# quote or omit quotes depending on YAML rules) from a
+	# `packages:`/`snapshots:` key (`  is-odd@0.1.2:` followed by
+	# EOL or `{...}`). A non-empty char after `: ` is enough.
+	run grep -E "^  is-odd@0\.1\.2: [^[:space:]]" aube-lock.yaml
+	assert_success
+	run grep -E "^  is-number@3\.0\.0: [^[:space:]]" aube-lock.yaml
+	assert_success
+	run grep -E "^  kind-of@3\.2\.2: [^[:space:]]" aube-lock.yaml
+	assert_success
+}


### PR DESCRIPTION
## Summary

- Route `aube update`, `add`, `dedupe`, `remove`, `audit` through install's `configure_resolver` so they inherit the full settings pipeline (`supportedArchitectures`, `resolutionMode`, `minimumReleaseAge`, `autoInstallPeers`, overrides, etc.).
- Opt these non-install commands out of the full-packument disk cache so an immediately-following re-resolve picks up registry `dist-tag` changes rather than serving the previous run's cache within its freshness window.
- Carry forward the prior lockfile's `time:` entry when a fresh corgi packument lacks a publish time for the resolved version, so direct deps don't lose their `time:` line on update.

Reported in [#345](https://github.com/endevco/aube/discussions/345#discussioncomment-16889343) by @mrazauskas.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `mise run test:bats test/update.bats test/pnpm_update.bats test/pnpm_update_slow.bats test/install.bats test/add.bats test/dedupe.bats test/remove.bats test/audit.bats test/optional_platform.bats test/minimum_release_age.bats test/resolution_mode.bats test/outdated.bats test/overrides.bats test/catalogs.bats test/workspace.bats test/peer_deps.bats`
- [x] New regression bats: `aube update preserves cross-platform optional deps in lockfile`, `aube update preserves time: entries for direct deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes how `update`/`add`/`dedupe`/`remove`/`audit` configure the resolver and packument caching, which can alter lockfile output and version selection across workflows.
> 
> **Overview**
> Fixes lockfile rewrites from `aube update` (and related commands) by routing them through install’s shared `configure_resolver`, so they honor the full settings pipeline (notably cross-platform `supportedArchitectures`, `resolutionMode`/`minimumReleaseAge`, overrides, and peer/optional handling).
> 
> Adjusts resolver configuration to **disable full-packument disk caching** for non-install commands (to avoid stale dist-tag resolution), while `install` keeps it enabled for performance.
> 
> Updates the resolver to **carry forward `time:` entries from the prior lockfile** when a freshly fetched packument lacks publish-time metadata, preventing direct deps from losing timestamps on update; adds Bats regression tests covering both the cross-platform optional-dep preservation and `time:` round-tripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f3d1d3e655740c8ae3fd735324f54d65140761d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->