### PR TITLE
fix(bun): apply top-level patchedDependencies

### DIFF
--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -532,6 +532,25 @@ impl PackageJson {
         out
     }
 
+    /// Extract Bun's top-level `patchedDependencies` as a map of
+    /// `name@version` -> patch file path (relative to the project root).
+    /// Empty when the field is missing or malformed.
+    pub fn bun_patched_dependencies(&self) -> BTreeMap<String, String> {
+        let mut out = BTreeMap::new();
+        if let Some(map) = self
+            .extra
+            .get("patchedDependencies")
+            .and_then(|v| v.as_object())
+        {
+            for (k, v) in map {
+                if let Some(s) = v.as_str() {
+                    out.insert(k.clone(), s.to_string());
+                }
+            }
+        }
+        out
+    }
+
     /// Extract `pnpm.patchedDependencies` / `aube.patchedDependencies`
     /// as a map of `name@version` -> patch file path (relative to the
     /// project root). Empty when the field is missing or malformed.
@@ -1742,6 +1761,24 @@ mod tests {
     fn trusted_dependencies_wrong_shape_returns_empty() {
         let p = parse(r#"{"trustedDependencies": {"esbuild": true}}"#);
         assert!(p.trusted_dependencies().is_empty());
+    }
+
+    #[test]
+    fn bun_patched_dependencies_reads_top_level_field() {
+        let p = parse(
+            r#"{
+                "patchedDependencies": {
+                    "is-number@7.0.0": "patches/is-number.patch",
+                    "ignored@1.0.0": false
+                }
+            }"#,
+        );
+        let got = p.bun_patched_dependencies();
+        assert_eq!(
+            got.get("is-number@7.0.0").unwrap(),
+            "patches/is-number.patch"
+        );
+        assert!(!got.contains_key("ignored@1.0.0"));
     }
 
     #[test]

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -230,7 +230,9 @@ pub fn upsert_patched_dependency(cwd: &Path, key: &str, rel_patch_path: &str) ->
 }
 
 /// Drop an entry from `patchedDependencies` in whichever file declares
-/// it (workspace yaml, `package.json#pnpm.patchedDependencies`,
+/// it (workspace yaml, Bun's top-level
+/// `package.json#patchedDependencies`,
+/// `package.json#pnpm.patchedDependencies`,
 /// `package.json#aube.patchedDependencies`, or any combination).
 /// Returns the files that were rewritten — empty when no location held
 /// the entry. Each side peeks before rewriting so the no-op case
@@ -244,13 +246,60 @@ pub fn remove_patched_dependency(cwd: &Path, key: &str) -> Result<Vec<PathBuf>> 
     {
         rewritten.push(ws_path);
     }
-    if aube_manifest::workspace::remove_setting_entry(cwd, "patchedDependencies", key)
-        .map_err(miette::Report::new)
-        .wrap_err("failed to write package.json")?
-    {
+    let removed_namespaced =
+        aube_manifest::workspace::remove_setting_entry(cwd, "patchedDependencies", key)
+            .map_err(miette::Report::new)
+            .wrap_err("failed to write package.json")?;
+    let removed_bun =
+        remove_bun_patched_dependency(cwd, key).wrap_err("failed to write package.json")?;
+    if removed_namespaced || removed_bun {
         rewritten.push(cwd.join("package.json"));
     }
     Ok(rewritten)
+}
+
+fn remove_bun_patched_dependency(cwd: &Path, key: &str) -> Result<bool> {
+    let path = cwd.join("package.json");
+    if !path.exists() {
+        return Ok(false);
+    }
+    let raw = std::fs::read_to_string(&path)
+        .into_diagnostic()
+        .map_err(|e| miette!("failed to read {}: {e}", path.display()))?;
+    let mut value: serde_json::Value = serde_json::from_str(&raw)
+        .into_diagnostic()
+        .map_err(|e| miette!("failed to parse {}: {e}", path.display()))?;
+    let obj = value
+        .as_object_mut()
+        .ok_or_else(|| miette!("package.json is not an object"))?;
+    let before = obj.clone();
+
+    let mut remove_empty_map = false;
+    let removed = if let Some(patched) = obj
+        .get_mut("patchedDependencies")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        let removed = patched.remove(key).is_some();
+        remove_empty_map = patched.is_empty();
+        removed
+    } else {
+        false
+    };
+    if remove_empty_map {
+        obj.remove("patchedDependencies");
+    }
+    if *obj == before {
+        return Ok(removed);
+    }
+
+    let mut out = serde_json::to_string_pretty(&value)
+        .into_diagnostic()
+        .map_err(|e| miette!("failed to serialize {}: {e}", path.display()))?;
+    out.push('\n');
+    std::fs::write(&path, out)
+        .into_diagnostic()
+        .map_err(|e| miette!("failed to write {}: {e}", path.display()))?;
+    Ok(removed)
 }
 
 /// Read every declared `patchedDependencies` entry across both the
@@ -459,6 +508,53 @@ mod tests {
         // The patch entry must be inside pnpm.
         let parsed: serde_json::Value = serde_json::from_str(&manifest).unwrap();
         assert!(parsed["pnpm"]["patchedDependencies"]["a@1.0.0"].is_string());
+    }
+
+    #[test]
+    fn remove_deletes_bun_top_level_patched_dependency() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{
+  "patchedDependencies": {
+    "a@1.0.0": "patches/a.patch",
+    "b@2.0.0": "patches/b.patch"
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        let rewritten = remove_patched_dependency(dir.path(), "a@1.0.0").unwrap();
+        assert_eq!(rewritten, vec![dir.path().join("package.json")]);
+        let parsed: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("package.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(parsed["patchedDependencies"]["a@1.0.0"].is_null());
+        assert_eq!(parsed["patchedDependencies"]["b@2.0.0"], "patches/b.patch");
+    }
+
+    #[test]
+    fn remove_drops_empty_bun_top_level_patched_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{
+  "patchedDependencies": {
+    "a@1.0.0": "patches/a.patch"
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        remove_patched_dependency(dir.path(), "a@1.0.0").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("package.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(parsed["patchedDependencies"].is_null());
     }
 
     #[test]

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -2,9 +2,10 @@
 //! commands and the install-time patch application path.
 //!
 //! Patches are stored alongside the project (default `patches/`) and
-//! tracked in `package.json` under `pnpm.patchedDependencies` —
-//! `{ "name@version": "patches/name@version.patch" }`. We mirror pnpm's
-//! shape exactly so the field round-trips between the two tools.
+//! tracked as `{ "name@version": "patches/name@version.patch" }`.
+//! Sources are merged from Bun's top-level `patchedDependencies`,
+//! `pnpm.patchedDependencies` / `aube.patchedDependencies`, then
+//! workspace-yaml `patchedDependencies`, in that precedence order.
 
 use miette::{Context, IntoDiagnostic, Result, miette};
 use sha2::{Digest, Sha256};
@@ -150,6 +151,7 @@ pub fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
         let manifest = aube_manifest::PackageJson::from_path(&manifest_path)
             .map_err(miette::Report::new)
             .wrap_err("failed to read package.json")?;
+        entries.extend(manifest.bun_patched_dependencies());
         entries.extend(manifest.pnpm_patched_dependencies());
     }
 
@@ -271,7 +273,9 @@ fn read_package_json_patched_dependencies(cwd: &Path) -> Result<BTreeMap<String,
     let manifest = aube_manifest::PackageJson::from_path(&manifest_path)
         .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
-    Ok(manifest.pnpm_patched_dependencies())
+    let mut out = manifest.bun_patched_dependencies();
+    out.extend(manifest.pnpm_patched_dependencies());
+    Ok(out)
 }
 
 /// Recursively copy `src` into `dst`, following file content but
@@ -374,6 +378,35 @@ mod tests {
             "should not introduce pnpm namespace, got:\n{manifest}"
         );
         assert!(manifest.contains("\"patchedDependencies\""));
+    }
+
+    #[test]
+    fn load_reads_bun_top_level_patched_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("patches")).unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{
+  "patchedDependencies": {
+    "is-number@7.0.0": "patches/is-number.patch"
+  }
+}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("patches/is-number.patch"),
+            "diff --git a/index.js b/index.js\n",
+        )
+        .unwrap();
+
+        let patches = load_patches(dir.path()).unwrap();
+        assert_eq!(
+            patches
+                .get("is-number@7.0.0")
+                .map(|p| p.path.strip_prefix(dir.path()).unwrap()),
+            Some(Path::new("patches/is-number.patch"))
+        );
     }
 
     #[test]

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -266,9 +266,8 @@ fn remove_bun_patched_dependency(cwd: &Path, key: &str) -> Result<bool> {
     let raw = std::fs::read_to_string(&path)
         .into_diagnostic()
         .map_err(|e| miette!("failed to read {}: {e}", path.display()))?;
-    let mut value: serde_json::Value = serde_json::from_str(&raw)
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to parse {}: {e}", path.display()))?;
+    let mut value =
+        aube_manifest::parse_json::<serde_json::Value>(&path, raw).map_err(miette::Report::new)?;
     let obj = value
         .as_object_mut()
         .ok_or_else(|| miette!("package.json is not an object"))?;
@@ -280,7 +279,9 @@ fn remove_bun_patched_dependency(cwd: &Path, key: &str) -> Result<bool> {
         .and_then(serde_json::Value::as_object_mut)
     {
         let removed = patched.remove(key).is_some();
-        remove_empty_map = patched.is_empty();
+        if removed {
+            remove_empty_map = patched.is_empty();
+        }
         removed
     } else {
         false
@@ -550,6 +551,41 @@ mod tests {
         .unwrap();
 
         remove_patched_dependency(dir.path(), "a@1.0.0").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("package.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(parsed["patchedDependencies"].is_null());
+    }
+
+    #[test]
+    fn remove_leaves_empty_bun_top_level_map_when_key_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            "{\n  \"patchedDependencies\": {}\n}\n",
+        )
+        .unwrap();
+
+        let rewritten = remove_patched_dependency(dir.path(), "missing@9.9.9").unwrap();
+        assert!(rewritten.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("package.json")).unwrap(),
+            "{\n  \"patchedDependencies\": {}\n}\n"
+        );
+    }
+
+    #[test]
+    fn remove_reads_bom_prefixed_package_json() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            "\u{feff}{\n  \"patchedDependencies\": {\n    \"a@1.0.0\": \"patches/a.patch\"\n  }\n}\n",
+        )
+        .unwrap();
+
+        let rewritten = remove_patched_dependency(dir.path(), "a@1.0.0").unwrap();
+        assert_eq!(rewritten, vec![dir.path().join("package.json")]);
         let parsed: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(dir.path().join("package.json")).unwrap(),
         )

--- a/test/import.bats
+++ b/test/import.bats
@@ -153,6 +153,10 @@ teardown() {
 	run aube install
 	assert_success
 
+	run node -e "try { require('is-odd')('nope') } catch (e) { console.log(e.message) }"
+	assert_success
+	assert_output "expected a numeric value"
+
 	run cmp -s bun.lock bun.lock.before
 	assert_success
 }


### PR DESCRIPTION
## Summary

- read Bun's top-level `package.json#patchedDependencies` field from the manifest model
- merge Bun patch declarations into install-time patch loading alongside existing pnpm/aube config
- add parser and install-level regression coverage for Bun-authored patched dependencies

## Root Cause

Aube preserved Bun `patchedDependencies` in `bun.lock`, but install-time patch loading only read `pnpm.patchedDependencies`, `aube.patchedDependencies`, and workspace YAML entries from `package.json`/`pnpm-workspace.yaml`. Bun-only projects could therefore install successfully while materializing the unpatched package contents.

## Validation

- `cargo test -p aube-manifest bun_patched_dependencies_reads_top_level_field`
- `cargo test -p aube load_reads_bun_top_level_patched_dependencies`
- `./test/bats/bin/bats test/import.bats --filter 'aube install smoke installs messy bun.lock fixture'`
- `cargo fmt --check`
- `git diff --check`
- linked repro under `/tmp/tmp-aube-issues-722/bun-patched-dependencies` with local `target/debug/aube`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time patch resolution to honor Bun’s top-level `package.json#patchedDependencies`, which can alter the on-disk contents of installed packages for Bun projects. Scope is limited to patch loading/removal paths with added regression tests.
> 
> **Overview**
> Aube now reads Bun’s top-level `package.json#patchedDependencies` and merges it into the patch sources used during `aube install`, alongside existing `pnpm`/`aube`-namespaced entries and workspace YAML declarations.
> 
> Patch management is updated to also remove Bun top-level patch entries (dropping the map when it becomes empty), and new unit/integration coverage ensures Bun-authored patches are loaded and applied correctly (including BOM-prefixed `package.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c2a7b14bf60c8fa9be853b3c8bef9fdff0c2abf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->