### PR TITLE
fix(resolver): skip fast fail for optional deps

### DIFF
--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -432,7 +432,40 @@ impl<'a> ResolveDriver<'a> {
                     self.resolver.cache.insert(name, packument);
                     self.packument_fetch_count += 1;
                 }
-                Some(Ok(Err(e))) => return Err(e),
+                Some(Ok(Err(e))) => {
+                    // Optional deps that can't be fetched from the
+                    // registry are silently skipped — they may not
+                    // exist for all platforms (e.g., napi-rs
+                    // platform-specific variants that were never
+                    // published but for some reason, it's included
+                    // in `optionalDependencies`). pnpm parity.
+                    // Only skip when the error is for *this* task's
+                    // packument — errors for unrelated packages
+                    // surfaced while we're waiting must still
+                    // propagate.
+                    if task.dep_type == DepType::Optional
+                        && matches!(&e, crate::Error::Registry(name, _) if name == &fetch_name)
+                    {
+                        tracing::debug!(
+                            "skipping optional dep {}@{}: registry fetch failed",
+                            task.name,
+                            task.range,
+                        );
+                        if task.is_root
+                            && let Some(spec) = task.original_specifier.as_ref()
+                        {
+                            self.skipped_optional_dependencies
+                                .entry(task.importer.clone())
+                                .or_default()
+                                .insert(task.name.clone(), spec.clone());
+                        }
+                        if task.is_root {
+                            self.note_root_done();
+                        }
+                        return Ok(());
+                    }
+                    return Err(e);
+                }
                 Some(Err(join_err)) => {
                     return Err(Error::Registry("(join)".to_string(), join_err.to_string()));
                 }
@@ -1049,15 +1082,6 @@ impl<'a> ResolveDriver<'a> {
                     task.name
                 );
                 continue;
-            }
-            if !self.existing_names.contains(dep_name.as_str())
-                && self.resolver.is_prefetchable(
-                    dep_name.as_str(),
-                    dep_range.as_str(),
-                    self.workspace_packages,
-                )
-            {
-                self.ensure_fetch(dep_name);
             }
             self.queue.push_back(ResolveTask::transitive(
                 dep_name.clone(),

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -475,26 +475,31 @@ impl<'a> ResolveDriver<'a> {
 
         // Post-loop: if this task's packument fetch failed, decide
         // whether to skip (optional) or propagate (required).
-        if let Some(e) = self.failed_fetches.remove(&fetch_name) {
-            if task.dep_type == DepType::Optional {
-                tracing::debug!(
-                    "skipping optional dep {}@{}: registry fetch failed",
-                    task.name,
-                    task.range,
-                );
-                if task.is_root
-                    && let Some(spec) = task.original_specifier.as_ref()
-                {
-                    self.skipped_optional_dependencies
-                        .entry(task.importer.clone())
-                        .or_default()
-                        .insert(task.name.clone(), spec.clone());
-                }
-                if task.is_root {
-                    self.note_root_done();
-                }
-                return Ok(());
+        // For optional deps the error stays in `failed_fetches` so
+        // sibling tasks that share the same transitive optional dep
+        // don't re-fetch and re-fail for each importer.
+        if task.dep_type == DepType::Optional
+            && self.failed_fetches.contains_key(&fetch_name)
+        {
+            tracing::debug!(
+                "skipping optional dep {}@{}: registry fetch failed",
+                task.name,
+                task.range,
+            );
+            if task.is_root
+                && let Some(spec) = task.original_specifier.as_ref()
+            {
+                self.skipped_optional_dependencies
+                    .entry(task.importer.clone())
+                    .or_default()
+                    .insert(task.name.clone(), spec.clone());
             }
+            if task.is_root {
+                self.note_root_done();
+            }
+            return Ok(());
+        }
+        if let Some(e) = self.failed_fetches.remove(&fetch_name) {
             return Err(e);
         }
 

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -79,6 +79,12 @@ pub(crate) struct ResolveDriver<'a> {
     /// Per-importer record of optionals dropped on this run (platform
     /// mismatch or `pnpm.ignoredOptionalDependencies`).
     skipped_optional_dependencies: BTreeMap<String, BTreeMap<String, String>>,
+    /// Packument fetches that failed (registry 404, network error, etc.),
+    /// keyed by package name. Errors are stored here instead of
+    /// propagated from `join_next` so a failed fetch for one package
+    /// doesn't crash the wrong task. Checked after the fetch-wait loop
+    /// to decide skip (optional) vs propagate (required).
+    failed_fetches: FxHashMap<String, Error>,
     /// Catalog picks gathered as the BFS rewrites `catalog:` task
     /// ranges. Outer key: catalog name. Inner: package name → spec.
     catalog_picks: BTreeMap<String, BTreeMap<String, String>>,
@@ -209,6 +215,7 @@ impl<'a> ResolveDriver<'a> {
             visited: FxHashSet::with_capacity_and_hasher(2048, Default::default()),
             resolved_times: BTreeMap::new(),
             skipped_optional_dependencies: BTreeMap::new(),
+            failed_fetches: FxHashMap::default(),
             catalog_picks: BTreeMap::new(),
             deferred_transitives: Vec::new(),
             published_by,
@@ -267,11 +274,6 @@ impl<'a> ResolveDriver<'a> {
     /// popped.
     fn seed_initial_prefetches(&mut self) {
         for task in self.queue.iter() {
-            // Don't prefetch optional deps and prefetch failures
-            // bubble up through join_next() incorrectly.
-            if task.dep_type == DepType::Optional {
-                continue;
-            }
             if !self.resolver.is_prefetchable(
                 task.name.as_str(),
                 task.range.as_str(),
@@ -426,7 +428,9 @@ impl<'a> ResolveDriver<'a> {
         let _diag_task_wait =
             aube_util::diag::Span::new(aube_util::diag::Category::Resolver, "task_wait_packument")
                 .with_meta_fn(|| format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(&fetch_name)));
-        while !self.resolver.cache.contains_key(&fetch_name) {
+        while !self.resolver.cache.contains_key(&fetch_name)
+            && !self.failed_fetches.contains_key(&fetch_name)
+        {
             self.ensure_fetch(&fetch_name);
             match self.fetcher.join_next().await {
                 Some(Ok(Ok((name, packument, from_primer)))) => {
@@ -438,56 +442,61 @@ impl<'a> ResolveDriver<'a> {
                     self.packument_fetch_count += 1;
                 }
                 Some(Ok(Err(e))) => {
-                    // Optional deps that can't be fetched from the
-                    // registry are silently skipped — they may not
-                    // exist for all platforms (e.g., napi-rs
-                    // platform-specific variants that were never
-                    // published but for some reason, it's included
-                    // in `optionalDependencies`). pnpm parity.
-                    // Only skip when the error is for *this* task's
-                    // packument — errors for unrelated packages
-                    // surfaced while we're waiting must still
-                    // propagate.
-                    if task.dep_type == DepType::Optional
-                        && matches!(&e, crate::Error::Registry(name, _) if name == &fetch_name)
-                    {
-                        tracing::debug!(
-                            "skipping optional dep {}@{}: registry fetch failed",
-                            task.name,
-                            task.range,
-                        );
-                        if task.is_root
-                            && let Some(spec) = task.original_specifier.as_ref()
-                        {
-                            self.skipped_optional_dependencies
-                                .entry(task.importer.clone())
-                                .or_default()
-                                .insert(task.name.clone(), spec.clone());
-                        }
-                        self.fetcher.release_in_flight(&fetch_name);
-                        if task.is_root {
-                            self.note_root_done();
-                        }
-                        return Ok(());
-                    }
-                    return Err(e);
+                    // Store failed fetches in the side table instead
+                    // of propagating immediately. pnpm parity.
+                    let name = match &e {
+                        crate::Error::Registry(n, _) => n.clone(),
+                        _ => return Err(e),
+                    };
+                    self.fetcher.release_in_flight(&name);
+                    self.failed_fetches.insert(name, e);
                 }
                 Some(Err(join_err)) => {
                     return Err(Error::Registry("(join)".to_string(), join_err.to_string()));
                 }
                 None => {
-                    // ensure_fetch! guarantees something is
-                    // in flight if the cache still doesn't
-                    // hold this name, so a None here means
-                    // the spawn failed silently. Surface it.
-                    return Err(Error::Registry(
-                        fetch_name.clone(),
-                        "packument fetch disappeared before completing".to_string(),
-                    ));
+                    // All in-flight tasks completed. If this task's
+                    // failure was already recorded in the side table,
+                    // break to the post-loop check.
+                    if !self.failed_fetches.contains_key(&fetch_name) {
+                        // ensure_fetch! guarantees something is
+                        // in flight if the cache still doesn't
+                        // hold this name, so a None here means
+                        // the spawn failed silently. Surface it.
+                        return Err(Error::Registry(
+                            fetch_name.clone(),
+                            "packument fetch disappeared before completing".to_string(),
+                        ));
+                    }
                 }
             }
         }
         self.packument_fetch_time += wait_start.elapsed();
+
+        // Post-loop: if this task's packument fetch failed, decide
+        // whether to skip (optional) or propagate (required).
+        if let Some(e) = self.failed_fetches.remove(&fetch_name) {
+            if task.dep_type == DepType::Optional {
+                tracing::debug!(
+                    "skipping optional dep {}@{}: registry fetch failed",
+                    task.name,
+                    task.range,
+                );
+                if task.is_root
+                    && let Some(spec) = task.original_specifier.as_ref()
+                {
+                    self.skipped_optional_dependencies
+                        .entry(task.importer.clone())
+                        .or_default()
+                        .insert(task.name.clone(), spec.clone());
+                }
+                if task.is_root {
+                    self.note_root_done();
+                }
+                return Ok(());
+            }
+            return Err(e);
+        }
 
         // TimeBased wave-0 gate. Transitives that reach
         // the version-pick step while the cutoff is still
@@ -1089,7 +1098,15 @@ impl<'a> ResolveDriver<'a> {
                 );
                 continue;
             }
-
+            if !self.existing_names.contains(dep_name.as_str())
+                && self.resolver.is_prefetchable(
+                    dep_name.as_str(),
+                    dep_range.as_str(),
+                    self.workspace_packages,
+                )
+            {
+                self.ensure_fetch(dep_name);
+            }
             self.queue.push_back(ResolveTask::transitive(
                 dep_name.clone(),
                 dep_range.clone(),

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -464,6 +464,7 @@ impl<'a> ResolveDriver<'a> {
                                 .or_default()
                                 .insert(task.name.clone(), spec.clone());
                         }
+                        self.fetcher.release_in_flight(&fetch_name);
                         if task.is_root {
                             self.note_root_done();
                         }

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -267,6 +267,11 @@ impl<'a> ResolveDriver<'a> {
     /// popped.
     fn seed_initial_prefetches(&mut self) {
         for task in self.queue.iter() {
+            // Don't prefetch optional deps and prefetch failures
+            // bubble up through join_next() incorrectly.
+            if task.dep_type == DepType::Optional {
+                continue;
+            }
             if !self.resolver.is_prefetchable(
                 task.name.as_str(),
                 task.range.as_str(),
@@ -1083,6 +1088,7 @@ impl<'a> ResolveDriver<'a> {
                 );
                 continue;
             }
+
             self.queue.push_back(ResolveTask::transitive(
                 dep_name.clone(),
                 dep_range.clone(),

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -455,19 +455,15 @@ impl<'a> ResolveDriver<'a> {
                     return Err(Error::Registry("(join)".to_string(), join_err.to_string()));
                 }
                 None => {
-                    // All in-flight tasks completed. If this task's
-                    // failure was already recorded in the side table,
-                    // break to the post-loop check.
-                    if !self.failed_fetches.contains_key(&fetch_name) {
-                        // ensure_fetch! guarantees something is
-                        // in flight if the cache still doesn't
-                        // hold this name, so a None here means
-                        // the spawn failed silently. Surface it.
-                        return Err(Error::Registry(
-                            fetch_name.clone(),
-                            "packument fetch disappeared before completing".to_string(),
-                        ));
-                    }
+                    // join_next returns None only when the JoinSet is
+                    // empty. ensure_fetch above guarantees at least one
+                    // task is in flight if the cache still doesn't
+                    // hold this name, so None means the spawn failed
+                    // silently. Surface it.
+                    return Err(Error::Registry(
+                        fetch_name.clone(),
+                        "packument fetch disappeared before completing".to_string(),
+                    ));
                 }
             }
         }

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -307,7 +307,7 @@ impl<'a> ResolveDriver<'a> {
     /// prefetching names already covered by the lockfile check
     /// `existing_names` explicitly before invoking this.
     fn ensure_fetch(&mut self, name: &str) {
-        if !self.resolver.cache.contains_key(name) {
+        if !self.resolver.cache.contains_key(name) && !self.failed_fetches.contains_key(name) {
             self.fetcher
                 .ensure_fetch(name, self.published_by.as_deref());
         }

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -484,14 +484,6 @@ impl<'a> ResolveDriver<'a> {
                 task.name,
                 task.range,
             );
-            if task.is_root
-                && let Some(spec) = task.original_specifier.as_ref()
-            {
-                self.skipped_optional_dependencies
-                    .entry(task.importer.clone())
-                    .or_default()
-                    .insert(task.name.clone(), spec.clone());
-            }
             if task.is_root {
                 self.note_root_done();
             }

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -478,9 +478,7 @@ impl<'a> ResolveDriver<'a> {
         // For optional deps the error stays in `failed_fetches` so
         // sibling tasks that share the same transitive optional dep
         // don't re-fetch and re-fail for each importer.
-        if task.dep_type == DepType::Optional
-            && self.failed_fetches.contains_key(&fetch_name)
-        {
+        if task.dep_type == DepType::Optional && self.failed_fetches.contains_key(&fetch_name) {
             tracing::debug!(
                 "skipping optional dep {}@{}: registry fetch failed",
                 task.name,

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -3696,6 +3696,14 @@ async fn optional_dep_is_skipped_while_required_dep_resolves() {
         .expect("optional dep 404 must not fail the resolve");
     assert!(graph_has_package(&graph, "p-map", "7.0.4"));
     assert!(!graph_has_package(&graph, "missing-optional", "1.0.0"));
+    // pnpm parity: fetch-failed optional deps leave no trace in the
+    // lockfile — no skippedOptionalDependencies entry.
+    assert!(
+        graph
+            .skipped_optional_dependencies
+            .get(".")
+            .map_or(true, |skipped| !skipped.contains_key("missing-optional"))
+    );
 
     server.abort();
 }
@@ -3798,6 +3806,14 @@ async fn optional_dep_with_both_fetches_in_flight() {
         .expect("optional dep 404 must not fail even with concurrent fetches");
     assert!(graph_has_package(&graph, "p-map", "7.0.4"));
     assert!(!graph_has_package(&graph, "missing-optional", "1.0.0"));
+    // pnpm parity: fetch-failed optional deps leave no trace in the
+    // lockfile — no skippedOptionalDependencies entry.
+    assert!(
+        graph
+            .skipped_optional_dependencies
+            .get(".")
+            .map_or(true, |skipped| !skipped.contains_key("missing-optional"))
+    );
 
     server.abort();
 }

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -3654,3 +3654,91 @@ fn direct_dep_info_empty_when_no_packument_cached() {
     let info = resolver.direct_dep_info(&graph);
     assert!(info.is_empty(), "no packument cached → empty map");
 }
+
+#[tokio::test]
+async fn optional_dep_is_skipped_while_required_dep_resolves() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 2048];
+                let _ = socket.read(&mut buf).await;
+                let response =
+                    "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+                socket.write_all(response.as_bytes()).await.unwrap();
+            });
+        }
+    });
+
+    // Pre-seed cache for the required dep so it never hits the network.
+    let pmap = make_packument("p-map", &["7.0.4"], "7.0.4");
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let mut resolver = Resolver::new(client);
+    resolver.cache.insert("p-map".to_string(), pmap);
+
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("p-map".to_string(), "7.0.4".to_string());
+    manifest
+        .optional_dependencies
+        .insert("missing-optional".to_string(), "1.0.0".to_string());
+
+    let graph = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect("optional dep 404 must not fail the resolve");
+    assert!(graph_has_package(&graph, "p-map", "7.0.4"));
+    assert!(!graph_has_package(&graph, "missing-optional", "1.0.0"));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn required_dep_propagates_registry_error() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 2048];
+                let _ = socket.read(&mut buf).await;
+                let response =
+                    "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+                socket.write_all(response.as_bytes()).await.unwrap();
+            });
+        }
+    });
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let mut resolver = Resolver::new(client);
+
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("missing-required".to_string(), "1.0.0".to_string());
+
+    let err = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect_err("required dep 404 must propagate");
+    match err {
+        Error::Registry(name, _) => {
+            assert_eq!(name, "missing-required");
+        }
+        other => panic!("expected Error::Registry, got {other:?}"),
+    }
+
+    server.abort();
+}

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -3742,3 +3742,62 @@ async fn required_dep_propagates_registry_error() {
 
     server.abort();
 }
+
+#[tokio::test]
+async fn optional_dep_with_both_fetches_in_flight() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // Server returns 200 for p-map and 404 for missing-optional,
+    // so BOTH deps trigger real concurrent fetches.
+    let pkg_body = serde_json::to_vec(&make_packument("p-map", &["7.0.4"], "7.0.4")).unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            let body = pkg_body.clone();
+            tokio::spawn(async move {
+                let mut buf = [0_u8; 2048];
+                let _ = socket.read(&mut buf).await;
+                let path = std::str::from_utf8(&buf)
+                    .ok()
+                    .and_then(|s| s.split_whitespace().nth(1))
+                    .unwrap_or("/");
+                if path.contains("missing-optional") {
+                    let response =
+                        "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+                    socket.write_all(response.as_bytes()).await.unwrap();
+                } else {
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    socket.write_all(response.as_bytes()).await.unwrap();
+                    socket.write_all(&body).await.unwrap();
+                }
+            });
+        }
+    });
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let mut resolver = Resolver::new(client);
+
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("p-map".to_string(), "7.0.4".to_string());
+    manifest
+        .optional_dependencies
+        .insert("missing-optional".to_string(), "1.0.0".to_string());
+
+    let graph = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect("optional dep 404 must not fail even with concurrent fetches");
+    assert!(graph_has_package(&graph, "p-map", "7.0.4"));
+    assert!(!graph_has_package(&graph, "missing-optional", "1.0.0"));
+
+    server.abort();
+}


### PR DESCRIPTION
Hello! I really like aube and have been trying to migrate all my open source projects to aube. I encountered some issues during use, so I submitted this PR to try to fix them.

## Problem

In the current logic, we always check all optional dependencies. However, in some packages based on native builds, certain packages may not be published for various reasons — some due to publishing issues, others intentionally — but they are unlikely to affect our tasks. For example, it could be a publishing issue for a native package on another platform. As a result, when users run commands like `aube update` in a clean workspace for the first time, an `ERR_AUBE_REGISTRY_ERROR` error occurs and the command terminates. In fact, pnpm also chooses to silently skip such issues in similar situations.

## Changes

On fetch failure, check whether the current task is of `DepType::Optional` and the error package name matches the task. If so, silently skip it and record it in `skipped_optional_dependencies`, consistent with the existing platform mismatch skip behavior. The `name == &fetch_name` guard ensures that error propagation for other concurrent fetches is not affected.

