### PR TITLE
fix(linker): anchor windows bin-shim relative path on the surface tree

### DIFF
--- a/crates/aube/src/commands/install/bin_linking.rs
+++ b/crates/aube/src/commands/install/bin_linking.rs
@@ -446,30 +446,52 @@ fn create_bin_link(
     // when the leaf sits behind a junction in the path, even when the
     // leaf is absent. The isolated layout's `.aube/<dep_path>` is a
     // junction into the global virtual store, so every `.bin/` under it
-    // hits the quirk. Fix: canonicalize the parent (`crate::dirs::canonicalize`
-    // already strips the `\\?\` verbatim prefix, which would otherwise
-    // trip CreateDirectoryW's own os-123 quirk, while keeping real
-    // `\\?\UNC\…` share paths intact), then create the leaf on the
-    // resulting plain drive path. No-op on Unix.
+    // hits the quirk. Workaround: canonicalize the parent
+    // (`crate::dirs::canonicalize` already strips the `\\?\` verbatim
+    // prefix, which would otherwise trip CreateDirectoryW's own os-123
+    // quirk, while keeping real `\\?\UNC\…` share paths intact), then
+    // create everything down to `link_path.parent()` on that plain-drive
+    // root. The leaf inode is shared with the surface side, so
+    // `create_bin_shim` later writes through the surface path into the
+    // same directory. Including the `link_path.parent()` here covers
+    // scoped bin names (`@scope/foo`): we have to pre-create
+    // `<bin_dir>/@scope/` on the canonical side too, because
+    // `create_bin_shim`'s own `create_dir_all` would otherwise trip the
+    // same quirk on the surface side and the shim's `@scope/foo.cmd`
+    // write would fail with `NotFound`. No-op on Unix.
+    //
+    // Pass the *surface* `bin_dir` (not the canonicalized form) to
+    // `create_bin_shim`: the shim's relative target is anchored on
+    // `link_parent`, and the canonical form lives on a different
+    // subtree (the GVS, e.g. `…\aube\virtual-store\…`) than the
+    // surface invocation path (`…\.aube\<dep_path>\node_modules\.bin\`).
+    // `pathdiff` would then find only `C:\Users\…\AppData\Local\` as a
+    // common prefix and emit a long `..\..\..\…` traversal back down
+    // through the surface tree, producing the duplicated install-root
+    // path Node surfaces as `Cannot find module
+    // '…\pnpm\global-aube\<hash>\pnpm\global-aube\<hash>\…'`
+    // (Discussion #654).
     #[cfg(windows)]
-    let target_for_mkdir_owned = bin_dir.parent().and_then(|parent| {
+    let mkdir_root_owned = bin_dir.parent().and_then(|parent| {
         let leaf = bin_dir.file_name()?;
         let canon = crate::dirs::canonicalize(parent).ok()?;
         Some(canon.join(leaf))
     });
     #[cfg(windows)]
-    let target_for_mkdir: &std::path::Path = target_for_mkdir_owned.as_deref().unwrap_or(bin_dir);
+    let mkdir_root: &std::path::Path = mkdir_root_owned.as_deref().unwrap_or(bin_dir);
     #[cfg(not(windows))]
-    let target_for_mkdir = bin_dir;
-    if let Err(e) = std::fs::create_dir_all(target_for_mkdir) {
-        let tolerated = e.kind() == std::io::ErrorKind::AlreadyExists && target_for_mkdir.is_dir();
+    let mkdir_root = bin_dir;
+    let mkdir_link_path = mkdir_root.join(name);
+    let mkdir_target = mkdir_link_path.parent().unwrap_or(mkdir_root);
+    if let Err(e) = std::fs::create_dir_all(mkdir_target) {
+        let tolerated = e.kind() == std::io::ErrorKind::AlreadyExists && mkdir_target.is_dir();
         if !tolerated {
             return Err(e)
                 .into_diagnostic()
                 .wrap_err_with(|| format!("failed to create bin directory {}", bin_dir.display()));
         }
     }
-    aube_linker::create_bin_shim(target_for_mkdir, name, target, shim_opts)
+    aube_linker::create_bin_shim(bin_dir, name, target, shim_opts)
         .into_diagnostic()
         .wrap_err_with(|| {
             format!(
@@ -556,5 +578,78 @@ mod tests {
         .unwrap();
 
         assert!(project_dir.join("node_modules/.bin/vitepress").exists());
+    }
+
+    /// Regression for Discussion #654. The isolated layout puts
+    /// `.aube/<dep_path>` as an NTFS junction into the global virtual
+    /// store, and per-dep `.bin/` lives under that junction. The
+    /// previous `create_bin_link` body canonicalized the bin-dir parent
+    /// (workaround for `CreateDirectoryW`'s ERROR_ALREADY_EXISTS quirk)
+    /// and *also* handed that canonical path to `create_bin_shim`. The
+    /// generated `.cmd` then anchored its relative target on the GVS
+    /// subtree, but `%~dp0` at runtime is the surface invocation path —
+    /// so the combined path re-descended through the install root and
+    /// Node surfaced `Cannot find module
+    /// '…\pnpm\global-aube\<hash>\pnpm\global-aube\<hash>\…'`. The fix
+    /// keeps the canonical mkdir but routes the shim writer through
+    /// the surface `bin_dir`, so `pathdiff` sees a short common prefix
+    /// and emits the expected `..\..\..\…` form.
+    #[cfg(windows)]
+    #[test]
+    fn create_bin_link_surface_relative_path_when_dep_dir_is_a_junction() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        let aube_dir = project.join("node_modules/.aube");
+        std::fs::create_dir_all(&aube_dir).unwrap();
+
+        // Stand-in for the GVS: a separate subtree the dep_path junction
+        // points at.
+        let gvs = project.join("gvs");
+        let gvs_dep = gvs.join("node-liblzma@2.2.0/node_modules");
+        std::fs::create_dir_all(&gvs_dep).unwrap();
+        aube_linker::create_dir_link(
+            &gvs.join("node-liblzma@2.2.0"),
+            &aube_dir.join("node-liblzma@2.2.0"),
+        )
+        .unwrap();
+
+        // Sibling `.aube/` entry housing the bin we want to shim into
+        // the junction's `.bin/`. Lives on the surface tree, not under
+        // the junction.
+        let target_pkg = aube_dir.join("prebuild-install@7.1.3/node_modules/prebuild-install");
+        std::fs::create_dir_all(&target_pkg).unwrap();
+        let target = target_pkg.join("bin.js");
+        std::fs::write(&target, "#!/usr/bin/env node\n").unwrap();
+
+        // Surface bin dir: traverses the junction. Pre-fix, the canonical
+        // form lived under `gvs/…`, which is precisely the mismatch this
+        // test pins down.
+        let bin_dir = aube_dir.join("node-liblzma@2.2.0/node_modules/.bin");
+
+        create_bin_link(
+            &bin_dir,
+            "prebuild-install",
+            &target,
+            aube_linker::BinShimOptions::default(),
+        )
+        .unwrap();
+
+        let cmd = std::fs::read_to_string(bin_dir.join("prebuild-install.cmd")).unwrap();
+        // Three uplevels out of `.bin/`: `.bin` → `node_modules` →
+        // `node-liblzma@2.2.0` → `.aube`, then descend into the sibling
+        // `prebuild-install@7.1.3` entry.
+        let expected = r"..\..\..\prebuild-install@7.1.3\node_modules\prebuild-install\bin.js";
+        assert!(
+            cmd.contains(expected),
+            ".cmd shim should embed surface-tree relative path `{expected}`; got:\n{cmd}"
+        );
+        // Belt-and-braces: the pre-fix bug embedded a path that re-descended
+        // through the project root after a long `..\` chain. Reject any
+        // absolute-style fragment or a relative path that escapes far enough
+        // to climb above `.aube/`.
+        assert!(
+            !cmd.contains(r"..\..\..\..\"),
+            ".cmd shim should not climb above the `.aube/` root; got:\n{cmd}"
+        );
     }
 }

--- a/crates/aube/src/commands/install/bin_linking.rs
+++ b/crates/aube/src/commands/install/bin_linking.rs
@@ -652,4 +652,72 @@ mod tests {
             ".cmd shim should not climb above the `.aube/` root; got:\n{cmd}"
         );
     }
+
+    /// Companion to the case above: scoped bin name (`@scope/foo`)
+    /// behind the same junction. The pre-fix code routed shim writes
+    /// through the canonical bin dir, so `create_bin_shim`'s internal
+    /// `create_dir_all(<bin>\@scope)` ran on the GVS subtree where no
+    /// junction is in the path — it just worked. With the fix, the
+    /// shim writer sees the *surface* path and would hit the same
+    /// "leaf behind junction" `ERROR_ALREADY_EXISTS` quirk on the
+    /// `@scope/` mkdir. The fix's other half is pre-creating
+    /// `link_path.parent()` on the canonical side; this test pins
+    /// that behavior — without it, `@scope/foo.cmd` would fail to
+    /// write through the junction with `NotFound`.
+    #[cfg(windows)]
+    #[test]
+    fn create_bin_link_creates_scoped_parent_when_dep_dir_is_a_junction() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        let aube_dir = project.join("node_modules/.aube");
+        std::fs::create_dir_all(&aube_dir).unwrap();
+
+        let gvs = project.join("gvs");
+        let gvs_dep = gvs.join("node-liblzma@2.2.0/node_modules");
+        std::fs::create_dir_all(&gvs_dep).unwrap();
+        aube_linker::create_dir_link(
+            &gvs.join("node-liblzma@2.2.0"),
+            &aube_dir.join("node-liblzma@2.2.0"),
+        )
+        .unwrap();
+
+        // Scoped sibling: target lives at
+        // `.aube/@scope+tool@1.0.0/node_modules/@scope/tool/cli.js` on
+        // the surface tree (the linker escapes `/` as `+` in the
+        // dep_path filename).
+        let target_pkg = aube_dir.join("@scope+tool@1.0.0/node_modules/@scope/tool");
+        std::fs::create_dir_all(&target_pkg).unwrap();
+        let target = target_pkg.join("cli.js");
+        std::fs::write(&target, "#!/usr/bin/env node\n").unwrap();
+
+        let bin_dir = aube_dir.join("node-liblzma@2.2.0/node_modules/.bin");
+
+        create_bin_link(
+            &bin_dir,
+            "@scope/tool",
+            &target,
+            aube_linker::BinShimOptions::default(),
+        )
+        .unwrap();
+
+        // `@scope/` must exist as an actual directory on the surface
+        // side (visible via the junction) so the shim file landed.
+        assert!(
+            bin_dir.join("@scope").is_dir(),
+            "scoped parent `@scope/` should be pre-created through the junction"
+        );
+        let cmd = std::fs::read_to_string(bin_dir.join("@scope/tool.cmd")).unwrap();
+        // Four uplevels out of `.bin/@scope/`: `@scope` → `.bin` →
+        // `node_modules` → `node-liblzma@2.2.0` → `.aube`, then descend
+        // into the sibling scoped entry.
+        let expected = r"..\..\..\..\@scope+tool@1.0.0\node_modules\@scope\tool\cli.js";
+        assert!(
+            cmd.contains(expected),
+            ".cmd shim should embed surface-tree relative path `{expected}`; got:\n{cmd}"
+        );
+        assert!(
+            !cmd.contains(r"..\..\..\..\..\"),
+            ".cmd shim should not climb above the `.aube/` root; got:\n{cmd}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the path-duplication half of [#654](https://github.com/endevco/aube/discussions/654) — on Windows, `aube add --global <pkg> --allow-build=<dep>` failed with:

```
Cannot find module 'C:\Users\…\AppData\Local\pnpm\global-aube\<hash>\pnpm\global-aube\<hash>\node_modules\.aube\prebuild-install@7.1.3\node_modules\prebuild-install\bin.js'
```

The duplicated `pnpm\global-aube\<hash>` segment came from a relative-path mismatch in the generated per-dep `.cmd` shim.

## Root cause

`create_bin_link` in [crates/aube/src/commands/install/bin_linking.rs](crates/aube/src/commands/install/bin_linking.rs) canonicalizes the bin-dir parent to dodge a Windows `CreateDirectoryW` quirk where the leaf returns `ERROR_ALREADY_EXISTS` (os 183) when it sits behind a junction. The isolated layout's `.aube/<dep_path>/` is precisely such a junction into the global virtual store.

Pre-fix, that canonical path was *also* handed to `create_bin_shim`, so `pathdiff` computed the shim's relative target anchored on the GVS subtree (e.g. `…\aube\virtual-store\…`). But `%~dp0` at script runtime is the *surface* invocation path. Their only common prefix is `C:\Users\…\AppData\Local\`, so `pathdiff` emitted a long `..\..\..\..\..\` chain that re-descended through `pnpm\global-aube\<hash>` — once via the surface anchor, and a second time as part of the relative target.

## Fix

Keep the canonical-side `mkdir` (still needed for the `CreateDirectoryW` quirk — also extended to pre-create any `@scope/` subdir so scoped bin names don't hit the same quirk via the surface tree). Route `create_bin_shim` through the *surface* `bin_dir` so the relative target is anchored on the same tree the shim will be invoked through. `pathdiff` now produces the expected short `..\..\..\<dep>\…` form.

## Out of scope

The other half of #654 — node-gyp grandchildren continuing to log to the console after aube has exited — is a separate issue rooted in `aube-scripts`' `cmd.status()` only waiting for the direct cmd.exe shell, plus the absence of a Windows Job Object to reap descendants on JoinSet abort. Tracking that in a follow-up.

## Test plan

- [x] `cargo build -p aube`
- [x] `cargo clippy -p aube --all-targets -- -D warnings`
- [x] `cargo test -p aube` (482 tests pass, including the existing `link_bins_reads_manifest_when_lockfile_metadata_is_mixed` case)
- [x] `cargo test -p aube-linker` (77 tests pass)
- [x] New `#[cfg(windows)]` regression test `create_bin_link_surface_relative_path_when_dep_dir_is_a_junction` builds the junction scenario, calls `create_bin_link`, and pins the expected `..\..\..\<dep>\…` form (plus a guard rejecting any climb above `.aube/`). Will run in Windows CI.
- [ ] Manual verification on Windows by re-running the reporter's repro: `aube add --global just-bash@3.0.0 --allow-build=@mongodb-js/zstd --allow-build=node-liblzma`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Windows-only bin-shim directory creation and path anchoring around junctions; could affect how `.cmd`/shim wrappers resolve targets for dependency bins, especially for scoped names.
> 
> **Overview**
> Fixes Windows bin shim generation when per-dep `.bin/` lives behind a junction (isolated layout). `create_bin_link` now **creates directories via a canonicalized mkdir root** (including `@scope/` parents) to avoid `CreateDirectoryW` junction quirks, but **always writes shims using the surface `bin_dir`** so `pathdiff` produces correct relative targets and avoids duplicated install-root paths.
> 
> Adds two Windows-only regression tests covering (1) junction-backed dep dirs producing surface-anchored relative paths in generated `.cmd` shims, and (2) scoped bin names ensuring the scoped parent directory is pre-created so shim writes don’t fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbe333ea8fbdb4f7bed24806a92b3105e3ddb94d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->