### PR TITLE
chore(bench): force AUBE_FORCE_METADATA_PRIMER=true for bench runs

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -65,6 +65,7 @@ jobs:
             BENCH_HERMETIC=1 \
             BENCH_BANDWIDTH=500mbit \
             BENCH_LATENCY=50ms \
+            AUBE_FORCE_METADATA_PRIMER=true \
             mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest bun@latest node@24 -- bash benchmarks/bench.sh
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -129,6 +129,10 @@ fi
 export BENCH_HERMETIC="${BENCH_HERMETIC:-1}"
 export BENCH_BANDWIDTH="${BENCH_BANDWIDTH:-500mbit}"
 export BENCH_LATENCY="${BENCH_LATENCY:-50ms}"
+# Force the bundled metadata primer on for the hermetic Verdaccio
+# mirror — the primer is keyed to npmjs.org, so without this aube
+# would skip its own warm-cache fast path on the bench registry.
+export AUBE_FORCE_METADATA_PRIMER="${AUBE_FORCE_METADATA_PRIMER:-true}"
 
 if [ -z "${AUBE_PGO_NO_LOCK:-}" ] && command -v flock >/dev/null 2>&1; then
 	echo ">>> Acquiring /tmp/aube-bench.lock (30 min timeout)"

--- a/mise.toml
+++ b/mise.toml
@@ -43,7 +43,12 @@ run = "../target/debug/aube install && exec ../target/debug/aube run docs:build"
 # https://github.com/aquaproj/aqua-registry/.
 [tasks.bench]
 dir = "{{config_root}}"
-env = { BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms", AUBE_FORCE_METADATA_PRIMER = "true" }
+env = {
+  BENCH_HERMETIC = "1",
+  BENCH_BANDWIDTH = "500mbit",
+  BENCH_LATENCY = "50ms",
+  AUBE_FORCE_METADATA_PRIMER = "true",
+}
 run = [
   "cargo build --release",
   "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest npm:@yarnpkg/cli-dist@latest bun@latest deno@latest npm:vlt@latest node@24 -- bash benchmarks/bench.sh",
@@ -51,7 +56,17 @@ run = [
 
 [tasks."bench:pr"]
 dir = "{{config_root}}"
-env = { RUNS = "3", WARMUP = "1", BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms", BENCH_TOOLS = "aube,bun,pnpm", BENCH_SCENARIOS = "gvs-warm,ci-warm,ci-cold", BENCH_PHASES = "0", AUBE_FORCE_METADATA_PRIMER = "true" }
+env = {
+  RUNS = "3",
+  WARMUP = "1",
+  BENCH_HERMETIC = "1",
+  BENCH_BANDWIDTH = "500mbit",
+  BENCH_LATENCY = "50ms",
+  BENCH_TOOLS = "aube,bun,pnpm",
+  BENCH_SCENARIOS = "gvs-warm,ci-warm,ci-cold",
+  BENCH_PHASES = "0",
+  AUBE_FORCE_METADATA_PRIMER = "true",
+}
 run = [
   "cargo build --release",
   "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest bun@latest node@24 -- bash benchmarks/bench.sh",
@@ -67,7 +82,15 @@ run = [
 # landing-page ratios stay in sync with the JSON.
 [tasks."bench:bump"]
 dir = "{{config_root}}"
-env = { RUNS = "10", WARMUP = "3", RESULTS_JSON = "{{config_root}}/benchmarks/results.json", BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms", AUBE_FORCE_METADATA_PRIMER = "true" }
+env = {
+  RUNS = "10",
+  WARMUP = "3",
+  RESULTS_JSON = "{{config_root}}/benchmarks/results.json",
+  BENCH_HERMETIC = "1",
+  BENCH_BANDWIDTH = "500mbit",
+  BENCH_LATENCY = "50ms",
+  AUBE_FORCE_METADATA_PRIMER = "true",
+}
 run = [
   "cargo build --release",
   "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest npm:@yarnpkg/cli-dist@latest bun@latest deno@latest npm:vlt@latest node@24 -- bash benchmarks/bench.sh",

--- a/mise.toml
+++ b/mise.toml
@@ -43,7 +43,7 @@ run = "../target/debug/aube install && exec ../target/debug/aube run docs:build"
 # https://github.com/aquaproj/aqua-registry/.
 [tasks.bench]
 dir = "{{config_root}}"
-env = { BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms" }
+env = { BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms", AUBE_FORCE_METADATA_PRIMER = "true" }
 run = [
   "cargo build --release",
   "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest npm:@yarnpkg/cli-dist@latest bun@latest deno@latest npm:vlt@latest node@24 -- bash benchmarks/bench.sh",
@@ -51,7 +51,7 @@ run = [
 
 [tasks."bench:pr"]
 dir = "{{config_root}}"
-env = { RUNS = "3", WARMUP = "1", BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms", BENCH_TOOLS = "aube,bun,pnpm", BENCH_SCENARIOS = "gvs-warm,ci-warm,ci-cold", BENCH_PHASES = "0" }
+env = { RUNS = "3", WARMUP = "1", BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms", BENCH_TOOLS = "aube,bun,pnpm", BENCH_SCENARIOS = "gvs-warm,ci-warm,ci-cold", BENCH_PHASES = "0", AUBE_FORCE_METADATA_PRIMER = "true" }
 run = [
   "cargo build --release",
   "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest bun@latest node@24 -- bash benchmarks/bench.sh",
@@ -67,7 +67,7 @@ run = [
 # landing-page ratios stay in sync with the JSON.
 [tasks."bench:bump"]
 dir = "{{config_root}}"
-env = { RUNS = "10", WARMUP = "3", RESULTS_JSON = "{{config_root}}/benchmarks/results.json", BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms" }
+env = { RUNS = "10", WARMUP = "3", RESULTS_JSON = "{{config_root}}/benchmarks/results.json", BENCH_HERMETIC = "1", BENCH_BANDWIDTH = "500mbit", BENCH_LATENCY = "50ms", AUBE_FORCE_METADATA_PRIMER = "true" }
 run = [
   "cargo build --release",
   "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest npm:@yarnpkg/cli-dist@latest bun@latest deno@latest npm:vlt@latest node@24 -- bash benchmarks/bench.sh",


### PR DESCRIPTION
## Summary
- Sets `AUBE_FORCE_METADATA_PRIMER=true` for the `bench`, `bench:pr`, and `bench:bump` mise tasks, the `pr-bench` GitHub workflow, and the PGO training script.
- Reason: the hermetic Verdaccio mirror serves the same packages as npmjs.org but at a different registry URL, so aube's bundled metadata primer would otherwise gate itself off. Forcing it on keeps benchmark runs exercising the same warm-cache fast path real npmjs users hit.

## Test plan
- [ ] `mise run bench` locally — verify the primer is applied (no skip log) and numbers match expectations
- [ ] `mise run bench:pr` against this branch
- [ ] Next bench-refresh cron run on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes benchmark/PGO harness environment variables and formatting, with no impact on production code paths. Primary risk is skewed or non-comparable benchmark results if the forced primer behavior is unintended.
> 
> **Overview**
> **Benchmark harness behavior change:** sets `AUBE_FORCE_METADATA_PRIMER=true` for PR benchmarks in `.github/workflows/bench-pr.yml`, for local `mise` tasks (`bench`, `bench:pr`, `bench:bump`), and for `benchmarks/pgo.bash`.
> 
> This makes hermetic Verdaccio-backed runs consistently use aube’s bundled metadata primer (and thus the warm-cache fast path), keeping benchmark and PGO training behavior aligned with expected real-registry performance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b9de07c0cecd68c4b0c029c61c1107aef3fcc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->