### PR TITLE
perf(resolver): drop primer version_cap from 1000 to 100

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ env:
   AUBE_PRIMER_TOP: "2000"
   # See `DEFAULT_VERSION_CAP` in crates/aube-resolver/build.rs for the
   # rationale — 100 covers ≥97% of resolved versions across the benchmark
-  # fixtures while shrinking the embedded primer by ~38%.
+  # fixtures while shrinking the embedded primer by ~54% (9.04 MB vs ~19.6 MB).
   AUBE_PRIMER_VERSION_CAP: "100"
   AUBE_REQUIRE_PRIMER: "1"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,10 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
   AUBE_PRIMER_TOP: "2000"
-  AUBE_PRIMER_VERSION_CAP: "1000"
+  # See `DEFAULT_VERSION_CAP` in crates/aube-resolver/build.rs for the
+  # rationale — 100 covers ≥97% of resolved versions across the benchmark
+  # fixtures while shrinking the embedded primer by ~38%.
+  AUBE_PRIMER_VERSION_CAP: "100"
   AUBE_REQUIRE_PRIMER: "1"
 
 jobs:

--- a/crates/aube-resolver/build.rs
+++ b/crates/aube-resolver/build.rs
@@ -12,7 +12,14 @@ use primer_schema::Seed;
 
 const DEV_TOP: usize = 100;
 const RELEASE_TOP: usize = 2000;
-const DEFAULT_VERSION_CAP: usize = 1000;
+// 100 covers ≥97% of resolved versions across our 7 benchmark fixtures
+// (aube-bench plus the vlt-benchmarks set: astro, babylon, large, next,
+// svelte, vue). Bumping back to v=1000 only buys ~1.1pp of aggregate
+// hit-rate for +7 MB on the embedded primer; misses fall back cleanly
+// via `PickResult::NoMatch` in resolve.rs (one extra packument fetch
+// per long-tail version pick — typically old `react-is`, hoisted
+// `@typescript-eslint/*`, or stale `core-js@2.x` style versions).
+const DEFAULT_VERSION_CAP: usize = 100;
 const FAST_COMPRESSION_LEVEL: i32 = 10;
 const RELEASE_CI_COMPRESSION_LEVEL: i32 = 19;
 // Bump when the on-disk rkyv schema (`src/primer_schema.rs`) changes


### PR DESCRIPTION
## Why

The primer caps each package's version list at `version_cap` (latest N). 1000 was overkill: a `(top-N, version_cap)` sweep across the 7 benchmark fixtures (aube-bench + vlt-benchmarks: astro, babylon, large, next, svelte, vue) shows going back to v=1000 buys only **+1.1pp aggregate hit-rate for +7-19 MB** on the embedded primer.

## Measured impact

Built locally with `AUBE_PRIMER_TOP=2000`:

| config | embedded primer | aggregate hit-rate |
|---|---:|---:|
| v=1000 (was) | ~19-28 MB | 74.3% |
| **v=100 (now)** | **9.04 MB** | **73.2%** (-1.1pp) |

(v=1000 wasn't built locally — fetching 2000 × 1000 = 2M packuments from npm is impractical. The 19-28 MB range covers my calibrated-model estimate of 19.6 MB and the v1.12.0 production primer size of ~28 MB after #664's schema-v2 drop.)

The 9.04 MB number is slightly better than my pre-build projection of 12.2 MB — zstd compresses smaller per-package version sets more efficiently than the linear model assumed.

## Per-fixture impact

| fixture | v=1000 | v=100 | Δ |
|---|---:|---:|---:|
| astro | 47.7% | 47.2% | -0.5pp |
| aube-bench | 79.5% | 78.3% | -1.2pp |
| babylon | 83.8% | 82.7% | -1.1pp |
| large | 66.4% | 65.5% | -0.9pp |
| next | 82.6% | 80.0% | -2.6pp |
| svelte | 58.7% | 57.8% | -0.9pp |
| vue | 78.8% | 78.3% | -0.5pp |

Misses fall back cleanly via the existing `PickResult::NoMatch` path in `resolve.rs` — one extra packument fetch per long-tail version pick. The packages that lose are predictable:

- old `react-is` versions (hoisted from older React deps)
- `@typescript-eslint/*@7.18.0` (pinned by older eslint configs)
- stale `core-js@2.x` (transitive in some build chains)
- `@next/env@15.0.3` (not-quite-latest framework pins)

## Why not v=50?

Doubles the savings (~12.6 MB total cut) but starts hurting big projects visibly: -2.5 to -3.5pp on babylon, large, and next. v=25 cliffs (-5 to -7pp on the same set). The hit-rate curve flattens around v=75-100 — that's the elbow.

## Why not also bump top-N?

The fixture corpus saturates at top-N=2000: every popular package in our installs is already in the popularity list, and the remaining misses are project-specific tail (framework internals, niche utility libs) that no popularity ranking would catch. The supplement from [endevco/aube-primer-packages#2](https://github.com/endevco/aube-primer-packages/pull/2) handles the cross-cutting transitive middle layer. Bumping top-N > 2000 doesn't move the needle on this dataset.

## Files

- `crates/aube-resolver/build.rs` — `DEFAULT_VERSION_CAP: usize = 100` (was 1000)
- `.github/workflows/release.yml` — `AUBE_PRIMER_VERSION_CAP: "100"` (was "1000")

## Test plan

- [x] `cargo test -p aube-resolver` — all 180 tests pass (including the 6 primer tests verifying URL synthesis, schema-v2 round-trip, etc.)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build -p aube-resolver --release` — produces `primer-top2000-v100-s2.rkyv.zst` at 9.04 MB
- [ ] CI release dry-run to confirm embedded primer size projection holds at the full release build (PGO, LTO, etc.)
- [ ] Hermetic bench run to confirm the extra packument fetches don't move the install-time numbers materially

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the size/coverage tradeoff of the embedded resolver primer used in releases, which may increase network packument fetches for long-tail versions and impact install performance in some cases.
> 
> **Overview**
> Reduces the resolver metadata primer’s per-package version list cap from **1000 to 100**, shrinking the embedded primer used in release builds.
> 
> Updates both the resolver’s `DEFAULT_VERSION_CAP` (`crates/aube-resolver/build.rs`) and the release workflow’s `AUBE_PRIMER_VERSION_CAP` env (`.github/workflows/release.yml`), with added inline rationale/comments about expected hit-rate impact and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d0c56e68f53ddd49f422aa7b2d630b4bbb69b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->