### PR TITLE
build(deps): bump hickory dns stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1daa54020e05aa0b163ee10434fff35a0f18d28a1cafa142bd1290e1abe630e"
 dependencies = [
  "astral-reqwest-middleware",
- "reqwest 0.13.3",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -194,7 +194,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "thiserror 2.0.18",
  "tower-service",
@@ -272,7 +272,7 @@ dependencies = [
  "predicates",
  "ratatui",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "sha1",
@@ -383,7 +383,7 @@ dependencies = [
  "miette",
  "node-semver",
  "proptest",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -488,7 +488,7 @@ dependencies = [
  "foldhash 0.1.5",
  "libc",
  "reflink-copy",
- "reqwest 0.12.28",
+ "reqwest",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -496,6 +496,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "webpki-root-certs",
 ]
 
 [[package]]
@@ -1381,18 +1382,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,23 +1794,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1830,21 +1818,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1960,7 +1973,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2205,6 +2217,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is-docker"
@@ -2615,6 +2630,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -3076,6 +3097,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -3500,6 +3532,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3514,46 +3547,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -3655,7 +3648,6 @@ checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4081,7 +4073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c60b95ecc87b2e279705e4a617cfb2d668bb9dfb15b3a99322524b6f44a4201b"
 dependencies = [
  "base64",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -4114,7 +4106,7 @@ dependencies = [
  "base64",
  "open",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -4132,7 +4124,7 @@ checksum = "641fdaaa40d0cd6e249cf1671c2240beff1a3ece578062cf43e750779e8db2b3"
 dependencies = [
  "base64",
  "hex",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -4195,7 +4187,7 @@ dependencies = [
  "der",
  "hex",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest",
  "rustls-pki-types",
  "rustls-webpki",
  "sigstore-crypto",
@@ -5254,9 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -5302,15 +5294,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,8 @@ clap = { version = "4", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 
 # HTTP
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "http2", "charset", "system-proxy", "gzip", "brotli", "zstd", "hickory-dns"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls", "http2", "charset", "system-proxy", "gzip", "brotli", "zstd", "hickory-dns"] }
+webpki-root-certs = "1"
 
 # Hashing
 sha1 = "0.10"

--- a/crates/aube-registry/src/client/http.rs
+++ b/crates/aube-registry/src/client/http.rs
@@ -103,7 +103,7 @@ fn build_http_client_inner(
             std::env::consts::ARCH
         )
     });
-    let mut builder = reqwest::Client::builder()
+    let mut builder = aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
         .user_agent(user_agent)
         // Wire-level decompression for packument JSON. Tarball
         // requests explicitly send `Accept-Encoding: identity`

--- a/crates/aube-registry/src/osv_bloom_client.rs
+++ b/crates/aube-registry/src/osv_bloom_client.rs
@@ -422,7 +422,11 @@ impl OsvBloomClient {
     }
 
     pub fn build_client() -> Result<reqwest::Client, BloomError> {
-        Ok(reqwest::Client::builder().timeout(FETCH_TIMEOUT).build()?)
+        Ok(
+            aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
+                .timeout(FETCH_TIMEOUT)
+                .build()?,
+        )
     }
 
     fn load_state(&self) -> LocalState {

--- a/crates/aube-registry/src/osv_mirror.rs
+++ b/crates/aube-registry/src/osv_mirror.rs
@@ -330,7 +330,11 @@ impl OsvMirror {
     /// 60s budget the bulk dump needs — the live-OSV probe's 8s
     /// timeout would never let a fresh sync finish.
     pub fn build_client() -> Result<reqwest::Client, MirrorError> {
-        Ok(reqwest::Client::builder().timeout(FETCH_TIMEOUT).build()?)
+        Ok(
+            aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
+                .timeout(FETCH_TIMEOUT)
+                .build()?,
+        )
     }
 
     /// Load the on-disk index, falling back to an empty default

--- a/crates/aube-registry/src/supply_chain.rs
+++ b/crates/aube-registry/src/supply_chain.rs
@@ -164,7 +164,11 @@ struct NpmDownloadsResponse {
 /// `aube add a b c` can reuse a single client + connection pool
 /// across all per-package downloads requests.
 pub fn build_probe_client() -> Result<reqwest::Client, SupplyChainError> {
-    Ok(reqwest::Client::builder().timeout(PROBE_TIMEOUT).build()?)
+    Ok(
+        aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
+            .timeout(PROBE_TIMEOUT)
+            .build()?,
+    )
 }
 
 /// Probe OSV for `MAL-*` advisories on every candidate against a

--- a/crates/aube-util/Cargo.toml
+++ b/crates/aube-util/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 bytes = "1"
 tokio = { workspace = true }
 reqwest = { workspace = true }
+webpki-root-certs = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/aube-util/src/http/mod.rs
+++ b/crates/aube-util/src/http/mod.rs
@@ -15,3 +15,29 @@ pub mod priority;
 pub mod race;
 pub mod resolve;
 pub mod ticket_cache;
+
+/// Add Mozilla's baked-in root bundle as extra trust roots while keeping
+/// reqwest's rustls-platform-verifier OS trust store active.
+///
+/// reqwest 0.13 can merge extra roots with the platform verifier on Unix
+/// (except Android) and Windows. On other targets, leave the builder alone
+/// so client construction does not fail at runtime.
+pub fn with_webpki_root_fallback(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+    #[cfg(any(all(unix, not(target_os = "android")), target_os = "windows"))]
+    {
+        let certs = webpki_root_certs::TLS_SERVER_ROOT_CERTS
+            .iter()
+            .map(|cert| {
+                reqwest::Certificate::from_der(cert.as_ref())
+                    // webpki-root-certs is generated as valid DER; failure means the dependency is corrupt.
+                    .expect("webpki root certificate must be valid DER")
+            })
+            .collect::<Vec<_>>();
+        builder.tls_certs_merge(certs)
+    }
+
+    #[cfg(not(any(all(unix, not(target_os = "android")), target_os = "windows")))]
+    {
+        builder
+    }
+}

--- a/crates/aube/src/commands/login.rs
+++ b/crates/aube/src/commands/login.rs
@@ -136,7 +136,7 @@ async fn web_login(registry: &str) -> miette::Result<String> {
     };
     let login_endpoint = format!("{base}-/v1/login");
 
-    let client = reqwest::Client::builder()
+    let client = aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
         .user_agent(concat!("aube/", env!("CARGO_PKG_VERSION")))
         .build()
         .into_diagnostic()

--- a/crates/aube/src/update_check.rs
+++ b/crates/aube/src/update_check.rs
@@ -85,7 +85,7 @@ async fn latest_version(cwd: &Path) -> Option<String> {
 }
 
 async fn fetch_latest() -> Option<String> {
-    let client = reqwest::Client::builder()
+    let client = aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
         .timeout(FETCH_TIMEOUT)
         .build()
         .ok()?;


### PR DESCRIPTION
## Summary
- bump workspace `reqwest` to `0.13` and use the renamed `rustls` feature
- keep OS/platform certificate verification primary, and merge Mozilla baked-in roots as a fallback on supported platforms
- refresh `Cargo.lock`, moving `hickory-proto` and `hickory-resolver` to `0.26.1`
- collapse the duplicate `reqwest` entries to `reqwest 0.13.4`

## Verification
- `cargo check`
- `git diff --check`
- `cargo tree -i hickory-proto@0.26.1`
- `cargo tree -i webpki-root-certs`

Note: `cargo clippy --all-targets -- -D warnings` was attempted, but current `main` has unrelated clippy warnings in `crates/aube-resolver/src/tests.rs` and `crates/aube/src/commands/update.rs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes TLS trust configuration and the HTTP/DNS stack used for registry, OSV, login, and update checks—any mis-merge of roots or reqwest 0.13 behavior could break installs or auth in production.
> 
> **Overview**
> Bumps the workspace **`reqwest`** stack to **0.13** (feature rename **`rustls-tls` → `rustls`**) and refreshes **`Cargo.lock`**, including **`hickory-proto` / `hickory-resolver` 0.26.1** and a single **`reqwest` 0.13.4** entry instead of duplicate 0.12/0.13 pins.
> 
> Adds **`webpki-root-certs`** and **`aube_util::http::with_webpki_root_fallback`**, which merges Mozilla’s baked-in roots with **`rustls-platform-verifier`** on Unix (except Android) and Windows. Registry HTTP clients, OSV/supply-chain probes, OSV bloom/mirror builders, **`aube login`**, and the update notifier all build **`reqwest::Client`** through that helper so TLS behavior stays consistent after the upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2219951eb3931c88790d9e9793fba5e8d4258877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->