### PR TITLE
fix(install): pass version to OSV in transitive MAL-* check

### DIFF
--- a/crates/aube-registry/src/osv_mirror.rs
+++ b/crates/aube-registry/src/osv_mirror.rs
@@ -14,9 +14,11 @@
 //!   `https://osv-vulnerabilities.storage.googleapis.com/npm/all.zip`.
 //!   Kept on disk so we can rebuild the derived index without
 //!   re-downloading when the on-disk index format changes.
-//! - `index.json` — derived `{name → [advisory_id]}` map for
+//! - `index.json` — derived `{name → [{id, versions}]}` map for
 //!   `MAL-*` advisories only, plus the source ETag and a fetched
-//!   timestamp. Sub-MB, loads in milliseconds.
+//!   timestamp. Per-advisory `versions` lets the install-time
+//!   gate filter to the resolver-picked version rather than
+//!   name-level block every release. Sub-MB, loads in milliseconds.
 //!
 //! Refresh policy: lazy and ETag-conditional. A `refresh_if_stale`
 //! call older than `max_age` performs `GET … If-None-Match: <etag>`;
@@ -84,7 +86,7 @@ pub enum MirrorError {
     NotInitialized,
 }
 
-/// In-memory `name → [advisory_id]` lookup over the most recently
+/// In-memory `name → [AdvisoryEntry]` lookup over the most recently
 /// loaded `MAL-*` set, plus the metadata needed to decide whether
 /// the next refresh round-trip needs to fetch or just revalidate.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -102,16 +104,38 @@ struct IndexFile {
     #[serde(default = "default_format")]
     format: u32,
     /// `MAL-*` advisories per npm package name. A single name can
-    /// carry multiple advisory IDs across the dataset.
+    /// carry multiple advisory IDs across the dataset; each entry
+    /// records the affected versions so [`OsvMirror::lookup_advisories_versioned`]
+    /// can filter to the resolver's actual pick.
     #[serde(default)]
-    advisories: HashMap<String, Vec<String>>,
+    advisories: HashMap<String, Vec<AdvisoryEntry>>,
+}
+
+/// One `MAL-*` advisory mapped to the exact npm versions it covers.
+///
+/// `versions` is the union of `affected[*].versions` for that
+/// (name, advisory) pair across the OSV dump. An empty list means
+/// the advisory didn't enumerate versions explicitly (range-only,
+/// or schema variant) — [`OsvMirror::lookup_advisories_versioned`]
+/// treats that as "affects every version" so we fail-closed on
+/// unknown shapes rather than silently skipping a malicious entry.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct AdvisoryEntry {
+    id: String,
+    #[serde(default)]
+    versions: Vec<String>,
 }
 
 fn default_format() -> u32 {
-    1
+    2
 }
 
-const CURRENT_FORMAT: u32 = 1;
+/// Bumped to `2` when per-advisory `versions` were added so the
+/// `MAL-*` mirror could filter by resolver-picked version. A v1
+/// index loads as empty via [`OsvMirror::load_or_default`], which
+/// forces a one-time re-extract from the cached `all.zip` (or a
+/// fresh fetch if that's gone too).
+const CURRENT_FORMAT: u32 = 2;
 
 /// Materialized OSV mirror handle.
 ///
@@ -230,9 +254,12 @@ impl OsvMirror {
     }
 
     /// Look up `names` against the loaded index, returning every
-    /// `(name, MAL-*)` hit. Mirrors the contract of
-    /// [`crate::supply_chain::fetch_malicious_advisories`] so the
-    /// install-time gate can swap one for the other.
+    /// `(name, MAL-*)` hit regardless of version. Kept for tests
+    /// and for callers that genuinely want a name-level check; the
+    /// install-time gate uses [`Self::lookup_advisories_versioned`]
+    /// instead so a version-specific compromise (e.g. the Sep 2025
+    /// `ansi-regex@6.2.1` worm) doesn't collapse into a name-level
+    /// block of every published release.
     ///
     /// Requires a successful [`refresh_if_stale`] earlier in the
     /// process; otherwise returns [`MirrorError::NotInitialized`].
@@ -245,14 +272,53 @@ impl OsvMirror {
         let index = self.index.get().ok_or(MirrorError::NotInitialized)?;
         let mut hits = Vec::new();
         for name in names {
-            let Some(ids) = index.advisories.get(name) else {
+            let Some(entries) = index.advisories.get(name) else {
                 continue;
             };
-            for id in ids {
+            for entry in entries {
                 hits.push(MaliciousAdvisory {
                     package: name.clone(),
-                    advisory_id: id.clone(),
+                    advisory_id: entry.id.clone(),
+                    version: None,
                 });
+            }
+        }
+        Ok(hits)
+    }
+
+    /// Version-aware sibling of [`Self::lookup_advisories`] for the
+    /// post-resolve install-time gate. Each `(name, version)` pair
+    /// only hits when the resolver-picked version is in the
+    /// advisory's `affected.versions` list.
+    ///
+    /// Empty `versions` on an advisory entry (range-only schema or
+    /// missing data) is treated as "affects every version" — same
+    /// fail-closed default as the index builder records, so an
+    /// unparseable OSV schema doesn't silently skip a malicious
+    /// package.
+    ///
+    /// Requires a successful [`refresh_if_stale`] earlier in the
+    /// process; otherwise returns [`MirrorError::NotInitialized`].
+    pub fn lookup_advisories_versioned(
+        &self,
+        pairs: &[(String, String)],
+    ) -> Result<Vec<MaliciousAdvisory>, MirrorError> {
+        let index = self.index.get().ok_or(MirrorError::NotInitialized)?;
+        let mut hits = Vec::new();
+        for (name, version) in pairs {
+            let Some(entries) = index.advisories.get(name) else {
+                continue;
+            };
+            for entry in entries {
+                let affects =
+                    entry.versions.is_empty() || entry.versions.iter().any(|v| v == version);
+                if affects {
+                    hits.push(MaliciousAdvisory {
+                        package: name.clone(),
+                        advisory_id: entry.id.clone(),
+                        version: Some(version.clone()),
+                    });
+                }
             }
         }
         Ok(hits)
@@ -362,14 +428,23 @@ async fn fetch_and_extract_from(
 }
 
 /// Walk the zip dump, parse each `MAL-*.json` advisory, and emit a
-/// `name → [id]` map keyed on the per-advisory npm package names.
+/// `name → [AdvisoryEntry]` map keyed on the per-advisory npm
+/// package names. Each entry carries the union of affected
+/// `versions` for that (name, advisory) pair so
+/// [`OsvMirror::lookup_advisories_versioned`] can filter to the
+/// resolver-picked version.
+///
 /// Non-`MAL-*` entries (CVE-*, GHSA-*) are skipped — the install-
 /// time gate is malicious-package-only, matching the live OSV API
 /// check the add-time gate already runs.
-fn build_index_from_zip(bytes: &[u8]) -> Result<HashMap<String, Vec<String>>, MirrorError> {
+fn build_index_from_zip(bytes: &[u8]) -> Result<HashMap<String, Vec<AdvisoryEntry>>, MirrorError> {
     let cursor = std::io::Cursor::new(bytes);
     let mut archive = zip::ZipArchive::new(cursor)?;
-    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    // Per (name, advisory_id) we collect the union of affected
+    // versions across every `affected` block. Same advisory id can
+    // appear multiple times against one name if the dump lists
+    // separate version ranges; merging keeps lookup simple.
+    let mut acc: HashMap<(String, String), Vec<String>> = HashMap::new();
     for i in 0..archive.len() {
         // `by_index` is the only way to iterate the central
         // directory in order without re-cloning the archive
@@ -404,12 +479,21 @@ fn build_index_from_zip(bytes: &[u8]) -> Result<HashMap<String, Vec<String>>, Mi
             if name.is_empty() {
                 continue;
             }
-            out.entry(name).or_default().push(adv.id.clone());
+            acc.entry((name, adv.id.clone()))
+                .or_default()
+                .extend(affected.versions);
         }
     }
-    for ids in out.values_mut() {
-        ids.sort();
-        ids.dedup();
+    let mut out: HashMap<String, Vec<AdvisoryEntry>> = HashMap::new();
+    for ((name, id), mut versions) in acc {
+        versions.sort();
+        versions.dedup();
+        out.entry(name)
+            .or_default()
+            .push(AdvisoryEntry { id, versions });
+    }
+    for entries in out.values_mut() {
+        entries.sort_by(|a, b| a.id.cmp(&b.id));
     }
     Ok(out)
 }
@@ -432,6 +516,14 @@ struct OsvAdvisory {
 #[derive(Debug, Deserialize)]
 struct OsvAffected {
     package: OsvPackage,
+    /// Exact-version list. Populated by the npm `MAL-*` advisories
+    /// (Open Source Insights / ghsa-malware), which track specific
+    /// compromised releases rather than semver ranges. Absent /
+    /// empty means the schema variant we can't filter on — see
+    /// [`OsvMirror::lookup_advisories_versioned`] for the
+    /// fail-closed handling.
+    #[serde(default)]
+    versions: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -583,6 +675,13 @@ mod tests {
         assert!(!is_mal_filename("README.md"));
     }
 
+    fn entry(id: &str, versions: &[&str]) -> AdvisoryEntry {
+        AdvisoryEntry {
+            id: id.to_string(),
+            versions: versions.iter().map(|v| (*v).to_string()).collect(),
+        }
+    }
+
     #[test]
     fn build_index_extracts_only_npm_mal_advisories() {
         // Three entries: one MAL-* for npm (should keep), one
@@ -591,7 +690,7 @@ mod tests {
         let zip = write_zip(&[
             (
                 "MAL-2024-0001.json",
-                r#"{"id":"MAL-2024-0001","affected":[{"package":{"name":"lodashh","ecosystem":"npm"}}]}"#,
+                r#"{"id":"MAL-2024-0001","affected":[{"package":{"name":"lodashh","ecosystem":"npm"},"versions":["1.2.3"]}]}"#,
             ),
             (
                 "MAL-2024-0002.json",
@@ -604,34 +703,56 @@ mod tests {
         ]);
         let idx = build_index_from_zip(&zip).expect("parse ok");
         assert_eq!(idx.len(), 1);
-        assert_eq!(idx["lodashh"], vec!["MAL-2024-0001"]);
+        assert_eq!(idx["lodashh"], vec![entry("MAL-2024-0001", &["1.2.3"])]);
     }
 
     #[test]
     fn build_index_collects_multiple_ids_per_name() {
         // Same package surfacing in two different MAL-* advisories
-        // should produce a single key with both IDs (sorted +
-        // deduped). Two separate authors flagging the same squat
-        // is a normal real-world shape.
+        // should produce a single key with both IDs (sorted by id).
+        // Two separate authors flagging the same squat is a normal
+        // real-world shape.
         let zip = write_zip(&[
             (
                 "MAL-2024-0001.json",
-                r#"{"id":"MAL-2024-0001","affected":[{"package":{"name":"evil","ecosystem":"npm"}}]}"#,
+                r#"{"id":"MAL-2024-0001","affected":[{"package":{"name":"evil","ecosystem":"npm"},"versions":["1.0.0"]}]}"#,
             ),
             (
                 "MAL-2024-0002.json",
-                r#"{"id":"MAL-2024-0002","affected":[{"package":{"name":"evil","ecosystem":"npm"}}]}"#,
+                r#"{"id":"MAL-2024-0002","affected":[{"package":{"name":"evil","ecosystem":"npm"},"versions":["2.0.0"]}]}"#,
             ),
             (
                 "MAL-2024-0003.json",
-                r#"{"id":"MAL-2024-0003","affected":[{"package":{"name":"evil","ecosystem":"npm"}},{"package":{"name":"evil","ecosystem":"npm"}}]}"#,
+                r#"{"id":"MAL-2024-0003","affected":[{"package":{"name":"evil","ecosystem":"npm"},"versions":["3.0.0"]},{"package":{"name":"evil","ecosystem":"npm"},"versions":["3.0.0"]}]}"#,
             ),
         ]);
         let idx = build_index_from_zip(&zip).expect("parse ok");
         assert_eq!(
             idx["evil"],
-            vec!["MAL-2024-0001", "MAL-2024-0002", "MAL-2024-0003"],
-            "ids sorted + deduped"
+            vec![
+                entry("MAL-2024-0001", &["1.0.0"]),
+                entry("MAL-2024-0002", &["2.0.0"]),
+                entry("MAL-2024-0003", &["3.0.0"]),
+            ],
+            "entries sorted by id, versions deduped within an id"
+        );
+    }
+
+    #[test]
+    fn build_index_merges_versions_across_affected_blocks() {
+        // One advisory listing the same name in two `affected`
+        // blocks with different versions: the per-(name, advisory)
+        // version list should be the union, sorted + deduped. The
+        // real OSV dump occasionally splits a multi-version
+        // compromise this way.
+        let zip = write_zip(&[(
+            "MAL-2024-0001.json",
+            r#"{"id":"MAL-2024-0001","affected":[{"package":{"name":"evil","ecosystem":"npm"},"versions":["1.0.0","1.0.1"]},{"package":{"name":"evil","ecosystem":"npm"},"versions":["1.0.1","1.0.2"]}]}"#,
+        )]);
+        let idx = build_index_from_zip(&zip).expect("parse ok");
+        assert_eq!(
+            idx["evil"],
+            vec![entry("MAL-2024-0001", &["1.0.0", "1.0.1", "1.0.2"])],
         );
     }
 
@@ -647,7 +768,7 @@ mod tests {
                 etag: None,
                 fetched_at: Some(now_rfc3339()),
                 format: CURRENT_FORMAT,
-                advisories: HashMap::from([("evil".to_string(), vec!["MAL-X".to_string()])]),
+                advisories: HashMap::from([("evil".to_string(), vec![entry("MAL-X", &["1.0.0"])])]),
             })
             .unwrap();
         let hits = mirror
@@ -668,7 +789,10 @@ mod tests {
                 format: CURRENT_FORMAT,
                 advisories: HashMap::from([(
                     "evil".to_string(),
-                    vec!["MAL-2024-0001".to_string(), "MAL-2024-0002".to_string()],
+                    vec![
+                        entry("MAL-2024-0001", &["1.0.0"]),
+                        entry("MAL-2024-0002", &["2.0.0"]),
+                    ],
                 )]),
             })
             .unwrap();
@@ -678,6 +802,60 @@ mod tests {
         assert_eq!(hits[0].package, "evil");
         assert_eq!(hits[0].advisory_id, "MAL-2024-0001");
         assert_eq!(hits[1].advisory_id, "MAL-2024-0002");
+    }
+
+    #[test]
+    fn lookup_versioned_filters_to_resolver_picked_version() {
+        // The regression that triggered the per-version split: an
+        // advisory covers only `6.2.1`, but an install pulls in
+        // `3.0.1` transitively. The mirror must NOT report a hit
+        // on the clean version.
+        let tmp = tempdir().unwrap();
+        let mirror = OsvMirror::open(tmp.path());
+        mirror
+            .index
+            .set(IndexFile {
+                etag: None,
+                fetched_at: Some(now_rfc3339()),
+                format: CURRENT_FORMAT,
+                advisories: HashMap::from([(
+                    "ansi-regex".to_string(),
+                    vec![entry("MAL-2025-46966", &["6.2.1"])],
+                )]),
+            })
+            .unwrap();
+        let clean = mirror
+            .lookup_advisories_versioned(&[("ansi-regex".to_string(), "3.0.1".to_string())])
+            .unwrap();
+        assert!(clean.is_empty(), "3.0.1 predates the compromise");
+        let compromised = mirror
+            .lookup_advisories_versioned(&[("ansi-regex".to_string(), "6.2.1".to_string())])
+            .unwrap();
+        assert_eq!(compromised.len(), 1);
+        assert_eq!(compromised[0].version.as_deref(), Some("6.2.1"));
+    }
+
+    #[test]
+    fn lookup_versioned_empty_versions_blocks_every_version() {
+        // Fail-closed default: an advisory entry with no version
+        // data (range-only schema or missing field) must still
+        // report a hit so the gate doesn't silently skip an
+        // unparseable malicious entry.
+        let tmp = tempdir().unwrap();
+        let mirror = OsvMirror::open(tmp.path());
+        mirror
+            .index
+            .set(IndexFile {
+                etag: None,
+                fetched_at: Some(now_rfc3339()),
+                format: CURRENT_FORMAT,
+                advisories: HashMap::from([("evil".to_string(), vec![entry("MAL-X", &[])])]),
+            })
+            .unwrap();
+        let hits = mirror
+            .lookup_advisories_versioned(&[("evil".to_string(), "9.9.9".to_string())])
+            .unwrap();
+        assert_eq!(hits.len(), 1);
     }
 
     #[test]
@@ -750,9 +928,10 @@ mod tests {
 
     #[test]
     fn load_or_default_ignores_stale_format() {
-        // A `format` field bumped past CURRENT_FORMAT (e.g. an
-        // upgrade-then-downgrade) must NOT be treated as the new
-        // schema — fall back to empty so the next refresh
+        // A `format` field that doesn't match CURRENT_FORMAT (an
+        // upgrade-then-downgrade, or the v1 → v2 transition that
+        // added per-advisory versions) must NOT be treated as the
+        // current schema — fall back to empty so the next refresh
         // rebuilds from `all.zip` against the current shape.
         let tmp = tempdir().unwrap();
         let mirror = OsvMirror::open(tmp.path());
@@ -760,7 +939,7 @@ mod tests {
             etag: None,
             fetched_at: Some(now_rfc3339()),
             format: 99,
-            advisories: HashMap::from([("evil".to_string(), vec!["MAL-X".to_string()])]),
+            advisories: HashMap::from([("evil".to_string(), vec![entry("MAL-X", &["1.0.0"])])]),
         };
         std::fs::create_dir_all(&mirror.root).unwrap();
         std::fs::write(mirror.index_path(), serde_json::to_vec(&stale).unwrap()).unwrap();
@@ -820,7 +999,10 @@ mod tests {
             etag: Some("\"v0\"".to_string()),
             fetched_at: Some("2000-01-01T00:00:00Z".to_string()),
             format: CURRENT_FORMAT,
-            advisories: HashMap::from([("evilpkg".to_string(), vec!["MAL-2024-9999".to_string()])]),
+            advisories: HashMap::from([(
+                "evilpkg".to_string(),
+                vec![entry("MAL-2024-9999", &["1.0.0"])],
+            )]),
         };
         std::fs::write(mirror.index_path(), serde_json::to_vec(&prior).unwrap()).unwrap();
 
@@ -902,7 +1084,7 @@ mod tests {
         let server = MockServer::start().await;
         let zip = write_zip(&[(
             "MAL-2024-9999.json",
-            r#"{"id":"MAL-2024-9999","affected":[{"package":{"name":"evilpkg","ecosystem":"npm"}}]}"#,
+            r#"{"id":"MAL-2024-9999","affected":[{"package":{"name":"evilpkg","ecosystem":"npm"},"versions":["1.0.0"]}]}"#,
         )]);
         // First request: full body + ETag.
         Mock::given(method("GET"))
@@ -943,7 +1125,10 @@ mod tests {
             .await
             .unwrap();
         let advisories = build_index_from_zip(&body).expect("parse ok");
-        assert_eq!(advisories["evilpkg"], vec!["MAL-2024-9999"]);
+        assert_eq!(
+            advisories["evilpkg"],
+            vec![entry("MAL-2024-9999", &["1.0.0"])],
+        );
 
         // ETag-conditional follow-up: server returns 304, we keep
         // prior advisories and bump the timestamp.

--- a/crates/aube-registry/src/supply_chain.rs
+++ b/crates/aube-registry/src/supply_chain.rs
@@ -45,10 +45,18 @@ const NPM_DOWNLOADS_BASE: &str = "https://api.npmjs.org/downloads/point/last-wee
 /// One malicious-package advisory hit. We surface the OSV id and the
 /// candidate package name; the caller composes a link of the form
 /// `https://osv.dev/vulnerability/{id}`.
+///
+/// `version` is populated by the post-resolve probes
+/// ([`fetch_malicious_advisories_versioned`] and
+/// [`crate::osv_mirror::OsvMirror::lookup_advisories_versioned`])
+/// where each name is paired with a resolved version. The pre-resolve
+/// `aube add` name-gate leaves it `None` because no resolver has run
+/// yet.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MaliciousAdvisory {
     pub package: String,
     pub advisory_id: String,
+    pub version: Option<String>,
 }
 
 /// Errors raised by the supply-chain probes. Distinct from
@@ -76,6 +84,12 @@ pub enum SupplyChainError {
 #[derive(Debug, serde::Serialize)]
 struct OsvQuery<'a> {
     package: OsvPackage<'a>,
+    /// Resolved version. Omitted (`None`) by the pre-resolve
+    /// `aube add` name-gate; populated by the post-resolve
+    /// transitive gate so OSV can filter advisories down to those
+    /// that actually affect the version the resolver picked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<&'a str>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -133,6 +147,12 @@ pub fn build_probe_client() -> Result<reqwest::Client, SupplyChainError> {
 /// are usually malicious in every published version, and we
 /// haven't run the resolver yet when this fires.
 ///
+/// Use [`fetch_malicious_advisories_versioned`] for post-resolve
+/// transitive checks where each name has a resolved version —
+/// otherwise a version-specific compromise (e.g. the Sep 2025
+/// shai-hulud worm that affected `ansi-regex@6.2.1` only) would
+/// collapse into a name-level block of every published release.
+///
 /// Returns the subset of input names that hit a `MAL-*` advisory.
 /// An `Err` is a fetch / decode / truncated-response failure — the
 /// caller decides whether to surface it (`advisoryCheck=required`)
@@ -156,6 +176,32 @@ pub async fn fetch_malicious_advisories(
     Ok(hits)
 }
 
+/// Version-aware sibling of [`fetch_malicious_advisories`] for the
+/// post-resolve transitive gate. Each pair becomes an OSV query that
+/// includes both `package.name` and `version`, so a `MAL-*` advisory
+/// only surfaces when it actually covers the resolved version.
+///
+/// Why this matters: the Sep 2025 shai-hulud worm compromised
+/// specific versions of widely-used names (`ansi-regex@6.2.1`,
+/// `strip-ansi@7.1.1`, etc.). The name-only query treats every
+/// release of those packages as malicious, which transitively
+/// breaks every install that pulls in an older, untouched version
+/// of the same name. Including the version flips OSV's filter on
+/// so only the actually-compromised pair fires.
+pub async fn fetch_malicious_advisories_versioned(
+    client: &reqwest::Client,
+    pairs: &[(String, String)],
+) -> Result<Vec<MaliciousAdvisory>, SupplyChainError> {
+    if pairs.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut hits = Vec::new();
+    for chunk in pairs.chunks(OSV_BATCH_LIMIT) {
+        hits.extend(fetch_malicious_advisories_versioned_chunk(client, chunk).await?);
+    }
+    Ok(hits)
+}
+
 async fn fetch_malicious_advisories_chunk(
     client: &reqwest::Client,
     names: &[String],
@@ -168,10 +214,40 @@ async fn fetch_malicious_advisories_chunk(
                     name: n.as_str(),
                     ecosystem: "npm",
                 },
+                version: None,
             })
             .collect(),
     };
-    let resp = client.post(OSV_ENDPOINT).json(&body).send().await?;
+    let parsed = post_osv_batch(client, &body, names.len()).await?;
+    Ok(extract_malicious(names, &parsed))
+}
+
+async fn fetch_malicious_advisories_versioned_chunk(
+    client: &reqwest::Client,
+    pairs: &[(String, String)],
+) -> Result<Vec<MaliciousAdvisory>, SupplyChainError> {
+    let body = OsvBatchRequest {
+        queries: pairs
+            .iter()
+            .map(|(name, version)| OsvQuery {
+                package: OsvPackage {
+                    name: name.as_str(),
+                    ecosystem: "npm",
+                },
+                version: Some(version.as_str()),
+            })
+            .collect(),
+    };
+    let parsed = post_osv_batch(client, &body, pairs.len()).await?;
+    Ok(extract_malicious_versioned(pairs, &parsed))
+}
+
+async fn post_osv_batch(
+    client: &reqwest::Client,
+    body: &OsvBatchRequest<'_>,
+    expected: usize,
+) -> Result<OsvBatchResponse, SupplyChainError> {
+    let resp = client.post(OSV_ENDPOINT).json(body).send().await?;
     if !resp.status().is_success() {
         return Err(SupplyChainError::Status(resp.status()));
     }
@@ -179,16 +255,16 @@ async fn fetch_malicious_advisories_chunk(
     let parsed: OsvBatchResponse = serde_json::from_slice(&bytes)?;
     // Enforce the OSV `results[i] ↔ queries[i]` parity contract.
     // A short response is treated as a probe failure (not "no
-    // advisories") so the trailing names aren't silently skipped —
+    // advisories") so the trailing entries aren't silently skipped —
     // the `advisoryCheck` policy then decides whether to warn-and-
     // continue or fail closed.
-    if parsed.results.len() != names.len() {
+    if parsed.results.len() != expected {
         return Err(SupplyChainError::TruncatedOsvResponse {
-            expected: names.len(),
+            expected,
             got: parsed.results.len(),
         });
     }
-    Ok(extract_malicious(names, &parsed))
+    Ok(parsed)
 }
 
 fn extract_malicious(names: &[String], resp: &OsvBatchResponse) -> Vec<MaliciousAdvisory> {
@@ -205,6 +281,26 @@ fn extract_malicious(names: &[String], resp: &OsvBatchResponse) -> Vec<Malicious
                 hits.push(MaliciousAdvisory {
                     package: name.clone(),
                     advisory_id: vuln.id.clone(),
+                    version: None,
+                });
+            }
+        }
+    }
+    hits
+}
+
+fn extract_malicious_versioned(
+    pairs: &[(String, String)],
+    resp: &OsvBatchResponse,
+) -> Vec<MaliciousAdvisory> {
+    let mut hits = Vec::new();
+    for ((name, version), result) in pairs.iter().zip(resp.results.iter()) {
+        for vuln in &result.vulns {
+            if vuln.id.starts_with("MAL-") {
+                hits.push(MaliciousAdvisory {
+                    package: name.clone(),
+                    advisory_id: vuln.id.clone(),
+                    version: Some(version.clone()),
                 });
             }
         }
@@ -303,6 +399,28 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].package, "evil-pkg");
         assert_eq!(hits[0].advisory_id, "MAL-2026-3652");
+        assert_eq!(hits[0].version, None);
+    }
+
+    #[test]
+    fn extract_malicious_versioned_carries_resolved_version() {
+        // The versioned path pairs each query with the resolved
+        // version, so callers can show `name@version` in the refusal
+        // message and reason about per-version compromise (e.g. the
+        // ansi-regex@6.2.1-only shai-hulud advisory).
+        let pairs = vec![("ansi-regex".to_string(), "6.2.1".to_string())];
+        let resp = OsvBatchResponse {
+            results: vec![OsvResult {
+                vulns: vec![OsvVuln {
+                    id: "MAL-2025-46966".to_string(),
+                }],
+            }],
+        };
+        let hits = extract_malicious_versioned(&pairs, &resp);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].package, "ansi-regex");
+        assert_eq!(hits[0].version.as_deref(), Some("6.2.1"));
+        assert_eq!(hits[0].advisory_id, "MAL-2025-46966");
     }
 
     #[test]

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -31,7 +31,8 @@ use aube_codes::warnings::{
 };
 use aube_registry::osv_mirror::OsvMirror;
 use aube_registry::supply_chain::{
-    DownloadCount, advisory_url, fetch_malicious_advisories, fetch_weekly_downloads_with,
+    DownloadCount, MaliciousAdvisory, advisory_url, fetch_malicious_advisories,
+    fetch_malicious_advisories_versioned, fetch_weekly_downloads_with,
 };
 use aube_settings::resolved::{AdvisoryCheck, AdvisoryCheckOnInstall};
 use miette::miette;
@@ -130,7 +131,7 @@ pub async fn run_gates(
 /// `advisory_check` is the caller's already-upgraded policy
 /// (paranoid → `Required`). Both gates internally short-circuit
 /// on `Off`, but skip the call entirely so an empty graph
-/// doesn't get a useless `transitive_registry_names` walk.
+/// doesn't get a useless `transitive_registry_pairs` walk.
 pub async fn run_post_resolve_osv_routing(
     cwd: &std::path::Path,
     graph: &aube_lockfile::LockfileGraph,
@@ -176,8 +177,8 @@ pub async fn run_transitive_osv_gate(
     if matches!(policy, AdvisoryCheck::Off) {
         return Ok(());
     }
-    let names = transitive_registry_names(cwd, graph);
-    if names.is_empty() {
+    let pairs = transitive_registry_pairs(cwd, graph);
+    if pairs.is_empty() {
         return Ok(());
     }
     let client = match aube_registry::supply_chain::build_probe_client() {
@@ -196,7 +197,7 @@ pub async fn run_transitive_osv_gate(
             return Ok(());
         }
     };
-    osv_gate(&client, &names, policy).await
+    osv_gate_versioned(&client, &pairs, policy).await
 }
 
 /// Mirror-backed transitive OSV `MAL-*` check for plain reinstalls.
@@ -227,8 +228,8 @@ pub async fn run_transitive_osv_gate_via_mirror(
     if matches!(policy, AdvisoryCheckOnInstall::Off) {
         return Ok(());
     }
-    let names = transitive_registry_names(cwd, graph);
-    if names.is_empty() {
+    let pairs = transitive_registry_pairs(cwd, graph);
+    if pairs.is_empty() {
         return Ok(());
     }
     let Some(cache_dir) = aube_store::dirs::cache_dir() else {
@@ -283,7 +284,7 @@ pub async fn run_transitive_osv_gate_via_mirror(
         // data is empty and lookup is a no-op — the warning is
         // the only user-visible signal in that case.
     }
-    let hits = match mirror.lookup_advisories(&names) {
+    let hits = match mirror.lookup_advisories_versioned(&pairs) {
         Ok(hits) => hits,
         Err(e) => {
             tracing::warn!(
@@ -302,21 +303,14 @@ pub async fn run_transitive_osv_gate_via_mirror(
     if hits.is_empty() {
         return Ok(());
     }
-    let mut lines = vec!["refusing to install malicious package(s):".to_string()];
-    for hit in &hits {
-        lines.push(format!(
-            "  - {} ({}: {})",
-            hit.package,
-            hit.advisory_id,
-            advisory_url(&hit.advisory_id),
-        ));
-    }
-    lines.push(String::new());
-    lines.push("Set `advisoryCheckOnInstall = off` to bypass (not recommended).".to_string());
     Err(miette!(
         code = ERR_AUBE_MALICIOUS_PACKAGE,
         "{}",
-        lines.join("\n")
+        format_malicious_message(
+            "refusing to install malicious package(s):",
+            &hits,
+            "Set `advisoryCheckOnInstall = off` to bypass (not recommended).",
+        ),
     ))
 }
 
@@ -364,29 +358,36 @@ pub fn lockfile_has_new_picks(
         .any(|p| !prior_pairs.contains(&(p.registry_name(), p.version.as_str())))
 }
 
-/// Distinct public-npmjs registry names in `graph`, filtered to
-/// match the CLI-name gate's `registry_bound_names_for_supply_chain`
-/// shape so a scoped registry override (`@myorg:registry=...`) or a
-/// swapped default registry doesn't ship internal package names to
-/// OSV. Workspace / `link:` / `file:` entries drop out via
+/// Distinct public-npmjs `(registry_name, version)` pairs in
+/// `graph`, filtered to match the CLI-name gate's
+/// `registry_bound_names_for_supply_chain` shape so a scoped
+/// registry override (`@myorg:registry=...`) or a swapped default
+/// registry doesn't ship internal package names to OSV. Workspace /
+/// `link:` / `file:` entries drop out via
 /// `LockedPackage::local_source.is_none()`. Sorted + deduped so
 /// aliased entries (`{"my-alias": "npm:lodash@^4"}`) collapse onto
 /// their real registry name.
-fn transitive_registry_names(
+///
+/// Pairs (not just names) because the post-resolve OSV check
+/// needs to ask "is *this specific version* malicious?" — a
+/// name-only query collapses version-specific compromises (e.g.
+/// the Sep 2025 `ansi-regex@6.2.1` worm) into a permanent
+/// name-level block of every published release.
+fn transitive_registry_pairs(
     cwd: &std::path::Path,
     graph: &aube_lockfile::LockfileGraph,
-) -> Vec<String> {
+) -> Vec<(String, String)> {
     let npm_config = aube_registry::config::NpmConfig::load(cwd);
-    let mut names: Vec<String> = graph
+    let mut pairs: Vec<(String, String)> = graph
         .packages
         .values()
         .filter(|pkg| pkg.local_source.is_none())
-        .map(|pkg| pkg.registry_name().to_string())
-        .filter(|name| npm_config.is_public_npmjs(name))
+        .filter(|pkg| npm_config.is_public_npmjs(pkg.registry_name()))
+        .map(|pkg| (pkg.registry_name().to_string(), pkg.version.clone()))
         .collect();
-    names.sort();
-    names.dedup();
-    names
+    pairs.sort();
+    pairs.dedup();
+    pairs
 }
 
 /// Parse `allowedUnpopularPackages` entries into compiled
@@ -413,36 +414,51 @@ async fn osv_gate(
     if matches!(policy, AdvisoryCheck::Off) {
         return Ok(());
     }
-    match fetch_malicious_advisories(client, names).await {
+    handle_osv_result(
+        fetch_malicious_advisories(client, names).await,
+        policy,
+        "refusing to add malicious package(s):",
+    )
+}
+
+async fn osv_gate_versioned(
+    client: &reqwest::Client,
+    pairs: &[(String, String)],
+    policy: AdvisoryCheck,
+) -> miette::Result<()> {
+    if matches!(policy, AdvisoryCheck::Off) {
+        return Ok(());
+    }
+    handle_osv_result(
+        fetch_malicious_advisories_versioned(client, pairs).await,
+        policy,
+        "refusing to install malicious package(s):",
+    )
+}
+
+fn handle_osv_result(
+    result: Result<Vec<MaliciousAdvisory>, aube_registry::supply_chain::SupplyChainError>,
+    policy: AdvisoryCheck,
+    refusal_header: &str,
+) -> miette::Result<()> {
+    match result {
         Ok(hits) if hits.is_empty() => Ok(()),
-        Ok(hits) => {
-            // First hit drives the error message; subsequent hits are
-            // chained in for visibility. Confirmed-malicious is a hard
-            // block — we don't care whether the user is interactive.
-            let mut lines = vec!["refusing to add malicious package(s):".to_string()];
-            for hit in &hits {
-                lines.push(format!(
-                    "  - {} ({}: {})",
-                    hit.package,
-                    hit.advisory_id,
-                    advisory_url(&hit.advisory_id),
-                ));
-            }
-            lines.push(String::new());
-            lines.push("Set `advisoryCheck = off` to bypass (not recommended).".to_string());
-            Err(miette!(
-                code = ERR_AUBE_MALICIOUS_PACKAGE,
-                "{}",
-                lines.join("\n")
-            ))
-        }
+        Ok(hits) => Err(miette!(
+            code = ERR_AUBE_MALICIOUS_PACKAGE,
+            "{}",
+            format_malicious_message(
+                refusal_header,
+                &hits,
+                "Set `advisoryCheck = off` to bypass (not recommended).",
+            ),
+        )),
         Err(e) => {
             tracing::warn!(
                 code = WARN_AUBE_ADVISORY_CHECK_FAILED,
                 "OSV advisory check failed: {e}"
             );
-            // `AdvisoryCheck::Off` short-circuits at the top of
-            // `osv_gate` and never reaches this branch — only the
+            // `AdvisoryCheck::Off` short-circuits at the top of the
+            // caller and never reaches this branch — only the
             // `On` / `Required` split needs handling here.
             if matches!(policy, AdvisoryCheck::Required) {
                 return Err(miette!(
@@ -453,6 +469,29 @@ async fn osv_gate(
             Ok(())
         }
     }
+}
+
+/// Format the user-facing refusal message. Versioned hits surface
+/// as `name@version (MAL-…)`; name-only hits (the pre-resolve `aube
+/// add` gate) surface as `name (MAL-…)` since no version was
+/// queried.
+fn format_malicious_message(header: &str, hits: &[MaliciousAdvisory], footer: &str) -> String {
+    let mut lines = vec![header.to_string()];
+    for hit in hits {
+        let display_name = match &hit.version {
+            Some(v) => format!("{}@{}", hit.package, v),
+            None => hit.package.clone(),
+        };
+        lines.push(format!(
+            "  - {} ({}: {})",
+            display_name,
+            hit.advisory_id,
+            advisory_url(&hit.advisory_id),
+        ));
+    }
+    lines.push(String::new());
+    lines.push(footer.to_string());
+    lines.join("\n")
 }
 
 async fn downloads_gate(
@@ -622,7 +661,7 @@ mod tests {
     }
 
     #[test]
-    fn transitive_registry_names_skips_local_source_entries() {
+    fn transitive_registry_pairs_skips_local_source_entries() {
         // `file:` / `link:` / workspace edges resolve outside the
         // public registry — OSV has nothing to say about them, and
         // forwarding the workspace package name to OSV could leak
@@ -641,12 +680,12 @@ mod tests {
             ..Default::default()
         };
         let tmp = tempfile::tempdir().expect("tempdir");
-        let names = transitive_registry_names(tmp.path(), &graph);
-        assert_eq!(names, vec!["lodash".to_string()]);
+        let pairs = transitive_registry_pairs(tmp.path(), &graph);
+        assert_eq!(pairs, vec![("lodash".to_string(), "4.17.21".to_string())],);
     }
 
     #[test]
-    fn transitive_registry_names_dedups_by_registry_name() {
+    fn transitive_registry_pairs_dedups_by_registry_name_and_version() {
         // Alias entries (`{"my-alias": "npm:lodash@^4"}`) and the
         // real package both report under `registry_name() = "lodash"`.
         // The mirror lookup shouldn't see duplicates — and shouldn't
@@ -665,8 +704,65 @@ mod tests {
             ..Default::default()
         };
         let tmp = tempfile::tempdir().expect("tempdir");
-        let names = transitive_registry_names(tmp.path(), &graph);
-        assert_eq!(names, vec!["lodash".to_string()]);
+        let pairs = transitive_registry_pairs(tmp.path(), &graph);
+        assert_eq!(pairs, vec![("lodash".to_string(), "4.17.21".to_string())],);
+    }
+
+    #[test]
+    fn transitive_registry_pairs_keeps_distinct_versions_of_one_name() {
+        // Two pinned versions of the same name (common when a peer
+        // pulls in an older copy) must both reach OSV — checking
+        // only one would leave the other's per-version compromise
+        // status unanswered.
+        use std::collections::BTreeMap;
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "ansi-regex@3.0.1".to_string(),
+            registry_pkg("ansi-regex", "3.0.1"),
+        );
+        packages.insert(
+            "ansi-regex@6.2.1".to_string(),
+            registry_pkg("ansi-regex", "6.2.1"),
+        );
+        let graph = aube_lockfile::LockfileGraph {
+            packages,
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let pairs = transitive_registry_pairs(tmp.path(), &graph);
+        assert_eq!(
+            pairs,
+            vec![
+                ("ansi-regex".to_string(), "3.0.1".to_string()),
+                ("ansi-regex".to_string(), "6.2.1".to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn format_malicious_message_includes_version_when_present() {
+        // Versioned hits should surface as `name@version` so the
+        // user can see which pinned version OSV flagged. The
+        // pre-resolve gate (no version) keeps the bare name shape
+        // it had before.
+        let hits = vec![
+            MaliciousAdvisory {
+                package: "ansi-regex".to_string(),
+                advisory_id: "MAL-2025-46966".to_string(),
+                version: Some("6.2.1".to_string()),
+            },
+            MaliciousAdvisory {
+                package: "evil".to_string(),
+                advisory_id: "MAL-9999".to_string(),
+                version: None,
+            },
+        ];
+        let msg = format_malicious_message("header:", &hits, "footer.");
+        assert!(msg.contains("ansi-regex@6.2.1"));
+        assert!(msg.contains("MAL-2025-46966"));
+        assert!(msg.contains("- evil ("), "name-only hit keeps bare name");
+        assert!(msg.starts_with("header:"));
+        assert!(msg.ends_with("footer."));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The post-resolve transitive OSV gate was reusing the pre-resolve name-only query, so a name-level `MAL-*` advisory hit every install that transitively pulled in *any* version of that package — even releases published years before the compromise.

Concrete failure: `aube add cowsay@1.6.0` (or [mise's `test_npm_aube` e2e](https://github.com/jdx/mise/actions/runs/25832744527/job/75901606726?pr=9846)) refused with `ERR_AUBE_MALICIOUS_PACKAGE` because cowsay's tree includes `ansi-regex@3.0.1`, and `ansi-regex` carries the Sep 2025 shai-hulud advisory `MAL-2025-46966` against `6.2.1`. The name-only query collapses the per-version compromise into a permanent block of every release.

Verified against the live API:

```
$ curl -sS -X POST https://api.osv.dev/v1/querybatch \
    -H 'Content-Type: application/json' \
    -d '{"queries":[{"package":{"name":"ansi-regex","ecosystem":"npm"},"version":"3.0.1"},
                    {"package":{"name":"ansi-regex","ecosystem":"npm"},"version":"6.2.1"}]}'
{"results":[{},{"vulns":[{"id":"MAL-2025-46966", ...}]}]}
```

The clean `3.0.1` returns no advisory; only the actually-compromised `6.2.1` hits.

## Fix

- `fetch_malicious_advisories_versioned(&[(name, version)])` and the matching `OsvMirror::lookup_advisories_versioned` so the post-resolve gates ask OSV \"is *this version* malicious?\" instead of \"has *any version* of this name ever been malicious?\".
- Pre-resolve `aube add` name-gate keeps the versionless query — typosquats really are malicious in every version, and the resolver hasn't run yet there.
- `MaliciousAdvisory` gains `version: Option<String>` so the user-facing refusal can surface `name@version (MAL-…)` for the post-resolve path while leaving the add-time name-only path unchanged.
- Mirror index bumped to `format = 2` (each entry now stores affected `versions`). v1 indexes load as empty via `load_or_default` and get rebuilt from the cached `all.zip` on the next refresh. An advisory with no enumerated versions still hits every version (fail-closed on unknown schema variants).

## Test plan

- [x] `cargo test --workspace` — 0 regressions, new coverage:
  - `extract_malicious_versioned_carries_resolved_version` (live-API extractor pairs name@version)
  - `lookup_versioned_filters_to_resolver_picked_version` (mirror: ansi-regex@3.0.1 clean, @6.2.1 hits)
  - `lookup_versioned_empty_versions_blocks_every_version` (fail-closed default)
  - `build_index_merges_versions_across_affected_blocks` (union semantics)
  - `transitive_registry_pairs_keeps_distinct_versions_of_one_name` (no name-level dedup)
  - `format_malicious_message_includes_version_when_present` (refusal display)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Re-run `mise`'s `test_npm_aube` e2e once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the install-time malicious-package blocking logic to become version-aware and updates the on-disk OSV mirror index format, which could affect whether installs are blocked or allowed if version parsing/index rebuilds go wrong.
> 
> **Overview**
> Fixes false-positive install blocks by making the **post-resolve transitive OSV `MAL-*` gate version-aware**: the live OSV batch query now includes `version`, and the lockfile walk now sends `(name, version)` pairs so only actually-affected versions hit.
> 
> Updates the local OSV mirror to store per-advisory affected `versions` (index `format` bumped to `2`) and adds `lookup_advisories_versioned`, with a fail-closed default when version data is missing.
> 
> Extends `MaliciousAdvisory` with `version: Option<String>` and reworks refusal-message formatting to show `name@version` when available; adds targeted tests for version filtering, index building/merging, and message formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d57d10c0cd71607ffd86d5a33013f725b61b6c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->