### PR TITLE
fix(install): skip prerelease dist-tag latest in postinstall summary

### DIFF
--- a/crates/aube-resolver/src/direct_dep_info.rs
+++ b/crates/aube-resolver/src/direct_dep_info.rs
@@ -29,8 +29,10 @@ pub struct DirectDepInfo {
     /// The registry's `dist-tags.latest` for this package, but only
     /// when it differs from the resolved version. `None` when latest
     /// matches the resolved version, when the registry omits `latest`
-    /// (common on private registries), or when the dep wasn't resolved
-    /// from a packument (git / file / link / remote tarball).
+    /// (common on private registries), when `latest` points to a
+    /// prerelease (we don't nudge users toward betas), or when the dep
+    /// wasn't resolved from a packument (git / file / link / remote
+    /// tarball).
     pub latest: Option<String>,
 }
 
@@ -67,6 +69,7 @@ impl Resolver {
                     .dist_tags
                     .get("latest")
                     .filter(|l| l.as_str() != pkg.version.as_str())
+                    .filter(|l| !is_prerelease(l))
                     .cloned();
                 if deprecated || latest.is_some() {
                     out.insert(dep.dep_path.clone(), DirectDepInfo { deprecated, latest });
@@ -74,5 +77,34 @@ impl Resolver {
             }
         }
         out
+    }
+}
+
+/// Whether a version string parses to a semver with a prerelease tag
+/// (e.g. `1.2.0-beta.3`, `2.0.0-rc.1`). Unparseable strings are treated
+/// as non-prerelease so a registry returning a non-semver `latest`
+/// (rare, but possible) still surfaces as an upgrade hint.
+fn is_prerelease(version: &str) -> bool {
+    node_semver::Version::parse(version)
+        .map(|v| !v.pre_release.is_empty())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_prerelease;
+
+    #[test]
+    fn detects_prerelease_versions() {
+        assert!(is_prerelease("1.0.0-beta.1"));
+        assert!(is_prerelease("2.0.0-rc.0"));
+        assert!(is_prerelease("0.1.0-alpha"));
+    }
+
+    #[test]
+    fn stable_versions_are_not_prerelease() {
+        assert!(!is_prerelease("1.0.0"));
+        assert!(!is_prerelease("0.0.1"));
+        assert!(!is_prerelease("not-a-version"));
     }
 }


### PR DESCRIPTION
## Summary

- The postinstall summary in `aube install` renders a `latest X` badge next to direct deps when the registry's `dist-tags.latest` differs from the resolved version.
- Today the value is passed through verbatim, so when a maintainer momentarily promotes a beta to `latest` (or a package intentionally publishes prereleases under that tag), aube nudges users toward the prerelease as the upgrade target.
- This filters out prerelease values at the source ([direct_dep_info.rs](crates/aube-resolver/src/direct_dep_info.rs)) so the badge only suggests stable upgrades. Unparseable `latest` values still surface (rare, but they're not betas).

## Test plan

- [x] `cargo test -p aube-resolver direct_dep_info::` — new unit tests cover beta / rc / alpha and stable / unparseable inputs
- [x] `cargo clippy -p aube-resolver --all-targets -- -D warnings`
- [ ] Manual `aube install` against a package whose registry `latest` is a beta — verify the `latest` badge no longer appears for that dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to `direct_dep_info` filtering logic that only affects install summary “latest” hints, plus added unit tests for prerelease detection.
> 
> **Overview**
> Install summary upgrade hints now **ignore `dist-tags.latest` values that are semver prereleases**, so direct dependencies won’t show a `latest` badge that points to beta/rc/alpha versions.
> 
> Adds an `is_prerelease` helper (using `node_semver`) and unit tests to validate prerelease vs stable/unparseable `latest` strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453f5b5fc38aed1180054184f506055d287e6aa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->