### PR TITLE
chore(deps): exclude fixtures from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>jdx/renovate-config"]
+  "extends": ["local>jdx/renovate-config"],
+  "ignorePaths": ["fixtures/**"]
 }


### PR DESCRIPTION
## Summary

- exclude `fixtures/**` from Renovate dependency scanning
- keep the shared Renovate preset unchanged

## Test

- `jq empty .github/renovate.json`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Renovate config change with no runtime, auth, or application code impact.
> 
> **Overview**
> Renovate will **skip** dependency updates under `fixtures/**`, so pinned or vendored fixture trees no longer generate noisy or unwanted bump PRs. The shared preset `local>jdx/renovate-config` is unchanged; only `ignorePaths` is added in `.github/renovate.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a833710b2c766ebca77e0ae9bfe9c3b211f705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->