### PR TITLE
fix(bench): work around bash 5.2 & backreference in phase-timing substitution

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -640,7 +640,16 @@ run_aube_phase_bench() {
 		cmd_tpl=$(cmd_template "$bench_name" "$tool")
 		local cmd
 		cmd=$(expand_template "$cmd_tpl" "$project" "$bin" "$home" "$store" "$cache" "$lockfile" "$lockfile_dest")
-		cmd="${cmd/&& /&& AUBE_BENCH_PHASES_FILE=$PHASES_FILE AUBE_BENCH_SCENARIO=$bench_name }"
+		# Inject phase-timing env vars after the `cd {project} && `
+		# prefix. We can't use `${cmd/&& /&& ...}` here: bash 5.2+
+		# treats `&` in the replacement of `${var/pat/repl}` as a
+		# backreference to the matched pattern (sed-like), so each
+		# unescaped `&` expands to the matched `&& ` and the result
+		# becomes `cd <p> && && ...` which fails at eval time.
+		# Escaping with `\&` works on 5.2+ but emits literal backslashes
+		# on bash 3.2 (macOS dev shell). Splitting around `&& ` avoids
+		# both traps and works the same on every bash we care about.
+		cmd="${cmd%%&& *}&& AUBE_BENCH_PHASES_FILE=$PHASES_FILE AUBE_BENCH_SCENARIO=$bench_name ${cmd#*&& }"
 
 		echo "  $bench_name"
 		if ! eval "$prepare"; then


### PR DESCRIPTION
## Summary

The aube install-phase timing scenarios in [\`benchmarks/bench.sh\`](benchmarks/bench.sh) have been silently failing on CI. Every run since the workflow moved to a bash 5.2+ runner has produced this at eval time for all four phase scenarios:

\`\`\`
benchmarks/bench.sh: eval: line 650: syntax error near unexpected token \`&&'
benchmarks/bench.sh: eval: line 650: \`cd /tmp/aube-bench.NRkEjS/project-aube && &&  AUBE_BENCH_PHASES_FILE=... aube install --frozen-lockfile >/dev/null 2>&1'
warning: phase timing run failed for gvs-warm - skipping sample
warning: phase timing run failed for gvs-cold - skipping sample
warning: phase timing run failed for ci-warm  - skipping sample
warning: phase timing run failed for ci-cold  - skipping sample
\`\`\`

(observed e.g. in [run 25762392174](https://github.com/endevco/aube/actions/runs/25762392174)).

### Root cause

\`run_aube_phase_bench\` was injecting \`AUBE_BENCH_PHASES_FILE\` / \`AUBE_BENCH_SCENARIO\` via:

\`\`\`bash
cmd=\"\${cmd/&& /&& AUBE_BENCH_PHASES_FILE=\$PHASES_FILE AUBE_BENCH_SCENARIO=\$bench_name }\"
\`\`\`

Bash 5.2 [introduced sed-like \`&\` backreferences](https://git.savannah.gnu.org/cgit/bash.git/tree/CHANGES?h=bash-5.2) in the replacement of \`\${var/pat/repl}\`: each unescaped \`&\` in the replacement now expands to the matched pattern (here \`&& \` — three chars). So the two \`&\`s at the start of the replacement each expanded to \`&& \`, producing \`cd <p> && && [space]AUBE_BENCH_PHASES_FILE=...\` — exactly the \`&& &&\` we saw in the error (confirmed by \`od -c\` on the raw bytes of the log: \`& & SP & & SP SP A U B E\`).

This silently regressed at some point when CI moved to a bash 5.2+ image; bash 3.2 (macOS dev shell) doesn't have the new behavior, which is why \`bash -n\` + local smoke tests on the original PR didn't catch it.

### Fix

Switch from \`\${cmd/&& /&& ...}\` to a structural split using \`\${cmd%%&& *}\` and \`\${cmd#*&& }\`. \`%%\` / \`#\` parameter expansions don't have the replacement-side ampersand semantics, so the rebuild produces a single \`&&\` on both bash 3.2 and 5.2+. I considered escaping with \`\\&\\&\` (works on 5.2+) but that emits literal backslashes on 3.2, which breaks dev-shell smoke tests.

### Impact

All aube install-phase numbers (resolver / fetch / link / scripts breakdown) in \`benchmarks/results.json\` have been stale since this broke — the JSONL sink wrote zero samples each refresh, so \`generate-phase-results.mjs\` had nothing fresh to fold in. After this lands, the next \`bench-refresh\` PR should bring the phase data back to current numbers.

## Test plan

- [x] \`bash -n benchmarks/bench.sh\` passes
- [x] Local substitution check produces a single \`&&\` and correct env-var ordering (verified on bash 3.2)
- [ ] Next \`bench-refresh\` run completes the \`Aube install phase timings\` block without \`phase timing run failed for ...\` warnings, and the resulting \`results.json\` carries fresh per-phase aube numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to the benchmark runner script and only affects how env vars are injected into the phase-timing command, restoring CI benchmarks on bash 5.2+.
> 
> **Overview**
> Fixes the aube install *phase-timing* benchmark command construction in `benchmarks/bench.sh` so it works on bash 5.2+.
> 
> Replaces the `${var/pat/repl}`-based `&&` substitution (which regressed due to bash 5.2 `&` backreference semantics) with a split/rebuild around the first `&&`, ensuring `AUBE_BENCH_PHASES_FILE` and `AUBE_BENCH_SCENARIO` are injected without producing `&& &&` and breaking `eval`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef05daf84f8e9455b9f8b58848d5669de8ba6a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->