### PR TITLE
fix(lockfile): parse yarn classic dependency tails

### DIFF
--- a/crates/aube-lockfile/src/yarn/classic.rs
+++ b/crates/aube-lockfile/src/yarn/classic.rs
@@ -97,7 +97,10 @@ pub(super) fn parse_classic_str(
         let mut deps: BTreeMap<String, String> = BTreeMap::new();
         for (name, raw_spec) in &pkg.dependencies {
             if let Some(resolved_path) = spec_to_dep_path.get(raw_spec) {
-                deps.insert(name.clone(), resolved_path.clone());
+                deps.insert(
+                    name.clone(),
+                    crate::npm::dep_path_tail(name, resolved_path).to_string(),
+                );
             }
         }
         resolved.insert(dep_path.clone(), deps);
@@ -243,13 +246,7 @@ fn parse_header_specs(header: &str) -> Result<Vec<String>, String> {
     let mut specs = Vec::new();
     for raw in header.split(',') {
         let s = raw.trim();
-        let unquoted = if (s.starts_with('"') && s.ends_with('"') && s.len() >= 2)
-            || (s.starts_with('\'') && s.ends_with('\'') && s.len() >= 2)
-        {
-            &s[1..s.len() - 1]
-        } else {
-            s
-        };
+        let unquoted = unquote_yarn_scalar(s);
         if unquoted.is_empty() {
             return Err(format!("empty spec in header '{header}'"));
         }
@@ -266,14 +263,20 @@ fn parse_header_specs(header: &str) -> Result<Vec<String>, String> {
 fn split_key_value(line: &str) -> Option<(String, String)> {
     let (key, rest) = line.split_once(char::is_whitespace)?;
     let value = rest.trim();
-    let unquoted = if (value.starts_with('"') && value.ends_with('"') && value.len() >= 2)
+    Some((
+        unquote_yarn_scalar(key).to_string(),
+        unquote_yarn_scalar(value).to_string(),
+    ))
+}
+
+fn unquote_yarn_scalar(value: &str) -> &str {
+    if (value.starts_with('"') && value.ends_with('"') && value.len() >= 2)
         || (value.starts_with('\'') && value.ends_with('\'') && value.len() >= 2)
     {
         &value[1..value.len() - 1]
     } else {
         value
-    };
-    Some((key.to_string(), unquoted.to_string()))
+    }
 }
 
 /// Extract the package name from a spec like `foo@^1.0.0` or `@scope/pkg@^1.0.0`.

--- a/crates/aube-lockfile/src/yarn/tests.rs
+++ b/crates/aube-lockfile/src/yarn/tests.rs
@@ -68,7 +68,7 @@ bar@^2.0.0:
     assert_eq!(foo.integrity.as_deref(), Some("sha512-aaa"));
     assert_eq!(
         foo.dependencies.get("bar").map(String::as_str),
-        Some("bar@2.5.0")
+        Some("2.5.0")
     );
 
     let root = graph.importers.get(".").unwrap();
@@ -141,7 +141,60 @@ fn test_parse_npm_protocol_alias_transitive() {
     let core = &graph.packages["@docusaurus/core@2.1.0"];
     assert_eq!(
         core.dependencies.get("react-loadable").map(String::as_str),
-        Some("react-loadable@5.5.2")
+        Some("5.5.2")
+    );
+}
+
+#[test]
+fn test_parse_classic_dependency_values_are_dep_path_tails() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"# yarn lockfile v1
+
+"@rollup/plugin-replace@2.4.1":
+  version "2.4.1"
+  integrity sha512-aaa
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    magic-string "^0.25.9"
+
+"@rollup/pluginutils@^3.1.0":
+  version "3.1.0"
+  integrity sha512-bbb
+
+magic-string@^0.25.9:
+  version "0.25.9"
+  integrity sha512-ccc
+  dependencies:
+    sourcemap-codec "^1.4.8"
+
+sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  integrity sha512-ddd
+"#;
+    std::fs::write(tmp.path(), content).unwrap();
+    let manifest = make_manifest(&[("@rollup/plugin-replace", "2.4.1")], &[]);
+    let graph = parse(tmp.path(), &manifest).unwrap();
+
+    let replace = &graph.packages["@rollup/plugin-replace@2.4.1"];
+    assert_eq!(
+        replace
+            .dependencies
+            .get("@rollup/pluginutils")
+            .map(String::as_str),
+        Some("3.1.0")
+    );
+    assert_eq!(
+        replace.dependencies.get("magic-string").map(String::as_str),
+        Some("0.25.9")
+    );
+
+    let magic_string = &graph.packages["magic-string@0.25.9"];
+    assert_eq!(
+        magic_string
+            .dependencies
+            .get("sourcemap-codec")
+            .map(String::as_str),
+        Some("1.4.8")
     );
 }
 
@@ -251,7 +304,7 @@ bar@^2.0.0:
             .dependencies
             .get("bar")
             .map(String::as_str),
-        Some("bar@2.5.0")
+        Some("2.5.0")
     );
 }
 


### PR DESCRIPTION
## Summary
- unquote Yarn classic dependency keys before resolving dependency edges
- normalize Yarn classic dependency values to dep-path tails so linker reconstruction finds scoped and transitive packages
- add regression coverage for @rollup/pluginutils and sourcemap-codec cases from Discussions #723 and #725

Fixes https://github.com/endevco/aube/discussions/723
Fixes https://github.com/endevco/aube/discussions/725

## Tests
- cargo fmt --check
- cargo test -p aube-lockfile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Yarn classic lockfile parsing for dependency edge normalization and unquoting, which can affect dependency graph reconstruction and installs for yarn v1 projects. Scope is contained to parsing logic with added regression tests covering scoped and transitive cases.
> 
> **Overview**
> Fixes Yarn classic (v1) parsing so dependency edges resolve correctly when dependency keys/values are quoted and when the linker expects *dep-path tails* (e.g. `"2.5.0"` instead of `"bar@2.5.0"`).
> 
> Transitive dependency resolution now stores `pkg.dependencies` as version tails via `crate::npm::dep_path_tail`, and tokenization unquotes both header specs and body key/value scalars via a new `unquote_yarn_scalar` helper. Tests are updated accordingly and a new regression test covers quoted scoped deps and transitive resolution (`@rollup/pluginutils`, `sourcemap-codec`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 446b64b2b55b0789753b87893bf3fad0efc1f7e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->