### PR TITLE
perf(store): gate posix_fallocate and posix_fadvise by file size

### DIFF
--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1584,11 +1584,15 @@ const CAS_SMALL_FILE_THRESHOLD_DEFAULT: usize = 64 * 1024;
 #[cfg(target_os = "linux")]
 fn cas_small_file_threshold() -> usize {
     static THRESHOLD: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *THRESHOLD.get_or_init(|| {
-        std::env::var("AUBE_CAS_SMALL_FILE_THRESHOLD")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(CAS_SMALL_FILE_THRESHOLD_DEFAULT)
+    *THRESHOLD.get_or_init(|| match std::env::var("AUBE_CAS_SMALL_FILE_THRESHOLD") {
+        Err(_) => CAS_SMALL_FILE_THRESHOLD_DEFAULT,
+        Ok(raw) => raw.parse::<usize>().unwrap_or_else(|_| {
+            warn!(
+                "AUBE_CAS_SMALL_FILE_THRESHOLD={raw:?} is not a non-negative integer; \
+                 falling back to default {CAS_SMALL_FILE_THRESHOLD_DEFAULT}"
+            );
+            CAS_SMALL_FILE_THRESHOLD_DEFAULT
+        }),
     })
 }
 

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1564,6 +1564,34 @@ enum OTmpfileFallback {
     Hard(Error),
 }
 
+// Size threshold below which we skip both `posix_fallocate` and
+// `posix_fadvise(DONTNEED)` on the CAS write path. Both are
+// fixed-cost-per-call best-effort advisory syscalls whose benefits
+// (avoid ext4 fragmentation, evict pages) don't apply to small
+// writes — the kernel won't fragment a single-block write, and tiny
+// pages don't meaningfully pressure the cache. samply on a cold
+// 1230-pkg install pinned the two at ~4.4% + ~4.8% of self time
+// before this gate; gating to ≥64KB skips them for >95% of npm
+// tarball entries while preserving the original behavior on the
+// large files (typescript.js, monaco-editor, etc.) where it pays.
+//
+// Overridable via `AUBE_CAS_SMALL_FILE_THRESHOLD` (bytes). Set to 0
+// to restore the always-on behavior; set to a very large number to
+// effectively disable both syscalls.
+#[cfg(target_os = "linux")]
+const CAS_SMALL_FILE_THRESHOLD_DEFAULT: usize = 64 * 1024;
+
+#[cfg(target_os = "linux")]
+fn cas_small_file_threshold() -> usize {
+    static THRESHOLD: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *THRESHOLD.get_or_init(|| {
+        std::env::var("AUBE_CAS_SMALL_FILE_THRESHOLD")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(CAS_SMALL_FILE_THRESHOLD_DEFAULT)
+    })
+}
+
 // Open anonymous file in parent dir, write, linkat via /proc/self/fd.
 // Skips the tempfile unique-name probe and explicit fchmod. Falls
 // back via Unsupported on EOPNOTSUPP, ENOENT (no /proc), or EXDEV.
@@ -1608,10 +1636,17 @@ fn try_o_tmpfile_publish(path: &Path, bytes: &[u8]) -> Result<CasWriteOutcome, O
     // SAFETY: raw_fd is owned, OwnedFd closes on drop.
     let owned = unsafe { std::os::fd::OwnedFd::from_raw_fd(raw_fd) };
     let mut file = std::fs::File::from(owned);
+    let small_threshold = cas_small_file_threshold();
+    let is_large = bytes.len() >= small_threshold;
     // Best-effort fallocate so the kernel allocates contiguous extents
     // up front. Skips ext4 fragmentation churn on the next write.
     // EOPNOTSUPP and ENOSYS are fine, regular write_all handles them.
-    let _ = posix_fallocate(&file, bytes.len() as libc::off_t);
+    // Skipped below `small_threshold`: fragmentation only matters for
+    // multi-block writes, and most npm tarball entries are well under
+    // that. See `cas_small_file_threshold` for rationale.
+    if is_large {
+        let _ = posix_fallocate(&file, bytes.len() as libc::off_t);
+    }
     file.write_all(bytes)
         .map_err(|e| OTmpfileFallback::Hard(Error::Io(path.to_path_buf(), e)))?;
     // No sync_data: contradicts the no-fsync CAS policy. Crash window
@@ -1645,13 +1680,18 @@ fn try_o_tmpfile_publish(path: &Path, bytes: &[u8]) -> Result<CasWriteOutcome, O
     if r == 0 {
         // CAS bytes are read-once into reflinks/hardlinks. Drop them
         // from the page cache so the parallel linker pass over many
-        // packages doesn't push the working set out.
-        use std::os::fd::AsRawFd;
-        let fd = file.as_raw_fd();
-        // SAFETY: fd is still owned by `file` here. POSIX_FADV_DONTNEED
-        // is advisory, return value is ignored.
-        unsafe {
-            libc::posix_fadvise(fd, 0, 0, libc::POSIX_FADV_DONTNEED);
+        // packages doesn't push the working set out. Per-file cost is
+        // roughly fixed regardless of size, so small files paid a
+        // disproportionate share — gate on `small_threshold` to match
+        // the fallocate gate above.
+        if is_large {
+            use std::os::fd::AsRawFd;
+            let fd = file.as_raw_fd();
+            // SAFETY: fd is still owned by `file` here. POSIX_FADV_DONTNEED
+            // is advisory, return value is ignored.
+            unsafe {
+                libc::posix_fadvise(fd, 0, 0, libc::POSIX_FADV_DONTNEED);
+            }
         }
         return Ok(CasWriteOutcome::Created);
     }


### PR DESCRIPTION
## Summary

samply on a 1230-pkg true-cold install (Ryzen 9 7950X3D, fresh `XDG_DATA_HOME` + `XDG_CACHE_HOME`, hermetic Verdaccio) showed two best-effort advisory syscalls in the CAS write path costing ~9% of cold-install self-time:

| self % | syscall | purpose |
|---|---|---|
| 4.4% | `posix_fallocate+0x16` | preallocate extents to avoid ext4 fragmentation on large writes |
| 4.8% | `posix_fadvise+0xe` | `POSIX_FADV_DONTNEED` — evict from page cache after write |

Both rationales largely don't apply to npm's actual workload shape:

- **`posix_fallocate`** matters for multi-block writes on ext4. Average npm tarball entry is well under one block group; the kernel doesn't fragment a single-block write.
- **`posix_fadvise(DONTNEED)`** is meant to free page cache for other working sets. Per-file cost is roughly fixed (look up inode, walk pages, drop), so small files paid a disproportionate share. A one-shot install on modern hardware has plenty of cache headroom and the kernel reclaims under pressure anyway.

This PR gates both behind a size threshold (default **64 KiB**, overridable via `AUBE_CAS_SMALL_FILE_THRESHOLD`). Above the threshold, behavior is unchanged — `typescript.js`, `monaco-editor`, and similar large files keep the preallocate + page-cache hints.

## Benchmark

hyperfine, 8 runs × 1 warmup, bamboo, **fresh `XDG_DATA_HOME` + `XDG_CACHE_HOME` per run** (true cold), 1230-pkg fixture, hermetic Verdaccio, two reproducible runs:

| metric  | main          | gate          | delta  |
|---------|---------------|---------------|--------|
| wall    | 7.079 ± 0.084 s | 7.007 ± 0.044 s | **-1.0%** |
| user    | 6.576 s       | 6.528 s       | -0.7%  |
| **system** | **6.767 s** | **5.616 s**   | **-17.0%** |

Wall-time delta is small because the gated syscalls happen on rayon workers in parallel with tarball extraction — the headline saving is in kernel work, not critical-path wall time. The cap=8 PR (closed earlier) had the same shape. Tighter std-dev on the gated build (0.044 vs 0.084) is a side benefit.

## Why this is safe

- Threshold is conservative: 64 KiB is well above where ext4 fragmentation kicks in and where `DONTNEED` has measurable cache-relief value.
- Above the threshold, behavior is byte-for-byte identical to today.
- `AUBE_CAS_SMALL_FILE_THRESHOLD=0` restores always-on behavior; arbitrarily large values effectively disable both.
- All 91 `aube-store` unit tests pass.
- The original comments explaining *why* the syscalls were added are preserved — future readers can understand the rationale and the gate.

## Test plan

- [x] `cargo clippy -p aube-store --all-targets -- -D warnings`
- [x] `cargo test -p aube-store --lib` (91/91 passing)
- [x] hyperfine cold-install A/B on bamboo (Linux, Ryzen 9 7950X3D, table above, run twice)
- [ ] follow-up bench on a large-file-heavy workload (e.g. `typescript`, `monaco-editor`) to confirm the >=64KB branch keeps the original behavior

*This PR was prepared by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Linux-only change that only skips best-effort advisory syscalls (`posix_fallocate`/`posix_fadvise`) for small writes; correctness should be unchanged aside from potential performance differences if the new env threshold is misconfigured.
> 
> **Overview**
> Improves CAS import performance on Linux by **gating `posix_fallocate` and `posix_fadvise(POSIX_FADV_DONTNEED)`** in the `O_TMPFILE + linkat` publish path to only run for files ≥ a configurable size threshold (default **64KiB**).
> 
> Adds `AUBE_CAS_SMALL_FILE_THRESHOLD` (cached via `OnceLock`) to override the cutoff, allowing restoring the previous always-on behavior or effectively disabling the syscalls entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edd93f5190a30d4517026310b0e5d4295970f868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->