### PR TITLE
chore(release): stop release-plz dependency updates

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -16,7 +16,6 @@
 # ("aube") that owns the binary. Every other crate publishes to
 # crates.io but is otherwise silent (no per-crate tag, no per-crate
 # GitHub release).
-dependencies_update = true
 publish = true
 changelog_update = true
 git_tag_enable = false


### PR DESCRIPTION
## Summary
- remove release-plz workspace dependency updates so release PRs only carry intentional version/changelog changes

## Testing
- cargo fmt --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config flag removal with no runtime or security impact; only affects what release-plz puts in release PRs.
> 
> **Overview**
> Disables **release-plz** workspace **`dependencies_update`**, so automated “chore: release” PRs no longer bump transitive crate versions alongside the workspace version and changelog.
> 
> Release PRs are limited to intentional version and changelog edits; other **`release-plz.toml`** settings (publishing, changelog, tags/releases for **`aube`**) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 585b5e1ad2216a8df9279dea19e5a48a891bdff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->