### PR TITLE
fix(lockfile): parse bun workspace paths as links

### DIFF
--- a/crates/aube-lockfile/src/bun.rs
+++ b/crates/aube-lockfile/src/bun.rs
@@ -627,12 +627,13 @@ fn classify_bun_ident(
         // `workspace:*` / `workspace:^` / `workspace:~` are version-
         // range selectors, not directory paths — a `PathBuf::from("*")`
         // would silently become `{project_root}/*` under any caller
-        // that does `project_root.join(link.path())`. Only treat the
-        // tail as a path when it looks like one (leading `.` or `/`);
-        // otherwise fall back to `.` so the link points at the
+        // that does `project_root.join(link.path())`. Bun's `packages`
+        // entries for workspace members use root-relative paths like
+        // `workspace:packages/lib`, so keep slash-bearing tails as paths.
+        // Otherwise fall back to `.` so range selectors point at the
         // workspace root and the caller resolves the actual location
         // from the graph's workspace map.
-        let is_path = rel.starts_with('.') || rel.starts_with('/');
+        let is_path = rel.starts_with('.') || rel.starts_with('/') || rel.contains('/');
         let path_buf = std::path::PathBuf::from(if rel.is_empty() || !is_path { "." } else { rel });
         return Ok((
             name,
@@ -3005,6 +3006,37 @@ mod tests {
             "https://*.tgz must be LocalSource::RemoteTarball, got {:?}",
             remote.local_source
         );
+    }
+
+    #[test]
+    fn test_parse_bun_workspace_package_path_as_link_target() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = r#"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "root" },
+    "packages/app": {
+      "name": "app",
+      "dependencies": { "lib": "workspace:*" }
+    },
+    "packages/lib": { "name": "lib" }
+  },
+  "packages": {
+    "app": ["app@workspace:packages/app"],
+    "lib": ["lib@workspace:packages/lib"]
+  }
+}"#;
+        std::fs::write(tmp.path(), content).unwrap();
+        let graph = parse(tmp.path()).unwrap();
+
+        let lib = graph.packages.get("lib@workspace:packages/lib").unwrap();
+        assert_eq!(
+            lib.local_source.as_ref().and_then(LocalSource::path),
+            Some(Path::new("packages/lib"))
+        );
+
+        let app_deps = graph.importers.get("packages/app").unwrap();
+        assert_eq!(app_deps[0].dep_path, "lib@workspace:packages/lib");
     }
 
     /// npm-alias ident: bun writes `<real>@<version>` as the ident

--- a/test/import.bats
+++ b/test/import.bats
@@ -94,6 +94,47 @@ teardown() {
 	assert_dir_exists "node_modules/@sindresorhus/is"
 }
 
+@test "aube install from bun.lock links workspace deps to their package dirs" {
+	cat >package.json <<'EOF'
+{"name":"root","version":"1.0.0","workspaces":["packages/*"]}
+EOF
+	mkdir -p packages/app packages/lib
+	cat >packages/app/package.json <<'EOF'
+{"name":"app","version":"0.0.0","dependencies":{"lib":"workspace:*"}}
+EOF
+	cat >packages/lib/package.json <<'EOF'
+{"name":"lib","version":"0.0.0"}
+EOF
+	cat >bun.lock <<'EOF'
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "root" },
+    "packages/app": {
+      "name": "app",
+      "version": "0.0.0",
+      "dependencies": { "lib": "workspace:*" }
+    },
+    "packages/lib": {
+      "name": "lib",
+      "version": "0.0.0"
+    }
+  },
+  "packages": {
+    "app": ["app@workspace:packages/app"],
+    "lib": ["lib@workspace:packages/lib"]
+  }
+}
+EOF
+
+	run aube install --frozen-lockfile
+	assert_success
+
+	actual="$(realpath packages/app/node_modules/lib)"
+	expected="$(realpath packages/lib)"
+	[[ "$actual" == "$expected" ]] || fail "lib link points to $actual, expected $expected"
+}
+
 @test "aube install applies peer-context suffixes when importing from bun.lock" {
 	# Regression for the bun.lock importer skipping
 	# `apply_peer_contexts`. Without the pass, `fdir` lands in the


### PR DESCRIPTION
## Summary
- parse Bun `workspace:packages/...` package entries as root-relative link targets
- keep `workspace:*` and other range-like workspace selectors rooted at `.`
- add parser and Bats regression coverage for Bun workspace dependency links

## Root Cause
Bun records workspace packages in `packages` as entries like `@scope/name@workspace:packages/name`. Aube treated non-dot `workspace:` tails as selectors instead of paths, so those entries became `LocalSource::Link(".")` and linked to the workspace root.

## Validation
- `cargo fmt --check`
- `cargo test -p aube-lockfile bun::tests::test_parse_bun_workspace_package_path_as_link_target`
- `mise run test:bats test/import.bats --filter 'bun.lock links workspace deps'`\n- reporter repro `./repro.sh` against `mwolson/tmp-aube-issues/bun-workspace-link`\n\nFixes discussion #691.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bun.lock parsing for `workspace:` specifiers, which can affect how workspace packages are linked during install. Risk is limited to Bun workspace handling and is covered by new unit + Bats regression tests.
> 
> **Overview**
> Fixes bun.lock import so `packages` entries like `name@workspace:packages/...` are treated as `LocalSource::Link("packages/..." )` (root-relative), while range-like selectors such as `workspace:*` still resolve to `.`.
> 
> Adds regression coverage in `crates/aube-lockfile/src/bun.rs` and an end-to-end `aube install --frozen-lockfile` Bats test to ensure workspace dependencies link to the correct workspace package directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b54daaaa826a1392b850ab54e58c744a5b82e83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->