### PR TITLE
docs(bench): scale chart bars per-row so short scenarios stay readable

### DIFF
--- a/docs/.vitepress/theme/BenchChart.vue
+++ b/docs/.vitepress/theme/BenchChart.vue
@@ -35,16 +35,14 @@ function legendLabel(pm: string): string {
 
 const nodeVersion = computed(() => props.versions?.node ?? "");
 
-const max = computed(() => {
+function rowMax(row: Row): number {
   let m = 0;
-  for (const r of props.rows) {
-    for (const pm of props.managers) {
-      const v = r.values[pm];
-      if (v != null && v > m) m = v;
-    }
+  for (const pm of props.managers) {
+    const v = row.values[pm];
+    if (v != null && v > m) m = v;
   }
   return m || 1;
-});
+}
 
 function format(ms: number): string {
   if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
@@ -86,7 +84,7 @@ function winner(row: Row): string | null {
                 class="bar"
                 :class="{ winner: winner(row) === pm }"
                 :style="{
-                  width: ((row.values[pm]! / max) * 100) + '%',
+                  width: ((row.values[pm]! / rowMax(row)) * 100) + '%',
                   background: COLORS[pm] || '#888',
                 }"
               ></div>


### PR DESCRIPTION
## Summary

- The bench chart on `/benchmarks` normalized every bar against a single global max (~15s for the cold-install row), so the install-test row (top ~1.3s, with aube at 12ms / bun at 51ms) rendered as unreadable slivers.
- Switch the bar width calculation to a per-row max so each scenario fills the track relative to its own slowest tool. Printed values stay as-is, so absolute magnitudes are still visible next to each bar.

## Trade-off

Cross-row absolute scale is no longer encoded visually — install-test bars used to look tiny next to cold-install bars, which gave a free at-a-glance hint that those scenarios are in different ballparks. That cue now only lives in the printed numbers. The user-facing win is that you can actually read each row, which was the original ask.

## Test plan

- [ ] `mise run docs:dev` and eyeball `/benchmarks` — install-test bars should now span the track instead of being slivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)