### PR TITLE
refactor(lockfile): clean up pnpm split feedback

### DIFF
--- a/crates/aube-lockfile/src/pnpm/raw.rs
+++ b/crates/aube-lockfile/src/pnpm/raw.rs
@@ -39,10 +39,7 @@ pub(super) fn parse_raw_lockfile(content: &str) -> Result<RawPnpmLockfile, yaml_
                 };
             }
             Err(e) => {
-                // Log every per-document failure so a multi-doc
-                // lockfile where every document fails surfaces all the
-                // diagnostic signal at `RUST_LOG=aube_lockfile=debug`.
-                // Break on the first failure: a malformed document
+                // Log the first per-document failure and stop. A malformed document
                 // typically puts yaml_serde's iterator into a state
                 // where further iteration is either more garbage or an
                 // infinite loop (see `test_parse_invalid_yaml`). The

--- a/crates/aube-lockfile/src/pnpm/write.rs
+++ b/crates/aube-lockfile/src/pnpm/write.rs
@@ -332,19 +332,17 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         deps.into_iter()
             .map(|(name, value)| {
                 let dp = version_to_dep_path(&name, &value);
-                if let Some(target) = graph
+                let target = graph
                     .packages
                     .get(&dp)
-                    .or_else(|| graph.packages.get(&peerless_dep_path(&name, &value)))
+                    .or_else(|| graph.packages.get(&peerless_dep_path(&name, &value)));
+                if let Some(target) = target
                     && let Some(ref local) = target.local_source
                     && !matches!(local, LocalSource::Link(_))
                 {
                     (name, local.specifier())
                 } else if native_pnpm_aliases
-                    && let Some(target) = graph
-                        .packages
-                        .get(&dp)
-                        .or_else(|| graph.packages.get(&peerless_dep_path(&name, &value)))
+                    && let Some(target) = target
                     && let Some(real_name) = target.alias_of.as_deref()
                 {
                     (name, format!("{real_name}@{value}"))


### PR DESCRIPTION
## Summary
- correct the pnpm multi-document parse comment to match the first-error break behavior
- avoid duplicate package map lookups while rewriting pnpm snapshot dependency values

## Validation
- cargo fmt --check
- cargo check -p aube-lockfile
- cargo clippy -p aube-lockfile --all-targets -- -D warnings
- cargo test -p aube-lockfile

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: only updates comments/logging semantics and reduces redundant `packages` map lookups during pnpm lockfile writing, without changing data formats or core resolution logic.
> 
> **Overview**
> Clarifies pnpm multi-document parsing behavior by updating the comment to match the actual **“log first error and break”** flow when a YAML document fails to deserialize.
> 
> Refactors pnpm snapshot dependency rewriting to **avoid duplicate `graph.packages` lookups** by reusing the resolved target package entry for both local-source specifier rewriting and alias handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b4f5c05405f70855490269e4b610b43373a021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->