### PR TITLE
perf(resolver): disable CUSUM shrink on packument fetch semaphore

### DIFF
--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -167,6 +167,23 @@ impl Resolver {
             ),
             None => aube_util::adaptive::AdaptiveLimit::new(packument_seed, 4, packument_max),
         };
+        // Disable CUSUM-driven shrink on the packument fetch path.
+        // The CUSUM controller fires on sustained RTT regime rise,
+        // which conflates "registry is asking us to back off" with
+        // "registry is slow to serve under load." On a fast hermetic
+        // mirror (Verdaccio, JSR, a corporate npm proxy) or any
+        // single-threaded registry, every fetch the resolver issues
+        // tends to push the next one's RTT up — and CUSUM shrinks,
+        // serializing the resolver behind a small permit pool.
+        // Measured impact on the bench fixture: 432 of 1124
+        // packument fetches waited on a permit (mean 170ms, p99
+        // 351ms, 73s cumulative wait) despite the seed being 256.
+        //
+        // Real backpressure from npmjs / private registries is still
+        // honored via `record_throttle` — that fires on HTTP 429/503
+        // and shrinks the limit immediately. CUSUM was a noise filter
+        // on top of that, and it's overcorrecting.
+        shared_semaphore.disable_cusum_shrink();
         let packument_persist_handle = persistent
             .as_ref()
             .map(|p| (Arc::clone(p), Arc::clone(&shared_semaphore)));

--- a/crates/aube-util/src/adaptive.rs
+++ b/crates/aube-util/src/adaptive.rs
@@ -204,18 +204,31 @@ struct ColdState {
      * the limit. Throttle-driven shrink (`record_throttle`, fired
      * on real backpressure: HTTP 429/503, IO errors) is unaffected.
      *
-     * Use case: filesystem-bound limiters where per-op latency
-     * variance is exogenous (antivirus scans, NTFS cold-cache
-     * reads, COW reflink fall-through to copy). Rising RTT on
-     * those paths is intrinsic noise, not a signal that more
-     * concurrency is making things worse — there is no upstream
-     * queue to relieve. Treating it as backpressure was observed
-     * to collapse the linker prewarm limit from seed 16 to 12 on
-     * Windows, queueing 1195 packages behind a 12-permit cap.
+     * Use it on limiters where rising RTT does *not* reliably
+     * indicate "consumers want me to back off." Two known cases:
      *
-     * Network limiters (registry packument, registry tarball)
-     * keep CUSUM enabled because rising RTT there does correlate
-     * with upstream queueing.
+     * - **Filesystem-bound limiters.** Per-op latency variance is
+     *   exogenous (antivirus scans, NTFS cold-cache reads, COW
+     *   reflink fall-through to copy). Treating it as backpressure
+     *   was observed to collapse the linker prewarm limit from
+     *   seed 16 to 12 on Windows, queueing 1195 packages behind a
+     *   12-permit cap.
+     *
+     * - **Network limiters against single-threaded / fragile
+     *   registries.** Verdaccio, JSR, corporate npm proxies serve
+     *   each request slowly under load. RTT climbs as a function of
+     *   the registry's own thread saturation, not because the
+     *   registry wants the client to back off — there's no upstream
+     *   queue we'd relieve by shrinking. Disabled on the resolver's
+     *   packument fetch path; observed to cut permit-wait
+     *   occurrences from 432 to 128 (cumulative 73.6 s → 17.8 s)
+     *   on a 1230-pkg cold install.
+     *
+     * The deciding factor is signal quality, not fs-vs-network.
+     * If a limiter's RTT rises mostly because of intrinsic peer
+     * variance rather than queueing aube can relieve, disable
+     * CUSUM and rely on `record_throttle` (which still fires on
+     * real HTTP 429/503 / IO errors).
      */
     cusum_shrink_disabled: AtomicBool,
 }
@@ -284,9 +297,12 @@ impl AdaptiveLimit {
 
     /**
      * Disable CUSUM-driven shrinking on the success path. Call
-     * once after construction for limiters that gate
-     * filesystem-bound work (linker, materializer). Throttle-path
-     * shrink (record_throttle on real IO errors) remains active.
+     * once after construction for limiters whose rising RTT
+     * doesn't reliably indicate that the consumer wants
+     * backpressure — filesystem-bound work (linker, materializer)
+     * or network fetches against single-threaded / fragile
+     * registries. Throttle-path shrink (`record_throttle` on real
+     * HTTP 429/503 / IO errors) remains active.
      * See [`ColdState::cusum_shrink_disabled`] for rationale.
      */
     pub fn disable_cusum_shrink(&self) {


### PR DESCRIPTION
## Summary

The adaptive packument-fetch semaphore's CUSUM controller treats rising RTT as backpressure and shrinks the concurrency limit. Against a slow-per-request registry — Verdaccio, JSR, corporate proxies, anywhere the server is single-threaded under load — every batch of fetches we send pushes the next batch's RTT up, since the registry struggles to keep up. CUSUM reads that as a back-off signal and serializes the resolver behind a small permit pool.

The linker's adaptive limit already disables CUSUM for the same reason (see [install/mod.rs:1132](crates/aube/src/commands/install/mod.rs#L1132)'s comment about storage-variance). Same logic applies to packument fetches: the controller fires on a signal that isn't really backpressure for our workload shape.

**Real backpressure (HTTP 429/503) is still honored** via the separate `record_throttle` path, which fires on actual rate-limit responses and shrinks immediately. CUSUM was a noise filter on top of that, and it overcorrects.

## Evidence

Diag-tracked permit waits on a 1230-pkg cold install (bamboo, hermetic Verdaccio, same fixture/harness as #643/#644):

| metric | main | this PR | delta |
|---|---|---|---|
| permit_wait events | 432 | 128 | **-70%** |
| total wait time | 73671 ms | 17805 ms | **-76%** |
| mean wait | 170 ms | 139 ms | -18% |
| p99 wait | 351 ms | 240 ms | -32% |

hyperfine cold install (8 runs × 1 warmup, two reproducible runs):

| run | main | this PR | wall delta |
|---|---|---|---|
| 1 | 6.916 ± 0.079 s | 6.738 ± 0.047 s | **-2.6%** |
| 2 | 6.770 ± 0.057 s | 6.720 ± 0.067 s | **-0.7%** |

Modest wall-time win (~1-3%), but **first measurable wall-time movement** after a series of PRs (#643, #644, etc.) that saved CPU without moving wall. Most of the permit-wait reduction is on parallel fetches off the critical path; the slice that *is* on the critical path is what shows up in the wall delta. Tighter timing distribution on the patched build is a side benefit.

## Why this is safe

- Real registry backpressure (HTTP 429/503) is unchanged — `AdaptiveLimit::record_throttle` still fires immediately on those.
- CUSUM remains active for the linker, registry tarball fetch, etc. — just disabled here on the packument fetch path where the signal is unreliable.
- 178/178 aube-resolver unit tests pass.
- `cargo clippy --all-targets -- -D warnings` clean.

## Test plan

- [x] `cargo test -p aube-resolver --lib` (178/178)
- [x] `cargo clippy -p aube-resolver --all-targets -- -D warnings`
- [x] hyperfine cold install A/B on bamboo (table above, two runs)
- [x] diag-driven verification that permit_wait counts drop as expected
- [ ] real-world: this should help most against single-threaded / fragile registries (Verdaccio, JSR, corporate proxies); against npmjs it's likely neutral-to-positive since CUSUM's main false positive is exactly what we observed here

*This PR was prepared by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes adaptive concurrency behavior for registry metadata fetches; could increase load against some registries, though explicit throttle (HTTP 429/503) shrinking remains in place.
> 
> **Overview**
> **Disables CUSUM-based adaptive shrinking for packument fetches** by calling `disable_cusum_shrink()` on the resolver’s shared packument `AdaptiveLimit`, to avoid RTT-regime rises on slow/single-threaded registries collapsing concurrency.
> 
> Updates `aube_util::adaptive` documentation to broaden the intended use of `disable_cusum_shrink` beyond filesystem work (including certain network/registry cases) while keeping throttle-driven shrink (`record_throttle` on 429/503/IO errors) unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25c3041074af6bc166563cc7abe80004165635be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->