### PR TITLE
docs: explain symlink-loaded package configs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,6 +37,44 @@ In the isolated linker, only direct dependencies are symlinked at the top level.
 Transitive dependencies live under the packages that declared them. If your app
 imports a package directly, add it to your own `package.json`.
 
+## A package config file cannot resolve its own dependency
+
+Some tools discover dependency-owned config files by walking
+`node_modules/<pkg>/...` and then evaluating the config file at that symlink
+path. In an isolated linker, the package's own dependencies are linked next to
+the package's real virtual-store path under `node_modules/.aube/`, not next to
+the top-level symlink.
+
+That means a package config file can fail to `require()` a dependency that the
+same package declares, even though the package was installed correctly. Some
+native or framework toolchains swallow the config-load error and fail later
+with generated code or build output that looks unrelated.
+
+This usually means the loader is not symlink-aware; it does not mean aube
+linked the package incorrectly.
+
+If you maintain the loader, resolve the config file's real path before
+evaluating it:
+
+```js
+const configPath = fs.realpathSync(discoveredConfigPath);
+```
+
+When reporting this upstream, ask the tool maintainer to load
+dependency-owned config files from their real path, or to create the `require`
+function from the real config path, before evaluating the file. Include a small
+repro that shows the config succeeds after `fs.realpathSync(...)`.
+
+If the toolchain cannot be changed, use hoisted mode for that project:
+
+```sh
+aube install --node-linker=hoisted
+```
+
+Hoisted mode gives legacy tooling an npm-style tree where more packages are
+visible from top-level `node_modules` paths. Treat it as a compatibility
+workaround for loaders that are not symlink-aware.
+
 ## A dependency build script did not run
 
 Dependency lifecycle scripts follow the pnpm v11 build approval model. Inspect the


### PR DESCRIPTION
## Summary
- document why dependency-owned config files loaded through top-level node_modules symlinks may fail to resolve their own deps
- recommend realpathing config files in loaders and using hoisted linker mode as a compatibility workaround

## Testing
- cargo fmt --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime or security-sensitive code paths are modified.
> 
> **Overview**
> Adds a new troubleshooting section explaining why dependency-owned config files discovered via `node_modules/<pkg>/...` symlinks can fail to `require()` their own dependencies under the isolated linker.
> 
> Recommends loader-side fixes (realpath the discovered config via `fs.realpathSync(...)` / create `require` from the real path) and suggests `aube install --node-linker=hoisted` as a compatibility workaround for tooling that isn’t symlink-aware.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95aef44e897c5a06962a4c30a4a6652683f2104c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->