### PR TITLE
fix(yarn): support esm exec generators

### DIFF
--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -36,7 +36,13 @@ globalThis.execEnv = env;
 for (const name of ['fs', 'path', 'child_process', 'os', 'crypto', 'url', 'util', 'stream', 'buffer']) {
   globalThis[name] = require(name);
 }
-require(process.argv[1]);
+(async () => {
+  const { pathToFileURL } = require('url');
+  await import(pathToFileURL(process.argv[1]).href);
+})().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});
 "#;
 
 use semver_util::version_satisfies;

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -37,11 +37,10 @@ for (const name of ['fs', 'path', 'child_process', 'os', 'crypto', 'url', 'util'
   globalThis[name] = require(name);
 }
 (async () => {
-  const { pathToFileURL } = require('url');
-  await import(pathToFileURL(process.argv[1]).href);
+  await import(url.pathToFileURL(process.argv[1]).href);
 })().catch((err) => {
   console.error(err);
-  process.exitCode = 1;
+  process.exit(1);
 });
 "#;
 

--- a/test/import.bats
+++ b/test/import.bats
@@ -114,6 +114,27 @@ teardown() {
 	assert_success
 }
 
+@test "aube install supports yarn berry esm exec generators" {
+	cat >package.json <<'EOF'
+{"name":"root","version":"1.0.0","dependencies":{"esm-exec-pkg":"exec:./scripts/generate-exec.mjs"}}
+EOF
+	mkdir -p scripts
+	cat >scripts/generate-exec.mjs <<'EOF'
+fs.writeFileSync(path.join(execEnv.buildDir, 'package.json'), JSON.stringify({
+  name: 'esm-exec-pkg',
+  version: '1.0.0',
+  main: 'index.js'
+}));
+fs.writeFileSync(path.join(execEnv.buildDir, 'index.js'), "module.exports = 'esm exec ok';\n");
+EOF
+
+	run aube install
+	assert_success
+
+	run node -e 'if (require("esm-exec-pkg") !== "esm exec ok") process.exit(1)'
+	assert_success
+}
+
 @test "aube install fresh-resolves yarn berry portal transitive exec protocol" {
 	cp -R "$PROJECT_ROOT/fixtures/import-yarn-portal-exec/." .
 	rm yarn.lock


### PR DESCRIPTION
## Summary

- load Yarn Berry `exec:` generator scripts with dynamic `import()` so `.mjs` and CommonJS generators both work
- add import coverage for an ESM `exec:` generator

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `mise run test:bats test/import.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Yarn Berry `exec:` generator scripts are executed (switching from `require()` to dynamic `import()`), which could affect script loading/behavior during installs and error handling.
> 
> **Overview**
> Yarn Berry `exec:` generator scripts are now loaded via dynamic `import()` (with file-URL conversion and explicit error handling) instead of `require()`, enabling `.mjs`/ESM generators to run alongside CommonJS ones.
> 
> Adds a new Bats integration test that installs a dependency generated by an ESM `exec:` script and verifies the resulting package can be `require()`’d successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c65ff28a6bb28c0a4079dbb32edd2b1037e91cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->