### PR TITLE
fix(publish): support npm trusted publishing auth

### DIFF
--- a/crates/aube-registry/src/client/request.rs
+++ b/crates/aube-registry/src/client/request.rs
@@ -60,6 +60,19 @@ impl RegistryClient {
         )
     }
 
+    /// Build an HTTP request using the TLS/proxy client selected for this
+    /// registry, but leave authentication to the caller. Publish uses this
+    /// for npm Trusted Publishing exchange tokens so an old `.npmrc` token
+    /// cannot be sent alongside the short-lived OIDC-derived bearer token.
+    pub fn request(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        registry_url: &str,
+    ) -> reqwest::RequestBuilder {
+        self.http_for(registry_url).request(method, url)
+    }
+
     pub fn has_resolved_auth_for(&self, registry_url: &str) -> bool {
         self.registry_auth_token_for(registry_url).is_some()
             || self.config.basic_auth_for(registry_url).is_some()

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -474,11 +474,6 @@ async fn publish_one(
         ));
     }
 
-    let trusted_publish_token = trusted_publish_token(client, &registry_url, &name).await?;
-    if trusted_publish_token.is_none() {
-        ensure_registry_auth(client, &registry_url)?;
-    }
-
     // Lifecycle hooks + tarball build only happen now that we know
     // we're actually going to PUT. For a re-run of `-r publish` where
     // every package is already on the registry, the loop never reaches
@@ -541,6 +536,10 @@ async fn publish_one(
     )?;
 
     let url = put_url(&registry_url, &archive.name);
+    let trusted_publish_token = trusted_publish_token(client, &registry_url, &archive.name).await?;
+    if trusted_publish_token.is_none() {
+        ensure_registry_auth(client, &registry_url)?;
+    }
     let mut req = if let Some(token) = trusted_publish_token.as_deref() {
         client
             .request(reqwest::Method::PUT, &url, &registry_url)
@@ -637,27 +636,38 @@ async fn npm_oidc_id_token(
         .wrap_err("invalid ACTIONS_ID_TOKEN_REQUEST_URL")?;
     url.query_pairs_mut().append_pair("audience", &audience);
 
-    let resp = client
+    let resp = match client
         .request(reqwest::Method::GET, url.as_str(), registry_url)
         .header(reqwest::header::ACCEPT, "application/json")
         .bearer_auth(request_token)
         .send()
         .await
-        .into_diagnostic()
-        .wrap_err("failed to request GitHub Actions OIDC token for npm")?;
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "GitHub Actions OIDC token request failed; falling back to configured registry auth"
+            );
+            return Ok(None);
+        }
+    };
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(miette!(
-            "failed to request GitHub Actions OIDC token for npm: {status}: {}",
-            body.trim()
-        ));
+        tracing::debug!(
+            %status,
+            body = body.trim(),
+            "GitHub Actions OIDC token request failed; falling back to configured registry auth"
+        );
+        return Ok(None);
     }
-    let body = resp
-        .json::<GitHubOidcResponse>()
-        .await
-        .into_diagnostic()
-        .wrap_err("failed to parse GitHub Actions OIDC token response")?;
+    let Ok(body) = resp.json::<GitHubOidcResponse>().await else {
+        tracing::debug!(
+            "failed to parse GitHub Actions OIDC token response; falling back to configured registry auth"
+        );
+        return Ok(None);
+    };
     Ok(body.value.filter(|token| !token.trim().is_empty()))
 }
 

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -36,6 +36,8 @@ use aube_registry::config::{NpmConfig, normalize_registry_url_pub};
 use base64::Engine;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
+use reqwest::Url;
+use serde::Deserialize;
 use sha1::Digest as _;
 use sha2::Sha512;
 use std::path::{Path, PathBuf};
@@ -449,7 +451,10 @@ async fn publish_one(
         });
     }
 
-    ensure_registry_auth(client, &registry_url)?;
+    let trusted_publish_token = trusted_publish_token(client, &registry_url, &name).await?;
+    if trusted_publish_token.is_none() {
+        ensure_registry_auth(client, &registry_url)?;
+    }
 
     // Pre-flight: ask the registry whether `name@version` is already
     // there. In fanout mode a hit is a silent skip (so `-r publish` is
@@ -536,10 +541,15 @@ async fn publish_one(
     )?;
 
     let url = put_url(&registry_url, &archive.name);
-    let mut req = client
-        .authed_request(reqwest::Method::PUT, &url, &registry_url)
-        .header("content-type", "application/json")
-        .body(serde_json::to_vec(&body).into_diagnostic()?);
+    let mut req = if let Some(token) = trusted_publish_token.as_deref() {
+        client
+            .request(reqwest::Method::PUT, &url, &registry_url)
+            .bearer_auth(token)
+    } else {
+        client.authed_request(reqwest::Method::PUT, &url, &registry_url)
+    }
+    .header("content-type", "application/json")
+    .body(serde_json::to_vec(&body).into_diagnostic()?);
     if let Some(otp) = &args.otp {
         req = req.header("npm-otp", otp);
     }
@@ -564,6 +574,121 @@ async fn publish_one(
         archive: Some(archive),
         status: PublishStatus::Published,
     })
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubOidcResponse {
+    value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NpmOidcExchangeResponse {
+    token: Option<String>,
+}
+
+/// Try npm Trusted Publishing before falling back to traditional `.npmrc`
+/// auth. npm's OIDC exchange is publish-specific: the CI-issued ID token must
+/// have audience `npm:<registry-host>`, then the registry returns a short-lived
+/// package-scoped token used as the PUT bearer token.
+async fn trusted_publish_token(
+    client: &RegistryClient,
+    registry_url: &str,
+    package_name: &str,
+) -> miette::Result<Option<String>> {
+    let Some(id_token) = npm_oidc_id_token(registry_url).await? else {
+        return Ok(None);
+    };
+    exchange_npm_oidc_token(client, registry_url, package_name, &id_token).await
+}
+
+async fn npm_oidc_id_token(registry_url: &str) -> miette::Result<Option<String>> {
+    if let Ok(token) = std::env::var("NPM_ID_TOKEN")
+        && !token.trim().is_empty()
+    {
+        return Ok(Some(token));
+    }
+
+    if std::env::var("GITHUB_ACTIONS").is_err() {
+        return Ok(None);
+    }
+    let Ok(request_url) = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL") else {
+        return Ok(None);
+    };
+    let Ok(request_token) = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN") else {
+        return Ok(None);
+    };
+    if request_url.trim().is_empty() || request_token.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let registry = Url::parse(registry_url)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("invalid registry URL for npm OIDC: {registry_url}"))?;
+    let host = registry
+        .host_str()
+        .ok_or_else(|| miette!("invalid registry URL for npm OIDC: missing host"))?;
+    let audience = format!("npm:{host}");
+
+    let mut url = Url::parse(&request_url)
+        .into_diagnostic()
+        .wrap_err("invalid ACTIONS_ID_TOKEN_REQUEST_URL")?;
+    url.query_pairs_mut().append_pair("audience", &audience);
+
+    let resp = reqwest::Client::new()
+        .get(url)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .bearer_auth(request_token)
+        .send()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to request GitHub Actions OIDC token for npm")?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(miette!(
+            "failed to request GitHub Actions OIDC token for npm: {status}: {}",
+            body.trim()
+        ));
+    }
+    let body = resp
+        .json::<GitHubOidcResponse>()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to parse GitHub Actions OIDC token response")?;
+    Ok(body.value.filter(|token| !token.trim().is_empty()))
+}
+
+async fn exchange_npm_oidc_token(
+    client: &RegistryClient,
+    registry_url: &str,
+    package_name: &str,
+    id_token: &str,
+) -> miette::Result<Option<String>> {
+    let endpoint = format!(
+        "{}/-/npm/v1/oidc/token/exchange/package/{}",
+        registry_url.trim_end_matches('/'),
+        encode_package_name(package_name)
+    );
+    let resp = client
+        .request(reqwest::Method::POST, &endpoint, registry_url)
+        .bearer_auth(id_token)
+        .send()
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to exchange npm OIDC token at {endpoint}"))?;
+    if !resp.status().is_success() {
+        tracing::debug!(
+            status = %resp.status(),
+            "npm OIDC token exchange failed; falling back to configured registry auth"
+        );
+        return Ok(None);
+    }
+    let body = resp
+        .json::<NpmOidcExchangeResponse>()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to parse npm OIDC token exchange response")?;
+    Ok(body.token.filter(|token| !token.trim().is_empty()))
 }
 
 /// Pre-pack chain for publish: `prepublishOnly` → `prepublish` →

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -451,11 +451,6 @@ async fn publish_one(
         });
     }
 
-    let trusted_publish_token = trusted_publish_token(client, &registry_url, &name).await?;
-    if trusted_publish_token.is_none() {
-        ensure_registry_auth(client, &registry_url)?;
-    }
-
     // Pre-flight: ask the registry whether `name@version` is already
     // there. In fanout mode a hit is a silent skip (so `-r publish` is
     // idempotent on partial success) and in single-package mode it is
@@ -477,6 +472,11 @@ async fn publish_one(
             "aube publish: {name}@{version} is already on {registry_url}\n\
              help: pass --force to republish (the registry must allow it; npm's public registry does not)"
         ));
+    }
+
+    let trusted_publish_token = trusted_publish_token(client, &registry_url, &name).await?;
+    if trusted_publish_token.is_none() {
+        ensure_registry_auth(client, &registry_url)?;
     }
 
     // Lifecycle hooks + tarball build only happen now that we know
@@ -595,13 +595,16 @@ async fn trusted_publish_token(
     registry_url: &str,
     package_name: &str,
 ) -> miette::Result<Option<String>> {
-    let Some(id_token) = npm_oidc_id_token(registry_url).await? else {
+    let Some(id_token) = npm_oidc_id_token(client, registry_url).await? else {
         return Ok(None);
     };
     exchange_npm_oidc_token(client, registry_url, package_name, &id_token).await
 }
 
-async fn npm_oidc_id_token(registry_url: &str) -> miette::Result<Option<String>> {
+async fn npm_oidc_id_token(
+    client: &RegistryClient,
+    registry_url: &str,
+) -> miette::Result<Option<String>> {
     if let Ok(token) = std::env::var("NPM_ID_TOKEN")
         && !token.trim().is_empty()
     {
@@ -634,8 +637,8 @@ async fn npm_oidc_id_token(registry_url: &str) -> miette::Result<Option<String>>
         .wrap_err("invalid ACTIONS_ID_TOKEN_REQUEST_URL")?;
     url.query_pairs_mut().append_pair("audience", &audience);
 
-    let resp = reqwest::Client::new()
-        .get(url)
+    let resp = client
+        .request(reqwest::Method::GET, url.as_str(), registry_url)
         .header(reqwest::header::ACCEPT, "application/json")
         .bearer_auth(request_token)
         .send()

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -68,6 +68,85 @@ EOF
 	assert_output --partial "no auth token"
 }
 
+@test "aube publish uses npm trusted publishing OIDC when no auth token is configured" {
+	_write_publishable_pkg
+
+	cat >trusted-publish-server.mjs <<'NODE'
+import http from 'node:http';
+import fs from 'node:fs';
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url.startsWith('/gha-oidc')) {
+    const url = new URL(req.url, 'http://127.0.0.1');
+    fs.writeFileSync('oidc-audience', url.searchParams.get('audience') || '');
+    if (req.headers.authorization !== 'Bearer gha-request-token') {
+      res.statusCode = 401;
+      res.end('{}');
+      return;
+    }
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ value: 'gha-id-token' }));
+    return;
+  }
+  if (req.method === 'GET' && req.url === '/publish-smoke') {
+    res.statusCode = 404;
+    res.end('{}');
+    return;
+  }
+  if (req.method === 'POST' && req.url === '/-/npm/v1/oidc/token/exchange/package/publish-smoke') {
+    fs.writeFileSync('exchange-auth', req.headers.authorization || '');
+    res.statusCode = 201;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ token_type: 'oidc', token: 'npm-exchange-token' }));
+    return;
+  }
+  if (req.method === 'PUT' && req.url === '/publish-smoke') {
+    fs.writeFileSync('put-auth', req.headers.authorization || '');
+    req.resume();
+    req.on('end', () => {
+      res.statusCode = req.headers.authorization === 'Bearer npm-exchange-token' ? 201 : 401;
+      res.end('{"ok":true}');
+    });
+    return;
+  }
+  res.statusCode = 404;
+  res.end('{}');
+});
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync('trusted-publish-server-port', String(server.address().port));
+});
+NODE
+	node trusted-publish-server.mjs &
+	PUBLISH_SERVER_PID=$!
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		[ -f trusted-publish-server-port ] && break
+		sleep 0.1
+	done
+	port="$(cat trusted-publish-server-port)"
+
+	run env \
+		GITHUB_ACTIONS=true \
+		ACTIONS_ID_TOKEN_REQUEST_URL="http://127.0.0.1:${port}/gha-oidc" \
+		ACTIONS_ID_TOKEN_REQUEST_TOKEN=gha-request-token \
+		aube publish --no-git-checks --registry "http://127.0.0.1:${port}/"
+	rc=$status
+	_stop_publish_server
+	[ "$rc" -eq 0 ]
+	assert_output --partial "+ publish-smoke@0.1.0"
+
+	run cat oidc-audience
+	assert_success
+	assert_output "npm:127.0.0.1"
+
+	run cat exchange-auth
+	assert_success
+	assert_output "Bearer gha-id-token"
+
+	run cat put-auth
+	assert_success
+	assert_output "Bearer npm-exchange-token"
+}
+
 @test "aube publish --provenance errors outside an OIDC-capable CI" {
 	_write_publishable_pkg
 

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -147,6 +147,132 @@ NODE
 	assert_output "Bearer npm-exchange-token"
 }
 
+@test "aube publish falls back to npmrc auth when GitHub OIDC request fails" {
+	_write_publishable_pkg
+	echo "//127.0.0.1/:_authToken=fallback-token" >.npmrc
+
+	cat >trusted-publish-server.mjs <<'NODE'
+import http from 'node:http';
+import fs from 'node:fs';
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url.startsWith('/gha-oidc')) {
+    res.statusCode = 500;
+    res.end('oidc unavailable');
+    return;
+  }
+  if (req.method === 'GET' && req.url === '/publish-smoke') {
+    res.statusCode = 404;
+    res.end('{}');
+    return;
+  }
+  if (req.method === 'PUT' && req.url === '/publish-smoke') {
+    fs.writeFileSync('put-auth', req.headers.authorization || '');
+    req.resume();
+    req.on('end', () => {
+      res.statusCode = req.headers.authorization === 'Bearer fallback-token' ? 201 : 401;
+      res.end('{"ok":true}');
+    });
+    return;
+  }
+  res.statusCode = 404;
+  res.end('{}');
+});
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync('trusted-publish-server-port', String(server.address().port));
+});
+NODE
+	node trusted-publish-server.mjs &
+	PUBLISH_SERVER_PID=$!
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		[ -f trusted-publish-server-port ] && break
+		sleep 0.1
+	done
+	port="$(cat trusted-publish-server-port)"
+	echo "//127.0.0.1:${port}/:_authToken=fallback-token" >.npmrc
+
+	run env \
+		GITHUB_ACTIONS=true \
+		ACTIONS_ID_TOKEN_REQUEST_URL="http://127.0.0.1:${port}/gha-oidc" \
+		ACTIONS_ID_TOKEN_REQUEST_TOKEN=gha-request-token \
+		aube publish --no-git-checks --registry "http://127.0.0.1:${port}/"
+	rc=$status
+	_stop_publish_server
+	[ "$rc" -eq 0 ]
+
+	run cat put-auth
+	assert_success
+	assert_output "Bearer fallback-token"
+}
+
+@test "aube publish exchanges OIDC token for post-hook package name" {
+	_write_publishable_pkg
+	cat >rewrite-name.mjs <<'NODE'
+import fs from 'node:fs';
+const m = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+m.name = 'publish-renamed';
+fs.writeFileSync('package.json', JSON.stringify(m, null, 2));
+NODE
+	node -e "const fs=require('fs'); const m=JSON.parse(fs.readFileSync('package.json','utf8')); m.scripts={prepublishOnly:'node ./rewrite-name.mjs'}; fs.writeFileSync('package.json', JSON.stringify(m, null, 2))"
+
+	cat >trusted-publish-server.mjs <<'NODE'
+import http from 'node:http';
+import fs from 'node:fs';
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/publish-smoke') {
+    res.statusCode = 404;
+    res.end('{}');
+    return;
+  }
+  if (req.method === 'POST' && req.url === '/-/npm/v1/oidc/token/exchange/package/publish-renamed') {
+    fs.writeFileSync('exchange-auth', req.headers.authorization || '');
+    res.statusCode = 201;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ token: 'renamed-exchange-token' }));
+    return;
+  }
+  if (req.method === 'PUT' && req.url === '/publish-renamed') {
+    fs.writeFileSync('put-auth', req.headers.authorization || '');
+    req.resume();
+    req.on('end', () => {
+      res.statusCode = req.headers.authorization === 'Bearer renamed-exchange-token' ? 201 : 401;
+      res.end('{"ok":true}');
+    });
+    return;
+  }
+  res.statusCode = 404;
+  res.end('{}');
+});
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync('trusted-publish-server-port', String(server.address().port));
+});
+NODE
+	node trusted-publish-server.mjs &
+	PUBLISH_SERVER_PID=$!
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		[ -f trusted-publish-server-port ] && break
+		sleep 0.1
+	done
+	port="$(cat trusted-publish-server-port)"
+
+	run env \
+		NPM_ID_TOKEN=gha-id-token \
+		aube publish --no-git-checks --registry "http://127.0.0.1:${port}/"
+	rc=$status
+	_stop_publish_server
+	[ "$rc" -eq 0 ]
+	assert_output --partial "+ publish-renamed@0.1.0"
+
+	run cat exchange-auth
+	assert_success
+	assert_output "Bearer gha-id-token"
+
+	run cat put-auth
+	assert_success
+	assert_output "Bearer renamed-exchange-token"
+}
+
 @test "aube publish --provenance errors outside an OIDC-capable CI" {
 	_write_publishable_pkg
 


### PR DESCRIPTION
## Summary
- add npm Trusted Publishing OIDC token exchange before publish
- use exchanged package-scoped token for the publish PUT
- keep existing .npmrc auth fallback and add a mock-registry regression test

## Root Cause
`aube publish --provenance` generated Sigstore provenance, but publish auth still required an .npmrc token. Tokenless npm Trusted Publishing workflows therefore failed before upload.

## Validation
- `cargo check -p aube -p aube-registry`
- `cargo build -p aube`
- `./test/bats/bin/bats test/publish.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI publish authentication timing and failure modes; behavior is more resilient but alters when .npmrc vs OIDC is used.
> 
> **Overview**
> **Publish** now resolves npm Trusted Publishing (OIDC exchange + bearer token) **after** the pre-pack lifecycle and tarball build, using the **final** `archive.name` from the packed artifact—not the pre-hook manifest name. That fixes trusted publishing when `prepublishOnly` (or similar) renames the package before upload.
> 
> GitHub Actions OIDC token fetch failures (network errors, non-2xx responses, or bad JSON) no longer fail the command; they **debug-log** and return no OIDC token so publish **falls back** to configured `.npmrc` auth, matching the existing exchange-failure behavior.
> 
> New **BATS** coverage: OIDC unavailable → PUT uses `.npmrc` token; `NPM_ID_TOKEN` exchange and PUT target the **post-hook** package name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5126ef2c0c4754be672fad2ab283eb2064f9ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->