### PR TITLE
docs(bench): drop "previous iteration" framing from add scenario

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -658,13 +658,11 @@ run_bench_preinstall() {
 }
 
 # Like `run_bench`, but tailored to the `add` scenario: the prepare step
-# restores `package.json` + the saved lockfile (undoing the previous
-# iteration's `add is-odd`) and then runs each tool's frozen install so
-# `node_modules` ends up matching the pre-add lockfile state. The timed
-# iteration therefore measures only the *incremental* add work — resolve
-# is-odd, write to package.json + lockfile, link it in — instead of
-# folding a full install into every run, which is what wiping
-# `node_modules` between iterations did.
+# restores `package.json` + the saved lockfile, then runs each tool's
+# frozen install so `node_modules` matches the pre-add lockfile state.
+# The timed run therefore measures only the *incremental* add work —
+# resolve is-odd, write to package.json + lockfile, link it in — rather
+# than folding a full install into the measurement.
 run_bench_warm_add() {
 	local bench_name=$1
 
@@ -846,13 +844,13 @@ echo "━━━ Benchmark 5: install + run test (already installed) ━━━"
 run_scenario "install-test" run_bench_preinstall "install-test"
 
 # ── Benchmark 6: Add dependency ────────────────────────────────────────────
-# Lockfile, store, and node_modules all warm; the prepare step undoes
-# the previous iteration's `add is-odd` and re-syncs node_modules to
-# the saved lockfile, so the timed run measures only the incremental
-# add work (resolve, lockfile write, link) instead of folding a full
-# install into every iteration. Kept last because the other scenarios
-# are install-shaped and this one is edit-shaped — it doesn't belong
-# in the "install at various warmth levels" progression above.
+# Lockfile, store, and node_modules all warm; the prepare step restores
+# `package.json` + the saved lockfile and re-syncs node_modules to match,
+# so the timed run measures only the incremental add work (resolve,
+# lockfile write, link) instead of folding a full install into the
+# measurement. Kept last because the other scenarios are install-shaped
+# and this one is edit-shaped — it doesn't belong in the "install at
+# various warmth levels" progression above.
 
 echo ""
 echo "━━━ Benchmark 6: Add dependency ━━━"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -53,7 +53,7 @@ store off and measure the shared per-project model.
 - **CI install (warm cache, GVS disabled)** — frozen lockfile, `node_modules` wiped, store and packument cache warm. Disables aube's global virtual store to match CI defaults.
 - **CI install (cold cache, GVS disabled)** — frozen lockfile but the store, packument cache, and `node_modules` are all wiped. Worst-case CI: every tarball is downloaded, extracted, and hashed into the CAS without aube's global virtual store path.
 - **npm install && npm run test (already installed)** — models the developer loop after dependencies are already installed. Each timed run repeats the tool's normal "install if needed, then run tests" command. aube can skip the install work when its install-state file is fresh; other tools still revalidate their lockfile or install state before dispatching the script. The fixture's `test` script is a no-op `node -e`, so this scenario mostly measures install short-circuiting and script dispatch.
-- **Add dependency** — `node_modules`, lockfile, and store all warm, then `<pm> add is-odd` to measure only the incremental add work (resolve, lockfile write, link). The previous iteration's `add` is undone between runs via a frozen-lockfile install so each timed run starts from the same pre-add state.
+- **Add dependency** — `node_modules`, lockfile, and store all warm, then `<pm> add is-odd` to measure only the incremental add work (resolve, lockfile write, link). A frozen-lockfile install runs between timed iterations so each one starts from the same pre-add state.
 
 ## Reproducing
 


### PR DESCRIPTION
## Summary

Follow-up to #666. The "Add dependency" row on `/benchmarks` and the two comment blocks in `bench.sh` were describing the prep in terms of what the *previous* iteration left behind ("undoes the previous iteration's \`add is-odd\`"). That leaks hyperfine's iteration loop into copy that should read as a steady-state description of the scenario.

## Changes

- `docs/benchmarks.md` row description rephrased: "A frozen-lockfile install runs between timed iterations so each one starts from the same pre-add state." No mention of "previous iteration's add" being undone.
- `benchmarks/bench.sh` doc-comments above `run_bench_warm_add` and above the Benchmark 6 call site rephrased to match — they describe what the prep does (restore + frozen install) without naming the iteration being reverted.

No behavior change.

## Test plan

- [x] `bash -n benchmarks/bench.sh` clean
- [x] `shellcheck benchmarks/bench.sh` clean
- [x] `grep -r "previous iteration"` in `benchmarks/` and `docs/` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/comment-only change that rewords the `add` benchmark’s prepare-step description; no benchmark logic or data handling is modified.
> 
> **Overview**
> Rewords the `add` benchmark scenario description in `benchmarks/bench.sh` and `docs/benchmarks.md` to describe the steady-state setup (*restore `package.json` + lockfile and run a frozen install to resync `node_modules`*) without referring to “undoing the previous iteration.”
> 
> No behavioral changes to the benchmark harness or scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 672632c0e695e7a1e8ec344ccea26d1b4a751e86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->