### PR TITLE
feat(add): skip supply-chain gates on private packages + allowlist globs

### DIFF
--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -451,6 +451,13 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub low_download_threshold: Option<u64>,
 
+    /// Glob patterns exempted from the `low_download_threshold` gate.
+    /// Each entry is matched against the full registry name (e.g.
+    /// `@scope/foo`). Matching names skip the weekly-downloads lookup;
+    /// the OSV `MAL-*` check still runs.
+    #[serde(default)]
+    pub allowed_unpopular_packages: Option<Vec<String>>,
+
     /// Bun-compatible security scanner module spec (npm package name
     /// or path) loaded via a `node` bridge at install / add time.
     /// Empty string disables the integration.

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -289,6 +289,19 @@ impl NpmConfig {
         &self.registry
     }
 
+    /// True when `package_name` resolves through the public
+    /// `registry.npmjs.org` registry. Used by supply-chain gates
+    /// (`crates/aube/src/commands/add_supply_chain.rs`) to skip
+    /// public-only signals (OSV `MAL-*` advisories, npmjs weekly
+    /// downloads) on packages a private/internal registry is the
+    /// source of truth for. The default registry being swapped out
+    /// (`registry=https://internal.example/`) or a scoped override
+    /// (`@myorg:registry=https://...`) both cause this to return
+    /// `false` so internal packages don't trip the gates.
+    pub fn is_public_npmjs(&self, package_name: &str) -> bool {
+        is_public_npmjs_url(self.registry_for(package_name))
+    }
+
     /// Get the auth token for a given registry URL.
     pub fn auth_token_for(&self, registry_url: &str) -> Option<&str> {
         if let Some(auth) = self.registry_config_for(registry_url)
@@ -1242,6 +1255,29 @@ pub fn normalize_registry_url_pub(url: &str) -> String {
 /// the scheme-stripping logic.
 pub fn registry_uri_key_pub(url: &str) -> String {
     registry_uri_key(url)
+}
+
+/// True when `url` points at `registry.npmjs.org` (the public npm
+/// registry). Lowercased + trailing-slash-tolerant so different
+/// equivalent spellings (`https://Registry.NPMJS.org/`, no slash,
+/// scheme-relative `//registry.npmjs.org/`) all resolve the same way.
+/// A scheme other than `https`/`http` is rejected — anything else
+/// (mirrors, replays, transports we don't speak) is by definition
+/// not the public registry.
+fn is_public_npmjs_url(url: &str) -> bool {
+    let url = url.trim();
+    let after_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .or_else(|| url.strip_prefix("//"))
+        .unwrap_or(url);
+    let host = after_scheme
+        .split_once('/')
+        .map(|(h, _)| h)
+        .unwrap_or(after_scheme);
+    let host = host.split_once('@').map(|(_, h)| h).unwrap_or(host);
+    let host = host.split_once(':').map(|(h, _)| h).unwrap_or(host);
+    host.eq_ignore_ascii_case("registry.npmjs.org")
 }
 
 /// Ensure registry URL has a trailing slash.
@@ -2900,6 +2936,59 @@ mod tests {
             config.registry, "https://env.registry/",
             "env var must override file-based registry"
         );
+    }
+
+    #[test]
+    fn is_public_npmjs_matches_canonical_and_normalised_urls() {
+        // The same npmjs.org URL spelled different ways should all
+        // resolve to "yes, public" — supply-chain gates skip on a
+        // mismatch and we don't want capitalization / trailing slash
+        // drift between npm, pnpm, and aube's own normalisation to
+        // accidentally flip a public package into "private" mode.
+        for url in [
+            "https://registry.npmjs.org/",
+            "https://registry.npmjs.org",
+            "https://Registry.NPMJS.org/",
+            "http://registry.npmjs.org/",
+            "//registry.npmjs.org/",
+        ] {
+            assert!(is_public_npmjs_url(url), "expected public for {url}");
+        }
+    }
+
+    #[test]
+    fn is_public_npmjs_rejects_private_and_mirror_urls() {
+        // Anything other than the canonical npmjs host counts as
+        // private from the gate's perspective: mirrors, internal
+        // Verdaccio installs, Artifactory proxies, and unrelated
+        // hosts that happen to embed `npmjs.org` as a subpath.
+        for url in [
+            "https://internal.example.com/",
+            "https://npm.pkg.github.com/",
+            "https://registry.yarnpkg.com/",
+            "https://example.com/registry.npmjs.org/",
+            "ftp://registry.npmjs.org/",
+        ] {
+            assert!(!is_public_npmjs_url(url), "expected private for {url}");
+        }
+    }
+
+    #[test]
+    fn is_public_npmjs_via_npm_config_uses_scope_override() {
+        // A scoped registry override flips the per-package answer
+        // even though the default registry is still npmjs. Verifies
+        // the gate filter respects scope→registry mapping rather
+        // than only looking at the global `registry=` field.
+        let mut cfg = NpmConfig {
+            registry: "https://registry.npmjs.org/".to_string(),
+            ..Default::default()
+        };
+        cfg.scoped_registries.insert(
+            "@myorg".to_string(),
+            "https://npm.internal.example/".to_string(),
+        );
+        assert!(cfg.is_public_npmjs("lodash"));
+        assert!(!cfg.is_public_npmjs("@myorg/utils"));
     }
 
     #[test]

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -1294,10 +1294,12 @@ fn is_public_npmjs_url(url: &str) -> bool {
 /// so a user-supplied `.npmrc` entry like `HTTPS://...` doesn't
 /// fall through and accidentally disable the supply-chain gates.
 fn strip_prefix_ignore_ascii_case<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
-    if s.len() < prefix.len() {
-        return None;
-    }
-    let (head, tail) = s.split_at(prefix.len());
+    // `split_at_checked` returns `None` rather than panicking when the
+    // byte offset isn't a UTF-8 char boundary, so a malformed
+    // `.npmrc` value like `https:/ñ...` (multi-byte char straddling
+    // the prefix length) gracefully fails the prefix match instead
+    // of crashing `aube add`.
+    let (head, tail) = s.split_at_checked(prefix.len())?;
     head.eq_ignore_ascii_case(prefix).then_some(tail)
 }
 
@@ -2997,6 +2999,20 @@ mod tests {
         ] {
             assert!(!is_public_npmjs_url(url), "expected private for {url}");
         }
+    }
+
+    #[test]
+    fn is_public_npmjs_does_not_panic_on_multibyte_char_at_prefix_boundary() {
+        // `https:/ñ...` — the `ñ` straddles byte offset 8 (the
+        // length of `"https://"`). A naive `split_at(8)` would
+        // panic; the helper has to use `split_at_checked` and
+        // return `None` so `aube add` doesn't crash on a typo'd
+        // `.npmrc` value.
+        assert!(!is_public_npmjs_url("https:/ñregistry.npmjs.org/"));
+        // Also exercise a multi-byte char inside what looks like a
+        // valid scheme — we should reject this as non-public
+        // without crashing.
+        assert!(!is_public_npmjs_url("htñps://registry.npmjs.org/"));
     }
 
     #[test]

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -1261,16 +1261,24 @@ pub fn registry_uri_key_pub(url: &str) -> String {
 /// registry). Lowercased + trailing-slash-tolerant so different
 /// equivalent spellings (`https://Registry.NPMJS.org/`, no slash,
 /// scheme-relative `//registry.npmjs.org/`) all resolve the same way.
-/// A scheme other than `https`/`http` is rejected — anything else
-/// (mirrors, replays, transports we don't speak) is by definition
-/// not the public registry.
+/// Scheme matching is case-insensitive per RFC 3986; `https`/`http`
+/// pass and anything else (mirrors, replays, transports we don't
+/// speak) is by definition not the public registry.
 fn is_public_npmjs_url(url: &str) -> bool {
     let url = url.trim();
-    let after_scheme = url
-        .strip_prefix("https://")
-        .or_else(|| url.strip_prefix("http://"))
+    let after_scheme = strip_prefix_ignore_ascii_case(url, "https://")
+        .or_else(|| strip_prefix_ignore_ascii_case(url, "http://"))
         .or_else(|| url.strip_prefix("//"))
         .unwrap_or(url);
+    // No scheme stripped AND no scheme-relative `//` prefix means a
+    // bare authority like `registry.npmjs.org/`. We accept that, but
+    // reject anything whose prefix *looks* like a scheme we didn't
+    // recognise (`ftp:`, `file:`) — `unwrap_or(url)` would otherwise
+    // happily split `ftp://registry.npmjs.org/` on `/` and walk away
+    // believing the host matched.
+    if after_scheme == url && url.contains("://") {
+        return false;
+    }
     let host = after_scheme
         .split_once('/')
         .map(|(h, _)| h)
@@ -1278,6 +1286,19 @@ fn is_public_npmjs_url(url: &str) -> bool {
     let host = host.split_once('@').map(|(_, h)| h).unwrap_or(host);
     let host = host.split_once(':').map(|(h, _)| h).unwrap_or(host);
     host.eq_ignore_ascii_case("registry.npmjs.org")
+}
+
+/// Strip a literal ASCII prefix from `s` ignoring case, returning the
+/// remainder. Matches the semantics of [`str::strip_prefix`] but
+/// folds case before comparing — used by [`is_public_npmjs_url`]
+/// so a user-supplied `.npmrc` entry like `HTTPS://...` doesn't
+/// fall through and accidentally disable the supply-chain gates.
+fn strip_prefix_ignore_ascii_case<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    if s.len() < prefix.len() {
+        return None;
+    }
+    let (head, tail) = s.split_at(prefix.len());
+    head.eq_ignore_ascii_case(prefix).then_some(tail)
 }
 
 /// Ensure registry URL has a trailing slash.
@@ -2951,6 +2972,11 @@ mod tests {
             "https://Registry.NPMJS.org/",
             "http://registry.npmjs.org/",
             "//registry.npmjs.org/",
+            // URI schemes are case-insensitive per RFC 3986. A
+            // user-typed `HTTPS://...` in `.npmrc` must not silently
+            // fall through and disable the supply-chain gates.
+            "HTTPS://registry.npmjs.org/",
+            "Http://registry.npmjs.org/",
         ] {
             assert!(is_public_npmjs_url(url), "expected public for {url}");
         }

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -332,8 +332,17 @@ on day one regardless of how cleverly they're named.
 Interactive sessions get a `[y/N]` prompt showing the weekly
 download count. Non-interactive contexts fail with
 `ERR_AUBE_LOW_DOWNLOAD_PACKAGE` unless `--allow-low-downloads` is
-passed. Scoped private packages and workspace deps are skipped (no
-public-registry signal → no false positive).
+passed.
+
+Packages that route through a non-`registry.npmjs.org` registry are
+skipped automatically: a scoped override like
+`@myorg:registry=https://npm.internal.example/` or a swapped-out
+default registry both mean npmjs has no signal on the package, so
+neither the downloads gate nor the OSV `MAL-*` check fires.
+Workspace deps and git/local specs are also skipped. To exempt
+specific names that *do* resolve through npmjs (e.g. you publish a
+low-download but trusted package internally), see
+`allowedUnpopularPackages`.
 
 Set to `0` to disable.
 """
@@ -341,6 +350,40 @@ sources.cli = []
 sources.env = ["npm_config_low_download_threshold", "NPM_CONFIG_LOW_DOWNLOAD_THRESHOLD", "AUBE_LOW_DOWNLOAD_THRESHOLD"]
 sources.npmrc = ["lowDownloadThreshold"]
 sources.workspaceYaml = ["lowDownloadThreshold"]
+precedence = ["workspaceYaml", "npmrc"]
+examples = []
+
+[allowedUnpopularPackages]
+description = "Glob patterns exempted from the `lowDownloadThreshold` gate."
+type = "list<string>"
+default = "undefined"
+docs = """
+Each pattern is matched against the registry name (`@scope/foo` or
+`bar`) of every candidate the `lowDownloadThreshold` gate would
+otherwise probe. Matches skip the weekly-downloads lookup entirely,
+so internal/low-traffic packages don't trip the prompt in CI or the
+`y/N` prompt locally.
+
+Patterns are full-name globs (the [`glob`](https://docs.rs/glob)
+crate's syntax — `*`, `?`, `[…]`). Match-everything (`*`) is allowed
+but defeats the gate; prefer to set `lowDownloadThreshold = 0` if
+that is what you want.
+
+The OSV `MAL-*` advisory check (`advisoryCheck`) is **not** affected
+— a hit there is confirmed-malicious and not the kind of judgement
+call this list is meant to suppress.
+
+```yaml
+# aube-workspace.yaml
+allowedUnpopularPackages:
+  - "@mycompany/*"
+  - "internal-*"
+```
+"""
+sources.cli = []
+sources.env = ["npm_config_allowed_unpopular_packages", "NPM_CONFIG_ALLOWED_UNPOPULAR_PACKAGES", "AUBE_ALLOWED_UNPOPULAR_PACKAGES"]
+sources.npmrc = ["allowedUnpopularPackages"]
+sources.workspaceYaml = ["allowedUnpopularPackages"]
 precedence = ["workspaceYaml", "npmrc"]
 examples = []
 

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -1903,10 +1903,14 @@ fn registry_bound_names_for_supply_chain(cwd: &Path, packages: &[String]) -> Vec
             continue;
         }
         if !npm_config.is_public_npmjs(&spec.name) {
+            // `redact_url` strips any embedded userinfo (`https://tok@host/`
+            // — uncommon but a registry URL can legally carry it) so a
+            // token doesn't slip into observability pipelines that ingest
+            // debug-level structured logs.
             tracing::debug!(
                 "skipping supply-chain gates for {}: routes through non-public registry {}",
                 spec.name,
-                npm_config.registry_for(&spec.name)
+                aube_util::url::redact_url(npm_config.registry_for(&spec.name))
             );
             continue;
         }

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -828,19 +828,25 @@ pub async fn run(
     // concrete versions + transitives the OSV/downloads probes
     // wouldn't see at this stage.
     let registry_names = registry_bound_names_for_supply_chain(&cwd, packages);
-    let (advisory_check, low_download_threshold) = super::with_settings_ctx(&cwd, |ctx| {
-        let policy = if aube_settings::resolved::paranoid(ctx) {
-            aube_settings::resolved::AdvisoryCheck::Required
-        } else {
-            aube_settings::resolved::advisory_check(ctx)
-        };
-        (policy, aube_settings::resolved::low_download_threshold(ctx))
-    });
+    let (advisory_check, low_download_threshold, allowed_unpopular) =
+        super::with_settings_ctx(&cwd, |ctx| {
+            let policy = if aube_settings::resolved::paranoid(ctx) {
+                aube_settings::resolved::AdvisoryCheck::Required
+            } else {
+                aube_settings::resolved::advisory_check(ctx)
+            };
+            (
+                policy,
+                aube_settings::resolved::low_download_threshold(ctx),
+                aube_settings::resolved::allowed_unpopular_packages(ctx).unwrap_or_default(),
+            )
+        });
     super::add_supply_chain::run_gates(
         &registry_names,
         advisory_check,
         low_download_threshold,
         allow_low_downloads,
+        &allowed_unpopular,
     )
     .await?;
 
@@ -1867,6 +1873,13 @@ fn apply_allow_build_flags(cwd: &std::path::Path, names: &[String]) -> miette::R
 fn registry_bound_names_for_supply_chain(cwd: &Path, packages: &[String]) -> Vec<String> {
     let mut names = Vec::with_capacity(packages.len());
     let workspace_versions = collect_workspace_versions(cwd);
+    // Scope→registry overrides + the default registry tell us which
+    // names route through public npmjs. Anything else (a swapped-out
+    // default registry, an `@myorg:registry=https://internal/`
+    // override) has no signal in the OSV `MAL-*` database or the
+    // npmjs weekly-downloads API — skip those names so private
+    // packages don't trip the gates on a public-registry collision.
+    let npm_config = aube_registry::config::NpmConfig::load(cwd);
     for raw in packages {
         let Ok(spec) = parse_pkg_spec(raw) else {
             // Parse failures get a richer diagnostic from
@@ -1887,6 +1900,14 @@ fn registry_bound_names_for_supply_chain(cwd: &Path, packages: &[String]) -> Vec
         // resolves locally — no public registry round-trip happens,
         // so the OSV / downloads probes have nothing to say.
         if workspace_versions.contains_key(&spec.name) {
+            continue;
+        }
+        if !npm_config.is_public_npmjs(&spec.name) {
+            tracing::debug!(
+                "skipping supply-chain gates for {}: routes through non-public registry {}",
+                spec.name,
+                npm_config.registry_for(&spec.name)
+            );
             continue;
         }
         // Scoped names (`@scope/name`) stay in the list. OSV's batch
@@ -1954,19 +1975,25 @@ async fn run_filtered(
     // NOT called here: it runs post-resolve from `install::run`
     // against the full resolved graph.
     let registry_names = registry_bound_names_for_supply_chain(&root, &args.packages);
-    let (advisory_check, low_download_threshold) = super::with_settings_ctx(&root, |ctx| {
-        let policy = if aube_settings::resolved::paranoid(ctx) {
-            aube_settings::resolved::AdvisoryCheck::Required
-        } else {
-            aube_settings::resolved::advisory_check(ctx)
-        };
-        (policy, aube_settings::resolved::low_download_threshold(ctx))
-    });
+    let (advisory_check, low_download_threshold, allowed_unpopular) =
+        super::with_settings_ctx(&root, |ctx| {
+            let policy = if aube_settings::resolved::paranoid(ctx) {
+                aube_settings::resolved::AdvisoryCheck::Required
+            } else {
+                aube_settings::resolved::advisory_check(ctx)
+            };
+            (
+                policy,
+                aube_settings::resolved::low_download_threshold(ctx),
+                aube_settings::resolved::allowed_unpopular_packages(ctx).unwrap_or_default(),
+            )
+        });
     super::add_supply_chain::run_gates(
         &registry_names,
         advisory_check,
         low_download_threshold,
         args.allow_low_downloads,
+        &allowed_unpopular,
     )
     .await?;
 

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -11,11 +11,16 @@
 //! 2. **Weekly-downloads floor** — interactive confirm prompt below
 //!    the threshold, hard refusal in non-interactive contexts unless
 //!    `--allow-low-downloads` is passed. Catches typosquats and
-//!    impersonations that haven't been reported to OSV yet.
+//!    impersonations that haven't been reported to OSV yet. The
+//!    `allowedUnpopularPackages` setting (glob patterns) bypasses
+//!    this gate for opted-in names, leaving the OSV check intact.
 //!
 //! The gate fires only on the names the user typed for *registry*
 //! packages — git/local/workspace/jsr/aliased specs all skip both
-//! checks because the public-registry signal doesn't apply.
+//! checks because the public-registry signal doesn't apply. Names
+//! whose resolved registry isn't `registry.npmjs.org` (per
+//! `NpmConfig::is_public_npmjs`) are filtered out upstream in
+//! `registry_bound_names_for_supply_chain`.
 
 use aube_codes::errors::{
     ERR_AUBE_ADVISORY_CHECK_FAILED, ERR_AUBE_LOW_DOWNLOAD_PACKAGE, ERR_AUBE_MALICIOUS_PACKAGE,
@@ -36,11 +41,18 @@ use std::io::{BufRead, IsTerminal, Write};
 /// `allow_low_downloads` is the per-invocation `--allow-low-downloads`
 /// override; when `true` the download gate is skipped entirely (the
 /// advisory check still runs).
+///
+/// `allowed_unpopular_globs` are the `allowedUnpopularPackages`
+/// setting entries: full-name globs that exempt matching names from
+/// the downloads gate only. The advisory check still runs against
+/// every name regardless — exempting confirmed-malicious advisories
+/// is not what this list is for.
 pub async fn run_gates(
     names: &[String],
     advisory_check: AdvisoryCheck,
     low_download_threshold: u64,
     allow_low_downloads: bool,
+    allowed_unpopular_globs: &[String],
 ) -> miette::Result<()> {
     if names.is_empty() {
         return Ok(());
@@ -80,9 +92,33 @@ pub async fn run_gates(
     };
     osv_gate(&client, names, advisory_check).await?;
     if !allow_low_downloads && low_download_threshold > 0 {
-        downloads_gate(&client, names, low_download_threshold).await?;
+        let patterns = compile_allowed_unpopular(allowed_unpopular_globs);
+        let gated: Vec<String> = names
+            .iter()
+            .filter(|n| !patterns.iter().any(|p| p.matches(n)))
+            .cloned()
+            .collect();
+        if !gated.is_empty() {
+            downloads_gate(&client, &gated, low_download_threshold).await?;
+        }
     }
     Ok(())
+}
+
+/// Parse `allowedUnpopularPackages` entries into compiled
+/// `glob::Pattern`s. Invalid entries are logged and dropped — we'd
+/// rather miss an exemption (and prompt the user) than fail the
+/// whole `aube add` over a typo in a user-defined glob.
+fn compile_allowed_unpopular(raw: &[String]) -> Vec<glob::Pattern> {
+    raw.iter()
+        .filter_map(|p| match glob::Pattern::new(p) {
+            Ok(pat) => Some(pat),
+            Err(e) => {
+                tracing::warn!("ignoring malformed allowedUnpopularPackages entry `{p}`: {e}");
+                None
+            }
+        })
+        .collect()
 }
 
 async fn osv_gate(
@@ -258,9 +294,38 @@ mod tests {
         // registry-name list. The function must be a no-op in that
         // case (no network, no error) so those code paths stay free.
         assert!(
-            run_gates(&[], AdvisoryCheck::Required, 1000, false)
+            run_gates(&[], AdvisoryCheck::Required, 1000, false, &[])
                 .await
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn compile_allowed_unpopular_drops_invalid_patterns() {
+        // `[` is a malformed range — we keep the well-formed entries
+        // and drop the broken one so a single typo doesn't disable
+        // every exemption.
+        let pats = compile_allowed_unpopular(&[
+            "@myorg/*".to_string(),
+            "[unterminated".to_string(),
+            "internal-*".to_string(),
+        ]);
+        assert_eq!(pats.len(), 2);
+        assert!(pats.iter().any(|p| p.matches("@myorg/foo")));
+        assert!(pats.iter().any(|p| p.matches("internal-thing")));
+        assert!(!pats.iter().any(|p| p.matches("public-pkg")));
+    }
+
+    #[test]
+    fn compile_allowed_unpopular_scope_glob_matches_only_in_scope() {
+        // `@myorg/*` should match every name in the `@myorg` scope
+        // but not a same-named unscoped package, and not a different
+        // scope. Catches the regression where a too-greedy pattern
+        // (e.g. plain `myorg*`) would skip arbitrary names.
+        let pats = compile_allowed_unpopular(&["@myorg/*".to_string()]);
+        assert!(pats[0].matches("@myorg/utils"));
+        assert!(pats[0].matches("@myorg/nested-name"));
+        assert!(!pats[0].matches("@otherorg/utils"));
+        assert!(!pats[0].matches("myorg-utils"));
     }
 }

--- a/docs/security.md
+++ b/docs/security.md
@@ -177,12 +177,24 @@ aube add supabase-javascript
 
 In non-interactive contexts the prompt becomes a hard refusal with
 `ERR_AUBE_LOW_DOWNLOAD_PACKAGE` unless `--allow-low-downloads` is passed.
-Scoped private packages and workspace deps are skipped (no public registry
-signal → no false positive).
+
+**Private packages skip both gates automatically.** Any package routed
+through a non-`registry.npmjs.org` registry — whether by a scoped
+override (`@myorg:registry=https://npm.internal.example/`) or by
+replacing the default `registry=` URL outright — is exempted from
+the OSV check and the downloads gate, because npmjs has no signal on
+it. Workspace deps and git/local specs are also skipped.
+
+For names that *do* route through public npmjs but are known-internal
+(e.g. you publish a low-traffic helper under your own brand), list
+them in `allowedUnpopularPackages` to skip the downloads gate alone:
 
 ```yaml
 advisoryCheck: on            # default; fail open on network error
 lowDownloadThreshold: 1000   # weekly downloads, 0 disables
+allowedUnpopularPackages:    # glob patterns; OSV check still runs
+  - "@mycompany/*"
+  - "internal-*"
 ```
 
 Set `advisoryCheck: required` to fail closed when OSV can't be reached —
@@ -191,7 +203,8 @@ appropriate for hardened CI, included in `paranoid: true`. Set
 independently.
 
 Settings: [`advisoryCheck`](/settings/#setting-advisorycheck),
-[`lowDownloadThreshold`](/settings/#setting-lowdownloadthreshold).
+[`lowDownloadThreshold`](/settings/#setting-lowdownloadthreshold),
+[`allowedUnpopularPackages`](/settings/#setting-allowedunpopularpackages).
 
 ## Block exotic transitive dependencies
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -25,6 +25,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`securityScanner`](#setting-securityscanner) | `string` | Bun-compatible security scanner module. |
 | [`advisoryCheck`](#setting-advisorycheck) | `"on" \| "required" \| "off"` | OSV `MAL-*` advisory check on `aube add`. |
 | [`lowDownloadThreshold`](#setting-lowdownloadthreshold) | `int` | Weekly-download floor for `aube add` (typosquat prompt). |
+| [`allowedUnpopularPackages`](#setting-allowedunpopularpackages) | `list<string>` | Glob patterns exempted from the `lowDownloadThreshold` gate. |
 | [`paranoid`](#setting-paranoid) | `bool` | Turn on the strict-security setting bundle in one switch. |
 | [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Fail install when a package's trust evidence weakens between releases. |
 | [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from `trustPolicy` checks. |
@@ -406,10 +407,51 @@ on day one regardless of how cleverly they're named.
 Interactive sessions get a `[y/N]` prompt showing the weekly
 download count. Non-interactive contexts fail with
 `ERR_AUBE_LOW_DOWNLOAD_PACKAGE` unless `--allow-low-downloads` is
-passed. Scoped private packages and workspace deps are skipped (no
-public-registry signal → no false positive).
+passed.
+
+Packages that route through a non-`registry.npmjs.org` registry are
+skipped automatically: a scoped override like
+`@myorg:registry=https://npm.internal.example/` or a swapped-out
+default registry both mean npmjs has no signal on the package, so
+neither the downloads gate nor the OSV `MAL-*` check fires.
+Workspace deps and git/local specs are also skipped. To exempt
+specific names that *do* resolve through npmjs (e.g. you publish a
+low-download but trusted package internally), see
+`allowedUnpopularPackages`.
 
 Set to `0` to disable.
+
+### `allowedUnpopularPackages` {#setting-allowedunpopularpackages}
+
+Glob patterns exempted from the `lowDownloadThreshold` gate.
+
+- Type: `list<string>`
+- Default: `undefined`
+- Environment: `npm_config_allowed_unpopular_packages`, `NPM_CONFIG_ALLOWED_UNPOPULAR_PACKAGES`, `AUBE_ALLOWED_UNPOPULAR_PACKAGES`
+- .npmrc keys: `allowedUnpopularPackages`, `allowed-unpopular-packages`
+- Workspace YAML keys: `allowedUnpopularPackages`
+
+Each pattern is matched against the registry name (`@scope/foo` or
+`bar`) of every candidate the `lowDownloadThreshold` gate would
+otherwise probe. Matches skip the weekly-downloads lookup entirely,
+so internal/low-traffic packages don't trip the prompt in CI or the
+`y/N` prompt locally.
+
+Patterns are full-name globs (the [`glob`](https://docs.rs/glob)
+crate's syntax — `*`, `?`, `[…]`). Match-everything (`*`) is allowed
+but defeats the gate; prefer to set `lowDownloadThreshold = 0` if
+that is what you want.
+
+The OSV `MAL-*` advisory check (`advisoryCheck`) is **not** affected
+— a hit there is confirmed-malicious and not the kind of judgement
+call this list is meant to suppress.
+
+```yaml
+# aube-workspace.yaml
+allowedUnpopularPackages:
+  - "@mycompany/*"
+  - "internal-*"
+```
 
 ### `paranoid` {#setting-paranoid}
 


### PR DESCRIPTION
## Summary

Two changes to cut false-positive noise from the `aube add` downloads gate on internal/private packages.

**1. Auto-skip non-public-registry packages.** Names whose resolved registry isn't `registry.npmjs.org` — whether by a scoped override (`@myorg:registry=https://npm.internal.example/`) or a swapped-out default `registry=` URL — now skip **both** the OSV `MAL-*` advisory check and the weekly-downloads gate. npmjs has no signal on those packages, so probing it is wasted at best and could collide with a public squatter sharing the name at worst. New `NpmConfig::is_public_npmjs(name)` powers the check; it's scheme/case/trailing-slash tolerant.

**2. `allowedUnpopularPackages` glob allowlist.** New list setting that takes full-name glob patterns. Matches skip the downloads gate only — the OSV `MAL-*` check still fires because confirmed-malicious isn't the kind of judgement call this list is meant to silence.

```yaml
# aube-workspace.yaml
allowedUnpopularPackages:
  - "@mycompany/*"
  - "internal-*"
```

## Why

Today, `aube add @mycompany/some-internal-thing` works quietly for scoped names (npm's downloads API returns `Unknown` for `@scope/*`), but a non-scoped internal package or a future change to that API would have it prompting for confirmation in CI. The two changes give two complementary opt-outs: automatic for anything routed through a private registry (the common case for orgs with an internal Verdaccio/Artifactory), and explicit for names that legitimately route through npmjs but the user knows are low-traffic.

## Reviewer notes

- The private-registry filter sits in `registry_bound_names_for_supply_chain` so it applies symmetrically to both gates. The glob allowlist is applied inside `run_gates` only against the downloads gate.
- Invalid glob patterns in `allowedUnpopularPackages` log a warning and are dropped — a single typo shouldn't disable every exemption or fail `aube add` outright.
- `is_public_npmjs_url` rejects `ftp://`, capitalisation drift, and URLs that merely embed `npmjs.org` as a subpath, with tests for each.

## Test plan

- [x] `cargo test` — all suites pass (incl. 3 new tests on `is_public_npmjs_url` and 2 on the glob compiler)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: `aube add @mycompany/foo` with `@mycompany:registry=https://internal/` configured → no OSV/downloads probe to npmjs
- [ ] Manual: `aube add lodash-impostor` (low downloads, public scope) with `allowedUnpopularPackages: ["lodash-*"]` → downloads gate skipped, OSV still queried

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `aube add` supply-chain gating behavior (OSV malicious advisory + weekly downloads) based on registry resolution and new allowlist patterns, which could alter security signal coverage if misconfigured. Logic is covered by new unit tests but affects a security-sensitive workflow.
> 
> **Overview**
> `aube add` now **skips both** the OSV `MAL-*` advisory check and the weekly-downloads gate for packages that resolve through a non-`registry.npmjs.org` registry (including scoped registry overrides and swapped default registries), preventing false positives/collisions for internal packages.
> 
> Adds a new setting, `allowedUnpopularPackages`, to exempt matching package-name globs from the **downloads** gate only (OSV check still runs), with invalid glob entries warned-and-ignored. Updates settings metadata and docs accordingly, and adds tests for public-registry URL detection and glob handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4e8c5d918fd3ead4a8c8ffb210ddc5a0a1593b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->