### PR TITLE
feat(add): add deny-build flag

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -86,11 +86,15 @@ cmd add help="Add a dependency" {
     }
     flag "-O --save-optional" help="Add as optional dependency"
     flag --allow-build help="Pre-approve a dependency's lifecycle scripts as part of the add" var=#true {
-        long_help "Pre-approve a dependency's lifecycle scripts as part of the add.\n\nWrites `allowBuilds: { <pkg>: true }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's `preinstall` / `install` / `postinstall` scripts execute on this invocation. Repeatable — pass the flag once per package. Mirrors `pnpm add --allow-build=<pkg>`.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned approval in the workspace yaml on restore."
+        long_help "Pre-approve a dependency's lifecycle scripts as part of the add.\n\nWrites `allowBuilds: { <pkg>: true }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's `preinstall` / `install` / `postinstall` scripts execute on this invocation. Repeatable — pass the flag once per package. Mirrors `pnpm add --allow-build=<pkg>`.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned approval in the workspace yaml on restore. Also conflicts with `--deny-build` for the same package name."
         arg <PKG>
     }
     flag --allow-low-downloads help="Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation" {
         long_help "Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation.\n\n`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`]. The flag is intended for the cases where you've already verified the package out-of-band — adding a brand-new niche tool, a fresh fork, an internal scratch package — and don't want the prompt to interrupt scripted workflows. Does not affect the OSV malicious-package check, which remains a hard block."
+    }
+    flag --deny-build help="Mark a dependency's lifecycle scripts as reviewed and denied" var=#true {
+        long_help "Mark a dependency's lifecycle scripts as reviewed and denied.\n\nWrites `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name."
+        arg <PKG>
     }
     flag --ignore-scripts help="Skip lifecycle scripts (no-op; aube already skips by default)" hide=#true
     flag --no-save help="Install without persisting the dependency to `package.json`" {

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -84,6 +84,7 @@ pub const ERR_AUBE_NPM_ONLY_COMMAND: &str = "ERR_AUBE_NPM_ONLY_COMMAND";
 pub const ERR_AUBE_COMPLETION_FAILED: &str = "ERR_AUBE_COMPLETION_FAILED";
 pub const ERR_AUBE_REMOVE_PRIOR_INSTALL_DIR: &str = "ERR_AUBE_REMOVE_PRIOR_INSTALL_DIR";
 pub const ERR_AUBE_CONFIG_NESTED_AUBE_KEY: &str = "ERR_AUBE_CONFIG_NESTED_AUBE_KEY";
+pub const ERR_AUBE_CONFLICTING_BUILD_FLAGS: &str = "ERR_AUBE_CONFLICTING_BUILD_FLAGS";
 
 // ── misc tracing::error! sites (non-fatal but high-severity) ────────
 pub const ERR_AUBE_PATCHES_TRACKING_WRITE: &str = "ERR_AUBE_PATCHES_TRACKING_WRITE";
@@ -430,6 +431,12 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_CONFIG_NESTED_AUBE_KEY,
         category: category::ENGINE_CLI,
         description: "`aube config set <prefix>.<sub> …` was used for a key whose prefix is an aube map setting (e.g. `allowBuilds.<pkg>`). Such nested writes would otherwise land in `.npmrc` where aube doesn't read them and npm warns/errors about the unknown key — set the map in workspace yaml or `package.json#aube.<prefix>` instead.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_CONFLICTING_BUILD_FLAGS,
+        category: category::ENGINE_CLI,
+        description: "`aube add` was passed the same package name in both `--allow-build` and `--deny-build`.",
         exit_code: None,
     },
     // Misc / safety

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -908,24 +908,33 @@ where
     Ok(())
 }
 
-/// Force-approve `names` in the project's `allowBuilds` map. Routes
+/// Force-write `names` in the project's `allowBuilds` map. Routes
 /// through [`config_write_target`]: workspace yaml when one exists,
 /// otherwise `package.json#pnpm.allowBuilds`. Returns the file that
 /// was written. Used by `aube approve-builds` and the
-/// `--allow-build=<pkg>` CLI flag — entries are forcibly set to
-/// `true`, overwriting any prior value.
-pub fn add_to_allow_builds(project_dir: &Path, names: &[String]) -> Result<PathBuf, crate::Error> {
+/// `--allow-build=<pkg>` / `--deny-build=<pkg>` CLI flags — entries
+/// are forcibly set, overwriting any prior value.
+pub fn set_allow_builds(
+    project_dir: &Path,
+    names: &[String],
+    allow: bool,
+) -> Result<PathBuf, crate::Error> {
     match config_write_target(project_dir) {
-        ConfigWriteTarget::WorkspaceYaml(path) => write_allow_builds_yaml(&path, names),
+        ConfigWriteTarget::WorkspaceYaml(path) => write_allow_builds_yaml(&path, names, allow),
         ConfigWriteTarget::PackageJson => {
             edit_setting_map(project_dir, "allowBuilds", |map| {
                 for name in names {
-                    map.insert(name.clone(), serde_json::Value::Bool(true));
+                    map.insert(name.clone(), serde_json::Value::Bool(allow));
                 }
             })?;
             Ok(project_dir.join("package.json"))
         }
     }
+}
+
+/// Force-approve `names` in the project's `allowBuilds` map.
+pub fn add_to_allow_builds(project_dir: &Path, names: &[String]) -> Result<PathBuf, crate::Error> {
+    set_allow_builds(project_dir, names, true)
 }
 
 /// Upsert a single `<map>.<entry>` pair into the project's
@@ -1124,12 +1133,16 @@ where
     Ok(path.to_path_buf())
 }
 
-fn write_allow_builds_yaml(path: &Path, names: &[String]) -> Result<PathBuf, crate::Error> {
+fn write_allow_builds_yaml(
+    path: &Path,
+    names: &[String],
+    allow: bool,
+) -> Result<PathBuf, crate::Error> {
     edit_workspace_yaml(path, |map| {
         let allow_builds = workspace_yaml_submap(map, "allowBuilds", path)?;
         for name in names {
             let key = yaml_serde::Value::String(name.clone());
-            allow_builds.insert(key, yaml_serde::Value::Bool(true));
+            allow_builds.insert(key, yaml_serde::Value::Bool(allow));
         }
         Ok(())
     })

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -56,6 +56,25 @@ pub struct AddArgs {
     /// which remains a hard block.
     #[arg(long)]
     pub allow_low_downloads: bool,
+    /// Mark a dependency's lifecycle scripts as reviewed and denied.
+    ///
+    /// Writes `allowBuilds: { <pkg>: false }` into the workspace yaml
+    /// (or `package.json#aube.allowBuilds`) before the install runs,
+    /// so the named package's lifecycle scripts stay skipped without
+    /// tripping `strictDepBuilds=true`. Repeatable — pass the flag
+    /// once per package.
+    ///
+    /// Conflicts with `--no-save`, which only snapshots `package.json`
+    /// and the lockfile and would leave an orphaned denial in the
+    /// workspace yaml on restore.
+    #[arg(
+        long = "deny-build",
+        value_name = "PKG",
+        conflicts_with = "no_save",
+        require_equals = true,
+        value_parser = parse_deny_build_value,
+    )]
+    pub deny_build: Vec<String>,
     /// Skip lifecycle scripts (no-op; aube already skips by default).
     #[arg(long, hide = true)]
     pub ignore_scripts: bool,
@@ -671,6 +690,7 @@ pub async fn run(
         save_catalog,
         save_catalog_name,
         allow_build,
+        deny_build,
         allow_low_downloads,
         lockfile,
         network,
@@ -692,6 +712,7 @@ pub async fn run(
         return run_global(
             packages,
             allow_build,
+            deny_build,
             allow_low_downloads,
             lockfile,
             network,
@@ -808,15 +829,16 @@ pub async fn run(
     } else {
         None
     };
-    // `--allow-build=<pkg>` pre-approves dep lifecycle scripts as part
-    // of the add. The conflict check (refuses to flip a pre-existing
-    // `false` to `true`) runs BEFORE `update_manifest_for_add` so a
-    // failure can't leave the manifest with new deps written but no
-    // matching install. Approval bytes themselves are also written here
-    // — the order doesn't matter for the install pipeline (it re-reads
-    // both files from disk) but keeps the failure-mode reasoning local.
+    // `--allow-build=<pkg>` / `--deny-build=<pkg>` pre-review dep
+    // lifecycle scripts as part of the add. The install pipeline
+    // re-reads the map from disk, so writing before manifest mutation
+    // keeps failure-mode reasoning local. Deny runs second so an
+    // accidental same-name overlap stays safely skipped.
     if !allow_build.is_empty() {
         apply_allow_build_flags(&cwd, &allow_build)?;
+    }
+    if !deny_build.is_empty() {
+        apply_deny_build_flags(&cwd, &deny_build)?;
     }
 
     // OSV / downloads gates fire pre-manifest-mutation — they're
@@ -1862,6 +1884,16 @@ fn parse_allow_build_value(s: &str) -> Result<String, String> {
     }
 }
 
+fn parse_deny_build_value(s: &str) -> Result<String, String> {
+    if s.is_empty() {
+        Err("The --deny-build flag is missing a package name. \
+             Please specify the package name(s) that are denied from running installation scripts."
+            .to_string())
+    } else {
+        Ok(s.to_string())
+    }
+}
+
 /// Apply `--allow-build=<pkg>` flags by writing each package as `true`
 /// to the project's `allowBuilds` map (workspace yaml or
 /// `package.json#aube.allowBuilds`), overwriting any prior value. An
@@ -1871,6 +1903,15 @@ fn apply_allow_build_flags(cwd: &std::path::Path, names: &[String]) -> miette::R
     aube_manifest::workspace::add_to_allow_builds(cwd, names)
         .into_diagnostic()
         .wrap_err("failed to write --allow-build entries")?;
+    Ok(())
+}
+
+/// Apply `--deny-build=<pkg>` flags by writing each package as `false`
+/// to the project's `allowBuilds` map, overwriting any prior value.
+fn apply_deny_build_flags(cwd: &std::path::Path, names: &[String]) -> miette::Result<()> {
+    aube_manifest::workspace::set_allow_builds(cwd, names, false)
+        .into_diagnostic()
+        .wrap_err("failed to write --deny-build entries")?;
     Ok(())
 }
 
@@ -1969,12 +2010,15 @@ async fn run_filtered(
     let (root, matched) = super::select_workspace_packages(&cwd, filter, "add")?;
     let _lock = super::take_project_lock(&root)?;
 
-    // `--allow-build=<pkg>` writes against the workspace root (where
+    // CLI build review flags write against the workspace root (where
     // `allowBuilds` lives) — same as the non-filtered path. Run before
-    // any per-package manifest mutation so a conflict can't leave the
+    // any per-package manifest mutation so a failure can't leave the
     // child manifests half-mutated.
     if !args.allow_build.is_empty() {
         apply_allow_build_flags(&root, &args.allow_build)?;
+    }
+    if !args.deny_build.is_empty() {
+        apply_deny_build_flags(&root, &args.deny_build)?;
     }
 
     // OSV / downloads gates fire once against the workspace root
@@ -2122,6 +2166,7 @@ async fn run_filtered(
 async fn run_global(
     packages: &[String],
     allow_build: Vec<String>,
+    deny_build: Vec<String>,
     allow_low_downloads: bool,
     lockfile: crate::cli_args::LockfileArgs,
     network: crate::cli_args::NetworkArgs,
@@ -2174,6 +2219,7 @@ async fn run_global(
     let result = run_global_inner(
         packages,
         allow_build,
+        deny_build,
         allow_low_downloads,
         &layout,
         &install_dir,
@@ -2214,6 +2260,7 @@ async fn run_global(
 async fn run_global_inner(
     packages: &[String],
     allow_build: Vec<String>,
+    deny_build: Vec<String>,
     allow_low_downloads: bool,
     layout: &super::global::GlobalLayout,
     install_dir: &std::path::Path,
@@ -2295,6 +2342,10 @@ async fn run_global_inner(
         // install" even when the user explicitly approved the dep
         // (see Discussion #617).
         allow_build,
+        // Same contract as `allow_build`, but force-denies matching
+        // packages so global installs can satisfy `strictDepBuilds=true`
+        // while keeping selected lifecycle scripts skipped.
+        deny_build,
         // The synthetic inner `run()` is the one that actually fires
         // the supply-chain gate (`add` only checks once, in the main
         // path). Forward the outer caller's `--allow-low-downloads`

--- a/crates/aube/src/commands/add.rs
+++ b/crates/aube/src/commands/add.rs
@@ -34,7 +34,8 @@ pub struct AddArgs {
     ///
     /// Conflicts with `--no-save`, which only snapshots `package.json`
     /// and the lockfile and would leave an orphaned approval in the
-    /// workspace yaml on restore.
+    /// workspace yaml on restore. Also conflicts with `--deny-build` for
+    /// the same package name.
     #[arg(
         long = "allow-build",
         value_name = "PKG",
@@ -66,7 +67,8 @@ pub struct AddArgs {
     ///
     /// Conflicts with `--no-save`, which only snapshots `package.json`
     /// and the lockfile and would leave an orphaned denial in the
-    /// workspace yaml on restore.
+    /// workspace yaml on restore. Also conflicts with `--allow-build` for
+    /// the same package name.
     #[arg(
         long = "deny-build",
         value_name = "PKG",
@@ -707,6 +709,7 @@ pub async fn run(
     if packages.is_empty() {
         return Err(miette!("no packages specified"));
     }
+    reject_conflicting_build_flags(&allow_build, &deny_build)?;
 
     if global {
         return run_global(
@@ -832,8 +835,7 @@ pub async fn run(
     // `--allow-build=<pkg>` / `--deny-build=<pkg>` pre-review dep
     // lifecycle scripts as part of the add. The install pipeline
     // re-reads the map from disk, so writing before manifest mutation
-    // keeps failure-mode reasoning local. Deny runs second so an
-    // accidental same-name overlap stays safely skipped.
+    // keeps failure-mode reasoning local.
     if !allow_build.is_empty() {
         apply_allow_build_flags(&cwd, &allow_build)?;
     }
@@ -1894,6 +1896,33 @@ fn parse_deny_build_value(s: &str) -> Result<String, String> {
     }
 }
 
+fn reject_conflicting_build_flags(
+    allow_build: &[String],
+    deny_build: &[String],
+) -> miette::Result<()> {
+    if allow_build.is_empty() || deny_build.is_empty() {
+        return Ok(());
+    }
+
+    let mut overlap: Vec<&str> = allow_build
+        .iter()
+        .filter(|name| deny_build.contains(name))
+        .map(String::as_str)
+        .collect();
+    overlap.sort_unstable();
+    overlap.dedup();
+    if overlap.is_empty() {
+        return Ok(());
+    }
+
+    Err(miette!(
+        code = aube_codes::errors::ERR_AUBE_CONFLICTING_BUILD_FLAGS,
+        "--allow-build and --deny-build both name the same package(s): {}. \
+         Each package may only appear in one flag.",
+        overlap.join(", ")
+    ))
+}
+
 /// Apply `--allow-build=<pkg>` flags by writing each package as `true`
 /// to the project's `allowBuilds` map (workspace yaml or
 /// `package.json#aube.allowBuilds`), overwriting any prior value. An
@@ -2000,6 +2029,7 @@ async fn run_filtered(
     if args.packages.is_empty() {
         return Err(miette!("no packages specified"));
     }
+    reject_conflicting_build_flags(&args.allow_build, &args.deny_build)?;
     let cwd = crate::dirs::cwd()?;
     // The workspace root — not the child `cwd` — is what owns the
     // lockfile and the project lock in yarn / npm / bun monorepos.

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -46,6 +46,14 @@ Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation
 
 `aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`]. The flag is intended for the cases where you've already verified the package out-of-band — adding a brand-new niche tool, a fresh fork, an internal scratch package — and don't want the prompt to interrupt scripted workflows. Does not affect the OSV malicious-package check, which remains a hard block.
 
+### `--deny-build… <PKG>`
+
+Mark a dependency's lifecycle scripts as reviewed and denied.
+
+Writes `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.
+
+Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore.
+
 ### `--no-save`
 
 Install without persisting the dependency to `package.json`.

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -38,7 +38,7 @@ Pre-approve a dependency's lifecycle scripts as part of the add.
 
 Writes `allowBuilds: { <pkg>: true }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's `preinstall` / `install` / `postinstall` scripts execute on this invocation. Repeatable — pass the flag once per package. Mirrors `pnpm add --allow-build=<pkg>`.
 
-Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned approval in the workspace yaml on restore.
+Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned approval in the workspace yaml on restore. Also conflicts with `--deny-build` for the same package name.
 
 ### `--allow-low-downloads`
 
@@ -52,7 +52,7 @@ Mark a dependency's lifecycle scripts as reviewed and denied.
 
 Writes `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.
 
-Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore.
+Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name.
 
 ### `--no-save`
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -109,7 +109,7 @@
             "name": "allow-build",
             "usage": "--allow-build… <PKG>",
             "help": "Pre-approve a dependency's lifecycle scripts as part of the add",
-            "help_long": "Pre-approve a dependency's lifecycle scripts as part of the add.\n\nWrites `allowBuilds: { <pkg>: true }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's `preinstall` / `install` / `postinstall` scripts execute on this invocation. Repeatable — pass the flag once per package. Mirrors `pnpm add --allow-build=<pkg>`.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned approval in the workspace yaml on restore.",
+            "help_long": "Pre-approve a dependency's lifecycle scripts as part of the add.\n\nWrites `allowBuilds: { <pkg>: true }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's `preinstall` / `install` / `postinstall` scripts execute on this invocation. Repeatable — pass the flag once per package. Mirrors `pnpm add --allow-build=<pkg>`.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned approval in the workspace yaml on restore. Also conflicts with `--deny-build` for the same package name.",
             "help_first_line": "Pre-approve a dependency's lifecycle scripts as part of the add",
             "short": [],
             "long": [
@@ -143,7 +143,7 @@
             "name": "deny-build",
             "usage": "--deny-build… <PKG>",
             "help": "Mark a dependency's lifecycle scripts as reviewed and denied",
-            "help_long": "Mark a dependency's lifecycle scripts as reviewed and denied.\n\nWrites `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore.",
+            "help_long": "Mark a dependency's lifecycle scripts as reviewed and denied.\n\nWrites `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name.",
             "help_first_line": "Mark a dependency's lifecycle scripts as reviewed and denied",
             "short": [],
             "long": [

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -140,6 +140,27 @@
             "global": false
           },
           {
+            "name": "deny-build",
+            "usage": "--deny-build… <PKG>",
+            "help": "Mark a dependency's lifecycle scripts as reviewed and denied",
+            "help_long": "Mark a dependency's lifecycle scripts as reviewed and denied.\n\nWrites `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore.",
+            "help_first_line": "Mark a dependency's lifecycle scripts as reviewed and denied",
+            "short": [],
+            "long": [
+              "deny-build"
+            ],
+            "var": true,
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "PKG",
+              "usage": "<PKG>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
             "name": "ignore-scripts",
             "usage": "--ignore-scripts",
             "help": "Skip lifecycle scripts (no-op; aube already skips by default)",

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -313,6 +313,12 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_CONFLICTING_BUILD_FLAGS",
+      "category": "Engine / CLI",
+      "description": "`aube add` was passed the same package name in both `--allow-build` and `--deny-build`.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_UNSAFE_INDEX_KEY",
       "category": "Misc / safety",
       "description": "A package index key tried to escape its directory (path traversal defense in depth).",

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -202,6 +202,23 @@ teardown() {
 	assert_success
 }
 
+@test "aube add -g --deny-build=<pkg> marks a global dep's build scripts reviewed" {
+	AUBE_STRICT_DEP_BUILDS=true run aube add -g \
+		--deny-build=aube-test-builds-marker \
+		aube-test-builds-marker@1.0.0
+	assert_success
+	refute_output --partial "must be reviewed before install"
+	refute_output --partial "ignored build scripts"
+
+	pkg_dir="$AUBE_HOME/global-aube"
+	install_dir="$(find "$pkg_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+	# Denied dep stayed skipped, but strictDepBuilds accepted the
+	# explicit review decision.
+	assert_file_not_exists "$install_dir/aube-builds-marker.txt"
+	run grep -q '"aube-test-builds-marker": false' "$install_dir/package.json"
+	assert_success
+}
+
 @test "aube remove -g on a missing package errors" {
 	run aube remove -g nonexistent-pkg
 	assert_failure

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -810,6 +810,17 @@ JSON
 	assert_success
 }
 
+@test "aube add rejects packages listed in both allow-build and deny-build" {
+	run aube add \
+		--allow-build=@pnpm.e2e/install-script-example \
+		--deny-build=@pnpm.e2e/install-script-example \
+		@pnpm.e2e/install-script-example
+	assert_failure
+	assert_output --partial "ERR_AUBE_CONFLICTING_BUILD_FLAGS"
+	assert_output --partial "--allow-build and --deny-build both name the same package(s)"
+	assert_output --partial "Each package may only appear in one flag"
+}
+
 @test "aube add --allow-build with no value errors and points at the = syntax" {
 	# Bare `--allow-build` is rejected by clap before it reaches our
 	# validator, because the arg has `require_equals = true` and no

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -792,6 +792,24 @@ JSON
 	assert_failure
 }
 
+@test "aube add --deny-build=<pkg> reviews and skips a dep's build scripts" {
+	cat >package.json <<'JSON'
+{
+  "name": "aube-lifecycle-deny-build-selective",
+  "version": "1.0.0"
+}
+JSON
+	AUBE_STRICT_DEP_BUILDS=true run aube add \
+		--deny-build=@pnpm.e2e/install-script-example \
+		@pnpm.e2e/install-script-example
+	assert_success
+	refute_output --partial "must be reviewed before install"
+	refute_output --partial "ignored build scripts"
+	assert [ ! -e node_modules/@pnpm.e2e/install-script-example/generated-by-install.js ]
+	run grep -F '"@pnpm.e2e/install-script-example": false' package.json
+	assert_success
+}
+
 @test "aube add --allow-build with no value errors and points at the = syntax" {
 	# Bare `--allow-build` is rejected by clap before it reaches our
 	# validator, because the arg has `require_equals = true` and no


### PR DESCRIPTION
## Summary
- add repeatable `aube add --deny-build=<pkg>` to write reviewed denied lifecycle-build entries
- forward the flag through global installs so `strictDepBuilds=true` can skip selected global package builds without failing
- document the new flag and cover local/global add behavior with BATS tests

Closes discussion #726.

## Tests
- `cargo check -p aube -p aube-manifest`
- `cargo fmt --check`
- `cargo build -p aube`
- `cargo test -p aube test_cli_ordering`
- `./test/bats/bin/bats test/global_install.bats --filter 'aube add -g --deny-build=<pkg> marks a global dep'`
- `./test/bats/bin/bats test/lifecycle_scripts.bats --filter 'aube add --deny-build=<pkg> reviews and skips'`
- `./test/bats/bin/bats test/global_install.bats --filter 'aube add -g --allow-build=<pkg> pre-approves'`
- `./test/bats/bin/bats test/lifecycle_scripts.bats --filter 'aube add --allow-build=<pkg> selectively pre-approves'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install-script review policy and `aube add`/global add flows; mistakes could unintentionally allow or block lifecycle scripts in strict build environments.
> 
> **Overview**
> Adds a new repeatable `aube add --deny-build=<pkg>` flag that *explicitly marks a dependency’s lifecycle scripts as reviewed and denied* by writing `allowBuilds.<pkg>=false` before install (including `-g` global installs), enabling `strictDepBuilds=true` workflows that still skip selected builds.
> 
> Refactors manifest writing to support setting `allowBuilds` entries to either `true` or `false`, and introduces a new error code (`ERR_AUBE_CONFLICTING_BUILD_FLAGS`) plus validation to reject package names specified in both `--allow-build` and `--deny-build`.
> 
> Updates CLI usage/spec docs (`aube.usage.kdl`, `docs/cli/add.md`, `commands.json`, `error-codes.data.json`) and adds BATS coverage for local/global deny behavior and conflict handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11bb53ff6b63cf9b5ac26bc2353095819d976d0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->