### PR TITLE
feat(yarn): support berry patch protocol

### DIFF
--- a/crates/aube-lockfile/src/yarn/berry.rs
+++ b/crates/aube-lockfile/src/yarn/berry.rs
@@ -45,6 +45,7 @@ pub(super) fn parse_berry_str(
     // every header-spec → dep_path mapping for the second pass.
     let mut spec_to_dep_path: BTreeMap<String, String> = BTreeMap::new();
     let mut packages: BTreeMap<String, LockedPackage> = BTreeMap::new();
+    let mut patched_dependencies: BTreeMap<String, String> = BTreeMap::new();
     // Transitive dep values written into each `LockedPackage` in this
     // pass are the raw header specs (e.g. `"foo@npm:^2.0.0"`); the
     // second pass collapses them down to dep_paths.
@@ -112,7 +113,19 @@ pub(super) fn parse_berry_str(
                 }
                 continue;
             }
-            "patch" | "portal" | "exec" => {
+            "patch" => {
+                let Some(patch_path) = patch_protocol_path(res_body) else {
+                    tracing::warn!(
+                        code = aube_codes::warnings::WARN_AUBE_YARN_BERRY_UNSUPPORTED,
+                        "yarn berry patch protocol in block '{}' is not supported — entry skipped",
+                        key_str,
+                    );
+                    continue;
+                };
+                patched_dependencies.insert(format!("{res_name}@{version}"), patch_path);
+                None
+            }
+            "portal" | "exec" => {
                 tracing::warn!(
                     code = aube_codes::warnings::WARN_AUBE_YARN_BERRY_UNSUPPORTED,
                     "yarn berry '{}' protocol in block '{}' is not supported — entry skipped",
@@ -290,6 +303,7 @@ pub(super) fn parse_berry_str(
     Ok(LockfileGraph {
         importers,
         packages,
+        patched_dependencies,
         ..Default::default()
     })
 }
@@ -436,6 +450,21 @@ fn file_protocol_source(body: &str) -> LocalSource {
     }
 }
 
+/// Extract the local patch file from Yarn's `patch:` protocol body.
+///
+/// Berry encodes patched npm packages as
+/// `name@patch:name@npm%3Aversion#./.yarn/patches/name.patch::version=...`.
+/// Aube applies the patch through its existing git-diff materializer, so
+/// the only part needed here is the project-relative path after `#`.
+fn patch_protocol_path(body: &str) -> Option<String> {
+    let (_, after_hash) = body.split_once('#')?;
+    let path = after_hash
+        .split_once("::")
+        .map(|(p, _)| p)
+        .unwrap_or(after_hash);
+    (!path.is_empty()).then(|| path.to_string())
+}
+
 fn strip_hash_fragment(s: &str) -> &str {
     s.split_once('#').map(|(a, _)| a).unwrap_or(s)
 }
@@ -486,9 +515,9 @@ fn classify_remote(url: &str, _block: &yaml_serde::Mapping) -> Option<LocalSourc
 ///
 /// ## What round-trips
 ///
-/// `yarn_checksum` (parsed from `checksum:`), peer-dep metadata, and
-/// all resolved transitive edges make it through parse → write →
-/// parse unchanged.
+/// `yarn_checksum` (parsed from `checksum:`), patch specs, peer-dep
+/// metadata, and all resolved transitive edges make it through parse →
+/// write → parse unchanged.
 ///
 /// ## What doesn't
 ///
@@ -500,8 +529,8 @@ fn classify_remote(url: &str, _block: &yaml_serde::Mapping) -> Option<LocalSourc
 ///   `yarn_checksum` from) are written without a `checksum:` field.
 ///   Yarn's default `checksumBehavior: throw` populates missing
 ///   checksums on the next install against its own cache.
-/// - `patch:` / `portal:` / `exec:` protocols aren't represented in
-///   aube's graph and never round-trip.
+/// - `portal:` / `exec:` protocols aren't represented in aube's graph
+///   and never round-trip.
 pub fn write_berry(
     path: &Path,
     graph: &LockfileGraph,
@@ -545,7 +574,10 @@ pub fn write_berry(
             continue;
         };
         let manifest_spec = format_berry_spec(&dep.name, range);
-        let exact_spec = berry_exact_spec(canonical.get(&canonical_key).copied().unwrap());
+        let exact_spec = berry_exact_spec(
+            canonical.get(&canonical_key).copied().unwrap(),
+            &graph.patched_dependencies,
+        );
         if manifest_spec != exact_spec {
             extra_specs
                 .entry(canonical_key)
@@ -566,7 +598,7 @@ pub fn write_berry(
                 continue;
             };
             let manifest_spec = format_berry_spec(dep_name, range);
-            let exact_spec = berry_exact_spec(target_pkg);
+            let exact_spec = berry_exact_spec(target_pkg, &graph.patched_dependencies);
             if manifest_spec != exact_spec {
                 extra_specs.entry(target).or_default().insert(manifest_spec);
             }
@@ -583,7 +615,7 @@ pub fn write_berry(
         // specifier so transitive lookups (which parse emits as
         // `"name@npm:version"`) find a header match, then appends the
         // manifest range specs collected above.
-        let exact_spec = berry_exact_spec(pkg);
+        let exact_spec = berry_exact_spec(pkg, &graph.patched_dependencies);
         let mut header_specs: Vec<String> = vec![exact_spec.clone()];
         if let Some(extras) = extra_specs.get(canonical_key) {
             for s in extras {
@@ -622,6 +654,7 @@ pub fn write_berry(
             &pkg.dependencies,
             &pkg.declared_dependencies,
             &canonical,
+            &graph.patched_dependencies,
         );
         write_berry_dep_map(
             &mut out,
@@ -629,6 +662,7 @@ pub fn write_berry(
             &pkg.optional_dependencies,
             &pkg.declared_dependencies,
             &canonical,
+            &graph.patched_dependencies,
         );
         write_berry_peer_deps(&mut out, &pkg.peer_dependencies);
         write_berry_peer_meta(&mut out, &pkg.peer_dependencies_meta);
@@ -664,10 +698,20 @@ pub fn write_berry(
 /// specifier and its `resolution:` field. Registry packages take the
 /// form `name@npm:version`; non-registry sources use the protocol
 /// recorded in `local_source`.
-fn berry_exact_spec(pkg: &LockedPackage) -> String {
-    match &pkg.local_source {
-        None => format!("{}@npm:{}", pkg.name, pkg.version),
-        Some(src) => format!("{}@{}", pkg.name, src.specifier()),
+fn berry_exact_spec(
+    pkg: &LockedPackage,
+    patched_dependencies: &BTreeMap<String, String>,
+) -> String {
+    let spec_key = pkg.spec_key();
+    match (&pkg.local_source, patched_dependencies.get(&spec_key)) {
+        (None, Some(path)) => {
+            format!(
+                "{}@patch:{}@npm%3A{}#{}",
+                pkg.name, pkg.name, pkg.version, path
+            )
+        }
+        (None, None) => format!("{}@npm:{}", pkg.name, pkg.version),
+        (Some(src), _) => format!("{}@{}", pkg.name, src.specifier()),
     }
 }
 
@@ -677,6 +721,7 @@ fn write_berry_dep_map(
     deps: &BTreeMap<String, String>,
     declared: &BTreeMap<String, String>,
     canonical: &BTreeMap<String, &LockedPackage>,
+    patched_dependencies: &BTreeMap<String, String>,
 ) {
     // Only emit edges whose target survives in `canonical`; the
     // graph-level filter layer (e.g. `--prod` prune) may have dropped
@@ -693,10 +738,17 @@ fn write_berry_dep_map(
             let target = canonical.get(&key)?;
             let spec_body = match &target.local_source {
                 None => {
-                    let body = declared
-                        .get(n)
-                        .cloned()
-                        .unwrap_or_else(|| crate::npm::dep_value_as_version(n, v).to_string());
+                    let body = declared.get(n).cloned().unwrap_or_else(|| {
+                        if patched_dependencies.contains_key(&target.spec_key()) {
+                            let exact = berry_exact_spec(target, patched_dependencies);
+                            exact
+                                .strip_prefix(&format!("{n}@"))
+                                .unwrap_or(&exact)
+                                .to_string()
+                        } else {
+                            crate::npm::dep_value_as_version(n, v).to_string()
+                        }
+                    });
                     // Declared ranges may already carry a protocol
                     // (`npm:^4`, `workspace:*`, `patch:…`) — don't
                     // double-prefix those. Bare ranges like `^4.1.0`

--- a/crates/aube-lockfile/src/yarn/berry.rs
+++ b/crates/aube-lockfile/src/yarn/berry.rs
@@ -462,7 +462,28 @@ fn patch_protocol_path(body: &str) -> Option<String> {
         .split_once("::")
         .map(|(p, _)| p)
         .unwrap_or(after_hash);
-    (!path.is_empty()).then(|| path.to_string())
+    if path.is_empty() || path.starts_with("builtin<") || path.starts_with("~builtin<") {
+        return None;
+    }
+    Some(path.to_string())
+}
+
+fn patch_spec_path(spec: &str) -> Option<String> {
+    let (_, protocol, body) = parse_berry_spec(spec)?;
+    (protocol == "patch").then(|| patch_protocol_path(body))?
+}
+
+fn patch_spec_matches(
+    spec: &str,
+    pkg: &LockedPackage,
+    patched_dependencies: &BTreeMap<String, String>,
+) -> bool {
+    let Some(path) = patch_spec_path(spec) else {
+        return false;
+    };
+    patched_dependencies
+        .get(&pkg.spec_key())
+        .is_some_and(|expected| expected == &path)
 }
 
 fn strip_hash_fragment(s: &str) -> &str {
@@ -550,6 +571,7 @@ pub fn write_berry(
     // gets folded into one block, so transitive lookups of a declared
     // range find a matching header.
     let mut extra_specs: BTreeMap<String, std::collections::BTreeSet<String>> = BTreeMap::new();
+    let mut patch_specs: BTreeMap<String, String> = BTreeMap::new();
     let manifest_ranges: Vec<(String, String)> = manifest
         .dependencies
         .iter()
@@ -574,10 +596,11 @@ pub fn write_berry(
             continue;
         };
         let manifest_spec = format_berry_spec(&dep.name, range);
-        let exact_spec = berry_exact_spec(
-            canonical.get(&canonical_key).copied().unwrap(),
-            &graph.patched_dependencies,
-        );
+        let pkg = canonical.get(&canonical_key).copied().unwrap();
+        if patch_spec_matches(&manifest_spec, pkg, &graph.patched_dependencies) {
+            patch_specs.insert(canonical_key.clone(), manifest_spec.clone());
+        }
+        let exact_spec = berry_exact_spec(pkg, &graph.patched_dependencies, &patch_specs);
         if manifest_spec != exact_spec {
             extra_specs
                 .entry(canonical_key)
@@ -598,7 +621,11 @@ pub fn write_berry(
                 continue;
             };
             let manifest_spec = format_berry_spec(dep_name, range);
-            let exact_spec = berry_exact_spec(target_pkg, &graph.patched_dependencies);
+            if patch_spec_matches(&manifest_spec, target_pkg, &graph.patched_dependencies) {
+                patch_specs.insert(target.clone(), manifest_spec.clone());
+            }
+            let exact_spec =
+                berry_exact_spec(target_pkg, &graph.patched_dependencies, &patch_specs);
             if manifest_spec != exact_spec {
                 extra_specs.entry(target).or_default().insert(manifest_spec);
             }
@@ -615,7 +642,7 @@ pub fn write_berry(
         // specifier so transitive lookups (which parse emits as
         // `"name@npm:version"`) find a header match, then appends the
         // manifest range specs collected above.
-        let exact_spec = berry_exact_spec(pkg, &graph.patched_dependencies);
+        let exact_spec = berry_exact_spec(pkg, &graph.patched_dependencies, &patch_specs);
         let mut header_specs: Vec<String> = vec![exact_spec.clone()];
         if let Some(extras) = extra_specs.get(canonical_key) {
             for s in extras {
@@ -655,6 +682,7 @@ pub fn write_berry(
             &pkg.declared_dependencies,
             &canonical,
             &graph.patched_dependencies,
+            &patch_specs,
         );
         write_berry_dep_map(
             &mut out,
@@ -663,6 +691,7 @@ pub fn write_berry(
             &pkg.declared_dependencies,
             &canonical,
             &graph.patched_dependencies,
+            &patch_specs,
         );
         write_berry_peer_deps(&mut out, &pkg.peer_dependencies);
         write_berry_peer_meta(&mut out, &pkg.peer_dependencies_meta);
@@ -701,9 +730,11 @@ pub fn write_berry(
 fn berry_exact_spec(
     pkg: &LockedPackage,
     patched_dependencies: &BTreeMap<String, String>,
+    patch_specs: &BTreeMap<String, String>,
 ) -> String {
     let spec_key = pkg.spec_key();
     match (&pkg.local_source, patched_dependencies.get(&spec_key)) {
+        (None, Some(_)) if patch_specs.contains_key(&spec_key) => patch_specs[&spec_key].clone(),
         (None, Some(path)) => {
             format!(
                 "{}@patch:{}@npm%3A{}#{}",
@@ -722,6 +753,7 @@ fn write_berry_dep_map(
     declared: &BTreeMap<String, String>,
     canonical: &BTreeMap<String, &LockedPackage>,
     patched_dependencies: &BTreeMap<String, String>,
+    patch_specs: &BTreeMap<String, String>,
 ) {
     // Only emit edges whose target survives in `canonical`; the
     // graph-level filter layer (e.g. `--prod` prune) may have dropped
@@ -740,7 +772,7 @@ fn write_berry_dep_map(
                 None => {
                     let body = declared.get(n).cloned().unwrap_or_else(|| {
                         if patched_dependencies.contains_key(&target.spec_key()) {
-                            let exact = berry_exact_spec(target, patched_dependencies);
+                            let exact = berry_exact_spec(target, patched_dependencies, patch_specs);
                             exact
                                 .strip_prefix(&format!("{n}@"))
                                 .unwrap_or(&exact)

--- a/crates/aube-lockfile/src/yarn/tests.rs
+++ b/crates/aube-lockfile/src/yarn/tests.rs
@@ -404,6 +404,29 @@ fn test_parse_berry_patch_protocol() {
     assert_eq!(graph.importers["."][0].dep_path, "is-number@7.0.0");
 }
 
+#[test]
+fn test_parse_berry_skips_builtin_patch_protocol() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"__metadata:
+  version: 8
+  cacheKey: 10c0
+
+"glob@patch:glob@npm%3A8.1.0#~builtin<compat/glob>":
+  version: 8.1.0
+  resolution: "glob@patch:glob@npm%3A8.1.0#~builtin<compat/glob>"
+  checksum: 10c0/patched
+  languageName: node
+  linkType: hard
+"#;
+    std::fs::write(tmp.path(), content).unwrap();
+    let manifest = make_manifest(&[("glob", "^8.1.0")], &[]);
+    let graph = parse(tmp.path(), &manifest).unwrap();
+
+    assert!(graph.packages.is_empty());
+    assert!(graph.patched_dependencies.is_empty());
+    assert!(graph.importers["."].is_empty());
+}
+
 /// Scoped package names (`@types/node`) and the `, `-joined
 /// multi-spec header format berry uses when two package.json
 /// ranges resolve to the same version.
@@ -709,7 +732,7 @@ fn test_write_berry_roundtrips_patch_protocol() {
     let manifest = make_manifest(
         &[(
             "is-number",
-            "patch:is-number@npm%3A7.0.0#.yarn/patches/is-number.patch",
+            "patch:is-number@npm%3A7.0.0#.yarn/patches/is-number.patch::version=7.0.0&hash=abc123",
         )],
         &[],
     );
@@ -717,9 +740,11 @@ fn test_write_berry_roundtrips_patch_protocol() {
     let out = tempfile::NamedTempFile::new().unwrap();
     write_berry(out.path(), &graph, &manifest).unwrap();
     let written = std::fs::read_to_string(out.path()).unwrap();
-    assert!(
-        written.contains("is-number@patch:is-number@npm%3A7.0.0#.yarn/patches/is-number.patch")
-    );
+    let full_spec = "is-number@patch:is-number@npm%3A7.0.0#.yarn/patches/is-number.patch::version=7.0.0&hash=abc123";
+    assert!(written.contains(full_spec));
+    assert!(!written.contains(&format!(
+        "is-number@patch:is-number@npm%3A7.0.0#.yarn/patches/is-number.patch, {full_spec}"
+    )));
 
     let reparsed = parse(out.path(), &manifest).unwrap();
     assert_eq!(

--- a/crates/aube-lockfile/src/yarn/tests.rs
+++ b/crates/aube-lockfile/src/yarn/tests.rs
@@ -369,6 +369,41 @@ __metadata:
     assert_eq!(root[0].dep_path, "foo@1.2.3");
 }
 
+#[test]
+fn test_parse_berry_patch_protocol() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"__metadata:
+  version: 8
+  cacheKey: 10c0
+
+"is-number@patch:is-number@npm%3A7.0.0#./.yarn/patches/is-number.patch::version=7.0.0&hash=abc123":
+  version: 7.0.0
+  resolution: "is-number@patch:is-number@npm%3A7.0.0#./.yarn/patches/is-number.patch::version=7.0.0&hash=abc123"
+  checksum: 10c0/patched
+  languageName: node
+  linkType: hard
+"#;
+    std::fs::write(tmp.path(), content).unwrap();
+    let manifest = make_manifest(
+        &[(
+            "is-number",
+            "patch:is-number@npm%3A7.0.0#./.yarn/patches/is-number.patch::version=7.0.0&hash=abc123",
+        )],
+        &[],
+    );
+    let graph = parse(tmp.path(), &manifest).unwrap();
+
+    assert!(graph.packages.contains_key("is-number@7.0.0"));
+    assert_eq!(
+        graph
+            .patched_dependencies
+            .get("is-number@7.0.0")
+            .map(String::as_str),
+        Some("./.yarn/patches/is-number.patch")
+    );
+    assert_eq!(graph.importers["."][0].dep_path, "is-number@7.0.0");
+}
+
 /// Scoped package names (`@types/node`) and the `, `-joined
 /// multi-spec header format berry uses when two package.json
 /// ranges resolve to the same version.
@@ -635,6 +670,66 @@ fn test_write_berry_roundtrip() {
     let root = reparsed.importers.get(".").unwrap();
     assert_eq!(root.len(), 1);
     assert_eq!(root[0].dep_path, "foo@1.2.3");
+}
+
+#[test]
+fn test_write_berry_roundtrips_patch_protocol() {
+    let mut packages = BTreeMap::new();
+    packages.insert(
+        "is-number@7.0.0".to_string(),
+        LockedPackage {
+            name: "is-number".to_string(),
+            version: "7.0.0".to_string(),
+            dep_path: "is-number@7.0.0".to_string(),
+            yarn_checksum: Some("10c0/patched".to_string()),
+            ..Default::default()
+        },
+    );
+    let graph = LockfileGraph {
+        importers: {
+            let mut m = BTreeMap::new();
+            m.insert(
+                ".".to_string(),
+                vec![crate::DirectDep {
+                    name: "is-number".to_string(),
+                    dep_path: "is-number@7.0.0".to_string(),
+                    dep_type: DepType::Production,
+                    specifier: None,
+                }],
+            );
+            m
+        },
+        packages,
+        patched_dependencies: BTreeMap::from([(
+            "is-number@7.0.0".to_string(),
+            ".yarn/patches/is-number.patch".to_string(),
+        )]),
+        ..Default::default()
+    };
+    let manifest = make_manifest(
+        &[(
+            "is-number",
+            "patch:is-number@npm%3A7.0.0#.yarn/patches/is-number.patch",
+        )],
+        &[],
+    );
+
+    let out = tempfile::NamedTempFile::new().unwrap();
+    write_berry(out.path(), &graph, &manifest).unwrap();
+    let written = std::fs::read_to_string(out.path()).unwrap();
+    assert!(
+        written.contains("is-number@patch:is-number@npm%3A7.0.0#.yarn/patches/is-number.patch")
+    );
+
+    let reparsed = parse(out.path(), &manifest).unwrap();
+    assert_eq!(
+        reparsed
+            .patched_dependencies
+            .get("is-number@7.0.0")
+            .map(String::as_str),
+        Some(".yarn/patches/is-number.patch")
+    );
+    assert_eq!(reparsed.importers["."][0].dep_path, "is-number@7.0.0");
 }
 
 /// `link:` deps are pure symlinks in berry's model, which means

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -140,7 +140,8 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     // Hoisted ahead of subtree-hash so re-patched packages land in
     // the `changed` bucket and side-effects skip can't trust a stale
     // marker.
-    let (patches_for_linker, patch_hashes) = crate::patches::load_patches_for_linker(cwd)?;
+    let (patches_for_linker, patch_hashes) =
+        crate::patches::load_patches_for_linker(cwd, &graph_for_link.patched_dependencies)?;
 
     // Compute leaf + subtree hashes together when both are needed.
     // Linker invalidation reads `current_subtree_hashes`; the late

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -969,7 +969,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             );
             let lock_build_policy = std::sync::Arc::new(build_policy.clone());
             let lock_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
-            let (lock_patches, lock_patch_hashes) = crate::patches::load_patches_for_linker(&cwd)?;
+            let (lock_patches, lock_patch_hashes) =
+                crate::patches::load_patches_for_linker(&cwd, &graph.patched_dependencies)?;
             let (lock_materialize_tx, lock_materialize_rx) = materialize_channel();
             let lock_prewarm_inputs = GvsPrewarmInputs {
                 graph: std::sync::Arc::new(graph.clone()),
@@ -1704,7 +1705,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let materialize_graph_arc = std::sync::Arc::new(graph.clone());
             let materialize_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
             let (materialize_patches, materialize_patch_hashes) =
-                crate::patches::load_patches_for_linker(&cwd)?;
+                crate::patches::load_patches_for_linker(&cwd, &graph.patched_dependencies)?;
             let materialize_inputs = GvsPrewarmInputs {
                 graph: materialize_graph_arc.clone(),
                 store: store.clone(),

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -148,7 +148,8 @@ pub fn load_patches_for_linker(
     Ok((patches, hashes))
 }
 
-pub fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
+#[cfg(test)]
+fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
     load_patches_with_lockfile_entries(cwd, &BTreeMap::new())
 }
 

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -92,12 +92,12 @@ pub fn split_patch_key(key: &str) -> Result<(String, String)> {
     Ok((name.to_string(), ver.to_string()))
 }
 
-/// Read every patch declared in the project's `package.json` and
-/// `pnpm-workspace.yaml` and return them keyed by `name@version`.
+/// Read every patch declared in the active lockfile, `package.json`,
+/// and `pnpm-workspace.yaml`, then return them keyed by `name@version`.
 /// Workspace-yaml entries (pnpm v10+ canonical location) win over
-/// `package.json` on key conflict. Missing patch files become a hard
-/// error — that matches pnpm, which refuses to install with a
-/// declared-but-missing patch.
+/// `package.json`, which wins over lockfile entries, on key conflict.
+/// Missing patch files become a hard error — that matches pnpm, which
+/// refuses to install with a declared-but-missing patch.
 /// Load patches and pre-build the two shapes the linker + GVS-prewarm
 /// materializer want: a `(name@version, content)` map and a
 /// `(name@version, content_hash)` map. Both materializer call sites
@@ -111,10 +111,12 @@ pub fn split_patch_key(key: &str) -> Result<(String, String)> {
 /// resolved at install entry; patch files are static across the run.
 pub fn load_patches_for_linker(
     cwd: &Path,
+    lockfile_patched_dependencies: &BTreeMap<String, String>,
 ) -> Result<(aube_linker::Patches, BTreeMap<String, String>)> {
     use std::sync::{Mutex, OnceLock};
+    type CacheKey = (PathBuf, BTreeMap<String, String>);
     type CachedShape = (aube_linker::Patches, BTreeMap<String, String>);
-    static CACHE: OnceLock<Mutex<std::collections::HashMap<PathBuf, CachedShape>>> =
+    static CACHE: OnceLock<Mutex<std::collections::HashMap<CacheKey, CachedShape>>> =
         OnceLock::new();
     let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
     // Canonicalize so `cwd` and `cwd.canonicalize()` collapse to one
@@ -122,13 +124,16 @@ pub fn load_patches_for_linker(
     // would otherwise miss the cache. Falls back to the raw path when
     // canonicalize fails (e.g. cwd is the parent of a not-yet-created
     // workspace dir).
-    let key = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let key = (
+        cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf()),
+        lockfile_patched_dependencies.clone(),
+    );
     if let Ok(guard) = cache.lock()
         && let Some(hit) = guard.get(&key)
     {
         return Ok(hit.clone());
     }
-    let resolved = load_patches(cwd)?;
+    let resolved = load_patches_with_lockfile_entries(cwd, lockfile_patched_dependencies)?;
     let patches: aube_linker::Patches = resolved
         .values()
         .map(|p| (p.key.clone(), p.content.clone()))
@@ -144,7 +149,15 @@ pub fn load_patches_for_linker(
 }
 
 pub fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
+    load_patches_with_lockfile_entries(cwd, &BTreeMap::new())
+}
+
+fn load_patches_with_lockfile_entries(
+    cwd: &Path,
+    lockfile_patched_dependencies: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, ResolvedPatch>> {
     let mut entries: BTreeMap<String, String> = BTreeMap::new();
+    entries.extend(lockfile_patched_dependencies.clone());
 
     let manifest_path = cwd.join("package.json");
     if manifest_path.exists() {
@@ -591,6 +604,32 @@ mod tests {
         )
         .unwrap();
         assert!(parsed["patchedDependencies"].is_null());
+    }
+
+    #[test]
+    fn load_reads_lockfile_patched_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".yarn/patches")).unwrap();
+        std::fs::write(
+            dir.path().join(".yarn/patches/is-number.patch"),
+            "diff --git a/index.js b/index.js\n",
+        )
+        .unwrap();
+
+        let (patches, hashes) = load_patches_for_linker(
+            dir.path(),
+            &BTreeMap::from([(
+                "is-number@7.0.0".to_string(),
+                ".yarn/patches/is-number.patch".to_string(),
+            )]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            patches.get("is-number@7.0.0").map(String::as_str),
+            Some("diff --git a/index.js b/index.js\n")
+        );
+        assert!(hashes.contains_key("is-number@7.0.0"));
     }
 
     #[test]

--- a/docs/yarn-users.md
+++ b/docs/yarn-users.md
@@ -38,11 +38,12 @@ aube reads berry's YAML-format `yarn.lock` (the one with the
 values are preserved verbatim so `yarn install` against the rewritten
 file still validates cached tarballs.
 
-Supported protocols: `npm:` (the common case), `workspace:`, `file:`,
-`link:`, plus `git:` / `git+ssh:` / `git+https:` / `https:` URLs for
-remote sources. Entries that use `patch:`, `portal:`, or `exec:` are
-skipped with a warning — aube's dependency graph doesn't model those
-yet, and they round-trip better through Yarn itself.
+Supported protocols: `npm:` (the common case), `patch:` for local
+patch files against npm-backed packages, `workspace:`, `file:`, `link:`,
+plus `git:` / `git+ssh:` / `git+https:` / `https:` URLs for remote
+sources. Entries that use `portal:` or `exec:` are skipped with a
+warning — aube's dependency graph doesn't model those yet, and they
+round-trip better through Yarn itself.
 
 ## Yarn PnP
 

--- a/fixtures/import-yarn-patch/.yarn/patches/is-number.patch
+++ b/fixtures/import-yarn-patch/.yarn/patches/is-number.patch
@@ -1,0 +1,13 @@
+diff --git a/index.js b/index.js
+index 5847425f1bb0af3b05522f41d741e5a63cd171e9..57fb5a2bef3ba007140f499d22da2ea16a949663 100644
+--- a/index.js
++++ b/index.js
+@@ -9,7 +9,7 @@
+ 
+ module.exports = function(num) {
+   if (typeof num === 'number') {
+-    return num - num === 0;
++    return num === 42;
+   }
+   if (typeof num === 'string' && num.trim() !== '') {
+     return Number.isFinite ? Number.isFinite(+num) : isFinite(+num);

--- a/fixtures/import-yarn-patch/package.json
+++ b/fixtures/import-yarn-patch/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "yarn-patch-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-number": "patch:is-number@npm%3A7.0.0#.yarn/patches/is-number.patch"
+  }
+}

--- a/fixtures/import-yarn-patch/yarn.lock
+++ b/fixtures/import-yarn-patch/yarn.lock
@@ -1,0 +1,10 @@
+__metadata:
+  version: 8
+  cacheKey: 10c0
+
+"is-number@patch:is-number@npm%3A7.0.0#.yarn/patches/is-number.patch":
+  version: 7.0.0
+  resolution: "is-number@patch:is-number@npm%3A7.0.0#.yarn/patches/is-number.patch"
+  checksum: 10c0/patched
+  languageName: node
+  linkType: hard

--- a/test/import.bats
+++ b/test/import.bats
@@ -94,6 +94,16 @@ teardown() {
 	assert_dir_exists "node_modules/@sindresorhus/is"
 }
 
+@test "aube install applies yarn berry patch protocol" {
+	cp -R "$PROJECT_ROOT/fixtures/import-yarn-patch/." .
+
+	run aube install --ignore-scripts
+	assert_success
+
+	run node -e 'const isNumber = require("is-number"); if (isNumber(41) || !isNumber(42)) process.exit(1)'
+	assert_success
+}
+
 @test "aube install from bun.lock links workspace deps to their package dirs" {
 	cat >package.json <<'EOF'
 {"name":"root","version":"1.0.0","workspaces":["packages/*"]}


### PR DESCRIPTION
## Summary

- parse Yarn Berry `patch:` resolution entries into aube's patched dependency map instead of skipping them
- feed lockfile-declared patches into install/link materialization so local Yarn patch files are applied
- preserve `patch:` specs when writing Berry lockfiles and document the supported protocol
- add a Yarn patch fixture plus parser, writer, loader, and install regression coverage

## Validation

- `cargo test -p aube-lockfile test_parse_berry_patch_protocol`
- `cargo test -p aube-lockfile test_write_berry_roundtrips_patch_protocol`
- `cargo test -p aube load_reads_lockfile_patched_dependencies`
- `cargo build -p aube`
- `./test/bats/bin/bats test/import.bats --filter 'aube install applies yarn berry patch protocol'`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds support for Yarn Berry `patch:` dependencies, affecting lockfile parsing/writing and patch application during install; risk is mainly incorrect patch resolution or caching causing wrong package contents to be linked.
> 
> **Overview**
> Adds end-to-end support for Yarn Berry `patch:` protocol entries: the Berry parser now records patched packages into `LockfileGraph.patched_dependencies` (skipping builtin patches), and the Berry writer preserves `patch:` specs in headers/resolutions and dependency maps for round-trip fidelity.
> 
> Install/link now passes lockfile-declared patched dependencies into `load_patches_for_linker`, which merges lockfile + manifest/workspace patch sources and caches by `(cwd, patched_dependencies)` so Yarn patch files are applied during materialization. Adds unit/integration coverage plus a `fixtures/import-yarn-patch` fixture, updates docs to list `patch:` as supported, and adds a bats regression test verifying the patch is applied at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f92559fd518f81529ba1232cee26779289c21a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->