### PR TITLE
ci: harden dependency update workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     exclude-paths:
       - "fixtures/**"
 
@@ -11,6 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     exclude-paths:
       - "fixtures/**"
 
@@ -18,3 +22,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
       # Trusted Publishing requires npm >= 11.5.1. Node 24 ships npm
       # 11, but the exact minor varies — upgrade explicitly so the
       # workflow doesn't break if Node's bundled npm drifts behind.


### PR DESCRIPTION
## Summary
- disable setup-node package-manager auto-cache in the npm publish workflow to satisfy zizmor
- add a 7-day Dependabot cooldown to Cargo, npm, and GitHub Actions updates

## Verification
- `zizmor --no-progress .github/workflows`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Dependabot configuration only; no runtime, auth, or publish script behavior changes beyond satisfying static workflow analysis.
> 
> **Overview**
> Tightens **dependency and publish CI** in two ways: **Dependabot** now waits **7 days** (`cooldown.default-days`) before opening Cargo, npm, and GitHub Actions update PRs, and **`publish-npm`** turns off **`setup-node`**’s automatic package-manager cache (`package-manager-cache: false`) so **zizmor** workflow checks pass.
> 
> No application code or publish logic changes—only when bot PRs appear and how Node is set up in that workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03883a1a5fcbc31f13777bc8e52bc88980387ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->