### PR TITLE
fix(lockfile): prune pnpm time entries to direct deps

### DIFF
--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -670,6 +670,117 @@ fn test_write_and_reparse_roundtrip() {
 }
 
 #[test]
+fn test_write_prunes_time_to_direct_importer_deps() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+
+    let mut packages = BTreeMap::new();
+    packages.insert(
+        "foo@1.0.0".to_string(),
+        LockedPackage {
+            name: "foo".to_string(),
+            version: "1.0.0".to_string(),
+            integrity: Some("sha512-foo==".to_string()),
+            dependencies: [("bar".to_string(), "2.0.0".to_string())]
+                .into_iter()
+                .collect(),
+            dep_path: "foo@1.0.0".to_string(),
+            ..Default::default()
+        },
+    );
+    packages.insert(
+        "bar@2.0.0".to_string(),
+        LockedPackage {
+            name: "bar".to_string(),
+            version: "2.0.0".to_string(),
+            integrity: Some("sha512-bar==".to_string()),
+            dep_path: "bar@2.0.0".to_string(),
+            ..Default::default()
+        },
+    );
+
+    let graph = LockfileGraph {
+        importers: [(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "foo".to_string(),
+                dep_path: "foo@1.0.0".to_string(),
+                dep_type: DepType::Production,
+                specifier: Some("^1.0.0".to_string()),
+            }],
+        )]
+        .into_iter()
+        .collect(),
+        packages,
+        times: [
+            (
+                "foo@1.0.0".to_string(),
+                "2026-01-01T00:00:00.000Z".to_string(),
+            ),
+            (
+                "bar@2.0.0".to_string(),
+                "2026-01-02T00:00:00.000Z".to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        ..Default::default()
+    };
+
+    write(&lockfile_path, &graph, &PackageJson::default()).unwrap();
+    let written = std::fs::read_to_string(&lockfile_path).unwrap();
+
+    assert!(written.contains("\n  foo@1.0.0: 2026-01-01T00:00:00.000Z\n"));
+    assert!(!written.contains("\n  bar@2.0.0: 2026-01-02T00:00:00.000Z\n"));
+}
+
+#[test]
+fn test_write_preserves_real_name_time_for_aube_aliases() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("aube-lock.yaml");
+
+    let graph = LockfileGraph {
+        importers: [(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "alias-pkg".to_string(),
+                dep_path: "alias-pkg@1.0.0".to_string(),
+                dep_type: DepType::Production,
+                specifier: Some("npm:real-pkg@^1.0.0".to_string()),
+            }],
+        )]
+        .into_iter()
+        .collect(),
+        packages: [(
+            "alias-pkg@1.0.0".to_string(),
+            LockedPackage {
+                name: "alias-pkg".to_string(),
+                version: "1.0.0".to_string(),
+                integrity: Some("sha512-alias==".to_string()),
+                dep_path: "alias-pkg@1.0.0".to_string(),
+                alias_of: Some("real-pkg".to_string()),
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect(),
+        times: [(
+            "real-pkg@1.0.0".to_string(),
+            "2026-01-01T00:00:00.000Z".to_string(),
+        )]
+        .into_iter()
+        .collect(),
+        ..Default::default()
+    };
+
+    write(&lockfile_path, &graph, &PackageJson::default()).unwrap();
+    let written = std::fs::read_to_string(&lockfile_path).unwrap();
+
+    assert!(written.contains("\n  alias-pkg@1.0.0: 2026-01-01T00:00:00.000Z\n"));
+    assert!(!written.contains("\n  real-pkg@1.0.0: 2026-01-01T00:00:00.000Z\n"));
+}
+
+#[test]
 fn writer_preserves_workspace_importer_specifiers() {
     let dir = tempfile::tempdir().unwrap();
     let lockfile_path = dir.path().join("pnpm-lock.yaml");

--- a/crates/aube-lockfile/src/pnpm/write.rs
+++ b/crates/aube-lockfile/src/pnpm/write.rs
@@ -400,11 +400,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         );
     }
 
-    let time = if graph.times.is_empty() {
-        None
-    } else {
-        Some(graph.times.clone())
-    };
+    let time = pruned_time_entries(graph, native_pnpm_aliases);
 
     let catalogs = if graph.catalogs.is_empty() {
         None
@@ -482,6 +478,57 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
     // atomic_write_lockfile for full rationale.
     crate::atomic_write_lockfile(path, yaml.as_bytes())?;
     Ok(())
+}
+
+fn pruned_time_entries(
+    graph: &LockfileGraph,
+    native_pnpm_aliases: bool,
+) -> Option<BTreeMap<String, String>> {
+    if graph.times.is_empty() {
+        return None;
+    }
+
+    let mut time = BTreeMap::new();
+    for deps in graph.importers.values() {
+        for dep in deps {
+            let Some(pkg) = graph.packages.get(&dep.dep_path) else {
+                tracing::debug!(
+                    dep_path = %dep.dep_path,
+                    "direct importer dep missing from package table while pruning pnpm time entries"
+                );
+                continue;
+            };
+            if pkg.local_source.is_some() {
+                continue;
+            }
+            let name = if native_pnpm_aliases {
+                pkg.alias_of.as_deref().unwrap_or(dep.name.as_str())
+            } else {
+                dep.name.as_str()
+            };
+            let tail = dep_path_tail(&dep.dep_path, &dep.name);
+            let version = tail.split('(').next().unwrap_or(tail);
+            let key = version_to_dep_path(name, version);
+            let internal_key = version_to_dep_path(&dep.name, version);
+            let value = graph
+                .times
+                .get(&key)
+                .or_else(|| graph.times.get(&internal_key))
+                .or_else(|| {
+                    (!native_pnpm_aliases)
+                        .then_some(pkg.alias_of.as_deref())
+                        .flatten()
+                        .and_then(|real_name| {
+                            graph.times.get(&version_to_dep_path(real_name, version))
+                        })
+                });
+            if let Some(value) = value {
+                time.insert(key, value.clone());
+            }
+        }
+    }
+
+    (!time.is_empty()).then_some(time)
 }
 
 // -- Writable serde types for pnpm-lock.yaml v9 --

--- a/test/update.bats
+++ b/test/update.bats
@@ -329,8 +329,8 @@ EOF
 # and (b) `aube update`'s `filtered_existing` strips direct deps from
 # `existing.packages` to force a fresh re-resolve, so the lockfile-
 # reuse path's time-carry-forward never fired for them. Transitive
-# deps stayed in `existing.packages` and kept their times — the
-# asymmetry @mrazauskas flagged.
+# deps stayed in `existing.packages`; the writer now prunes transitive
+# publish times for pnpm v11 parity.
 @test "aube update preserves time: entries for direct deps" {
 	# `^0.1.0` is the only spec that exposes the bug cleanly: `>=0.1.0`
 	# would bump is-odd to 3.0.1 and the resolver would (correctly)
@@ -387,22 +387,17 @@ EOF
 	run aube update
 	assert_success
 
-	# Every locked dep — direct AND transitive — must keep a `time:`
-	# entry after the rewrite. We can't pin the timestamp value
-	# because the resolver may have refreshed it from the packument
-	# during re-resolve, but the entry MUST be present. The
-	# pre-fix bug dropped the is-odd line entirely while leaving the
-	# transitive entries intact.
+	# The direct dep must keep a `time:` entry after the rewrite. We
+	# can't pin the timestamp value because the resolver may have
+	# refreshed it from the packument during re-resolve, but the entry
+	# MUST be present. pnpm v11 prunes transitive publish times from the
+	# written lockfile, so only the importer dep is asserted here.
 	#
-	# The character after the colon-space distinguishes a `time:`
-	# block entry (`  is-odd@0.1.2: <ISO>` — pnpm-style writers may
-	# quote or omit quotes depending on YAML rules) from a
-	# `packages:`/`snapshots:` key (`  is-odd@0.1.2:` followed by
-	# EOL or `{...}`). A non-empty char after `: ` is enough.
-	run grep -E "^  is-odd@0\.1\.2: [^[:space:]]" aube-lock.yaml
+	time_block="$(awk '/^time:/{f=1;next} /^[^[:space:]].*:/{f=0} f' aube-lock.yaml)"
+	run bash -c "grep -E '^  is-odd@0\\.1\\.2: [^[:space:]]' <<<\"\$1\"" _ "$time_block"
 	assert_success
-	run grep -E "^  is-number@3\.0\.0: [^[:space:]]" aube-lock.yaml
-	assert_success
-	run grep -E "^  kind-of@3\.2\.2: [^[:space:]]" aube-lock.yaml
-	assert_success
+	run bash -c "grep -E '^  is-number@3\\.0\\.0: [^[:space:]]' <<<\"\$1\"" _ "$time_block"
+	assert_failure
+	run bash -c "grep -E '^  kind-of@3\\.2\\.2: [^[:space:]]' <<<\"\$1\"" _ "$time_block"
+	assert_failure
 }


### PR DESCRIPTION
## Summary

- Prune pnpm lockfile `time:` output to direct importer dependencies for pnpm v11 parity.
- Preserve direct dependency publish times while omitting transitive publish times from the written lockfile.
- Add unit coverage and update the existing update regression expectation.

## Validation

- `cargo fmt --check`
- `cargo clippy -p aube-lockfile --all-targets -- -D warnings`
- `cargo test -p aube-lockfile`

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes serialized lockfile contents by dropping transitive `time:` entries, which can affect downstream tooling that relied on those timestamps. Logic also touches alias keying, so incorrect mapping could silently omit a direct dep’s `time:` entry.
> 
> **Overview**
> Writes now **prune pnpm `time:` output to direct importer dependencies only**, instead of carrying through all `graph.times`, for pnpm v11 parity.
> 
> Adds pruning logic in `pnpm/write.rs` that skips local deps and resolves the correct `time:` key for aliases (including falling back between alias vs real-name keys), plus new unit tests and an updated `aube update` bats regression to assert only direct deps retain `time:` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733ccc7861309de8a77dfab71ad4a384b11e0821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->