### PR TITLE
chore(bench): silence aube supply-chain probes in add scenario

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -447,10 +447,16 @@ BUN_BASE="HOME={home} BUN_INSTALL={home}/.bun {bin} install --cache-dir {cache} 
 # apples-to-apples guarantee for any non-default override.
 #
 # `advisory_check=off` and `low_download_threshold=0` silence
-# aube's OSV and npm-downloads probes for the `add` scenario.
-# No other PM in the comparison set runs equivalent network probes
-# on add, so leaving them on turns the bench into a partial
-# supply-chain latency measurement: one OSV batch POST plus one
+# aube's OSV-advisory and npm-downloads probes. They only fire
+# inside `aube add`; the install / install-test / ci scenarios
+# never reach `run_gates`, so the env vars are no-ops there and
+# the only practical effect is on `add:aube`. Set on the base
+# `AUBE_ENV` rather than `add:aube` so the policy stays in one
+# place — no incentive to scatter `advisory_check=off` across
+# every future scenario that happens to chain into `add`.
+#
+# Disabled here because no other PM in the comparison set runs
+# equivalent network probes on add: one OSV batch POST plus one
 # downloads GET that other PMs don't pay for, ~200-500ms per run
 # when the public APIs respond and a full `PROBE_TIMEOUT` (8s)
 # when they don't. Off here, on by default in the shipped binary.

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -445,7 +445,16 @@ BUN_BASE="HOME={home} BUN_INSTALL={home}/.bun {bin} install --cache-dir {cache} 
 # compiled-in default (1440) regardless of
 # `BENCH_MIN_RELEASE_AGE_MINUTES`, silently breaking the
 # apples-to-apples guarantee for any non-default override.
-AUBE_ENV="HOME={home} XDG_CACHE_HOME={cache} XDG_DATA_HOME={home}/.local/share npm_config_minimum_release_age=${MIN_RELEASE_AGE_MINUTES}"
+#
+# `advisory_check=off` and `low_download_threshold=0` silence
+# aube's OSV and npm-downloads probes for the `add` scenario.
+# No other PM in the comparison set runs equivalent network probes
+# on add, so leaving them on turns the bench into a partial
+# supply-chain latency measurement: one OSV batch POST plus one
+# downloads GET that other PMs don't pay for, ~200-500ms per run
+# when the public APIs respond and a full `PROBE_TIMEOUT` (8s)
+# when they don't. Off here, on by default in the shipped binary.
+AUBE_ENV="HOME={home} XDG_CACHE_HOME={cache} XDG_DATA_HOME={home}/.local/share npm_config_minimum_release_age=${MIN_RELEASE_AGE_MINUTES} npm_config_advisory_check=off npm_config_low_download_threshold=0"
 
 # Per-scenario AUBE_ENV variants that pin aube's global virtual store mode
 # via the `enableGlobalVirtualStore` setting's auto-synthesized env-var


### PR DESCRIPTION
## Summary
`aube add` defaults to a pair of network probes (OSV `MAL-*` batch + npm weekly-downloads GET) on every invocation. No other PM in the bench comparison set runs equivalent on-add probes, so leaving them on turned the `add` scenario into a partial supply-chain-latency measurement: ~200-500ms per run when `api.osv.dev` and `api.npmjs.org` respond, a full `PROBE_TIMEOUT` (8s) when they don't.

Threading `npm_config_advisory_check=off` and `npm_config_low_download_threshold=0` through `AUBE_ENV` short-circuits both gates before any HTTP. The shipped binary still defaults to `advisoryCheck=on` / `lowDownloadThreshold=1000` — this only affects the benchmark.

## Test plan
- [x] `cargo build --bin aube`
- [ ] `mise run bench` — pick up new numbers via `mise run bench:bump` (or the daily cron) since the bench will now be ~200ms-8s faster on `add:aube`
- [x] No code changes; only `benchmarks/bench.sh` is touched.

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: benchmark-only change that alters `aube add` timing by disabling two network probes; no product/runtime code paths are modified.
> 
> **Overview**
> The benchmark script now sets `npm_config_advisory_check=off` and `npm_config_low_download_threshold=0` in the shared `AUBE_ENV`, which short-circuits aube’s OSV-advisory and npm-download probes when running the `add` scenario.
> 
> This keeps `add:aube` results focused on dependency-add performance rather than external API latency/timeouts, without changing aube’s shipped defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 215edf2888971ada7ca968f488ee177dd3244dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->