### PR TITLE
fix(add): accept linkWorkspacePackages deep

### DIFF
--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -74,6 +74,23 @@ storeDir: /tmp/my-store
     }
 
     #[test]
+    fn test_link_workspace_packages_deep() {
+        let yaml = r#"
+packages:
+  - 'packages/*'
+linkWorkspacePackages: deep
+"#;
+        let config: WorkspaceConfig = yaml_serde::from_str(yaml).unwrap();
+        assert_eq!(
+            config
+                .link_workspace_packages
+                .as_ref()
+                .and_then(yaml_serde::Value::as_str),
+            Some("deep")
+        );
+    }
+
+    #[test]
     fn test_catalog() {
         let yaml = r#"
 catalog:

--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -379,12 +379,12 @@ pub struct WorkspaceConfig {
 
     // -- Workspace-protocol settings --
     /// Resolve `aube add <name>` against local workspace siblings
-    /// before falling back to the registry. Wired through
-    /// `aube_settings::resolved::link_workspace_packages`; the typed
-    /// field exists so `meta::workspace_yaml_keys_...` sees the key
-    /// as a real field and doesn't fall through to `extra`.
+    /// before falling back to the registry. The yaml value can be the
+    /// booleans `true` / `false` or the string `"deep"`, so the typed
+    /// field lands at `yaml_serde::Value` and the resolver normalizes
+    /// via `aube_settings::resolved::LinkWorkspacePackages`.
     #[serde(default)]
-    pub link_workspace_packages: Option<bool>,
+    pub link_workspace_packages: Option<yaml_serde::Value>,
 
     /// Spec form written to `package.json` when `aube add` matches a
     /// workspace sibling. The yaml value can be the booleans `true` /

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -2273,11 +2273,11 @@ examples = []
 
 [linkWorkspacePackages]
 description = "Resolve `aube add <name>` against local workspace siblings before falling back to the registry."
-type = "bool"
-default = "false"
+type = '"false" | "true" | "deep"'
+default = "\"false\""
 docs = """
-When `true`, `aube add <name>` checks the workspace for a package
-whose `name` matches the spec before falling back to the registry.
+When `true` or `"deep"`, `aube add <name>` checks the workspace for
+a package whose `name` matches the spec before falling back to the registry.
 A match wires the dep up as a workspace link; the manifest specifier
 written to `package.json` is controlled by `saveWorkspaceProtocol`.
 
@@ -2289,10 +2289,8 @@ linked.
 Off by default to match pnpm 8+ — opt in via `pnpm-workspace.yaml`
 when you want every `aube add` to prefer the local copy of a sibling.
 Aube's resolver already prefers workspace siblings on bare semver
-ranges at install time, so this setting only controls `aube add`'s
-manifest-write path; pnpm's `"deep"` value (which extends the
-preference to transitive deps) is therefore not implemented and
-treating the value as a plain bool is intentional.
+ranges at install time, including transitives, so pnpm's `"deep"`
+mode is accepted as an alias for the add-time manifest behavior.
 """
 sources.cli = []
 sources.env = [

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -1197,6 +1197,40 @@ mod tests {
     }
 
     #[test]
+    fn link_workspace_packages_accepts_deep_from_workspace_yaml() {
+        let npmrc: Vec<(String, String)> = Vec::new();
+        let ws = raw_yaml("linkWorkspacePackages: deep\n");
+        let ctx = ResolveCtx::files_only(&npmrc, &ws);
+        assert_eq!(
+            resolved::link_workspace_packages(&ctx),
+            resolved::LinkWorkspacePackages::Deep
+        );
+    }
+
+    #[test]
+    fn link_workspace_packages_accepts_yaml_bool_values() {
+        let npmrc: Vec<(String, String)> = Vec::new();
+        let ws = raw_yaml("linkWorkspacePackages: true\n");
+        let ctx = ResolveCtx::files_only(&npmrc, &ws);
+        assert_eq!(
+            resolved::link_workspace_packages(&ctx),
+            resolved::LinkWorkspacePackages::True
+        );
+    }
+
+    #[test]
+    fn link_workspace_packages_accepts_deep_from_npmrc() {
+        let npmrc = entries(&[("link-workspace-packages", "deep")]);
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
+            std::collections::BTreeMap::new();
+        let ctx = ResolveCtx::files_only(&npmrc, &ws);
+        assert_eq!(
+            resolved::link_workspace_packages(&ctx),
+            resolved::LinkWorkspacePackages::Deep
+        );
+    }
+
+    #[test]
     fn npmrc_accepts_kebab_alias_for_camel_only_setting() {
         // `virtualStoreDirMaxLength` is declared in settings.toml
         // with the single npmrc key `virtualStoreDirMaxLength`. The

--- a/crates/aube/src/commands/add/manifest.rs
+++ b/crates/aube/src/commands/add/manifest.rs
@@ -158,7 +158,11 @@ pub(super) async fn update_manifest_for_add(
     // (name → version) map once for this invocation and tag any
     // matching specs so the packument-fetch loop skips them and the
     // manifest-write path branches into the workspace formatter.
-    if link_workspace_packages || matches!(opts.workspace_protocol_override, Some(true)) {
+    if !matches!(
+        link_workspace_packages,
+        aube_settings::resolved::LinkWorkspacePackages::False
+    ) || matches!(opts.workspace_protocol_override, Some(true))
+    {
         let workspace_versions = collect_workspace_versions(cwd);
         for spec in &mut parsed {
             if spec.linked_workspace_version.is_some() {

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -116,7 +116,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`nodeVersion`](#setting-nodeversion) | `string` | Node.js version aube reports when evaluating `engines` checks. |
 | [`nodeDownloadMirrors`](#setting-nodedownloadmirrors) | `object` | Custom Node.js download mirror URLs. |
 | [`savePrefix`](#setting-saveprefix) | `"^" \| "~" \| ""` | Version prefix used when installing a package. |
-| [`linkWorkspacePackages`](#setting-linkworkspacepackages) | `bool` | Resolve `aube add &lt;name&gt;` against local workspace siblings before falling back to the registry. |
+| [`linkWorkspacePackages`](#setting-linkworkspacepackages) | `"false" \| "true" \| "deep"` | Resolve `aube add &lt;name&gt;` against local workspace siblings before falling back to the registry. |
 | [`saveWorkspaceProtocol`](#setting-saveworkspaceprotocol) | `"true" \| "false" \| "rolling"` | Spec form written to `package.json` when `aube add` resolves against a workspace sibling. |
 | [`tag`](#setting-tag) | `string` | Default dist-tag used by `aube add` without a version. |
 | [`globalDir`](#setting-globaldir) | `path` | Directory where globally installed packages live. |
@@ -2282,14 +2282,14 @@ Resolved from `.npmrc`. `--save-exact` overrides to empty prefix.
 
 Resolve `aube add <name>` against local workspace siblings before falling back to the registry.
 
-- Type: `bool`
-- Default: `false`
+- Type: `"false" | "true" | "deep"`
+- Default: `"false"`
 - Environment: `npm_config_link_workspace_packages`, `NPM_CONFIG_LINK_WORKSPACE_PACKAGES`, `AUBE_LINK_WORKSPACE_PACKAGES`
 - .npmrc keys: `link-workspace-packages`, `linkWorkspacePackages`
 - Workspace YAML keys: `linkWorkspacePackages`
 
-When `true`, `aube add <name>` checks the workspace for a package
-whose `name` matches the spec before falling back to the registry.
+When `true` or `"deep"`, `aube add <name>` checks the workspace for
+a package whose `name` matches the spec before falling back to the registry.
 A match wires the dep up as a workspace link; the manifest specifier
 written to `package.json` is controlled by `saveWorkspaceProtocol`.
 
@@ -2301,10 +2301,8 @@ linked.
 Off by default to match pnpm 8+ — opt in via `pnpm-workspace.yaml`
 when you want every `aube add` to prefer the local copy of a sibling.
 Aube's resolver already prefers workspace siblings on bare semver
-ranges at install time, so this setting only controls `aube add`'s
-manifest-write path; pnpm's `"deep"` value (which extends the
-preference to transitive deps) is therefore not implemented and
-treating the value as a plain bool is intentional.
+ranges at install time, including transitives, so pnpm's `"deep"`
+mode is accepted as an alias for the add-time manifest behavior.
 
 ### `saveWorkspaceProtocol` {#setting-saveworkspaceprotocol}
 

--- a/test/pnpm_monorepo_index.bats
+++ b/test/pnpm_monorepo_index.bats
@@ -376,6 +376,24 @@ _link_workspace_packages_fixture() {
 	assert_link_exists node_modules/project-4
 }
 
+@test "aube add: linkWorkspacePackages=deep writes workspace:^ for siblings" {
+	_link_workspace_packages_fixture
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - "**"
+		  - "!store/**"
+		linkWorkspacePackages: deep
+	EOF
+
+	cd project-1
+	run aube add project-2
+	assert_success
+
+	run grep -F '"project-2": "workspace:^"' package.json
+	assert_success
+	assert_link_exists node_modules/project-2
+}
+
 # Ported from pnpm/test/monorepo/index.ts:156
 # ('linking a package inside a monorepo with --link-workspace-packages
 # when installing new dependencies and save-workspace-protocol is


### PR DESCRIPTION
## Summary
- accept `linkWorkspacePackages: deep` alongside boolean values
- normalize the setting through a generated enum and treat `deep` as workspace-link enabled for `aube add`
- add Rust and Bats regression coverage, plus regenerated settings docs

## Tests
- `cargo test -p aube-settings link_workspace_packages -- --nocapture`
- `cargo test -p aube-manifest link_workspace_packages_deep -- --nocapture`
- `mise run test:bats test/pnpm_monorepo_index.bats --filter 'linkWorkspacePackages=deep'`\n\n*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config parsing and `aube add` manifest behavior only; no auth or install-graph changes beyond aligning with pnpm’s tri-state setting.
> 
> **Overview**
> **`linkWorkspacePackages`** now accepts pnpm-style **`true`**, **`false`**, and **`"deep"`** (not just booleans). Workspace YAML deserializes the key as a raw **`yaml_serde::Value`**, **`settings.toml`** / generated docs declare the union type, and resolution maps values to **`LinkWorkspacePackages`** (`False` / `True` / **`Deep`**).
> 
> **`aube add`** enables workspace-sibling lookup whenever the resolved setting is anything other than **`False`**, so **`deep`** behaves like **`true`** for manifest writes (e.g. **`workspace:^`**). Docs no longer claim **`deep`** is unsupported; they describe it as an alias for add-time linking given install-time workspace preference.
> 
> Regression coverage: manifest YAML parse, settings resolution from workspace yaml and **`.npmrc`**, and a Bats monorepo case with **`linkWorkspacePackages: deep`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abff7c065aff77ebc5b125270e8726659e43bc76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->