### PR TITLE
perf(linker): cap default rayon pool at 8 threads on linux

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -504,8 +504,15 @@ pub fn default_linker_parallelism() -> usize {
     // workers busy. 8 covers the working set with headroom and trims
     // the thread-pool startup tail visible on small warm installs.
     // macOS keeps a tighter cap because per-thread Mach IPC overhead
-    // dominates on small jobs.
-    let default_limit = if cfg!(target_os = "macos") { 4 } else { 8 };
+    // dominates on small jobs. Other platforms (Windows, BSDs) stay
+    // at the prior 16 cap until we have profiling data for them.
+    let default_limit = if cfg!(target_os = "macos") {
+        4
+    } else if cfg!(target_os = "linux") {
+        8
+    } else {
+        16
+    };
 
     std::thread::available_parallelism()
         .map(|n| n.get())
@@ -545,7 +552,6 @@ fn with_link_pool<R: Send>(threads: usize, f: impl FnOnce() -> R + Send) -> R {
         None => f(),
     }
 }
-
 
 /// Strategy for linking files from the store to node_modules.
 #[derive(Debug, Clone, Copy)]

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -498,7 +498,14 @@ pub struct Linker {
 pub type Patches = std::collections::BTreeMap<String, String>;
 
 pub fn default_linker_parallelism() -> usize {
-    let default_limit = if cfg!(target_os = "macos") { 4 } else { 16 };
+    // Cap based on observed utilization, not core count. samply on a
+    // 1230-pkg fixture (Ryzen 9 7950X3D, 32 threads, warm linker pass)
+    // showed `wait_until_cold` at 74.7% inclusive — average ~4 of 16
+    // workers busy. 8 covers the working set with headroom and trims
+    // the thread-pool startup tail visible on small warm installs.
+    // macOS keeps a tighter cap because per-thread Mach IPC overhead
+    // dominates on small jobs.
+    let default_limit = if cfg!(target_os = "macos") { 4 } else { 8 };
 
     std::thread::available_parallelism()
         .map(|n| n.get())
@@ -538,6 +545,7 @@ fn with_link_pool<R: Send>(threads: usize, f: impl FnOnce() -> R + Send) -> R {
         None => f(),
     }
 }
+
 
 /// Strategy for linking files from the store to node_modules.
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Summary

samply on a 1230-pkg install (Ryzen 9 7950X3D, warm linker pass) showed `rayon_core::WorkerThread::wait_until_cold` at **74.7% inclusive** — average ~4 of 16 workers actually busy. The remainder was thread-pool overhead: post-clone init, parking/unparking churn, scheduler attention.

Halving the default linker cap from 16 → 8 on Linux keeps the working set covered with headroom and trims the idle-thread tail. macOS already ran at 4.

## Measurement

hyperfine on `benchmarks/fixture.package.json` (15 runs × 3 warmup, hermetic Verdaccio, warm store, `aube install --frozen-lockfile` against wiped node_modules), comparing `origin/main` cap=16 vs this PR cap=8 — same binary architecture, same machine, same registry:

| metric        | main (cap=16)      | this PR (cap=8)    | delta |
|---------------|--------------------|--------------------|-------|
| wall time     | 132.6 ± 2.9 ms     | 129.7 ± 3.5 ms     | **-2.2%** |
| user CPU      | 106.7 ms           | 116.5 ms           | +9.2% |
| **system CPU** | **586.8 ms**     | **397.2 ms**       | **-32%** |

Two independent hyperfine runs reproduced the same shape (first run was 134.4 vs 131.9 ms with system 621→435). Wall time savings are small because the warm linker is already fast; the headline is kernel-time savings — half the pthread_create / context-switch / scheduler work for the same throughput.

## Why this is safe

- The `link_concurrency` setting still overrides the default for users who want to dial up on storage that benefits from more parallelism (parallel network FS, very large monorepos on fast NVMe).
- All 77 `aube-linker` unit tests pass.
- The profile is the source of truth: 74.7% wait time at 16 threads says the work was already CPU-underutilized; no scenario where adding 8 idle threads would help linker throughput.

## What this is *not*

I also tried an eager linker-pool prewarm (separately measured). The sync version regressed wall time by 5% (blocks the tokio runtime). The async-spawn version was statistically indistinguishable from main. The actual lever is pool *size*, not when it spawns.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p aube-linker --lib` (77/77 passing)
- [x] hyperfine before/after on bamboo (Linux, 32-thread)
- [ ] benchmark refresh — wall time delta is within the noise floor of `mise run bench:bump`; the daily cron will pick up the new ratios naturally on next refresh

*This PR was prepared by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance-tuning change: reduces the default linker concurrency cap on Linux, which may slightly affect install throughput on some workloads but does not change linking correctness or override behavior.
> 
> **Overview**
> Adjusts `aube_linker::default_linker_parallelism()` to use a lower default thread cap on Linux (**16 → 8**), while keeping macOS at 4 and leaving other platforms at 16.
> 
> This changes the default seed used by the linker’s rayon pool/concurrency when users do not explicitly set `linkConcurrency`, aiming to reduce idle thread-pool overhead on typical Linux installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41e1b9aee7abce16c65162fb6f9e6ab7905d7bcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->