### PR TITLE
fix(scripts): align generate-primer.mjs default to version_cap=100

### DIFF
--- a/scripts/generate-primer.mjs
+++ b/scripts/generate-primer.mjs
@@ -12,7 +12,11 @@ for (let i = 2; i < process.argv.length; i++) {
 }
 
 const top = Number(args.get('top') ?? 2000)
-const versionsArg = args.get('versions') ?? '1000'
+// Keep this default in sync with `DEFAULT_VERSION_CAP` in
+// crates/aube-resolver/build.rs and `AUBE_PRIMER_VERSION_CAP` in
+// .github/workflows/release.yml — the calibrated trade-off is
+// documented in the build.rs comment.
+const versionsArg = args.get('versions') ?? '100'
 const versions = versionsArg === 'all' ? Infinity : Number(versionsArg)
 const out = resolve(args.get('out') ?? `crates/aube-resolver/data/primer-top${top}.json`)
 const namesFile = args.get('names')


### PR DESCRIPTION
## Summary

Follow-up to [#674](https://github.com/endevco/aube/pull/674), which dropped `DEFAULT_VERSION_CAP` in `build.rs` and `AUBE_PRIMER_VERSION_CAP` in `release.yml` from 1000 to 100 but left the matching default in `scripts/generate-primer.mjs` at `1000`.

Both automated paths (the CI release workflow and `build.rs`) pass `--versions` explicitly, so the embedded primer the binary ships with was unaffected. The drift only matters for manual invocations — anyone running `node scripts/generate-primer.mjs` without `--versions` would silently get the old 1000-version behavior instead of the now-intended 100.

## Test plan

- [x] `node scripts/generate-primer.mjs --top 1 --supplement= --out /tmp/x.json` prints `(latest 100)`

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the default CLI behavior of `scripts/generate-primer.mjs` for manual runs, reducing the default version cap from 1000 to 100 and adding a clarifying comment.
> 
> **Overview**
> Updates `scripts/generate-primer.mjs` to default `--versions` to `100` (down from `1000`) so manual primer generation matches the `DEFAULT_VERSION_CAP`/`AUBE_PRIMER_VERSION_CAP` behavior used by the build and release pipeline.
> 
> Adds a short comment documenting that these defaults should stay in sync across `build.rs`, the release workflow, and this script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 211f8a21aeff7ecd16298642b76fd9353d458177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->