### PR TITLE
perf(registry): single-flight concurrent packument fetches per name

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -164,6 +164,20 @@ pub struct RegistryClient {
     /// for the lifetime of the process (helpers are already memoized
     /// in `token_helper_cache`), so per-URL caching is safe.
     auth_token_by_url: Mutex<BTreeMap<String, Option<String>>>,
+    /// Single-flight gate for concurrent packument fetches. Keyed by
+    /// `<variant>:<registry_url>:<name>` so corgi and full lookups
+    /// against the same name are independently coalesced. The first
+    /// task to acquire the per-key tokio Mutex does the real network
+    /// fetch + cache write; later tasks block on the same mutex and
+    /// re-read the (now warm) disk cache on wake-up, skipping the
+    /// duplicate GET. Without this, a pre-resolver speculative
+    /// prefetch races against the resolver's own BFS fetches for the
+    /// same name and we pay 2× bandwidth + 2× server load on every
+    /// overlap. Entries are never removed — the lock itself is tiny
+    /// (`Arc<tokio::sync::Mutex<()>>`) and bounded by the dep graph
+    /// size for the install duration.
+    packument_in_flight:
+        Mutex<aube_util::collections::FxMap<String, std::sync::Arc<tokio::sync::Mutex<()>>>>,
     config: NpmConfig,
     network_mode: NetworkMode,
     fetch_policy: FetchPolicy,
@@ -229,11 +243,29 @@ impl RegistryClient {
             http_tarball,
             token_helper_cache: Mutex::new(BTreeMap::new()),
             auth_token_by_url: Mutex::new(BTreeMap::new()),
+            packument_in_flight: Mutex::new(aube_util::collections::FxMap::default()),
             config,
             network_mode: NetworkMode::Online,
             fetch_policy,
             default_registry_parsed: std::sync::OnceLock::new(),
         }
+    }
+
+    /// Return (and lazily insert) the per-name mutex from
+    /// `packument_in_flight`. Held in a `Mutex<FxMap>`: the std lock
+    /// is only held for the find-or-insert, not for the actual network
+    /// fetch — that's gated by the returned tokio `Mutex`. Callers
+    /// pass a `key` distinct per cache variant (corgi vs full) per
+    /// registry URL so concurrent fetches of the same name against
+    /// different caches don't serialize through each other.
+    fn packument_singleflight_mutex(&self, key: String) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+        let mut map = self
+            .packument_in_flight
+            .lock()
+            .expect("packument_in_flight mutex poisoned");
+        map.entry(key)
+            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 
     /// Force this client into a given network mode (online, prefer-offline,
@@ -909,7 +941,19 @@ impl RegistryClient {
             return Err(Error::Offline(format!("packument for {name}")));
         }
 
+        // Single-flight: same shape as `fetch_packument_cached_with_entry`.
+        // See that method's comment for the why. Keyed `full:<registry>:<name>`
+        // so the full and corgi paths don't serialize through each other.
         let (url, registry_url) = self.packument_url(name);
+        let sf_key = format!("full:{registry_url}:{name}");
+        let sf_mutex = self.packument_singleflight_mutex(sf_key);
+        let _sf_guard = sf_mutex.lock().await;
+        let cached = match read_cached_full_packument(&cache_path) {
+            Some(c) if force_cache || cached_is_fresh(c.fetched_at, c.max_age_secs) => {
+                return Ok(c.packument);
+            }
+            recheck => recheck.or(cached),
+        };
         let started = std::time::Instant::now();
 
         // Rebuild the conditional request on each retry. Held in a
@@ -1123,6 +1167,17 @@ impl RegistryClient {
         let cache_path = packument_full_cache_path(cache_dir, name, &registry_url)
             .ok_or_else(|| Error::InvalidName(name.to_string()))?;
         let (url, registry_url) = self.packument_url(name);
+
+        // Single-flight: see `fetch_packument_cached_with_entry`.
+        // Coalesce concurrent revalidations for the same name into one
+        // network conditional-GET; later waiters re-read the warm cache.
+        let sf_key = format!("full:{registry_url}:{name}");
+        let sf_mutex = self.packument_singleflight_mutex(sf_key);
+        let _sf_guard = sf_mutex.lock().await;
+        if let Some(refreshed) = read_cached_full_packument_typed(&cache_path, force_cache) {
+            return Ok(refreshed);
+        }
+
         let label = format!("packument {name}");
         let started = std::time::Instant::now();
         let max_attempts = self.fetch_policy.retries.saturating_add(1);
@@ -1444,7 +1499,28 @@ impl RegistryClient {
             return Err(Error::Offline(format!("packument for {name}")));
         }
 
+        // Single-flight: when a pre-resolver speculative prefetch and
+        // the resolver's BFS both ask for the same name within the
+        // same install, the first one to land here does the network
+        // fetch + cache write. The second one blocks on the per-name
+        // tokio Mutex and re-reads the (now warm) disk cache on
+        // wake-up, skipping the duplicate GET entirely. Keyed by
+        // `corgi:<registry>:<name>` so corgi and full caches stay
+        // independent. Drops the std lock immediately — only the
+        // tokio Mutex is held across the network await.
         let (url, registry_url) = self.packument_url(name);
+        let sf_key = format!("corgi:{registry_url}:{name}");
+        let sf_mutex = self.packument_singleflight_mutex(sf_key);
+        let _sf_guard = sf_mutex.lock().await;
+        // Re-read the cache under the lock — another task may have
+        // populated it while we waited. Costs one disk read per
+        // coalesced caller but saves a full HTTP round-trip.
+        let cached = match read_cached_packument(&cache_path) {
+            Some(c) if force_cache || cached_is_fresh(c.fetched_at, c.max_age_secs) => {
+                return Ok(c.packument);
+            }
+            recheck => recheck.or(cached),
+        };
 
         // Normally we ask for the abbreviated (corgi) response so we
         // get a smaller payload. See `force_full_packument()` for why
@@ -3357,6 +3433,104 @@ mod retry_tests {
 
         let requests = server.received_requests().await.unwrap();
         assert_eq!(requests.len(), 2, "expected retry after decode error");
+    }
+
+    #[tokio::test]
+    async fn concurrent_corgi_fetches_for_same_name_coalesce_to_one_request() {
+        // Two concurrent `fetch_packument_cached` calls for "demo"
+        // must hit the registry exactly once: the second caller
+        // waits on the per-name single-flight mutex and re-reads
+        // the warmed disk cache on wake-up. The mock injects a
+        // 100ms delay so both callers land inside the singleflight
+        // window deterministically.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/demo"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_millis(100))
+                    .set_body_json(make_packument_json()),
+            )
+            .mount(&server)
+            .await;
+
+        let policy = FetchPolicy {
+            timeout_ms: 5_000,
+            ..FetchPolicy::default()
+        };
+        let client = std::sync::Arc::new(client_with(&server, policy));
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().to_path_buf();
+
+        let c1 = std::sync::Arc::clone(&client);
+        let c2 = std::sync::Arc::clone(&client);
+        let d1 = dir.clone();
+        let d2 = dir.clone();
+        let h1 = tokio::spawn(async move { c1.fetch_packument_cached("demo", &d1).await });
+        let h2 = tokio::spawn(async move { c2.fetch_packument_cached("demo", &d2).await });
+        let (r1, r2) = tokio::join!(h1, h2);
+        let p1 = r1.unwrap().expect("first fetch ok");
+        let p2 = r2.unwrap().expect("second fetch ok");
+        assert_eq!(p1.name, "demo");
+        assert_eq!(p2.name, "demo");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(
+            requests.len(),
+            1,
+            "expected single-flight to coalesce concurrent fetches into one network call"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_full_fetches_for_same_name_coalesce_to_one_request() {
+        // Mirror of the corgi test for the full-packument path:
+        // `fetch_packument_full_cached` must also dedup concurrent
+        // calls. The resolver hits this variant whenever
+        // `trustPolicy=no-downgrade` or `minimumReleaseAge` requires
+        // the `time` field — which is the default for npmjs.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/demo"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_millis(100))
+                    .set_body_json(serde_json::json!({
+                        "name": "demo",
+                        "versions": {},
+                        "dist-tags": {},
+                        "time": {},
+                    })),
+            )
+            .mount(&server)
+            .await;
+
+        let policy = FetchPolicy {
+            timeout_ms: 5_000,
+            ..FetchPolicy::default()
+        };
+        let client = std::sync::Arc::new(client_with(&server, policy));
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().to_path_buf();
+
+        let c1 = std::sync::Arc::clone(&client);
+        let c2 = std::sync::Arc::clone(&client);
+        let d1 = dir.clone();
+        let d2 = dir.clone();
+        let h1 = tokio::spawn(async move { c1.fetch_packument_full_cached("demo", &d1).await });
+        let h2 = tokio::spawn(async move { c2.fetch_packument_full_cached("demo", &d2).await });
+        let (r1, r2) = tokio::join!(h1, h2);
+        let v1 = r1.unwrap().expect("first fetch ok");
+        let v2 = r2.unwrap().expect("second fetch ok");
+        assert_eq!(v1["name"], "demo");
+        assert_eq!(v2["name"], "demo");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(
+            requests.len(),
+            1,
+            "expected single-flight to coalesce concurrent full-packument fetches"
+        );
     }
 
     #[tokio::test]

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -944,10 +944,12 @@ impl RegistryClient {
         // Single-flight: same shape as `fetch_packument_cached_with_entry`.
         // See that method's comment for the why. Keyed `full:<registry>:<name>`
         // so the full and corgi paths don't serialize through each other.
+        // Released before any retry backoff sleep so waiters don't pay
+        // a serialized recovery cost when the winner hits transient errors.
         let (url, registry_url) = self.packument_url(name);
         let sf_key = format!("full:{registry_url}:{name}");
         let sf_mutex = self.packument_singleflight_mutex(sf_key);
-        let _sf_guard = sf_mutex.lock().await;
+        let mut sf_guard = Some(sf_mutex.lock().await);
         let cached = match read_cached_full_packument(&cache_path) {
             Some(c) if force_cache || cached_is_fresh(c.fetched_at, c.max_age_secs) => {
                 return Ok(c.packument);
@@ -1004,6 +1006,7 @@ impl RegistryClient {
                         code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
                         "retrying HTTP request after transient failure",
                     );
+                    drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
                 }
                 Ok(resp) => {
@@ -1069,6 +1072,7 @@ impl RegistryClient {
                                     code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_BODY_DECODE,
                             "retrying HTTP request after response body decode error",
                                 );
+                            drop(sf_guard.take());
                             tokio::time::sleep(wait).await;
                         }
                         Err(err) => return Err(err),
@@ -1085,6 +1089,7 @@ impl RegistryClient {
                         code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSPORT,
                         "retrying HTTP request after transport error",
                     );
+                    drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
                 }
                 Err(err) => return Err(err.into()),
@@ -1171,9 +1176,11 @@ impl RegistryClient {
         // Single-flight: see `fetch_packument_cached_with_entry`.
         // Coalesce concurrent revalidations for the same name into one
         // network conditional-GET; later waiters re-read the warm cache.
+        // Released before any retry backoff sleep so waiters don't pay
+        // a serialized recovery cost when the winner hits transient errors.
         let sf_key = format!("full:{registry_url}:{name}");
         let sf_mutex = self.packument_singleflight_mutex(sf_key);
-        let _sf_guard = sf_mutex.lock().await;
+        let mut sf_guard = Some(sf_mutex.lock().await);
         if let Some(refreshed) = read_cached_full_packument_typed(&cache_path, force_cache) {
             return Ok(refreshed);
         }
@@ -1211,6 +1218,7 @@ impl RegistryClient {
                         code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
                         "retrying HTTP request after transient failure",
                     );
+                    drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
                 }
                 Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => {
@@ -1293,6 +1301,7 @@ impl RegistryClient {
                                     code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_BODY_DECODE,
                             "retrying HTTP request after response body decode error",
                                 );
+                            drop(sf_guard.take());
                             tokio::time::sleep(wait).await;
                         }
                         Err(err) => return Err(err),
@@ -1309,6 +1318,7 @@ impl RegistryClient {
                         code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSPORT,
                         "retrying HTTP request after transport error",
                     );
+                    drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
                 }
                 Err(err) => return Err(err.into()),
@@ -1508,10 +1518,14 @@ impl RegistryClient {
         // `corgi:<registry>:<name>` so corgi and full caches stay
         // independent. Drops the std lock immediately — only the
         // tokio Mutex is held across the network await.
+        //
+        // Released before any retry backoff sleep so a winner stuck
+        // in exponential backoff against a flaky registry doesn't
+        // serialize the recovery of N concurrent waiters behind it.
         let (url, registry_url) = self.packument_url(name);
         let sf_key = format!("corgi:{registry_url}:{name}");
         let sf_mutex = self.packument_singleflight_mutex(sf_key);
-        let _sf_guard = sf_mutex.lock().await;
+        let mut sf_guard = Some(sf_mutex.lock().await);
         // Re-read the cache under the lock — another task may have
         // populated it while we waited. Costs one disk read per
         // coalesced caller but saves a full HTTP round-trip.
@@ -1573,6 +1587,7 @@ impl RegistryClient {
                         code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
                         "retrying HTTP request after transient failure",
                     );
+                    drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
                 }
                 Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => {
@@ -1637,6 +1652,7 @@ impl RegistryClient {
                                     code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_BODY_DECODE,
                             "retrying HTTP request after response body decode error",
                                 );
+                            drop(sf_guard.take());
                             tokio::time::sleep(wait).await;
                         }
                         Err(err) => return Err(err),
@@ -1653,6 +1669,7 @@ impl RegistryClient {
                         code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_BODY_DECODE,
                         "retrying HTTP request after response body decode error",
                     );
+                    drop(sf_guard.take());
                     tokio::time::sleep(wait).await;
                 }
                 Err(err) => return Err(err.into()),
@@ -3530,6 +3547,80 @@ mod retry_tests {
             requests.len(),
             1,
             "expected single-flight to coalesce concurrent full-packument fetches"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_typed_revalidations_for_same_name_coalesce_to_one_request() {
+        // Companion to the corgi/full tests for the typed
+        // revalidation path. Seeds a stale full-cache entry so
+        // `cached_packument_lookup` hands back `Some(Full(...))`,
+        // which routes both concurrent callers through
+        // `revalidate_full_packument_typed`. The winner does the
+        // conditional GET and writes a fresh cache; the loser
+        // re-reads the now-warm cache via the typed deserializer
+        // and skips the network entirely.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/demo"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_millis(100))
+                    .set_body_json(serde_json::json!({
+                        "name": "demo",
+                        "versions": {},
+                        "dist-tags": {},
+                        "time": {},
+                    })),
+            )
+            .mount(&server)
+            .await;
+
+        let policy = FetchPolicy {
+            timeout_ms: 5_000,
+            ..FetchPolicy::default()
+        };
+        let client = std::sync::Arc::new(client_with(&server, policy));
+        let temp = tempfile::tempdir().unwrap();
+        let dir = temp.path().to_path_buf();
+
+        let seed = Packument {
+            name: "demo".to_owned(),
+            modified: None,
+            versions: BTreeMap::new(),
+            dist_tags: BTreeMap::new(),
+            time: BTreeMap::new(),
+        };
+        client.seed_full_packument_cache("demo", &dir, &seed, None, None, false);
+
+        let lookup1 = client.cached_packument_lookup("demo", &dir);
+        let lookup2 = client.cached_packument_lookup("demo", &dir);
+        assert!(lookup1.stale, "seed should be reported as stale");
+        assert!(lookup2.stale, "seed should be reported as stale");
+
+        let c1 = std::sync::Arc::clone(&client);
+        let c2 = std::sync::Arc::clone(&client);
+        let d1 = dir.clone();
+        let d2 = dir.clone();
+        let h1 = tokio::spawn(async move {
+            c1.fetch_packument_with_time_cached_after_lookup("demo", &d1, lookup1)
+                .await
+        });
+        let h2 = tokio::spawn(async move {
+            c2.fetch_packument_with_time_cached_after_lookup("demo", &d2, lookup2)
+                .await
+        });
+        let (r1, r2) = tokio::join!(h1, h2);
+        let p1 = r1.unwrap().expect("first revalidate ok");
+        let p2 = r2.unwrap().expect("second revalidate ok");
+        assert_eq!(p1.name, "demo");
+        assert_eq!(p2.name, "demo");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(
+            requests.len(),
+            1,
+            "expected single-flight to coalesce concurrent typed revalidations into one network call"
         );
     }
 


### PR DESCRIPTION
## Summary

Two correctness improvements in the registry client that coalesce concurrent packument fetches and free waiters from each other's retry backoff:

1. **Per-name single-flight on packument fetches.** A `Mutex<FxMap<String, Arc<tokio::sync::Mutex<()>>>>` on `RegistryClient` keyed by `<variant>:<registry>:<name>` coalesces concurrent fetches for the same name into one network round-trip. The first task does the GET + cache write; later tasks block on the per-name tokio Mutex and re-read the now-warm disk cache on wake-up. Covers all three packument entry points (`fetch_packument_cached_with_entry`, `fetch_packument_full_cached`, `revalidate_full_packument_typed`).

2. **Release the single-flight lock before retry backoff.** Earlier draft of the dedup held the guard across `tokio::time::sleep(wait)` inside each retry-loop branch, which under sustained registry stress would serialize N waiters behind the winner's cumulative backoff (`N × retry_time` instead of pre-dedup `retry_time` with parallel failures). The guard is now wrapped in `Option<MutexGuard<'_, ()>>` and dropped via `sf_guard.take()` immediately before each backoff sleep. Happy-path single-flight (one network round-trip for N concurrent callers) is unchanged; the error path lets waiters retry in parallel.

## Why this is correctness, not perf

This PR doesn't move the canonical bench. Singleflight only fires when two callers reach the same `<variant>:<registry>:<name>` slot concurrently — and on every default-aube path I've benched, the existing prefetch and the resolver never actually contend through this slot:

- On **npmjs default**: the resolver mostly hits the bundled primer (~76% hit rate) and writes the *full* cache for the rest. The existing `spawn_direct_dep_prefetch` writes the *corgi* cache. Different singleflight keys → never coalesce.
- On **canonical hermetic bench** (`AUBE_FORCE_METADATA_PRIMER=true`): the resolver bypasses almost all packument fetches via the forced primer, so there's little for singleflight to even dedup.
- On **custom registry default** (Artifactory/Nexus): the primer is off, so the resolver fetches everything from the full cache; prefetch writes corgi; still different keys.

What this PR *is* useful for is closing the door on duplicate work whenever it does happen: future prefetch redesigns, cache-revalidation races, or pnpmfile hooks that ask the same name through different code paths now coalesce cleanly. The lock-release-before-backoff fix is the real teeth — it makes the dedup safe under sustained registry stress.

## What changed since the previous version of this PR

The earlier shape carried a speculative primer-transitive prefetch + a cache-variant fix + a concurrency throttle + a revert. Benching on bamboo across hermetic loopback, hermetic at 200ms RTT, and real npmjs revealed:

- The speculative walk consistently regressed wall time at non-trivial latency (+1% at 200ms RTT against a 50mbit hermetic registry).
- The cache-variant fix (matching the resolver's `needs_time` decision so prefetch writes land in the cache the resolver reads) inflated User CPU by ~1.4s because the full packument is ~5× larger than corgi.
- Underneath both of those, the **pre-existing `spawn_direct_dep_prefetch` itself** turned out to cost ~14% wall on 200ms-RTT hermetic and ~20% on loopback — independent of this PR. Disabling it via `AUBE_DISABLE_PREFETCH=1` on plain `main` matches a head-only-warmup variant exactly.

That makes the existing direct-dep prefetch a separate concern worth its own PR rather than something to build more speculation on top of. This PR narrows back to just the two registry-client improvements that stand on their own; the prefetch cleanup is queued as follow-up.

## Bench summary (bamboo, real npmjs not throttled, hermetic via Verdaccio + throttle-proxy)

Numbers are from runs that isolated each variable; full diag and per-arm hyperfine output preserved in the PR thread.

| Scenario | main | this PR | delete prefetch (follow-up) |
|---|---|---|---|
| Hermetic loopback (default Verdaccio, no `AUBE_FORCE_METADATA_PRIMER`) | 7.31s ± 0.10 | 7.17s ± 0.08 | **6.10s ± 0.08 (−17%)** |
| Hermetic 50mbit / 200ms RTT | 24.30s ± 0.13 | (was 24.53s with speculative) | **21.27s ± 0.10 (−14%)** |
| Canonical hermetic + `AUBE_FORCE_METADATA_PRIMER=true` (470ms bench) | within σ | within σ | within σ |
| Real npmjs from bamboo (30 runs, σ huge) | 1.79s ± 0.57 | 1.93s ± 0.80 | 1.93s ± 0.80 |
| User CPU per install | 5.77s | 5.79s | 5.10s |

The PR-as-shipped (singleflight + lock-release only) is within σ of main on every scenario — it's neutral on wall time, which is the right shape for a correctness change.

## Test plan

- [x] `cargo test -p aube-registry --lib concurrent_` (3 new tests, one per fetch entry point)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Hermetic + real npmjs benches on bamboo (5+ separate runs, see PR thread)
- [ ] CI: existing matrix

## Test additions

- `concurrent_corgi_fetches_for_same_name_coalesce_to_one_request`
- `concurrent_full_fetches_for_same_name_coalesce_to_one_request`
- `concurrent_typed_revalidations_for_same_name_coalesce_to_one_request`

Each spins up a wiremock that injects a 100ms delay, fires two concurrent fetches for the same name, asserts the server saw exactly one request.

## Follow-up

A separate PR (build from spike on `claude/prefetch-head-only`) should delete `spawn_direct_dep_prefetch` and lean on the existing `prewarm_connection()` at install/mod.rs:3447 for TCP/TLS warmup. The bench numbers above are the justification; the spike's diag shows the body-prefetch's harm is concentrated on the first BFS wave (single direct-dep packument waits go from 2098ms → 367ms at 200ms RTT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)