### PR TITLE
docs(resolver): correct build.rs version_cap comment to match measured numbers

### DIFF
--- a/crates/aube-resolver/build.rs
+++ b/crates/aube-resolver/build.rs
@@ -15,10 +15,11 @@ const RELEASE_TOP: usize = 2000;
 // 100 covers ≥97% of resolved versions across our 7 benchmark fixtures
 // (aube-bench plus the vlt-benchmarks set: astro, babylon, large, next,
 // svelte, vue). Bumping back to v=1000 only buys ~1.1pp of aggregate
-// hit-rate for +7 MB on the embedded primer; misses fall back cleanly
-// via `PickResult::NoMatch` in resolve.rs (one extra packument fetch
-// per long-tail version pick — typically old `react-is`, hoisted
-// `@typescript-eslint/*`, or stale `core-js@2.x` style versions).
+// hit-rate for +10.6 MB on the embedded primer (9.04 MB vs ~19.6 MB,
+// both measured locally with PRIMER_DATA_SCHEMA=2). Misses fall back
+// cleanly via `PickResult::NoMatch` in resolve.rs — one extra packument
+// fetch per long-tail version pick, typically old `react-is`, hoisted
+// `@typescript-eslint/*`, or stale `core-js@2.x` style versions.
 const DEFAULT_VERSION_CAP: usize = 100;
 const FAST_COMPRESSION_LEVEL: i32 = 10;
 const RELEASE_CI_COMPRESSION_LEVEL: i32 = 19;


### PR DESCRIPTION
## Summary

[#674](https://github.com/endevco/aube/pull/674) cited a pre-build projection (`+7 MB at v=1000`) in the `DEFAULT_VERSION_CAP` comment. The matching comment in `release.yml` got corrected inline during merge to reflect the measured numbers (9.04 MB at v=100 vs ~19.6 MB at v=1000, ~54% shrink); `build.rs` was missed. Bringing the two source-of-truth comments back in sync so they don't drift over time.

Original drift flagged by Greptile P2 on #674.

## Test plan

- [x] `cargo build -p aube-resolver`
- [x] `cargo fmt --check`

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in `crates/aube-resolver/build.rs`; no functional or build logic modifications.
> 
> **Overview**
> Updates the `DEFAULT_VERSION_CAP` rationale comment in `crates/aube-resolver/build.rs` to reflect the measured embedded primer size delta (+10.6 MB; 9.04 MB vs ~19.6 MB at `PRIMER_DATA_SCHEMA=2`) and clarifies the fallback behavior when long-tail versions miss the primer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d80f00668e4f0dfe8630bf62256ad68ff179165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->