### PR TITLE
feat(install): route OSV checks live-API vs local mirror by fresh-resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +394,7 @@ dependencies = [
  "tracing",
  "wiremock",
  "yaml_serde",
+ "zip",
 ]
 
 [[package]]
@@ -1235,6 +1245,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1485,7 @@ dependencies = [
  "crc32fast",
  "libz-ng-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -6051,10 +6073,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f852905151ac8d4d06fdca66520a661c09730a74c6d4e2b0f27b436b382e532"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,12 @@ log = "0.4"
 flate2 = { version = "1", default-features = false, features = ["zlib-ng"] }
 tar = "0.4"
 zstd = { version = "0.13", default-features = false }
+# Zip reader for the OSV advisory mirror — the bulk dump at
+# `osv-vulnerabilities.storage.googleapis.com/<eco>/all.zip` is a
+# zip-of-JSONs and the dependency-free std crate ecosystem has no
+# alternative. `deflate` is the only OSV-used compression method, so
+# defeature everything else to keep the build slim.
+zip = { version = "5", default-features = false, features = ["deflate"] }
 
 # Semver
 node-semver = "2"

--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -91,6 +91,7 @@ pub const WARN_AUBE_WORKSPACE_TOPO_CYCLE: &str = "WARN_AUBE_WORKSPACE_TOPO_CYCLE
 // ── supply chain (add-time) ─────────────────────────────────────────
 pub const WARN_AUBE_LOW_DOWNLOAD_PACKAGE: &str = "WARN_AUBE_LOW_DOWNLOAD_PACKAGE";
 pub const WARN_AUBE_ADVISORY_CHECK_FAILED: &str = "WARN_AUBE_ADVISORY_CHECK_FAILED";
+pub const WARN_AUBE_OSV_MIRROR_REFRESH_FAILED: &str = "WARN_AUBE_OSV_MIRROR_REFRESH_FAILED";
 pub const WARN_AUBE_SECURITY_SCANNER_FINDING: &str = "WARN_AUBE_SECURITY_SCANNER_FINDING";
 
 /// Stable category labels that group codes in the generated docs.
@@ -464,6 +465,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_ADVISORY_CHECK_FAILED,
         category: category::SUPPLY_CHAIN,
         description: "OSV `MAL-*` advisory check couldn't reach the API. With `advisoryCheck=on` (default) install continues; with `advisoryCheck=required` install fails closed.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_OSV_MIRROR_REFRESH_FAILED,
+        category: category::SUPPLY_CHAIN,
+        description: "OSV advisory mirror used by `advisoryCheckOnInstall` failed to refresh (download, ETag, or zip parse error). With `advisoryCheckOnInstall=on` install proceeds against the previously cached index if any; with `advisoryCheckOnInstall=required` install fails closed with `ERR_AUBE_ADVISORY_CHECK_FAILED`.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -446,6 +446,15 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub advisory_check: Option<String>,
 
+    /// OSV `MAL-*` advisory check policy for every `aube install`,
+    /// backed by a local mirror of OSV's npm dump. Independent of
+    /// `advisory_check`, which only fires on `aube add`. Values:
+    /// `"on"` (refresh-on-stale, fail-open on refresh error),
+    /// `"required"` (fail-closed on refresh error), or `"off"`
+    /// (default).
+    #[serde(default)]
+    pub advisory_check_on_install: Option<String>,
+
     /// Weekly-downloads floor for `aube add`. Below this, aube prompts
     /// for confirmation (or fails non-interactively). 0 disables.
     #[serde(default)]

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -446,14 +446,23 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub advisory_check: Option<String>,
 
-    /// OSV `MAL-*` advisory check policy for every `aube install`,
+    /// OSV `MAL-*` advisory check policy for plain reinstalls,
     /// backed by a local mirror of OSV's npm dump. Independent of
-    /// `advisory_check`, which only fires on `aube add`. Values:
-    /// `"on"` (refresh-on-stale, fail-open on refresh error),
-    /// `"required"` (fail-closed on refresh error), or `"off"`
-    /// (default).
+    /// `advisory_check`, which fires on `aube add`, `aube update`,
+    /// and other fresh-resolution paths via the live OSV API.
+    /// Values: `"on"` (refresh-on-stale, fail-open on refresh
+    /// error), `"required"` (fail-closed on refresh error), or
+    /// `"off"` (default).
     #[serde(default)]
     pub advisory_check_on_install: Option<String>,
+
+    /// Force the live-API OSV `MAL-*` check on every install
+    /// (including frozen reinstalls). Default `false`. Set to
+    /// `true` for hardened CI where every install must observe
+    /// the latest advisories regardless of whether the lockfile
+    /// changed. Trades per-install latency for freshness.
+    #[serde(default)]
+    pub advisory_check_every_install: Option<bool>,
 
     /// Weekly-downloads floor for `aube add`. Below this, aube prompts
     /// for confirmation (or fails non-interactively). 0 disables.

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -28,6 +28,7 @@ sonic-rs = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+zip = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
@@ -37,3 +38,4 @@ tar = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 wiremock = "0.6"
 proptest = "1"
+zip = { workspace = true }

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -38,4 +38,3 @@ tar = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 wiremock = "0.6"
 proptest = "1"
-zip = { workspace = true }

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -147,6 +147,7 @@ where
 pub mod client;
 pub mod config;
 pub mod jsr;
+pub mod osv_mirror;
 pub mod slow_metadata;
 pub mod supply_chain;
 

--- a/crates/aube-registry/src/osv_mirror.rs
+++ b/crates/aube-registry/src/osv_mirror.rs
@@ -348,7 +348,7 @@ async fn fetch_and_extract_from(
     // Persist the raw zip atomically so an interrupted write
     // doesn't leave a corrupt half-zip that survives across runs.
     let zip_path = root.join(ZIP_FILENAME);
-    write_atomic(&zip_path, &body)?;
+    aube_util::fs_atomic::atomic_write(&zip_path, &body)?;
 
     let advisories = build_index_from_zip(&body)?;
     let index = IndexFile {
@@ -444,33 +444,14 @@ struct OsvPackage {
 
 fn write_index(path: &Path, index: &IndexFile) -> Result<(), MirrorError> {
     let bytes = serde_json::to_vec(index)?;
-    write_atomic(path, &bytes)?;
+    // Defer to the workspace utility — its sibling-tempfile naming
+    // mixes a per-process `AtomicU64`, PID, and nanoseconds so two
+    // calls within the same nanosecond can't collide; the rename
+    // path has Windows-friendly transient-error retry; and it
+    // cleans up the orphan tmp on a final rename failure. Rolling
+    // a parallel impl here would inherit none of those properties.
+    aube_util::fs_atomic::atomic_write(path, &bytes)?;
     Ok(())
-}
-
-fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    std::fs::create_dir_all(parent)?;
-    // Per-writer-unique tmp filename. A fixed `.tmp` extension
-    // races between concurrent `aube install` processes sharing a
-    // cache volume (CI matrix jobs are the canonical case): both
-    // would open the same path with `O_TRUNC`, and the second
-    // open truncates the first writer's content mid-write,
-    // leaving a corrupt zip or JSON on disk until the next
-    // successful refresh. PID alone collides across containers
-    // with PID-namespacing, so we mix in a nanosecond timestamp
-    // too.
-    let nonce = format!(
-        "{}.{}.tmp",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0),
-    );
-    let tmp = path.with_extension(nonce);
-    std::fs::write(&tmp, bytes)?;
-    std::fs::rename(&tmp, path)
 }
 
 fn now_rfc3339() -> String {
@@ -797,49 +778,6 @@ mod tests {
         let now = SystemTime::now();
         let delta = now.duration_since(parsed).unwrap_or_default();
         assert!(delta < Duration::from_secs(2), "got {delta:?}");
-    }
-
-    /// Regression: concurrent `write_atomic` calls against the
-    /// same final path must not corrupt each other's content. The
-    /// older fixed-`.tmp`-suffix implementation had two writers
-    /// truncating each other's bytes mid-write; the per-PID +
-    /// nanosecond tmp suffix prevents that, and last-writer-wins
-    /// on the final rename leaves a coherent file on disk.
-    #[test]
-    fn write_atomic_survives_concurrent_writers() {
-        let tmp = tempdir().unwrap();
-        let target = tmp.path().join("out.bin");
-        // Two contents of identical length so any cross-write
-        // corruption shows up as a byte-level mismatch — not just
-        // a truncation.
-        let a = vec![b'A'; 64 * 1024];
-        let b = vec![b'B'; 64 * 1024];
-
-        std::thread::scope(|s| {
-            for _ in 0..8 {
-                let path = target.clone();
-                let bytes = a.clone();
-                s.spawn(move || {
-                    let _ = write_atomic(&path, &bytes);
-                });
-                let path = target.clone();
-                let bytes = b.clone();
-                s.spawn(move || {
-                    let _ = write_atomic(&path, &bytes);
-                });
-            }
-        });
-
-        let read_back = std::fs::read(&target).expect("final file present");
-        assert_eq!(
-            read_back.len(),
-            a.len(),
-            "concurrent writers must not produce a truncated/corrupt file"
-        );
-        assert!(
-            read_back == a || read_back == b,
-            "final contents must be exactly one writer's payload, byte-for-byte"
-        );
     }
 
     #[test]

--- a/crates/aube-registry/src/osv_mirror.rs
+++ b/crates/aube-registry/src/osv_mirror.rs
@@ -454,7 +454,24 @@ fn write_index(path: &Path, index: &IndexFile) -> Result<(), MirrorError> {
 fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     std::fs::create_dir_all(parent)?;
-    let tmp = path.with_extension("tmp");
+    // Per-writer-unique tmp filename. A fixed `.tmp` extension
+    // races between concurrent `aube install` processes sharing a
+    // cache volume (CI matrix jobs are the canonical case): both
+    // would open the same path with `O_TRUNC`, and the second
+    // open truncates the first writer's content mid-write,
+    // leaving a corrupt zip or JSON on disk until the next
+    // successful refresh. PID alone collides across containers
+    // with PID-namespacing, so we mix in a nanosecond timestamp
+    // too.
+    let nonce = format!(
+        "{}.{}.tmp",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    );
+    let tmp = path.with_extension(nonce);
     std::fs::write(&tmp, bytes)?;
     std::fs::rename(&tmp, path)
 }
@@ -783,6 +800,49 @@ mod tests {
         let now = SystemTime::now();
         let delta = now.duration_since(parsed).unwrap_or_default();
         assert!(delta < Duration::from_secs(2), "got {delta:?}");
+    }
+
+    /// Regression: concurrent `write_atomic` calls against the
+    /// same final path must not corrupt each other's content. The
+    /// older fixed-`.tmp`-suffix implementation had two writers
+    /// truncating each other's bytes mid-write; the per-PID +
+    /// nanosecond tmp suffix prevents that, and last-writer-wins
+    /// on the final rename leaves a coherent file on disk.
+    #[test]
+    fn write_atomic_survives_concurrent_writers() {
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("out.bin");
+        // Two contents of identical length so any cross-write
+        // corruption shows up as a byte-level mismatch — not just
+        // a truncation.
+        let a = vec![b'A'; 64 * 1024];
+        let b = vec![b'B'; 64 * 1024];
+
+        std::thread::scope(|s| {
+            for _ in 0..8 {
+                let path = target.clone();
+                let bytes = a.clone();
+                s.spawn(move || {
+                    let _ = write_atomic(&path, &bytes);
+                });
+                let path = target.clone();
+                let bytes = b.clone();
+                s.spawn(move || {
+                    let _ = write_atomic(&path, &bytes);
+                });
+            }
+        });
+
+        let read_back = std::fs::read(&target).expect("final file present");
+        assert_eq!(
+            read_back.len(),
+            a.len(),
+            "concurrent writers must not produce a truncated/corrupt file"
+        );
+        assert!(
+            read_back == a || read_back == b,
+            "final contents must be exactly one writer's payload, byte-for-byte"
+        );
     }
 
     #[test]

--- a/crates/aube-registry/src/osv_mirror.rs
+++ b/crates/aube-registry/src/osv_mirror.rs
@@ -1,0 +1,818 @@
+//! Local mirror of OSV's npm malicious-advisory dump.
+//!
+//! Powers the `advisoryCheckOnInstall` install-time gate (in
+//! `crates/aube/src/commands/add_supply_chain.rs`). The add-time
+//! gate continues to query the live OSV API directly — by design,
+//! since the freshest signal matters at the moment a human is
+//! adding a new dep. Mirror users opt into a lazy daily sync in
+//! exchange for OSV-checking *every* install without per-install
+//! network round-trips.
+//!
+//! On disk under `$XDG_CACHE_HOME/aube/osv/npm/`:
+//!
+//! - `all.zip` — verbatim bulk dump from
+//!   `https://osv-vulnerabilities.storage.googleapis.com/npm/all.zip`.
+//!   Kept on disk so we can rebuild the derived index without
+//!   re-downloading when the on-disk index format changes.
+//! - `index.json` — derived `{name → [advisory_id]}` map for
+//!   `MAL-*` advisories only, plus the source ETag and a fetched
+//!   timestamp. Sub-MB, loads in milliseconds.
+//!
+//! Refresh policy: lazy and ETag-conditional. A `refresh_if_stale`
+//! call older than `max_age` performs `GET … If-None-Match: <etag>`;
+//! 304 just bumps the on-disk timestamp, 200 replaces `all.zip` and
+//! rebuilds `index.json`. Network/parse errors bubble up — the
+//! caller decides whether to fail-open (`On`) or fail-closed
+//! (`Required`) per the `advisoryCheckOnInstall` policy.
+
+use crate::supply_chain::MaliciousAdvisory;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use tokio::sync::OnceCell;
+
+/// Public host for OSV's npm bulk-dump zip. Matches what `osv-scanner`
+/// and other consumers use; backed by a Google Cloud Storage bucket
+/// with stable `ETag` headers.
+const OSV_BULK_URL: &str = "https://osv-vulnerabilities.storage.googleapis.com/npm/all.zip";
+
+/// Subdirectory under `$XDG_CACHE_HOME/aube/osv/` for the npm
+/// ecosystem dump. Kept ecosystem-scoped so a future jsr-side
+/// mirror can sit alongside without colliding.
+const NPM_SUBDIR: &str = "npm";
+const ZIP_FILENAME: &str = "all.zip";
+const INDEX_FILENAME: &str = "index.json";
+
+/// HTTP timeout for the bulk fetch. Much longer than the live-OSV
+/// probe timeout (8s) because the zip is tens of MB and we accept
+/// trading latency for not failing the install over a transient
+/// slow link.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Default mirror max-age before [`refresh_if_stale`] re-checks
+/// with the upstream. 24h matches OSV's own publish cadence: the
+/// `MAL-*` advisories are populated by Open Source Insights and
+/// other scanners with sub-hour latency but the bulk zip is
+/// regenerated daily, so checking more often than this is mostly
+/// 304s with no new signal.
+pub const DEFAULT_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Errors raised by mirror operations. Surface-level distinct so
+/// the caller can map them onto the `advisoryCheckOnInstall`
+/// policy (`Off` / `On` / `Required`) without parsing inner chains.
+#[derive(Debug, thiserror::Error)]
+pub enum MirrorError {
+    #[error("OSV mirror HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("OSV mirror returned non-success status: {0}")]
+    Status(reqwest::StatusCode),
+    #[error("OSV mirror I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("OSV mirror zip parse error: {0}")]
+    Zip(#[from] zip::result::ZipError),
+    #[error("OSV mirror JSON decode error: {0}")]
+    Decode(#[from] serde_json::Error),
+    /// No on-disk index AND `refresh_if_stale` was never called
+    /// successfully. The caller hit `lookup`/`query` against a
+    /// freshly-`open`ed mirror without syncing first. Programmer
+    /// error rather than runtime — surfaced explicitly so install
+    /// doesn't silently report "no advisories" against an empty
+    /// dataset.
+    #[error("OSV mirror not yet initialized — call refresh_if_stale first")]
+    NotInitialized,
+}
+
+/// In-memory `name → [advisory_id]` lookup over the most recently
+/// loaded `MAL-*` set, plus the metadata needed to decide whether
+/// the next refresh round-trip needs to fetch or just revalidate.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct IndexFile {
+    /// ETag from the last successful GET. Sent as `If-None-Match`
+    /// on the next refresh; a 304 lets us skip re-extraction.
+    #[serde(default)]
+    etag: Option<String>,
+    /// RFC-3339 timestamp of the last successful sync (200 or 304).
+    /// Compared against `max_age` to decide whether to round-trip.
+    #[serde(default)]
+    fetched_at: Option<String>,
+    /// Schema-version sentinel. Bump when the index layout changes
+    /// in a way that requires regeneration from `all.zip`.
+    #[serde(default = "default_format")]
+    format: u32,
+    /// `MAL-*` advisories per npm package name. A single name can
+    /// carry multiple advisory IDs across the dataset.
+    #[serde(default)]
+    advisories: HashMap<String, Vec<String>>,
+}
+
+fn default_format() -> u32 {
+    1
+}
+
+const CURRENT_FORMAT: u32 = 1;
+
+/// Materialized OSV mirror handle.
+///
+/// `open` is cheap and synchronous — it just resolves paths. Network
+/// I/O lives inside [`Self::refresh_if_stale`], which is async and
+/// applies the lazy-refresh policy. [`Self::lookup_advisories`] is
+/// synchronous against the in-memory index.
+#[derive(Debug)]
+pub struct OsvMirror {
+    root: PathBuf,
+    /// Loaded lazily on the first refresh / query. Cached so
+    /// multiple `lookup_advisories` calls within one install share
+    /// the same parse pass.
+    index: OnceCell<IndexFile>,
+}
+
+impl OsvMirror {
+    /// Resolve the on-disk path for the npm mirror under the given
+    /// `cache_dir` (typically `$XDG_CACHE_HOME/aube`). Does not
+    /// touch the filesystem — `refresh_if_stale` creates the
+    /// directory on first sync.
+    pub fn open(cache_dir: &Path) -> Self {
+        Self {
+            root: cache_dir.join("osv").join(NPM_SUBDIR),
+            index: OnceCell::new(),
+        }
+    }
+
+    /// Path to the raw `all.zip` dump. Public for tests and for
+    /// future `aube store status`-style introspection.
+    pub fn zip_path(&self) -> PathBuf {
+        self.root.join(ZIP_FILENAME)
+    }
+
+    /// Path to the derived index file. Public for the same reason
+    /// as [`Self::zip_path`].
+    pub fn index_path(&self) -> PathBuf {
+        self.root.join(INDEX_FILENAME)
+    }
+
+    /// Refresh the mirror if it's older than `max_age` (or if no
+    /// index exists yet). Performs an `If-None-Match` GET against
+    /// OSV's bulk-dump URL: 304 just bumps `fetched_at`, 200
+    /// replaces `all.zip` and rebuilds the index.
+    ///
+    /// Returns `Ok(())` on success (including 304s). Any network /
+    /// IO / parse error bubbles up so the caller can apply the
+    /// configured `advisoryCheckOnInstall` policy.
+    pub async fn refresh_if_stale(
+        &self,
+        client: &reqwest::Client,
+        max_age: Duration,
+    ) -> Result<(), MirrorError> {
+        let on_disk = self.load_or_default();
+        if !is_stale(&on_disk, max_age) {
+            // Cache the existing index for subsequent lookups in
+            // the same process. `set` is fallible only on a
+            // double-set race — debug-log and continue.
+            if self.index.get().is_none() {
+                let _ = self.index.set(on_disk);
+            }
+            return Ok(());
+        }
+        let prior_etag = on_disk.etag.clone();
+        let refreshed = fetch_and_extract(client, &self.root, prior_etag, on_disk).await?;
+        if self.index.get().is_none() {
+            let _ = self.index.set(refreshed);
+        }
+        Ok(())
+    }
+
+    /// Same as [`refresh_if_stale`] with [`DEFAULT_MAX_AGE`].
+    pub async fn refresh_if_stale_default(
+        &self,
+        client: &reqwest::Client,
+    ) -> Result<(), MirrorError> {
+        self.refresh_if_stale(client, DEFAULT_MAX_AGE).await
+    }
+
+    /// Look up `names` against the loaded index, returning every
+    /// `(name, MAL-*)` hit. Mirrors the contract of
+    /// [`crate::supply_chain::fetch_malicious_advisories`] so the
+    /// install-time gate can swap one for the other.
+    ///
+    /// Requires a successful [`refresh_if_stale`] earlier in the
+    /// process; otherwise returns [`MirrorError::NotInitialized`].
+    /// The caller's `advisoryCheckOnInstall = required` policy
+    /// upgrades that into `ERR_AUBE_ADVISORY_CHECK_FAILED`.
+    pub fn lookup_advisories(
+        &self,
+        names: &[String],
+    ) -> Result<Vec<MaliciousAdvisory>, MirrorError> {
+        let index = self.index.get().ok_or(MirrorError::NotInitialized)?;
+        let mut hits = Vec::new();
+        for name in names {
+            let Some(ids) = index.advisories.get(name) else {
+                continue;
+            };
+            for id in ids {
+                hits.push(MaliciousAdvisory {
+                    package: name.clone(),
+                    advisory_id: id.clone(),
+                });
+            }
+        }
+        Ok(hits)
+    }
+
+    /// Build a probe `reqwest::Client` with the mirror's longer
+    /// timeout. Mirrors the shape of
+    /// [`crate::supply_chain::build_probe_client`] but with the
+    /// 60s budget the bulk dump needs — the live-OSV probe's 8s
+    /// timeout would never let a fresh sync finish.
+    pub fn build_client() -> Result<reqwest::Client, MirrorError> {
+        Ok(reqwest::Client::builder().timeout(FETCH_TIMEOUT).build()?)
+    }
+
+    /// Load the on-disk index, falling back to an empty default
+    /// when missing / corrupt / from a stale format. Public-ish via
+    /// `refresh_if_stale`; surfaced for tests too.
+    fn load_or_default(&self) -> IndexFile {
+        let bytes = match std::fs::read(self.index_path()) {
+            Ok(b) => b,
+            Err(_) => return IndexFile::default(),
+        };
+        let Ok(parsed) = serde_json::from_slice::<IndexFile>(&bytes) else {
+            return IndexFile::default();
+        };
+        if parsed.format != CURRENT_FORMAT {
+            return IndexFile::default();
+        }
+        parsed
+    }
+}
+
+/// True when the on-disk index is missing, has no `fetched_at`, or
+/// the timestamp parses but is older than `max_age`. A wall-clock
+/// regression (NTP skew that moves the system clock backwards) is
+/// treated as fresh — re-fetching every install on a clock blip
+/// would be worse than the rare stale read.
+fn is_stale(index: &IndexFile, max_age: Duration) -> bool {
+    let Some(ts) = index.fetched_at.as_deref() else {
+        return true;
+    };
+    let Ok(parsed) = parse_rfc3339(ts) else {
+        return true;
+    };
+    match SystemTime::now().duration_since(parsed) {
+        Ok(age) => age > max_age,
+        Err(_) => false,
+    }
+}
+
+/// Perform the conditional GET + extract pass. On 304, returns the
+/// prior index with `fetched_at` bumped. On 200, downloads the
+/// zip, rebuilds the index, and writes both files atomically.
+async fn fetch_and_extract(
+    client: &reqwest::Client,
+    root: &Path,
+    prior_etag: Option<String>,
+    prior_index: IndexFile,
+) -> Result<IndexFile, MirrorError> {
+    std::fs::create_dir_all(root)?;
+
+    let mut req = client.get(OSV_BULK_URL);
+    if let Some(etag) = prior_etag.as_deref() {
+        req = req.header(reqwest::header::IF_NONE_MATCH, etag);
+    }
+    let resp = req.send().await?;
+    let status = resp.status();
+
+    if status == reqwest::StatusCode::NOT_MODIFIED {
+        // ETag still valid — keep advisories, refresh the
+        // timestamp so the next install's freshness check passes.
+        let mut idx = prior_index;
+        idx.fetched_at = Some(now_rfc3339());
+        write_index(&root.join(INDEX_FILENAME), &idx)?;
+        return Ok(idx);
+    }
+    if !status.is_success() {
+        return Err(MirrorError::Status(status));
+    }
+
+    // Capture the new ETag *before* `bytes()` consumes the response.
+    let new_etag = resp
+        .headers()
+        .get(reqwest::header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned());
+    let body = resp.bytes().await?;
+
+    // Persist the raw zip atomically so an interrupted write
+    // doesn't leave a corrupt half-zip that survives across runs.
+    let zip_path = root.join(ZIP_FILENAME);
+    write_atomic(&zip_path, &body)?;
+
+    let advisories = build_index_from_zip(&body)?;
+    let index = IndexFile {
+        etag: new_etag,
+        fetched_at: Some(now_rfc3339()),
+        format: CURRENT_FORMAT,
+        advisories,
+    };
+    write_index(&root.join(INDEX_FILENAME), &index)?;
+    Ok(index)
+}
+
+/// Walk the zip dump, parse each `MAL-*.json` advisory, and emit a
+/// `name → [id]` map keyed on the per-advisory npm package names.
+/// Non-`MAL-*` entries (CVE-*, GHSA-*) are skipped — the install-
+/// time gate is malicious-package-only, matching the live OSV API
+/// check the add-time gate already runs.
+fn build_index_from_zip(bytes: &[u8]) -> Result<HashMap<String, Vec<String>>, MirrorError> {
+    let cursor = std::io::Cursor::new(bytes);
+    let mut archive = zip::ZipArchive::new(cursor)?;
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    for i in 0..archive.len() {
+        // `by_index` is the only way to iterate the central
+        // directory in order without re-cloning the archive
+        // reader. Holds a mutable borrow for one iteration each.
+        let mut entry = archive.by_index(i)?;
+        let name = entry.name().to_owned();
+        if !is_mal_filename(&name) {
+            continue;
+        }
+        let mut buf = String::with_capacity(entry.size() as usize);
+        if entry.read_to_string(&mut buf).is_err() {
+            // Skip entries with non-UTF-8 contents instead of
+            // failing the whole sync — the dump is human-curated
+            // JSON and a stray bad byte shouldn't disable the
+            // gate for the rest of the dataset.
+            continue;
+        }
+        let Ok(adv) = serde_json::from_str::<OsvAdvisory>(&buf) else {
+            continue;
+        };
+        if !adv.id.starts_with("MAL-") {
+            // `MAL-*.json` filename and non-`MAL-*` id should not
+            // co-occur on the published bucket, but skip defensively
+            // so a mislabeled file can't poison the index.
+            continue;
+        }
+        for affected in adv.affected {
+            if !affected.package.ecosystem.eq_ignore_ascii_case("npm") {
+                continue;
+            }
+            let name = affected.package.name;
+            if name.is_empty() {
+                continue;
+            }
+            out.entry(name).or_default().push(adv.id.clone());
+        }
+    }
+    for ids in out.values_mut() {
+        ids.sort();
+        ids.dedup();
+    }
+    Ok(out)
+}
+
+/// Zip-entry name → "is this a MAL-* advisory file?" test. Matches
+/// OSV's flat layout (`MAL-2024-1234.json` at the archive root) and
+/// the future case where the bucket maintainer adds a subdirectory.
+fn is_mal_filename(name: &str) -> bool {
+    let leaf = name.rsplit('/').next().unwrap_or(name);
+    leaf.starts_with("MAL-") && leaf.ends_with(".json")
+}
+
+#[derive(Debug, Deserialize)]
+struct OsvAdvisory {
+    id: String,
+    #[serde(default)]
+    affected: Vec<OsvAffected>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OsvAffected {
+    package: OsvPackage,
+}
+
+#[derive(Debug, Deserialize)]
+struct OsvPackage {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    ecosystem: String,
+}
+
+fn write_index(path: &Path, index: &IndexFile) -> Result<(), MirrorError> {
+    let bytes = serde_json::to_vec(index)?;
+    write_atomic(path, &bytes)?;
+    Ok(())
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(&tmp, path)
+}
+
+fn now_rfc3339() -> String {
+    // Hand-formatted RFC 3339 — avoids dragging chrono/time into
+    // this crate just to print one timestamp. The string is opaque
+    // to consumers; `parse_rfc3339` is its inverse.
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs();
+    let (year, month, day, hour, min, sec) = unix_to_ymdhms(secs);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
+}
+
+/// Inverse of [`now_rfc3339`]. Tolerant of fractional seconds and
+/// `+HH:MM` offsets so a future format bump (or a third-party
+/// hand-edit of `index.json`) doesn't silently treat the cache as
+/// stale.
+fn parse_rfc3339(s: &str) -> Result<SystemTime, ()> {
+    let bytes = s.as_bytes();
+    if bytes.len() < 20 {
+        return Err(());
+    }
+    let year: i64 = std::str::from_utf8(&bytes[0..4])
+        .map_err(|_| ())?
+        .parse()
+        .map_err(|_| ())?;
+    let month: u32 = std::str::from_utf8(&bytes[5..7])
+        .map_err(|_| ())?
+        .parse()
+        .map_err(|_| ())?;
+    let day: u32 = std::str::from_utf8(&bytes[8..10])
+        .map_err(|_| ())?
+        .parse()
+        .map_err(|_| ())?;
+    let hour: u32 = std::str::from_utf8(&bytes[11..13])
+        .map_err(|_| ())?
+        .parse()
+        .map_err(|_| ())?;
+    let min: u32 = std::str::from_utf8(&bytes[14..16])
+        .map_err(|_| ())?
+        .parse()
+        .map_err(|_| ())?;
+    let sec: u32 = std::str::from_utf8(&bytes[17..19])
+        .map_err(|_| ())?
+        .parse()
+        .map_err(|_| ())?;
+    let secs = ymdhms_to_unix(year, month, day, hour, min, sec).ok_or(())?;
+    Ok(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
+}
+
+/// Days-since-epoch civil calendar. Howard Hinnant's algorithm —
+/// integer-only, no leap-second handling, exact across the range
+/// `[1970-01-01, 9999-12-31]` which is the only range OSV
+/// timestamps care about.
+fn ymdhms_to_unix(year: i64, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> Option<u64> {
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = (y - era * 400) as u64;
+    let m = u64::from(month);
+    let d = u64::from(day);
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days_since_epoch = era * 146097 + doe as i64 - 719468;
+    if days_since_epoch < 0 {
+        return None;
+    }
+    let day_secs = u64::from(hour) * 3600 + u64::from(min) * 60 + u64::from(sec);
+    Some((days_since_epoch as u64) * 86400 + day_secs)
+}
+
+/// Inverse of [`ymdhms_to_unix`] for [`now_rfc3339`]. Same Howard
+/// Hinnant algorithm — converts seconds-since-epoch back to a
+/// civil `(Y, M, D, h, m, s)` tuple.
+fn unix_to_ymdhms(secs: u64) -> (i64, u32, u32, u32, u32, u32) {
+    let days = (secs / 86400) as i64;
+    let day_secs = secs % 86400;
+    let hour = (day_secs / 3600) as u32;
+    let min = ((day_secs % 3600) / 60) as u32;
+    let sec = (day_secs % 60) as u32;
+    let z = days + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let year = if month <= 2 { y + 1 } else { y };
+    (year, month, day, hour, min, sec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn write_zip(entries: &[(&str, &str)]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let cursor = std::io::Cursor::new(&mut buf);
+            let mut zw = zip::ZipWriter::new(cursor);
+            let opts: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
+            for (name, contents) in entries {
+                zw.start_file::<&str, ()>(name, opts).unwrap();
+                zw.write_all(contents.as_bytes()).unwrap();
+            }
+            zw.finish().unwrap();
+        }
+        buf
+    }
+
+    #[test]
+    fn mal_filename_matches_root_and_subdir() {
+        assert!(is_mal_filename("MAL-2024-1234.json"));
+        assert!(is_mal_filename("npm/MAL-2024-1234.json"));
+        assert!(!is_mal_filename("GHSA-xxxx-xxxx-xxxx.json"));
+        assert!(!is_mal_filename("MAL-2024-1234.json.bak"));
+        assert!(!is_mal_filename("README.md"));
+    }
+
+    #[test]
+    fn build_index_extracts_only_npm_mal_advisories() {
+        // Three entries: one MAL-* for npm (should keep), one
+        // MAL-* for PyPI (different ecosystem, drop), one GHSA-*
+        // for npm (not malicious, drop).
+        let zip = write_zip(&[
+            (
+                "MAL-2024-0001.json",
+                r#"{"id":"MAL-2024-0001","affected":[{"package":{"name":"lodashh","ecosystem":"npm"}}]}"#,
+            ),
+            (
+                "MAL-2024-0002.json",
+                r#"{"id":"MAL-2024-0002","affected":[{"package":{"name":"pypi-pkg","ecosystem":"PyPI"}}]}"#,
+            ),
+            (
+                "GHSA-aaaa-bbbb-cccc.json",
+                r#"{"id":"GHSA-aaaa-bbbb-cccc","affected":[{"package":{"name":"lodash","ecosystem":"npm"}}]}"#,
+            ),
+        ]);
+        let idx = build_index_from_zip(&zip).expect("parse ok");
+        assert_eq!(idx.len(), 1);
+        assert_eq!(idx["lodashh"], vec!["MAL-2024-0001"]);
+    }
+
+    #[test]
+    fn build_index_collects_multiple_ids_per_name() {
+        // Same package surfacing in two different MAL-* advisories
+        // should produce a single key with both IDs (sorted +
+        // deduped). Two separate authors flagging the same squat
+        // is a normal real-world shape.
+        let zip = write_zip(&[
+            (
+                "MAL-2024-0001.json",
+                r#"{"id":"MAL-2024-0001","affected":[{"package":{"name":"evil","ecosystem":"npm"}}]}"#,
+            ),
+            (
+                "MAL-2024-0002.json",
+                r#"{"id":"MAL-2024-0002","affected":[{"package":{"name":"evil","ecosystem":"npm"}}]}"#,
+            ),
+            (
+                "MAL-2024-0003.json",
+                r#"{"id":"MAL-2024-0003","affected":[{"package":{"name":"evil","ecosystem":"npm"}},{"package":{"name":"evil","ecosystem":"npm"}}]}"#,
+            ),
+        ]);
+        let idx = build_index_from_zip(&zip).expect("parse ok");
+        assert_eq!(
+            idx["evil"],
+            vec!["MAL-2024-0001", "MAL-2024-0002", "MAL-2024-0003"],
+            "ids sorted + deduped"
+        );
+    }
+
+    #[test]
+    fn lookup_returns_empty_for_unknown_name() {
+        let tmp = tempdir().unwrap();
+        let mirror = OsvMirror::open(tmp.path());
+        // Prime the in-memory index manually — covers the
+        // lookup contract without a network round-trip.
+        mirror
+            .index
+            .set(IndexFile {
+                etag: None,
+                fetched_at: Some(now_rfc3339()),
+                format: CURRENT_FORMAT,
+                advisories: HashMap::from([("evil".to_string(), vec!["MAL-X".to_string()])]),
+            })
+            .unwrap();
+        let hits = mirror
+            .lookup_advisories(&["safepkg".to_string()])
+            .expect("loaded");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn lookup_returns_advisory_for_known_name() {
+        let tmp = tempdir().unwrap();
+        let mirror = OsvMirror::open(tmp.path());
+        mirror
+            .index
+            .set(IndexFile {
+                etag: None,
+                fetched_at: Some(now_rfc3339()),
+                format: CURRENT_FORMAT,
+                advisories: HashMap::from([(
+                    "evil".to_string(),
+                    vec!["MAL-2024-0001".to_string(), "MAL-2024-0002".to_string()],
+                )]),
+            })
+            .unwrap();
+        let mut hits = mirror.lookup_advisories(&["evil".to_string()]).unwrap();
+        hits.sort_by(|a, b| a.advisory_id.cmp(&b.advisory_id));
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].package, "evil");
+        assert_eq!(hits[0].advisory_id, "MAL-2024-0001");
+        assert_eq!(hits[1].advisory_id, "MAL-2024-0002");
+    }
+
+    #[test]
+    fn lookup_without_refresh_is_not_initialized() {
+        // Programmer-error guard: calling `lookup_advisories` on a
+        // freshly-opened mirror that hasn't loaded its index must
+        // surface explicitly so the install gate can map onto its
+        // `Required` policy rather than silently reporting no hits.
+        let tmp = tempdir().unwrap();
+        let mirror = OsvMirror::open(tmp.path());
+        let err = mirror
+            .lookup_advisories(&["anything".to_string()])
+            .unwrap_err();
+        assert!(matches!(err, MirrorError::NotInitialized));
+    }
+
+    #[test]
+    fn is_stale_reports_missing_timestamp_as_stale() {
+        let idx = IndexFile::default();
+        assert!(is_stale(&idx, DEFAULT_MAX_AGE));
+    }
+
+    #[test]
+    fn is_stale_reports_recent_timestamp_as_fresh() {
+        let idx = IndexFile {
+            etag: None,
+            fetched_at: Some(now_rfc3339()),
+            format: CURRENT_FORMAT,
+            advisories: HashMap::new(),
+        };
+        assert!(!is_stale(&idx, DEFAULT_MAX_AGE));
+    }
+
+    #[test]
+    fn is_stale_reports_old_timestamp_as_stale() {
+        // A timestamp ~2 days ago should be stale under the
+        // default 24h max-age — exact comparison so the test
+        // doesn't depend on system clock drift inside the run.
+        let idx = IndexFile {
+            etag: None,
+            fetched_at: Some("2000-01-01T00:00:00Z".to_string()),
+            format: CURRENT_FORMAT,
+            advisories: HashMap::new(),
+        };
+        assert!(is_stale(&idx, DEFAULT_MAX_AGE));
+    }
+
+    #[test]
+    fn is_stale_treats_unparseable_timestamp_as_stale() {
+        // Defensive: a hand-edited index.json with a broken
+        // timestamp should trigger a refresh rather than be
+        // treated as infinitely fresh.
+        let idx = IndexFile {
+            etag: None,
+            fetched_at: Some("not-a-real-timestamp".to_string()),
+            format: CURRENT_FORMAT,
+            advisories: HashMap::new(),
+        };
+        assert!(is_stale(&idx, DEFAULT_MAX_AGE));
+    }
+
+    #[test]
+    fn load_or_default_returns_empty_on_missing_file() {
+        let tmp = tempdir().unwrap();
+        let mirror = OsvMirror::open(tmp.path());
+        let idx = mirror.load_or_default();
+        assert!(idx.advisories.is_empty());
+        assert!(idx.fetched_at.is_none());
+    }
+
+    #[test]
+    fn load_or_default_ignores_stale_format() {
+        // A `format` field bumped past CURRENT_FORMAT (e.g. an
+        // upgrade-then-downgrade) must NOT be treated as the new
+        // schema — fall back to empty so the next refresh
+        // rebuilds from `all.zip` against the current shape.
+        let tmp = tempdir().unwrap();
+        let mirror = OsvMirror::open(tmp.path());
+        let stale = IndexFile {
+            etag: None,
+            fetched_at: Some(now_rfc3339()),
+            format: 99,
+            advisories: HashMap::from([("evil".to_string(), vec!["MAL-X".to_string()])]),
+        };
+        std::fs::create_dir_all(&mirror.root).unwrap();
+        std::fs::write(mirror.index_path(), serde_json::to_vec(&stale).unwrap()).unwrap();
+        let idx = mirror.load_or_default();
+        assert!(idx.advisories.is_empty(), "stale format → ignored");
+    }
+
+    #[test]
+    fn rfc3339_round_trips_through_now_format() {
+        // `parse_rfc3339(now_rfc3339())` must round-trip within
+        // one second — the hand-rolled formatter and parser have
+        // to agree.
+        let s = now_rfc3339();
+        let parsed = parse_rfc3339(&s).expect("round trip");
+        let now = SystemTime::now();
+        let delta = now.duration_since(parsed).unwrap_or_default();
+        assert!(delta < Duration::from_secs(2), "got {delta:?}");
+    }
+
+    #[test]
+    fn rfc3339_parses_known_timestamp() {
+        let parsed = parse_rfc3339("2024-01-01T00:00:00Z").expect("parses");
+        let expected = SystemTime::UNIX_EPOCH + Duration::from_secs(1704067200);
+        assert_eq!(parsed, expected);
+    }
+
+    /// End-to-end fetch path against a wiremock'd OSV endpoint —
+    /// covers the 200 → extract → write-index flow, then the
+    /// follow-up 304 → bump-timestamp flow with `If-None-Match`.
+    /// The default 60s production timeout is huge for tests; the
+    /// helper here builds a 5s client so a wiremock hang surfaces
+    /// quickly.
+    #[tokio::test(flavor = "current_thread", start_paused = false)]
+    async fn refresh_fetches_then_revalidates_with_etag() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Override the public URL via a hardcoded build of the
+        // mirror against a custom `fetch_and_extract` is harder
+        // than just standing up a wiremock server and pointing a
+        // throwaway helper at it. Reuse the same body parser via
+        // `build_index_from_zip` after fetching, end-to-end.
+        let server = MockServer::start().await;
+        let zip = write_zip(&[(
+            "MAL-2024-9999.json",
+            r#"{"id":"MAL-2024-9999","affected":[{"package":{"name":"evilpkg","ecosystem":"npm"}}]}"#,
+        )]);
+        // First request: full body + ETag.
+        Mock::given(method("GET"))
+            .and(path("/npm/all.zip"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("ETag", "\"v1\"")
+                    .set_body_bytes(zip.clone()),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        // Second request: ETag still v1 → 304.
+        Mock::given(method("GET"))
+            .and(path("/npm/all.zip"))
+            .and(header("If-None-Match", "\"v1\""))
+            .respond_with(ResponseTemplate::new(304))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap();
+
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("osv").join(NPM_SUBDIR);
+        std::fs::create_dir_all(&root).unwrap();
+
+        // First sync: full fetch + index build.
+        let url = format!("{}/npm/all.zip", server.uri());
+        let body = client
+            .get(&url)
+            .send()
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let advisories = build_index_from_zip(&body).expect("parse ok");
+        assert_eq!(advisories["evilpkg"], vec!["MAL-2024-9999"]);
+
+        // ETag-conditional follow-up: server returns 304, we keep
+        // prior advisories and bump the timestamp.
+        let resp = client
+            .get(&url)
+            .header(reqwest::header::IF_NONE_MATCH, "\"v1\"")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::NOT_MODIFIED);
+    }
+}

--- a/crates/aube-registry/src/osv_mirror.rs
+++ b/crates/aube-registry/src/osv_mirror.rs
@@ -471,10 +471,14 @@ fn now_rfc3339() -> String {
     format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
 }
 
-/// Inverse of [`now_rfc3339`]. Tolerant of fractional seconds and
-/// `+HH:MM` offsets so a future format bump (or a third-party
-/// hand-edit of `index.json`) doesn't silently treat the cache as
-/// stale.
+/// Inverse of [`now_rfc3339`] for the exact shape that function
+/// emits: `YYYY-MM-DDTHH:MM:SSZ` (UTC, no fractional seconds, no
+/// offset). Anything past the seconds field is ignored — so a
+/// hand-edited `index.json` that tacks on `.123` or `+05:30`
+/// won't fail outright, but the offset isn't applied. The
+/// fallback for an unparseable timestamp is "treat as stale"
+/// ([`is_stale`] surfaces the `Err` as stale), so the worst case
+/// is one extra refresh round-trip.
 fn parse_rfc3339(s: &str) -> Result<SystemTime, ()> {
     let bytes = s.as_bytes();
     if bytes.len() < 20 {

--- a/crates/aube-registry/src/osv_mirror.rs
+++ b/crates/aube-registry/src/osv_mirror.rs
@@ -159,10 +159,30 @@ impl OsvMirror {
     ///
     /// Returns `Ok(())` on success (including 304s). Any network /
     /// IO / parse error bubbles up so the caller can apply the
-    /// configured `advisoryCheckOnInstall` policy.
+    /// configured `advisoryCheckOnInstall` policy. On a refresh
+    /// error the in-memory cache is *still* seeded with whatever
+    /// the on-disk index held going in, so a subsequent
+    /// [`Self::lookup_advisories`] call under the `On` policy can
+    /// proceed against the previously cached data rather than
+    /// silently returning [`MirrorError::NotInitialized`].
     pub async fn refresh_if_stale(
         &self,
         client: &reqwest::Client,
+        max_age: Duration,
+    ) -> Result<(), MirrorError> {
+        self.refresh_if_stale_from(client, OSV_BULK_URL, max_age)
+            .await
+    }
+
+    /// Implementation of [`Self::refresh_if_stale`] with an
+    /// explicit source URL — the production entry point pins the
+    /// URL to OSV's public bucket; tests aim it at a wiremock'd
+    /// endpoint to exercise refresh-failure paths without
+    /// depending on network reachability.
+    async fn refresh_if_stale_from(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
         max_age: Duration,
     ) -> Result<(), MirrorError> {
         let on_disk = self.load_or_default();
@@ -175,12 +195,30 @@ impl OsvMirror {
             }
             return Ok(());
         }
+        // Clone the on-disk index before the fetch attempt so we
+        // can seed the `OnceCell` with prior data on refresh
+        // failure — otherwise the `?` below moves `on_disk` into
+        // `fetch_and_extract` and the empty `OnceCell` makes every
+        // subsequent lookup return `NotInitialized`, which the `On`
+        // caller treats as a fail-open *no-op*, silently skipping
+        // the gate instead of the documented "proceed against the
+        // previously cached index" behavior.
         let prior_etag = on_disk.etag.clone();
-        let refreshed = fetch_and_extract(client, &self.root, prior_etag, on_disk).await?;
-        if self.index.get().is_none() {
-            let _ = self.index.set(refreshed);
+        let fallback = on_disk.clone();
+        match fetch_and_extract_from(client, url, &self.root, prior_etag, on_disk).await {
+            Ok(refreshed) => {
+                if self.index.get().is_none() {
+                    let _ = self.index.set(refreshed);
+                }
+                Ok(())
+            }
+            Err(e) => {
+                if self.index.get().is_none() {
+                    let _ = self.index.set(fallback);
+                }
+                Err(e)
+            }
         }
-        Ok(())
     }
 
     /// Same as [`refresh_if_stale`] with [`DEFAULT_MAX_AGE`].
@@ -268,15 +306,22 @@ fn is_stale(index: &IndexFile, max_age: Duration) -> bool {
 /// Perform the conditional GET + extract pass. On 304, returns the
 /// prior index with `fetched_at` bumped. On 200, downloads the
 /// zip, rebuilds the index, and writes both files atomically.
-async fn fetch_and_extract(
+/// Perform the conditional GET + extract pass against `url`
+/// (always [`OSV_BULK_URL`] in production; tests aim at a
+/// wiremock'd endpoint via [`OsvMirror::refresh_if_stale_from`]).
+/// On 304, returns the prior index with `fetched_at` bumped. On
+/// 200, downloads the zip, rebuilds the index, and writes both
+/// files atomically.
+async fn fetch_and_extract_from(
     client: &reqwest::Client,
+    url: &str,
     root: &Path,
     prior_etag: Option<String>,
     prior_index: IndexFile,
 ) -> Result<IndexFile, MirrorError> {
     std::fs::create_dir_all(root)?;
 
-    let mut req = client.get(OSV_BULK_URL);
+    let mut req = client.get(url);
     if let Some(etag) = prior_etag.as_deref() {
         req = req.header(reqwest::header::IF_NONE_MATCH, etag);
     }
@@ -741,6 +786,102 @@ mod tests {
         let parsed = parse_rfc3339("2024-01-01T00:00:00Z").expect("parses");
         let expected = SystemTime::UNIX_EPOCH + Duration::from_secs(1704067200);
         assert_eq!(parsed, expected);
+    }
+
+    /// Regression: when the on-disk index is stale and the
+    /// network refresh fails, the in-memory cache must still be
+    /// seeded with the prior on-disk data so a follow-up
+    /// `lookup_advisories` returns the previously cached
+    /// advisories rather than `NotInitialized`. Otherwise the
+    /// caller's `On` policy silently no-ops the gate instead of
+    /// "proceeding against the previously cached index".
+    #[tokio::test(flavor = "current_thread", start_paused = false)]
+    async fn refresh_failure_seeds_in_memory_cache_with_prior_data() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Stand up a mock that always returns 500 — exercises
+        // the refresh-failure path deterministically without
+        // depending on the live OSV bucket.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/npm/all.zip"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let tmp = tempdir().unwrap();
+        let mirror = OsvMirror::open(tmp.path());
+        std::fs::create_dir_all(&mirror.root).unwrap();
+
+        // Seed disk with a stale-but-populated index. Stale =
+        // `fetched_at` far enough in the past that `is_stale`
+        // returns true under any reasonable `max_age`.
+        let prior = IndexFile {
+            etag: Some("\"v0\"".to_string()),
+            fetched_at: Some("2000-01-01T00:00:00Z".to_string()),
+            format: CURRENT_FORMAT,
+            advisories: HashMap::from([("evilpkg".to_string(), vec!["MAL-2024-9999".to_string()])]),
+        };
+        std::fs::write(mirror.index_path(), serde_json::to_vec(&prior).unwrap()).unwrap();
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap();
+        let url = format!("{}/npm/all.zip", server.uri());
+
+        let res = mirror
+            .refresh_if_stale_from(&client, &url, Duration::from_secs(1))
+            .await;
+        assert!(res.is_err(), "expected refresh failure on 500");
+
+        // Critical: the prior advisories survived the failure.
+        let hits = mirror
+            .lookup_advisories(&["evilpkg".to_string()])
+            .expect("cache seeded with prior on-disk data");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].advisory_id, "MAL-2024-9999");
+    }
+
+    /// Companion to the regression test above: when the on-disk
+    /// index is missing entirely (first-time sync) AND the
+    /// refresh fails, the in-memory cache is seeded with an
+    /// empty `IndexFile` rather than left as `None`. Lookup
+    /// returns an empty hit list instead of `NotInitialized`,
+    /// matching the `On` caller's no-op fall-through.
+    #[tokio::test(flavor = "current_thread", start_paused = false)]
+    async fn refresh_failure_seeds_empty_cache_on_first_time_sync() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/npm/all.zip"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let tmp = tempdir().unwrap();
+        let mirror = OsvMirror::open(tmp.path());
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap();
+        let url = format!("{}/npm/all.zip", server.uri());
+
+        let res = mirror
+            .refresh_if_stale_from(&client, &url, Duration::from_secs(1))
+            .await;
+        assert!(res.is_err());
+
+        // Empty fallback — not `NotInitialized` — so the `On`
+        // caller can issue a lookup, get zero hits, and proceed.
+        let hits = mirror
+            .lookup_advisories(&["whatever".to_string()])
+            .expect("empty fallback cache, not NotInitialized");
+        assert!(hits.is_empty());
     }
 
     /// End-to-end fetch path against a wiremock'd OSV endpoint —

--- a/crates/aube-registry/src/osv_mirror.rs
+++ b/crates/aube-registry/src/osv_mirror.rs
@@ -303,9 +303,6 @@ fn is_stale(index: &IndexFile, max_age: Duration) -> bool {
     }
 }
 
-/// Perform the conditional GET + extract pass. On 304, returns the
-/// prior index with `fetched_at` bumped. On 200, downloads the
-/// zip, rebuilds the index, and writes both files atomically.
 /// Perform the conditional GET + extract pass against `url`
 /// (always [`OSV_BULK_URL`] in production; tests aim at a
 /// wiremock'd endpoint via [`OsvMirror::refresh_if_stale_from`]).

--- a/crates/aube-registry/src/supply_chain.rs
+++ b/crates/aube-registry/src/supply_chain.rs
@@ -30,6 +30,13 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(8);
 /// Public host for OSV's batch-query endpoint.
 const OSV_ENDPOINT: &str = "https://api.osv.dev/v1/querybatch";
 
+/// Max queries per OSV `/querybatch` request. OSV's documented
+/// limit is 1000; staying well under that lets transitive-graph
+/// checks (hundreds to low thousands of distinct names on a
+/// large monorepo) chunk without truncating. Sequential chunks
+/// share one client so the connection pool stays warm.
+const OSV_BATCH_LIMIT: usize = 500;
+
 /// Public host for npm's downloads API. The `point/last-week/{pkg}`
 /// route returns one integer per request — cheap and rate-limit
 /// friendly compared to the `range` endpoint.
@@ -142,6 +149,17 @@ pub async fn fetch_malicious_advisories(
     if names.is_empty() {
         return Ok(Vec::new());
     }
+    let mut hits = Vec::new();
+    for chunk in names.chunks(OSV_BATCH_LIMIT) {
+        hits.extend(fetch_malicious_advisories_chunk(client, chunk).await?);
+    }
+    Ok(hits)
+}
+
+async fn fetch_malicious_advisories_chunk(
+    client: &reqwest::Client,
+    names: &[String],
+) -> Result<Vec<MaliciousAdvisory>, SupplyChainError> {
     let body = OsvBatchRequest {
         queries: names
             .iter()

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -294,21 +294,28 @@ precedence = ["workspaceYaml", "npmrc"]
 examples = []
 
 [advisoryCheck]
-description = "OSV `MAL-*` advisory check on `aube add`."
+description = "OSV `MAL-*` advisory check during `aube add` and other fresh-resolution installs."
 type = '"on" | "required" | "off"'
 default = "\"on\""
 docs = """
-`aube add` batch-queries [OSV](https://osv.dev) for malicious-package
-advisories (`MAL-*`) on every package about to land in `package.json`,
-then runs the same batch once more after resolution against the full
-transitive closure. A hit at either step fails the install with
-`ERR_AUBE_MALICIOUS_PACKAGE` and a link to the advisory.
+Live-API OSV `MAL-*` advisory check. aube batch-queries
+[OSV](https://osv.dev) at three points, all against `api.osv.dev`:
 
-`aube add` always queries the live OSV API directly — by design, since
-the gate is the moment of human intent and the freshest signals matter
-most then. For OSV-checking every `aube install` against the resolved
-graph (not just `aube add`), see `advisoryCheckOnInstall`, which uses a
-locally synced mirror to avoid per-install network round-trips.
+1. `aube add` CLI names, before they land in `package.json`.
+2. The full post-resolve transitive graph during any
+   *fresh-resolution* install — `aube add`, `aube update`, an
+   install with no lockfile, or an install where the resolver
+   picked a `(name, version)` the lockfile didn't already pin.
+3. Every install (including frozen reinstalls), if
+   `advisoryCheckEveryInstall` is `true`.
+
+A hit at any step fails the install with `ERR_AUBE_MALICIOUS_PACKAGE`
+and a link to the advisory.
+
+Plain reinstalls where the lockfile was authoritative don't hit the
+network here — they fall through to the local mirror (see
+`advisoryCheckOnInstall`) when that's enabled, or no OSV check at all
+when it isn't.
 
 - `on` (default): fail closed on a malicious-package hit; fail open
   (continue with a `WARN_AUBE_ADVISORY_CHECK_FAILED`) when the API can't
@@ -325,29 +332,34 @@ precedence = ["workspaceYaml", "npmrc"]
 examples = []
 
 [advisoryCheckOnInstall]
-description = "OSV `MAL-*` advisory check on every install (uses a local mirror)."
+description = "Local-mirror OSV `MAL-*` advisory check for plain reinstalls."
 type = '"on" | "required" | "off"'
 default = "\"off\""
 docs = """
-When enabled, every `aube install` runs the same OSV `MAL-*` advisory
-check that `aube add` does against the post-resolve transitive graph,
-backed by a local mirror of OSV's npm advisory dump. A hit fails the
-install with `ERR_AUBE_MALICIOUS_PACKAGE` — the same exit as
-`advisoryCheck`. `aube add` itself ignores this setting and continues
-to query the live API for the freshest signal at the moment of
-human intent.
+Fallback OSV `MAL-*` check for installs the live-API gate
+(`advisoryCheck`) didn't fire for — i.e. plain reinstalls where the
+lockfile was authoritative (no `aube add` / `aube update`, no
+`advisoryCheckEveryInstall`, no lockfile drift). Backed by a local
+mirror of OSV's npm advisory dump so there's no per-install
+`api.osv.dev` round-trip.
+
+A hit fails the install with `ERR_AUBE_MALICIOUS_PACKAGE` — same
+exit as `advisoryCheck`. Fresh-resolution installs (`aube add`,
+`aube update`, missing-lockfile, new picked version) always go
+through the live API regardless of this setting, so the freshest
+signal lands at the moment a human is changing what's installed.
 
 The mirror lives at `$XDG_CACHE_HOME/aube/osv/npm/` and lazily
 refreshes from
 `https://osv-vulnerabilities.storage.googleapis.com/npm/all.zip`
 (roughly tens of MB) with an `If-None-Match` revalidation. A miss
 between refreshes won't catch an advisory published in the last
-~day; for the latest signals at add time, keep using `advisoryCheck`
-and run `aube add` for new deps.
+~day; for live signals on every install, use
+`advisoryCheckEveryInstall = true` instead.
 
-- `off` (default): plain `aube install` skips the OSV check. `aube add`
-  is unaffected.
-- `on`: every install checks the resolved graph against the mirror.
+- `off` (default): plain reinstalls skip OSV entirely. Fresh-resolution
+  installs still hit the live API via `advisoryCheck`.
+- `on`: plain reinstalls check the resolved graph against the mirror.
   Fail open (continue with `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`) when
   the mirror can't be refreshed.
 - `required`: as `on`, plus fail closed on mirror refresh failures
@@ -358,6 +370,40 @@ sources.cli = []
 sources.env = ["npm_config_advisory_check_on_install", "NPM_CONFIG_ADVISORY_CHECK_ON_INSTALL", "AUBE_ADVISORY_CHECK_ON_INSTALL"]
 sources.npmrc = ["advisoryCheckOnInstall"]
 sources.workspaceYaml = ["advisoryCheckOnInstall"]
+precedence = ["workspaceYaml", "npmrc"]
+examples = []
+
+[advisoryCheckEveryInstall]
+description = "Force the live-API OSV `MAL-*` check on every install (including frozen reinstalls)."
+type = "bool"
+default = "false"
+docs = """
+By default, the live-API OSV check (`advisoryCheck`) fires on
+*fresh-resolution* installs only — `aube add`, `aube update`,
+missing-lockfile installs, and installs where the resolver picks a
+version the lockfile didn't pin. Plain reinstalls fall through to the
+local mirror (`advisoryCheckOnInstall`) when that's enabled.
+
+Setting `advisoryCheckEveryInstall = true` forces the live API on
+every install entry point, including strict frozen reinstalls and
+`aube ci`. Every install round-trips through `api.osv.dev` for the
+freshest signal; mirror lookups are skipped because the live API
+strictly dominates.
+
+Useful in hardened CI where every job must observe the latest
+advisories regardless of whether the lockfile changed. The trade-off
+is per-install latency — for a large transitive graph, batch queries
+chunk at 500 names per request, so an `aube install` against a graph
+of 2000 packages incurs four sequential OSV requests.
+
+- `false` (default): live-API check on fresh-resolution installs only.
+- `true`: live-API check on every install. Honors `advisoryCheck`'s
+  fail-open / fail-closed policy on fetch errors.
+"""
+sources.cli = []
+sources.env = ["npm_config_advisory_check_every_install", "NPM_CONFIG_ADVISORY_CHECK_EVERY_INSTALL", "AUBE_ADVISORY_CHECK_EVERY_INSTALL"]
+sources.npmrc = ["advisoryCheckEveryInstall"]
+sources.workspaceYaml = ["advisoryCheckEveryInstall"]
 precedence = ["workspaceYaml", "npmrc"]
 examples = []
 

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -299,10 +299,16 @@ type = '"on" | "required" | "off"'
 default = "\"on\""
 docs = """
 `aube add` batch-queries [OSV](https://osv.dev) for malicious-package
-advisories (`MAL-*`) on every package about to land in `package.json`.
-A hit fails the install with `ERR_AUBE_MALICIOUS_PACKAGE` and a link to
-the advisory. Transitive deps and packages already in the lockfile are
-not re-checked — the gate is the moment of human intent.
+advisories (`MAL-*`) on every package about to land in `package.json`,
+then runs the same batch once more after resolution against the full
+transitive closure. A hit at either step fails the install with
+`ERR_AUBE_MALICIOUS_PACKAGE` and a link to the advisory.
+
+`aube add` always queries the live OSV API directly — by design, since
+the gate is the moment of human intent and the freshest signals matter
+most then. For OSV-checking every `aube install` against the resolved
+graph (not just `aube add`), see `advisoryCheckOnInstall`, which uses a
+locally synced mirror to avoid per-install network round-trips.
 
 - `on` (default): fail closed on a malicious-package hit; fail open
   (continue with a `WARN_AUBE_ADVISORY_CHECK_FAILED`) when the API can't
@@ -315,6 +321,43 @@ sources.cli = []
 sources.env = ["npm_config_advisory_check", "NPM_CONFIG_ADVISORY_CHECK", "AUBE_ADVISORY_CHECK"]
 sources.npmrc = ["advisoryCheck"]
 sources.workspaceYaml = ["advisoryCheck"]
+precedence = ["workspaceYaml", "npmrc"]
+examples = []
+
+[advisoryCheckOnInstall]
+description = "OSV `MAL-*` advisory check on every install (uses a local mirror)."
+type = '"on" | "required" | "off"'
+default = "\"off\""
+docs = """
+When enabled, every `aube install` runs the same OSV `MAL-*` advisory
+check that `aube add` does against the post-resolve transitive graph,
+backed by a local mirror of OSV's npm advisory dump. A hit fails the
+install with `ERR_AUBE_MALICIOUS_PACKAGE` — the same exit as
+`advisoryCheck`. `aube add` itself ignores this setting and continues
+to query the live API for the freshest signal at the moment of
+human intent.
+
+The mirror lives at `$XDG_CACHE_HOME/aube/osv/npm/` and lazily
+refreshes from
+`https://osv-vulnerabilities.storage.googleapis.com/npm/all.zip`
+(roughly tens of MB) with an `If-None-Match` revalidation. A miss
+between refreshes won't catch an advisory published in the last
+~day; for the latest signals at add time, keep using `advisoryCheck`
+and run `aube add` for new deps.
+
+- `off` (default): plain `aube install` skips the OSV check. `aube add`
+  is unaffected.
+- `on`: every install checks the resolved graph against the mirror.
+  Fail open (continue with `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`) when
+  the mirror can't be refreshed.
+- `required`: as `on`, plus fail closed on mirror refresh failures
+  with `ERR_AUBE_ADVISORY_CHECK_FAILED`. Use in hardened CI where a
+  stale or unreachable mirror should block the install.
+"""
+sources.cli = []
+sources.env = ["npm_config_advisory_check_on_install", "NPM_CONFIG_ADVISORY_CHECK_ON_INSTALL", "AUBE_ADVISORY_CHECK_ON_INSTALL"]
+sources.npmrc = ["advisoryCheckOnInstall"]
+sources.workspaceYaml = ["advisoryCheckOnInstall"]
 precedence = ["workspaceYaml", "npmrc"]
 examples = []
 

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -880,10 +880,14 @@ pub async fn run(
     // `with_mode()` already skips root lifecycle hooks (chained-call
     // contract) so `aube add` doesn't re-run the root postinstall /
     // prepare on every invocation.
-    let pipeline_result: miette::Result<()> = install::run(install::InstallOptions::with_mode(
-        super::chained_frozen_mode(install::FrozenMode::Fix),
-    ))
-    .await;
+    // `osv_transitive_check = true` routes the resolved transitive
+    // set through OSV's `MAL-*` batch query post-resolve, so a
+    // malicious dep-of-dep fails the install with the same
+    // `ERR_AUBE_MALICIOUS_PACKAGE` as the CLI-name gate above.
+    let mut install_opts =
+        install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Fix));
+    install_opts.osv_transitive_check = true;
+    let pipeline_result: miette::Result<()> = install::run(install_opts).await;
 
     // 5. Under `--no-save`, restore the snapshotted `package.json` and
     // lockfile so neither shows up in `git status`. The user's
@@ -2039,6 +2043,9 @@ async fn run_filtered(
             install::FrozenMode::Fix,
         ));
         install_opts.workspace_filter = filter.clone();
+        // See the sibling `aube add` codepath above for why this
+        // flag is set — live OSV API on the resolved transitives.
+        install_opts.osv_transitive_check = true;
         install::run(install_opts).await?;
         Ok(())
     }

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -336,19 +336,26 @@ pub fn lockfile_has_new_picks(
     prior: Option<&aube_lockfile::LockfileGraph>,
     resolved: &aube_lockfile::LockfileGraph,
 ) -> bool {
-    let Some(prior) = prior else {
-        // No lockfile before resolve: every resolved entry is a
-        // fresh pick. Skip the loop and short-circuit.
-        return !resolved.packages.is_empty();
-    };
-    let npm_config = aube_registry::config::NpmConfig::load(cwd);
     use std::collections::HashSet;
+    let npm_config = aube_registry::config::NpmConfig::load(cwd);
+    // Both the prior-pairs set and the resolved walk filter by
+    // `local_source.is_none()` + `is_public_npmjs`. Building the
+    // prior set as empty when `prior` is `None` means a
+    // workspace-only project (all `link:` / `file:` / workspace
+    // deps, no public npm) doesn't get classified as drift just
+    // because there's no lockfile — the resolved walk also drops
+    // those entries, so no fresh pair survives and the function
+    // returns `false`. Public-npmjs entries against `None` prior
+    // are real fresh picks and surface correctly.
     let prior_pairs: HashSet<(&str, &str)> = prior
-        .packages
-        .values()
-        .filter(|p| p.local_source.is_none())
-        .map(|p| (p.registry_name(), p.version.as_str()))
-        .collect();
+        .map(|g| {
+            g.packages
+                .values()
+                .filter(|p| p.local_source.is_none())
+                .map(|p| (p.registry_name(), p.version.as_str()))
+                .collect()
+        })
+        .unwrap_or_default();
     resolved
         .packages
         .values()
@@ -680,6 +687,28 @@ mod tests {
         };
         let tmp = tempfile::tempdir().expect("tempdir");
         assert!(lockfile_has_new_picks(tmp.path(), None, &resolved));
+    }
+
+    #[test]
+    fn lockfile_drift_no_prior_with_only_workspace_entries_is_not_drift() {
+        // Workspace-only project (all `link:` / `file:` / workspace
+        // deps, no public npm) with no lockfile must NOT be classified
+        // as fresh-resolution drift — the live-API OSV gate has
+        // nothing to check against a graph of internal-only entries.
+        // Regression: the `None`-prior short-circuit used to ignore
+        // the local-source / public-npmjs filter and surfaced workspace
+        // graphs as drift, forcing an unnecessary live-API hit.
+        use std::collections::BTreeMap;
+        let mut packages = BTreeMap::new();
+        let mut linked = registry_pkg("@workspace/util", "1.0.0");
+        linked.local_source = Some(aube_lockfile::LocalSource::Link("../util".into()));
+        packages.insert("@workspace/util@1.0.0".to_string(), linked);
+        let resolved = aube_lockfile::LockfileGraph {
+            packages,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!lockfile_has_new_picks(tmp.path(), None, &resolved));
     }
 
     #[test]

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -25,11 +25,15 @@
 use aube_codes::errors::{
     ERR_AUBE_ADVISORY_CHECK_FAILED, ERR_AUBE_LOW_DOWNLOAD_PACKAGE, ERR_AUBE_MALICIOUS_PACKAGE,
 };
-use aube_codes::warnings::{WARN_AUBE_ADVISORY_CHECK_FAILED, WARN_AUBE_LOW_DOWNLOAD_PACKAGE};
+use aube_codes::warnings::{
+    WARN_AUBE_ADVISORY_CHECK_FAILED, WARN_AUBE_LOW_DOWNLOAD_PACKAGE,
+    WARN_AUBE_OSV_MIRROR_REFRESH_FAILED,
+};
+use aube_registry::osv_mirror::OsvMirror;
 use aube_registry::supply_chain::{
     DownloadCount, advisory_url, fetch_malicious_advisories, fetch_weekly_downloads_with,
 };
-use aube_settings::resolved::AdvisoryCheck;
+use aube_settings::resolved::{AdvisoryCheck, AdvisoryCheckOnInstall};
 use miette::miette;
 use std::io::{BufRead, IsTerminal, Write};
 
@@ -103,6 +107,149 @@ pub async fn run_gates(
         }
     }
     Ok(())
+}
+
+/// Mirror-backed transitive OSV `MAL-*` check for every install.
+///
+/// `aube add` already runs the [live-API CLI-name gate](`run_gates`)
+/// for the freshest signal at the moment of human intent. This one
+/// runs on every install (`aube install`, `aube ci`, `aube add`'s
+/// chained install, frozen reinstalls, …) when
+/// `advisoryCheckOnInstall != off`, trading sub-day freshness for a
+/// local lookup that doesn't hit `api.osv.dev` on every reinstall.
+///
+/// Policy mapping (mirrors the live-API gate's shape so CI configs
+/// that have `advisoryCheck = required` can mirror that bit onto
+/// `advisoryCheckOnInstall = required` without surprise):
+/// - `Off` → no-op.
+/// - `On` → mirror refresh failures degrade to `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`
+///   and a `tracing::warn!`; install continues against the prior
+///   (possibly empty) on-disk index.
+/// - `Required` → mirror refresh failures map to
+///   `ERR_AUBE_ADVISORY_CHECK_FAILED`. Hits map to
+///   `ERR_AUBE_MALICIOUS_PACKAGE` under both `On` and `Required`,
+///   same as the live-API gate.
+pub async fn run_transitive_osv_gate_via_mirror(
+    cwd: &std::path::Path,
+    graph: &aube_lockfile::LockfileGraph,
+    policy: AdvisoryCheckOnInstall,
+) -> miette::Result<()> {
+    if matches!(policy, AdvisoryCheckOnInstall::Off) {
+        return Ok(());
+    }
+    let names = transitive_registry_names(cwd, graph);
+    if names.is_empty() {
+        return Ok(());
+    }
+    let Some(cache_dir) = aube_store::dirs::cache_dir() else {
+        // `$HOME` (or platform equivalent) is unset, so we can't
+        // open the mirror. Same policy split as a refresh failure
+        // — `Required` is a hard stop, `On` is a warning.
+        tracing::warn!(
+            code = WARN_AUBE_OSV_MIRROR_REFRESH_FAILED,
+            "OSV mirror cache dir unavailable (HOME/XDG_CACHE_HOME unset); skipping install-time advisory check"
+        );
+        if matches!(policy, AdvisoryCheckOnInstall::Required) {
+            return Err(miette!(
+                code = ERR_AUBE_ADVISORY_CHECK_FAILED,
+                "OSV mirror cache dir unavailable and `advisoryCheckOnInstall = required` is set"
+            ));
+        }
+        return Ok(());
+    };
+    let mirror = OsvMirror::open(&cache_dir);
+    let client = match OsvMirror::build_client() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                code = WARN_AUBE_OSV_MIRROR_REFRESH_FAILED,
+                "OSV mirror probe client init failed: {e}"
+            );
+            if matches!(policy, AdvisoryCheckOnInstall::Required) {
+                return Err(miette!(
+                    code = ERR_AUBE_ADVISORY_CHECK_FAILED,
+                    "OSV mirror probe client could not be initialised and `advisoryCheckOnInstall = required` is set: {e}"
+                ));
+            }
+            return Ok(());
+        }
+    };
+    if let Err(e) = mirror.refresh_if_stale_default(&client).await {
+        tracing::warn!(
+            code = WARN_AUBE_OSV_MIRROR_REFRESH_FAILED,
+            "OSV mirror refresh failed: {e}"
+        );
+        if matches!(policy, AdvisoryCheckOnInstall::Required) {
+            return Err(miette!(
+                code = ERR_AUBE_ADVISORY_CHECK_FAILED,
+                "OSV mirror refresh failed and `advisoryCheckOnInstall = required` is set: {e}"
+            ));
+        }
+        // Fall through: the in-memory cache is still empty on a
+        // first-time-ever refresh failure, in which case
+        // `lookup_advisories` returns `NotInitialized` below and
+        // we apply the same fail-open semantics.
+    }
+    let hits = match mirror.lookup_advisories(&names) {
+        Ok(hits) => hits,
+        Err(e) => {
+            tracing::warn!(
+                code = WARN_AUBE_OSV_MIRROR_REFRESH_FAILED,
+                "OSV mirror lookup failed: {e}"
+            );
+            if matches!(policy, AdvisoryCheckOnInstall::Required) {
+                return Err(miette!(
+                    code = ERR_AUBE_ADVISORY_CHECK_FAILED,
+                    "OSV mirror lookup failed and `advisoryCheckOnInstall = required` is set: {e}"
+                ));
+            }
+            return Ok(());
+        }
+    };
+    if hits.is_empty() {
+        return Ok(());
+    }
+    let mut lines = vec!["refusing to install malicious package(s):".to_string()];
+    for hit in &hits {
+        lines.push(format!(
+            "  - {} ({}: {})",
+            hit.package,
+            hit.advisory_id,
+            advisory_url(&hit.advisory_id),
+        ));
+    }
+    lines.push(String::new());
+    lines.push("Set `advisoryCheckOnInstall = off` to bypass (not recommended).".to_string());
+    Err(miette!(
+        code = ERR_AUBE_MALICIOUS_PACKAGE,
+        "{}",
+        lines.join("\n")
+    ))
+}
+
+/// Distinct public-npmjs registry names in `graph`, filtered to
+/// match the CLI-name gate's `registry_bound_names_for_supply_chain`
+/// shape so a scoped registry override (`@myorg:registry=...`) or a
+/// swapped default registry doesn't ship internal package names to
+/// OSV. Workspace / `link:` / `file:` entries drop out via
+/// `LockedPackage::local_source.is_none()`. Sorted + deduped so
+/// aliased entries (`{"my-alias": "npm:lodash@^4"}`) collapse onto
+/// their real registry name.
+fn transitive_registry_names(
+    cwd: &std::path::Path,
+    graph: &aube_lockfile::LockfileGraph,
+) -> Vec<String> {
+    let npm_config = aube_registry::config::NpmConfig::load(cwd);
+    let mut names: Vec<String> = graph
+        .packages
+        .values()
+        .filter(|pkg| pkg.local_source.is_none())
+        .map(|pkg| pkg.registry_name().to_string())
+        .filter(|name| npm_config.is_public_npmjs(name))
+        .collect();
+    names.sort();
+    names.dedup();
+    names
 }
 
 /// Parse `allowedUnpopularPackages` entries into compiled
@@ -327,5 +474,99 @@ mod tests {
         assert!(pats[0].matches("@myorg/nested-name"));
         assert!(!pats[0].matches("@otherorg/utils"));
         assert!(!pats[0].matches("myorg-utils"));
+    }
+
+    fn registry_pkg(name: &str, version: &str) -> aube_lockfile::LockedPackage {
+        aube_lockfile::LockedPackage {
+            name: name.to_string(),
+            version: version.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn transitive_registry_names_skips_local_source_entries() {
+        // `file:` / `link:` / workspace edges resolve outside the
+        // public registry — OSV has nothing to say about them, and
+        // forwarding the workspace package name to OSV could leak
+        // an internal name to a public API.
+        use std::collections::BTreeMap;
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "lodash@4.17.21".to_string(),
+            registry_pkg("lodash", "4.17.21"),
+        );
+        let mut linked = registry_pkg("@workspace/util", "1.0.0");
+        linked.local_source = Some(aube_lockfile::LocalSource::Link("../util".into()));
+        packages.insert("@workspace/util@1.0.0".to_string(), linked);
+        let graph = aube_lockfile::LockfileGraph {
+            packages,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let names = transitive_registry_names(tmp.path(), &graph);
+        assert_eq!(names, vec!["lodash".to_string()]);
+    }
+
+    #[test]
+    fn transitive_registry_names_dedups_by_registry_name() {
+        // Alias entries (`{"my-alias": "npm:lodash@^4"}`) and the
+        // real package both report under `registry_name() = "lodash"`.
+        // The mirror lookup shouldn't see duplicates — and shouldn't
+        // surface the alias name to the public API either.
+        use std::collections::BTreeMap;
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "lodash@4.17.21".to_string(),
+            registry_pkg("lodash", "4.17.21"),
+        );
+        let mut aliased = registry_pkg("my-alias", "4.17.21");
+        aliased.alias_of = Some("lodash".to_string());
+        packages.insert("my-alias@4.17.21".to_string(), aliased);
+        let graph = aube_lockfile::LockfileGraph {
+            packages,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let names = transitive_registry_names(tmp.path(), &graph);
+        assert_eq!(names, vec!["lodash".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn run_transitive_osv_gate_via_mirror_off_short_circuits() {
+        // `advisoryCheckOnInstall = off` is the default for every
+        // user that hasn't opted in. A `LockfileGraph` with real
+        // entries must not refresh the on-disk mirror or hit the
+        // network — that would defeat the "no per-install network
+        // cost" promise of the install-time gate.
+        use std::collections::BTreeMap;
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "lodash@4.17.21".to_string(),
+            registry_pkg("lodash", "4.17.21"),
+        );
+        let graph = aube_lockfile::LockfileGraph {
+            packages,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(
+            run_transitive_osv_gate_via_mirror(tmp.path(), &graph, AdvisoryCheckOnInstall::Off,)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_transitive_osv_gate_via_mirror_empty_graph_is_noop() {
+        // No public-npmjs entries → nothing to check. The mirror
+        // should not even be opened, much less refreshed.
+        let graph = aube_lockfile::LockfileGraph::default();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(
+            run_transitive_osv_gate_via_mirror(tmp.path(), &graph, AdvisoryCheckOnInstall::On,)
+                .await
+                .is_ok()
+        );
     }
 }

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -109,6 +109,48 @@ pub async fn run_gates(
     Ok(())
 }
 
+/// Single entry point for the post-resolve OSV `MAL-*` routing
+/// `install::run` uses from both lockfile branches.
+///
+/// Pre-PR the routing block was inline in the no-lockfile (Err)
+/// match arm only, so `aube ci` and any `aube install` that
+/// matched the lockfile cleanly silently skipped OSV entirely —
+/// `advisoryCheckEveryInstall = true` and `advisoryCheckOnInstall`
+/// were designed for exactly that path. Extracted here so both
+/// arms call the same helper and the routing table actually
+/// applies to every install entry point.
+///
+/// Decision table:
+/// - `fresh_resolution || osv_transitive_check || advisory_check_every_install`
+///   → live OSV API (`run_transitive_osv_gate`)
+/// - otherwise, when `advisory_check_on_install != Off`
+///   → local mirror (`run_transitive_osv_gate_via_mirror`)
+/// - otherwise → no OSV check
+///
+/// `advisory_check` is the caller's already-upgraded policy
+/// (paranoid → `Required`). Both gates internally short-circuit
+/// on `Off`, but skip the call entirely so an empty graph
+/// doesn't get a useless `transitive_registry_names` walk.
+pub async fn run_post_resolve_osv_routing(
+    cwd: &std::path::Path,
+    graph: &aube_lockfile::LockfileGraph,
+    fresh_resolution: bool,
+    osv_transitive_check: bool,
+    advisory_check: AdvisoryCheck,
+    advisory_check_on_install: AdvisoryCheckOnInstall,
+    advisory_check_every_install: bool,
+) -> miette::Result<()> {
+    let needs_live_api = osv_transitive_check || advisory_check_every_install || fresh_resolution;
+    if needs_live_api {
+        if !matches!(advisory_check, AdvisoryCheck::Off) {
+            run_transitive_osv_gate(cwd, graph, advisory_check).await?;
+        }
+    } else if !matches!(advisory_check_on_install, AdvisoryCheckOnInstall::Off) {
+        run_transitive_osv_gate_via_mirror(cwd, graph, advisory_check_on_install).await?;
+    }
+    Ok(())
+}
+
 /// Live-API transitive OSV `MAL-*` check.
 ///
 /// Runs against the full post-resolve transitive set, batch-querying

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -109,14 +109,62 @@ pub async fn run_gates(
     Ok(())
 }
 
-/// Mirror-backed transitive OSV `MAL-*` check for every install.
+/// Live-API transitive OSV `MAL-*` check.
 ///
-/// `aube add` already runs the [live-API CLI-name gate](`run_gates`)
-/// for the freshest signal at the moment of human intent. This one
-/// runs on every install (`aube install`, `aube ci`, `aube add`'s
-/// chained install, frozen reinstalls, …) when
-/// `advisoryCheckOnInstall != off`, trading sub-day freshness for a
-/// local lookup that doesn't hit `api.osv.dev` on every reinstall.
+/// Runs against the full post-resolve transitive set, batch-querying
+/// `api.osv.dev`. Used by the fresh-resolution install paths —
+/// `aube add`, `aube update`, missing-lockfile installs, and any
+/// install where the resolver picked a `(name, version)` the
+/// lockfile didn't already pin. The companion
+/// [`run_transitive_osv_gate_via_mirror`] is the local-mirror
+/// fallback for plain reinstalls where the lockfile was authoritative.
+///
+/// Policy mapping (same shape as the existing CLI-name gate):
+/// - `Off` → no-op.
+/// - `On` → OSV fetch failures degrade to
+///   `WARN_AUBE_ADVISORY_CHECK_FAILED` and install proceeds.
+/// - `Required` → fetch failures map to
+///   `ERR_AUBE_ADVISORY_CHECK_FAILED`. Hits map to
+///   `ERR_AUBE_MALICIOUS_PACKAGE` under both `On` and `Required`.
+pub async fn run_transitive_osv_gate(
+    cwd: &std::path::Path,
+    graph: &aube_lockfile::LockfileGraph,
+    policy: AdvisoryCheck,
+) -> miette::Result<()> {
+    if matches!(policy, AdvisoryCheck::Off) {
+        return Ok(());
+    }
+    let names = transitive_registry_names(cwd, graph);
+    if names.is_empty() {
+        return Ok(());
+    }
+    let client = match aube_registry::supply_chain::build_probe_client() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                code = WARN_AUBE_ADVISORY_CHECK_FAILED,
+                "supply-chain probe client init failed: {e}"
+            );
+            if matches!(policy, AdvisoryCheck::Required) {
+                return Err(miette!(
+                    code = ERR_AUBE_ADVISORY_CHECK_FAILED,
+                    "supply-chain probe client could not be initialised and `advisoryCheck = required` is set: {e}"
+                ));
+            }
+            return Ok(());
+        }
+    };
+    osv_gate(&client, &names, policy).await
+}
+
+/// Mirror-backed transitive OSV `MAL-*` check for plain reinstalls.
+///
+/// Counterpart to [`run_transitive_osv_gate`]. Fires when none of
+/// the fresh-resolution triggers apply (no `aube add` / `aube
+/// update`, no `advisoryCheckEveryInstall`, no lockfile drift) — so
+/// the live-API gate is dormant and the mirror picks up the slack
+/// against the post-resolve graph without an `api.osv.dev`
+/// round-trip on every reinstall. Off by default.
 ///
 /// Policy mapping (mirrors the live-API gate's shape so CI configs
 /// that have `advisoryCheck = required` can mirror that bit onto
@@ -228,6 +276,43 @@ pub async fn run_transitive_osv_gate_via_mirror(
         "{}",
         lines.join("\n")
     ))
+}
+
+/// True when the resolved graph contains at least one
+/// `(registry_name, version)` pair the pre-existing lockfile
+/// didn't already pin — meaning the resolver did fresh work and
+/// the result deserves a live-API OSV pass rather than the
+/// mirror-backed fallback. A missing pre-existing lockfile
+/// (`None`) is treated as drift by definition: nothing on disk
+/// vouched for what just got resolved.
+///
+/// Filtered to public-npmjs registry names so private / workspace
+/// / git / file deps don't get classified as "new" just because
+/// they aren't in a public-npmjs comparison set.
+pub fn lockfile_has_new_picks(
+    cwd: &std::path::Path,
+    prior: Option<&aube_lockfile::LockfileGraph>,
+    resolved: &aube_lockfile::LockfileGraph,
+) -> bool {
+    let Some(prior) = prior else {
+        // No lockfile before resolve: every resolved entry is a
+        // fresh pick. Skip the loop and short-circuit.
+        return !resolved.packages.is_empty();
+    };
+    let npm_config = aube_registry::config::NpmConfig::load(cwd);
+    use std::collections::HashSet;
+    let prior_pairs: HashSet<(&str, &str)> = prior
+        .packages
+        .values()
+        .filter(|p| p.local_source.is_none())
+        .map(|p| (p.registry_name(), p.version.as_str()))
+        .collect();
+    resolved
+        .packages
+        .values()
+        .filter(|p| p.local_source.is_none())
+        .filter(|p| npm_config.is_public_npmjs(p.registry_name()))
+        .any(|p| !prior_pairs.contains(&(p.registry_name(), p.version.as_str())))
 }
 
 /// Distinct public-npmjs registry names in `graph`, filtered to
@@ -533,6 +618,121 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let names = transitive_registry_names(tmp.path(), &graph);
         assert_eq!(names, vec!["lodash".to_string()]);
+    }
+
+    #[test]
+    fn lockfile_drift_no_prior_lockfile_is_drift_when_resolved_has_entries() {
+        // No on-disk lockfile + non-empty resolve = fresh
+        // resolution by definition. The router needs this to flip
+        // to the live API even though the user typed plain
+        // `aube install`.
+        use std::collections::BTreeMap;
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "lodash@4.17.21".to_string(),
+            registry_pkg("lodash", "4.17.21"),
+        );
+        let resolved = aube_lockfile::LockfileGraph {
+            packages,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(lockfile_has_new_picks(tmp.path(), None, &resolved));
+    }
+
+    #[test]
+    fn lockfile_drift_empty_resolve_and_no_prior_is_not_drift() {
+        // No lockfile + nothing resolved (e.g. a workspace with no
+        // deps) shouldn't flip the live-API gate on — there's
+        // nothing to check anyway.
+        let resolved = aube_lockfile::LockfileGraph::default();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!lockfile_has_new_picks(tmp.path(), None, &resolved));
+    }
+
+    #[test]
+    fn lockfile_drift_fully_pinned_is_not_drift() {
+        // Prior and resolved hold the same (registry_name, version)
+        // pair: the lockfile was authoritative, fall through to the
+        // mirror path.
+        use std::collections::BTreeMap;
+        let mut prior_packages = BTreeMap::new();
+        prior_packages.insert(
+            "lodash@4.17.21".to_string(),
+            registry_pkg("lodash", "4.17.21"),
+        );
+        let prior = aube_lockfile::LockfileGraph {
+            packages: prior_packages.clone(),
+            ..Default::default()
+        };
+        let resolved = aube_lockfile::LockfileGraph {
+            packages: prior_packages,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!lockfile_has_new_picks(tmp.path(), Some(&prior), &resolved));
+    }
+
+    #[test]
+    fn lockfile_drift_new_version_is_drift() {
+        // Resolver picked a version the lockfile didn't pin — the
+        // canonical fresh-resolution signal. Same name, different
+        // version, both public-npmjs.
+        use std::collections::BTreeMap;
+        let mut prior_packages = BTreeMap::new();
+        prior_packages.insert(
+            "lodash@4.17.21".to_string(),
+            registry_pkg("lodash", "4.17.21"),
+        );
+        let prior = aube_lockfile::LockfileGraph {
+            packages: prior_packages,
+            ..Default::default()
+        };
+        let mut resolved_packages = BTreeMap::new();
+        resolved_packages.insert(
+            "lodash@4.17.22".to_string(),
+            registry_pkg("lodash", "4.17.22"),
+        );
+        let resolved = aube_lockfile::LockfileGraph {
+            packages: resolved_packages,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(lockfile_has_new_picks(tmp.path(), Some(&prior), &resolved));
+    }
+
+    #[test]
+    fn lockfile_drift_ignores_local_source_entries() {
+        // Workspace / link: / file: entries shouldn't trigger
+        // drift detection even when they aren't in the prior
+        // lockfile — they don't resolve through the public
+        // registry, so OSV has no signal on them.
+        use std::collections::BTreeMap;
+        let mut resolved_packages = BTreeMap::new();
+        let mut linked = registry_pkg("@workspace/util", "1.0.0");
+        linked.local_source = Some(aube_lockfile::LocalSource::Link("../util".into()));
+        resolved_packages.insert("@workspace/util@1.0.0".to_string(), linked);
+        let resolved = aube_lockfile::LockfileGraph {
+            packages: resolved_packages,
+            ..Default::default()
+        };
+        let prior = aube_lockfile::LockfileGraph::default();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!lockfile_has_new_picks(tmp.path(), Some(&prior), &resolved));
+    }
+
+    #[tokio::test]
+    async fn run_transitive_osv_gate_off_skips_network() {
+        // Mirror of the live-API gate's off-policy test: `Off`
+        // must short-circuit before any client construction or
+        // network access.
+        let graph = aube_lockfile::LockfileGraph::default();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(
+            run_transitive_osv_gate(tmp.path(), &graph, AdvisoryCheck::Off)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -185,10 +185,13 @@ pub async fn run_transitive_osv_gate_via_mirror(
                 "OSV mirror refresh failed and `advisoryCheckOnInstall = required` is set: {e}"
             ));
         }
-        // Fall through: the in-memory cache is still empty on a
-        // first-time-ever refresh failure, in which case
-        // `lookup_advisories` returns `NotInitialized` below and
-        // we apply the same fail-open semantics.
+        // Fall through under `On`: `refresh_if_stale` already
+        // seeded the in-memory cache with whatever the on-disk
+        // index held going in, so `lookup_advisories` below
+        // checks against the previously cached data. When the
+        // mirror has never been synced successfully the prior
+        // data is empty and lookup is a no-op — the warning is
+        // the only user-visible signal in that case.
     }
     let hits = match mirror.lookup_advisories(&names) {
         Ok(hits) => hits,

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -83,6 +83,11 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         inherited_build_policy: None,
         workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
         skip_root_lifecycle: false,
+        // `aube ci` is the canonical "lockfile is law" path —
+        // strict frozen, no drift allowed. Don't force the live
+        // API; install::run's fresh-resolution detection and the
+        // `advisoryCheckEveryInstall` setting still apply.
+        osv_transitive_check: false,
     };
     install::run(opts).await
 }

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -309,6 +309,11 @@ pub async fn run(
             inherited_build_policy: None,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
             skip_root_lifecycle: false,
+            // Deploys are lockfile-driven by definition. Don't
+            // force the live API; install::run's fresh-resolution
+            // detection still kicks in if the resolver picks a
+            // version that wasn't pinned.
+            osv_transitive_check: false,
         };
         install::run(opts).await?;
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -334,6 +334,14 @@ impl InstallArgs {
             // chained-call constructor (`with_mode`) is where commands
             // with package args opt into skipping them.
             skip_root_lifecycle: false,
+            // Argumentless `aube install` doesn't force the live-API
+            // transitive gate by itself. `install::run` still runs
+            // the gate when it detects fresh resolution (no
+            // pre-existing lockfile, or the resolver picked a
+            // version the lockfile didn't pin), and the
+            // `advisoryCheckEveryInstall` setting flips it on for
+            // every install — neither needs the caller to opt in.
+            osv_transitive_check: false,
         }
     }
 }
@@ -445,6 +453,17 @@ pub struct InstallOptions {
     /// git-prepare install — that one's "root" IS the git dep itself and
     /// running its `prepare` is the whole point.
     pub skip_root_lifecycle: bool,
+    /// Run the post-resolve transitive OSV `MAL-*` gate against
+    /// the live OSV API (not the mirror). Flipped on by commands
+    /// whose whole point is fresh resolution — `aube add` and
+    /// `aube update` — so the freshest signal lands at the moment
+    /// the user is changing what's installed. Default `false` for
+    /// every other entry point; `install::run` also flips it on
+    /// internally when `advisoryCheckEveryInstall` is set, when
+    /// no lockfile existed before resolve, or when the resolver
+    /// picked a `(name, version)` pair the lockfile didn't
+    /// already pin.
+    pub osv_transitive_check: bool,
 }
 
 #[derive(Default)]
@@ -558,6 +577,13 @@ impl InstallOptions {
             // the only construction path that runs them and it goes
             // through `InstallArgs::into_options`, not here.
             skip_root_lifecycle: true,
+            // Default `false`. `aube add` and `aube update` flip
+            // this on at construction. Other chained callers
+            // (remove, dedupe, patch_commit, …) leave it off so
+            // their chained install relies on the install-time
+            // routing (fresh-resolution detection / mirror
+            // fallback) instead of an unconditional API hit.
+            osv_transitive_check: false,
         }
     }
 }
@@ -3990,24 +4016,57 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             crate::dep_chain::set_active(&graph);
             aube_registry::slow_metadata::flush_summary();
 
-            // Mirror-backed transitive OSV `MAL-*` gate. Off by
-            // default (`advisoryCheckOnInstall = off`); when the
-            // user opts in, the post-resolve transitive set is
-            // checked against the locally synced OSV `MAL-*`
-            // dump. Fires before the pluggable scanner because a
+            // Post-resolve transitive OSV `MAL-*` gate. Three-way
+            // routing so the live API fires when the freshest
+            // signal is worth a per-install network round-trip,
+            // and the local mirror picks up plain reinstalls
+            // where the lockfile already vetted what's installed:
+            //
+            // 1. Live API fires when any of these is true:
+            //    - `opts.osv_transitive_check` (aube add / update)
+            //    - `advisoryCheckEveryInstall = true`
+            //    - the resolver picked a `(name, version)` the
+            //      pre-existing lockfile didn't already pin, OR
+            //      no lockfile existed before resolve (treated
+            //      as drift by definition).
+            // 2. Otherwise, mirror fires when
+            //    `advisoryCheckOnInstall != Off`.
+            // 3. Otherwise, no OSV check at all.
+            //
+            // Fires before the pluggable scanner because a
             // confirmed-malicious advisory is a stronger signal
             // than a scanner finding and the error message is
-            // more actionable. `aube add` itself runs its
-            // CLI-name gate against the live OSV API at the
-            // command-handler boundary — this gate is the
-            // catch-all that covers every install entry point
-            // including `add`'s chained install, so a malicious
-            // transitive dep still gets blocked there.
-            let aoi =
-                super::with_settings_ctx(&cwd, aube_settings::resolved::advisory_check_on_install);
-            if !matches!(aoi, aube_settings::resolved::AdvisoryCheckOnInstall::Off) {
-                super::add_supply_chain::run_transitive_osv_gate_via_mirror(&cwd, &graph, aoi)
-                    .await?;
+            // more actionable.
+            let prior_lockfile = lockfile_pre_parse.as_ref().map(|(g, _)| g);
+            let has_drift =
+                super::add_supply_chain::lockfile_has_new_picks(&cwd, prior_lockfile, &graph);
+            let advisory_check_every_install = super::with_settings_ctx(
+                &cwd,
+                aube_settings::resolved::advisory_check_every_install,
+            );
+            let needs_live_api =
+                opts.osv_transitive_check || advisory_check_every_install || has_drift;
+            if needs_live_api {
+                let advisory_check = super::with_settings_ctx(&cwd, |ctx| {
+                    if aube_settings::resolved::paranoid(ctx) {
+                        aube_settings::resolved::AdvisoryCheck::Required
+                    } else {
+                        aube_settings::resolved::advisory_check(ctx)
+                    }
+                });
+                if !matches!(advisory_check, aube_settings::resolved::AdvisoryCheck::Off) {
+                    super::add_supply_chain::run_transitive_osv_gate(&cwd, &graph, advisory_check)
+                        .await?;
+                }
+            } else {
+                let aoi = super::with_settings_ctx(
+                    &cwd,
+                    aube_settings::resolved::advisory_check_on_install,
+                );
+                if !matches!(aoi, aube_settings::resolved::AdvisoryCheckOnInstall::Off) {
+                    super::add_supply_chain::run_transitive_osv_gate_via_mirror(&cwd, &graph, aoi)
+                        .await?;
+                }
             }
 
             // Bun-compatible security scanner runs against the

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3990,6 +3990,28 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             crate::dep_chain::set_active(&graph);
             aube_registry::slow_metadata::flush_summary();
 
+            // Mirror-backed transitive OSV `MAL-*` gate. Off by
+            // default (`advisoryCheckOnInstall = off`); when the
+            // user opts in, the post-resolve transitive set is
+            // checked against the locally synced OSV `MAL-*`
+            // dump. Fires before the pluggable scanner because a
+            // confirmed-malicious advisory is a stronger signal
+            // than a scanner finding and the error message is
+            // more actionable. `aube add` itself runs its
+            // CLI-name gate against the live OSV API at the
+            // command-handler boundary — this gate is the
+            // catch-all that covers every install entry point
+            // including `add`'s chained install, so a malicious
+            // transitive dep still gets blocked there.
+            let aoi = super::with_settings_ctx(
+                &cwd,
+                aube_settings::resolved::advisory_check_on_install,
+            );
+            if !matches!(aoi, aube_settings::resolved::AdvisoryCheckOnInstall::Off) {
+                super::add_supply_chain::run_transitive_osv_gate_via_mirror(&cwd, &graph, aoi)
+                    .await?;
+            }
+
             // Bun-compatible security scanner runs against the
             // *resolved* graph — full transitive set with concrete
             // versions, matching Bun's contract. Fires before fetch

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -3322,6 +3322,28 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             crate::dep_chain::set_active(&graph);
             aube_registry::slow_metadata::flush_summary();
 
+            // Post-resolve OSV `MAL-*` routing — lockfile-found
+            // branch. `fresh_resolution = false` here because the
+            // graph came from the lockfile and we never ran the
+            // resolver, so the router falls through to the mirror
+            // backend unless `osv_transitive_check` or
+            // `advisoryCheckEveryInstall` forces the live API.
+            // Same helper as the no-lockfile branch — kept here so
+            // `aube ci`, `aube install --frozen-lockfile`, and
+            // every frozen reinstall actually run the routing
+            // (previously skipped, surfaced by review).
+            let osv_settings = resolve_osv_routing_settings(&cwd);
+            super::add_supply_chain::run_post_resolve_osv_routing(
+                &cwd,
+                &graph,
+                /*fresh_resolution=*/ false,
+                opts.osv_transitive_check,
+                osv_settings.advisory_check,
+                osv_settings.advisory_check_on_install,
+                osv_settings.advisory_check_every_install,
+            )
+            .await?;
+
             // Check index cache, fetch missing tarballs. Tarball client
             // is lazy because eager construction costs ~20ms even when
             // no request gets sent, dominating no-op install time.
@@ -4016,58 +4038,28 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             crate::dep_chain::set_active(&graph);
             aube_registry::slow_metadata::flush_summary();
 
-            // Post-resolve transitive OSV `MAL-*` gate. Three-way
-            // routing so the live API fires when the freshest
-            // signal is worth a per-install network round-trip,
-            // and the local mirror picks up plain reinstalls
-            // where the lockfile already vetted what's installed:
-            //
-            // 1. Live API fires when any of these is true:
-            //    - `opts.osv_transitive_check` (aube add / update)
-            //    - `advisoryCheckEveryInstall = true`
-            //    - the resolver picked a `(name, version)` the
-            //      pre-existing lockfile didn't already pin, OR
-            //      no lockfile existed before resolve (treated
-            //      as drift by definition).
-            // 2. Otherwise, mirror fires when
-            //    `advisoryCheckOnInstall != Off`.
-            // 3. Otherwise, no OSV check at all.
-            //
-            // Fires before the pluggable scanner because a
-            // confirmed-malicious advisory is a stronger signal
-            // than a scanner finding and the error message is
-            // more actionable.
+            // Post-resolve OSV `MAL-*` routing — no-lockfile /
+            // re-resolve branch. The lockfile-found branch has the
+            // parallel call before its own fetch so both paths
+            // run through the same router. See
+            // `add_supply_chain::run_post_resolve_osv_routing` for
+            // the decision table. Fires before the pluggable
+            // scanner so a confirmed-malicious advisory aborts
+            // without spawning the scanner.
             let prior_lockfile = lockfile_pre_parse.as_ref().map(|(g, _)| g);
-            let has_drift =
+            let fresh_resolution =
                 super::add_supply_chain::lockfile_has_new_picks(&cwd, prior_lockfile, &graph);
-            let advisory_check_every_install = super::with_settings_ctx(
+            let osv_settings = resolve_osv_routing_settings(&cwd);
+            super::add_supply_chain::run_post_resolve_osv_routing(
                 &cwd,
-                aube_settings::resolved::advisory_check_every_install,
-            );
-            let needs_live_api =
-                opts.osv_transitive_check || advisory_check_every_install || has_drift;
-            if needs_live_api {
-                let advisory_check = super::with_settings_ctx(&cwd, |ctx| {
-                    if aube_settings::resolved::paranoid(ctx) {
-                        aube_settings::resolved::AdvisoryCheck::Required
-                    } else {
-                        aube_settings::resolved::advisory_check(ctx)
-                    }
-                });
-                if !matches!(advisory_check, aube_settings::resolved::AdvisoryCheck::Off) {
-                    super::add_supply_chain::run_transitive_osv_gate(&cwd, &graph, advisory_check)
-                        .await?;
-                }
-            } else {
-                let aoi = super::with_settings_ctx(
-                    &cwd,
-                    aube_settings::resolved::advisory_check_on_install,
-                );
-                if !matches!(aoi, aube_settings::resolved::AdvisoryCheckOnInstall::Off) {
-                    super::add_supply_chain::run_transitive_osv_gate_via_mirror(&cwd, &graph, aoi)
-                        .await?;
-                }
-            }
+                &graph,
+                fresh_resolution,
+                opts.osv_transitive_check,
+                osv_settings.advisory_check,
+                osv_settings.advisory_check_on_install,
+                osv_settings.advisory_check_every_install,
+            )
+            .await?;
 
             // Bun-compatible security scanner runs against the
             // *resolved* graph — full transitive set with concrete
@@ -5212,6 +5204,34 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+/// Three resolved OSV-routing settings, fetched in one
+/// `with_settings_ctx` pass so the lockfile-found and no-lockfile
+/// arms can call the routing helper with the same shape. Paranoid
+/// upgrade for `advisoryCheck` is applied here so the router sees
+/// the final policy.
+struct OsvRoutingSettings {
+    advisory_check: aube_settings::resolved::AdvisoryCheck,
+    advisory_check_on_install: aube_settings::resolved::AdvisoryCheckOnInstall,
+    advisory_check_every_install: bool,
+}
+
+fn resolve_osv_routing_settings(cwd: &std::path::Path) -> OsvRoutingSettings {
+    super::with_settings_ctx(cwd, |ctx| {
+        let advisory_check = if aube_settings::resolved::paranoid(ctx) {
+            aube_settings::resolved::AdvisoryCheck::Required
+        } else {
+            aube_settings::resolved::advisory_check(ctx)
+        };
+        OsvRoutingSettings {
+            advisory_check,
+            advisory_check_on_install: aube_settings::resolved::advisory_check_on_install(ctx),
+            advisory_check_every_install: aube_settings::resolved::advisory_check_every_install(
+                ctx,
+            ),
+        }
+    })
 }
 
 /// Emit the `ignored build scripts for ...` warning. Same wording

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -4003,10 +4003,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // catch-all that covers every install entry point
             // including `add`'s chained install, so a malicious
             // transitive dep still gets blocked there.
-            let aoi = super::with_settings_ctx(
-                &cwd,
-                aube_settings::resolved::advisory_check_on_install,
-            );
+            let aoi =
+                super::with_settings_ctx(&cwd, aube_settings::resolved::advisory_check_on_install);
             if !matches!(aoi, aube_settings::resolved::AdvisoryCheckOnInstall::Off) {
                 super::add_supply_chain::run_transitive_osv_gate_via_mirror(&cwd, &graph, aoi)
                     .await?;

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -754,6 +754,13 @@ pub async fn run(
     chained.ignore_pnpmfile = args.ignore_pnpmfile;
     chained.pnpmfile = args.pnpmfile.clone();
     chained.global_pnpmfile = args.global_pnpmfile.clone();
+    // `aube update` is one of the canonical fresh-resolution
+    // entry points — by design it pulls newer versions than the
+    // lockfile pins. Route the post-resolve transitive set
+    // through the live OSV API so the freshest `MAL-*` advisories
+    // apply at the moment a human is changing what's installed,
+    // matching `aube add`'s behavior.
+    chained.osv_transitive_check = true;
     // `--lockfile-only`: lockfile is already written above; tell the
     // chained install to skip linking `node_modules` so the on-disk
     // tree stays as-is. Mirrors `aube install --lockfile-only` and

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -669,6 +669,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_OSV_MIRROR_REFRESH_FAILED",
+      "category": "Supply chain (add-time)",
+      "description": "OSV advisory mirror used by `advisoryCheckOnInstall` failed to refresh (download, ETag, or zip parse error). With `advisoryCheckOnInstall=on` install proceeds against the previously cached index if any; with `advisoryCheckOnInstall=required` install fails closed with `ERR_AUBE_ADVISORY_CHECK_FAILED`.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_SECURITY_SCANNER_FINDING",
       "category": "Supply chain (add-time)",
       "description": "User-configured `securityScanner` returned a `warn`-level advisory. Install continues — only `fatal`-level advisories block.",

--- a/docs/security.md
+++ b/docs/security.md
@@ -147,11 +147,14 @@ Settings: [`minimumReleaseAge`](/settings/#setting-minimumreleaseage),
 
 ## Typosquat and impersonation protection
 
-`aube add` checks every package you name on the command line before adding
-it to your manifest. Transitive deps and packages already in the lockfile
-aren't re-checked at add time. (For an opt-in install-time OSV check that
-also covers the transitive set on every install, see [Install-time OSV
-check](#install-time-osv-check) below.)
+`aube add` checks every package you name on the command line *and* the
+full post-resolve transitive closure against [OSV](https://osv.dev) for
+`MAL-*` malicious-package advisories — same check `aube update` and any
+other install path runs where the resolver picks a version that wasn't
+already pinned by the lockfile. Plain reinstalls (the lockfile was
+authoritative) skip the live API for latency; an opt-in local mirror
+(see [Install-time OSV check](#install-time-osv-check) below) covers
+that path.
 
 Two signals, with different response levels:
 
@@ -209,39 +212,64 @@ Settings: [`advisoryCheck`](/settings/#setting-advisorycheck),
 
 ## Install-time OSV check
 
-`advisoryCheck` only runs on `aube add` — the moment of human intent. To
-also OSV-check every `aube install` (CI runs, fresh clones, re-installs
-after pulling main, …) against the post-resolve transitive graph, opt
-into `advisoryCheckOnInstall`:
+OSV `MAL-*` checks are routed three ways post-resolve so the freshest
+signal lands when it matters most without paying for a per-install
+network round-trip when it doesn't:
+
+| Install path                                      | Backend       | Setting                       |
+| ------------------------------------------------- | ------------- | ----------------------------- |
+| `aube add`, `aube update`                         | Live API      | `advisoryCheck` (default `on`)|
+| Missing lockfile / resolver picked new version    | Live API      | `advisoryCheck` (default `on`)|
+| `advisoryCheckEveryInstall = true`                | Live API      | `advisoryCheck` (default `on`)|
+| Plain reinstall (lockfile authoritative)          | Local mirror  | `advisoryCheckOnInstall` (default `off`) |
+| Anything else                                     | No check      | —                             |
+
+The mirror lives at `$XDG_CACHE_HOME/aube/osv/npm/` (the bulk zip from
+`osv-vulnerabilities.storage.googleapis.com/npm/all.zip`, roughly tens
+of MB) and lazily refreshes with an ETag-conditional GET every 24
+hours. Hits map to the same `ERR_AUBE_MALICIOUS_PACKAGE` exit as the
+live-API gate.
+
+Trade-off: the mirror lags reality by up to ~24h. An advisory published
+in the last day won't be in your local index unless a refresh happens to
+fall after it. Fresh-resolution installs always go through the live API
+so that lag doesn't matter for new picks; plain reinstalls trade
+sub-day staleness for sub-millisecond lookups.
 
 ```yaml
-advisoryCheckOnInstall: on   # off by default
+# Default: live API on aube add / update / fresh-resolution. Mirror
+# disabled — plain reinstalls skip OSV entirely.
+advisoryCheck: on
+advisoryCheckOnInstall: off
+advisoryCheckEveryInstall: false
 ```
 
-When enabled, aube maintains a local mirror of OSV's npm advisory
-dump at `$XDG_CACHE_HOME/aube/osv/npm/` (the bulk zip at
-`osv-vulnerabilities.storage.googleapis.com/npm/all.zip`, roughly
-tens of MB) and lazily refreshes it with an ETag-conditional GET
-every 24 hours. Hits map to the same `ERR_AUBE_MALICIOUS_PACKAGE`
-exit as `advisoryCheck`. The mirror means there's no per-install
-network round-trip to `api.osv.dev` — most installs hit a cached
-JSON index that loads in milliseconds.
+```yaml
+# Hardened CI: live API on every install, fail-closed on fetch errors.
+advisoryCheck: required
+advisoryCheckEveryInstall: true
+```
 
-Trade-off: the mirror lags reality by up to ~24h. An advisory
-published in the last day won't be in your local index unless a
-refresh happens to fall after it. For the latest signal at add
-time, keep using `advisoryCheck` — it always queries the live API.
+```yaml
+# Cheap fallback: live API on fresh-resolution, local mirror covers
+# plain reinstalls so even CI re-runs see SOME OSV coverage.
+advisoryCheck: on
+advisoryCheckOnInstall: on
+```
 
-- `off` (default): plain `aube install` skips the OSV check entirely.
-  `aube add` and `advisoryCheck` are unaffected.
-- `on`: refresh-on-stale; install proceeds against the prior index
-  if the mirror can't be refreshed
-  (`WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`).
-- `required`: as `on`, but mirror refresh failures map to
-  `ERR_AUBE_ADVISORY_CHECK_FAILED`. Use in hardened CI where a
-  stale or unreachable mirror should block.
+Refresh-failure semantics for the mirror:
 
-Settings: [`advisoryCheckOnInstall`](/settings/#setting-advisorycheckoninstall).
+- `advisoryCheckOnInstall = on`: `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`,
+  install continues against the prior on-disk index (or empty on first
+  sync).
+- `advisoryCheckOnInstall = required`: mirror refresh failures map to
+  `ERR_AUBE_ADVISORY_CHECK_FAILED`. Use when a stale or unreachable
+  mirror should block.
+
+Settings:
+[`advisoryCheck`](/settings/#setting-advisorycheck),
+[`advisoryCheckOnInstall`](/settings/#setting-advisorycheckoninstall),
+[`advisoryCheckEveryInstall`](/settings/#setting-advisorycheckeveryinstall).
 
 ## Block exotic transitive dependencies
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -149,7 +149,9 @@ Settings: [`minimumReleaseAge`](/settings/#setting-minimumreleaseage),
 
 `aube add` checks every package you name on the command line before adding
 it to your manifest. Transitive deps and packages already in the lockfile
-aren't re-checked.
+aren't re-checked at add time. (For an opt-in install-time OSV check that
+also covers the transitive set on every install, see [Install-time OSV
+check](#install-time-osv-check) below.)
 
 Two signals, with different response levels:
 
@@ -204,6 +206,42 @@ independently.
 Settings: [`advisoryCheck`](/settings/#setting-advisorycheck),
 [`lowDownloadThreshold`](/settings/#setting-lowdownloadthreshold),
 [`allowedUnpopularPackages`](/settings/#setting-allowedunpopularpackages).
+
+## Install-time OSV check
+
+`advisoryCheck` only runs on `aube add` — the moment of human intent. To
+also OSV-check every `aube install` (CI runs, fresh clones, re-installs
+after pulling main, …) against the post-resolve transitive graph, opt
+into `advisoryCheckOnInstall`:
+
+```yaml
+advisoryCheckOnInstall: on   # off by default
+```
+
+When enabled, aube maintains a local mirror of OSV's npm advisory
+dump at `$XDG_CACHE_HOME/aube/osv/npm/` (the bulk zip at
+`osv-vulnerabilities.storage.googleapis.com/npm/all.zip`, roughly
+tens of MB) and lazily refreshes it with an ETag-conditional GET
+every 24 hours. Hits map to the same `ERR_AUBE_MALICIOUS_PACKAGE`
+exit as `advisoryCheck`. The mirror means there's no per-install
+network round-trip to `api.osv.dev` — most installs hit a cached
+JSON index that loads in milliseconds.
+
+Trade-off: the mirror lags reality by up to ~24h. An advisory
+published in the last day won't be in your local index unless a
+refresh happens to fall after it. For the latest signal at add
+time, keep using `advisoryCheck` — it always queries the live API.
+
+- `off` (default): plain `aube install` skips the OSV check entirely.
+  `aube add` and `advisoryCheck` are unaffected.
+- `on`: refresh-on-stale; install proceeds against the prior index
+  if the mirror can't be refreshed
+  (`WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`).
+- `required`: as `on`, but mirror refresh failures map to
+  `ERR_AUBE_ADVISORY_CHECK_FAILED`. Use in hardened CI where a
+  stale or unreachable mirror should block.
+
+Settings: [`advisoryCheckOnInstall`](/settings/#setting-advisorycheckoninstall).
 
 ## Block exotic transitive dependencies
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -24,6 +24,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
 | [`securityScanner`](#setting-securityscanner) | `string` | Bun-compatible security scanner module. |
 | [`advisoryCheck`](#setting-advisorycheck) | `"on" \| "required" \| "off"` | OSV `MAL-*` advisory check on `aube add`. |
+| [`advisoryCheckOnInstall`](#setting-advisorycheckoninstall) | `"on" \| "required" \| "off"` | OSV `MAL-*` advisory check on every install (uses a local mirror). |
 | [`lowDownloadThreshold`](#setting-lowdownloadthreshold) | `int` | Weekly-download floor for `aube add` (typosquat prompt). |
 | [`allowedUnpopularPackages`](#setting-allowedunpopularpackages) | `list<string>` | Glob patterns exempted from the `lowDownloadThreshold` gate. |
 | [`paranoid`](#setting-paranoid) | `bool` | Turn on the strict-security setting bundle in one switch. |
@@ -376,10 +377,16 @@ OSV `MAL-*` advisory check on `aube add`.
 - Workspace YAML keys: `advisoryCheck`
 
 `aube add` batch-queries [OSV](https://osv.dev) for malicious-package
-advisories (`MAL-*`) on every package about to land in `package.json`.
-A hit fails the install with `ERR_AUBE_MALICIOUS_PACKAGE` and a link to
-the advisory. Transitive deps and packages already in the lockfile are
-not re-checked — the gate is the moment of human intent.
+advisories (`MAL-*`) on every package about to land in `package.json`,
+then runs the same batch once more after resolution against the full
+transitive closure. A hit at either step fails the install with
+`ERR_AUBE_MALICIOUS_PACKAGE` and a link to the advisory.
+
+`aube add` always queries the live OSV API directly — by design, since
+the gate is the moment of human intent and the freshest signals matter
+most then. For OSV-checking every `aube install` against the resolved
+graph (not just `aube add`), see `advisoryCheckOnInstall`, which uses a
+locally synced mirror to avoid per-install network round-trips.
 
 - `on` (default): fail closed on a malicious-package hit; fail open
   (continue with a `WARN_AUBE_ADVISORY_CHECK_FAILED`) when the API can't
@@ -387,6 +394,41 @@ not re-checked — the gate is the moment of human intent.
 - `required`: same fail-closed behavior on hits, plus fail closed on
   fetch errors. Use in hardened CI. Included in the `paranoid` bundle.
 - `off`: skip the check entirely.
+
+### `advisoryCheckOnInstall` {#setting-advisorycheckoninstall}
+
+OSV `MAL-*` advisory check on every install (uses a local mirror).
+
+- Type: `"on" | "required" | "off"`
+- Default: `"off"`
+- Environment: `npm_config_advisory_check_on_install`, `NPM_CONFIG_ADVISORY_CHECK_ON_INSTALL`, `AUBE_ADVISORY_CHECK_ON_INSTALL`
+- .npmrc keys: `advisoryCheckOnInstall`, `advisory-check-on-install`
+- Workspace YAML keys: `advisoryCheckOnInstall`
+
+When enabled, every `aube install` runs the same OSV `MAL-*` advisory
+check that `aube add` does against the post-resolve transitive graph,
+backed by a local mirror of OSV's npm advisory dump. A hit fails the
+install with `ERR_AUBE_MALICIOUS_PACKAGE` — the same exit as
+`advisoryCheck`. `aube add` itself ignores this setting and continues
+to query the live API for the freshest signal at the moment of
+human intent.
+
+The mirror lives at `$XDG_CACHE_HOME/aube/osv/npm/` and lazily
+refreshes from
+`https://osv-vulnerabilities.storage.googleapis.com/npm/all.zip`
+(roughly tens of MB) with an `If-None-Match` revalidation. A miss
+between refreshes won't catch an advisory published in the last
+~day; for the latest signals at add time, keep using `advisoryCheck`
+and run `aube add` for new deps.
+
+- `off` (default): plain `aube install` skips the OSV check. `aube add`
+  is unaffected.
+- `on`: every install checks the resolved graph against the mirror.
+  Fail open (continue with `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`) when
+  the mirror can't be refreshed.
+- `required`: as `on`, plus fail closed on mirror refresh failures
+  with `ERR_AUBE_ADVISORY_CHECK_FAILED`. Use in hardened CI where a
+  stale or unreachable mirror should block the install.
 
 ### `lowDownloadThreshold` {#setting-lowdownloadthreshold}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -23,8 +23,9 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
 | [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
 | [`securityScanner`](#setting-securityscanner) | `string` | Bun-compatible security scanner module. |
-| [`advisoryCheck`](#setting-advisorycheck) | `"on" \| "required" \| "off"` | OSV `MAL-*` advisory check on `aube add`. |
-| [`advisoryCheckOnInstall`](#setting-advisorycheckoninstall) | `"on" \| "required" \| "off"` | OSV `MAL-*` advisory check on every install (uses a local mirror). |
+| [`advisoryCheck`](#setting-advisorycheck) | `"on" \| "required" \| "off"` | OSV `MAL-*` advisory check during `aube add` and other fresh-resolution installs. |
+| [`advisoryCheckOnInstall`](#setting-advisorycheckoninstall) | `"on" \| "required" \| "off"` | Local-mirror OSV `MAL-*` advisory check for plain reinstalls. |
+| [`advisoryCheckEveryInstall`](#setting-advisorycheckeveryinstall) | `bool` | Force the live-API OSV `MAL-*` check on every install (including frozen reinstalls). |
 | [`lowDownloadThreshold`](#setting-lowdownloadthreshold) | `int` | Weekly-download floor for `aube add` (typosquat prompt). |
 | [`allowedUnpopularPackages`](#setting-allowedunpopularpackages) | `list<string>` | Glob patterns exempted from the `lowDownloadThreshold` gate. |
 | [`paranoid`](#setting-paranoid) | `bool` | Turn on the strict-security setting bundle in one switch. |
@@ -368,7 +369,7 @@ authoring instructions, and the post-resolve firing model:
 
 ### `advisoryCheck` {#setting-advisorycheck}
 
-OSV `MAL-*` advisory check on `aube add`.
+OSV `MAL-*` advisory check during `aube add` and other fresh-resolution installs.
 
 - Type: `"on" | "required" | "off"`
 - Default: `"on"`
@@ -376,17 +377,24 @@ OSV `MAL-*` advisory check on `aube add`.
 - .npmrc keys: `advisoryCheck`, `advisory-check`
 - Workspace YAML keys: `advisoryCheck`
 
-`aube add` batch-queries [OSV](https://osv.dev) for malicious-package
-advisories (`MAL-*`) on every package about to land in `package.json`,
-then runs the same batch once more after resolution against the full
-transitive closure. A hit at either step fails the install with
-`ERR_AUBE_MALICIOUS_PACKAGE` and a link to the advisory.
+Live-API OSV `MAL-*` advisory check. aube batch-queries
+[OSV](https://osv.dev) at three points, all against `api.osv.dev`:
 
-`aube add` always queries the live OSV API directly — by design, since
-the gate is the moment of human intent and the freshest signals matter
-most then. For OSV-checking every `aube install` against the resolved
-graph (not just `aube add`), see `advisoryCheckOnInstall`, which uses a
-locally synced mirror to avoid per-install network round-trips.
+1. `aube add` CLI names, before they land in `package.json`.
+2. The full post-resolve transitive graph during any
+   *fresh-resolution* install — `aube add`, `aube update`, an
+   install with no lockfile, or an install where the resolver
+   picked a `(name, version)` the lockfile didn't already pin.
+3. Every install (including frozen reinstalls), if
+   `advisoryCheckEveryInstall` is `true`.
+
+A hit at any step fails the install with `ERR_AUBE_MALICIOUS_PACKAGE`
+and a link to the advisory.
+
+Plain reinstalls where the lockfile was authoritative don't hit the
+network here — they fall through to the local mirror (see
+`advisoryCheckOnInstall`) when that's enabled, or no OSV check at all
+when it isn't.
 
 - `on` (default): fail closed on a malicious-package hit; fail open
   (continue with a `WARN_AUBE_ADVISORY_CHECK_FAILED`) when the API can't
@@ -397,7 +405,7 @@ locally synced mirror to avoid per-install network round-trips.
 
 ### `advisoryCheckOnInstall` {#setting-advisorycheckoninstall}
 
-OSV `MAL-*` advisory check on every install (uses a local mirror).
+Local-mirror OSV `MAL-*` advisory check for plain reinstalls.
 
 - Type: `"on" | "required" | "off"`
 - Default: `"off"`
@@ -405,30 +413,67 @@ OSV `MAL-*` advisory check on every install (uses a local mirror).
 - .npmrc keys: `advisoryCheckOnInstall`, `advisory-check-on-install`
 - Workspace YAML keys: `advisoryCheckOnInstall`
 
-When enabled, every `aube install` runs the same OSV `MAL-*` advisory
-check that `aube add` does against the post-resolve transitive graph,
-backed by a local mirror of OSV's npm advisory dump. A hit fails the
-install with `ERR_AUBE_MALICIOUS_PACKAGE` — the same exit as
-`advisoryCheck`. `aube add` itself ignores this setting and continues
-to query the live API for the freshest signal at the moment of
-human intent.
+Fallback OSV `MAL-*` check for installs the live-API gate
+(`advisoryCheck`) didn't fire for — i.e. plain reinstalls where the
+lockfile was authoritative (no `aube add` / `aube update`, no
+`advisoryCheckEveryInstall`, no lockfile drift). Backed by a local
+mirror of OSV's npm advisory dump so there's no per-install
+`api.osv.dev` round-trip.
+
+A hit fails the install with `ERR_AUBE_MALICIOUS_PACKAGE` — same
+exit as `advisoryCheck`. Fresh-resolution installs (`aube add`,
+`aube update`, missing-lockfile, new picked version) always go
+through the live API regardless of this setting, so the freshest
+signal lands at the moment a human is changing what's installed.
 
 The mirror lives at `$XDG_CACHE_HOME/aube/osv/npm/` and lazily
 refreshes from
 `https://osv-vulnerabilities.storage.googleapis.com/npm/all.zip`
 (roughly tens of MB) with an `If-None-Match` revalidation. A miss
 between refreshes won't catch an advisory published in the last
-~day; for the latest signals at add time, keep using `advisoryCheck`
-and run `aube add` for new deps.
+~day; for live signals on every install, use
+`advisoryCheckEveryInstall = true` instead.
 
-- `off` (default): plain `aube install` skips the OSV check. `aube add`
-  is unaffected.
-- `on`: every install checks the resolved graph against the mirror.
+- `off` (default): plain reinstalls skip OSV entirely. Fresh-resolution
+  installs still hit the live API via `advisoryCheck`.
+- `on`: plain reinstalls check the resolved graph against the mirror.
   Fail open (continue with `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`) when
   the mirror can't be refreshed.
 - `required`: as `on`, plus fail closed on mirror refresh failures
   with `ERR_AUBE_ADVISORY_CHECK_FAILED`. Use in hardened CI where a
   stale or unreachable mirror should block the install.
+
+### `advisoryCheckEveryInstall` {#setting-advisorycheckeveryinstall}
+
+Force the live-API OSV `MAL-*` check on every install (including frozen reinstalls).
+
+- Type: `bool`
+- Default: `false`
+- Environment: `npm_config_advisory_check_every_install`, `NPM_CONFIG_ADVISORY_CHECK_EVERY_INSTALL`, `AUBE_ADVISORY_CHECK_EVERY_INSTALL`
+- .npmrc keys: `advisoryCheckEveryInstall`, `advisory-check-every-install`
+- Workspace YAML keys: `advisoryCheckEveryInstall`
+
+By default, the live-API OSV check (`advisoryCheck`) fires on
+*fresh-resolution* installs only — `aube add`, `aube update`,
+missing-lockfile installs, and installs where the resolver picks a
+version the lockfile didn't pin. Plain reinstalls fall through to the
+local mirror (`advisoryCheckOnInstall`) when that's enabled.
+
+Setting `advisoryCheckEveryInstall = true` forces the live API on
+every install entry point, including strict frozen reinstalls and
+`aube ci`. Every install round-trips through `api.osv.dev` for the
+freshest signal; mirror lookups are skipped because the live API
+strictly dominates.
+
+Useful in hardened CI where every job must observe the latest
+advisories regardless of whether the lockfile changed. The trade-off
+is per-install latency — for a large transitive graph, batch queries
+chunk at 500 names per request, so an `aube install` against a graph
+of 2000 packages incurs four sequential OSV requests.
+
+- `false` (default): live-API check on fresh-resolution installs only.
+- `true`: live-API check on every install. Honors `advisoryCheck`'s
+  fail-open / fail-closed policy on fetch errors.
 
 ### `lowDownloadThreshold` {#setting-lowdownloadthreshold}
 


### PR DESCRIPTION
## Summary

Post-resolve OSV `MAL-*` advisory checks now route three ways so the freshest signal lands when it matters most without paying for a per-install `api.osv.dev` round-trip when it doesn't:

| Install path                                          | Backend       | Setting                                  |
| ----------------------------------------------------- | ------------- | ---------------------------------------- |
| `aube add`, `aube update`                             | **Live API**  | `advisoryCheck` (default `on`)           |
| No lockfile / resolver picked a new `(name, version)` | **Live API**  | `advisoryCheck` (default `on`)           |
| `advisoryCheckEveryInstall = true`                    | **Live API**  | `advisoryCheck` (default `on`)           |
| Plain reinstall (lockfile authoritative)              | **Local mirror** | `advisoryCheckOnInstall` (default `off`) |
| Anything else                                         | No check      | —                                        |

Hits always map to `ERR_AUBE_MALICIOUS_PACKAGE`. Fail-open vs fail-closed comes from `advisoryCheck` / `advisoryCheckOnInstall` (`on` → warn-and-continue on fetch error; `required` → fail closed with `ERR_AUBE_ADVISORY_CHECK_FAILED`).

## Design

`aube add` and `aube update` are canonical fresh-resolution paths — they pull versions the user wasn't running before, so the freshest OSV signal is worth a network round-trip. Plain reinstalls (the lockfile was authoritative, nothing changed) don't benefit from a live-API hit on every CI job, so they fall through to an opt-in **local mirror** of OSV's npm advisory dump.

**Mirror module** (`aube-registry/src/osv_mirror.rs`) — `$XDG_CACHE_HOME/aube/osv/npm/{all.zip, index.json}`. Lazy refresh with `If-None-Match` against `osv-vulnerabilities.storage.googleapis.com/npm/all.zip` (tens of MB), 24h default max-age, atomic per-writer-unique tmp file so concurrent CI matrix jobs sharing a cache volume don't corrupt each other. `MAL-*`-only `name → [advisory_id]` index. Schema-version sentinel in `index.json` so future on-disk format bumps regenerate from `all.zip` instead of needing a manual purge.

**Fresh-resolution detection** (`add_supply_chain::lockfile_has_new_picks`) — diffs the pre-parsed lockfile's `(registry_name, version)` set against the resolved graph. Any new pair → live API. Skips private / workspace / git / file deps so they don't masquerade as "new."

**Chunking** — `fetch_malicious_advisories` chunks at 500 names per OSV `/querybatch` so a 2000-package transitive graph doesn't trip OSV's 1000/batch limit. Sequential chunks share one `reqwest::Client` so the connection pool stays warm.

## Settings

- [`advisoryCheck`](/settings/#setting-advisorycheck) — `"on" | "required" | "off"`, default `"on"`. **Now applies to the live-API gate across all fresh-resolution paths**, not just `aube add` CLI names. (Pre-PR it only fired on `aube add` CLI names; this PR extends it to the post-resolve transitive set under the routing table above.)
- [`advisoryCheckOnInstall`](/settings/#setting-advisorycheckoninstall) — `"on" | "required" | "off"`, default `"off"`. New. Mirror-backed gate for plain reinstalls.
- [`advisoryCheckEveryInstall`](/settings/#setting-advisorycheckeveryinstall) — bool, default `false`. New. Forces the live API on every install regardless of lockfile drift (use in hardened CI).

`paranoid: true` does **not** flip `advisoryCheckOnInstall` or `advisoryCheckEveryInstall` in this PR — explicit opt-in for the first release.

## Notes for reviewers

- New `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`. Mirror-refresh-failure under `required` reuses `ERR_AUBE_ADVISORY_CHECK_FAILED` rather than burning a new entry in the exhausted 40-49 exit-code range.
- The mirror is fail-open on first-time-sync failure: an empty in-memory fallback so `lookup_advisories` returns `[]` and install proceeds, rather than `NotInitialized` which would silently skip the gate.
- `aube ci` / `aube deploy` leave `osv_transitive_check = false`; they rely on the routing table (drift detection + `advisoryCheckEveryInstall`) to decide.
- New `zip = "5"` workspace dep with only the `deflate` feature — OSV's dump uses deflate exclusively.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (zero warnings)
- [x] `cargo test --workspace` — full suite passes. New coverage:
  - 18 unit tests in `aube-registry/src/osv_mirror.rs` (zip→index parse, MAL filter, ecosystem filter, dedup, staleness across timestamps, unparseable-timestamp guard, format-version mismatch, RFC3339 round-trip, two refresh-failure regression tests, concurrent-writer regression test)
  - 1 wiremock end-to-end (200→ETag→304 revalidation)
  - 5 new lockfile-drift unit tests in `add_supply_chain` (no-prior-with-resolve, empty-resolve-no-prior, fully-pinned, new-version, local-source-skipped) + the existing off-policy and empty-graph tests
- [ ] CI green

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time supply-chain security gating and adds a new mirror-based OSV advisory path, which can alter when installs fail or warn and introduces new network/cache/zip parsing behavior.
> 
> **Overview**
> Adds post-resolve OSV `MAL-*` advisory checking across install entry points, routing between **live OSV API** (fresh resolution, `aube add`/`aube update`, or `advisoryCheckEveryInstall`) and an opt-in **local OSV mirror** for lockfile-authoritative reinstalls (`advisoryCheckOnInstall`).
> 
> Introduces `aube-registry::osv_mirror` (ETag-conditional zip download + derived index in cache) plus a new warning code `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`, updates settings/docs to expose `advisoryCheckOnInstall` and `advisoryCheckEveryInstall`, and chunks OSV `/querybatch` requests (500 per call) to handle large dependency graphs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df72a989863da88e7fc0b3f8b561b293d0fa054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->