### PR TITLE
bench(add): keep node_modules warm between iterations

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -657,6 +657,69 @@ run_bench_preinstall() {
 	done
 }
 
+# Like `run_bench`, but tailored to the `add` scenario: the prepare step
+# restores `package.json` + the saved lockfile (undoing the previous
+# iteration's `add is-odd`) and then runs each tool's frozen install so
+# `node_modules` ends up matching the pre-add lockfile state. The timed
+# iteration therefore measures only the *incremental* add work — resolve
+# is-odd, write to package.json + lockfile, link it in — instead of
+# folding a full install into every run, which is what wiping
+# `node_modules` between iterations did.
+run_bench_warm_add() {
+	local bench_name=$1
+
+	for i in "${!TOOLS[@]}"; do
+		local tool="${TOOLS[$i]}"
+		local project="${TOOL_PROJECTS[$i]}"
+		local bin="${TOOL_BINS[$i]}"
+		local home="${TOOL_HOMES[$i]}"
+		local store="${TOOL_STORES[$i]}"
+		local cache="${TOOL_CACHES[$i]}"
+		local lockfile="$BENCH_DIR/saved-lockfile-$tool"
+		local lockfile_dest
+		lockfile_dest="$project/$(lockfile_name_for "$tool")"
+
+		local cmd_tpl
+		cmd_tpl=$(cmd_template "$bench_name" "$tool")
+		if [ -z "$cmd_tpl" ]; then
+			echo "warning: no $bench_name command for $tool — skipping" >&2
+			continue
+		fi
+
+		# Reuse the tool's `gvs-warm` template as the settle install:
+		# it's whichever flavor of frozen-lockfile install the tool
+		# supports, so each PM ends up syncing `node_modules` to the
+		# restored lockfile via its own native code path.
+		local settle_tpl
+		settle_tpl=$(cmd_template "gvs-warm" "$tool")
+		if [ -z "$settle_tpl" ]; then
+			echo "warning: no gvs-warm settle command for $tool — skipping $bench_name" >&2
+			continue
+		fi
+
+		local cmd
+		cmd=$(expand_template "$cmd_tpl" "$project" "$bin" "$home" "$store" "$cache" "$lockfile" "$lockfile_dest")
+		local settle
+		settle=$(expand_template "$settle_tpl" "$project" "$bin" "$home" "$store" "$cache" "$lockfile" "$lockfile_dest")
+
+		local prepare="cp $BENCH_DIR/original-package.json $project/package.json && cp $lockfile $lockfile_dest && $settle"
+
+		local tool_runs
+		tool_runs=$(runs_for_tool "$tool")
+		echo ""
+		echo "  $tool:"
+		hyperfine \
+			--warmup "$WARMUP" \
+			--runs "$tool_runs" \
+			--ignore-failure \
+			--prepare "$prepare" \
+			--command-name "$tool" \
+			"$cmd" \
+			--export-json "$BENCH_DIR/${bench_name}-${tool}.json" ||
+			true
+	done
+}
+
 PHASES_FILE="$BENCH_DIR/aube-install-phases.jsonl"
 : >"$PHASES_FILE"
 
@@ -783,16 +846,17 @@ echo "━━━ Benchmark 5: install + run test (already installed) ━━━"
 run_scenario "install-test" run_bench_preinstall "install-test"
 
 # ── Benchmark 6: Add dependency ────────────────────────────────────────────
-# Lockfile present, add a new dependency to trigger re-resolution.
-# Store and cache warm. Exercises the incremental resolution path.
-# Kept last because the other scenarios are install-shaped and this
-# one is edit-shaped — it doesn't belong in the "install at various
-# warmth levels" progression above.
+# Lockfile, store, and node_modules all warm; the prepare step undoes
+# the previous iteration's `add is-odd` and re-syncs node_modules to
+# the saved lockfile, so the timed run measures only the incremental
+# add work (resolve, lockfile write, link) instead of folding a full
+# install into every iteration. Kept last because the other scenarios
+# are install-shaped and this one is edit-shaped — it doesn't belong
+# in the "install at various warmth levels" progression above.
 
 echo ""
 echo "━━━ Benchmark 6: Add dependency ━━━"
-run_scenario "add" run_bench "add" \
-	"$WARM_PREP && cp $BENCH_DIR/original-package.json {project}/package.json"
+run_scenario "add" run_bench_warm_add "add"
 
 # ── Summary ────────────────────────────────────────────────────────────────
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -53,7 +53,7 @@ store off and measure the shared per-project model.
 - **CI install (warm cache, GVS disabled)** — frozen lockfile, `node_modules` wiped, store and packument cache warm. Disables aube's global virtual store to match CI defaults.
 - **CI install (cold cache, GVS disabled)** — frozen lockfile but the store, packument cache, and `node_modules` are all wiped. Worst-case CI: every tarball is downloaded, extracted, and hashed into the CAS without aube's global virtual store path.
 - **npm install && npm run test (already installed)** — models the developer loop after dependencies are already installed. Each timed run repeats the tool's normal "install if needed, then run tests" command. aube can skip the install work when its install-state file is fresh; other tools still revalidate their lockfile or install state before dispatching the script. The fixture's `test` script is a no-op `node -e`, so this scenario mostly measures install short-circuiting and script dispatch.
-- **Add dependency** — lockfile and store both warm, then `<pm> add is-odd` to exercise the incremental resolve path.
+- **Add dependency** — `node_modules`, lockfile, and store all warm, then `<pm> add is-odd` to measure only the incremental add work (resolve, lockfile write, link). The previous iteration's `add` is undone between runs via a frozen-lockfile install so each timed run starts from the same pre-add state.
 
 ## Reproducing
 


### PR DESCRIPTION
## Summary

The **Add dependency** scenario's prepare step was wiping `node_modules` between every timed iteration via `WARM_PREP`. That meant `<pm> add is-odd` was actually measuring **full install + add**, not the incremental add path the row's description on `/benchmarks` claimed. This disproportionately punished pnpm (and any other PM that doesn't short-circuit a fresh install against a fully populated store).

Reproduced locally on the same fixture + flags as the bench:

| state of `node_modules` before `pnpm add is-odd` | wall time |
|---|---|
| wiped (previous bench prep)                     | **3.5s**  |
| warm (this PR)                                  | **1.0s**  |

aube barely moved (0.86s vs 0.83s) because its full install is already fast, so the previous bench had aube looking ~3.4× faster than pnpm on `add` mostly because of the install gap rather than the actual add overhead.

## Changes

- New `run_bench_warm_add` in `benchmarks/bench.sh` that prepares each iteration by restoring `original-package.json` + the saved lockfile and then running each tool's `gvs-warm` command template (i.e. `install --frozen-lockfile` / `install --immutable` / `npm ci` / `install --frozen` etc.) so `node_modules` is re-synced to the pre-add state. The timed run then measures only the incremental add work — resolve is-odd, write to lockfile + package.json, link it in — instead of folding a full install into every iteration.
- Swap the `add` scenario at the bottom of `bench.sh` from `run_bench` to `run_bench_warm_add`. The doc-comment block above the call site is updated to describe the new prep accurately.
- `docs/benchmarks.md` row description updated to match: "`node_modules`, lockfile, and store all warm" instead of "lockfile and store both warm".

The `gvs-warm` templates are already defined for every tool the bench targets (aube, bun, npm, pnpm, yarn, deno, vlt), so no new per-PM plumbing is needed.

## Notes for reviewers

- **The published `pnpm` (and likely `npm`, `yarn`, `bun`, `deno`) `add` numbers will move in the next `bench:bump` cycle.** Lower across the board, with the ratio between aube and pnpm shrinking from ~3.4× to whatever the actual add overhead difference is. That's the intended outcome — the prior numbers were measuring the wrong thing.
- Per-iteration prep cost goes up (each iteration now runs a frozen-lockfile install on top of the file copies), but prep time doesn't enter the timed measurement. Verified locally that the pnpm settle install is ~0.5s when `node_modules` is already mostly in place. `npm ci` will be the slowest settle since npm rebuilds node_modules from scratch — that adds ~10s × iterations to the npm leg of this scenario, which is annoying but not blocking. Open to a follow-up that uses a lighter cleanup for npm specifically (rm is-odd targets vs full `npm ci`) if the wall-clock matters.
- The `run_bench_preinstall` precedent in the same file already established the "double install in prep" pattern, so this isn't a new shape.

## Test plan

- [x] `bash -n benchmarks/bench.sh` — syntax clean
- [x] `shellcheck benchmarks/bench.sh` — clean
- [x] Manually reproduced the warm-vs-wiped timing gap (3.5s → 1.0s) against the bench fixture using the exact `pnpm add` flags from the script
- [ ] CI: the daily `bench-refresh` workflow will re-run `bench:bump` and open a PR with the refreshed `results.json` + README BENCH_RATIOS block. The `add` row values for pnpm/npm/yarn/bun/deno should drop; aube should be roughly unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to benchmark harness logic and docs, affecting only how the `add` scenario is prepared/measured (not production behavior). Main risk is skewing reported benchmark numbers or increasing wall-clock runtime due to the new per-iteration settle install.
> 
> **Overview**
> Adjusts the **Benchmark 6: Add dependency** scenario to stop wiping `node_modules` between timed runs, so results reflect *incremental* `add` work rather than `install + add`.
> 
> Introduces `run_bench_warm_add()` in `benchmarks/bench.sh`, which prepares each iteration by restoring `package.json` and the saved lockfile, then running the tool’s `gvs-warm` (frozen-lockfile) install to re-sync `node_modules` before timing `<pm> add is-odd`. Updates `docs/benchmarks.md` to match the new methodology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f094f2fe8f50a8e4357969ae18fda796bc84b75c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->