### PR TITLE
fix(bench): restore force-with-lease tracking ref for bench-refresh push

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -131,12 +131,14 @@ jobs:
           git checkout -B bench-refresh
           git add -A
           git commit -m "chore: refresh benchmarks"
-          # Auth via x-access-token URL: persist-credentials: false on
-          # checkout means .git/config has no token to authenticate
-          # this push.
-          git push --force-with-lease \
-            "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" \
-            HEAD:refs/heads/bench-refresh
+          # persist-credentials: false on checkout means we need to auth
+          # the push explicitly. Re-point origin (rather than pushing to
+          # a one-shot URL) so --force-with-lease has a remote-tracking
+          # ref to compare against; pushing to an unnamed URL leaves no
+          # tracking ref and git rejects every push with "stale info".
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          git fetch origin bench-refresh || true
+          git push --force-with-lease -u origin HEAD:refs/heads/bench-refresh
 
       - name: Create or update PR
         if: steps.dirty.outputs.dirty == 'true'


### PR DESCRIPTION
## Summary

- [Run 25762392174](https://github.com/endevco/aube/actions/runs/25762392174) of `bench-refresh` failed at the `Force-push bench-refresh branch` step with `! [rejected]        HEAD -> bench-refresh (stale info)`. Same root cause as [#642](https://github.com/endevco/aube/pull/642): pushing to a one-shot `x-access-token@…` URL leaves no remote-tracking ref, so `--force-with-lease` rejects every push.
- This started failing once `persist-credentials: false` was added to the checkout (zizmor compliance); today's 05:00 UTC cron only "succeeded" because the dirty-check guard short-circuited (no diff to push).
- Apply the same fix pattern as 9121dd0: re-point `origin` to the authenticated URL and `git fetch origin bench-refresh || true` so the lease has a real tracking ref before `git push --force-with-lease -u origin`.

## Test plan

- [ ] Next `bench-refresh` run that produces a diff completes the `Force-push bench-refresh branch` step and either creates or updates the PR.
- [ ] zizmor still passes — no new credential-leak findings (the token URL was already present, just re-pointed instead of inlined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `bench-refresh` GitHub Actions push/auth flow; if misconfigured it can break the automated benchmark refresh PR updates or fail pushes to `bench-refresh`. Scope is limited to CI/workflow behavior and does not affect runtime code.
> 
> **Overview**
> Fixes the `bench-refresh` workflow’s force-push step to work with `persist-credentials: false` by authenticating via `origin` instead of a one-shot token URL.
> 
> The workflow now sets `origin` to the token-authenticated URL, fetches `bench-refresh` to create a remote-tracking ref, and then uses `git push --force-with-lease` so the lease check no longer fails with *stale info*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42c5a99ef5cc520426758ca117e47c1064cf1ee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->