### PR TITLE
refactor(install): split resolve phase

### DIFF
--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -1,0 +1,474 @@
+use super::dep_selection::DepSelection;
+use super::lifecycle::{
+    JailBuildPolicy, run_dep_lifecycle_scripts, run_root_lifecycle, unreviewed_dep_builds,
+};
+use super::side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root};
+use super::summary::{print_direct_dependency_summary, should_print_human_install_summary};
+use super::sweep::sweep_orphaned_aube_entries;
+use super::workspace::importer_project_dir;
+use super::{InstallPhaseTimings, delta, unreviewed_builds};
+use crate::state;
+use miette::{Context, IntoDiagnostic, miette};
+use std::collections::BTreeMap;
+
+pub(super) struct FinalizePhaseInput<'a> {
+    pub(super) cwd: &'a std::path::Path,
+    pub(super) settings_ctx: &'a aube_settings::ResolveCtx<'a>,
+    pub(super) store: &'a aube_store::Store,
+    pub(super) graph: &'a aube_lockfile::LockfileGraph,
+    pub(super) graph_for_link: &'a aube_lockfile::LockfileGraph,
+    pub(super) manifests: &'a [(String, aube_manifest::PackageJson)],
+    pub(super) lifecycle_manifests: &'a [(String, aube_manifest::PackageJson)],
+    pub(super) direct_dep_info: &'a std::collections::HashMap<String, aube_resolver::DirectDepInfo>,
+    pub(super) deprecations:
+        &'a std::sync::Arc<std::sync::Mutex<Vec<crate::deprecations::DeprecationRecord>>>,
+    pub(super) build_policy: &'a aube_scripts::BuildPolicy,
+    pub(super) jail_policy: &'a JailBuildPolicy,
+    pub(super) stats: &'a aube_linker::LinkStats,
+    pub(super) node_linker: aube_linker::NodeLinker,
+    pub(super) virtual_store_only: bool,
+    pub(super) current_leaf_hashes: Option<BTreeMap<String, String>>,
+    pub(super) current_subtree_hashes: Option<BTreeMap<String, String>>,
+    pub(super) patch_hashes: BTreeMap<String, String>,
+    pub(super) modules_dir_name: &'a str,
+    pub(super) aube_dir: &'a std::path::Path,
+    pub(super) virtual_store_dir_max_length: usize,
+    pub(super) child_concurrency: usize,
+    pub(super) side_effects_cache_setting: bool,
+    pub(super) side_effects_cache_readonly_setting: bool,
+    pub(super) strict_dep_builds_setting: bool,
+    pub(super) ignore_scripts: bool,
+    pub(super) skip_root_lifecycle: bool,
+    pub(super) workspace_filter_empty: bool,
+    pub(super) dep_selection: DepSelection,
+    pub(super) cli_flags: &'a [(String, String)],
+    pub(super) cached_count: usize,
+    pub(super) fetch_count: usize,
+    pub(super) start: std::time::Instant,
+    pub(super) prog_ref: Option<&'a crate::progress::InstallProgress>,
+    pub(super) phase_timings: &'a mut InstallPhaseTimings,
+}
+
+pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette::Result<()> {
+    let FinalizePhaseInput {
+        cwd,
+        settings_ctx,
+        store,
+        graph,
+        graph_for_link,
+        manifests,
+        lifecycle_manifests,
+        direct_dep_info,
+        deprecations,
+        build_policy,
+        jail_policy,
+        stats,
+        node_linker,
+        virtual_store_only,
+        current_leaf_hashes,
+        current_subtree_hashes,
+        patch_hashes,
+        modules_dir_name,
+        aube_dir,
+        virtual_store_dir_max_length,
+        child_concurrency,
+        side_effects_cache_setting,
+        side_effects_cache_readonly_setting,
+        strict_dep_builds_setting,
+        ignore_scripts,
+        skip_root_lifecycle,
+        workspace_filter_empty,
+        dep_selection,
+        cli_flags,
+        cached_count,
+        fetch_count,
+        start,
+        prog_ref,
+        phase_timings,
+    } = input;
+
+    let placements_ref = stats.hoisted_placements.as_ref();
+
+    // Tear down the progress display before running post-link lifecycle
+    // scripts or printing the final summary — scripts write directly to
+    // stdout/stderr and would collide with an active progress bar.
+    //
+    // Skip the CI-mode framed summary on a no-op install: `print_install_summary`
+    // below will print the "Already up to date" branded line, and we don't
+    // want CI users to see both the framed `[ ✓ … resolved N · reused N ]`
+    // block and the branded line as redundant twins.
+    let install_is_noop = stats.packages_linked == 0 && stats.top_level_linked == 0;
+    if let Some(p) = prog_ref {
+        p.finish(!install_is_noop);
+    }
+
+    if !ignore_scripts && strict_dep_builds_setting && !virtual_store_only {
+        let unreviewed = unreviewed_dep_builds(
+            aube_dir,
+            graph_for_link,
+            build_policy,
+            virtual_store_dir_max_length,
+            placements_ref,
+        )?;
+        if !unreviewed.is_empty() {
+            return Err(miette!(
+                "dependencies with build scripts must be reviewed before install:\n{}\nhelp: add the package(s) to `allowBuilds` with `true`/`false`, or set `strictDepBuilds=false`",
+                unreviewed
+                    .into_iter()
+                    .map(|b| format!("  - {}", b.spec_key))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ));
+        }
+    }
+
+    // 7a. Dependency lifecycle scripts (allowBuilds).
+    //     Every dep that the `BuildPolicy` explicitly allows runs its
+    //     `preinstall` / `install` / `postinstall` scripts from inside
+    //     its linked directory under `node_modules/.aube`. Reuses the
+    //     already-constructed `build_policy` from above. Skipped
+    //     entirely under `--ignore-scripts` (pnpm parity) and when the
+    //     policy has no allow rules at all (fast path: no config, no
+    //     cost). A failing dep script fails the whole install —
+    //     matching pnpm's fail-fast default. No cross-project
+    //     collision warning here: step 6a content-addresses the
+    //     global store so two projects resolving the same
+    //     `(dep-graph, engine)` share a safe directory and divergent
+    //     resolutions land at distinct paths.
+    if !ignore_scripts && build_policy.has_any_allow_rule() && !virtual_store_only {
+        let phase_start = std::time::Instant::now();
+        let side_effects_cache_root =
+            side_effects_cache_setting.then(|| side_effects_cache_root(store));
+        let side_effects_cache = side_effects_cache_root
+            .as_deref()
+            .map(|root| {
+                if side_effects_cache_readonly_setting {
+                    SideEffectsCacheConfig::RestoreOnly(root)
+                } else {
+                    SideEffectsCacheConfig::RestoreAndSave(root)
+                }
+            })
+            .unwrap_or(SideEffectsCacheConfig::Disabled);
+        let ran = run_dep_lifecycle_scripts(
+            cwd,
+            modules_dir_name,
+            aube_dir,
+            graph_for_link,
+            build_policy,
+            virtual_store_dir_max_length,
+            child_concurrency,
+            placements_ref,
+            side_effects_cache,
+            jail_policy,
+            None,
+        )
+        .await?;
+        if ran > 0 {
+            tracing::debug!("allowBuilds: ran {ran} dep lifecycle script(s)");
+        }
+        phase_timings.record("dep_lifecycle", phase_start.elapsed());
+    }
+
+    // 7b. Post-link root lifecycle hooks: install → postinstall → prepare.
+    //     npm and pnpm run these in this order after deps are linked so the
+    //     scripts can use anything they depend on. Skipped with --ignore-scripts
+    //     and under `virtualStoreOnly` — scripts typically resolve
+    //     binaries via `node_modules/.bin`, which doesn't exist in
+    //     that mode.
+    //     A hook that's not defined in package.json is a silent no-op.
+    //     A hook that exits non-zero fails the install (fail-fast, matching pnpm).
+    if !ignore_scripts && !virtual_store_only && !skip_root_lifecycle {
+        let phase_start = std::time::Instant::now();
+        for (importer_path, importer_manifest) in lifecycle_manifests {
+            let project_dir = importer_project_dir(cwd, importer_path);
+            for hook in [
+                aube_scripts::LifecycleHook::Install,
+                aube_scripts::LifecycleHook::PostInstall,
+                aube_scripts::LifecycleHook::Prepare,
+            ] {
+                run_root_lifecycle(&project_dir, modules_dir_name, importer_manifest, hook).await?;
+            }
+        }
+        phase_timings.record("root_lifecycle", phase_start.elapsed());
+    }
+
+    // 8. Write state file for auto-install tracking.
+    //    Record whether this was a --prod install so ensure_installed knows
+    //    to re-install the full graph before running dev tooling.
+    //    Skipped under `virtualStoreOnly` — the state sidecar is
+    //    keyed off a materialized node_modules tree that doesn't
+    //    exist, and writing it would lie on the next auto-install
+    //    freshness check. Same skip when a workspace filter scoped the
+    //    run to a subset of importers. State hash is derived from full
+    //    manifest + lockfile inputs, so writing it after a partial
+    //    materialize would let the next unfiltered `aube install` hit
+    //    the warm path while unfiltered importers are still empty.
+    //    Observed via `aube add <pkg> --filter <ws>` leaving the new
+    //    dep unmaterialized.
+    let filtered_install = !workspace_filter_empty || dep_selection.is_filtered();
+
+    // Walk the linked graph once for the unreviewed-builds set; reused
+    // by both the state writer (so warm-path repeats keep nudging) and
+    // the post-install warning emission below. The walk does a stat per
+    // package, so collapsing two callers into one cuts the linker-tail
+    // cost on large graphs roughly in half.
+    let unreviewed_builds = if !ignore_scripts && !strict_dep_builds_setting && !virtual_store_only
+    {
+        unreviewed_dep_builds(
+            aube_dir,
+            graph_for_link,
+            build_policy,
+            virtual_store_dir_max_length,
+            placements_ref,
+        )?
+    } else {
+        Vec::new()
+    };
+
+    if !virtual_store_only && !filtered_install {
+        let phase_start = std::time::Instant::now();
+        // Fingerprint every package in the final graph so the next
+        // install can diff and skip unchanged entries. Missing or
+        // stale fingerprints fall back to a full install on the
+        // read side. Safe for older readers that ignore the field.
+        // When the early pass already produced the leaf map for
+        // `graph_for_link`, reuse it here as long as it covers every
+        // dep_path in the writeback `graph`. Filtered installs short-
+        // circuit before this branch so the two graphs are normally
+        // identical, but verifying every key keeps the reuse safe
+        // against any future code path that diverges them. Any miss
+        // falls back to a fresh compute over `graph`.
+        let package_content_hashes = current_leaf_hashes
+            .filter(|leaf| {
+                leaf.len() == graph.packages.len()
+                    && graph.packages.keys().all(|k| leaf.contains_key(k))
+            })
+            .unwrap_or_else(|| delta::compute_package_hashes(graph, &patch_hashes));
+        let package_subtree_hashes = current_subtree_hashes.unwrap_or_else(|| {
+            delta::compute_subtree_hashes_from_leaf(graph, &package_content_hashes)
+        });
+        let graph_lthash = hex::encode(delta::lthash_of(&package_content_hashes).digest());
+        let package_json_hashes = state::collect_package_json_hashes_from_manifests(cwd, manifests);
+        // Diff against the previous install. Logs delta counts at
+        // debug so `-v` installs surface what actually moved. A
+        // later pass feeds the plan into fetch and link as a
+        // pre-filter.
+        if let Some(prior) = state::read_state_package_content_hashes(cwd) {
+            let plan = delta::diff(&prior, &package_content_hashes);
+            if !plan.is_empty() {
+                // Touched set built once. Doubles as a membership
+                // probe so future wiring exercises the same shape
+                // of predicate shipped in production.
+                let touched = plan.touched_set();
+                tracing::debug!(
+                    "delta: +{} ~{} -{} ({} touched vs {} total, should_touch(first-added)={})",
+                    plan.added.len(),
+                    plan.changed.len(),
+                    plan.removed.len(),
+                    touched.len(),
+                    package_content_hashes.len(),
+                    plan.added.first().is_some_and(|dp| plan.should_touch(dp)),
+                );
+            }
+            // Incremental LtHash self-check. Start from the prior
+            // accumulator, apply the observed delta, confirm the
+            // result matches a from-scratch hash of the new graph.
+            // Cheap sanity on the homomorphic add/remove ops. The
+            // future causal scheduler needs these two to stay in
+            // lockstep with the full recompute.
+            if let Some(prior_lthash_hex) = state::read_state_graph_lthash(cwd)
+                && let Ok(prior_bytes) = hex::decode(&prior_lthash_hex)
+                && prior_bytes.len() == 32
+            {
+                let mut incr = delta::lthash_of(&prior);
+                for dp in &plan.removed {
+                    if let Some(fp) = prior.get(dp) {
+                        incr.remove(fp);
+                    }
+                }
+                for dp in &plan.added {
+                    if let Some(fp) = package_content_hashes.get(dp) {
+                        incr.add(fp);
+                    }
+                }
+                for dp in &plan.changed {
+                    if let Some(old_fp) = prior.get(dp) {
+                        incr.remove(old_fp);
+                    }
+                    if let Some(new_fp) = package_content_hashes.get(dp) {
+                        incr.add(new_fp);
+                    }
+                }
+                if hex::encode(incr.digest()) != graph_lthash {
+                    // Real bug signal, not routine noise. `debug`
+                    // hides it behind `-v` so CI would silently
+                    // ship broken homomorphic bookkeeping.
+                    tracing::warn!(
+                        code = aube_codes::warnings::WARN_AUBE_LTHASH_MISMATCH,
+                        "lthash: incremental/full mismatch, homomorphic invariant broken"
+                    );
+                }
+            }
+        }
+        // LtHash diagnostic. One 32-byte compare proves graph
+        // equivalence with the last install. Beats the map diff
+        // when both sides are known good.
+        if let Some(prior_lthash) = state::read_state_graph_lthash(cwd)
+            && prior_lthash != graph_lthash
+        {
+            tracing::debug!(
+                "lthash: graph content digest changed ({}..{} -> {}..{})",
+                &prior_lthash[..8.min(prior_lthash.len())],
+                &prior_lthash[prior_lthash.len().saturating_sub(8)..],
+                &graph_lthash[..8],
+                &graph_lthash[graph_lthash.len() - 8..],
+            );
+        }
+        // Merkle subtree diagnostic. How many subtree roots moved
+        // vs how many leaves moved. Fewer roots means tighter
+        // re-link scope once the delta linker lands.
+        if let Some(prior_subtrees) = state::read_state_subtree_hashes(cwd) {
+            let changed_subtrees = package_subtree_hashes
+                .iter()
+                .filter(|(k, v)| prior_subtrees.get(*k).is_none_or(|old| old != *v))
+                .count();
+            if changed_subtrees > 0 {
+                tracing::debug!(
+                    "merkle: {} subtree hashes changed of {}",
+                    changed_subtrees,
+                    package_subtree_hashes.len()
+                );
+            }
+        }
+        // Persist the unreviewed-builds set so the warm-path
+        // short-circuit can re-emit the warning on repeat installs.
+        // Computed once above and reused here. The state file
+        // carries only spec_keys; per-package suspicion data is
+        // re-derived from the live tree on each install rather
+        // than persisted, since the regex set evolves with aube.
+        let unreviewed_builds_for_state: Vec<String> = unreviewed_builds
+            .iter()
+            .map(|b| b.spec_key.clone())
+            .collect();
+        state::write_state(
+            cwd,
+            state::WriteStateInput {
+                section_filtered: dep_selection.prod_or_dev_axis(),
+                package_json_hashes,
+                cli_flags,
+                package_content_hashes,
+                graph_lthash,
+                package_subtree_hashes,
+                layout: state::WriteStateLayout {
+                    graph: graph_for_link,
+                    node_linker,
+                    modules_dir_name,
+                    aube_dir,
+                    virtual_store_dir_max_length,
+                    placements: placements_ref,
+                },
+                unreviewed_builds: unreviewed_builds_for_state,
+            },
+        )
+        .into_diagnostic()
+        .wrap_err("failed to write install state")?;
+        phase_timings.record("state", phase_start.elapsed());
+    }
+
+    // 8a. Sweep orphaned `.aube/<dep_path>` entries older than
+    //     `modulesCacheMaxAge`. The "in use" set is built from the
+    //     **unfiltered** `graph`, not `graph_for_link`, so that a
+    //     `--prod` / `--dev` / `--no-optional` / `--filter` install
+    //     doesn't treat the deps it skipped this run as orphans —
+    //     a subsequent full install would otherwise have to re-fetch
+    //     them. Runs best-effort: I/O errors are logged and swallowed
+    //     so a partial sweep never fails an install that otherwise
+    //     succeeded.
+    let modules_cache_max_age_minutes =
+        aube_settings::resolved::modules_cache_max_age(settings_ctx);
+    if modules_cache_max_age_minutes > 0 && !virtual_store_only {
+        let phase_start = std::time::Instant::now();
+        let removed = sweep_orphaned_aube_entries(
+            aube_dir,
+            graph,
+            virtual_store_dir_max_length,
+            std::time::Duration::from_secs(modules_cache_max_age_minutes.saturating_mul(60)),
+        );
+        if removed > 0 {
+            tracing::debug!("modulesCacheMaxAge: swept {removed} orphaned .aube entry/entries");
+        }
+        phase_timings.record("sweep", phase_start.elapsed());
+    }
+
+    let elapsed = start.elapsed();
+    tracing::debug!(
+        "Done in {:.0?}: {} packages ({} cached), {} files linked, {} top-level",
+        elapsed,
+        stats.packages_linked + stats.packages_cached,
+        stats.packages_cached,
+        stats.files_linked,
+        stats.top_level_linked
+    );
+    phase_timings.write(
+        cwd,
+        elapsed,
+        graph_for_link.packages.len(),
+        cached_count,
+        fetch_count,
+    );
+
+    if stats.packages_linked == 0
+        && stats.packages_cached == 0
+        && graph_for_link
+            .packages
+            .values()
+            .any(|p| p.local_source.is_none())
+    {
+        return Err(miette!("no packages were linked — something went wrong"));
+    }
+
+    // Deprecation warnings, gated by the `deprecationWarnings` setting.
+    // Prune to packages still in the finalized graph so we don't warn
+    // on platform-mismatched optionals that `filter_graph` trimmed,
+    // then dedupe across peer-context dep_path variants.
+    {
+        let mut records = std::mem::take(&mut *deprecations.lock().unwrap());
+        crate::deprecations::retain_in_graph(&mut records, graph_for_link);
+        let records = crate::deprecations::dedupe(records);
+        if !records.is_empty() {
+            let mode = aube_settings::resolved::deprecation_warnings(settings_ctx);
+            crate::deprecations::render_install_warnings(&records, graph_for_link, mode);
+        }
+    }
+
+    // Final user-facing output. When linking did real work, print the
+    // direct deps that now exist at the top level before the green
+    // `✓ installed N packages in Xs` line. Text modes such as `-v` and
+    // `--reporter=append-only` skip the progress object but still get the
+    // dependency summary; silent and ndjson stay machine-clean.
+    if !install_is_noop && should_print_human_install_summary() {
+        print_direct_dependency_summary(graph_for_link, manifests, direct_dep_info);
+    }
+    if let Some(p) = prog_ref {
+        p.print_install_summary(
+            stats.packages_linked,
+            stats.top_level_linked,
+            graph_for_link.packages.len(),
+            elapsed,
+        );
+    }
+
+    // Surface packages whose build scripts were skipped because they're
+    // not on the `allowBuilds` / `onlyBuiltDependencies` allowlist. Without
+    // this, a fresh install of a project that depends on native bindings
+    // (`better-sqlite3`, `esbuild`, napi-rs packages, etc.) looks like it
+    // succeeded but leaves those packages unbuilt — the failure only
+    // surfaces later when something tries to `require` the binding.
+    // Skipped under `--ignore-scripts`, `virtualStoreOnly`, and
+    // `strictDepBuilds=true` (the strict path already errored above).
+    if !unreviewed_builds.is_empty() {
+        unreviewed_builds::emit_warning(&unreviewed_builds);
+    }
+
+    Ok(())
+}

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1,7 +1,6 @@
 use super::make_client;
 use crate::progress::InstallProgress;
 use crate::state;
-use aube_lockfile::DriftStatus;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -22,6 +21,7 @@ mod link;
 mod lockfile_dir;
 mod materialize;
 pub(crate) mod node_gyp_bootstrap;
+mod resolve;
 mod settings;
 mod side_effects_cache;
 mod summary;
@@ -58,10 +58,8 @@ pub(crate) use side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_r
 
 use settings::{
     check_unmet_peers, default_streaming_network_concurrency, detect_aube_dir_gvs_mode,
-    find_gvs_incompatible_trigger, maybe_cleanup_unused_catalogs, resolve_dedupe_peer_dependents,
-    resolve_dedupe_peers, resolve_git_shallow_hosts, resolve_link_concurrency,
-    resolve_network_concurrency, resolve_peers_from_workspace_root,
-    resolve_peers_suffix_max_length, resolve_side_effects_cache,
+    find_gvs_incompatible_trigger, maybe_cleanup_unused_catalogs, resolve_git_shallow_hosts,
+    resolve_link_concurrency, resolve_network_concurrency, resolve_side_effects_cache,
     resolve_side_effects_cache_readonly, resolve_strict_peer_dependencies,
     resolve_strict_store_pkg_content_check, resolve_symlink, resolve_use_running_store_server,
     resolve_verify_store_integrity,
@@ -673,22 +671,13 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // full re-resolve without surfacing the actionable diagnostic.
     // `NotFound` is the one error we treat as expected — it just means
     // the lockfile is absent, which the downstream arms already handle.
-    let lockfile_pre_parse: Option<(aube_lockfile::LockfileGraph, aube_lockfile::LockfileKind)> =
-        if lockfile_enabled && matches!(mode, FrozenMode::Fix | FrozenMode::Prefer) {
-            match parse_lockfile_dir_remapped_with_kind(
-                &lockfile_dir,
-                &lockfile_importer_key,
-                &manifest,
-            ) {
-                Ok(parsed) => Some(parsed),
-                Err(aube_lockfile::Error::NotFound(_)) => None,
-                Err(e) => {
-                    return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile");
-                }
-            }
-        } else {
-            None
-        };
+    let lockfile_pre_parse = resolve::pre_parse_lockfile(
+        lockfile_enabled,
+        mode,
+        &lockfile_dir,
+        &lockfile_importer_key,
+        &manifest,
+    )?;
     let existing_for_resolver: Option<&aube_lockfile::LockfileGraph> =
         lockfile_pre_parse.as_ref().map(|(g, _)| g);
 
@@ -702,198 +691,33 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // projects that persistently disable node_modules materialization
     // share the exact same control flow.
     if lockfile_only_effective {
-        // `--no-frozen-lockfile` means "always re-resolve", so skip the
-        // freshness check entirely in that mode. Otherwise (Prefer, Fix,
-        // or CI's auto-Frozen) a fresh lockfile is a no-op — for Fix
-        // specifically, "fresh" means "nothing to fix."
-        let force_resolve = matches!(mode, FrozenMode::No);
-        // Reuse the up-front pre-parse when we already have it so we
-        // don't read and parse the same lockfile twice on
-        // `--lockfile-only`. The borrowed form is all the freshness
-        // check needs — `existing_for_resolver` still points at the
-        // same graph for the resolver call below.
-        let parsed_owned;
-        let parsed: Result<
-            (&aube_lockfile::LockfileGraph, aube_lockfile::LockfileKind),
-            &aube_lockfile::Error,
-        > = if let Some((g, k)) = lockfile_pre_parse.as_ref() {
-            Ok((g, *k))
-        } else {
-            parsed_owned = parse_lockfile_dir_remapped_with_kind(
-                &lockfile_dir,
-                &lockfile_importer_key,
-                &manifest,
-            );
-            match &parsed_owned {
-                Ok((g, k)) => Ok((g, *k)),
-                Err(e) => Err(e),
-            }
-        };
-        if let Err(e) = parsed
-            && !matches!(e, aube_lockfile::Error::NotFound(_))
-        {
-            // Can't hand &Error to miette::Report since Diagnostic
-            // is only implemented on owned Error. Re-parse once to
-            // get an owned Error value for the Diagnostic path.
-            // Slightly wasteful on the error branch, install is
-            // about to abort anyway so speed does not matter here.
-            // What matters: keeping the source span and miette help
-            // text instead of flattening to one line via `{e}`.
-            match parse_lockfile_dir_remapped_with_kind(
-                &lockfile_dir,
-                &lockfile_importer_key,
-                &manifest,
-            ) {
-                Ok(_) => {
-                    // Race: second parse succeeded while first failed.
-                    // Surface the observed error text as a best
-                    // effort flat message. Extremely unlikely.
-                    return Err(miette!("failed to parse lockfile: {e}"));
-                }
-                Err(owned) => {
-                    return Err(miette::Report::new(owned)).wrap_err("failed to parse lockfile");
-                }
-            }
-        }
-        let fresh = !force_resolve
-            && matches!(
-                parsed,
-                Ok((g, _))
-                    if matches!(
-                        g.check_drift_workspace(&manifests, &ws_config_shared.overrides, &ws_config_shared.ignored_optional_dependencies, &workspace_catalogs, is_workspace_project),
-                        DriftStatus::Fresh,
-                    )
-                        && matches!(g.check_catalogs_drift(&workspace_catalogs), DriftStatus::Fresh)
-            );
-        if fresh {
-            tracing::debug!("--lockfile-only: lockfile already up to date");
-            if let Some(p) = prog_ref {
-                p.finish(true);
-            }
-            eprintln!("Lockfile is up to date, resolution step is skipped");
-            return Ok(());
-        }
-        if let Some(p) = prog_ref {
-            p.set_phase("resolving");
-        }
-        let client = std::sync::Arc::new(make_client(&cwd).with_network_mode(opts.network_mode));
-        let pnpmfile_paths = if opts.ignore_pnpmfile {
-            Vec::new()
-        } else {
-            crate::pnpmfile::ordered_paths(
-                crate::pnpmfile::detect_global(&cwd, opts.global_pnpmfile.as_deref()).as_deref(),
-                crate::pnpmfile::detect(
-                    &cwd,
-                    opts.pnpmfile.as_deref(),
-                    ws_config_shared.pnpmfile_path.as_deref(),
-                )
-                .as_deref(),
-            )
-        };
-        super::run_pnpmfile_pre_resolution(&pnpmfile_paths, &cwd, existing_for_resolver).await?;
-        let (read_package_host, read_package_forwarders) =
-            match crate::pnpmfile::ReadPackageHostChain::spawn(&pnpmfile_paths, &cwd)
-                .await
-                .wrap_err("failed to start pnpmfile readPackage host")?
-            {
-                Some((h, f)) => (Some(h), f),
-                None => (None, Vec::new()),
-            };
-        let read_package_hook: Option<Box<dyn aube_resolver::ReadPackageHook>> =
-            read_package_host.map(|h| Box::new(h) as Box<dyn aube_resolver::ReadPackageHook>);
-        let mut resolver = configure_resolver(
-            aube_resolver::Resolver::new(client.clone()),
-            &cwd,
-            &manifest,
-            ResolverConfigInputs {
-                settings_ctx: &settings_ctx,
-                workspace_config: &ws_config_shared,
-                workspace_catalogs: &workspace_catalogs,
-                minimum_release_age_override: opts.minimum_release_age_override,
-                // `lockfile=false` collapses to `None` so the resolver
-                // doesn't waste a fetch widening a lockfile that will
-                // never be written. With lockfiles enabled, a missing
-                // `source_kind_before` means "we'll create the default
-                // aube-lock.yaml", so the aube-native wide default
-                // applies.
-                target_lockfile_kind: lockfile_enabled
-                    .then(|| source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube)),
-                cache_full_packuments: true,
-            },
-            read_package_hook,
-        );
-        let mut graph = if has_workspace {
-            resolver
-                .resolve_workspace(&manifests, existing_for_resolver, &ws_package_versions)
-                .await
-        } else {
-            resolver.resolve(&manifest, existing_for_resolver).await
-        }
-        .map_err(miette::Report::new)
-        .wrap_err("failed to resolve dependencies")?;
-        drop(resolver);
-        // Drain the readPackage stderr forwarders so every `ctx.log`
-        // record they captured during resolve flushes to stdout before
-        // afterAllResolved emits its own pnpm:hook records — keeps
-        // resolve-time logs strictly ahead of post-resolve logs in the
-        // ndjson stream.
-        crate::pnpmfile::ReadPackageHostChain::drain_forwarders(read_package_forwarders).await;
-        crate::pnpmfile::run_after_all_resolved_chain(&pnpmfile_paths, &cwd, &mut graph).await?;
-        // Same tarball-URL population pass as the main fetch branch —
-        // keeps `--lockfile-only` and regular installs byte-identical.
-        // Reuses the resolver's `client` (already built above) to avoid
-        // re-walking `.npmrc` and rebuilding the rustls client just to
-        // construct registry URLs.
-        if lockfile_include_tarball_url {
-            let lo_client = client.as_ref();
-            graph.settings.lockfile_include_tarball_url = true;
-            for pkg in graph.packages.values_mut() {
-                if pkg.local_source.is_some() {
-                    continue;
-                }
-                // Preserve any URL the parser already captured from an
-                // aliased `resolved:` field — deriving from
-                // `(registry_name, version)` would also work for
-                // aliases but skips a redundant allocation.
-                if pkg.tarball_url.is_none() {
-                    pkg.tarball_url =
-                        Some(lo_client.tarball_url(pkg.registry_name(), &pkg.version));
-                }
-            }
-        }
-        let lo_write_kind = source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube);
-        if shared_workspace_lockfile || !has_workspace {
-            let lo_written = write_lockfile_dir_remapped(
-                &lockfile_dir,
-                &lockfile_importer_key,
-                &graph,
-                &manifest,
-                lo_write_kind,
-            )
-            .into_diagnostic()
-            .wrap_err("failed to write lockfile")?;
-            tracing::debug!(
-                "--lockfile-only: wrote {}",
-                lo_written
-                    .file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| lo_written.display().to_string())
-            );
-        } else {
-            write_per_project_lockfiles(&cwd, &graph, &manifests, lo_write_kind)?;
-        }
-        // Prune unused catalog entries *after* the lockfile hits disk —
-        // same ordering as the main install path below, so a
-        // workspace-yaml write error can't block the command's
-        // primary output.
-        maybe_cleanup_unused_catalogs(&cwd, &settings_ctx, &workspace_catalogs, &graph.catalogs)?;
-        if let Some(p) = prog_ref {
-            p.finish(true);
-        }
-        eprintln!(
-            "Lockfile written ({} packages); skipped node_modules linking",
-            graph.packages.len()
-        );
+        resolve::run_lockfile_only(resolve::LockfileOnlyInput {
+            cwd: &cwd,
+            mode,
+            lockfile_dir: &lockfile_dir,
+            lockfile_importer_key: &lockfile_importer_key,
+            manifest: &manifest,
+            manifests: &manifests,
+            ws_config: &ws_config_shared,
+            workspace_catalogs: &workspace_catalogs,
+            settings_ctx: &settings_ctx,
+            lockfile_pre_parse: lockfile_pre_parse.as_ref(),
+            existing_for_resolver,
+            source_kind_before,
+            lockfile_enabled,
+            lockfile_include_tarball_url,
+            shared_workspace_lockfile,
+            has_workspace,
+            is_workspace_project,
+            ignore_pnpmfile: opts.ignore_pnpmfile,
+            network_mode: opts.network_mode,
+            global_pnpmfile: opts.global_pnpmfile.as_deref(),
+            pnpmfile: opts.pnpmfile.as_deref(),
+            minimum_release_age_override: opts.minimum_release_age_override,
+            ws_package_versions: &ws_package_versions,
+            prog_ref,
+        })
+        .await?;
         return Ok(());
     }
 
@@ -1035,104 +859,19 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         }
     };
 
-    // Decide what to do with whatever lockfile is on disk based on FrozenMode + drift.
-    // Returns either:
-    //   - Ok((graph, kind))           → use the lockfile as-is
-    //   - Err(NotFound)                → fall through to the resolver
-    //   - Err(other) / early return    → hard fail
-    //
-    // When `lockfile=false`, skip the lockfile layer entirely: we
-    // always fall through to the resolver. This explicitly overrides
-    // FrozenMode::Frozen, since "use the lockfile strictly" contradicts
-    // "don't use a lockfile" — the canonical interpretation is that
-    // frozen mode is a no-op without a lockfile to freeze against.
-    let lockfile_result = if !lockfile_enabled {
-        tracing::debug!("lockfile=false: skipping lockfile parse, re-resolving");
-        Err(aube_lockfile::Error::NotFound(cwd.clone()))
-    } else {
-        match mode {
-            FrozenMode::No => {
-                // Always re-resolve.
-                Err(aube_lockfile::Error::NotFound(cwd.clone()))
-            }
-            FrozenMode::Fix => {
-                // Always fall through to re-resolve; `existing_for_resolver`
-                // carries the current lockfile (if any) so the resolver
-                // reuses locked versions for unchanged specs and only
-                // re-resolves entries whose spec drifted.
-                Err(aube_lockfile::Error::NotFound(cwd.clone()))
-            }
-            FrozenMode::Frozen => {
-                // Use the lockfile, but error out on any drift across all workspace importers.
-                let parsed = parse_lockfile_dir_remapped_with_kind(
-                    &lockfile_dir,
-                    &lockfile_importer_key,
-                    &manifest,
-                );
-                if let Ok((ref graph, _)) = parsed {
-                    if let DriftStatus::Stale { reason } =
-                        graph.check_catalogs_drift(&workspace_catalogs)
-                    {
-                        return Err(miette!(
-                            "lockfile is out of date with pnpm-workspace.yaml: {reason}\n\
-                         help: run without --frozen-lockfile to update the lockfile"
-                        ));
-                    }
-                    if let DriftStatus::Stale { reason } = graph.check_drift_workspace(
-                        &manifests,
-                        &ws_config_shared.overrides,
-                        &ws_config_shared.ignored_optional_dependencies,
-                        &workspace_catalogs,
-                        is_workspace_project,
-                    ) {
-                        return Err(miette!(
-                            "lockfile is out of date with package.json: {reason}\n\
-                         help: run without --frozen-lockfile to update the lockfile, \
-                         or run `aube install --no-frozen-lockfile` to regenerate it"
-                        ));
-                    }
-                }
-                parsed
-            }
-            FrozenMode::Prefer => {
-                // Use the lockfile when fresh, otherwise pretend there isn't one
-                // so the existing "no lockfile → resolve" branch handles it.
-                // Reuse `lockfile_pre_parse` instead of parsing the same file
-                // a second time — on Prefer-fresh we clone the graph so the
-                // borrow held by `existing_for_resolver` keeps pointing at
-                // the original (unused on the fresh path, but safe to leave).
-                match lockfile_pre_parse.as_ref() {
-                    Some((graph, kind)) => {
-                        if let DriftStatus::Stale { reason } =
-                            graph.check_catalogs_drift(&workspace_catalogs)
-                        {
-                            tracing::debug!(
-                                "Lockfile out of date with workspace catalogs ({reason}), re-resolving..."
-                            );
-                            Err(aube_lockfile::Error::NotFound(cwd.clone()))
-                        } else {
-                            match graph.check_drift_workspace(
-                                &manifests,
-                                &ws_config_shared.overrides,
-                                &ws_config_shared.ignored_optional_dependencies,
-                                &workspace_catalogs,
-                                is_workspace_project,
-                            ) {
-                                DriftStatus::Fresh => Ok((graph.clone(), *kind)),
-                                DriftStatus::Stale { reason } => {
-                                    tracing::debug!(
-                                        "Lockfile out of date ({reason}), re-resolving..."
-                                    );
-                                    Err(aube_lockfile::Error::NotFound(cwd.clone()))
-                                }
-                            }
-                        }
-                    }
-                    None => Err(aube_lockfile::Error::NotFound(cwd.clone())),
-                }
-            }
-        }
-    };
+    let lockfile_result = resolve::select_lockfile_result(resolve::SelectLockfileInput {
+        lockfile_enabled,
+        mode,
+        cwd: &cwd,
+        lockfile_dir: &lockfile_dir,
+        lockfile_importer_key: &lockfile_importer_key,
+        manifest: &manifest,
+        manifests: &manifests,
+        ws_config: &ws_config_shared,
+        workspace_catalogs: &workspace_catalogs,
+        is_workspace_project,
+        lockfile_pre_parse: lockfile_pre_parse.as_ref(),
+    })?;
 
     // Deprecation messages from freshly-resolved packages. Only the
     // no-lockfile branch below populates this; the lockfile-reuse branch
@@ -1158,110 +897,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     let mut prewarm_graph_hashes: Option<std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>> =
         None;
     let (graph, package_indices, cached_count, fetch_count) = match lockfile_result {
-        Ok((mut graph, kind)) => {
-            // Drop optional deps that don't match the current platform
-            // (or are in `pnpm.ignoredOptionalDependencies`) before we
-            // start fetching tarballs. The resolver's inline filter
-            // never runs on the lockfile-happy path, so this pass is
-            // what makes cross-platform lockfile installs work.
-            let (sup_os, sup_cpu, sup_libc) =
-                aube_manifest::effective_supported_architectures(&manifest, &ws_config_shared);
-            let supported_architectures = aube_resolver::SupportedArchitectures {
-                os: sup_os,
-                cpu: sup_cpu,
-                libc: sup_libc,
-                ..Default::default()
-            };
-            let ignored_optional_deps = aube_manifest::effective_ignored_optional_dependencies(
+        Ok((graph, kind)) => {
+            let graph = resolve::apply_lockfile_graph_platform_rules(
+                graph,
+                kind,
                 &manifest,
                 &ws_config_shared,
-            );
-            // npm/bun lockfiles serialize a flat, pre-hoisted tree
-            // with no peer context — they rely on Node's upward
-            // `node_modules/` walk to find peer deps, which the
-            // isolated virtual store breaks. Fresh resolves flow
-            // through `Resolver::resolve_workspace`, which runs
-            // `hoist_auto_installed_peers` + `apply_peer_contexts` on
-            // its way out; the lockfile path has to replicate those
-            // two steps explicitly or peer-dependent packages
-            // (e.g. `@tanstack/devtools-vite` peering on `vite`)
-            // install with no sibling peer link and die at runtime
-            // with `Cannot find package`.
-            //
-            // `aube-lock.yaml` / `pnpm-lock.yaml` already carry
-            // peer-context suffixes and peer edges merged into
-            // `dependencies`, so we skip them — re-running the pass
-            // would double-suffix every key.
-            //
-            // Yarn v1 has the same flat shape but is intentionally
-            // omitted: real-world `yarn.lock` files don't record
-            // `peerDependencies` per entry (yarn 1.22 emits them
-            // only on the workspace root), so running the pass would
-            // be a no-op. Making yarn v1 imports peer-correct needs
-            // a packument fetch on the import path to graft peer
-            // ranges back onto each `LockedPackage` — a deeper
-            // change than this match arm.
-            //
-            // The hoist must run *before* `filter_graph`: bun records
-            // peer-only-installed packages (e.g. `@mui/material` when
-            // the importer only depends on `@textea/json-viewer`, which
-            // peers on MUI) in its packages map, but our bun parser
-            // doesn't merge those into the consumer's `dependencies`
-            // map. `filter_graph`'s GC walk only follows `dependencies`,
-            // so without the hoist running first it prunes every
-            // peer-only package as unreachable — and a post-prune hoist
-            // has nothing left to promote.
-            let needs_peer_pass = matches!(
-                kind,
-                aube_lockfile::LockfileKind::Npm
-                    | aube_lockfile::LockfileKind::NpmShrinkwrap
-                    | aube_lockfile::LockfileKind::Bun
-            );
-            // Time the hoist on its own, then `filter_graph` runs untimed
-            // (it's not part of the peer pass), then apply is timed below.
-            // Snapshotting `pkgs_before` after `filter_graph` keeps the
-            // logged delta a pure measure of `apply_peer_contexts`'s
-            // additions, not filter_graph's prunes.
-            let mut hoist_elapsed: Option<std::time::Duration> = None;
-            if needs_peer_pass {
-                let hoist_start = std::time::Instant::now();
-                graph = aube_resolver::hoist_auto_installed_peers(graph);
-                hoist_elapsed = Some(hoist_start.elapsed());
-            }
-            aube_resolver::platform::filter_graph(
-                &mut graph,
-                &supported_architectures,
-                &ignored_optional_deps,
-            );
-            if let Some(hoist_elapsed) = hoist_elapsed {
-                let peer_options = aube_resolver::PeerContextOptions {
-                    dedupe_peer_dependents: resolve_dedupe_peer_dependents(&settings_ctx),
-                    dedupe_peers: resolve_dedupe_peers(&settings_ctx),
-                    resolve_from_workspace_root: resolve_peers_from_workspace_root(&settings_ctx),
-                    peers_suffix_max_length: resolve_peers_suffix_max_length(&settings_ctx),
-                };
-                let pkgs_before = graph.packages.len();
-                let apply_start = std::time::Instant::now();
-                graph = aube_resolver::apply_peer_contexts(graph, &peer_options)
-                    .map_err(|e| miette!("peer-context pass failed: {e}"))?;
-                tracing::debug!(
-                    "peer-context pass (lockfile={:?}) {} → {} packages in {:.1?}",
-                    kind,
-                    pkgs_before,
-                    graph.packages.len(),
-                    hoist_elapsed + apply_start.elapsed()
-                );
-            }
-            let source_label = match kind {
-                aube_lockfile::LockfileKind::Aube => "Lockfile",
-                aube_lockfile::LockfileKind::Pnpm => "pnpm-lock.yaml",
-                aube_lockfile::LockfileKind::Yarn | aube_lockfile::LockfileKind::YarnBerry => {
-                    "yarn.lock"
-                }
-                aube_lockfile::LockfileKind::Npm => "package-lock.json",
-                aube_lockfile::LockfileKind::NpmShrinkwrap => "npm-shrinkwrap.json",
-                aube_lockfile::LockfileKind::Bun => "bun.lock",
-            };
+                &settings_ctx,
+            )?;
+            let source_label = resolve::lockfile_source_label(kind);
             tracing::debug!(
                 "{source_label}: {} packages for {project_name}",
                 graph.packages.len()

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -13,6 +13,7 @@ mod critical_path;
 mod delta;
 mod dep_selection;
 mod fetch;
+mod finalize;
 mod frozen;
 mod git_prepare;
 mod layout;
@@ -43,8 +44,7 @@ pub(crate) use lifecycle::{
     run_dep_lifecycle_scripts,
 };
 use lifecycle::{
-    resolve_link_strategy, run_import_on_blocking, run_root_lifecycle, unreviewed_dep_builds,
-    validate_required_scripts,
+    resolve_link_strategy, run_import_on_blocking, run_root_lifecycle, validate_required_scripts,
 };
 use lockfile_dir::{
     parse_lockfile_dir_remapped, parse_lockfile_dir_remapped_with_kind, write_lockfile_dir_remapped,
@@ -66,10 +66,7 @@ use settings::{
     resolve_strict_store_pkg_content_check, resolve_symlink, resolve_use_running_store_server,
     resolve_verify_store_integrity,
 };
-use summary::{
-    print_already_up_to_date, print_direct_dependency_summary, should_print_human_install_summary,
-};
-use sweep::sweep_orphaned_aube_entries;
+use summary::print_already_up_to_date;
 use workspace::{
     filter_graph_to_importers, filter_graph_to_workspace_selection, importer_project_dir,
     order_lifecycle_manifests, write_per_project_lockfiles,
@@ -2468,390 +2465,42 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         prog_ref,
         phase_timings: &mut phase_timings,
     })?;
-    let placements_ref = stats.hoisted_placements.as_ref();
-
-    // Tear down the progress display before running post-link lifecycle
-    // scripts or printing the final summary — scripts write directly to
-    // stdout/stderr and would collide with an active progress bar.
-    //
-    // Skip the CI-mode framed summary on a no-op install: `print_install_summary`
-    // below will print the "Already up to date" branded line, and we don't
-    // want CI users to see both the framed `[ ✓ … resolved N · reused N ]`
-    // block and the branded line as redundant twins.
-    let install_is_noop = stats.packages_linked == 0 && stats.top_level_linked == 0;
-    if let Some(p) = prog_ref {
-        p.finish(!install_is_noop);
-    }
-
-    if !opts.ignore_scripts && strict_dep_builds_setting && !virtual_store_only {
-        let unreviewed = unreviewed_dep_builds(
-            &aube_dir,
-            &graph_for_link,
-            &build_policy,
-            virtual_store_dir_max_length,
-            placements_ref,
-        )?;
-        if !unreviewed.is_empty() {
-            return Err(miette!(
-                "dependencies with build scripts must be reviewed before install:\n{}\nhelp: add the package(s) to `allowBuilds` with `true`/`false`, or set `strictDepBuilds=false`",
-                unreviewed
-                    .into_iter()
-                    .map(|b| format!("  - {}", b.spec_key))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            ));
-        }
-    }
-
-    // 7a. Dependency lifecycle scripts (allowBuilds).
-    //     Every dep that the `BuildPolicy` explicitly allows runs its
-    //     `preinstall` / `install` / `postinstall` scripts from inside
-    //     its linked directory under `node_modules/.aube`. Reuses the
-    //     already-constructed `build_policy` from above. Skipped
-    //     entirely under `--ignore-scripts` (pnpm parity) and when the
-    //     policy has no allow rules at all (fast path: no config, no
-    //     cost). A failing dep script fails the whole install —
-    //     matching pnpm's fail-fast default. No cross-project
-    //     collision warning here: step 6a content-addresses the
-    //     global store so two projects resolving the same
-    //     `(dep-graph, engine)` share a safe directory and divergent
-    //     resolutions land at distinct paths.
-    if !opts.ignore_scripts && build_policy.has_any_allow_rule() && !virtual_store_only {
-        let phase_start = std::time::Instant::now();
-        let side_effects_cache_root =
-            side_effects_cache_setting.then(|| side_effects_cache_root(store.as_ref()));
-        let side_effects_cache = side_effects_cache_root
-            .as_deref()
-            .map(|root| {
-                if side_effects_cache_readonly_setting {
-                    SideEffectsCacheConfig::RestoreOnly(root)
-                } else {
-                    SideEffectsCacheConfig::RestoreAndSave(root)
-                }
-            })
-            .unwrap_or(SideEffectsCacheConfig::Disabled);
-        let ran = run_dep_lifecycle_scripts(
-            &cwd,
-            &modules_dir_name,
-            &aube_dir,
-            &graph_for_link,
-            &build_policy,
-            virtual_store_dir_max_length,
-            child_concurrency,
-            placements_ref,
-            side_effects_cache,
-            &jail_policy,
-            None,
-        )
-        .await?;
-        if ran > 0 {
-            tracing::debug!("allowBuilds: ran {ran} dep lifecycle script(s)");
-        }
-        phase_timings.record("dep_lifecycle", phase_start.elapsed());
-    }
-
-    // 7b. Post-link root lifecycle hooks: install → postinstall → prepare.
-    //     npm and pnpm run these in this order after deps are linked so the
-    //     scripts can use anything they depend on. Skipped with --ignore-scripts
-    //     and under `virtualStoreOnly` — scripts typically resolve
-    //     binaries via `node_modules/.bin`, which doesn't exist in
-    //     that mode.
-    //     A hook that's not defined in package.json is a silent no-op.
-    //     A hook that exits non-zero fails the install (fail-fast, matching pnpm).
-    if !opts.ignore_scripts && !virtual_store_only && !opts.skip_root_lifecycle {
-        let phase_start = std::time::Instant::now();
-        for (importer_path, importer_manifest) in &lifecycle_manifests {
-            let project_dir = importer_project_dir(&cwd, importer_path);
-            for hook in [
-                aube_scripts::LifecycleHook::Install,
-                aube_scripts::LifecycleHook::PostInstall,
-                aube_scripts::LifecycleHook::Prepare,
-            ] {
-                run_root_lifecycle(&project_dir, &modules_dir_name, importer_manifest, hook)
-                    .await?;
-            }
-        }
-        phase_timings.record("root_lifecycle", phase_start.elapsed());
-    }
-
-    // 8. Write state file for auto-install tracking.
-    //    Record whether this was a --prod install so ensure_installed knows
-    //    to re-install the full graph before running dev tooling.
-    //    Skipped under `virtualStoreOnly` — the state sidecar is
-    //    keyed off a materialized node_modules tree that doesn't
-    //    exist, and writing it would lie on the next auto-install
-    //    freshness check. Same skip when a workspace filter scoped the
-    //    run to a subset of importers. State hash is derived from full
-    //    manifest + lockfile inputs, so writing it after a partial
-    //    materialize would let the next unfiltered `aube install` hit
-    //    the warm path while unfiltered importers are still empty.
-    //    Observed via `aube add <pkg> --filter <ws>` leaving the new
-    //    dep unmaterialized.
-    let filtered_install = !opts.workspace_filter.is_empty() || opts.dep_selection.is_filtered();
-
-    // Walk the linked graph once for the unreviewed-builds set; reused
-    // by both the state writer (so warm-path repeats keep nudging) and
-    // the post-install warning emission below. The walk does a stat per
-    // package, so collapsing two callers into one cuts the linker-tail
-    // cost on large graphs roughly in half.
-    let unreviewed_builds =
-        if !opts.ignore_scripts && !strict_dep_builds_setting && !virtual_store_only {
-            unreviewed_dep_builds(
-                &aube_dir,
-                &graph_for_link,
-                &build_policy,
-                virtual_store_dir_max_length,
-                placements_ref,
-            )?
-        } else {
-            Vec::new()
-        };
-
-    if !virtual_store_only && !filtered_install {
-        let phase_start = std::time::Instant::now();
-        // Fingerprint every package in the final graph so the next
-        // install can diff and skip unchanged entries. Missing or
-        // stale fingerprints fall back to a full install on the
-        // read side. Safe for older readers that ignore the field.
-        // When the early pass already produced the leaf map for
-        // `graph_for_link`, reuse it here as long as it covers every
-        // dep_path in the writeback `graph`. Filtered installs short-
-        // circuit before this branch so the two graphs are normally
-        // identical, but verifying every key keeps the reuse safe
-        // against any future code path that diverges them. Any miss
-        // falls back to a fresh compute over `graph`.
-        let package_content_hashes = current_leaf_hashes
-            .filter(|leaf| {
-                leaf.len() == graph.packages.len()
-                    && graph.packages.keys().all(|k| leaf.contains_key(k))
-            })
-            .unwrap_or_else(|| delta::compute_package_hashes(&graph, &patch_hashes));
-        let package_subtree_hashes = current_subtree_hashes.unwrap_or_else(|| {
-            delta::compute_subtree_hashes_from_leaf(&graph, &package_content_hashes)
-        });
-        let graph_lthash = hex::encode(delta::lthash_of(&package_content_hashes).digest());
-        let package_json_hashes =
-            state::collect_package_json_hashes_from_manifests(&cwd, &manifests);
-        // Diff against the previous install. Logs delta counts at
-        // debug so `-v` installs surface what actually moved. A
-        // later pass feeds the plan into fetch and link as a
-        // pre-filter.
-        if let Some(prior) = state::read_state_package_content_hashes(&cwd) {
-            let plan = delta::diff(&prior, &package_content_hashes);
-            if !plan.is_empty() {
-                // Touched set built once. Doubles as a membership
-                // probe so future wiring exercises the same shape
-                // of predicate shipped in production.
-                let touched = plan.touched_set();
-                tracing::debug!(
-                    "delta: +{} ~{} -{} ({} touched vs {} total, should_touch(first-added)={})",
-                    plan.added.len(),
-                    plan.changed.len(),
-                    plan.removed.len(),
-                    touched.len(),
-                    package_content_hashes.len(),
-                    plan.added.first().is_some_and(|dp| plan.should_touch(dp)),
-                );
-            }
-            // Incremental LtHash self-check. Start from the prior
-            // accumulator, apply the observed delta, confirm the
-            // result matches a from-scratch hash of the new graph.
-            // Cheap sanity on the homomorphic add/remove ops. The
-            // future causal scheduler needs these two to stay in
-            // lockstep with the full recompute.
-            if let Some(prior_lthash_hex) = state::read_state_graph_lthash(&cwd)
-                && let Ok(prior_bytes) = hex::decode(&prior_lthash_hex)
-                && prior_bytes.len() == 32
-            {
-                let mut incr = delta::lthash_of(&prior);
-                for dp in &plan.removed {
-                    if let Some(fp) = prior.get(dp) {
-                        incr.remove(fp);
-                    }
-                }
-                for dp in &plan.added {
-                    if let Some(fp) = package_content_hashes.get(dp) {
-                        incr.add(fp);
-                    }
-                }
-                for dp in &plan.changed {
-                    if let Some(old_fp) = prior.get(dp) {
-                        incr.remove(old_fp);
-                    }
-                    if let Some(new_fp) = package_content_hashes.get(dp) {
-                        incr.add(new_fp);
-                    }
-                }
-                if hex::encode(incr.digest()) != graph_lthash {
-                    // Real bug signal, not routine noise. `debug`
-                    // hides it behind `-v` so CI would silently
-                    // ship broken homomorphic bookkeeping.
-                    tracing::warn!(
-                        code = aube_codes::warnings::WARN_AUBE_LTHASH_MISMATCH,
-                        "lthash: incremental/full mismatch, homomorphic invariant broken"
-                    );
-                }
-            }
-        }
-        // LtHash diagnostic. One 32-byte compare proves graph
-        // equivalence with the last install. Beats the map diff
-        // when both sides are known good.
-        if let Some(prior_lthash) = state::read_state_graph_lthash(&cwd)
-            && prior_lthash != graph_lthash
-        {
-            tracing::debug!(
-                "lthash: graph content digest changed ({}..{} -> {}..{})",
-                &prior_lthash[..8.min(prior_lthash.len())],
-                &prior_lthash[prior_lthash.len().saturating_sub(8)..],
-                &graph_lthash[..8],
-                &graph_lthash[graph_lthash.len() - 8..],
-            );
-        }
-        // Merkle subtree diagnostic. How many subtree roots moved
-        // vs how many leaves moved. Fewer roots means tighter
-        // re-link scope once the delta linker lands.
-        if let Some(prior_subtrees) = state::read_state_subtree_hashes(&cwd) {
-            let changed_subtrees = package_subtree_hashes
-                .iter()
-                .filter(|(k, v)| prior_subtrees.get(*k).is_none_or(|old| old != *v))
-                .count();
-            if changed_subtrees > 0 {
-                tracing::debug!(
-                    "merkle: {} subtree hashes changed of {}",
-                    changed_subtrees,
-                    package_subtree_hashes.len()
-                );
-            }
-        }
-        // Persist the unreviewed-builds set so the warm-path
-        // short-circuit can re-emit the warning on repeat installs.
-        // Computed once above and reused here. The state file
-        // carries only spec_keys; per-package suspicion data is
-        // re-derived from the live tree on each install rather
-        // than persisted, since the regex set evolves with aube.
-        let unreviewed_builds_for_state: Vec<String> = unreviewed_builds
-            .iter()
-            .map(|b| b.spec_key.clone())
-            .collect();
-        state::write_state(
-            &cwd,
-            state::WriteStateInput {
-                section_filtered: opts.dep_selection.prod_or_dev_axis(),
-                package_json_hashes,
-                cli_flags: &opts.cli_flags,
-                package_content_hashes,
-                graph_lthash,
-                package_subtree_hashes,
-                layout: state::WriteStateLayout {
-                    graph: &graph_for_link,
-                    node_linker,
-                    modules_dir_name: &modules_dir_name,
-                    aube_dir: &aube_dir,
-                    virtual_store_dir_max_length,
-                    placements: placements_ref,
-                },
-                unreviewed_builds: unreviewed_builds_for_state,
-            },
-        )
-        .into_diagnostic()
-        .wrap_err("failed to write install state")?;
-        phase_timings.record("state", phase_start.elapsed());
-    }
-
-    // 8a. Sweep orphaned `.aube/<dep_path>` entries older than
-    //     `modulesCacheMaxAge`. The "in use" set is built from the
-    //     **unfiltered** `graph`, not `graph_for_link`, so that a
-    //     `--prod` / `--dev` / `--no-optional` / `--filter` install
-    //     doesn't treat the deps it skipped this run as orphans —
-    //     a subsequent full install would otherwise have to re-fetch
-    //     them. Runs best-effort: I/O errors are logged and swallowed
-    //     so a partial sweep never fails an install that otherwise
-    //     succeeded.
-    let modules_cache_max_age_minutes =
-        aube_settings::resolved::modules_cache_max_age(&settings_ctx);
-    if modules_cache_max_age_minutes > 0 && !virtual_store_only {
-        let phase_start = std::time::Instant::now();
-        let removed = sweep_orphaned_aube_entries(
-            &aube_dir,
-            &graph,
-            virtual_store_dir_max_length,
-            std::time::Duration::from_secs(modules_cache_max_age_minutes.saturating_mul(60)),
-        );
-        if removed > 0 {
-            tracing::debug!("modulesCacheMaxAge: swept {removed} orphaned .aube entry/entries");
-        }
-        phase_timings.record("sweep", phase_start.elapsed());
-    }
-
-    let elapsed = start.elapsed();
-    tracing::debug!(
-        "Done in {:.0?}: {} packages ({} cached), {} files linked, {} top-level",
-        elapsed,
-        stats.packages_linked + stats.packages_cached,
-        stats.packages_cached,
-        stats.files_linked,
-        stats.top_level_linked
-    );
-    phase_timings.write(
-        &cwd,
-        elapsed,
-        graph_for_link.packages.len(),
+    finalize::run_finalize_phase(finalize::FinalizePhaseInput {
+        cwd: &cwd,
+        settings_ctx: &settings_ctx,
+        store: store.as_ref(),
+        graph: &graph,
+        graph_for_link: &graph_for_link,
+        manifests: &manifests,
+        lifecycle_manifests: &lifecycle_manifests,
+        direct_dep_info: &direct_dep_info,
+        deprecations: &deprecations,
+        build_policy: &build_policy,
+        jail_policy: &jail_policy,
+        stats: &stats,
+        node_linker,
+        virtual_store_only,
+        current_leaf_hashes,
+        current_subtree_hashes,
+        patch_hashes,
+        modules_dir_name: &modules_dir_name,
+        aube_dir: &aube_dir,
+        virtual_store_dir_max_length,
+        child_concurrency,
+        side_effects_cache_setting,
+        side_effects_cache_readonly_setting,
+        strict_dep_builds_setting,
+        ignore_scripts: opts.ignore_scripts,
+        skip_root_lifecycle: opts.skip_root_lifecycle,
+        workspace_filter_empty: opts.workspace_filter.is_empty(),
+        dep_selection: opts.dep_selection,
+        cli_flags: &opts.cli_flags,
         cached_count,
         fetch_count,
-    );
-
-    if stats.packages_linked == 0
-        && stats.packages_cached == 0
-        && graph_for_link
-            .packages
-            .values()
-            .any(|p| p.local_source.is_none())
-    {
-        return Err(miette!("no packages were linked — something went wrong"));
-    }
-
-    // Deprecation warnings, gated by the `deprecationWarnings` setting.
-    // Prune to packages still in the finalized graph so we don't warn
-    // on platform-mismatched optionals that `filter_graph` trimmed,
-    // then dedupe across peer-context dep_path variants.
-    {
-        let mut records = std::mem::take(&mut *deprecations.lock().unwrap());
-        crate::deprecations::retain_in_graph(&mut records, &graph_for_link);
-        let records = crate::deprecations::dedupe(records);
-        if !records.is_empty() {
-            let mode = aube_settings::resolved::deprecation_warnings(&settings_ctx);
-            crate::deprecations::render_install_warnings(&records, &graph_for_link, mode);
-        }
-    }
-
-    // Final user-facing output. When linking did real work, print the
-    // direct deps that now exist at the top level before the green
-    // `✓ installed N packages in Xs` line. Text modes such as `-v` and
-    // `--reporter=append-only` skip the progress object but still get the
-    // dependency summary; silent and ndjson stay machine-clean.
-    if !install_is_noop && should_print_human_install_summary() {
-        print_direct_dependency_summary(&graph_for_link, &manifests, &direct_dep_info);
-    }
-    if let Some(p) = prog_ref {
-        p.print_install_summary(
-            stats.packages_linked,
-            stats.top_level_linked,
-            graph_for_link.packages.len(),
-            elapsed,
-        );
-    }
-
-    // Surface packages whose build scripts were skipped because they're
-    // not on the `allowBuilds` / `onlyBuiltDependencies` allowlist. Without
-    // this, a fresh install of a project that depends on native bindings
-    // (`better-sqlite3`, `esbuild`, napi-rs packages, etc.) looks like it
-    // succeeded but leaves those packages unbuilt — the failure only
-    // surfaces later when something tries to `require` the binding.
-    // Skipped under `--ignore-scripts`, `virtualStoreOnly`, and
-    // `strictDepBuilds=true` (the strict path already errored above).
-    if !unreviewed_builds.is_empty() {
-        unreviewed_builds::emit_warning(&unreviewed_builds);
-    }
-
+        start,
+        prog_ref,
+        phase_timings: &mut phase_timings,
+    })
+    .await?;
     Ok(())
 }

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -158,7 +158,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         p.set_phase("resolving");
     }
     let client =
-        std::sync::Arc::new(super::super::make_client(cwd).with_network_mode(network_mode));
+        std::sync::Arc::new(crate::commands::make_client(cwd).with_network_mode(network_mode));
     let pnpmfile_paths = if ignore_pnpmfile {
         Vec::new()
     } else {
@@ -167,7 +167,8 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
             crate::pnpmfile::detect(cwd, pnpmfile, ws_config.pnpmfile_path.as_deref()).as_deref(),
         )
     };
-    super::super::run_pnpmfile_pre_resolution(&pnpmfile_paths, cwd, existing_for_resolver).await?;
+    crate::commands::run_pnpmfile_pre_resolution(&pnpmfile_paths, cwd, existing_for_resolver)
+        .await?;
     let (read_package_host, read_package_forwarders) =
         match crate::pnpmfile::ReadPackageHostChain::spawn(&pnpmfile_paths, cwd)
             .await
@@ -308,9 +309,13 @@ pub(super) fn select_lockfile_result(
         return Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf())));
     }
     match mode {
-        FrozenMode::No | FrozenMode::Fix => {
-            Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf())))
-        }
+        // Always re-resolve.
+        FrozenMode::No => Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf()))),
+        // Always fall through to re-resolve; `existing_for_resolver`
+        // carries the current lockfile (if any) so the resolver
+        // reuses locked versions for unchanged specs and only
+        // re-resolves entries whose spec drifted.
+        FrozenMode::Fix => Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf()))),
         FrozenMode::Frozen => {
             // Use the lockfile, but error out on any drift across all workspace importers.
             let parsed = parse_lockfile_dir_remapped_with_kind(

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -1,0 +1,494 @@
+use crate::progress::InstallProgress;
+use aube_lockfile::{DriftStatus, LockfileGraph, LockfileKind};
+use miette::{Context, IntoDiagnostic, miette};
+use std::collections::HashMap;
+use std::path::Path;
+
+use super::frozen::FrozenMode;
+use super::lockfile_dir::{parse_lockfile_dir_remapped_with_kind, write_lockfile_dir_remapped};
+use super::settings::{ResolverConfigInputs, configure_resolver, maybe_cleanup_unused_catalogs};
+use super::workspace::write_per_project_lockfiles;
+
+pub(super) type ParsedLockfile = Option<(LockfileGraph, LockfileKind)>;
+
+pub(super) fn pre_parse_lockfile(
+    lockfile_enabled: bool,
+    mode: FrozenMode,
+    lockfile_dir: &Path,
+    lockfile_importer_key: &str,
+    manifest: &aube_manifest::PackageJson,
+) -> miette::Result<ParsedLockfile> {
+    if !lockfile_enabled || !matches!(mode, FrozenMode::Fix | FrozenMode::Prefer) {
+        return Ok(None);
+    }
+    match parse_lockfile_dir_remapped_with_kind(lockfile_dir, lockfile_importer_key, manifest) {
+        Ok(parsed) => Ok(Some(parsed)),
+        Err(aube_lockfile::Error::NotFound(_)) => Ok(None),
+        Err(e) => Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
+    }
+}
+
+pub(super) struct LockfileOnlyInput<'a> {
+    pub cwd: &'a Path,
+    pub mode: FrozenMode,
+    pub lockfile_dir: &'a Path,
+    pub lockfile_importer_key: &'a str,
+    pub manifest: &'a aube_manifest::PackageJson,
+    pub manifests: &'a [(String, aube_manifest::PackageJson)],
+    pub ws_config: &'a aube_manifest::workspace::WorkspaceConfig,
+    pub workspace_catalogs: &'a crate::commands::CatalogMap,
+    pub settings_ctx: &'a aube_settings::ResolveCtx<'a>,
+    pub lockfile_pre_parse: Option<&'a (LockfileGraph, LockfileKind)>,
+    pub existing_for_resolver: Option<&'a LockfileGraph>,
+    pub source_kind_before: Option<LockfileKind>,
+    pub lockfile_enabled: bool,
+    pub lockfile_include_tarball_url: bool,
+    pub shared_workspace_lockfile: bool,
+    pub has_workspace: bool,
+    pub is_workspace_project: bool,
+    pub ignore_pnpmfile: bool,
+    pub network_mode: aube_registry::NetworkMode,
+    pub global_pnpmfile: Option<&'a Path>,
+    pub pnpmfile: Option<&'a Path>,
+    pub minimum_release_age_override: Option<u64>,
+    pub ws_package_versions: &'a HashMap<String, String>,
+    pub prog_ref: Option<&'a InstallProgress>,
+}
+
+pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::Result<()> {
+    let LockfileOnlyInput {
+        cwd,
+        mode,
+        lockfile_dir,
+        lockfile_importer_key,
+        manifest,
+        manifests,
+        ws_config,
+        workspace_catalogs,
+        settings_ctx,
+        lockfile_pre_parse,
+        existing_for_resolver,
+        source_kind_before,
+        lockfile_enabled,
+        lockfile_include_tarball_url,
+        shared_workspace_lockfile,
+        has_workspace,
+        is_workspace_project,
+        ignore_pnpmfile,
+        network_mode,
+        global_pnpmfile,
+        pnpmfile,
+        minimum_release_age_override,
+        ws_package_versions,
+        prog_ref,
+    } = input;
+
+    // `--no-frozen-lockfile` means "always re-resolve", so skip the
+    // freshness check entirely in that mode. Otherwise (Prefer, Fix,
+    // or CI's auto-Frozen) a fresh lockfile is a no-op — for Fix
+    // specifically, "fresh" means "nothing to fix."
+    let force_resolve = matches!(mode, FrozenMode::No);
+    // Reuse the up-front pre-parse when we already have it so we
+    // don't read and parse the same lockfile twice on
+    // `--lockfile-only`. The borrowed form is all the freshness
+    // check needs — `existing_for_resolver` still points at the
+    // same graph for the resolver call below.
+    let parsed_owned;
+    let parsed: Result<(&LockfileGraph, LockfileKind), &aube_lockfile::Error> =
+        if let Some((g, k)) = lockfile_pre_parse {
+            Ok((g, *k))
+        } else {
+            parsed_owned = parse_lockfile_dir_remapped_with_kind(
+                lockfile_dir,
+                lockfile_importer_key,
+                manifest,
+            );
+            match &parsed_owned {
+                Ok((g, k)) => Ok((g, *k)),
+                Err(e) => Err(e),
+            }
+        };
+    if let Err(e) = parsed
+        && !matches!(e, aube_lockfile::Error::NotFound(_))
+    {
+        // Can't hand &Error to miette::Report since Diagnostic
+        // is only implemented on owned Error. Re-parse once to
+        // get an owned Error value for the Diagnostic path.
+        // Slightly wasteful on the error branch, install is
+        // about to abort anyway so speed does not matter here.
+        // What matters: keeping the source span and miette help
+        // text instead of flattening to one line via `{e}`.
+        match parse_lockfile_dir_remapped_with_kind(lockfile_dir, lockfile_importer_key, manifest) {
+            Ok(_) => {
+                // Race: second parse succeeded while first failed.
+                // Surface the observed error text as a best
+                // effort flat message. Extremely unlikely.
+                return Err(miette!("failed to parse lockfile: {e}"));
+            }
+            Err(owned) => {
+                return Err(miette::Report::new(owned)).wrap_err("failed to parse lockfile");
+            }
+        }
+    }
+    let fresh = !force_resolve
+        && matches!(
+            parsed,
+            Ok((g, _))
+                if matches!(
+                    g.check_drift_workspace(
+                        manifests,
+                        &ws_config.overrides,
+                        &ws_config.ignored_optional_dependencies,
+                        workspace_catalogs,
+                        is_workspace_project
+                    ),
+                    DriftStatus::Fresh,
+                )
+                    && matches!(g.check_catalogs_drift(workspace_catalogs), DriftStatus::Fresh)
+        );
+    if fresh {
+        tracing::debug!("--lockfile-only: lockfile already up to date");
+        if let Some(p) = prog_ref {
+            p.finish(true);
+        }
+        eprintln!("Lockfile is up to date, resolution step is skipped");
+        return Ok(());
+    }
+    if let Some(p) = prog_ref {
+        p.set_phase("resolving");
+    }
+    let client =
+        std::sync::Arc::new(super::super::make_client(cwd).with_network_mode(network_mode));
+    let pnpmfile_paths = if ignore_pnpmfile {
+        Vec::new()
+    } else {
+        crate::pnpmfile::ordered_paths(
+            crate::pnpmfile::detect_global(cwd, global_pnpmfile).as_deref(),
+            crate::pnpmfile::detect(cwd, pnpmfile, ws_config.pnpmfile_path.as_deref()).as_deref(),
+        )
+    };
+    super::super::run_pnpmfile_pre_resolution(&pnpmfile_paths, cwd, existing_for_resolver).await?;
+    let (read_package_host, read_package_forwarders) =
+        match crate::pnpmfile::ReadPackageHostChain::spawn(&pnpmfile_paths, cwd)
+            .await
+            .wrap_err("failed to start pnpmfile readPackage host")?
+        {
+            Some((h, f)) => (Some(h), f),
+            None => (None, Vec::new()),
+        };
+    let read_package_hook: Option<Box<dyn aube_resolver::ReadPackageHook>> =
+        read_package_host.map(|h| Box::new(h) as Box<dyn aube_resolver::ReadPackageHook>);
+    let mut resolver = configure_resolver(
+        aube_resolver::Resolver::new(client.clone()),
+        cwd,
+        manifest,
+        ResolverConfigInputs {
+            settings_ctx,
+            workspace_config: ws_config,
+            workspace_catalogs,
+            minimum_release_age_override,
+            // `lockfile=false` collapses to `None` so the resolver
+            // doesn't waste a fetch widening a lockfile that will
+            // never be written. With lockfiles enabled, a missing
+            // `source_kind_before` means "we'll create the default
+            // aube-lock.yaml", so the aube-native wide default
+            // applies.
+            target_lockfile_kind: lockfile_enabled
+                .then(|| source_kind_before.unwrap_or(LockfileKind::Aube)),
+            cache_full_packuments: true,
+        },
+        read_package_hook,
+    );
+    let mut graph = if has_workspace {
+        resolver
+            .resolve_workspace(manifests, existing_for_resolver, ws_package_versions)
+            .await
+    } else {
+        resolver.resolve(manifest, existing_for_resolver).await
+    }
+    .map_err(miette::Report::new)
+    .wrap_err("failed to resolve dependencies")?;
+    drop(resolver);
+    // Drain the readPackage stderr forwarders so every `ctx.log`
+    // record they captured during resolve flushes to stdout before
+    // afterAllResolved emits its own pnpm:hook records — keeps
+    // resolve-time logs strictly ahead of post-resolve logs in the
+    // ndjson stream.
+    crate::pnpmfile::ReadPackageHostChain::drain_forwarders(read_package_forwarders).await;
+    crate::pnpmfile::run_after_all_resolved_chain(&pnpmfile_paths, cwd, &mut graph).await?;
+    // Same tarball-URL population pass as the main fetch branch —
+    // keeps `--lockfile-only` and regular installs byte-identical.
+    // Reuses the resolver's `client` (already built above) to avoid
+    // re-walking `.npmrc` and rebuilding the rustls client just to
+    // construct registry URLs.
+    if lockfile_include_tarball_url {
+        let lo_client = client.as_ref();
+        graph.settings.lockfile_include_tarball_url = true;
+        for pkg in graph.packages.values_mut() {
+            if pkg.local_source.is_some() {
+                continue;
+            }
+            // Preserve any URL the parser already captured from an
+            // aliased `resolved:` field — deriving from
+            // `(registry_name, version)` would also work for
+            // aliases but skips a redundant allocation.
+            if pkg.tarball_url.is_none() {
+                pkg.tarball_url = Some(lo_client.tarball_url(pkg.registry_name(), &pkg.version));
+            }
+        }
+    }
+    let lo_write_kind = source_kind_before.unwrap_or(LockfileKind::Aube);
+    if shared_workspace_lockfile || !has_workspace {
+        let lo_written = write_lockfile_dir_remapped(
+            lockfile_dir,
+            lockfile_importer_key,
+            &graph,
+            manifest,
+            lo_write_kind,
+        )
+        .into_diagnostic()
+        .wrap_err("failed to write lockfile")?;
+        tracing::debug!(
+            "--lockfile-only: wrote {}",
+            lo_written
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| lo_written.display().to_string())
+        );
+    } else {
+        write_per_project_lockfiles(cwd, &graph, manifests, lo_write_kind)?;
+    }
+    // Prune unused catalog entries *after* the lockfile hits disk —
+    // same ordering as the main install path below, so a
+    // workspace-yaml write error can't block the command's
+    // primary output.
+    maybe_cleanup_unused_catalogs(cwd, settings_ctx, workspace_catalogs, &graph.catalogs)?;
+    if let Some(p) = prog_ref {
+        p.finish(true);
+    }
+    eprintln!(
+        "Lockfile written ({} packages); skipped node_modules linking",
+        graph.packages.len()
+    );
+    Ok(())
+}
+
+pub(super) struct SelectLockfileInput<'a> {
+    pub lockfile_enabled: bool,
+    pub mode: FrozenMode,
+    pub cwd: &'a Path,
+    pub lockfile_dir: &'a Path,
+    pub lockfile_importer_key: &'a str,
+    pub manifest: &'a aube_manifest::PackageJson,
+    pub manifests: &'a [(String, aube_manifest::PackageJson)],
+    pub ws_config: &'a aube_manifest::workspace::WorkspaceConfig,
+    pub workspace_catalogs: &'a crate::commands::CatalogMap,
+    pub is_workspace_project: bool,
+    pub lockfile_pre_parse: Option<&'a (LockfileGraph, LockfileKind)>,
+}
+
+pub(super) fn select_lockfile_result(
+    input: SelectLockfileInput<'_>,
+) -> miette::Result<Result<(LockfileGraph, LockfileKind), aube_lockfile::Error>> {
+    let SelectLockfileInput {
+        lockfile_enabled,
+        mode,
+        cwd,
+        lockfile_dir,
+        lockfile_importer_key,
+        manifest,
+        manifests,
+        ws_config,
+        workspace_catalogs,
+        is_workspace_project,
+        lockfile_pre_parse,
+    } = input;
+    if !lockfile_enabled {
+        tracing::debug!("lockfile=false: skipping lockfile parse, re-resolving");
+        return Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf())));
+    }
+    match mode {
+        FrozenMode::No | FrozenMode::Fix => {
+            Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf())))
+        }
+        FrozenMode::Frozen => {
+            // Use the lockfile, but error out on any drift across all workspace importers.
+            let parsed = parse_lockfile_dir_remapped_with_kind(
+                lockfile_dir,
+                lockfile_importer_key,
+                manifest,
+            );
+            if let Ok((ref graph, _)) = parsed {
+                if let DriftStatus::Stale { reason } =
+                    graph.check_catalogs_drift(workspace_catalogs)
+                {
+                    return Err(miette!(
+                        "lockfile is out of date with pnpm-workspace.yaml: {reason}\n\
+                         help: run without --frozen-lockfile to update the lockfile"
+                    ));
+                }
+                if let DriftStatus::Stale { reason } = graph.check_drift_workspace(
+                    manifests,
+                    &ws_config.overrides,
+                    &ws_config.ignored_optional_dependencies,
+                    workspace_catalogs,
+                    is_workspace_project,
+                ) {
+                    return Err(miette!(
+                        "lockfile is out of date with package.json: {reason}\n\
+                         help: run without --frozen-lockfile to update the lockfile, \
+                         or run `aube install --no-frozen-lockfile` to regenerate it"
+                    ));
+                }
+            }
+            Ok(parsed)
+        }
+        FrozenMode::Prefer => {
+            // Use the lockfile when fresh, otherwise pretend there isn't one
+            // so the existing "no lockfile → resolve" branch handles it.
+            // Reuse `lockfile_pre_parse` instead of parsing the same file
+            // a second time — on Prefer-fresh we clone the graph so the
+            // borrow held by `existing_for_resolver` keeps pointing at
+            // the original (unused on the fresh path, but safe to leave).
+            match lockfile_pre_parse {
+                Some((graph, kind)) => {
+                    if let DriftStatus::Stale { reason } =
+                        graph.check_catalogs_drift(workspace_catalogs)
+                    {
+                        tracing::debug!(
+                            "Lockfile out of date with workspace catalogs ({reason}), re-resolving..."
+                        );
+                        Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf())))
+                    } else {
+                        match graph.check_drift_workspace(
+                            manifests,
+                            &ws_config.overrides,
+                            &ws_config.ignored_optional_dependencies,
+                            workspace_catalogs,
+                            is_workspace_project,
+                        ) {
+                            DriftStatus::Fresh => Ok(Ok((graph.clone(), *kind))),
+                            DriftStatus::Stale { reason } => {
+                                tracing::debug!("Lockfile out of date ({reason}), re-resolving...");
+                                Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf())))
+                            }
+                        }
+                    }
+                }
+                None => Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf()))),
+            }
+        }
+    }
+}
+
+pub(super) fn apply_lockfile_graph_platform_rules(
+    mut graph: LockfileGraph,
+    kind: LockfileKind,
+    manifest: &aube_manifest::PackageJson,
+    ws_config: &aube_manifest::workspace::WorkspaceConfig,
+    settings_ctx: &aube_settings::ResolveCtx<'_>,
+) -> miette::Result<LockfileGraph> {
+    // Drop optional deps that don't match the current platform
+    // (or are in `pnpm.ignoredOptionalDependencies`) before we
+    // start fetching tarballs. The resolver's inline filter
+    // never runs on the lockfile-happy path, so this pass is
+    // what makes cross-platform lockfile installs work.
+    let (sup_os, sup_cpu, sup_libc) =
+        aube_manifest::effective_supported_architectures(manifest, ws_config);
+    let supported_architectures = aube_resolver::SupportedArchitectures {
+        os: sup_os,
+        cpu: sup_cpu,
+        libc: sup_libc,
+        ..Default::default()
+    };
+    let ignored_optional_deps =
+        aube_manifest::effective_ignored_optional_dependencies(manifest, ws_config);
+    // npm/bun lockfiles serialize a flat, pre-hoisted tree
+    // with no peer context — they rely on Node's upward
+    // `node_modules/` walk to find peer deps, which the
+    // isolated virtual store breaks. Fresh resolves flow
+    // through `Resolver::resolve_workspace`, which runs
+    // `hoist_auto_installed_peers` + `apply_peer_contexts` on
+    // its way out; the lockfile path has to replicate those
+    // two steps explicitly or peer-dependent packages
+    // (e.g. `@tanstack/devtools-vite` peering on `vite`)
+    // install with no sibling peer link and die at runtime
+    // with `Cannot find package`.
+    //
+    // `aube-lock.yaml` / `pnpm-lock.yaml` already carry
+    // peer-context suffixes and peer edges merged into
+    // `dependencies`, so we skip them — re-running the pass
+    // would double-suffix every key.
+    //
+    // Yarn v1 has the same flat shape but is intentionally
+    // omitted: real-world `yarn.lock` files don't record
+    // `peerDependencies` per entry (yarn 1.22 emits them
+    // only on the workspace root), so running the pass would
+    // be a no-op. Making yarn v1 imports peer-correct needs
+    // a packument fetch on the import path to graft peer
+    // ranges back onto each `LockedPackage` — a deeper
+    // change than this match arm.
+    //
+    // The hoist must run *before* `filter_graph`: bun records
+    // peer-only-installed packages (e.g. `@mui/material` when
+    // the importer only depends on `@textea/json-viewer`, which
+    // peers on MUI) in its packages map, but our bun parser
+    // doesn't merge those into the consumer's `dependencies`
+    // map. `filter_graph`'s GC walk only follows `dependencies`,
+    // so without the hoist running first it prunes every
+    // peer-only package as unreachable — and a post-prune hoist
+    // has nothing left to promote.
+    let needs_peer_pass = matches!(
+        kind,
+        LockfileKind::Npm | LockfileKind::NpmShrinkwrap | LockfileKind::Bun
+    );
+    // Time the hoist on its own, then `filter_graph` runs untimed
+    // (it's not part of the peer pass), then apply is timed below.
+    // Snapshotting `pkgs_before` after `filter_graph` keeps the
+    // logged delta a pure measure of `apply_peer_contexts`'s
+    // additions, not filter_graph's prunes.
+    let mut hoist_elapsed: Option<std::time::Duration> = None;
+    if needs_peer_pass {
+        let hoist_start = std::time::Instant::now();
+        graph = aube_resolver::hoist_auto_installed_peers(graph);
+        hoist_elapsed = Some(hoist_start.elapsed());
+    }
+    aube_resolver::platform::filter_graph(
+        &mut graph,
+        &supported_architectures,
+        &ignored_optional_deps,
+    );
+    if let Some(hoist_elapsed) = hoist_elapsed {
+        let peer_options = aube_resolver::PeerContextOptions {
+            dedupe_peer_dependents: super::settings::resolve_dedupe_peer_dependents(settings_ctx),
+            dedupe_peers: super::settings::resolve_dedupe_peers(settings_ctx),
+            resolve_from_workspace_root: super::settings::resolve_peers_from_workspace_root(
+                settings_ctx,
+            ),
+            peers_suffix_max_length: super::settings::resolve_peers_suffix_max_length(settings_ctx),
+        };
+        let pkgs_before = graph.packages.len();
+        let apply_start = std::time::Instant::now();
+        graph = aube_resolver::apply_peer_contexts(graph, &peer_options)
+            .map_err(|e| miette!("peer-context pass failed: {e}"))?;
+        tracing::debug!(
+            "peer-context pass (lockfile={:?}) {} → {} packages in {:.1?}",
+            kind,
+            pkgs_before,
+            graph.packages.len(),
+            hoist_elapsed + apply_start.elapsed()
+        );
+    }
+    Ok(graph)
+}
+
+pub(super) fn lockfile_source_label(kind: LockfileKind) -> &'static str {
+    match kind {
+        LockfileKind::Aube => "Lockfile",
+        LockfileKind::Pnpm => "pnpm-lock.yaml",
+        LockfileKind::Yarn | LockfileKind::YarnBerry => "yarn.lock",
+        LockfileKind::Npm => "package-lock.json",
+        LockfileKind::NpmShrinkwrap => "npm-shrinkwrap.json",
+        LockfileKind::Bun => "bun.lock",
+    }
+}


### PR DESCRIPTION
## Summary

- split install lockfile pre-parse, lockfile-only resolution, lockfile selection, and lockfile graph preparation into install/resolve.rs
- keep install::run focused on phase orchestration before fetch/link/finalize

## Validation

- cargo fmt --check
- cargo check -p aube
- cargo clippy -p aube --all-targets -- -D warnings
- cargo test -p aube

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core `install` control flow (lockfile parsing/selection, lockfile-only path, and post-link finalize steps) into new modules; behavior should be equivalent but mistakes could affect lockfile handling or lifecycle execution order.
> 
> **Overview**
> Refactors `aube install` by extracting large chunks of logic from `install/mod.rs` into two new modules: `install/resolve.rs` (lockfile pre-parse, `--lockfile-only` resolution/write flow, frozen-mode lockfile selection, and lockfile-graph platform/peer-context preparation) and `install/finalize.rs` (post-link lifecycle scripts, state writeback, orphan sweep, deprecation rendering, and final user output).
> 
> `install::run` is updated to orchestrate phases by delegating to these helpers, reducing inline branching and centralizing lockfile/result selection and finalize-time side effects behind structured input structs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51d7d0d02eff7f7b15a2f0c44117da383e3ac53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->