### PR TITLE
docs: clarify prune commands

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1330,7 +1330,9 @@ cmd pkg hide=#true help="Manage package.json entries (not implemented — use `n
     }
     arg "[ARGS]…" help="Unused; captured so `aube <cmd> foo bar` parses instead of erroring on unexpected args before the fallback message prints" required=#false double_dash=automatic var=#true hide=#true
 }
-cmd prune help="Remove extraneous packages from node_modules" {
+cmd prune help="Remove extraneous packages from project `node_modules`" {
+    long_help "Remove extraneous packages from project `node_modules`.\n\nReads the lockfile, computes the packages still reachable from each importer, and removes stale top-level links, stale virtual-store entries, and dangling .bin links. Does not modify package.json or the lockfile."
+    after_long_help "Global store cleanup: use `aube store prune` to clean unreferenced files from the global\ncontent-addressable store."
     flag "-P --prod --production" help="Remove devDependencies from node_modules"
     flag --no-optional help="Also remove optionalDependencies"
 }
@@ -1726,7 +1728,9 @@ cmd store subcommand_required=#true help="Manage the global store" {
         arg <PACKAGES>… help="Package specs to fetch into the store" var=#true
     }
     cmd path help="Show the store path"
-    cmd prune help="Remove unreferenced packages from the global store"
+    cmd prune help="Remove unreferenced packages from the global store" {
+        long_help "Remove unreferenced packages from the global store.\n\nOperates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.\n\nIt keeps files referenced by cached package indexes and, on hardlink filesystems, files that still have project hardlink references.\n\nOn reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so pruning relies on cached package indexes."
+    }
     cmd status help="Verify the store against cached package indexes" {
         long_help "Verify the store against cached package indexes.\n\nConfirms every file referenced by a cached package index is still present in the store and that its BLAKE3 hash matches. Exits non-zero when any corruption is detected."
     }

--- a/crates/aube/src/commands/prune.rs
+++ b/crates/aube/src/commands/prune.rs
@@ -22,6 +22,10 @@ use miette::{Context, IntoDiagnostic};
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
+pub const AFTER_LONG_HELP: &str = "\
+Global store cleanup: use `aube store prune` to clean unreferenced files from the global
+content-addressable store.";
+
 #[derive(Debug, Args)]
 pub struct PruneArgs {
     /// Remove devDependencies from node_modules

--- a/crates/aube/src/commands/store.rs
+++ b/crates/aube/src/commands/store.rs
@@ -53,6 +53,15 @@ pub enum StoreCommand {
     /// Show the store path.
     Path,
     /// Remove unreferenced packages from the global store.
+    ///
+    /// Operates on the store printed by `aube store path`; it does not touch
+    /// project node_modules directories, manifests, or lockfiles.
+    ///
+    /// It keeps files referenced by cached package indexes and, on hardlink
+    /// filesystems, files that still have project hardlink references.
+    ///
+    /// On reflink filesystems such as APFS or btrfs, link counts cannot prove
+    /// project reachability, so pruning relies on cached package indexes.
     Prune,
     /// Verify the store against cached package indexes.
     ///

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -421,7 +421,12 @@ enum Commands {
     /// Manage package.json entries (not implemented — use `npm pkg`)
     #[command(hide = true)]
     Pkg(commands::npm_fallback::FallbackArgs),
-    /// Remove extraneous packages from node_modules
+    /// Remove extraneous packages from project `node_modules`.
+    ///
+    /// Reads the lockfile, computes the packages still reachable from each
+    /// importer, and removes stale top-level links, stale virtual-store entries,
+    /// and dangling .bin links. Does not modify package.json or the lockfile.
+    #[command(after_long_help = commands::prune::AFTER_LONG_HELP)]
     Prune(commands::prune::PruneArgs),
     /// Publish the current package to the registry
     Publish(commands::publish::PublishArgs),

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -7559,10 +7559,12 @@
         ],
         "mounts": [],
         "hide": false,
-        "help": "Remove extraneous packages from node_modules",
+        "help": "Remove extraneous packages from project `node_modules`",
+        "help_long": "Remove extraneous packages from project `node_modules`.\n\nReads the lockfile, computes the packages still reachable from each importer, and removes stale top-level links, stale virtual-store entries, and dangling .bin links. Does not modify package.json or the lockfile.",
         "name": "prune",
         "aliases": [],
         "hidden_aliases": [],
+        "after_help_long": "Global store cleanup: use `aube store prune` to clean unreferenced files from the global\ncontent-addressable store.",
         "examples": []
       },
       "publish": {
@@ -9931,6 +9933,7 @@
             "mounts": [],
             "hide": false,
             "help": "Remove unreferenced packages from the global store",
+            "help_long": "Remove unreferenced packages from the global store.\n\nOperates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.\n\nIt keeps files referenced by cached package indexes and, on hardlink filesystems, files that still have project hardlink references.\n\nOn reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so pruning relies on cached package indexes.",
             "name": "prune",
             "aliases": [],
             "hidden_aliases": [],

--- a/docs/cli/prune.md
+++ b/docs/cli/prune.md
@@ -3,7 +3,9 @@
 
 - **Usage**: `aube prune [-P --prod] [--no-optional]`
 
-Remove extraneous packages from node_modules
+Remove extraneous packages from project `node_modules`.
+
+Reads the lockfile, computes the packages still reachable from each importer, and removes stale top-level links, stale virtual-store entries, and dangling .bin links. Does not modify package.json or the lockfile.
 
 ## Flags
 
@@ -14,3 +16,6 @@ Remove devDependencies from node_modules
 ### `--no-optional`
 
 Also remove optionalDependencies
+
+Global store cleanup: use `aube store prune` to clean unreferenced files from the global
+content-addressable store.

--- a/docs/cli/store/prune.md
+++ b/docs/cli/store/prune.md
@@ -3,4 +3,10 @@
 
 - **Usage**: `aube store prune`
 
-Remove unreferenced packages from the global store
+Remove unreferenced packages from the global store.
+
+Operates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.
+
+It keeps files referenced by cached package indexes and, on hardlink filesystems, files that still have project hardlink references.
+
+On reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so pruning relies on cached package indexes.

--- a/docs/package-manager/dependencies.md
+++ b/docs/package-manager/dependencies.md
@@ -78,3 +78,7 @@ aube prune --no-optional
 `prune` removes extraneous packages from `node_modules`, including stale
 virtual-store entries and dangling `.bin` links.
 
+It reads the lockfile to decide what should remain installed, but it does not
+modify `package.json` or the lockfile. Use `aube store prune` instead when you
+want to clean unreferenced files from the global store printed by
+`aube store path`.


### PR DESCRIPTION
## Summary
- expand `aube prune` help and docs with lockfile/node_modules behavior
- point project prune users to `aube store prune` for global store cleanup
- document `aube store prune` scope, cached-index reachability, and hardlink/reflink behavior

## Validation
- `cargo build`
- `cargo fmt --check`
- `./target/debug/aube prune --help`
- `./target/debug/aube store prune --help`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI help/long-help text and generated docs, with no changes to pruning behavior or data handling.
> 
> **Overview**
> Clarifies the CLI/documentation for pruning by expanding `aube prune` help text to explicitly describe its lockfile-driven cleanup of *project* `node_modules` (including virtual-store entries and `.bin` links) without modifying manifests/lockfiles, and adds an `after_long_help` hint pointing users to `aube store prune` for global store cleanup.
> 
> Adds detailed long help for `aube store prune` documenting that it only operates on the global store returned by `aube store path`, and explains how cached indexes and hardlink vs reflink filesystems affect reachability. Regenerates the CLI docs/JSON to reflect these help updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05ab94a90afce66d0c3064a9a8894815f3faa438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->