### PR TITLE
fix(manifest): track yamlpatch value type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,9 +4401,9 @@ dependencies = [
 
 [[package]]
 name = "subfeature"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce89b340c4df706a70c1f25834c10a768fc11afeb69c832e4aa182d3158fac1"
+checksum = "08e860b3674e63a4ec53f99c94fe596c64cb17e94776e15c03d856e826a459e2"
 dependencies = [
  "memchr",
  "regex",
@@ -4930,9 +4930,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-iter"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f90e647c44106848cae33ec24309a2cea64de58066dc279731812be5aa6faf"
+checksum = "d9381a9c1ad0edfe47eda0218c94bcced73741be660a00baa2ceabaa9289375f"
 dependencies = [
  "tree-sitter",
 ]
@@ -5928,25 +5928,25 @@ dependencies = [
 
 [[package]]
 name = "yamlpatch"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5afc92d2beb7a811cbda1fc0db34b6afaa3f4218c3da792ffc5dc633b26b723a"
+checksum = "d29204c690e53bb66d04e9cb6d7c34075f087d81f7ef5d8ee77c2c2081da7414"
 dependencies = [
  "indexmap 2.14.0",
  "line-index",
  "serde",
  "serde_json",
- "serde_yaml",
  "subfeature",
  "thiserror 2.0.18",
+ "yaml_serde",
  "yamlpath",
 ]
 
 [[package]]
 name = "yamlpath"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dfc10af3a0b762c85fe94c3d9e00343078bef7048793a652430393faa50e47e"
+checksum = "7ee69e8a2c397c2cdd831389213743f92e48f5998d32d650d40767e919ee663e"
 dependencies = [
  "line-index",
  "self_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,10 @@ yaml_serde = "0.10.4"
 # aube to surgically rewrite user-authored workspace YAML files
 # (catalogs, allowBuilds, patchedDependencies) without stripping
 # comments — yaml_serde's round-trip would otherwise destroy them.
-# yamlpatch's value/parse types come from serde_yaml 0.9, which is the
-# upstream of yaml_serde; we keep yaml_serde for typed reads and only
-# touch serde_yaml at the patch boundary.
-yamlpatch = "1.24"
-yamlpath = "1.24"
+# yamlpatch uses yaml_serde for patch payloads; serde_yaml remains only
+# for the manual block injector that works around nested Add formatting.
+yamlpatch = "1.25"
+yamlpath = "1.25"
 serde_yaml = "0.9"
 sonic-rs = "0.5"
 toml = "0.8"

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -1340,7 +1340,7 @@ mod yaml_patch {
                     } else {
                         out.push(Edit::Yp(Patch {
                             route: route_obj.with_key(key.to_string()),
-                            operation: Op::Replace(to_serde_value(path, after_v)?),
+                            operation: Op::Replace(after_v.clone()),
                         }));
                     }
                 }
@@ -1540,7 +1540,8 @@ mod yaml_patch {
     }
 
     /// Bridge `yaml_serde::Value` (our typed parse type) to
-    /// `serde_yaml::Value` (yamlpatch's payload type). yaml_serde is
+    /// `serde_yaml::Value` (the manual injector's render type).
+    /// yaml_serde is
     /// the maintained fork of serde_yaml 0.9, so a YAML round-trip is
     /// lossless for every variant we use (scalars, sequences,
     /// mappings, tagged values). Errors on either side propagate


### PR DESCRIPTION
## Summary

Fixes the `release-plz PR` workflow failure in `Regenerate CLI docs` after `release-plz update` refreshes the lockfile to `yamlpatch v1.25.0`.

`yamlpatch` now uses `yaml_serde::Value` for `Op::Replace`, but `aube-manifest` was still converting replacement payloads through `serde_yaml::Value`. Normal local checks on the old lockfile did not catch this, while release-plz's dependency refresh did.

This PR updates the workspace dependency pins to `yamlpatch/yamlpath 1.25`, passes the existing `yaml_serde::Value` directly to `Op::Replace`, and keeps `serde_yaml` only for the manual block injector.

## Validation

- `cargo fmt --check`
- `cargo check -p aube-manifest`
- `cargo test -p aube-manifest`
- `cargo clippy -p aube-manifest --all-targets -- -D warnings`
- `mise run render ::: lint-fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it updates YAML patching dependencies and changes the payload type used for `Op::Replace`, which could affect how workspace YAML edits are applied/serialized.
> 
> **Overview**
> Fixes workspace YAML rewriting after `yamlpatch` switched `Op::Replace` to accept `yaml_serde::Value` by **upgrading `yamlpatch`/`yamlpath` to `1.25`** and passing replacement values through without converting via `serde_yaml`.
> 
> `serde_yaml` is now kept only for the manual block-injection path, and the lockfile is refreshed to reflect the new `yamlpatch` dependency graph (including the `serde_yaml` → `yaml_serde` payload change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8790fec43749f61d6ddc4bc9d64fb1af165ad4d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->