### PR TITLE
bench: pin minimum-release-age across bun/pnpm for apples-to-apples comparison

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -420,7 +420,7 @@ MIN_RELEASE_AGE_MINUTES="${BENCH_MIN_RELEASE_AGE_MINUTES:-1440}"
 MIN_RELEASE_AGE_SECONDS=$((MIN_RELEASE_AGE_MINUTES * 60))
 # npm uses days as the unit. Round up so the gate is at least as
 # strict as aube's, never weaker. (60*24 = 1440 → 1 day exactly.)
-MIN_RELEASE_AGE_DAYS=$(( (MIN_RELEASE_AGE_MINUTES + 60 * 24 - 1) / (60 * 24) ))
+MIN_RELEASE_AGE_DAYS=$(((MIN_RELEASE_AGE_MINUTES + 60 * 24 - 1) / (60 * 24)))
 
 # Per-tool boilerplate factored out of the `CMDS` declarations below.
 # Every bun invocation threads the same hermetic environment

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -397,18 +397,30 @@ expand_template() {
 # as a supply-chain mitigation — the resolver skips versions newer
 # than this window. The default forces aube to fetch the full
 # (non-corgi) packument format so it can read the per-version `time`
-# map; corgi omits `time` on npmjs.org. Bun and pnpm both support an
-# equivalent flag; npm/yarn/deno/vlt don't. Pinning all supported
-# PMs to the same value is what makes the bench an apples-to-apples
-# comparison — otherwise aube alone pays the full-packument cost
-# (5x larger response on @types/node and similar heavily-versioned
-# packuments) while bun/pnpm cruise on corgi.
+# map; corgi omits `time` on npmjs.org. Most modern PMs support an
+# equivalent flag, each with their own unit:
+#
+#   aube  minimumReleaseAge          (minutes; default 1440)
+#   npm   --min-release-age          (days)
+#   pnpm  --config.minimum-release-age (minutes)
+#   bun   --minimum-release-age      (seconds)
+#   deno  --minimum-dependency-age   (minutes, marked Unstable)
+#   yarn  not supported
+#   vlt   not investigated (currently disabled in BENCH_TOOLS anyway)
+#
+# Pinning all supported PMs to the same value makes the bench an
+# apples-to-apples comparison — otherwise aube alone pays the
+# full-packument cost (5x larger response on @types/node and similar
+# heavily-versioned packuments) while bun/pnpm cruise on corgi.
 #
 # Override via `BENCH_MIN_RELEASE_AGE_MINUTES=0` to disable the gate
 # across all PMs (useful for measuring raw resolver speed without
 # the security-feature axis).
 MIN_RELEASE_AGE_MINUTES="${BENCH_MIN_RELEASE_AGE_MINUTES:-1440}"
 MIN_RELEASE_AGE_SECONDS=$((MIN_RELEASE_AGE_MINUTES * 60))
+# npm uses days as the unit. Round up so the gate is at least as
+# strict as aube's, never weaker. (60*24 = 1440 → 1 day exactly.)
+MIN_RELEASE_AGE_DAYS=$(( (MIN_RELEASE_AGE_MINUTES + 60 * 24 - 1) / (60 * 24) ))
 
 # Per-tool boilerplate factored out of the `CMDS` declarations below.
 # Every bun invocation threads the same hermetic environment
@@ -456,7 +468,7 @@ cmd_template() {
 		echo "cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1"
 		;;
 	gvs-warm:npm | ci-warm:npm)
-		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps --prefer-offline >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps --prefer-offline --min-release-age=${MIN_RELEASE_AGE_DAYS} >/dev/null 2>&1"
 		;;
 	gvs-warm:pnpm | gvs-cold:pnpm | ci-warm:pnpm | ci-cold:pnpm)
 		echo "cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts --config.minimum-release-age=${MIN_RELEASE_AGE_MINUTES} >/dev/null 2>&1"
@@ -471,7 +483,9 @@ cmd_template() {
 		# Deno 2: --frozen errors out if the lockfile would change,
 		# the equivalent of --frozen-lockfile elsewhere. Lifecycle
 		# scripts are off unless --allow-scripts is passed.
-		echo "cd {project} && HOME={home} DENO_DIR={cache} {bin} install --frozen --quiet >/dev/null 2>&1"
+		# `--minimum-dependency-age` is flagged "Unstable" in deno's
+		# help but the flag itself parses fine; takes minutes.
+		echo "cd {project} && HOME={home} DENO_DIR={cache} {bin} install --frozen --quiet --minimum-dependency-age=${MIN_RELEASE_AGE_MINUTES} >/dev/null 2>&1"
 		;;
 	gvs-warm:vlt | gvs-cold:vlt | ci-warm:vlt | ci-cold:vlt)
 		# vlt's --frozen-lockfile mirrors pnpm/npm/aube semantics: refuse
@@ -481,7 +495,7 @@ cmd_template() {
 		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install --frozen-lockfile >/dev/null 2>&1"
 		;;
 	gvs-cold:npm | ci-cold:npm)
-		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps --min-release-age=${MIN_RELEASE_AGE_DAYS} >/dev/null 2>&1"
 		;;
 	ci-warm:aube | ci-cold:aube)
 		echo "cd {project} && $AUBE_ENV_GVS_OFF {bin} install --frozen-lockfile >/dev/null 2>&1"
@@ -493,7 +507,7 @@ cmd_template() {
 		echo "cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1 && HOME={home} BUN_INSTALL={home}/.bun {bin} run test >/dev/null 2>&1"
 		;;
 	install-test:npm)
-		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install-test --ignore-scripts --no-audit --no-fund --legacy-peer-deps --prefer-offline >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install-test --ignore-scripts --no-audit --no-fund --legacy-peer-deps --prefer-offline --min-release-age=${MIN_RELEASE_AGE_DAYS} >/dev/null 2>&1"
 		;;
 	install-test:pnpm)
 		echo "cd {project} && HOME={home} {bin} install-test --frozen-lockfile --ignore-scripts --config.minimum-release-age=${MIN_RELEASE_AGE_MINUTES} >/dev/null 2>&1"
@@ -502,7 +516,7 @@ cmd_template() {
 		echo "cd {project} && HOME={home} {bin} install --immutable >/dev/null 2>&1 && HOME={home} {bin} test >/dev/null 2>&1"
 		;;
 	install-test:deno)
-		echo "cd {project} && HOME={home} DENO_DIR={cache} {bin} install --frozen --quiet >/dev/null 2>&1 && HOME={home} DENO_DIR={cache} {bin} task --quiet test >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} DENO_DIR={cache} {bin} install --frozen --quiet --minimum-dependency-age=${MIN_RELEASE_AGE_MINUTES} >/dev/null 2>&1 && HOME={home} DENO_DIR={cache} {bin} task --quiet test >/dev/null 2>&1"
 		;;
 	install-test:vlt)
 		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install --frozen-lockfile >/dev/null 2>&1 && HOME={home} npm_config_cache={cache} {bin} run test >/dev/null 2>&1"
@@ -514,7 +528,7 @@ cmd_template() {
 		echo "cd {project} && HOME={home} BUN_INSTALL={home}/.bun {bin} add is-odd --cache-dir {cache} --ignore-scripts --no-summary --minimum-release-age=${MIN_RELEASE_AGE_SECONDS} >/dev/null 2>&1"
 		;;
 	add:npm)
-		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install --ignore-scripts --no-audit --no-fund --legacy-peer-deps is-odd >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install --ignore-scripts --no-audit --no-fund --legacy-peer-deps --min-release-age=${MIN_RELEASE_AGE_DAYS} is-odd >/dev/null 2>&1"
 		;;
 	add:pnpm)
 		echo "cd {project} && HOME={home} {bin} add is-odd --ignore-scripts --config.minimum-release-age=${MIN_RELEASE_AGE_MINUTES} >/dev/null 2>&1"
@@ -523,7 +537,7 @@ cmd_template() {
 		echo "cd {project} && HOME={home} {bin} add is-odd >/dev/null 2>&1"
 		;;
 	add:deno)
-		echo "cd {project} && HOME={home} DENO_DIR={cache} {bin} add --quiet npm:is-odd >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} DENO_DIR={cache} {bin} add --quiet --minimum-dependency-age=${MIN_RELEASE_AGE_MINUTES} npm:is-odd >/dev/null 2>&1"
 		;;
 	add:vlt)
 		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install is-odd >/dev/null 2>&1"

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -393,12 +393,33 @@ expand_template() {
 	echo "$tpl"
 }
 
+# Minimum publish-age gate, in minutes. aube defaults to 1440 (24h)
+# as a supply-chain mitigation — the resolver skips versions newer
+# than this window. The default forces aube to fetch the full
+# (non-corgi) packument format so it can read the per-version `time`
+# map; corgi omits `time` on npmjs.org. Bun and pnpm both support an
+# equivalent flag; npm/yarn/deno/vlt don't. Pinning all supported
+# PMs to the same value is what makes the bench an apples-to-apples
+# comparison — otherwise aube alone pays the full-packument cost
+# (5x larger response on @types/node and similar heavily-versioned
+# packuments) while bun/pnpm cruise on corgi.
+#
+# Override via `BENCH_MIN_RELEASE_AGE_MINUTES=0` to disable the gate
+# across all PMs (useful for measuring raw resolver speed without
+# the security-feature axis).
+MIN_RELEASE_AGE_MINUTES="${BENCH_MIN_RELEASE_AGE_MINUTES:-1440}"
+MIN_RELEASE_AGE_SECONDS=$((MIN_RELEASE_AGE_MINUTES * 60))
+
 # Per-tool boilerplate factored out of the `CMDS` declarations below.
 # Every bun invocation threads the same hermetic environment
 # (isolated `HOME`, `BUN_INSTALL`, `--cache-dir`, `--ignore-scripts`,
 # `--no-summary`) so the scenarios only have to spell out the
 # install-mode flags that actually vary per scenario.
-BUN_BASE="HOME={home} BUN_INSTALL={home}/.bun {bin} install --cache-dir {cache} --ignore-scripts --no-summary"
+#
+# `--minimum-release-age` is bun's name for the same supply-chain
+# gate aube defaults on; matching the value here keeps the bench
+# from advantaging bun by silently skipping work aube does.
+BUN_BASE="HOME={home} BUN_INSTALL={home}/.bun {bin} install --cache-dir {cache} --ignore-scripts --no-summary --minimum-release-age=${MIN_RELEASE_AGE_SECONDS}"
 
 # aube reads the global store root from `$XDG_DATA_HOME/aube/store`
 # (falling back to `$HOME/.local/share/aube/store`). We must pin
@@ -438,7 +459,7 @@ cmd_template() {
 		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} ci --ignore-scripts --no-audit --no-fund --legacy-peer-deps --prefer-offline >/dev/null 2>&1"
 		;;
 	gvs-warm:pnpm | gvs-cold:pnpm | ci-warm:pnpm | ci-cold:pnpm)
-		echo "cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} {bin} install --frozen-lockfile --ignore-scripts --config.minimum-release-age=${MIN_RELEASE_AGE_MINUTES} >/dev/null 2>&1"
 		;;
 	gvs-warm:yarn | gvs-cold:yarn | ci-warm:yarn | ci-cold:yarn)
 		# Yarn 4: --immutable replaces --frozen-lockfile and aborts
@@ -475,7 +496,7 @@ cmd_template() {
 		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install-test --ignore-scripts --no-audit --no-fund --legacy-peer-deps --prefer-offline >/dev/null 2>&1"
 		;;
 	install-test:pnpm)
-		echo "cd {project} && HOME={home} {bin} install-test --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} {bin} install-test --frozen-lockfile --ignore-scripts --config.minimum-release-age=${MIN_RELEASE_AGE_MINUTES} >/dev/null 2>&1"
 		;;
 	install-test:yarn)
 		echo "cd {project} && HOME={home} {bin} install --immutable >/dev/null 2>&1 && HOME={home} {bin} test >/dev/null 2>&1"
@@ -490,13 +511,13 @@ cmd_template() {
 		echo "cd {project} && $AUBE_ENV_GVS_ON {bin} add is-odd >/dev/null 2>&1"
 		;;
 	add:bun)
-		echo "cd {project} && HOME={home} BUN_INSTALL={home}/.bun {bin} add is-odd --cache-dir {cache} --ignore-scripts --no-summary >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} BUN_INSTALL={home}/.bun {bin} add is-odd --cache-dir {cache} --ignore-scripts --no-summary --minimum-release-age=${MIN_RELEASE_AGE_SECONDS} >/dev/null 2>&1"
 		;;
 	add:npm)
 		echo "cd {project} && HOME={home} npm_config_cache={cache} {bin} install --ignore-scripts --no-audit --no-fund --legacy-peer-deps is-odd >/dev/null 2>&1"
 		;;
 	add:pnpm)
-		echo "cd {project} && HOME={home} {bin} add is-odd --ignore-scripts >/dev/null 2>&1"
+		echo "cd {project} && HOME={home} {bin} add is-odd --ignore-scripts --config.minimum-release-age=${MIN_RELEASE_AGE_MINUTES} >/dev/null 2>&1"
 		;;
 	add:yarn)
 		echo "cd {project} && HOME={home} {bin} add is-odd >/dev/null 2>&1"

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -439,7 +439,13 @@ BUN_BASE="HOME={home} BUN_INSTALL={home}/.bun {bin} install --cache-dir {cache} 
 # a host that already has `XDG_DATA_HOME` set in its environment
 # would leak the benchmark's store out of the isolated `{home}`,
 # and `COLD_WIPE` wouldn't find it to clean up between iterations.
-AUBE_ENV="HOME={home} XDG_CACHE_HOME={cache} XDG_DATA_HOME={home}/.local/share"
+# `npm_config_minimum_release_age` propagates the bench's
+# minimum-release-age value into aube (aube reads this env var via
+# its npm-compatible settings layer). Without it, aube uses its
+# compiled-in default (1440) regardless of
+# `BENCH_MIN_RELEASE_AGE_MINUTES`, silently breaking the
+# apples-to-apples guarantee for any non-default override.
+AUBE_ENV="HOME={home} XDG_CACHE_HOME={cache} XDG_DATA_HOME={home}/.local/share npm_config_minimum_release_age=${MIN_RELEASE_AGE_MINUTES}"
 
 # Per-scenario AUBE_ENV variants that pin aube's global virtual store mode
 # via the `enableGlobalVirtualStore` setting's auto-synthesized env-var

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -525,6 +525,9 @@ cmd_template() {
 		echo "cd {project} && $AUBE_ENV_GVS_ON {bin} add is-odd >/dev/null 2>&1"
 		;;
 	add:bun)
+		# Can't reuse $BUN_BASE: that template hardcodes `install`,
+		# this scenario needs `add`. Flag list below is intentionally
+		# kept in sync with BUN_BASE — update both together.
 		echo "cd {project} && HOME={home} BUN_INSTALL={home}/.bun {bin} add is-odd --cache-dir {cache} --ignore-scripts --no-summary --minimum-release-age=${MIN_RELEASE_AGE_SECONDS} >/dev/null 2>&1"
 		;;
 	add:npm)


### PR DESCRIPTION
## Summary

The bench was silently advantaging bun / pnpm / npm / deno by leaving the minimum-release-age gate unset (default = no gate) while aube applies its default of **1440 minutes (24h)** unconditionally. Because aube needs the per-version `time` map to apply the gate, and **npmjs corgi omits `time`**, aube's resolver falls back to the full (non-corgi) packument format — ~5× more bytes per packument for heavily-versioned packages like `@types/node`, `@typescript-eslint/*`, etc.

The other PMs cruise on corgi while aube does the security work. That's a real default-setting difference, and the bench should expose it via *equivalent settings on the other side*, not by leaving the gate off everywhere else.

## Changes

Every PM that supports a minimum-release-age equivalent gets the same gate (24h, matching aube's default):

| PM | flag | unit |
|---|---|---|
| **aube** | (default `minimumReleaseAge=1440`) | minutes |
| **npm** | `--min-release-age <days>` | days |
| **pnpm** | `--config.minimum-release-age=<n>` | minutes |
| **bun** | `--minimum-release-age=<n>` | seconds |
| **deno** | `--minimum-dependency-age=<n>` | minutes (marked Unstable but works) |
| yarn | not supported | — |
| vlt | not investigated (currently disabled in `BENCH_TOOLS`) | — |

Shared constant `MIN_RELEASE_AGE_MINUTES` at the top of `bench.sh` (default **1440**, override via `BENCH_MIN_RELEASE_AGE_MINUTES=<value>`). Each per-PM line converts to its native unit.

## Validation

Quick bench on bamboo (Ryzen 9 7950X3D, hermetic Verdaccio @ 500mbit/50ms, RUNS=4 WARMUP=1, BENCH_SCENARIOS=gvs-cold):

| PM | wall time | vs aube |
|---|---|---|
| **aube** | **1.309 ± 0.087 s** | — |
| bun | 1.423 ± 0.031 s | 1.09× slower |
| deno | 1.500 ± 0.026 s | 1.15× slower |
| pnpm | 2.339 ± 0.009 s | 1.79× slower |
| npm | 5.850 ± 0.026 s | 4.47× slower |

For comparison, the published `results.json` had aube *1.37× slower than bun* on the same scenario — entirely because the previous bench had bun (and npm/pnpm/deno) skipping the security gate. Under the leveled comparison, **aube is fastest across all five PMs that have the feature**.

## Test plan

- [x] shellcheck `benchmarks/bench.sh` clean
- [x] verify flag acceptance per PM (npm 11.14.1, pnpm 11.1.1, bun 1.3.13, deno latest — all exit 0 with their flags)
- [x] one-scenario bench across all five (numbers above)
- [ ] the daily `.github/workflows/bench-refresh.yml` cron will re-bench the full scenario matrix with `bench:bump` and open a PR to update `results.json` + the README BENCH_RATIOS block

## Notes for reviewers

- This **changes the published bench numbers in the next refresh cycle**. The README "ratios" block and `docs/benchmarks.data.ts` chart will reflect aube as faster than every other PM (that has the feature) on cold install where it previously showed slower. That's the intended outcome of the leveled comparison.
- The min-release-age value (1440 min / 24h) matches aube's *current* default. If aube's default changes, update this in lockstep.
- yarn doesn't have an equivalent. vlt is currently disabled in `BENCH_TOOLS` and wasn't investigated. They remain at the "no gate" baseline, which is honest about their feature set.

*This PR was prepared by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates benchmark harness flags/env vars only, but will materially change published benchmark numbers by making tools perform equivalent minimum-release-age work.
> 
> **Overview**
> Adds a shared `MIN_RELEASE_AGE_*` configuration to `benchmarks/bench.sh` (default 24h, overrideable via `BENCH_MIN_RELEASE_AGE_MINUTES`) and threads the equivalent minimum publish-age flags into bun/npm/pnpm/deno so benchmark runs are comparable with aube’s default security gate.
> 
> Also propagates the same value into aube via `npm_config_minimum_release_age` and keeps the bun `add` scenario’s flags in sync with the new `BUN_BASE` template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d198b2c9ed872a887cb3a199bbf5230b37f05350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->