### PR TITLE
fix(packaging): materialize npm platform bin shims

### DIFF
--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 // Build and publish the @endevco/aube npm packages for a given tag.
 //
-// For each of the 5 release targets this:
+// For each release target this:
 //   1. downloads `aube-<tag>-<target>.{tar.gz,zip}` directly from the
 //      public GitHub release asset URL (no API, no auth token),
-//   2. extracts the three binaries (aube, aubr, aubx) into a staging
-//      dir,
+//   2. extracts the three binary entries (aube, aubr, aubx) into a
+//      staging dir,
 //   3. generates a platform-scoped package.json and publishes it as
 //      `@endevco/aube-<os>-<arch>`.
 // Then rewrites the root `npm/package.json` version and publishes
@@ -24,7 +24,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { createWriteStream } from 'node:fs';
-import { mkdirSync, readFileSync, writeFileSync, cpSync, rmSync, existsSync, chmodSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync, cpSync, copyFileSync, rmSync, existsSync, chmodSync, realpathSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -149,7 +149,11 @@ async function buildPlatformPackage(repo, tag, version, target) {
         const src = resolve(extractDir, bin + target.exe);
         const destName = bin + target.exe;
         const dest = resolve(binDir, destName);
-        cpSync(src, dest);
+        // Release archives store aubr/aubx as symlinks to aube on Unix
+        // to avoid shipping duplicate binaries. npm pack drops those
+        // symlinked bin entries, so platform packages must stage real
+        // files for every declared bin target.
+        copyFileSync(realpathSync(src), dest);
         if (target.os !== 'win32') chmodSync(dest, 0o755);
         bins[bin] = `bin/${destName}`;
     }


### PR DESCRIPTION
## Summary
- materialize Unix npm platform bin shims as real files during publish staging
- keep release archives small while ensuring npm package tarballs include every declared bin target

## Root Cause
The release archive stores `aubr` and `aubx` as symlinks to `aube`. `npm pack` omits those symlinked bin entries from the platform package tarball, leaving `package.json` declaring `bin/aubr` and `bin/aubx` paths that do not exist.

## Validation
- `node --check npm/scripts/publish.mjs`
- `git diff --check`
- local npm-pack simulation confirmed `package/bin/aube`, `package/bin/aubr`, and `package/bin/aubx` are present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the npm publish staging process for platform packages, which can affect the contents/executability of published tarballs across OS/arch targets.
> 
> **Overview**
> Fixes platform npm packages missing `aubr`/`aubx` when release archives store them as symlinks to `aube` on Unix.
> 
> During staging, the publish script now **resolves symlinks and copies real files** (`realpathSync` + `copyFileSync`) for each declared `bin` entry so `npm pack`/publish always includes `aube`, `aubr`, and `aubx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da51f4a3429fc0171d48912a7984afa5121fcddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->