### PR TITLE
chore(deps): exclude fixtures from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "fixtures/**"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "fixtures/**"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- add Dependabot version update config for Cargo, npm, and GitHub Actions
- exclude `fixtures/**` from Cargo and npm Dependabot scans

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "ok"'`

Dependabot's `exclude-paths` option is documented in GitHub's configuration reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#exclude-paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds CI dependency-bot configuration; no runtime, auth, or application code changes.
> 
> **Overview**
> Introduces **Dependabot version updates** via a new `.github/dependabot.yml`, with **weekly** scans for **Cargo**, **npm**, and **GitHub Actions** at the repo root.
> 
> For **Cargo** and **npm**, **`fixtures/**`** is listed under **`exclude-paths`** so Dependabot does not propose bumps for fixture/test lockfiles—matching the existing Renovate **`ignorePaths`** for the same tree. **GitHub Actions** has no fixture exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496b1b91d55b20960224e7602f8a60b4986fb890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->