### PR TITLE
perf(resolver): shrink primer by dropping deterministic tarball URLs and shasum

### DIFF
--- a/crates/aube-resolver/build.rs
+++ b/crates/aube-resolver/build.rs
@@ -15,6 +15,11 @@ const RELEASE_TOP: usize = 2000;
 const DEFAULT_VERSION_CAP: usize = 1000;
 const FAST_COMPRESSION_LEVEL: i32 = 10;
 const RELEASE_CI_COMPRESSION_LEVEL: i32 = 19;
+// Bump when the on-disk rkyv schema (`src/primer_schema.rs`) changes
+// in a layout-breaking way. The on-disk `primer-topN-vM-sK.rkyv.zst`
+// artifact is gitignored, so older `sK` files orphan harmlessly and
+// the new `sK+1` is regenerated on the next build.
+const PRIMER_DATA_SCHEMA: u32 = 2;
 
 fn main() {
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
@@ -24,9 +29,9 @@ fn main() {
         .unwrap_or_else(|| {
             let top = primer_top();
             let version_cap = version_cap();
-            manifest_dir
-                .join("data")
-                .join(format!("primer-top{top}-v{version_cap}.rkyv.zst"))
+            manifest_dir.join("data").join(format!(
+                "primer-top{top}-v{version_cap}-s{PRIMER_DATA_SCHEMA}.rkyv.zst"
+            ))
         });
 
     println!("cargo:rerun-if-env-changed=AUBE_PRIMER_PATH");

--- a/crates/aube-resolver/src/primer.rs
+++ b/crates/aube-resolver/src/primer.rs
@@ -78,7 +78,7 @@ impl PrimerVersionMetadata {
                 .bundled_dependencies
                 .as_ref()
                 .map(PrimerBundledDependencies::to_bundled_dependencies),
-            dist: self.dist.as_ref().map(PrimerDist::to_dist),
+            dist: self.dist.as_ref().map(|d| d.to_dist(name, version)),
             os: self.os.clone(),
             cpu: self.cpu.clone(),
             libc: self.libc.clone(),
@@ -113,11 +113,14 @@ impl PrimerBundledDependencies {
 }
 
 impl PrimerDist {
-    fn to_dist(&self) -> Dist {
+    fn to_dist(&self, name: &str, version: &str) -> Dist {
         Dist {
-            tarball: self.tarball.clone(),
+            tarball: self
+                .tarball
+                .clone()
+                .unwrap_or_else(|| deterministic_tarball_url(name, version)),
             integrity: self.integrity.clone(),
-            shasum: self.shasum.clone(),
+            shasum: None,
             unpacked_size: None,
             attestations: self.provenance.then(|| Attestations {
                 provenance: Some(serde_json::json!({
@@ -126,6 +129,20 @@ impl PrimerDist {
             }),
         }
     }
+}
+
+/// Reconstruct the npmjs tarball URL when the primer omitted it
+/// (the common case — see PrimerDist::tarball docs). Mirrors
+/// `RegistryClient::tarball_url`'s format for `registry.npmjs.org`.
+/// In force-metadata-primer mode the URL is rewritten to the active
+/// registry by the resolver, so this default is only consulted on
+/// the default-registry path.
+fn deterministic_tarball_url(name: &str, version: &str) -> String {
+    let unscoped = name
+        .strip_prefix('@')
+        .and_then(|rest| rest.split('/').nth(1))
+        .unwrap_or(name);
+    format!("https://registry.npmjs.org/{name}/-/{unscoped}-{version}.tgz")
 }
 
 static GENERATED_AT: OnceLock<Option<String>> = OnceLock::new();
@@ -273,6 +290,37 @@ mod tests {
             return;
         };
         assert!(super::get(name).is_some());
+    }
+
+    #[test]
+    fn bundled_primer_synthesizes_tarball_urls() {
+        // The generator omits the tarball URL when it matches the
+        // deterministic `{registry}/{name}/-/{unscoped}-{version}.tgz`
+        // pattern. Verify the runtime fills it in: every dist in the
+        // embedded primer must surface a non-empty tarball URL.
+        let Some((name, _, _)) = PRIMER_INDEX.first() else {
+            return;
+        };
+        let packument = super::get(name).expect("primer hit").packument();
+        let dist = packument
+            .versions
+            .values()
+            .find_map(|v| v.dist.as_ref())
+            .expect("packument has at least one version with dist metadata");
+        assert!(dist.tarball.starts_with("https://"));
+        assert!(dist.tarball.ends_with(".tgz"));
+    }
+
+    #[test]
+    fn deterministic_tarball_url_handles_scoped_names() {
+        assert_eq!(
+            deterministic_tarball_url("react", "18.2.0"),
+            "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
+        );
+        assert_eq!(
+            deterministic_tarball_url("@types/node", "20.10.0"),
+            "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz"
+        );
     }
 
     #[test]

--- a/crates/aube-resolver/src/primer.rs
+++ b/crates/aube-resolver/src/primer.rs
@@ -296,19 +296,36 @@ mod tests {
     fn bundled_primer_synthesizes_tarball_urls() {
         // The generator omits the tarball URL when it matches the
         // deterministic `{registry}/{name}/-/{unscoped}-{version}.tgz`
-        // pattern. Verify the runtime fills it in: every dist in the
-        // embedded primer must surface a non-empty tarball URL.
+        // pattern. Verify the runtime fills it in correctly: every
+        // dist must surface a tarball URL whose path segments match
+        // the package name + version we asked for, so a synthesis bug
+        // that drops or swaps either field can't pass silently.
         let Some((name, _, _)) = PRIMER_INDEX.first() else {
             return;
         };
         let packument = super::get(name).expect("primer hit").packument();
-        let dist = packument
+        let (version, meta) = packument
             .versions
-            .values()
-            .find_map(|v| v.dist.as_ref())
+            .iter()
+            .find(|(_, v)| v.dist.is_some())
             .expect("packument has at least one version with dist metadata");
-        assert!(dist.tarball.starts_with("https://"));
-        assert!(dist.tarball.ends_with(".tgz"));
+        let dist = meta.dist.as_ref().unwrap();
+        assert!(
+            dist.tarball.starts_with("https://"),
+            "tarball: {}",
+            dist.tarball
+        );
+        assert!(dist.tarball.ends_with(".tgz"), "tarball: {}", dist.tarball);
+        assert!(
+            dist.tarball.contains(*name),
+            "tarball {} missing package name {name}",
+            dist.tarball,
+        );
+        assert!(
+            dist.tarball.contains(version),
+            "tarball {} missing version {version}",
+            dist.tarball,
+        );
     }
 
     #[test]

--- a/crates/aube-resolver/src/primer_schema.rs
+++ b/crates/aube-resolver/src/primer_schema.rs
@@ -83,12 +83,15 @@ pub(super) enum PrimerBundledDependencies {
 
 #[derive(Archive, Clone, RkyvSerialize, RkyvDeserialize, serde::Deserialize)]
 pub(super) struct PrimerDist {
-    #[serde(rename = "t")]
-    pub(super) tarball: String,
+    /// `None` for npm publishes whose tarball URL matches the
+    /// deterministic `{registry}/{name}/-/{unscoped}-{version}.tgz`
+    /// pattern (the generator omits the field). Carried explicitly
+    /// only for the legacy outliers (e.g. `handlebars@1.0.2-beta`
+    /// publishes as `handlebars-1.0.2beta.tgz`) that diverge.
+    #[serde(default, rename = "t")]
+    pub(super) tarball: Option<String>,
     #[serde(default, rename = "i")]
     pub(super) integrity: Option<String>,
-    #[serde(default, rename = "s")]
-    pub(super) shasum: Option<String>,
     #[serde(default, rename = "a")]
     pub(super) provenance: bool,
 }

--- a/scripts/generate-primer.mjs
+++ b/scripts/generate-primer.mjs
@@ -104,9 +104,15 @@ function trimVersion(v = {}) {
     dt:
       typeof v.dist?.tarball === 'string'
         ? {
-            t: v.dist.tarball,
+            // Omit the tarball URL when it matches the deterministic
+            // `{registry}/{name}/-/{unscoped}-{version}.tgz` pattern.
+            // The runtime synthesizes that form from name+version, so
+            // dropping it shaves ~20% of primer bytes. A handful of
+            // legacy publishes (e.g. handlebars@1.0.2-beta -> `1.0.2beta`
+            // in the basename) diverge from the pattern and still need
+            // the field.
+            t: deterministicTarball(v.name, v.version) === v.dist.tarball ? undefined : v.dist.tarball,
             i: typeof v.dist.integrity === 'string' ? v.dist.integrity : undefined,
-            s: typeof v.dist.shasum === 'string' ? v.dist.shasum : undefined,
             a: hasProvenance(v.dist.attestations),
           }
         : undefined,
@@ -160,6 +166,11 @@ function binMap(name, bin) {
 
 function unscopedName(name = '') {
   return name.split('/').pop() || name
+}
+
+function deterministicTarball(name, version) {
+  if (typeof name !== 'string' || typeof version !== 'string') return undefined
+  return `https://registry.npmjs.org/${name}/-/${unscopedName(name)}-${version}.tgz`
 }
 
 function fundingUrl(funding) {


### PR DESCRIPTION
## Summary

The bundled metadata primer was carrying two highly compressible payloads that the install path doesn't actually need. Dropping them shrinks the embedded primer by ~30% with no correctness or hit-rate cost.

- **`dist.tarball`**: deterministic for npm-published packages (`{registry}/{name}/-/{unscoped}-{version}.tgz`). Across a 30,937-version sample from the top-500 packages, only 17 (0.05%) diverged — all pre-2012 legacy publishes like `handlebars@1.0.2-beta` whose tarball basename is `handlebars-1.0.2beta.tgz`. The generator now only stores the URL for those outliers; the runtime synthesizes the standard form from name + version. Force-metadata-primer mode already overwrites the URL via `client.tarball_url()`, so that path is unaffected.
- **`dist.shasum`**: only consumed by `aube view` and `aube publish`, both of which refetch the full packument independently. The install path verifies tarballs via `dist.integrity` (sha512).

## Measured impact

At top=100, version_cap=1000 (dev-profile primer shape):

| artifact | before | after | delta |
|---|---:|---:|---:|
| `primer-topN-vM.rkyv.zst` | 2,089,367 | 1,432,687 | **-31.4%** |
| embedded `primer-packages.bin` | 2,082,255 | 1,455,388 | **-30.1%** |
| `target/release/aube` binary | 26.4 MB | 25.8 MB | **-644 KB (-2.4%)** |

At release scale (top=2000) the absolute savings scale proportionally — roughly ~12 MB off the release binary.

## Schema migration

The rkyv archive layout changed (`tarball: String` → `Option<String>`, `shasum` removed), so an `s2` schema version suffix is baked into the on-disk artifact name (`primer-topN-vM-s2.rkyv.zst`). The existing `.gitignore` pattern `primer-top*.rkyv.zst` still matches both naming schemes; stale `s1` files orphan harmlessly and `build.rs` regenerates fresh on the next build. Without this rename, a locally-cached `s1` artifact would panic the build script with `InvalidEnumDiscriminantError` when rkyv tries to decode the old `String` layout as the new `Option<String>`.

## Why not also reduce version_cap or top-N?

Resolved 7 fixtures (this repo's `benchmarks/fixture.package.json` + the 6 vlt-benchmarks fixtures: astro, babylon, large, next, svelte, vue) via `npm install --package-lock-only` and measured what each lever would cost. Summary:

- **Halving top-N (2000 → 1000)** drops overall hit rate 66.7% → 50.7%. For aube-bench it means **+277 extra packument fetches per install**; for next.js +34, babylon +118. At 50ms latency that's seconds added to cold installs — not worth it for the size delta.
- **version_cap 1000 → 100** keeps 97.1% coverage. Across all 7 fixtures combined it loses 49 primer hits (the deeply-hoisted long tail: old `react-is`, `@typescript-eslint/*@7.18.0`, `core-js@2.6.12`). Worth exploring in a follow-up but kept separate from this PR to isolate measurement.

## Test plan

- [x] `cargo test -p aube-resolver` (180 tests pass, including 2 new primer tests asserting URL synthesis and scoped-name handling)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `AUBE_PRIMER_TOP=100 AUBE_PRIMER_VERSION_CAP=1000 cargo build -p aube --release` (binary 26.4 MB → 25.8 MB)
- [ ] CI release build at top=2000 to confirm size projection
- [ ] hermetic bench run to confirm no resolver regression from URL synthesis

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the serialized primer schema and runtime reconstruction of `dist.tarball`, which could break installs if URL synthesis or cache/schema versioning is wrong; impact is limited to primer-backed resolution paths.
> 
> **Overview**
> Reduces bundled primer size by changing the primer schema to store `dist.tarball` as `Option<String>` (omitted when it matches the standard npmjs URL pattern) and by dropping `dist.shasum` entirely.
> 
> Updates resolver runtime conversion to **synthesize missing tarball URLs deterministically** from package `name` + `version`, and forces `shasum` to `None`. Build output naming is versioned via a new `-s{PRIMER_DATA_SCHEMA}` suffix to avoid decoding stale cached primer artifacts after schema changes, and new tests assert tarball synthesis (including scoped packages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e81258c3a65885db1a4220cbef47103f73758dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->