### PR TITLE
security(linker): reject unsafe package aliases

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -57,6 +57,7 @@ pub const ERR_AUBE_LINK_FAILED: &str = "ERR_AUBE_LINK_FAILED";
 pub const ERR_AUBE_PATCH_FAILED: &str = "ERR_AUBE_PATCH_FAILED";
 pub const ERR_AUBE_MISSING_PACKAGE_INDEX: &str = "ERR_AUBE_MISSING_PACKAGE_INDEX";
 pub const ERR_AUBE_UNSAFE_INDEX_KEY: &str = "ERR_AUBE_UNSAFE_INDEX_KEY";
+pub const ERR_AUBE_UNSAFE_PACKAGE_NAME: &str = "ERR_AUBE_UNSAFE_PACKAGE_NAME";
 pub const ERR_AUBE_MISSING_STORE_FILE: &str = "ERR_AUBE_MISSING_STORE_FILE";
 
 // ── scripts ─────────────────────────────────────────────────────────
@@ -445,6 +446,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::MISC_SAFETY,
         description: "A package index key tried to escape its directory (path traversal defense in depth).",
         exit_code: Some(90),
+    },
+    CodeMeta {
+        name: ERR_AUBE_UNSAFE_PACKAGE_NAME,
+        category: category::MISC_SAFETY,
+        description: "A package/dependency alias would escape its `node_modules` slot if linked.",
+        exit_code: Some(92),
     },
     CodeMeta {
         name: ERR_AUBE_UNSAFE_SHEBANG_INTERPRETER,

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -448,16 +448,16 @@ pub const ALL: &[CodeMeta] = &[
         exit_code: Some(90),
     },
     CodeMeta {
-        name: ERR_AUBE_UNSAFE_PACKAGE_NAME,
-        category: category::MISC_SAFETY,
-        description: "A package/dependency alias would escape its `node_modules` slot if linked.",
-        exit_code: Some(92),
-    },
-    CodeMeta {
         name: ERR_AUBE_UNSAFE_SHEBANG_INTERPRETER,
         category: category::MISC_SAFETY,
         description: "A `#!` shebang named an unsafe interpreter when generating a shim — substituted with `node` instead. Surfaced as `tracing::error!` but install continues.",
         exit_code: Some(91),
+    },
+    CodeMeta {
+        name: ERR_AUBE_UNSAFE_PACKAGE_NAME,
+        category: category::MISC_SAFETY,
+        description: "A package/dependency alias would escape its `node_modules` slot if linked.",
+        exit_code: Some(92),
     },
     CodeMeta {
         name: ERR_AUBE_PATCHES_TRACKING_WRITE,

--- a/crates/aube-linker/src/error.rs
+++ b/crates/aube-linker/src/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
     #[error("refusing to materialize unsafe index key: {0:?}")]
     #[diagnostic(code(ERR_AUBE_UNSAFE_INDEX_KEY))]
     UnsafeIndexKey(String),
+    #[error("refusing to create node_modules entry for unsafe package name: {0:?}")]
+    #[diagnostic(code(ERR_AUBE_UNSAFE_PACKAGE_NAME))]
+    UnsafePackageName(String),
     #[error(
         "cached package index references a missing CAS shard at {store_path} (file: {rel_path:?}). The store and its index cache are out of sync — rerun the install to re-fetch the tarball."
     )]

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -64,7 +64,11 @@ impl HoistedPlacements {
     /// not relink node_modules. `modules_dir_name` must match the
     /// `modulesDir` setting the install used, or the computed paths
     /// won't match what's on disk.
-    pub fn from_graph(root_dir: &Path, graph: &LockfileGraph, modules_dir_name: &str) -> Self {
+    pub fn from_graph(
+        root_dir: &Path,
+        graph: &LockfileGraph,
+        modules_dir_name: &str,
+    ) -> Result<Self, Error> {
         let mut placements = Self::default();
         for (importer_path, deps) in &graph.importers {
             if !crate::is_physical_importer(importer_path) {
@@ -76,9 +80,7 @@ impl HoistedPlacements {
                 root_dir.join(importer_path)
             };
             let nm = importer_dir.join(modules_dir_name);
-            let Ok(plan) = plan_importer(&nm, deps, graph) else {
-                continue;
-            };
+            let plan = plan_importer(&nm, deps, graph)?;
             for node in &plan.nodes {
                 let (Some(dep_path), Some(pkg_dir)) = (&node.dep_path, &node.pkg_dir) else {
                     continue;
@@ -88,7 +90,7 @@ impl HoistedPlacements {
                 }
             }
         }
-        placements
+        Ok(placements)
     }
 
     /// Shallowest placement for `dep_path`, or `None` if the dep is

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -76,7 +76,9 @@ impl HoistedPlacements {
                 root_dir.join(importer_path)
             };
             let nm = importer_dir.join(modules_dir_name);
-            let plan = plan_importer(&nm, deps, graph);
+            let Ok(plan) = plan_importer(&nm, deps, graph) else {
+                continue;
+            };
             for node in &plan.nodes {
                 let (Some(dep_path), Some(pkg_dir)) = (&node.dep_path, &node.pkg_dir) else {
                     continue;
@@ -172,7 +174,13 @@ impl PlacementPlan {
     /// `requester`. Returns the resulting node index and whether a
     /// fresh entry was created (so the caller knows whether to
     /// enqueue transitive deps).
-    fn place(&mut self, requester: usize, name: &str, dep_path: &str) -> PlaceOutcome {
+    fn place(
+        &mut self,
+        requester: usize,
+        name: &str,
+        dep_path: &str,
+    ) -> Result<PlaceOutcome, Error> {
+        crate::validate_package_link_name(name)?;
         // Walk up from the requester looking for the shallowest
         // ancestor that doesn't already host a different version of
         // `name`. If any ancestor has a matching entry, reuse it.
@@ -181,10 +189,10 @@ impl PlacementPlan {
         loop {
             if let Some(&existing) = self.nodes[cursor].children.get(name) {
                 if self.nodes[existing].dep_path.as_deref() == Some(dep_path) {
-                    return PlaceOutcome {
+                    return Ok(PlaceOutcome {
                         node_idx: existing,
                         created: false,
-                    };
+                    });
                 }
                 // Conflict: must stay at or below `candidate`.
                 break;
@@ -210,10 +218,10 @@ impl PlacementPlan {
         self.nodes[candidate]
             .children
             .insert(name.to_string(), new_idx);
-        PlaceOutcome {
+        Ok(PlaceOutcome {
             node_idx: new_idx,
             created: true,
-        }
+        })
     }
 
     /// Names placed directly in the importer root's `node_modules/`.
@@ -231,7 +239,7 @@ pub(crate) fn plan_importer(
     importer_nm: &Path,
     root_deps: &[DirectDep],
     graph: &LockfileGraph,
-) -> PlacementPlan {
+) -> Result<PlacementPlan, Error> {
     let mut plan = PlacementPlan::new(importer_nm.to_path_buf());
     let mut queue: VecDeque<(usize, String, String)> = VecDeque::new();
 
@@ -246,7 +254,7 @@ pub(crate) fn plan_importer(
     }
 
     while let Some((requester, name, dep_path)) = queue.pop_front() {
-        let outcome = plan.place(requester, &name, &dep_path);
+        let outcome = plan.place(requester, &name, &dep_path)?;
         if !outcome.created {
             continue;
         }
@@ -269,7 +277,7 @@ pub(crate) fn plan_importer(
         }
     }
 
-    plan
+    Ok(plan)
 }
 
 /// Materialize a planned tree onto disk for a single importer.
@@ -297,7 +305,7 @@ pub(crate) fn link_hoisted_importer(
     let nm = importer_dir.join(linker.modules_dir_name());
     crate::mkdirp(&nm)?;
 
-    let plan = plan_importer(&nm, root_deps, graph);
+    let plan = plan_importer(&nm, root_deps, graph)?;
 
     // Sweep any top-level entries that are no longer claimed by the
     // plan. Dotfiles (`.aube`, `.bin`, …) are preserved — .aube in

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -27,7 +27,9 @@ mod tests;
 pub use error::Error;
 pub use hoisted::HoistedPlacements;
 pub use link::build_nested_link_targets;
-pub(crate) use materialize::{invalidate_stale_index_for_package, validate_index_key};
+pub(crate) use materialize::{
+    invalidate_stale_index_for_package, validate_index_key, validate_package_link_name,
+};
 pub use patches::Patches;
 pub(crate) use patches::apply_multi_file_patch;
 pub use pool::default_linker_parallelism;

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -389,6 +389,7 @@ impl Linker {
             root_deps
                 .par_iter()
                 .map(|dep| {
+                    crate::validate_package_link_name(&dep.name)?;
                     let target_dir = nm.join(&dep.name);
 
                     // `link:` direct deps point at the on-disk target with
@@ -561,6 +562,7 @@ impl Linker {
                 continue;
             }
             for dep in deps {
+                crate::validate_package_link_name(&dep.name)?;
                 let Some(ws_dir) = workspace_dirs.get(&dep.name) else {
                     continue;
                 };
@@ -1010,6 +1012,7 @@ impl Linker {
                         return Ok(false);
                     }
 
+                    crate::validate_package_link_name(&dep.name)?;
                     let link_path = nm.join(&dep.name);
 
                     // Workspace dep (`workspace:` protocol or bare

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -279,6 +279,10 @@ impl Linker {
         // this graph", which is the common case.
         nested_link_targets: Option<&BTreeMap<String, PathBuf>>,
     ) -> Result<(), Error> {
+        validate_package_link_name(&pkg.name)?;
+        for dep_name in pkg.dependencies.keys() {
+            validate_package_link_name(dep_name)?;
+        }
         let subdir = if apply_hashes {
             self.virtual_store_subdir(dep_path)
         } else {
@@ -677,4 +681,86 @@ pub(crate) fn validate_index_key(key: &str) -> Result<(), Error> {
         }
     }
     Ok(())
+}
+
+/// Validate a package/dependency alias before it becomes a path below
+/// `node_modules`. npm names allow either `name` or `@scope/name`; every
+/// other slash shape is a filesystem path, not a package slot.
+pub(crate) fn validate_package_link_name(name: &str) -> Result<(), Error> {
+    if name.is_empty()
+        || name.contains('\0')
+        || name.contains('\\')
+        || name.starts_with('/')
+        || name.starts_with('\\')
+    {
+        return Err(Error::UnsafePackageName(name.to_string()));
+    }
+    let parts: Vec<&str> = name.split('/').collect();
+    let ok = match parts.as_slice() {
+        [bare] => is_safe_package_component(bare),
+        [scope, bare] => {
+            scope.starts_with('@')
+                && scope.len() > 1
+                && is_safe_package_component(scope)
+                && is_safe_package_component(bare)
+        }
+        _ => false,
+    };
+    if ok {
+        Ok(())
+    } else {
+        Err(Error::UnsafePackageName(name.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod package_name_tests {
+    use super::*;
+
+    #[test]
+    fn validate_package_link_name_accepts_npm_slots() {
+        validate_package_link_name("react").unwrap();
+        validate_package_link_name("@scope/pkg").unwrap();
+    }
+
+    #[test]
+    fn validate_package_link_name_rejects_path_shapes() {
+        for name in [
+            "",
+            ".",
+            "..",
+            "../evil",
+            "@scope/../evil",
+            "@scope/pkg/extra",
+            "/abs",
+            "C:evil",
+            "pkg\\evil",
+            "pkg\0evil",
+        ] {
+            assert!(
+                matches!(
+                    validate_package_link_name(name),
+                    Err(Error::UnsafePackageName(_))
+                ),
+                "{name:?} should be rejected"
+            );
+        }
+    }
+}
+
+fn is_safe_package_component(component: &str) -> bool {
+    if component.is_empty() || matches!(component, "." | "..") {
+        return false;
+    }
+    if component.len() >= 2 && component.as_bytes()[1] == b':' {
+        return false;
+    }
+    !std::path::Path::new(component).components().any(|c| {
+        matches!(
+            c,
+            std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_)
+        )
+    })
 }

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -687,12 +687,7 @@ pub(crate) fn validate_index_key(key: &str) -> Result<(), Error> {
 /// `node_modules`. npm names allow either `name` or `@scope/name`; every
 /// other slash shape is a filesystem path, not a package slot.
 pub(crate) fn validate_package_link_name(name: &str) -> Result<(), Error> {
-    if name.is_empty()
-        || name.contains('\0')
-        || name.contains('\\')
-        || name.starts_with('/')
-        || name.starts_with('\\')
-    {
+    if name.is_empty() || name.contains('\0') || name.contains('\\') || name.starts_with('/') {
         return Err(Error::UnsafePackageName(name.to_string()));
     }
     let parts: Vec<&str> = name.split('/').collect();

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -130,7 +130,7 @@ pub async fn run(
                     ));
                 }
                 aube_settings::resolved::NodeLinker::Hoisted => Some(
-                    aube_linker::HoistedPlacements::from_graph(&cwd, &graph, &modules_dir_name),
+                    aube_linker::HoistedPlacements::from_graph(&cwd, &graph, &modules_dir_name)?,
                 ),
                 aube_settings::resolved::NodeLinker::Isolated => None,
             };

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -325,16 +325,16 @@
       "exit_code": 90
     },
     {
-      "name": "ERR_AUBE_UNSAFE_PACKAGE_NAME",
-      "category": "Misc / safety",
-      "description": "A package/dependency alias would escape its `node_modules` slot if linked.",
-      "exit_code": 92
-    },
-    {
       "name": "ERR_AUBE_UNSAFE_SHEBANG_INTERPRETER",
       "category": "Misc / safety",
       "description": "A `#!` shebang named an unsafe interpreter when generating a shim — substituted with `node` instead. Surfaced as `tracing::error!` but install continues.",
       "exit_code": 91
+    },
+    {
+      "name": "ERR_AUBE_UNSAFE_PACKAGE_NAME",
+      "category": "Misc / safety",
+      "description": "A package/dependency alias would escape its `node_modules` slot if linked.",
+      "exit_code": 92
     },
     {
       "name": "ERR_AUBE_PATCHES_TRACKING_WRITE",

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -325,6 +325,12 @@
       "exit_code": 90
     },
     {
+      "name": "ERR_AUBE_UNSAFE_PACKAGE_NAME",
+      "category": "Misc / safety",
+      "description": "A package/dependency alias would escape its `node_modules` slot if linked.",
+      "exit_code": 92
+    },
+    {
       "name": "ERR_AUBE_UNSAFE_SHEBANG_INTERPRETER",
       "category": "Misc / safety",
       "description": "A `#!` shebang named an unsafe interpreter when generating a shim — substituted with `node` instead. Surfaced as `tracing::error!` but install continues.",


### PR DESCRIPTION
## Summary
- reject package/dependency aliases that are not npm node_modules slots before linking
- cover isolated and hoisted linker paths
- register ERR_AUBE_UNSAFE_PACKAGE_NAME for reporters/CI

## Tests
- PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check
- PATH="$HOME/.cargo/bin:$PATH" cargo test -p aube-linker validate_package_link_name
- PATH="$HOME/.cargo/bin:$PATH" cargo test -p aube-codes

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-hardening on install/link paths can fail installs if lockfiles contain unusual dependency keys that previously linked; behavior is intentional fail-closed.
> 
> **Overview**
> Adds **defense-in-depth** so only valid npm `node_modules` slot names (`name` or `@scope/name`) are used when building paths under `node_modules`.
> 
> A new `validate_package_link_name` helper rejects path-like aliases (`..`, extra slashes, absolute paths, Windows drive prefixes, null bytes, etc.). It runs during **materialize** (package name and dependency keys), **isolated** top-level and workspace symlinks, and **hoisted** placement planning. Hoisted planning and `HoistedPlacements::from_graph` now return `Result` so unsafe names fail install/rebuild instead of silently planning bad paths.
> 
> Registers **`ERR_AUBE_UNSAFE_PACKAGE_NAME`** (exit code 92) in `aube-codes`, linker diagnostics, and `docs/error-codes.data.json`, alongside unit tests for accepted and rejected names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9072c5c7d20b74adde7f336087838d5c363e9596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->