### PR TITLE
docs: fix minimum release age default

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -139,7 +139,7 @@ minimumReleaseAge: 4320  # 3 days
 the range; otherwise the resolver falls back to the lowest satisfying version
 ignoring the cutoff for that pick only.
 
-Default: `0` (disabled).
+Default: `1440` (24 hours). Set `minimumReleaseAge: 0` to disable.
 
 Settings: [`minimumReleaseAge`](/settings/#setting-minimumreleaseage),
 [`minimumReleaseAgeExclude`](/settings/#setting-minimumreleaseageexclude),


### PR DESCRIPTION
## Summary
- Correct the security page minimumReleaseAge default from 0 to 1440 minutes
- Note that setting minimumReleaseAge to 0 disables the gate

## Validation
- mise run docs:build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change correcting the stated default for `minimumReleaseAge`; no runtime behavior is modified.
> 
> **Overview**
> Updates `docs/security.md` to correct the documented default for `minimumReleaseAge` from `0` (disabled) to `1440` minutes (24 hours), and clarifies that setting `minimumReleaseAge: 0` disables the gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5099b4759504e2ab64df77fd226603e0d37c78f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->