### PR TITLE
perf(resolver): plumb optional supplement list into primer generation

### DIFF
--- a/crates/aube-resolver/build.rs
+++ b/crates/aube-resolver/build.rs
@@ -24,6 +24,11 @@ const PRIMER_DATA_SCHEMA: u32 = 2;
 fn main() {
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    let workspace = manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .expect("resolver crate lives under crates/aube-resolver")
+        .to_path_buf();
     let source = std::env::var_os("AUBE_PRIMER_PATH")
         .map(PathBuf::from)
         .unwrap_or_else(|| {
@@ -38,6 +43,8 @@ fn main() {
     println!("cargo:rerun-if-env-changed=AUBE_PRIMER_TOP");
     println!("cargo:rerun-if-env-changed=AUBE_PRIMER_VERSION_CAP");
     println!("cargo:rerun-if-env-changed=AUBE_REQUIRE_PRIMER");
+    println!("cargo:rerun-if-env-changed=AUBE_PRIMER_SUPPLEMENT");
+    println!("cargo:rerun-if-env-changed=AUBE_PRIMER_SUPPLEMENT_MIN_STACKS");
     println!("cargo:rerun-if-changed={}", source.display());
     let json = source.with_extension("json");
     println!("cargo:rerun-if-changed={}", json.display());
@@ -54,12 +61,8 @@ fn main() {
             let _ = std::fs::remove_file(&json);
             true
         } else {
-            let script = manifest_dir
-                .parent()
-                .and_then(Path::parent)
-                .map(|w| w.join("scripts/generate-primer.mjs"));
-            matches!(&script, Some(s) if s.is_file())
-                && generate(&manifest_dir, &source, primer_top())
+            let script = workspace.join("scripts/generate-primer.mjs");
+            script.is_file() && generate(&workspace, &source, primer_top())
         };
         if !generated {
             if primer_required() {
@@ -121,24 +124,31 @@ fn version_cap() -> usize {
     DEFAULT_VERSION_CAP
 }
 
-fn generate(manifest_dir: &Path, source: &Path, top: usize) -> bool {
-    let workspace = manifest_dir
-        .parent()
-        .and_then(Path::parent)
-        .expect("resolver crate lives under crates/aube-resolver");
+fn generate(workspace: &Path, source: &Path, top: usize) -> bool {
     let json = source.with_extension("json");
     std::fs::create_dir_all(source.parent().unwrap()).unwrap();
 
-    let status = match Command::new("node")
-        .arg(workspace.join("scripts/generate-primer.mjs"))
+    let mut cmd = Command::new("node");
+    cmd.arg(workspace.join("scripts/generate-primer.mjs"))
         .arg("--top")
         .arg(top.to_string())
         .arg("--versions")
         .arg(version_cap().to_string())
         .arg("--out")
-        .arg(&json)
-        .status()
-    {
+        .arg(&json);
+
+    // Pass through supplement-override env vars. The script defaults to
+    // fetching the upstream `transitives.json` published by
+    // `endevco/aube-primer-packages`; setting `AUBE_PRIMER_SUPPLEMENT` to
+    // a URL, file path, or empty string overrides that.
+    if let Some(sup) = std::env::var_os("AUBE_PRIMER_SUPPLEMENT") {
+        cmd.arg("--supplement").arg(sup);
+    }
+    if let Some(min) = std::env::var_os("AUBE_PRIMER_SUPPLEMENT_MIN_STACKS") {
+        cmd.arg("--supplement-min-stacks").arg(min);
+    }
+
+    let status = match cmd.status() {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             println!(

--- a/scripts/generate-primer.mjs
+++ b/scripts/generate-primer.mjs
@@ -17,20 +17,60 @@ const versions = versionsArg === 'all' ? Infinity : Number(versionsArg)
 const out = resolve(args.get('out') ?? `crates/aube-resolver/data/primer-top${top}.json`)
 const namesFile = args.get('names')
 const namesUrl = args.get('names-url') ?? 'https://raw.githubusercontent.com/endevco/aube-primer-packages/main/data/packages.json'
+// The supplement is a JSON document (`{packages: [{name, score, ...}]}`
+// or a plain string array) that adds packages to the primer beyond the
+// popularity list. Mining and hosting live in
+// `endevco/aube-primer-packages` — this script just consumes the
+// rendered JSON. Pass a URL or local path via `--supplement`; pass an
+// empty value to disable. The default URL 404s harmlessly until
+// upstream publishes the file, at which point existing builds pick it
+// up automatically.
+const supplementUrl = args.get('supplement-url') ?? 'https://raw.githubusercontent.com/endevco/aube-primer-packages/main/data/transitives.json'
+const supplementArg = args.get('supplement')
+const supplementSource = supplementArg === '' ? null : (supplementArg ?? supplementUrl)
+const supplementMinStacks = Number(args.get('supplement-min-stacks') ?? 5)
 
 if (!Number.isInteger(top) || top < 1) throw new Error('--top must be a positive integer')
 if (versions !== Infinity && (!Number.isInteger(versions) || versions < 1)) {
   throw new Error('--versions must be a positive integer or "all"')
 }
+if (!Number.isInteger(supplementMinStacks) || supplementMinStacks < 1) {
+  throw new Error('--supplement-min-stacks must be a positive integer')
+}
 
-const names = namesFile
+const popularNames = namesFile
   ? parseNames(await readFile(namesFile, 'utf8'), namesFile)
   : await fetchPopularNames(namesUrl)
-if (!Array.isArray(names)) throw new Error('package-name source must be a JSON array')
+if (!Array.isArray(popularNames)) throw new Error('package-name source must be a JSON array')
+
+const names = popularNames.slice(0, top)
+const seen = new Set(names)
+let supplementAdded = 0
+if (supplementSource) {
+  const doc = await loadSupplement(supplementSource)
+  if (doc) {
+    const entries = Array.isArray(doc) ? doc : doc.packages
+    if (!Array.isArray(entries)) {
+      throw new Error(`supplement ${supplementSource} must be a JSON array or have a 'packages' array`)
+    }
+    for (const entry of entries) {
+      const name = typeof entry === 'string' ? entry : entry?.name
+      const score = typeof entry === 'string' ? Infinity : (entry?.score ?? Infinity)
+      if (typeof name !== 'string' || !name) continue
+      if (score < supplementMinStacks) continue
+      if (seen.has(name)) continue
+      names.push(name)
+      seen.add(name)
+      supplementAdded++
+    }
+    console.error(`supplement: added ${supplementAdded} packages from ${supplementSource} (min score ${supplementMinStacks})`)
+  }
+}
+const total = names.length
 
 const primer = {}
-for (const [index, name] of names.slice(0, top).entries()) {
-  console.error(`[${index + 1}/${top}] ${name} (${versions === Infinity ? 'all versions' : `latest ${versions}`})`)
+for (const [index, name] of names.entries()) {
+  console.error(`[${index + 1}/${total}] ${name} (${versions === Infinity ? 'all versions' : `latest ${versions}`})`)
   const seed = await packumentSeed(name, versions)
   if (seed) primer[name] = seed
 }
@@ -194,6 +234,22 @@ function hasTrustedPublisher(user) {
 function hasProvenance(attestations) {
   const predicate = attestations?.provenance?.predicateType
   return typeof predicate === 'string' && /^https:\/\/slsa\.dev\/provenance\/v\d+$/.test(predicate)
+}
+
+// Load the supplement from a URL or local path. A 404 (upstream hasn't
+// published the file yet) is treated as "no supplement" rather than an
+// error so the supplement plumbing can land before the upstream side.
+async function loadSupplement(source) {
+  if (/^https?:\/\//i.test(source)) {
+    const { res, body } = await fetchBodyWithRetry(source, undefined, (res) => res.text())
+    if (res.status === 404) {
+      console.error(`supplement: ${source} not found (404); proceeding without it`)
+      return null
+    }
+    if (!res.ok) throw new Error(`supplement ${source}: HTTP ${res.status}`)
+    return JSON.parse(body)
+  }
+  return JSON.parse(await readFile(resolve(source), 'utf8'))
 }
 
 async function fetchPopularNames(url) {


### PR DESCRIPTION
## Why

The primer's source list ([endevco/aube-primer-packages](https://github.com/endevco/aube-primer-packages)) ranks packages by direct npm install count — which misses *transitives* that everyone gets via dep graphs but few install directly. PR #664's miss-rate analysis identified ~18 such packages that appeared in 4-5 of 7 benchmark fixtures while sitting outside top-2000: `fdir`, `tinyglobby`, `dunder-proto`, `get-proto`, `math-intrinsics`, `side-channel-{list,map,weakmap}`, `call-bind-apply-helpers`, `@babel/helper-globals`, `@jridgewell/remapping`, `@emnapi/runtime`, `@csstools/css-parser-algorithms`, the @esbuild/@rolldown/lightningcss platform variants, etc.

The right place to actually *mine* transitive popularity (resolve popular stacks via `npm install --package-lock-only`, score by cross-stack frequency, etc.) is the primer-packages repo, so it can share a refresh cadence and source-of-truth with `packages.json`. This PR lands the aube-side plumbing so the upstream work can publish a `data/transitives.json` and have every aube build pick it up automatically.

## What this PR does

[`scripts/generate-primer.mjs`](scripts/generate-primer.mjs):
- New `--supplement <url|path>` flag (default: `https://raw.githubusercontent.com/endevco/aube-primer-packages/main/data/transitives.json`)
- New `--supplement-min-stacks <int>` flag (default: 5) for the score-threshold filter
- New `--supplement-url <url>` flag for overriding just the default URL
- `loadSupplement()` fetches the doc (URL or path), 404s are logged and treated as "no supplement" so this PR is harmless before upstream publishes
- Merges supplement entries into the popularity-derived name list (deduped)

[`crates/aube-resolver/build.rs`](crates/aube-resolver/build.rs):
- Passes `AUBE_PRIMER_SUPPLEMENT` and `AUBE_PRIMER_SUPPLEMENT_MIN_STACKS` through to the generator script
- Declares both as `rerun-if-env-changed`

The supplement file shape is intentionally permissive: a plain array of strings, or `{packages: [{name, score}]}`. Score is optional (treated as Infinity when absent).

## Verified

- `--supplement` (default URL, currently 404): logged warning, build proceeds with empty supplement
- `--supplement=` (explicit disable): no fetch attempt, build proceeds
- `--supplement /path/to/local.json`: parses local file, applies threshold filter
- `cargo test -p aube-resolver` (180 pass, including primer round-trip tests from #664)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`

## What's not in this PR

- The actual mining of cross-stack transitive popularity (curated stack list + miner script) — moving to `endevco/aube-primer-packages` so popularity and transitives share a release cadence
- Hit-rate impact data — will materialize once upstream publishes the file; the methodology is documented in #664's discussion and prior local runs showed +3.3pp aggregate / +24pp on svelte / +7pp on astro+vue at threshold ≥5

## Follow-ups

- [ ] Upstream PR in `endevco/aube-primer-packages` to add the miner + publish `data/transitives.json`
- [ ] Once upstream is published, sanity-check via local `cargo build` that the supplement is being applied (and review the actual hit-rate numbers)
- [ ] (Stretch) Skip packument fetches for `os`/`cpu`/`libc`-filtered optional deps in the resolver entirely, which would obsolete the platform-binary entries in the supplement

*This PR was generated by Claude.*