### PR TITLE
fix(release): include schema suffix in generate-primer artifact name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,16 +86,31 @@ jobs:
         with:
           node-version: '24'
       - name: Generate metadata primer
+        id: primer
         shell: bash
+        # File name has to include the `-sK` schema suffix so `build.rs`
+        # picks the artifact up directly (`source.with_extension("json")`
+        # branch); otherwise it falls back to spawning `node` to regenerate
+        # in-tree, which fails inside `cross` Docker containers where node
+        # isn't on PATH. Schema is parsed out of build.rs so a bump there
+        # (and the matching `.gitignore` entry) propagates automatically.
         run: |
+          schema=$(grep -E '^const PRIMER_DATA_SCHEMA: u32 = [0-9]+;' \
+            crates/aube-resolver/build.rs | awk -F'= ' '{print $2}' | tr -d ';')
+          if [ -z "$schema" ]; then
+            echo "::error::failed to parse PRIMER_DATA_SCHEMA from crates/aube-resolver/build.rs"
+            exit 1
+          fi
+          out="crates/aube-resolver/data/primer-top${AUBE_PRIMER_TOP}-v${AUBE_PRIMER_VERSION_CAP}-s${schema}.rkyv.json"
           node scripts/generate-primer.mjs \
             --top "$AUBE_PRIMER_TOP" \
             --versions "$AUBE_PRIMER_VERSION_CAP" \
-            --out "crates/aube-resolver/data/primer-top${AUBE_PRIMER_TOP}-v${AUBE_PRIMER_VERSION_CAP}.rkyv.json"
+            --out "$out"
+          echo "path=$out" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: metadata-primer
-          path: crates/aube-resolver/data/primer-top${{ env.AUBE_PRIMER_TOP }}-v${{ env.AUBE_PRIMER_VERSION_CAP }}.rkyv.json
+          path: ${{ steps.primer.outputs.path }}
 
   # Non-PGO Windows targets (untested PGO toolchain). Built via taiki-e
   # straight from the release profile. `aarch64-unknown-linux-musl` lives


### PR DESCRIPTION
## Summary

The release dry-run I triggered after merging [#667](https://github.com/endevco/aube/pull/667) ([run 25811781021](https://github.com/endevco/aube/actions/runs/25811781021)) panicked at build on three of the cross-built tarball targets:

```
thread 'main' panicked at crates/aube-resolver/build.rs:66:17:
metadata primer is required, but
/project/crates/aube-resolver/data/primer-top2000-v1000-s2.rkyv.zst
was missing and could not be generated
```

[#664](https://github.com/endevco/aube/pull/664) (merged earlier today) bumped `PRIMER_DATA_SCHEMA` from 1 to 2 so [build.rs](crates/aube-resolver/build.rs:33) now looks at `primer-topN-vM-s2.rkyv.{zst,json}`. The workflow's `generate-primer` step is still writing `primer-topN-vM.rkyv.json` (no `-sK`), so the downloaded artifact is invisible to build.rs and it falls back to spawning `node scripts/generate-primer.mjs` to regenerate. That fallback works in:

- Windows runners (node pre-installed)
- macOS arm64 + native linux-arm64 PGO rows (`setup-node` runs first)

…and fails for:

- `upload-assets-pgo` `x86_64-unknown-linux-gnu` (cross container)
- `upload-assets-pgo` `x86_64-unknown-linux-musl` (cross container)
- `upload-assets-musl-arm64` `aarch64-unknown-linux-musl` (cross container, new in #667)

`cross` images don't carry node.

## What changed

Parse `PRIMER_DATA_SCHEMA` out of `crates/aube-resolver/build.rs` in the `generate-primer` step and bake `-s${schema}` into the artifact filename. build.rs now picks the downloaded `.rkyv.json` up directly via the `compress_json_primer` branch — no node needed in the cross container.

Schema parsing means a future bump in build.rs propagates automatically; no second source of truth to keep in sync.

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"` parses
- [x] `grep -E '^const PRIMER_DATA_SCHEMA: u32 = [0-9]+;' crates/aube-resolver/build.rs | awk -F'= ' '{print \$2}' | tr -d ';'` → `2` locally
- [ ] Re-trigger the release.yml dry-run after merge — all five tarball targets should now build (previous run cancelled after the cross-build failures surfaced)

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release workflow artifact generation/upload path; a parsing or path mismatch could break release builds, but changes are localized to CI scripting.
> 
> **Overview**
> Fixes the release workflow’s `generate-primer` job to **name the generated metadata primer with the `-s<schema>` suffix** expected by `crates/aube-resolver/build.rs`.
> 
> The workflow now parses `PRIMER_DATA_SCHEMA` from `crates/aube-resolver/build.rs`, builds the output path from that value, and wires the computed path through a step output so `actions/upload-artifact` uploads the correctly named file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 337a74369c0b9f317b0e8ffb6317c4cf7de72a45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->