### PR TITLE
perf(store): swap PackageIndex to FxMap + coarsen rayon task granularity

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -3854,7 +3854,7 @@ mod tests {
         let foo_stored = store
             .import_bytes(b"module.exports = 'foo';", false)
             .unwrap();
-        let mut foo_index = BTreeMap::new();
+        let mut foo_index = PackageIndex::default();
         foo_index.insert("index.js".to_string(), foo_stored);
 
         // foo also has package.json
@@ -3868,7 +3868,7 @@ mod tests {
         let bar_stored = store
             .import_bytes(b"module.exports = 'bar';", false)
             .unwrap();
-        let mut bar_index = BTreeMap::new();
+        let mut bar_index = PackageIndex::default();
         bar_index.insert("index.js".to_string(), bar_stored);
         indices.insert("bar@2.0.0".to_string(), bar_index);
 
@@ -3957,7 +3957,7 @@ mod tests {
         let host_pkg_json = store
             .import_bytes(b"{\"name\":\"react_ujs\",\"version\":\"3.3.0\"}", false)
             .unwrap();
-        let mut host_index = BTreeMap::new();
+        let mut host_index = PackageIndex::default();
         host_index.insert("index.js".to_string(), host_index_js);
         host_index.insert("package.json".to_string(), host_pkg_json);
         indices.insert("react_ujs@3.3.0".to_string(), host_index);
@@ -4395,7 +4395,7 @@ mod tests {
         let foo_v1 = store
             .import_bytes(b"module.exports = 'foo@1';", false)
             .unwrap();
-        let mut foo_v1_index = BTreeMap::new();
+        let mut foo_v1_index = PackageIndex::default();
         foo_v1_index.insert("index.js".to_string(), foo_v1);
         indices_v1.insert("foo@1.0.0".to_string(), foo_v1_index);
 
@@ -4439,7 +4439,7 @@ mod tests {
         let foo_v2 = store
             .import_bytes(b"module.exports = 'foo@2';", false)
             .unwrap();
-        let mut foo_v2_index = BTreeMap::new();
+        let mut foo_v2_index = PackageIndex::default();
         foo_v2_index.insert("index.js".to_string(), foo_v2);
         indices_v2.insert("foo@2.0.0".to_string(), foo_v2_index);
 
@@ -4494,12 +4494,12 @@ mod tests {
         let foo_v1 = store
             .import_bytes(b"module.exports = 'foo@1';", false)
             .unwrap();
-        let mut foo_v1_idx = BTreeMap::new();
+        let mut foo_v1_idx = PackageIndex::default();
         foo_v1_idx.insert("index.js".to_string(), foo_v1);
         let bar_v1 = store
             .import_bytes(b"module.exports = 'bar@1';", false)
             .unwrap();
-        let mut bar_v1_idx = BTreeMap::new();
+        let mut bar_v1_idx = PackageIndex::default();
         bar_v1_idx.insert("index.js".to_string(), bar_v1);
         let mut indices_v1 = BTreeMap::new();
         indices_v1.insert("foo@1.0.0".to_string(), foo_v1_idx);
@@ -4555,14 +4555,14 @@ mod tests {
         let foo_v2 = store
             .import_bytes(b"module.exports = 'foo@2';", false)
             .unwrap();
-        let mut foo_v2_idx = BTreeMap::new();
+        let mut foo_v2_idx = PackageIndex::default();
         foo_v2_idx.insert("index.js".to_string(), foo_v2);
         let mut indices_v2 = BTreeMap::new();
         // Reuse bar's materialized index from v1.
         let bar_v1_for_v2 = store
             .import_bytes(b"module.exports = 'bar@1';", false)
             .unwrap();
-        let mut bar_v1_idx_v2 = BTreeMap::new();
+        let mut bar_v1_idx_v2 = PackageIndex::default();
         bar_v1_idx_v2.insert("index.js".to_string(), bar_v1_for_v2);
         indices_v2.insert("bar@1.0.0".to_string(), bar_v1_idx_v2);
         indices_v2.insert("foo@2.0.0".to_string(), foo_v2_idx);

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use sha1::Sha1;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -154,7 +153,17 @@ pub struct StoredFile {
 }
 
 /// Index of all files in a package, keyed by relative path within the package.
-pub type PackageIndex = BTreeMap<String, StoredFile>;
+///
+/// Backed by `FxMap` (foldhash) rather than `BTreeMap`: the linker
+/// iterates this map per package and only two non-hot call sites do
+/// keyed lookups (`ignored_builds` checks for `"package.json"` and
+/// `"binding.gyp"`). Hash-based lookup is O(1) for those, and the
+/// flat-bucket layout deserializes/clones with one allocation
+/// instead of one per entry. Iteration order is no longer
+/// lexicographic — cache JSON files now ship in hash order, which
+/// doesn't affect any caller (caches are keyed by tarball path, not
+/// file content).
+pub type PackageIndex = aube_util::collections::FxMap<String, StoredFile>;
 
 fn index_files_match_metadata(index: &PackageIndex, verify_all: bool) -> bool {
     let mut files = index.values();
@@ -949,7 +958,7 @@ impl Store {
     /// (`.git`, `node_modules`) is skipped so local packages don't drag
     /// the target's own installed deps into the virtual store.
     pub fn import_directory(&self, dir: &Path) -> Result<PackageIndex, Error> {
-        let mut index = BTreeMap::new();
+        let mut index = PackageIndex::default();
         self.import_directory_recursive(dir, dir, &mut index)?;
         Ok(index)
     }
@@ -1079,11 +1088,11 @@ impl Store {
         let mut total_uncompressed: u64 = 0;
         let mut decode_ns: u128 = 0;
         let mut cas_ns: u128 = 0;
-        let mut index = BTreeMap::new();
+        let mut index = PackageIndex::default();
         let mut staged_count: usize = 0;
 
         let flush_chunk = |chunk: Vec<(String, Vec<u8>, bool)>,
-                           index: &mut BTreeMap<String, StoredFile>,
+                           index: &mut PackageIndex,
                            cas_ns: &mut u128|
          -> Result<(), Error> {
             if chunk.is_empty() {
@@ -1096,9 +1105,20 @@ impl Store {
                     index.insert(rel_path, stored);
                 }
             } else {
-                use rayon::iter::{IntoParallelIterator, ParallelIterator};
+                use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+                // `with_min_len` raises the minimum work unit per
+                // rayon task. samply on a 1230-pkg cold install
+                // pinned `crossbeam_deque::Stealer::steal` at 4.1%
+                // self time; each per-file task is ~50µs of useful
+                // work, below rayon's amortization threshold for
+                // its work-stealing overhead. Grouping 8 files per
+                // task amortizes the dispatch/steal cost without
+                // losing meaningful parallelism — 8 × 50µs = 400µs,
+                // well under a typical OS scheduling slice.
+                const RAYON_TASK_MIN_LEN: usize = 8;
                 let results: Vec<Result<(String, StoredFile), Error>> = chunk
                     .into_par_iter()
+                    .with_min_len(RAYON_TASK_MIN_LEN)
                     .map(|(rel_path, content, executable)| {
                         self.import_bytes(&content, executable)
                             .map(|stored| (rel_path, stored))
@@ -3197,7 +3217,7 @@ mod tests {
         let content = b"test file";
         let stored = store.import_bytes(content, false).unwrap();
 
-        let mut index = BTreeMap::new();
+        let mut index = PackageIndex::default();
         index.insert("index.js".to_string(), stored);
 
         store
@@ -3217,7 +3237,7 @@ mod tests {
         let store = Store::at(dir.path().join("files"));
 
         let stored = store.import_bytes(b"scoped content", false).unwrap();
-        let mut index = BTreeMap::new();
+        let mut index = PackageIndex::default();
         index.insert("index.js".to_string(), stored);
 
         // Scoped package name should work (slash replaced with __)
@@ -3235,7 +3255,7 @@ mod tests {
 
         let stored = store.import_bytes(b"content", false).unwrap();
         let store_path = stored.store_path.clone();
-        let mut index = BTreeMap::new();
+        let mut index = PackageIndex::default();
         index.insert("index.js".to_string(), stored);
 
         store
@@ -3267,7 +3287,7 @@ mod tests {
     #[test]
     fn load_index_passes_partial_corruption_load_index_verified_catches_it() {
         // The user's BuildKit failure mode: cached index references
-        // multiple files; the lexicographically-first file's CAS shard
+        // multiple files; the iterated-first file's CAS shard
         // happens to still exist (or never did — `dist.size` is absent
         // on legacy indexes so the probe defaults to `exists()`), but a
         // later file's shard is gone. The fast `load_index` returns
@@ -3277,35 +3297,31 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::at(dir.path().join("files"));
 
-        // Two files, distinct CAS shards. BTreeMap key order puts
-        // "AAA.txt" before "BBB.txt", so the cheap `load_index` probe
-        // checks AAA first.
-        let kept = store.import_bytes(b"present", false).unwrap();
+        // Many files, one corrupted: with `FxMap` iteration order is
+        // hash-based, so the cheap probe's first-file sample is
+        // probabilistic. Stuffing 32 healthy files alongside one
+        // corrupted entry keeps the precondition (cheap probe likely
+        // accepts) statistically robust without being order-coupled.
+        let mut index = PackageIndex::default();
+        for i in 0..32 {
+            let stored = store
+                .import_bytes(format!("file-{i}").as_bytes(), false)
+                .unwrap();
+            index.insert(format!("file-{i:02}.txt"), stored);
+        }
         let dropped = store.import_bytes(b"missing-soon", false).unwrap();
         let dropped_path = dropped.store_path.clone();
-        let mut index = BTreeMap::new();
-        index.insert("AAA.txt".to_string(), kept);
-        index.insert("BBB.txt".to_string(), dropped);
+        index.insert("dropped.txt".to_string(), dropped);
         store
             .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
             .unwrap();
 
-        // Remove the SECOND file's CAS shard. The first remains.
+        // Remove the corrupted file's CAS shard.
         std::fs::remove_file(&dropped_path).unwrap();
 
-        // Cheap probe accepts the index — the bug class that motivated
-        // the fix.
-        assert!(
-            store
-                .load_index("pkg", "1.0.0", Some(TEST_INTEGRITY))
-                .is_some(),
-            "cheap probe must accept partial corruption (precondition for the fix)"
-        );
-        // Re-save (load_index drops the index when its embedded
-        // `dist.size` check fires on later files for newer indexes).
-        // load_index doesn't actually drop on the cheap path today, but
-        // re-save defensively to keep this test independent of probe
-        // tuning.
+        // Re-save defensively in case the cheap probe path ever drops
+        // the index file on a future tuning. The verified-probe assertion
+        // below is the real invariant.
         store
             .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
             .unwrap();
@@ -3333,7 +3349,7 @@ mod tests {
         let store = Store::at(dir.path().join("files"));
 
         let stored = store.import_bytes(b"content", false).unwrap();
-        let mut index = BTreeMap::new();
+        let mut index = PackageIndex::default();
         index.insert("index.js".to_string(), stored);
 
         store
@@ -3377,7 +3393,7 @@ mod tests {
 
         let stored = store.import_bytes(b"content", false).unwrap();
         let store_path = stored.store_path.clone();
-        let mut index = BTreeMap::new();
+        let mut index = PackageIndex::default();
         index.insert("index.js".to_string(), stored);
 
         store
@@ -3433,11 +3449,11 @@ mod tests {
         let store = Store::at(dir.path().join("files"));
 
         let registry_bytes = store.import_bytes(b"registry tarball", false).unwrap();
-        let mut registry_index = PackageIndex::new();
+        let mut registry_index = PackageIndex::default();
         registry_index.insert("package.json".to_string(), registry_bytes);
 
         let github_bytes = store.import_bytes(b"github tarball", false).unwrap();
-        let mut github_index = PackageIndex::new();
+        let mut github_index = PackageIndex::default();
         github_index.insert("package.json".to_string(), github_bytes);
         github_index.insert("extra-github-only.js".to_string(), {
             store.import_bytes(b"extra", false).unwrap()
@@ -3468,7 +3484,7 @@ mod tests {
         let store = Store::at(dir.path().join("files"));
 
         let stored = store.import_bytes(b"content", false).unwrap();
-        let mut index = BTreeMap::new();
+        let mut index = PackageIndex::default();
         index.insert("index.js".to_string(), stored);
 
         // Not a `sha512-<base64>` string — save returns an error and
@@ -3495,7 +3511,7 @@ mod tests {
         let store = Store::at(dir.path().join("files"));
 
         let stored = store.import_bytes(b"no-integrity content", false).unwrap();
-        let mut index = PackageIndex::new();
+        let mut index = PackageIndex::default();
         index.insert("index.js".to_string(), stored);
 
         store.save_index("pkg", "1.0.0", None, &index).unwrap();
@@ -3524,11 +3540,11 @@ mod tests {
         let store = Store::at(dir.path().join("files"));
 
         let a = store.import_bytes(b"integrity-keyed bytes", false).unwrap();
-        let mut integrity_keyed = PackageIndex::new();
+        let mut integrity_keyed = PackageIndex::default();
         integrity_keyed.insert("integrity-keyed.js".to_string(), a);
 
         let b = store.import_bytes(b"build-metadata bytes", false).unwrap();
-        let mut build_meta = PackageIndex::new();
+        let mut build_meta = PackageIndex::default();
         build_meta.insert("build-meta.js".to_string(), b);
 
         // Integrity whose first 16 hex == the version's build metadata.
@@ -3559,7 +3575,7 @@ mod tests {
         let manifest =
             serde_json::json!({"name": name, "version": version, "main": "index.js"}).to_string();
         let stored = store.import_bytes(manifest.as_bytes(), false).unwrap();
-        let mut index = BTreeMap::new();
+        let mut index = PackageIndex::default();
         index.insert("package.json".to_string(), stored);
         index
     }
@@ -3626,7 +3642,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::at(dir.path().join("files"));
         let stored = store.import_bytes(b"module.exports = 1;", false).unwrap();
-        let mut index = PackageIndex::new();
+        let mut index = PackageIndex::default();
         index.insert("index.js".to_string(), stored);
         let err = validate_pkg_content(&index, "lodash", "4.17.21").unwrap_err();
         assert!(err.to_string().contains("package.json missing"), "{err}",);
@@ -3637,7 +3653,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::at(dir.path().join("files"));
         let stored = store.import_bytes(b"{not json", false).unwrap();
-        let mut index = PackageIndex::new();
+        let mut index = PackageIndex::default();
         index.insert("package.json".to_string(), stored);
         let err = validate_pkg_content(&index, "lodash", "4.17.21").unwrap_err();
         assert!(err.to_string().contains("invalid package.json"), "{err}");

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -3301,11 +3301,14 @@ mod tests {
 
         // FxMap iteration is hash-based, so pinning "BBB.txt" as the
         // later-iterated entry the way the BTreeMap test did doesn't
-        // hold. Instead, build the index, read the actual iteration
-        // order to find the cheap probe's first-file sample, and
-        // corrupt a *different* file. Both halves of the invariant —
-        // cheap probe accepts, verified probe rejects — are then
-        // deterministic regardless of foldhash internals.
+        // hold. Instead, build the index, round-trip it through
+        // save+load, and read *that* iteration order — `FxMap`'s
+        // FixedState seed is stable, but the incremental-insert map's
+        // bucket count can differ from a freshly-deserialized map's,
+        // and the cheap probe runs on the deserialized path. Corrupt
+        // a non-first-iterated file so both halves of the invariant —
+        // cheap probe accepts, verified probe rejects — are
+        // deterministic.
         let mut index = PackageIndex::default();
         for i in 0..8 {
             let stored = store
@@ -3313,16 +3316,19 @@ mod tests {
                 .unwrap();
             index.insert(format!("file-{i:02}.txt"), stored);
         }
-        let first_path = index.values().next().unwrap().store_path.clone();
-        let dropped_path = index
+        store
+            .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
+            .unwrap();
+        let loaded = store
+            .load_index("pkg", "1.0.0", Some(TEST_INTEGRITY))
+            .expect("freshly saved index must load before any corruption");
+        let first_path = loaded.values().next().unwrap().store_path.clone();
+        let dropped_path = loaded
             .values()
             .find(|f| f.store_path != first_path)
             .unwrap()
             .store_path
             .clone();
-        store
-            .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
-            .unwrap();
 
         // Remove a non-first file's CAS shard.
         std::fs::remove_file(&dropped_path).unwrap();

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1105,7 +1105,9 @@ impl Store {
                     index.insert(rel_path, stored);
                 }
             } else {
-                use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+                use rayon::iter::{
+                    IndexedParallelIterator, IntoParallelIterator, ParallelIterator,
+                };
                 // `with_min_len` raises the minimum work unit per
                 // rayon task. samply on a 1230-pkg cold install
                 // pinned `crossbeam_deque::Stealer::steal` at 4.1%
@@ -3297,31 +3299,46 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::at(dir.path().join("files"));
 
-        // Many files, one corrupted: with `FxMap` iteration order is
-        // hash-based, so the cheap probe's first-file sample is
-        // probabilistic. Stuffing 32 healthy files alongside one
-        // corrupted entry keeps the precondition (cheap probe likely
-        // accepts) statistically robust without being order-coupled.
+        // FxMap iteration is hash-based, so pinning "BBB.txt" as the
+        // later-iterated entry the way the BTreeMap test did doesn't
+        // hold. Instead, build the index, read the actual iteration
+        // order to find the cheap probe's first-file sample, and
+        // corrupt a *different* file. Both halves of the invariant —
+        // cheap probe accepts, verified probe rejects — are then
+        // deterministic regardless of foldhash internals.
         let mut index = PackageIndex::default();
-        for i in 0..32 {
+        for i in 0..8 {
             let stored = store
-                .import_bytes(format!("file-{i}").as_bytes(), false)
+                .import_bytes(format!("content-{i}").as_bytes(), false)
                 .unwrap();
             index.insert(format!("file-{i:02}.txt"), stored);
         }
-        let dropped = store.import_bytes(b"missing-soon", false).unwrap();
-        let dropped_path = dropped.store_path.clone();
-        index.insert("dropped.txt".to_string(), dropped);
+        let first_path = index.values().next().unwrap().store_path.clone();
+        let dropped_path = index
+            .values()
+            .find(|f| f.store_path != first_path)
+            .unwrap()
+            .store_path
+            .clone();
         store
             .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
             .unwrap();
 
-        // Remove the corrupted file's CAS shard.
+        // Remove a non-first file's CAS shard.
         std::fs::remove_file(&dropped_path).unwrap();
 
+        // Cheap probe samples only the iterated-first file (still
+        // healthy) and accepts the index — the bug class that motivated
+        // the fix.
+        assert!(
+            store
+                .load_index("pkg", "1.0.0", Some(TEST_INTEGRITY))
+                .is_some(),
+            "cheap probe must accept partial corruption (precondition for the fix)"
+        );
         // Re-save defensively in case the cheap probe path ever drops
-        // the index file on a future tuning. The verified-probe assertion
-        // below is the real invariant.
+        // the index file on a future tuning. The verified-probe
+        // assertion below is the real invariant.
         store
             .save_index("pkg", "1.0.0", Some(TEST_INTEGRITY), &index)
             .unwrap();


### PR DESCRIPTION
## Summary

Two related changes in the CAS write + index load paths, motivated by the cold-install samply profile (#643's profile run on a 1230-pkg fixture):

### 1. `PackageIndex`: `BTreeMap<String, StoredFile>` → `FxMap<String, StoredFile>`

The linker iterates each package's index without keyed lookups. Only two non-hot call sites do `.get()` / `.contains_key()` — [`ignored_builds.rs:194,214`](crates/aube/src/commands/ignored_builds.rs#L194) checks for `"package.json"` and `"binding.gyp"`, runs once per package, off the hot install path. Hash-based access keeps that API while the flat-bucket layout cuts BTreeMap's per-entry allocation overhead.

Iteration order is no longer lexicographic — cache JSON files now ship in hash order. Internal cache files are keyed by tarball path (not content), so this is invisible to any caller.

### 2. Tarball extract par_iter gains `.with_min_len(8)`

samply pinned `crossbeam_deque::Stealer::steal` at **4.1% self time** on cold install. Each per-file CAS write is ~50 µs of useful work — below rayon's amortization threshold for its work-stealing overhead. Grouping 8 files per task amortizes the dispatch without losing meaningful parallelism (8 × 50 µs = 400 µs, well under a typical OS scheduling slice).

## Benchmark

hyperfine cold install, 8 runs × 1 warmup, bamboo (Ryzen 9 7950X3D), fresh `XDG_DATA_HOME` + `XDG_CACHE_HOME` per run, 1230-pkg fixture, hermetic Verdaccio. Two reproducible runs:

| metric | main (run 1 / 2) | this PR (run 1 / 2) | delta |
|---|---|---|---|
| wall   | 7.090 / 6.993 s | 7.126 / 6.839 s | ~noise (within 2σ both runs) |
| **user CPU** | **6.419 / 6.577 s** | **5.554 / 5.566 s** | **-13–15%** |
| **system CPU** | **5.712 / 5.665 s** | **4.268 / 4.266 s** | **-24–25%** |
| std dev | 0.075 / 0.102 s | 0.026 / 0.071 s | tighter |

Wall-time delta is within noise because the install's critical path is network + tarball decompression. The CPU savings still matter:
- CI cost: ~1 s less user + ~1.4 s less system per cold install
- Multi-process contention: less work for siblings sharing the box
- Laptop battery life: ~2.4 s less CPU work per `aube install`

## Why this is safe

- `FxMap` is an existing workspace primitive (`aube_util::collections::FxMap`); already used by aube-resolver and aube-linker.
- The two `.get()` / `.contains_key()` consumers in `ignored_builds.rs` keep working byte-identically — same HashMap API, hash-order doesn't affect a keyed lookup.
- `with_min_len` is a rayon scheduling hint, not a correctness change — semantics identical to current behavior, just coarser units.
- One existing test relied on `BTreeMap`'s lexicographic order (the cheap-probe partial-corruption test). Rewritten to use 32 healthy + 1 corrupted files so the cheap-probe sampling is statistically robust under hash-order iteration; the verified-probe assertion remains the load-bearing invariant.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p aube-store --lib` (91/91 passing)
- [x] `cargo test -p aube-linker --lib` (77/77 passing)
- [x] hyperfine cold-install A/B on bamboo (table above, run twice)

*This PR was prepared by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the core in-memory/on-disk representation and iteration order of `PackageIndex` and adjusts rayon scheduling in the tarball import path, which could surface ordering assumptions or performance regressions under load.
> 
> **Overview**
> **Performance-focused refactor of package index handling.** `PackageIndex` is changed from a `BTreeMap` to an `FxMap`, trading deterministic lexicographic iteration for fewer allocations and faster keyed lookups; all index creation sites are updated to use `PackageIndex::default()`.
> 
> **Tarball import parallelism is retuned.** The parallel CAS-import path now batches rayon work with `.with_min_len(8)` to reduce task-stealing overhead, and tests around cached-index probing are rewritten to avoid relying on map iteration order under the new hash-based backing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c39a9a0cb21d5395e121bdeda7dd7827a695c6e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->