### PR TITLE
fix(global): unlink hash pointer via remove_dir fallback on Windows

### DIFF
--- a/crates/aube/src/commands/global.rs
+++ b/crates/aube/src/commands/global.rs
@@ -455,20 +455,16 @@ pub fn remove_package(info: &GlobalPackageInfo, layout: &GlobalLayout) -> miette
     let bins = bin_names_for(&info.install_dir, &info.aliases);
     unlink_bins(&info.install_dir, &layout.bin_dir, &bins);
 
-    // Remove the hash pointer first. Propagate errors other than
-    // NotFound — a missing pointer is fine (the caller may have already
-    // cleaned it up), but permission denied or similar means the package
-    // is still findable and we must not report success.
+    // Remove the hash pointer first. A missing pointer is fine (the
+    // caller may have already cleaned it up), but permission denied or
+    // similar means the package is still findable and we must not
+    // report success. `super::remove_existing` handles the Windows
+    // directory-junction case where `remove_file` fails with
+    // `Access is denied`; we created the pointer via `create_dir_link`
+    // (NTFS junction), so a plain `remove_file` here would leak it.
     let hash_ptr = hash_link(&layout.pkg_dir, &info.hash);
-    match std::fs::remove_file(&hash_ptr) {
-        Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => {
-            return Err(e)
-                .into_diagnostic()
-                .wrap_err_with(|| format!("failed to remove hash pointer {}", hash_ptr.display()));
-        }
-    }
+    super::remove_existing(&hash_ptr)
+        .wrap_err_with(|| format!("failed to remove hash pointer {}", hash_ptr.display()))?;
 
     // `crate::dirs::canonicalize` so `pkg_canon` is comparable with the
     // `info.install_dir` `scan_packages` produced — both must be in the

--- a/crates/aube/src/commands/global.rs
+++ b/crates/aube/src/commands/global.rs
@@ -463,8 +463,7 @@ pub fn remove_package(info: &GlobalPackageInfo, layout: &GlobalLayout) -> miette
     // `Access is denied`; we created the pointer via `create_dir_link`
     // (NTFS junction), so a plain `remove_file` here would leak it.
     let hash_ptr = hash_link(&layout.pkg_dir, &info.hash);
-    super::remove_existing(&hash_ptr)
-        .wrap_err_with(|| format!("failed to remove hash pointer {}", hash_ptr.display()))?;
+    super::remove_existing(&hash_ptr)?;
 
     // `crate::dirs::canonicalize` so `pkg_canon` is comparable with the
     // `info.install_dir` `scan_packages` produced — both must be in the

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -1442,20 +1442,34 @@ fn resolve_verify_deps_before_run(cwd: &std::path::Path) -> miette::Result<Verif
 }
 
 /// Remove an existing file/dir/symlink at the given path, if present.
+///
+/// Windows quirk: directory junctions and directory symlinks report as
+/// symlinks via `symlink_metadata`, but `std::fs::remove_file` returns
+/// `Access is denied (os error 5)` for them — the Win32 `DeleteFile`
+/// syscall only works on file-shaped entries. The link entry has to be
+/// torn down with `RemoveDirectory` (= `std::fs::remove_dir`), which is
+/// non-recursive and so leaves the junction target untouched. Falling
+/// back on `remove_file` failure keeps every other platform on the
+/// usual single-syscall path.
 pub(crate) fn remove_existing(path: &std::path::Path) -> miette::Result<()> {
-    if path.symlink_metadata().is_err() {
+    let Ok(md) = path.symlink_metadata() else {
         return Ok(());
-    }
-    if path.is_dir() && !path.is_symlink() {
-        std::fs::remove_dir_all(path)
+    };
+    let file_type = md.file_type();
+    if file_type.is_dir() {
+        return std::fs::remove_dir_all(path)
             .into_diagnostic()
-            .wrap_err_with(|| format!("failed to remove {}", path.display()))?;
-    } else {
-        std::fs::remove_file(path)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to remove {}", path.display()))?;
+            .wrap_err_with(|| format!("failed to remove {}", path.display()));
     }
-    Ok(())
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(_) if file_type.is_symlink() => std::fs::remove_dir(path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to remove {}", path.display())),
+        Err(e) => Err(e)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to remove {}", path.display())),
+    }
 }
 
 pub(crate) fn workspace_importer_path(
@@ -1643,5 +1657,38 @@ mod manifest_write_tests {
             panic!("expected object");
         };
         obj.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod remove_existing_tests {
+    use super::*;
+
+    #[test]
+    fn removes_a_symlink_pointing_at_a_populated_directory_without_touching_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        let canary = target.join("keep.txt");
+        std::fs::write(&canary, b"keep me").unwrap();
+
+        let link = dir.path().join("link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        #[cfg(windows)]
+        aube_linker::create_dir_link(&target, &link).unwrap();
+
+        remove_existing(&link).unwrap();
+        assert!(!link.exists());
+        assert!(
+            canary.exists(),
+            "remove_existing must not recurse into the symlink's target"
+        );
+    }
+
+    #[test]
+    fn missing_path_is_a_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        remove_existing(&dir.path().join("does-not-exist")).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- `aube remove --global` failed on Windows with `failed to remove hash pointer ... Access is denied (os error 5)` because the hash pointer is created as an NTFS directory junction (via `create_dir_link`) and `std::fs::remove_file` cannot unlink junctions — Win32 `DeleteFile` only works on file-shaped entries. Reported in [#653](https://github.com/endevco/aube/discussions/653).
- Fixed by routing the hash-pointer removal through `remove_existing`, which now falls back to non-recursive `remove_dir` on symlink-typed entries. The fallback is non-recursive, so the junction target (the actual install dir) is left untouched and gets cleaned up by the subsequent `remove_dir_all` pass.
- The shared `remove_existing` helper had the same trap (`is_dir() && !is_symlink()` routed junctions into `remove_file`), so callers in `clean`, `prune`, `link`, `ci`, and `symlink_force` all benefit from the same fix.

## Test plan
- [x] `cargo test -p aube` — 484/484 pass, including a new test that creates a directory symlink/junction over a populated directory, calls `remove_existing` on the link, and asserts the link is gone while a canary file inside the target survives (catches recursion regressions on top of the original `Access is denied`).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] Manual Windows verification of `aube add -g <pkg>` followed by `aube remove -g <pkg>` against an NTFS directory junction (cannot run from this environment — reporter on the discussion is best placed to confirm against a release build).

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared filesystem deletion logic used by multiple commands; incorrect link-type handling could accidentally delete real directories or leave stale links on Windows.
> 
> **Overview**
> Fixes `aube remove -g` on Windows by deleting global hash pointers (NTFS junctions) through the shared `remove_existing` helper instead of `remove_file`, avoiding `Access is denied` failures.
> 
> Updates `remove_existing` to use `symlink_metadata` and, for symlink-typed entries where `remove_file` fails, fall back to non-recursive `remove_dir` so junctions are removed without recursing into their targets; adds regression tests ensuring directory-link removal doesn’t delete the linked directory and that missing paths are a no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 658da98ff6fb9d27a543ad66578744a768096758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->