### PR TITLE
fix(install): hoist bun.lock peer-only packages before GC

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3181,11 +3181,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 &manifest,
                 &ws_config_shared,
             );
-            aube_resolver::platform::filter_graph(
-                &mut graph,
-                &supported_architectures,
-                &ignored_optional_deps,
-            );
             // npm/bun lockfiles serialize a flat, pre-hoisted tree
             // with no peer context — they rely on Node's upward
             // `node_modules/` walk to find peer deps, which the
@@ -3211,15 +3206,33 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // a packument fetch on the import path to graft peer
             // ranges back onto each `LockedPackage` — a deeper
             // change than this match arm.
-            if matches!(
+            //
+            // The hoist must run *before* `filter_graph`: bun records
+            // peer-only-installed packages (e.g. `@mui/material` when
+            // the importer only depends on `@textea/json-viewer`, which
+            // peers on MUI) in its packages map, but our bun parser
+            // doesn't merge those into the consumer's `dependencies`
+            // map. `filter_graph`'s GC walk only follows `dependencies`,
+            // so without the hoist running first it prunes every
+            // peer-only package as unreachable — and a post-prune hoist
+            // has nothing left to promote.
+            let needs_peer_pass = matches!(
                 kind,
                 aube_lockfile::LockfileKind::Npm
                     | aube_lockfile::LockfileKind::NpmShrinkwrap
                     | aube_lockfile::LockfileKind::Bun
-            ) {
-                let peer_pass_start = std::time::Instant::now();
-                let pkgs_before = graph.packages.len();
+            );
+            let peer_pass_start = std::time::Instant::now();
+            let pkgs_before = graph.packages.len();
+            if needs_peer_pass {
                 graph = aube_resolver::hoist_auto_installed_peers(graph);
+            }
+            aube_resolver::platform::filter_graph(
+                &mut graph,
+                &supported_architectures,
+                &ignored_optional_deps,
+            );
+            if needs_peer_pass {
                 let peer_options = aube_resolver::PeerContextOptions {
                     dedupe_peer_dependents: resolve_dedupe_peer_dependents(&settings_ctx),
                     dedupe_peers: resolve_dedupe_peers(&settings_ctx),

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3222,26 +3222,31 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     | aube_lockfile::LockfileKind::NpmShrinkwrap
                     | aube_lockfile::LockfileKind::Bun
             );
-            let peer_pass_telemetry = if needs_peer_pass {
-                let start = std::time::Instant::now();
-                let pkgs_before = graph.packages.len();
+            // Time the hoist on its own, then `filter_graph` runs untimed
+            // (it's not part of the peer pass), then apply is timed below.
+            // Snapshotting `pkgs_before` after `filter_graph` keeps the
+            // logged delta a pure measure of `apply_peer_contexts`'s
+            // additions, not filter_graph's prunes.
+            let mut hoist_elapsed: Option<std::time::Duration> = None;
+            if needs_peer_pass {
+                let hoist_start = std::time::Instant::now();
                 graph = aube_resolver::hoist_auto_installed_peers(graph);
-                Some((start, pkgs_before))
-            } else {
-                None
-            };
+                hoist_elapsed = Some(hoist_start.elapsed());
+            }
             aube_resolver::platform::filter_graph(
                 &mut graph,
                 &supported_architectures,
                 &ignored_optional_deps,
             );
-            if let Some((peer_pass_start, pkgs_before)) = peer_pass_telemetry {
+            if let Some(hoist_elapsed) = hoist_elapsed {
                 let peer_options = aube_resolver::PeerContextOptions {
                     dedupe_peer_dependents: resolve_dedupe_peer_dependents(&settings_ctx),
                     dedupe_peers: resolve_dedupe_peers(&settings_ctx),
                     resolve_from_workspace_root: resolve_peers_from_workspace_root(&settings_ctx),
                     peers_suffix_max_length: resolve_peers_suffix_max_length(&settings_ctx),
                 };
+                let pkgs_before = graph.packages.len();
+                let apply_start = std::time::Instant::now();
                 graph = aube_resolver::apply_peer_contexts(graph, &peer_options)
                     .map_err(|e| miette!("peer-context pass failed: {e}"))?;
                 tracing::debug!(
@@ -3249,7 +3254,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     kind,
                     pkgs_before,
                     graph.packages.len(),
-                    peer_pass_start.elapsed()
+                    hoist_elapsed + apply_start.elapsed()
                 );
             }
             let source_label = match kind {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3222,17 +3222,20 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     | aube_lockfile::LockfileKind::NpmShrinkwrap
                     | aube_lockfile::LockfileKind::Bun
             );
-            let peer_pass_start = std::time::Instant::now();
-            let pkgs_before = graph.packages.len();
-            if needs_peer_pass {
+            let peer_pass_telemetry = if needs_peer_pass {
+                let start = std::time::Instant::now();
+                let pkgs_before = graph.packages.len();
                 graph = aube_resolver::hoist_auto_installed_peers(graph);
-            }
+                Some((start, pkgs_before))
+            } else {
+                None
+            };
             aube_resolver::platform::filter_graph(
                 &mut graph,
                 &supported_architectures,
                 &ignored_optional_deps,
             );
-            if needs_peer_pass {
+            if let Some((peer_pass_start, pkgs_before)) = peer_pass_telemetry {
                 let peer_options = aube_resolver::PeerContextOptions {
                     dedupe_peer_dependents: resolve_dedupe_peer_dependents(&settings_ctx),
                     dedupe_peers: resolve_dedupe_peers(&settings_ctx),

--- a/fixtures/import-bun-peer-only-in-packages/bun.lock
+++ b/fixtures/import-bun-peer-only-in-packages/bun.lock
@@ -1,0 +1,17 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "import-bun-peer-only-in-packages",
+      "dependencies": {
+        "fdir": "6.5.0",
+      },
+    },
+  },
+  "packages": {
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+  }
+}

--- a/fixtures/import-bun-peer-only-in-packages/package.json
+++ b/fixtures/import-bun-peer-only-in-packages/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "import-bun-peer-only-in-packages",
+  "version": "1.0.0",
+  "dependencies": {
+    "fdir": "6.5.0"
+  }
+}

--- a/test/import.bats
+++ b/test/import.bats
@@ -119,6 +119,33 @@ teardown() {
 	assert_link_exists "${matches[0]}/node_modules/picomatch"
 }
 
+@test "aube install hoists peer-only packages from bun.lock that aren't in workspace deps" {
+	# Regression for bun.lock importer pruning peer-only-installed
+	# packages before the peer-hoist pass could promote them. The
+	# workspace declares only `fdir`, but bun has materialized
+	# `picomatch` in `packages:` because fdir peers on it. Before the
+	# fix, `filter_graph`'s GC walk ran first and dropped `picomatch`
+	# as unreachable from importers; the subsequent
+	# `hoist_auto_installed_peers` then had nothing to promote.
+	cp "$PROJECT_ROOT/fixtures/import-bun-peer-only-in-packages/package.json" .
+	cp "$PROJECT_ROOT/fixtures/import-bun-peer-only-in-packages/bun.lock" .
+
+	run aube install
+	assert_success
+
+	# Both packages should be installed and reachable from the root.
+	assert_dir_exists node_modules/fdir
+	assert_dir_exists node_modules/picomatch
+
+	# fdir's isolated dir should carry the peer-context suffix and
+	# wire picomatch as a sibling so fdir can resolve it from its
+	# own require() context.
+	local matches=(node_modules/.aube/fdir@6.5.0_picomatch@4.0.4*)
+	[ "${#matches[@]}" -eq 1 ] || fail "expected exactly one peer-qualified fdir dir, got: ${matches[*]}"
+	[ -d "${matches[0]}" ] || fail "peer-qualified fdir dir missing: ${matches[0]}"
+	assert_link_exists "${matches[0]}/node_modules/picomatch"
+}
+
 @test "aube install smoke installs messy bun.lock fixture and doesn't change lockfile" {
 	cp -R "$PROJECT_ROOT/fixtures/import-bun-messy/." .
 	cp bun.lock bun.lock.before


### PR DESCRIPTION
## Summary
- Fixes peer-only-installed packages (like `@mui/material`) being silently dropped when aube installs from a `bun.lock` whose workspace `dependencies:` doesn't list them directly.
- Root cause: `filter_graph`'s GC walk ran *before* `hoist_auto_installed_peers`, so the peers were pruned as unreachable from importers before the hoist could promote them to direct deps.
- Fix reorders the pipeline so the hoist for bun/npm-shaped lockfiles runs first, then `filter_graph` walks from the now-expanded direct deps.

## Repro
[johnpyp/2026-05-12-aube-mui-peer-repro](https://github.com/johnpyp/2026-05-12-aube-mui-peer-repro), reported in [discussion #345](https://github.com/endevco/aube/discussions/345#discussioncomment-16895257). Before the fix, `aube install` produced 6 packages and `@textea/json-viewer` couldn't resolve `@mui/material` / `@emotion/react` / `@emotion/styled`. After: 44 packages, all peers resolve.

## Test plan
- [x] New bats regression: `aube install hoists peer-only packages from bun.lock that aren't in workspace deps` with a fixture where only `fdir` is in workspace deps and `picomatch` (its peer) lives only in `bun.lock`'s `packages:` map.
- [x] All 22 existing import.bats pass.
- [x] All 66 install.bats pass.
- [x] `cargo test` (478 aube + 178 aube-resolver + 5 aube-lockfile) green.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Manually reproduced and verified the original `aube-mui-peer-repro` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the lockfile-based install pipeline ordering for npm/bun imports, which can affect dependency graph pruning and peer resolution across platforms.
> 
> **Overview**
> Fixes `aube install` from `bun.lock` (and npm-shaped lockfiles) dropping *peer-only-installed* packages by running `hoist_auto_installed_peers` **before** `platform::filter_graph` GC, then applying peer contexts afterward.
> 
> Adds a new bun.lock fixture and a Bats regression test asserting peer-only packages present only in `bun.lock`’s `packages` map remain installed and correctly peer-qualified in the virtual store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62932075907ff8df26f72a4d7c2be647c9b8b12e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->