### PR TITLE
ci(release): stop release-plz cargo lock bumps

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -251,8 +251,8 @@ jobs:
 
       # Step 1: let release-plz compute the next workspace version and
       # write Cargo.toml / Cargo.lock / CHANGELOG.md bumps into the
-      # working tree. `bump=true` iff release-plz actually produced a
-      # version-bump diff.
+      # working tree.
+      # `bump=true` iff release-plz actually produced a version-bump diff.
       - name: Apply version bumps
         id: update
         env:
@@ -331,16 +331,6 @@ jobs:
             if (!found) throw new Error(`path dependency ${name} not found in Cargo.toml`);
           }
           fs.writeFileSync('Cargo.toml', cargoToml);
-
-          const lock = fs.readFileSync('Cargo.lock', 'utf8')
-            .split(/\n(?=\[\[package\]\]\n)/)
-            .map((block) => {
-              const name = block.match(/^name = "([^"]+)"/m)?.[1];
-              if (!packages.has(name)) return block;
-              return block.replace(/^version = "\d+\.\d+\.\d+"/m, `version = "${newVersion}"`);
-            })
-            .join('\n');
-          fs.writeFileSync('Cargo.lock', lock);
 
           const subjects = execFileSync('git', ['log', '--format=%s', `${latestTag}..HEAD`], { encoding: 'utf8' })
             .trim()


### PR DESCRIPTION
## Summary

Stops the forced patch-bump fallback from manually editing `Cargo.lock`.

`release-plz update` can keep owning its normal `Cargo.toml` / `Cargo.lock` / changelog output. The custom repo-only patch bump path should not hand-edit lockfile package blocks; later Cargo commands can update workspace crate lock entries naturally, and third-party dependency refreshes remain Renovate's job.

## Validation

- `actionlint .github/workflows/release-plz.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only workflow change that stops editing `Cargo.lock` during forced version bumps; main impact is on release PR contents and should not affect runtime code.
> 
> **Overview**
> Prevents automated release PRs from carrying `Cargo.lock` version rewrites by removing the workflow’s manual `Cargo.lock` update logic during the forced patch-bump step.
> 
> Also slightly clarifies the `release-plz update` step comments about when `bump=true` is emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64716e797f7711a84f6d0c32ace2024483e6797f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->