### PR TITLE
fix(release-plz): restore force-with-lease tracking ref for PR push

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -358,10 +358,13 @@ jobs:
           git add -A
           git commit -m "$MSG"
           # persist-credentials: false on checkout means we need to auth
-          # the push explicitly.
-          git push --force-with-lease \
-            "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" \
-            "HEAD:refs/heads/${BRANCH}"
+          # the push explicitly. Re-point origin (rather than pushing to
+          # a one-shot URL) so --force-with-lease has a remote-tracking
+          # ref to compare against; pushing to an unnamed URL leaves no
+          # tracking ref and git rejects every push with "stale info".
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          git fetch origin "$BRANCH" || true
+          git push --force-with-lease -u origin "HEAD:refs/heads/${BRANCH}"
 
       # Step 6: open the PR if it's new, or refresh its title if an
       # existing one is being reused. We keep the body minimal — the


### PR DESCRIPTION
## Summary

- [#631](https://github.com/endevco/aube/pull/631) switched the release-plz PR push from `origin` to a one-shot authenticated URL (needed because `persist-credentials: false` was added for zizmor compliance).
- Pushing to a one-shot URL leaves git with no remote-tracking ref, so `--force-with-lease` has nothing to lease against and rejects every push with `"stale info"`. Every release-plz PR run since #631 merged has failed at this step — e.g. [run 25758285227](https://github.com/endevco/aube/actions/runs/25758285227/job/75652469000) and [run 25756148074](https://github.com/endevco/aube/actions/runs/25756148074).
- Re-point `origin` to the authenticated URL and keep `-u origin` so the lease has a real tracking ref. Fetch the branch first (tolerating the first-run case where it doesn't exist yet) so the tracking ref is populated before push.

## Test plan

- [ ] Next push to `main` triggers release-plz; `Commit and push` step succeeds and `Create or update PR` runs.
- [ ] zizmor workflow still passes (no new credential-leak findings — the token URL was already present, just moved one line up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation’s git push mechanics in `.github/workflows/release-plz.yml`; if incorrect, `release-plz` PR updates could fail or overwrite the wrong branch, impacting the release process.
> 
> **Overview**
> Fixes the `release-plz` PR workflow push step to work with `--force-with-lease` when `persist-credentials: false` is used.
> 
> Instead of pushing to a one-shot authenticated URL, the job now repoints `origin` to the token-auth URL, fetches the target PR branch (tolerating first-run absence), and pushes with `--force-with-lease -u origin` so git has a remote-tracking ref to lease against.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2798217208b4ff7125bece05661f76c4b1e02637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->