### PR TITLE
build(release): ship aubr/aubx as symlinks to aube in PGO tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,13 @@
 name: release
 
-# Reusable workflow: builds + (on macOS) codesigns the `aube`, `aubr`,
-# and `aubx` binaries for every target, then uploads a single archive
-# per target onto the draft GitHub release that `release-plz` already
-# created for the tag. `aubr`/`aubx` are multicall shims that share
-# `src/main.rs` with `aube`; see `crates/aube-cli/Cargo.toml`.
+# Reusable workflow: builds + (on macOS) codesigns the `aube` binary
+# for every target, then uploads a single archive per target onto the
+# draft GitHub release that `release-plz` already created for the tag.
+# `aubr`/`aubx` are multicall shims that share `src/main.rs` with
+# `aube`; see `crates/aube-cli/Cargo.toml`. In tar.gz archives they
+# ship as symlinks to `aube` (Linux + macOS); in Windows .zip
+# archives, where zip can't reliably represent symlinks, they ship as
+# full duplicate binaries.
 # Driven by `.github/workflows/release-plz.yml` — not triggered
 # directly on tag push, since release-plz owns the tag/release
 # lifecycle and dispatching on both would race.
@@ -374,10 +377,12 @@ jobs:
           IDENTITY: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           BIN_DIR: target/${{ matrix.target }}/release-pgo
         run: |
-          for bin in aube aubr aubx; do
-            codesign --sign "$IDENTITY" --options runtime --timestamp \
-              --prefix dev.jdx. "$BIN_DIR/$bin"
-          done
+          # Sign aube only — aubr/aubx become symlinks to aube in the
+          # archive step below and share its signature. Gatekeeper
+          # validates the underlying file's signature; the invocation
+          # name only matters for argv[0] dispatch inside the binary.
+          codesign --sign "$IDENTITY" --options runtime --timestamp \
+            --prefix dev.jdx. "$BIN_DIR/aube"
       - name: Archive PGO binaries
         id: archive
         shell: bash
@@ -386,7 +391,19 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: |
           archive="aube-${TAG}-${TARGET}.tar.gz"
-          tar -czf "$archive" -C "target/${TARGET}/release-pgo" aube aubr aubx
+          # Replace aubr/aubx with symlinks to aube before tar-ing.
+          # They're multicall shims (Cargo just had to compile them
+          # separately because it doesn't natively support multicall);
+          # at runtime `rewrite_multicall_argv` keys off argv[0], so a
+          # symlink invoked as `aubr` runs `aube run` correctly. tar
+          # stores symlinks as ~zero-byte entries pointing at "aube",
+          # cutting the archive from three full binaries to one.
+          # Symlinks match the existing convention in packaging/copr/
+          # and .github/workflows/ppa-publish.yml.
+          BIN_DIR="target/${TARGET}/release-pgo"
+          ln -sf aube "$BIN_DIR/aubr"
+          ln -sf aube "$BIN_DIR/aubx"
+          tar -czf "$archive" -C "$BIN_DIR" aube aubr aubx
           echo "path=$archive" >> "$GITHUB_OUTPUT"
       - name: Upload archive to release
         if: ${{ !fromJSON(inputs.dry_run || 'false') }}


### PR DESCRIPTION
## Summary

The v1.12.0 release tarballs are ~115-128 MB each, of which the bulk is three near-identical 65 MB binaries. Inside `aube-v1.12.0-x86_64-unknown-linux-gnu.tar.gz`:

```
aube  64,793,344 bytes
aubr  68,999,040 bytes
aubx  68,999,160 bytes
```

`aubr` and `aubx` are multicall shims that `include!` `src/main.rs` and dispatch on `argv[0]` at runtime — they're only separate `[[bin]]` targets because Cargo doesn't natively support multicall. Functionally the three binaries are identical (the file-byte differences are just rustc metadata + the fact that the workflow only PGOs `aube`).

This change replaces `aubr` and `aubx` with symlinks to `aube` before the PGO tar step. Matches the existing convention in [`packaging/copr/build-copr.sh`](packaging/copr/build-copr.sh#L241) and [`.github/workflows/ppa-publish.yml`](.github/workflows/ppa-publish.yml#L265), which both already install aubr/aubx as symlinks.

## Expected impact

Across the 5 PGO release targets (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-apple-darwin`):

| | before | after |
|---|---:|---:|
| per-tarball size | ~115-128 MB | ~45 MB (-65%) |
| total release upload | ~615 MB across 5 tarballs | ~225 MB |

## macOS codesigning

Simplified to sign `aube` only. Gatekeeper validates the signature on the underlying file; the invocation name is irrelevant. The previous loop signed each binary with a unique identifier (`dev.jdx.aube`, `dev.jdx.aubr`, `dev.jdx.aubx`) — now there's just `dev.jdx.aube`. When `aubr`/`aubx` are invoked via symlink, the kernel execs `aube` and `rewrite_multicall_argv` handles dispatch from there.

## Out of scope (for future PRs)

- **`aarch64-unknown-linux-musl`** ships ~122 MB via `taiki-e/upload-rust-binary-action` which handles build+tar in one step. Replacing it with a manual build+symlink+tar block would deliver the same savings here, but it's a heavier change.
- **Windows `.zip`** archives (x86_64 + aarch64, ~115 MB each) — zip doesn't reliably represent symlinks across implementations (Info-ZIP, 7-Zip, NTFS reparse points all behave differently), so Windows stays at 3× for now.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML still parses
- [x] Local `tar -czf` / `tar -xzf` round-trip preserves symlinks on macOS (BSD tar) and produces a working binary when invoked through either name
- [ ] Trigger `workflow_dispatch` with `dry_run: true` to validate the PGO build + symlink + codesign chain end-to-end on a real runner
- [ ] Verify mise / homebrew install scripts handle the symlinked archive correctly (they use `tar -xzf` so should be fine, but worth a smoke test on the first dry-run)

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow’s packaging and macOS codesigning behavior, which could break installed artifacts or Gatekeeper validation if symlinks/signing behave differently across targets.
> 
> **Overview**
> PGO `tar.gz` release archives now replace `aubr`/`aubx` with symlinks to `aube` before archiving, so each tarball ships one real binary instead of three duplicates.
> 
> On macOS PGO builds, the workflow now codesigns only `aube` (since `aubr`/`aubx` are symlinks in the archive), and the workflow header comments are updated to document the tar vs Windows zip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee545d9e9aca8ba542035defa73d2fc8cd9af78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->