### PR TITLE
feat(yarn): support berry portal and exec protocols

### DIFF
--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -330,10 +330,12 @@ pub(crate) fn link_hoisted_importer(
         };
 
         // `link:` deps: symlink the package dir straight at the
-        // target. No files to copy, no transitive symlinks — Node
-        // will follow the link and pick the target's own deps up
-        // naturally. `rebase_local` in the resolver already
-        // normalized the relative path to be importer-relative.
+        // target. `link:` packages were excluded from the dependency
+        // plan above because their target owns its deps. `portal:`
+        // packages stay on the materialized-package path so their
+        // graph-visible deps are linked like Yarn expects.
+        // `rebase_local` in the resolver already normalized the
+        // relative path to be importer-relative.
         if let Some(LocalSource::Link(rel)) = pkg.local_source.as_ref() {
             if let Some(parent) = pkg_dir.parent() {
                 crate::mkdirp(parent)?;

--- a/crates/aube-lockfile/src/bun/source.rs
+++ b/crates/aube-lockfile/src/bun/source.rs
@@ -176,6 +176,8 @@ pub(super) fn rebase_workspace_scoped_local_source(
         LocalSource::Directory(_) => LocalSource::Directory(rebased),
         LocalSource::Tarball(_) => LocalSource::Tarball(rebased),
         LocalSource::Link(_) => LocalSource::Link(rebased),
+        LocalSource::Portal(_) => LocalSource::Portal(rebased),
+        LocalSource::Exec(_) => LocalSource::Exec(rebased),
         LocalSource::Git(_) | LocalSource::RemoteTarball(_) => local,
     }
 }

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -1229,6 +1229,10 @@ fn writer_uses_pnpm_resolution_types_for_portal_and_exec() {
         "portal should use pnpm's directory resolution type:\n{yaml}"
     );
     assert!(
+        !yaml.contains("exec-pkg@exec:./scripts/generate-exec.js:"),
+        "exec packages should be omitted from pnpm packages entries:\n{yaml}"
+    );
+    assert!(
         !yaml.contains("type: portal") && !yaml.contains("type: exec"),
         "pnpm lockfiles must not contain non-standard local source types:\n{yaml}"
     );

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -1156,6 +1156,85 @@ fn exclude_links_from_lockfile_drops_link_deps_from_importer() {
 }
 
 #[test]
+fn writer_uses_pnpm_resolution_types_for_portal_and_exec() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+
+    let portal_source = LocalSource::Portal(std::path::PathBuf::from("./packages/portal"));
+    let exec_source = LocalSource::Exec(std::path::PathBuf::from("./scripts/generate-exec.js"));
+    let portal_dep_path = portal_source.dep_path("portal-pkg");
+    let exec_dep_path = exec_source.dep_path("exec-pkg");
+
+    let mut packages = BTreeMap::new();
+    packages.insert(
+        portal_dep_path.clone(),
+        LockedPackage {
+            name: "portal-pkg".to_string(),
+            version: "1.0.0".to_string(),
+            dep_path: portal_dep_path.clone(),
+            local_source: Some(portal_source),
+            ..Default::default()
+        },
+    );
+    packages.insert(
+        exec_dep_path.clone(),
+        LockedPackage {
+            name: "exec-pkg".to_string(),
+            version: "2.0.0".to_string(),
+            dep_path: exec_dep_path.clone(),
+            local_source: Some(exec_source),
+            ..Default::default()
+        },
+    );
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        vec![
+            DirectDep {
+                name: "portal-pkg".to_string(),
+                dep_path: portal_dep_path,
+                dep_type: DepType::Production,
+                specifier: Some("portal:./packages/portal".to_string()),
+            },
+            DirectDep {
+                name: "exec-pkg".to_string(),
+                dep_path: exec_dep_path,
+                dep_type: DepType::Production,
+                specifier: Some("exec:./scripts/generate-exec.js".to_string()),
+            },
+        ],
+    );
+
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+    let manifest = PackageJson {
+        name: Some("root".to_string()),
+        version: Some("0.0.0".to_string()),
+        ..Default::default()
+    };
+
+    write(&lockfile_path, &graph, &manifest).unwrap();
+    let yaml = std::fs::read_to_string(&lockfile_path).unwrap();
+
+    assert!(
+        yaml.contains("portal-pkg@portal:./packages/portal:"),
+        "portal package should be written:\n{yaml}"
+    );
+    assert!(
+        yaml.contains("resolution: {directory: ./packages/portal, type: directory}"),
+        "portal should use pnpm's directory resolution type:\n{yaml}"
+    );
+    assert!(
+        !yaml.contains("type: portal") && !yaml.contains("type: exec"),
+        "pnpm lockfiles must not contain non-standard local source types:\n{yaml}"
+    );
+}
+
+#[test]
 fn test_parse_invalid_yaml() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("pnpm-lock.yaml");

--- a/crates/aube-lockfile/src/pnpm/write.rs
+++ b/crates/aube-lockfile/src/pnpm/write.rs
@@ -230,6 +230,17 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 path: None,
             }),
             Some(LocalSource::Link(_)) => None,
+            Some(local @ LocalSource::Portal(_)) | Some(local @ LocalSource::Exec(_)) => {
+                Some(WritableResolution {
+                    integrity: None,
+                    directory: Some(local.path_posix()),
+                    tarball: None,
+                    commit: None,
+                    repo: None,
+                    type_: Some(local.kind_str().to_string()),
+                    path: None,
+                })
+            }
             Some(LocalSource::Git(g)) => Some(WritableResolution {
                 integrity: None,
                 directory: None,

--- a/crates/aube-lockfile/src/pnpm/write.rs
+++ b/crates/aube-lockfile/src/pnpm/write.rs
@@ -229,18 +229,16 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 type_: None,
                 path: None,
             }),
-            Some(LocalSource::Link(_)) => None,
-            Some(local @ LocalSource::Portal(_)) | Some(local @ LocalSource::Exec(_)) => {
-                Some(WritableResolution {
-                    integrity: None,
-                    directory: Some(local.path_posix()),
-                    tarball: None,
-                    commit: None,
-                    repo: None,
-                    type_: Some(local.kind_str().to_string()),
-                    path: None,
-                })
-            }
+            Some(LocalSource::Link(_)) | Some(LocalSource::Exec(_)) => None,
+            Some(local @ LocalSource::Portal(_)) => Some(WritableResolution {
+                integrity: None,
+                directory: Some(local.path_posix()),
+                tarball: None,
+                commit: None,
+                repo: None,
+                type_: Some("directory".to_string()),
+                path: None,
+            }),
             Some(LocalSource::Git(g)) => Some(WritableResolution {
                 integrity: None,
                 directory: None,

--- a/crates/aube-lockfile/src/pnpm/write.rs
+++ b/crates/aube-lockfile/src/pnpm/write.rs
@@ -147,7 +147,9 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         // Local deps use the canonical specifier in their key (e.g.
         // `foo@file:./vendor/foo`) so pnpm can read the lockfile.
         // `link:` deps are omitted from the packages section entirely,
-        // matching pnpm.
+        // matching pnpm. `exec:` has no pnpm resolution analogue, so
+        // keep it out too instead of writing a package key with no
+        // resolution block.
         // Non-registry transitive entries (github overrides, remote
         // tarballs fetched by URL) keep the URL in their dep-path key
         // and carry the real semver on `pkg.version`. `tarball_url`
@@ -161,7 +163,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
             .as_ref()
             .is_some_and(|url| parse_dep_path(&pkg.dep_path).is_some_and(|(_, v)| v == *url));
         let canonical = match pkg.local_source.as_ref() {
-            Some(LocalSource::Link(_)) => continue,
+            Some(LocalSource::Link(_)) | Some(LocalSource::Exec(_)) => continue,
             Some(local) => format!("{}@{}", pkg.name, local.specifier()),
             None => {
                 if native_pnpm_aliases && let Some(real_name) = pkg.alias_of.as_deref() {
@@ -363,11 +365,13 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
     };
     let mut snapshots = BTreeMap::new();
     for (dep_path, pkg) in &graph.packages {
-        // `link:` deps are omitted from snapshots (pnpm parity); other
-        // local deps use the canonical specifier key so pnpm's parser
-        // lines them up with the packages entry above.
+        // `link:` deps are omitted from snapshots (pnpm parity). `exec:`
+        // is omitted for the same reason it is omitted from packages:
+        // pnpm has no resolution shape for generated packages.
+        // Other local deps use the canonical specifier key so pnpm's
+        // parser lines them up with the packages entry above.
         let key = match pkg.local_source.as_ref() {
-            Some(LocalSource::Link(_)) => continue,
+            Some(LocalSource::Link(_)) | Some(LocalSource::Exec(_)) => continue,
             Some(local) => format!("{}@{}", pkg.name, local.specifier()),
             None => {
                 if native_pnpm_aliases && let Some(real_name) = pkg.alias_of.as_deref() {

--- a/crates/aube-lockfile/src/source.rs
+++ b/crates/aube-lockfile/src/source.rs
@@ -199,6 +199,8 @@ impl LocalSource {
             ("link", r)
         } else if let Some(r) = spec.strip_prefix("portal:") {
             ("portal", r)
+        } else if let Some(r) = spec.strip_prefix("exec:") {
+            return Some(LocalSource::Exec(PathBuf::from(r)));
         } else {
             return None;
         };
@@ -655,6 +657,15 @@ mod tests {
         use std::path::Path;
         let parsed = LocalSource::parse("https://github.com/user/repo.git", Path::new(""));
         assert!(matches!(parsed, Some(LocalSource::Git(_))));
+    }
+
+    #[test]
+    fn parse_classifies_exec_as_local_source() {
+        let parsed = LocalSource::parse("exec:./scripts/generate.js", Path::new(""));
+        assert_eq!(
+            parsed,
+            Some(LocalSource::Exec(PathBuf::from("./scripts/generate.js")))
+        );
     }
 
     #[test]

--- a/crates/aube-lockfile/src/source.rs
+++ b/crates/aube-lockfile/src/source.rs
@@ -19,6 +19,14 @@ pub enum LocalSource {
     /// materialized into the virtual store. Transitive deps are the
     /// target's responsibility.
     Link(PathBuf),
+    /// `portal:<dir>` — a Yarn Berry package portal. The target is a
+    /// package on disk, but unlike `link:` its dependencies are still
+    /// modeled in the lockfile graph.
+    Portal(PathBuf),
+    /// `exec:<script>` — a Yarn Berry generator script. The script is
+    /// executed at fetch time and writes the package files into a
+    /// generated build directory.
+    Exec(PathBuf),
     /// `git+https://`, `git+ssh://`, `github:user/repo`, etc. — a
     /// remote git repo. Cloned at fetch time and imported like a
     /// `file:` directory. `url` is the normalized clone URL (what
@@ -62,7 +70,11 @@ impl LocalSource {
     /// in `package.json`. `None` for non-path sources like git.
     pub fn path(&self) -> Option<&Path> {
         match self {
-            LocalSource::Directory(p) | LocalSource::Tarball(p) | LocalSource::Link(p) => Some(p),
+            LocalSource::Directory(p)
+            | LocalSource::Tarball(p)
+            | LocalSource::Link(p)
+            | LocalSource::Portal(p)
+            | LocalSource::Exec(p) => Some(p),
             LocalSource::Git(_) | LocalSource::RemoteTarball(_) => None,
         }
     }
@@ -72,6 +84,8 @@ impl LocalSource {
         match self {
             LocalSource::Directory(_) | LocalSource::Tarball(_) => "file",
             LocalSource::Link(_) => "link",
+            LocalSource::Portal(_) => "portal",
+            LocalSource::Exec(_) => "exec",
             LocalSource::Git(_) => "git",
             LocalSource::RemoteTarball(_) => "url",
         }
@@ -183,6 +197,8 @@ impl LocalSource {
             ("file", r)
         } else if let Some(r) = spec.strip_prefix("link:") {
             ("link", r)
+        } else if let Some(r) = spec.strip_prefix("portal:") {
+            ("portal", r)
         } else {
             return None;
         };
@@ -190,6 +206,9 @@ impl LocalSource {
         let abs = project_root.join(&rel);
         if kind == "link" {
             return Some(LocalSource::Link(rel));
+        }
+        if kind == "portal" {
+            return Some(LocalSource::Portal(rel));
         }
         if abs.is_file() && Self::path_looks_like_tarball(&rel) {
             return Some(LocalSource::Tarball(rel));

--- a/crates/aube-lockfile/src/yarn/berry.rs
+++ b/crates/aube-lockfile/src/yarn/berry.rs
@@ -125,15 +125,12 @@ pub(super) fn parse_berry_str(
                 patched_dependencies.insert(format!("{res_name}@{version}"), patch_path);
                 None
             }
-            "portal" | "exec" => {
-                tracing::warn!(
-                    code = aube_codes::warnings::WARN_AUBE_YARN_BERRY_UNSUPPORTED,
-                    "yarn berry '{}' protocol in block '{}' is not supported — entry skipped",
-                    res_protocol,
-                    key_str,
-                );
-                continue;
-            }
+            "portal" => Some(LocalSource::Portal(PathBuf::from(strip_hash_fragment(
+                res_body,
+            )))),
+            "exec" => Some(LocalSource::Exec(PathBuf::from(strip_hash_fragment(
+                res_body,
+            )))),
             "file" => Some(file_protocol_source(res_body)),
             "link" => Some(LocalSource::Link(PathBuf::from(strip_hash_fragment(
                 res_body,
@@ -550,8 +547,6 @@ fn classify_remote(url: &str, _block: &yaml_serde::Mapping) -> Option<LocalSourc
 ///   `yarn_checksum` from) are written without a `checksum:` field.
 ///   Yarn's default `checksumBehavior: throw` populates missing
 ///   checksums on the next install against its own cache.
-/// - `portal:` / `exec:` protocols aren't represented in aube's graph
-///   and never round-trip.
 pub fn write_berry(
     path: &Path,
     graph: &LockfileGraph,
@@ -711,7 +706,7 @@ pub fn write_berry(
         // output, which breaks `link:` projects that round-trip
         // through aube.
         let link_type = match &pkg.local_source {
-            Some(LocalSource::Link(_)) => "soft",
+            Some(LocalSource::Link(_) | LocalSource::Portal(_)) => "soft",
             _ => "hard",
         };
         out.push_str("  linkType: ");

--- a/crates/aube-lockfile/src/yarn/berry.rs
+++ b/crates/aube-lockfile/src/yarn/berry.rs
@@ -698,13 +698,11 @@ pub fn write_berry(
         }
         out.push_str("  languageName: node\n");
         // `linkType: soft` means "just symlink, don't materialize into
-        // the virtual store" — what berry uses for `link:` (and
-        // `workspace:`) entries. `hard` is the default for registry
-        // packages and everything that does get materialized. Portal
-        // packages are materialized by aube so their graph-visible deps
-        // can be linked under the package, so they stay `hard` here.
+        // the virtual store" — what berry uses for local directory refs
+        // (`link:`, `portal:`, and `workspace:`). `hard` is the default
+        // for registry packages and generated/cache-backed sources.
         let link_type = match &pkg.local_source {
-            Some(LocalSource::Link(_)) => "soft",
+            Some(LocalSource::Link(_) | LocalSource::Portal(_)) => "soft",
             _ => "hard",
         };
         out.push_str("  linkType: ");

--- a/crates/aube-lockfile/src/yarn/berry.rs
+++ b/crates/aube-lockfile/src/yarn/berry.rs
@@ -700,13 +700,11 @@ pub fn write_berry(
         // `linkType: soft` means "just symlink, don't materialize into
         // the virtual store" — what berry uses for `link:` (and
         // `workspace:`) entries. `hard` is the default for registry
-        // packages and everything that does get materialized. Picking
-        // `hard` for a `link:` block would send yarn's own linker
-        // down the tarball-import path the next time it reads our
-        // output, which breaks `link:` projects that round-trip
-        // through aube.
+        // packages and everything that does get materialized. Portal
+        // packages are materialized by aube so their graph-visible deps
+        // can be linked under the package, so they stay `hard` here.
         let link_type = match &pkg.local_source {
-            Some(LocalSource::Link(_) | LocalSource::Portal(_)) => "soft",
+            Some(LocalSource::Link(_)) => "soft",
             _ => "hard",
         };
         out.push_str("  linkType: ");

--- a/crates/aube-lockfile/src/yarn/tests.rs
+++ b/crates/aube-lockfile/src/yarn/tests.rs
@@ -925,7 +925,7 @@ fn test_write_berry_roundtrips_portal_and_exec_protocols() {
     );
     let portal_block = &written[portal_idx..];
     let exec_block = &written[exec_idx..portal_idx];
-    assert!(portal_block.contains("linkType: hard"));
+    assert!(portal_block.contains("linkType: soft"));
     assert!(exec_block.contains("linkType: hard"));
 }
 

--- a/crates/aube-lockfile/src/yarn/tests.rs
+++ b/crates/aube-lockfile/src/yarn/tests.rs
@@ -632,6 +632,64 @@ fn test_parse_berry_http_and_git_protocols() {
     assert!(matches!(&ssh.local_source, Some(LocalSource::Git(_))));
 }
 
+#[test]
+fn test_parse_berry_portal_and_exec_protocols() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"__metadata:
+  version: 8
+  cacheKey: 10c0
+
+"portal-pkg@portal:./packages/portal":
+  version: 1.0.0
+  resolution: "portal-pkg@portal:./packages/portal"
+  dependencies:
+    left-pad: "npm:^1.3.0"
+  languageName: node
+  linkType: soft
+
+"exec-pkg@exec:./scripts/generate-exec.js":
+  version: 2.0.0
+  resolution: "exec-pkg@exec:./scripts/generate-exec.js"
+  languageName: node
+  linkType: hard
+
+"left-pad@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "left-pad@npm:1.3.0"
+  languageName: node
+  linkType: hard
+"#;
+    std::fs::write(tmp.path(), content).unwrap();
+    let manifest = make_manifest(
+        &[
+            ("portal-pkg", "portal:./packages/portal"),
+            ("exec-pkg", "exec:./scripts/generate-exec.js"),
+        ],
+        &[],
+    );
+    let graph = parse(tmp.path(), &manifest).unwrap();
+
+    let portal_key = LocalSource::Portal(PathBuf::from("./packages/portal")).dep_path("portal-pkg");
+    let portal = &graph.packages[&portal_key];
+    assert!(matches!(
+        &portal.local_source,
+        Some(LocalSource::Portal(p)) if p == &PathBuf::from("./packages/portal")
+    ));
+    assert_eq!(
+        portal.dependencies.get("left-pad").map(String::as_str),
+        Some("left-pad@1.3.0")
+    );
+
+    let exec_key =
+        LocalSource::Exec(PathBuf::from("./scripts/generate-exec.js")).dep_path("exec-pkg");
+    let exec = &graph.packages[&exec_key];
+    assert!(matches!(
+        &exec.local_source,
+        Some(LocalSource::Exec(p)) if p == &PathBuf::from("./scripts/generate-exec.js")
+    ));
+    assert_eq!(graph.importers["."].len(), 2);
+}
+
 /// Round-trip: parse berry → write berry → parse berry should
 /// preserve packages, versions, checksum (via `yarn_checksum`),
 /// and transitive edges. This is the core round-trip contract.
@@ -815,6 +873,56 @@ fn test_write_berry_link_type_soft_for_link_deps() {
         regular_block.contains("linkType: hard"),
         "registry block should be hard-linked:\n{regular_block}"
     );
+}
+
+#[test]
+fn test_write_berry_roundtrips_portal_and_exec_protocols() {
+    let portal_source = LocalSource::Portal(PathBuf::from("./packages/portal"));
+    let exec_source = LocalSource::Exec(PathBuf::from("./scripts/generate-exec.js"));
+    let mut packages = BTreeMap::new();
+    packages.insert(
+        portal_source.dep_path("portal-pkg"),
+        LockedPackage {
+            name: "portal-pkg".to_string(),
+            version: "1.0.0".to_string(),
+            dep_path: portal_source.dep_path("portal-pkg"),
+            local_source: Some(portal_source),
+            ..Default::default()
+        },
+    );
+    packages.insert(
+        exec_source.dep_path("exec-pkg"),
+        LockedPackage {
+            name: "exec-pkg".to_string(),
+            version: "2.0.0".to_string(),
+            dep_path: exec_source.dep_path("exec-pkg"),
+            local_source: Some(exec_source),
+            ..Default::default()
+        },
+    );
+    let graph = LockfileGraph {
+        importers: {
+            let mut m = BTreeMap::new();
+            m.insert(".".to_string(), vec![]);
+            m
+        },
+        packages,
+        ..Default::default()
+    };
+    let manifest = make_manifest(&[], &[]);
+
+    let out = tempfile::NamedTempFile::new().unwrap();
+    write_berry(out.path(), &graph, &manifest).unwrap();
+    let written = std::fs::read_to_string(out.path()).unwrap();
+
+    assert!(written.contains("portal-pkg@portal:./packages/portal"));
+    assert!(written.contains("exec-pkg@exec:./scripts/generate-exec.js"));
+    let portal_idx = written.find("portal-pkg@portal:").unwrap();
+    let exec_idx = written.find("exec-pkg@exec:").unwrap();
+    let portal_block = &written[portal_idx..];
+    let exec_block = &written[exec_idx..portal_idx];
+    assert!(portal_block.contains("linkType: soft"));
+    assert!(exec_block.contains("linkType: hard"));
 }
 
 /// Header and `resolution:` both carry spec strings that may

--- a/crates/aube-lockfile/src/yarn/tests.rs
+++ b/crates/aube-lockfile/src/yarn/tests.rs
@@ -919,6 +919,10 @@ fn test_write_berry_roundtrips_portal_and_exec_protocols() {
     assert!(written.contains("exec-pkg@exec:./scripts/generate-exec.js"));
     let portal_idx = written.find("portal-pkg@portal:").unwrap();
     let exec_idx = written.find("exec-pkg@exec:").unwrap();
+    assert!(
+        exec_idx < portal_idx,
+        "expected exec block before portal block:\n{written}"
+    );
     let portal_block = &written[portal_idx..];
     let exec_block = &written[exec_idx..portal_idx];
     assert!(portal_block.contains("linkType: soft"));

--- a/crates/aube-lockfile/src/yarn/tests.rs
+++ b/crates/aube-lockfile/src/yarn/tests.rs
@@ -925,7 +925,7 @@ fn test_write_berry_roundtrips_portal_and_exec_protocols() {
     );
     let portal_block = &written[portal_idx..];
     let exec_block = &written[exec_idx..portal_idx];
-    assert!(portal_block.contains("linkType: soft"));
+    assert!(portal_block.contains("linkType: hard"));
     assert!(exec_block.contains("linkType: hard"));
 }
 

--- a/crates/aube-resolver/Cargo.toml
+++ b/crates/aube-resolver/Cargo.toml
@@ -32,9 +32,9 @@ thiserror = { workspace = true }
 miette = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"
 
 [build-dependencies]
 rkyv = { workspace = true }

--- a/crates/aube-resolver/src/builder.rs
+++ b/crates/aube-resolver/src/builder.rs
@@ -38,6 +38,7 @@ impl Resolver {
             ignored_optional_dependencies: BTreeSet::new(),
             resolution_mode: ResolutionMode::Highest,
             project_root: PathBuf::from("."),
+            ignore_scripts: false,
             minimum_release_age: None,
             catalogs: BTreeMap::new(),
             read_package_hook: None,
@@ -83,6 +84,7 @@ impl Resolver {
                 ignored_optional_dependencies: BTreeSet::new(),
                 resolution_mode: ResolutionMode::Highest,
                 project_root: PathBuf::from("."),
+                ignore_scripts: false,
                 minimum_release_age: None,
                 catalogs: BTreeMap::new(),
                 read_package_hook: None,
@@ -263,6 +265,11 @@ impl Resolver {
     /// local package's transitive deps.
     pub fn with_project_root(mut self, project_root: PathBuf) -> Self {
         self.project_root = project_root;
+        self
+    }
+
+    pub fn with_ignore_scripts(mut self, ignore_scripts: bool) -> Self {
+        self.ignore_scripts = ignore_scripts;
         self
     }
 

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -15,6 +15,7 @@ mod types;
 
 pub use direct_dep_info::DirectDepInfo;
 pub use error::{AgeGateDetails, CatalogDetails, Error, ExoticSubdepDetails, NoMatchDetails};
+pub use local_source::resolve_exec_script_path;
 pub use package_ext::is_deprecation_allowed;
 pub use peer_context::{
     PeerContextOptions, UnmetPeer, apply_peer_contexts, detect_unmet_peers,

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -29,6 +29,15 @@ pub use types::{
     ResolvedPackage, TrustPolicy,
 };
 
+pub const YARN_EXEC_WRAPPER: &str = r#"
+const env = JSON.parse(process.env.AUBE_YARN_EXEC_ENV);
+globalThis.execEnv = env;
+for (const name of ['fs', 'path', 'child_process', 'os', 'crypto', 'url', 'util', 'stream', 'buffer']) {
+  globalThis[name] = require(name);
+}
+require(process.argv[1]);
+"#;
+
 use semver_util::version_satisfies;
 
 #[cfg(test)]
@@ -120,6 +129,9 @@ pub struct Resolver {
     /// target directory. Defaults to the current working directory;
     /// callers set it via `with_project_root`.
     project_root: PathBuf,
+    /// When true, resolver-time `exec:` generators are blocked the
+    /// same way fetch-time execution is blocked.
+    ignore_scripts: bool,
     /// pnpm v11's `minimumReleaseAge` triplet. `None` disables the
     /// supply-chain age gate entirely (matching `minimumReleaseAge: 0`).
     minimum_release_age: Option<MinimumReleaseAge>,

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -149,14 +149,17 @@ pub(crate) fn dep_path_for(name: &str, version: &str) -> String {
 }
 
 /// Match specifier prefixes that resolve to a non-registry source
-/// (`file:`, `link:`, or a git URL form). Used by the resolver to
-/// decide whether to dispatch the local/git branch instead of the
-/// normal version-range lookup.
+/// (`file:`, `link:`, `portal:`, `exec:`, or a git URL form). Used
+/// by the resolver to decide whether to dispatch the local/git branch
+/// instead of the normal version-range lookup.
 pub(crate) fn is_non_registry_specifier(s: &str) -> bool {
     if s.starts_with("link:") {
         return true;
     }
     if s.starts_with("portal:") {
+        return true;
+    }
+    if s.starts_with("exec:") {
         return true;
     }
     // Git first so `https://host/repo.git` dispatches the git branch

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -40,6 +40,8 @@ pub(crate) fn rebase_local(
         LocalSource::Directory(_) => LocalSource::Directory(rebased),
         LocalSource::Tarball(_) => LocalSource::Tarball(rebased),
         LocalSource::Link(_) => LocalSource::Link(rebased),
+        LocalSource::Portal(_) => LocalSource::Portal(rebased),
+        LocalSource::Exec(_) => LocalSource::Exec(rebased),
         LocalSource::Git(_) | LocalSource::RemoteTarball(_) => local.clone(),
     }
 }
@@ -97,10 +99,11 @@ fn read_tarball_package_json(bytes: &[u8]) -> Result<Vec<u8>, String> {
 /// Read the `package.json` of a `file:` / `link:` target to discover
 /// the real package name, version, and production dependencies.
 ///
-/// For `LocalSource::Directory` and `LocalSource::Link` we read the
-/// target dir's `package.json` directly. For `LocalSource::Tarball` we
-/// open the `.tgz`, find the first `*/package.json` entry, and parse
-/// its contents without extracting the rest of the archive.
+/// For `LocalSource::Directory`, `LocalSource::Link`, and
+/// `LocalSource::Portal` we read the target dir's `package.json`
+/// directly. For `LocalSource::Tarball` we open the `.tgz`, find the
+/// first `*/package.json` entry, and parse its contents without
+/// extracting the rest of the archive.
 pub(crate) fn read_local_manifest(
     local: &LocalSource,
     importer_root: &std::path::Path,
@@ -114,7 +117,7 @@ pub(crate) fn read_local_manifest(
     let path = importer_root.join(local_path);
 
     let content = match local {
-        LocalSource::Directory(_) | LocalSource::Link(_) => {
+        LocalSource::Directory(_) | LocalSource::Link(_) | LocalSource::Portal(_) => {
             std::fs::read(path.join("package.json"))
                 .map_err(|e| Error::Registry(local.specifier(), e.to_string()))?
         }
@@ -123,10 +126,10 @@ pub(crate) fn read_local_manifest(
                 .map_err(|e| Error::Registry(local.specifier(), e.to_string()))?;
             read_tarball_package_json(&bytes).map_err(|e| Error::Registry(local.specifier(), e))?
         }
-        LocalSource::Git(_) | LocalSource::RemoteTarball(_) => {
+        LocalSource::Exec(_) | LocalSource::Git(_) | LocalSource::RemoteTarball(_) => {
             return Err(Error::Registry(
                 local.specifier(),
-                "read_local_manifest: remote source handled separately".to_string(),
+                "read_local_manifest: generated or remote source handled separately".to_string(),
             ));
         }
     };
@@ -151,6 +154,9 @@ pub(crate) fn dep_path_for(name: &str, version: &str) -> String {
 /// normal version-range lookup.
 pub(crate) fn is_non_registry_specifier(s: &str) -> bool {
     if s.starts_with("link:") {
+        return true;
+    }
+    if s.starts_with("portal:") {
         return true;
     }
     // Git first so `https://host/repo.git` dispatches the git branch
@@ -183,7 +189,9 @@ pub(crate) fn should_block_exotic_subdep(
             .is_some_and(|pkg| {
                 matches!(
                     pkg.local_source,
-                    Some(LocalSource::Directory(_)) | Some(LocalSource::Link(_))
+                    Some(LocalSource::Directory(_))
+                        | Some(LocalSource::Link(_))
+                        | Some(LocalSource::Portal(_))
                 )
             })
 }

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -28,6 +28,9 @@ pub(crate) fn rebase_local(
     // case — no rewrite needed and we preserve the raw specifier
     // bytes for a byte-identical lockfile round-trip.
     if importer_root == project_root {
+        if let LocalSource::Exec(path) = local {
+            return LocalSource::Exec(normalize_lexical(path));
+        }
         return local.clone();
     }
     let Some(local_path) = local.path() else {
@@ -183,17 +186,9 @@ pub(crate) async fn resolve_exec_manifest(
         "buildDir": build_dir,
         "locator": format!("{name}@{}", local.specifier()),
     });
-    let wrapper = r#"
-const env = JSON.parse(process.env.AUBE_YARN_EXEC_ENV);
-globalThis.execEnv = env;
-for (const name of ['fs', 'path', 'child_process', 'os', 'crypto', 'url', 'util', 'stream', 'buffer']) {
-  globalThis[name] = require(name);
-}
-require(process.argv[1]);
-"#;
     let status = tokio::process::Command::new("node")
         .arg("-e")
-        .arg(wrapper)
+        .arg(crate::YARN_EXEC_WRAPPER)
         .arg(&script)
         .env("AUBE_YARN_EXEC_ENV", env.to_string())
         .current_dir(project_root)
@@ -606,6 +601,21 @@ mod rebase_local_tests {
             Path::new(""),
         );
         assert_eq!(a.dep_path("vendor-dir"), b.dep_path("vendor-dir"));
+    }
+
+    #[test]
+    fn root_and_transitive_exec_paths_collide_on_dep_path() {
+        let root = rebase_local(
+            &LocalSource::Exec(PathBuf::from("./scripts/generate-exec.js")),
+            Path::new(""),
+            Path::new(""),
+        );
+        let transitive = rebase_local(
+            &LocalSource::Exec(PathBuf::from("../../scripts/generate-exec.js")),
+            Path::new("packages/portal"),
+            Path::new(""),
+        );
+        assert_eq!(root.dep_path("exec-pkg"), transitive.dep_path("exec-pkg"));
     }
 
     #[test]

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -195,6 +195,7 @@ pub(crate) fn should_block_exotic_subdep(
                     Some(LocalSource::Directory(_))
                         | Some(LocalSource::Link(_))
                         | Some(LocalSource::Portal(_))
+                        | Some(LocalSource::Exec(_))
                 )
             })
 }

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -144,6 +144,92 @@ pub(crate) fn read_local_manifest(
     ))
 }
 
+pub(crate) async fn resolve_exec_manifest(
+    name: &str,
+    local: &LocalSource,
+    project_root: &std::path::Path,
+) -> Result<(String, BTreeMap<String, String>), Error> {
+    let LocalSource::Exec(rel) = local else {
+        return Err(Error::Registry(
+            name.to_string(),
+            "resolve_exec_manifest called on non-exec source".to_string(),
+        ));
+    };
+    let script = project_root.join(rel);
+    if !script.is_file() {
+        return Err(Error::Registry(
+            name.to_string(),
+            format!(
+                "exec dependency {}: {} is not a file",
+                local.specifier(),
+                script.display()
+            ),
+        ));
+    }
+
+    let temp = tempfile::Builder::new()
+        .prefix("aube-exec-resolve-")
+        .tempdir()
+        .map_err(|e| Error::Registry(name.to_string(), e.to_string()))?;
+    let build_dir = temp.path().join("build");
+    let temp_dir = temp.path().join("temp");
+    std::fs::create_dir_all(&build_dir)
+        .map_err(|e| Error::Registry(name.to_string(), e.to_string()))?;
+    std::fs::create_dir_all(&temp_dir)
+        .map_err(|e| Error::Registry(name.to_string(), e.to_string()))?;
+
+    let env = serde_json::json!({
+        "tempDir": temp_dir,
+        "buildDir": build_dir,
+        "locator": format!("{name}@{}", local.specifier()),
+    });
+    let wrapper = r#"
+const env = JSON.parse(process.env.AUBE_YARN_EXEC_ENV);
+globalThis.execEnv = env;
+for (const name of ['fs', 'path', 'child_process', 'os', 'crypto', 'url', 'util', 'stream', 'buffer']) {
+  globalThis[name] = require(name);
+}
+require(process.argv[1]);
+"#;
+    let status = tokio::process::Command::new("node")
+        .arg("-e")
+        .arg(wrapper)
+        .arg(&script)
+        .env("AUBE_YARN_EXEC_ENV", env.to_string())
+        .current_dir(project_root)
+        .status()
+        .await
+        .map_err(|e| {
+            Error::Registry(
+                name.to_string(),
+                format!("execute {} with Node.js from PATH: {e}", local.specifier()),
+            )
+        })?;
+    if !status.success() {
+        return Err(Error::Registry(
+            name.to_string(),
+            format!(
+                "exec dependency {} failed with status {status}",
+                local.specifier()
+            ),
+        ));
+    }
+
+    let content = std::fs::read(build_dir.join("package.json")).map_err(|e| {
+        Error::Registry(
+            name.to_string(),
+            format!("read generated package.json for {}: {e}", local.specifier()),
+        )
+    })?;
+    let pj: aube_manifest::PackageJson = sonic_rs::from_slice(&content)
+        .or_else(|_| serde_json::from_slice(&content))
+        .map_err(|e| Error::Registry(name.to_string(), e.to_string()))?;
+    Ok((
+        pj.version.unwrap_or_else(|| "0.0.0".to_string()),
+        pj.dependencies,
+    ))
+}
+
 pub(crate) fn dep_path_for(name: &str, version: &str) -> String {
     format!("{name}@{version}")
 }

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -3,6 +3,7 @@ use aube_lockfile::{LocalSource, LockedPackage};
 use aube_registry::client::RegistryClient;
 use aube_util::path::normalize_lexical;
 use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 /// Rewrite a `LocalSource` whose path is relative to `importer_root`
 /// into one whose path is relative to `project_root`, so downstream
@@ -20,8 +21,8 @@ use std::collections::BTreeMap;
 /// lockfile's `version:` string.
 pub(crate) fn rebase_local(
     local: &LocalSource,
-    importer_root: &std::path::Path,
-    project_root: &std::path::Path,
+    importer_root: &Path,
+    project_root: &Path,
 ) -> LocalSource {
     // The fast path: importer_root == project_root. Root-importer
     // installs take this branch, which is also the single-project
@@ -47,6 +48,34 @@ pub(crate) fn rebase_local(
         LocalSource::Exec(_) => LocalSource::Exec(rebased),
         LocalSource::Git(_) | LocalSource::RemoteTarball(_) => local.clone(),
     }
+}
+
+/// Resolve an `exec:` generator path and reject scripts outside the project root.
+pub fn resolve_exec_script_path(
+    local: &LocalSource,
+    project_root: &Path,
+) -> Result<PathBuf, String> {
+    let LocalSource::Exec(rel) = local else {
+        return Err("resolve_exec_script_path called on non-exec source".to_string());
+    };
+    let script = project_root.join(rel);
+    if !script.is_file() {
+        return Err(format!("{} is not a file", script.display()));
+    }
+    let canonical_root = project_root
+        .canonicalize()
+        .map_err(|e| format!("canonicalize project root {}: {e}", project_root.display()))?;
+    let canonical_script = script
+        .canonicalize()
+        .map_err(|e| format!("canonicalize exec script {}: {e}", script.display()))?;
+    if !canonical_script.starts_with(&canonical_root) {
+        return Err(format!(
+            "{} resolves outside project root {}",
+            script.display(),
+            canonical_root.display()
+        ));
+    }
+    Ok(canonical_script)
 }
 
 /// Walk a gzipped npm tarball once and return the raw bytes of its
@@ -109,7 +138,7 @@ fn read_tarball_package_json(bytes: &[u8]) -> Result<Vec<u8>, String> {
 /// extracting the rest of the archive.
 pub(crate) fn read_local_manifest(
     local: &LocalSource,
-    importer_root: &std::path::Path,
+    importer_root: &Path,
 ) -> Result<(String, String, BTreeMap<String, String>), Error> {
     let Some(local_path) = local.path() else {
         return Err(Error::Registry(
@@ -150,25 +179,20 @@ pub(crate) fn read_local_manifest(
 pub(crate) async fn resolve_exec_manifest(
     name: &str,
     local: &LocalSource,
-    project_root: &std::path::Path,
+    project_root: &Path,
 ) -> Result<(String, BTreeMap<String, String>), Error> {
-    let LocalSource::Exec(rel) = local else {
+    let LocalSource::Exec(_) = local else {
         return Err(Error::Registry(
             name.to_string(),
             "resolve_exec_manifest called on non-exec source".to_string(),
         ));
     };
-    let script = project_root.join(rel);
-    if !script.is_file() {
-        return Err(Error::Registry(
+    let script = resolve_exec_script_path(local, project_root).map_err(|e| {
+        Error::Registry(
             name.to_string(),
-            format!(
-                "exec dependency {}: {} is not a file",
-                local.specifier(),
-                script.display()
-            ),
-        ));
-    }
+            format!("exec dependency {}: {e}", local.specifier()),
+        )
+    })?;
 
     let temp = tempfile::Builder::new()
         .prefix("aube-exec-resolve-")
@@ -638,6 +662,33 @@ mod rebase_local_tests {
         assert_eq!(win.dep_path("foo"), unix.dep_path("foo"));
         assert_eq!(win.specifier(), "file:vendor/nested/dir");
         assert_eq!(unix.specifier(), "file:vendor/nested/dir");
+    }
+
+    #[test]
+    fn exec_script_must_stay_inside_project_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_root = temp.path().join("project");
+        let outside = temp.path().join("outside.js");
+        std::fs::create_dir(&project_root).unwrap();
+        std::fs::write(&outside, "").unwrap();
+
+        let local = LocalSource::Exec(PathBuf::from("../outside.js"));
+        let err = resolve_exec_script_path(&local, &project_root).unwrap_err();
+        assert!(err.contains("resolves outside project root"), "{err}");
+    }
+
+    #[test]
+    fn exec_script_inside_project_root_is_allowed() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_root = temp.path().join("project");
+        let script_dir = project_root.join("scripts");
+        let script = script_dir.join("generate.js");
+        std::fs::create_dir_all(&script_dir).unwrap();
+        std::fs::write(&script, "").unwrap();
+
+        let local = LocalSource::Exec(PathBuf::from("scripts/generate.js"));
+        let resolved = resolve_exec_script_path(&local, &project_root).unwrap();
+        assert_eq!(resolved, script.canonicalize().unwrap());
     }
 }
 

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -1,6 +1,6 @@
 use crate::local_source::{
-    dep_path_for, is_non_registry_specifier, read_local_manifest, rebase_local, resolve_git_source,
-    resolve_remote_tarball, should_block_exotic_subdep,
+    dep_path_for, is_non_registry_specifier, read_local_manifest, rebase_local,
+    resolve_exec_manifest, resolve_git_source, resolve_remote_tarball, should_block_exotic_subdep,
 };
 use crate::package_ext::{apply_package_extensions, pick_override_spec};
 use crate::semver_util::{PickResult, pick_version, version_satisfies};
@@ -891,10 +891,15 @@ impl Resolver {
                         // can resolve it with a single
                         // `project_root.join(rel)`.
                         let local = rebase_local(&raw_local, &importer_root, &self.project_root);
-                        let (_target_name, version, deps) =
-                            read_local_manifest(&raw_local, &importer_root).unwrap_or_else(|_| {
-                                (task.name.clone(), "0.0.0".to_string(), BTreeMap::new())
-                            });
+                        let (version, deps) = if matches!(local, LocalSource::Exec(_)) {
+                            resolve_exec_manifest(&task.name, &local, &self.project_root).await?
+                        } else {
+                            let (_target_name, version, deps) =
+                                read_local_manifest(&raw_local, &importer_root).unwrap_or_else(
+                                    |_| (task.name.clone(), "0.0.0".to_string(), BTreeMap::new()),
+                                );
+                            (version, deps)
+                        };
                         (local, version, deps)
                     };
                     let dep_path = local.dep_path(&task.name);

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -795,7 +795,7 @@ impl Resolver {
                         })));
                     }
                     // Pull the parent's on-disk source root, when the
-                    // parent is a Directory/Link source. The BFS always
+                    // parent is a path-backed source. The BFS always
                     // inserts a parent into `resolved` before enqueuing
                     // its children, so for transitive tasks the parent
                     // record is reliably present here.
@@ -808,7 +808,8 @@ impl Resolver {
                                 .and_then(|src| match src {
                                     LocalSource::Directory(p)
                                     | LocalSource::Link(p)
-                                    | LocalSource::Portal(p) => Some(self.project_root.join(p)),
+                                    | LocalSource::Portal(p)
+                                    | LocalSource::Exec(p) => Some(self.project_root.join(p)),
                                     _ => None,
                                 })
                         })

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -794,11 +794,11 @@ impl Resolver {
                             importer: task.importer.clone(),
                         })));
                     }
-                    // Pull the parent's on-disk source root, when the
-                    // parent is a path-backed source. The BFS always
-                    // inserts a parent into `resolved` before enqueuing
-                    // its children, so for transitive tasks the parent
-                    // record is reliably present here.
+                    // Pull the parent's on-disk package root, when the
+                    // parent is a directory-backed source. `exec:` stores
+                    // the generator script path, not the generated package
+                    // directory, so it cannot safely anchor relative
+                    // transitive local specifiers.
                     let parent_source_root: Option<std::path::PathBuf> = (!task.is_root)
                         .then(|| {
                             task.parent
@@ -808,8 +808,7 @@ impl Resolver {
                                 .and_then(|src| match src {
                                     LocalSource::Directory(p)
                                     | LocalSource::Link(p)
-                                    | LocalSource::Portal(p)
-                                    | LocalSource::Exec(p) => Some(self.project_root.join(p)),
+                                    | LocalSource::Portal(p) => Some(self.project_root.join(p)),
                                     _ => None,
                                 })
                         })

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -892,6 +892,15 @@ impl Resolver {
                         // `project_root.join(rel)`.
                         let local = rebase_local(&raw_local, &importer_root, &self.project_root);
                         let (version, deps) = if matches!(local, LocalSource::Exec(_)) {
+                            if self.ignore_scripts {
+                                return Err(Error::Registry(
+                                    task.name.clone(),
+                                    format!(
+                                        "{} requires executing its generator, but scripts are disabled",
+                                        local.specifier()
+                                    ),
+                                ));
+                            }
                             resolve_exec_manifest(&task.name, &local, &self.project_root).await?
                         } else {
                             let (_target_name, version, deps) =

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -806,9 +806,9 @@ impl Resolver {
                                 .and_then(|dp| resolved.get(dp))
                                 .and_then(|pkg| pkg.local_source.as_ref())
                                 .and_then(|src| match src {
-                                    LocalSource::Directory(p) | LocalSource::Link(p) => {
-                                        Some(self.project_root.join(p))
-                                    }
+                                    LocalSource::Directory(p)
+                                    | LocalSource::Link(p)
+                                    | LocalSource::Portal(p) => Some(self.project_root.join(p)),
                                     _ => None,
                                 })
                         })
@@ -848,6 +848,8 @@ impl Resolver {
                             LocalSource::Directory(_)
                                 | LocalSource::Tarball(_)
                                 | LocalSource::Link(_)
+                                | LocalSource::Portal(_)
+                                | LocalSource::Exec(_)
                         )
                     {
                         return Err(Error::Registry(
@@ -987,8 +989,9 @@ impl Resolver {
                                 .await;
                         }
                         // Enqueue transitive deps of the local package
-                        // (directories + tarballs only — `link:` deps
-                        // are fully the target's responsibility).
+                        // (directories, tarballs, portals, and exec
+                        // outputs — `link:` deps are fully the
+                        // target's responsibility).
                         if !matches!(local, LocalSource::Link(_)) {
                             let mut child_ancestors = task.ancestors.clone();
                             child_ancestors.push((linked_name.clone(), real_version.clone()));

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -1326,13 +1326,22 @@ mod windows_job_object_tests {
             let _ = run_command_killing_descendants(cmd, "test-grandchild").await;
         });
 
-        let appeared = wait_until(|| pid_file.exists(), Duration::from_secs(20)).await;
+        let appeared = wait_until(
+            || {
+                std::fs::read_to_string(&pid_file)
+                    .ok()
+                    .and_then(|pid| pid.trim().parse::<u32>().ok())
+                    .is_some()
+            },
+            Duration::from_secs(20),
+        )
+        .await;
         assert!(appeared, "grandchild never wrote pid file at {pid_file:?}");
         let pid: u32 = std::fs::read_to_string(&pid_file)
             .expect("read pid file")
             .trim()
             .parse()
-            .expect("parse pid");
+            .expect("pid file was parseable before reading");
         assert!(
             is_process_alive(pid),
             "grandchild pid {pid} not alive immediately after writing pid file"

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -418,6 +418,7 @@ fn seed_target_lockfile(
                     src,
                     aube_lockfile::LocalSource::Link(_)
                         | aube_lockfile::LocalSource::Portal(_)
+                        | aube_lockfile::LocalSource::Exec(_)
                         | aube_lockfile::LocalSource::Directory(_)
                         | aube_lockfile::LocalSource::Tarball(_)
                 )

--- a/crates/aube/src/commands/deploy.rs
+++ b/crates/aube/src/commands/deploy.rs
@@ -417,6 +417,7 @@ fn seed_target_lockfile(
                 matches!(
                     src,
                     aube_lockfile::LocalSource::Link(_)
+                        | aube_lockfile::LocalSource::Portal(_)
                         | aube_lockfile::LocalSource::Directory(_)
                         | aube_lockfile::LocalSource::Tarball(_)
                 )
@@ -672,7 +673,8 @@ fn plan_injections(
             } else if let Some(local) = aube_lockfile::LocalSource::parse(&dep_spec, &pkg_dir) {
                 match local {
                     aube_lockfile::LocalSource::Directory(rel)
-                    | aube_lockfile::LocalSource::Link(rel) => {
+                    | aube_lockfile::LocalSource::Link(rel)
+                    | aube_lockfile::LocalSource::Portal(rel) => {
                         let abs = pkg_dir.join(&rel);
                         let canonical = canonicalize(&abs);
                         // Same back-ref guard as the `workspace:` branch:
@@ -730,10 +732,11 @@ fn plan_injections(
                             );
                         }
                     }
-                    // Git / RemoteTarball: install fetches these
+                    // Exec / Git / RemoteTarball: install fetches these
                     // standalone from their source — the deploy target
                     // doesn't need a bundled copy.
-                    aube_lockfile::LocalSource::Git(_)
+                    aube_lockfile::LocalSource::Exec(_)
+                    | aube_lockfile::LocalSource::Git(_)
                     | aube_lockfile::LocalSource::RemoteTarball(_) => {}
                 }
             }
@@ -1264,8 +1267,10 @@ fn rewrite_local_refs(
                 let abs = match &local {
                     aube_lockfile::LocalSource::Directory(rel)
                     | aube_lockfile::LocalSource::Link(rel)
+                    | aube_lockfile::LocalSource::Portal(rel)
                     | aube_lockfile::LocalSource::Tarball(rel) => source_pkg_dir.join(rel),
-                    aube_lockfile::LocalSource::Git(_)
+                    aube_lockfile::LocalSource::Exec(_)
+                    | aube_lockfile::LocalSource::Git(_)
                     | aube_lockfile::LocalSource::RemoteTarball(_) => continue,
                 };
                 let canonical = canonicalize(&abs);

--- a/crates/aube/src/commands/install/delta.rs
+++ b/crates/aube/src/commands/install/delta.rs
@@ -466,6 +466,14 @@ fn fingerprint(pkg: &LockedPackage, patch_hash: Option<&str>) -> String {
                 h.update(b"link");
                 update_field(&mut h, b"path", p.to_string_lossy().as_bytes());
             }
+            LocalSource::Portal(p) => {
+                h.update(b"portal");
+                update_field(&mut h, b"path", p.to_string_lossy().as_bytes());
+            }
+            LocalSource::Exec(p) => {
+                h.update(b"exec");
+                update_field(&mut h, b"path", p.to_string_lossy().as_bytes());
+            }
             LocalSource::Git(g) => {
                 h.update(b"git");
                 update_field(&mut h, b"url", g.url.as_bytes());

--- a/crates/aube/src/commands/install/delta.rs
+++ b/crates/aube/src/commands/install/delta.rs
@@ -28,7 +28,10 @@
 use aube_lockfile::{LocalSource, LockedPackage, LockfileGraph};
 use blake3::Hasher;
 use rayon::prelude::*;
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
 
 /// 2048-bit wide-add multiset hash over per-package fingerprints.
 /// LtHash construction from Maitin-Shepard et al. 2017.
@@ -178,6 +181,7 @@ impl DeltaPlan {
 pub fn compute_package_hashes(
     graph: &LockfileGraph,
     patch_hashes: &BTreeMap<String, String>,
+    project_root: &Path,
 ) -> BTreeMap<String, String> {
     // Pure, per-package, CPU-bound. Perfect rayon target. 500-pkg
     // graph drops from ~25 ms serial to ~6 ms on 4 cores.
@@ -187,7 +191,7 @@ pub fn compute_package_hashes(
         .map(|(dep_path, pkg)| {
             let patch_key = format!("{}@{}", pkg.name, pkg.version);
             let patch = patch_hashes.get(&patch_key).map(String::as_str);
-            (dep_path.clone(), fingerprint(pkg, patch))
+            (dep_path.clone(), fingerprint(pkg, patch, project_root))
         })
         .collect()
 }
@@ -209,8 +213,9 @@ pub fn compute_package_hashes(
 pub fn compute_leaf_and_subtree_hashes(
     graph: &LockfileGraph,
     patch_hashes: &BTreeMap<String, String>,
+    project_root: &Path,
 ) -> (BTreeMap<String, String>, BTreeMap<String, String>) {
-    let leaf = compute_package_hashes(graph, patch_hashes);
+    let leaf = compute_package_hashes(graph, patch_hashes, project_root);
     let subtree = compute_subtree_hashes_from_leaf(graph, &leaf);
     (leaf, subtree)
 }
@@ -426,7 +431,7 @@ pub fn diff(stored: &BTreeMap<String, String>, current: &BTreeMap<String, String
 /// Field order matters. Changing it invalidates every stored
 /// fingerprint on the next install. That still cascades to a full
 /// install, just costs one "already up to date" miss.
-fn fingerprint(pkg: &LockedPackage, patch_hash: Option<&str>) -> String {
+fn fingerprint(pkg: &LockedPackage, patch_hash: Option<&str>, project_root: &Path) -> String {
     let mut h = Hasher::new();
     update_field(&mut h, b"name", pkg.name.as_bytes());
     update_field(&mut h, b"version", pkg.version.as_bytes());
@@ -473,6 +478,14 @@ fn fingerprint(pkg: &LockedPackage, patch_hash: Option<&str>) -> String {
             LocalSource::Exec(p) => {
                 h.update(b"exec");
                 update_field(&mut h, b"path", p.to_string_lossy().as_bytes());
+                let script = if p.is_absolute() {
+                    p.as_path().to_path_buf()
+                } else {
+                    project_root.join(p)
+                };
+                if let Ok(content) = std::fs::read(script) {
+                    update_field(&mut h, b"content", &content);
+                }
             }
             LocalSource::Git(g) => {
                 h.update(b"git");
@@ -548,15 +561,15 @@ mod tests {
     }
 
     fn fp(p: &LockedPackage) -> String {
-        fingerprint(p, None)
+        fingerprint(p, None, Path::new(""))
     }
 
     fn cph(g: &LockfileGraph) -> BTreeMap<String, String> {
-        compute_package_hashes(g, &BTreeMap::new())
+        compute_package_hashes(g, &BTreeMap::new(), Path::new(""))
     }
 
     fn csh(g: &LockfileGraph) -> BTreeMap<String, String> {
-        compute_leaf_and_subtree_hashes(g, &BTreeMap::new()).1
+        compute_leaf_and_subtree_hashes(g, &BTreeMap::new(), Path::new("")).1
     }
 
     #[test]
@@ -588,6 +601,22 @@ mod tests {
         b.dependencies
             .insert("loose-envify".into(), "loose-envify@1.5.0".into());
         assert_ne!(fp(&a), fp(&b));
+    }
+
+    #[test]
+    fn fingerprint_changes_on_exec_script_edit() {
+        let temp = tempfile::tempdir().unwrap();
+        let script = temp.path().join("generate.js");
+        std::fs::write(&script, "module.exports = { name: 'before' }").unwrap();
+        let rel = script.strip_prefix(temp.path()).unwrap();
+        let mut pkg = pkg("generated", "1.0.0");
+        pkg.local_source = Some(LocalSource::Exec(rel.to_path_buf()));
+
+        let before = fingerprint(&pkg, None, temp.path());
+        std::fs::write(&script, "module.exports = { name: 'after' }").unwrap();
+        let after = fingerprint(&pkg, None, temp.path());
+
+        assert_ne!(before, after);
     }
 
     #[test]
@@ -705,8 +734,8 @@ mod tests {
         before_patches.insert("react@18.2.0".to_string(), "patch-old".to_string());
         let mut after_patches = BTreeMap::new();
         after_patches.insert("react@18.2.0".to_string(), "patch-new".to_string());
-        let before = compute_package_hashes(&graph, &before_patches);
-        let after = compute_package_hashes(&graph, &after_patches);
+        let before = compute_package_hashes(&graph, &before_patches, Path::new(""));
+        let after = compute_package_hashes(&graph, &after_patches, Path::new(""));
         let plan = diff(&before, &after);
         assert_eq!(plan.changed, vec!["react@18.2.0".to_string()]);
         assert!(plan.added.is_empty());
@@ -725,8 +754,8 @@ mod tests {
                 .into_iter()
                 .collect();
         assert_eq!(
-            compute_package_hashes(&graph, &empty),
-            compute_package_hashes(&graph, &unrelated_patch)
+            compute_package_hashes(&graph, &empty, Path::new("")),
+            compute_package_hashes(&graph, &unrelated_patch, Path::new(""))
         );
     }
 

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -108,6 +108,7 @@ require(process.argv[1]);
                 .arg(wrapper)
                 .arg(&script)
                 .env("AUBE_YARN_EXEC_ENV", env.to_string())
+                .current_dir(project_root)
                 .status()
                 .await
                 .into_diagnostic()

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -89,23 +89,14 @@ pub(super) async fn import_local_source(
                 .wrap_err_with(|| {
                     format!("create exec temp dir for {}{chain}", local.specifier())
                 })?;
-            let locator = format!("{pkg_name}@{pkg_version}");
             let env = serde_json::json!({
                 "tempDir": temp_dir,
                 "buildDir": build_dir,
-                "locator": locator,
+                "locator": format!("{pkg_name}@{}", local.specifier()),
             });
-            let wrapper = r#"
-const env = JSON.parse(process.env.AUBE_YARN_EXEC_ENV);
-globalThis.execEnv = env;
-for (const name of ['fs', 'path', 'child_process', 'os', 'crypto', 'url', 'util', 'stream', 'buffer']) {
-  globalThis[name] = require(name);
-}
-require(process.argv[1]);
-"#;
             let status = tokio::process::Command::new("node")
                 .arg("-e")
-                .arg(wrapper)
+                .arg(aube_resolver::YARN_EXEC_WRAPPER)
                 .arg(&script)
                 .env("AUBE_YARN_EXEC_ENV", env.to_string())
                 .current_dir(project_root)

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -57,21 +57,15 @@ pub(super) async fn import_local_source(
                 .map_err(|e| miette!("failed to import {}: {e}{chain}", local.specifier()))?;
             Ok(Some(index))
         }
-        LocalSource::Exec(rel) => {
+        LocalSource::Exec(_) => {
             if ignore_scripts {
                 return Err(miette!(
                     "{} requires executing its generator, but scripts are disabled{chain}",
                     local.specifier()
                 ));
             }
-            let script = project_root.join(rel);
-            if !script.is_file() {
-                return Err(miette!(
-                    "exec dependency {}: {} is not a file{chain}",
-                    local.specifier(),
-                    script.display()
-                ));
-            }
+            let script = aube_resolver::resolve_exec_script_path(local, project_root)
+                .map_err(|e| miette!("exec dependency {}: {e}{chain}", local.specifier()))?;
             let temp = tempfile::Builder::new()
                 .prefix("aube-exec-")
                 .tempdir()

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -13,12 +13,14 @@ use miette::{Context, IntoDiagnostic, miette};
 use rayon::prelude::*;
 use std::collections::BTreeMap;
 
-/// Materialize a `file:` / `link:` package into the store.
+/// Materialize a local-source package into the store.
 ///
 /// `Directory` walks the target and hash-imports every file; `Tarball`
 /// opens the `.tgz` and reuses the normal tarball importer. `Link`
 /// returns `None` because link deps never have a store-backed index —
-/// the linker symlinks directly to the target in step 2.
+/// the linker symlinks directly to the target in step 2. `Portal`
+/// imports the target package like a directory so its dependency graph
+/// is linked, and `Exec` runs the generator into a temp build dir.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn import_local_source(
     store: &std::sync::Arc<aube_store::Store>,
@@ -41,7 +43,7 @@ pub(super) async fn import_local_source(
     use aube_lockfile::LocalSource;
     match local {
         LocalSource::Link(_) => Ok(None),
-        LocalSource::Directory(rel) => {
+        LocalSource::Directory(rel) | LocalSource::Portal(rel) => {
             let abs = project_root.join(rel);
             if !abs.is_dir() {
                 return Err(miette!(
@@ -53,6 +55,75 @@ pub(super) async fn import_local_source(
             let index = store
                 .import_directory(&abs)
                 .map_err(|e| miette!("failed to import {}: {e}{chain}", local.specifier()))?;
+            Ok(Some(index))
+        }
+        LocalSource::Exec(rel) => {
+            if ignore_scripts {
+                return Err(miette!(
+                    "{} requires executing its generator, but scripts are disabled{chain}",
+                    local.specifier()
+                ));
+            }
+            let script = project_root.join(rel);
+            if !script.is_file() {
+                return Err(miette!(
+                    "exec dependency {}: {} is not a file{chain}",
+                    local.specifier(),
+                    script.display()
+                ));
+            }
+            let temp = tempfile::Builder::new()
+                .prefix("aube-exec-")
+                .tempdir()
+                .into_diagnostic()
+                .wrap_err_with(|| format!("create temp dir for {}{chain}", local.specifier()))?;
+            let build_dir = temp.path().join("build");
+            let temp_dir = temp.path().join("temp");
+            std::fs::create_dir_all(&build_dir)
+                .into_diagnostic()
+                .wrap_err_with(|| {
+                    format!("create exec build dir for {}{chain}", local.specifier())
+                })?;
+            std::fs::create_dir_all(&temp_dir)
+                .into_diagnostic()
+                .wrap_err_with(|| {
+                    format!("create exec temp dir for {}{chain}", local.specifier())
+                })?;
+            let locator = format!("{pkg_name}@{pkg_version}");
+            let env = serde_json::json!({
+                "tempDir": temp_dir,
+                "buildDir": build_dir,
+                "locator": locator,
+            });
+            let wrapper = r#"
+const env = JSON.parse(process.env.AUBE_YARN_EXEC_ENV);
+globalThis.execEnv = env;
+for (const name of ['fs', 'path', 'child_process', 'os', 'crypto', 'url', 'util', 'stream', 'buffer']) {
+  globalThis[name] = require(name);
+}
+require(process.argv[1]);
+"#;
+            let status = tokio::process::Command::new("node")
+                .arg("-e")
+                .arg(wrapper)
+                .arg(&script)
+                .env("AUBE_YARN_EXEC_ENV", env.to_string())
+                .status()
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| format!("execute {}{chain}", local.specifier()))?;
+            if !status.success() {
+                return Err(miette!(
+                    "exec dependency {} failed with status {status}{chain}",
+                    local.specifier()
+                ));
+            }
+            let index = store.import_directory(&build_dir).map_err(|e| {
+                miette!(
+                    "failed to import generated {}: {e}{chain}",
+                    local.specifier()
+                )
+            })?;
             Ok(Some(index))
         }
         LocalSource::Tarball(rel) => {

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -111,8 +111,12 @@ require(process.argv[1]);
                 .current_dir(project_root)
                 .status()
                 .await
-                .into_diagnostic()
-                .wrap_err_with(|| format!("execute {}{chain}", local.specifier()))?;
+                .map_err(|e| {
+                    miette!(
+                        "execute {} with Node.js from PATH: {e}{chain}",
+                        local.specifier()
+                    )
+                })?;
             if !status.success() {
                 return Err(miette!(
                     "exec dependency {} failed with status {status}{chain}",

--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -243,7 +243,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
                 leaf.len() == graph.packages.len()
                     && graph.packages.keys().all(|k| leaf.contains_key(k))
             })
-            .unwrap_or_else(|| delta::compute_package_hashes(graph, &patch_hashes));
+            .unwrap_or_else(|| delta::compute_package_hashes(graph, &patch_hashes, cwd));
         let package_subtree_hashes = current_subtree_hashes.unwrap_or_else(|| {
             delta::compute_subtree_hashes_from_leaf(graph, &package_content_hashes)
         });

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -152,7 +152,8 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         && !dep_selection_filtered
         && workspace_filter_empty
     {
-        let (leaf, subtree) = delta::compute_leaf_and_subtree_hashes(graph_for_link, &patch_hashes);
+        let (leaf, subtree) =
+            delta::compute_leaf_and_subtree_hashes(graph_for_link, &patch_hashes, cwd);
         (Some(leaf), Some(subtree))
     } else {
         (None, None)

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -715,6 +715,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             pnpmfile: opts.pnpmfile.as_deref(),
             minimum_release_age_override: opts.minimum_release_age_override,
             ws_package_versions: &ws_package_versions,
+            ignore_scripts: opts.ignore_scripts,
             prog_ref,
         })
         .await?;
@@ -1151,6 +1152,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     target_lockfile_kind: lockfile_enabled
                         .then(|| source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube)),
                     cache_full_packuments: true,
+                    ignore_scripts: opts.ignore_scripts,
                 },
                 read_package_hook,
             );

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -52,6 +52,7 @@ pub(super) struct LockfileOnlyInput<'a> {
     pub pnpmfile: Option<&'a Path>,
     pub minimum_release_age_override: Option<u64>,
     pub ws_package_versions: &'a HashMap<String, String>,
+    pub ignore_scripts: bool,
     pub prog_ref: Option<&'a InstallProgress>,
 }
 
@@ -80,6 +81,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         pnpmfile,
         minimum_release_age_override,
         ws_package_versions,
+        ignore_scripts,
         prog_ref,
     } = input;
 
@@ -197,6 +199,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
             target_lockfile_kind: lockfile_enabled
                 .then(|| source_kind_before.unwrap_or(LockfileKind::Aube)),
             cache_full_packuments: true,
+            ignore_scripts,
         },
         read_package_hook,
     );

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -659,6 +659,7 @@ pub(crate) struct ResolverConfigInputs<'a> {
     /// window only matters when `needs_time` routes through the full
     /// cache.
     pub(crate) cache_full_packuments: bool,
+    pub(crate) ignore_scripts: bool,
 }
 
 pub(crate) fn configure_resolver(
@@ -675,6 +676,7 @@ pub(crate) fn configure_resolver(
         minimum_release_age_override,
         target_lockfile_kind,
         cache_full_packuments,
+        ignore_scripts,
     } = inputs;
     let auto_install_peers = resolve_auto_install_peers(settings_ctx);
     let exclude_links_from_lockfile = resolve_exclude_links_from_lockfile(settings_ctx);
@@ -787,6 +789,7 @@ pub(crate) fn configure_resolver(
         .with_minimum_release_age(minimum_release_age)
         .with_catalogs(workspace_catalogs.clone())
         .with_project_root(cwd.to_path_buf())
+        .with_ignore_scripts(ignore_scripts)
         .with_dependency_policy(dependency_policy)
         .with_git_shallow_hosts(git_shallow_hosts);
     if let Some(hook) = read_package_hook {

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -571,6 +571,7 @@ pub(crate) fn build_resolver(
             // mutating `dist-tags` between commands). The abbreviated
             // cache stays on either way.
             cache_full_packuments: false,
+            ignore_scripts: false,
         },
         None,
     )

--- a/crates/aube/src/commands/query.rs
+++ b/crates/aube/src/commands/query.rs
@@ -522,6 +522,8 @@ fn source_kind(pkg: &LockedPackage) -> &'static str {
         Some(LocalSource::Directory(_)) => "file",
         Some(LocalSource::Tarball(_)) => "file",
         Some(LocalSource::Link(_)) => "link",
+        Some(LocalSource::Portal(_)) => "portal",
+        Some(LocalSource::Exec(_)) => "exec",
         Some(LocalSource::Git(_)) => "git",
         Some(LocalSource::RemoteTarball(_)) => "remote",
     }

--- a/docs/yarn-users.md
+++ b/docs/yarn-users.md
@@ -40,10 +40,11 @@ file still validates cached tarballs.
 
 Supported protocols: `npm:` (the common case), `patch:` for local
 patch files against npm-backed packages, `workspace:`, `file:`, `link:`,
-plus `git:` / `git+ssh:` / `git+https:` / `https:` URLs for remote
-sources. Entries that use `portal:` or `exec:` are skipped with a
-warning — aube's dependency graph doesn't model those yet, and they
-round-trip better through Yarn itself.
+`portal:`, `exec:`, plus `git:` / `git+ssh:` /
+`git+https:` / `https:` URLs for remote sources. Entries that use
+unsupported protocols are skipped with a warning — aube's dependency
+graph doesn't model those yet, and they round-trip better through Yarn
+itself.
 
 ## Yarn PnP
 

--- a/fixtures/import-yarn-portal-exec/package.json
+++ b/fixtures/import-yarn-portal-exec/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "yarn-portal-exec-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "portal-pkg": "portal:./packages/portal",
+    "exec-pkg": "exec:./scripts/generate-exec.js"
+  }
+}

--- a/fixtures/import-yarn-portal-exec/packages/portal/index.js
+++ b/fixtures/import-yarn-portal-exec/packages/portal/index.js
@@ -1,0 +1,1 @@
+module.exports = `portal ok + ${require('exec-pkg')}`;

--- a/fixtures/import-yarn-portal-exec/packages/portal/package.json
+++ b/fixtures/import-yarn-portal-exec/packages/portal/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "portal-pkg",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "exec-pkg": "exec:./scripts/generate-exec.js"
+  }
+}

--- a/fixtures/import-yarn-portal-exec/packages/portal/package.json
+++ b/fixtures/import-yarn-portal-exec/packages/portal/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "exec-pkg": "exec:./scripts/generate-exec.js"
+    "exec-pkg": "exec:../../scripts/generate-exec.js"
   }
 }

--- a/fixtures/import-yarn-portal-exec/scripts/generate-exec.js
+++ b/fixtures/import-yarn-portal-exec/scripts/generate-exec.js
@@ -1,7 +1,10 @@
 fs.writeFileSync(path.join(execEnv.buildDir, 'package.json'), JSON.stringify({
   name: 'exec-pkg',
   version: '2.0.0',
-  main: 'index.js'
+  main: 'index.js',
+  dependencies: {
+    'is-number': '7.0.0'
+  }
 }));
 
-fs.writeFileSync(path.join(execEnv.buildDir, 'index.js'), "module.exports = 'exec ok';\n");
+fs.writeFileSync(path.join(execEnv.buildDir, 'index.js'), "module.exports = require('is-number')(42) ? 'exec ok' : 'exec bad';\n");

--- a/fixtures/import-yarn-portal-exec/scripts/generate-exec.js
+++ b/fixtures/import-yarn-portal-exec/scripts/generate-exec.js
@@ -1,0 +1,7 @@
+fs.writeFileSync(path.join(execEnv.buildDir, 'package.json'), JSON.stringify({
+  name: 'exec-pkg',
+  version: '2.0.0',
+  main: 'index.js'
+}));
+
+fs.writeFileSync(path.join(execEnv.buildDir, 'index.js'), "module.exports = 'exec ok';\n");

--- a/fixtures/import-yarn-portal-exec/yarn.lock
+++ b/fixtures/import-yarn-portal-exec/yarn.lock
@@ -5,6 +5,14 @@ __metadata:
 "exec-pkg@exec:./scripts/generate-exec.js":
   version: 2.0.0
   resolution: "exec-pkg@exec:./scripts/generate-exec.js"
+  dependencies:
+    is-number: "npm:7.0.0"
+  languageName: node
+  linkType: hard
+
+"is-number@npm:7.0.0":
+  version: 7.0.0
+  resolution: "is-number@npm:7.0.0"
   languageName: node
   linkType: hard
 

--- a/fixtures/import-yarn-portal-exec/yarn.lock
+++ b/fixtures/import-yarn-portal-exec/yarn.lock
@@ -1,0 +1,17 @@
+__metadata:
+  version: 8
+  cacheKey: 10c0
+
+"exec-pkg@exec:./scripts/generate-exec.js":
+  version: 2.0.0
+  resolution: "exec-pkg@exec:./scripts/generate-exec.js"
+  languageName: node
+  linkType: hard
+
+"portal-pkg@portal:./packages/portal":
+  version: 1.0.0
+  resolution: "portal-pkg@portal:./packages/portal"
+  dependencies:
+    exec-pkg: "exec:./scripts/generate-exec.js"
+  languageName: node
+  linkType: soft

--- a/test/import.bats
+++ b/test/import.bats
@@ -123,6 +123,12 @@ teardown() {
 
 	run node -e 'if (require("portal-pkg") !== "portal ok + exec ok") process.exit(1); if (require("exec-pkg") !== "exec ok") process.exit(1)'
 	assert_success
+	run grep -F "is-number@7.0.0:" aube-lock.yaml
+	assert_success
+	run grep -A 4 -F "portal-pkg@portal:./packages/portal:" aube-lock.yaml
+	assert_output --partial "exec-pkg: exec:scripts/generate-exec.js"
+	run grep -F "0.0.0" aube-lock.yaml
+	assert_failure
 }
 
 @test "aube install from bun.lock links workspace deps to their package dirs" {

--- a/test/import.bats
+++ b/test/import.bats
@@ -114,6 +114,17 @@ teardown() {
 	assert_success
 }
 
+@test "aube install fresh-resolves yarn berry portal transitive exec protocol" {
+	cp -R "$PROJECT_ROOT/fixtures/import-yarn-portal-exec/." .
+	rm yarn.lock
+
+	run aube install
+	assert_success
+
+	run node -e 'if (require("portal-pkg") !== "portal ok + exec ok") process.exit(1); if (require("exec-pkg") !== "exec ok") process.exit(1)'
+	assert_success
+}
+
 @test "aube install from bun.lock links workspace deps to their package dirs" {
 	cat >package.json <<'EOF'
 {"name":"root","version":"1.0.0","workspaces":["packages/*"]}

--- a/test/import.bats
+++ b/test/import.bats
@@ -125,10 +125,21 @@ teardown() {
 	assert_success
 	run grep -F "is-number@7.0.0:" aube-lock.yaml
 	assert_success
+	run grep -F "version: exec:scripts/generate-exec.js" aube-lock.yaml
+	assert_success
 	run grep -A 4 -F "portal-pkg@portal:./packages/portal:" aube-lock.yaml
 	assert_output --partial "exec-pkg: exec:scripts/generate-exec.js"
 	run grep -F "0.0.0" aube-lock.yaml
 	assert_failure
+}
+
+@test "aube install --ignore-scripts does not run yarn berry exec generator during fresh resolve" {
+	cp -R "$PROJECT_ROOT/fixtures/import-yarn-portal-exec/." .
+	rm yarn.lock
+
+	run aube install --ignore-scripts
+	assert_failure
+	assert_output --partial "scripts are disabled"
 }
 
 @test "aube install from bun.lock links workspace deps to their package dirs" {

--- a/test/import.bats
+++ b/test/import.bats
@@ -104,6 +104,16 @@ teardown() {
 	assert_success
 }
 
+@test "aube install supports yarn berry portal and exec protocols" {
+	cp -R "$PROJECT_ROOT/fixtures/import-yarn-portal-exec/." .
+
+	run aube install
+	assert_success
+
+	run node -e 'if (require("portal-pkg") !== "portal ok + exec ok") process.exit(1); if (require("exec-pkg") !== "exec ok") process.exit(1)'
+	assert_success
+}
+
 @test "aube install from bun.lock links workspace deps to their package dirs" {
 	cat >package.json <<'EOF'
 {"name":"root","version":"1.0.0","workspaces":["packages/*"]}


### PR DESCRIPTION
## Summary

- add `LocalSource::Portal` and `LocalSource::Exec` so Yarn Berry `portal:` and `exec:` lockfile entries are parsed instead of skipped
- preserve both protocols when writing Berry lockfiles, with `portal:` emitted as `linkType: soft` and `exec:` emitted as a generated hard-link package
- materialize `portal:` targets as local packages so graph-visible dependencies are linked, and run `exec:` generators into a temp build directory before importing the generated package
- resolve `exec:` generators during fresh resolution so generated versions and dependencies are locked, while normalizing root/transitive script paths to a single dep path
- keep resolve-time and fetch-time exec environments aligned, block exec generator execution under `--ignore-scripts`, and reject `exec:` scripts that resolve outside the project root
- add parser/writer tests, resolver regression coverage, and an install fixture covering a portal package that depends on an exec-generated package
- stabilize the Windows job-object regression test by waiting for a parseable grandchild PID before asserting process liveness

## Notes

Yarn documents `portal:` as a local package whose dependencies are followed, unlike `link:`. It documents `exec:` as a generator script that populates `execEnv.buildDir`; this PR implements that shape for both fresh resolution and lockfile-backed installs.

`exec:` generators require Node.js on `PATH` and are treated as script execution. Fresh resolution fails before running them when `--ignore-scripts` is set, and both resolve-time and fetch-time execution canonicalize the generator path and require it to stay inside the project root.

## Validation

- `cargo test -p aube-lockfile test_parse_berry_portal_and_exec_protocols`
- `cargo test -p aube-lockfile test_write_berry_roundtrips_portal_and_exec_protocols`
- `cargo test -p aube-resolver --no-fail-fast`
- `cargo test -p aube-scripts --lib`
- `cargo build`
- `mise run test:bats test/import.bats`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
