### PR TITLE
security(registry): scope unqualified credentials

### DIFF
--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -49,6 +49,7 @@ pub const WARN_AUBE_UNTRUSTED_PROXY: &str = "WARN_AUBE_UNTRUSTED_PROXY";
 pub const WARN_AUBE_UNTRUSTED_STRICT_SSL_DISABLE: &str = "WARN_AUBE_UNTRUSTED_STRICT_SSL_DISABLE";
 pub const WARN_AUBE_INVALID_LOCAL_ADDRESS: &str = "WARN_AUBE_INVALID_LOCAL_ADDRESS";
 pub const WARN_AUBE_INVALID_MAXSOCKETS: &str = "WARN_AUBE_INVALID_MAXSOCKETS";
+pub const WARN_AUBE_UNSCOPED_AUTH_RESCOPED: &str = "WARN_AUBE_UNSCOPED_AUTH_RESCOPED";
 pub const WARN_AUBE_UNTRUSTED_TOKEN_HELPER: &str = "WARN_AUBE_UNTRUSTED_TOKEN_HELPER";
 pub const WARN_AUBE_INVALID_TOKEN_HELPER: &str = "WARN_AUBE_INVALID_TOKEN_HELPER";
 pub const WARN_AUBE_TOKEN_HELPER_SPAWN_FAILED: &str = "WARN_AUBE_TOKEN_HELPER_SPAWN_FAILED";
@@ -303,6 +304,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_INVALID_MAXSOCKETS,
         category: category::REGISTRY_CONFIG,
         description: "`maxsockets` was 0 or non-numeric.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_UNSCOPED_AUTH_RESCOPED,
+        category: category::REGISTRY_CONFIG,
+        description: "An unscoped registry credential was pinned to the registry declared by the same config source.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -89,10 +89,4 @@ pub struct RegistryClient {
     config: NpmConfig,
     network_mode: NetworkMode,
     fetch_policy: FetchPolicy,
-    /// Cached parsed default-registry URL. The default registry never
-    /// changes mid-process, but `authed()` previously re-parsed
-    /// `self.config.registry` on every authed request via
-    /// `same_host`. On a 2000-pkg install that was thousands of
-    /// `Url::parse` calls. Initialized lazily on first use.
-    default_registry_parsed: std::sync::OnceLock<Option<reqwest::Url>>,
 }

--- a/crates/aube-registry/src/client/lifecycle.rs
+++ b/crates/aube-registry/src/client/lifecycle.rs
@@ -62,7 +62,6 @@ impl RegistryClient {
             config,
             network_mode: NetworkMode::Online,
             fetch_policy,
-            default_registry_parsed: std::sync::OnceLock::new(),
         }
     }
 

--- a/crates/aube-registry/src/client/request.rs
+++ b/crates/aube-registry/src/client/request.rs
@@ -76,28 +76,6 @@ impl RegistryClient {
     pub fn has_resolved_auth_for(&self, registry_url: &str) -> bool {
         self.registry_auth_token_for(registry_url).is_some()
             || self.config.basic_auth_for(registry_url).is_some()
-            || self.config.global_auth_token.is_some()
-    }
-
-    /// Cached equivalent of the previous free `same_host` function.
-    /// The default registry never changes for the lifetime of the
-    /// client, so the previous per-call `Url::parse(&self.config.registry)`
-    /// was pure waste on every authed request. Comparison shape
-    /// (scheme + host + port) is preserved byte-for-byte to keep the
-    /// auth-leak guard semantics identical.
-    fn same_host_as_default(&self, registry_url: &str) -> bool {
-        let parsed_default = self
-            .default_registry_parsed
-            .get_or_init(|| reqwest::Url::parse(&self.config.registry).ok());
-        let Some(a) = parsed_default.as_ref() else {
-            return false;
-        };
-        let Ok(b) = reqwest::Url::parse(registry_url) else {
-            return false;
-        };
-        a.scheme() == b.scheme()
-            && a.host_str() == b.host_str()
-            && a.port_or_known_default() == b.port_or_known_default()
     }
 
     /// Attach auth headers to any `RequestBuilder` keyed off the registry
@@ -114,14 +92,6 @@ impl RegistryClient {
             req.bearer_auth(token)
         } else if let Some(auth) = self.config.basic_auth_for(registry_url) {
             req.header("Authorization", format!("Basic {auth}"))
-        } else if let Some(token) = self.config.global_auth_token.as_ref()
-            && self.same_host_as_default(registry_url)
-        {
-            // Only send the default _authToken when the request hits the
-            // default registry. Stops a malicious scoped registry or a
-            // packument with a dist.tarball pointing at attacker.example
-            // from grabbing the user's npmjs token.
-            req.bearer_auth(token)
         } else {
             req
         }

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -140,7 +140,6 @@ impl NpmConfig {
         let mut project_registry = "https://registry.npmjs.org/".to_string();
         let mut npmrc_auth_file_registry = "https://registry.npmjs.org/".to_string();
         let mut env_registry = "https://registry.npmjs.org/".to_string();
-        let mut explicit_uri_fields = BTreeSet::new();
 
         for (source, key, value) in &entries {
             if key == "registry" {
@@ -152,14 +151,10 @@ impl NpmConfig {
                     &mut npmrc_auth_file_registry,
                     &mut env_registry,
                 ) = normalize_registry_url(value);
-            } else if key.starts_with("//")
-                && let Some((uri, suffix)) = key.rsplit_once(':')
-                && let Some(suffix) = canonical_rescoped_suffix(suffix)
-            {
-                explicit_uri_fields.insert((normalize_npmrc_uri_key(uri), suffix));
             }
         }
 
+        let mut explicit_uri_fields = BTreeSet::new();
         for (source, key, value) in entries {
             if key == "registry" {
                 self.registry = normalize_registry_url(&value);
@@ -400,15 +395,25 @@ impl NpmConfig {
                     // to the same key — matches what `registry_uri_key`
                     // produces on the lookup side after stripping the
                     // scheme's default port.
-                    let entry = self
-                        .auth_by_uri
-                        .entry(normalize_npmrc_uri_key(uri))
-                        .or_default();
+                    let uri_key = normalize_npmrc_uri_key(uri);
+                    let entry = self.auth_by_uri.entry(uri_key.clone()).or_default();
                     match suffix {
-                        "_authToken" => entry.auth_token = Some(value),
-                        "_auth" => entry.auth = Some(value),
-                        "username" => entry.username = Some(value),
-                        "_password" => entry.password = Some(value),
+                        "_authToken" => {
+                            entry.auth_token = Some(value);
+                            explicit_uri_fields.insert((uri_key, "_authToken"));
+                        }
+                        "_auth" => {
+                            entry.auth = Some(value);
+                            explicit_uri_fields.insert((uri_key, "_auth"));
+                        }
+                        "username" => {
+                            entry.username = Some(value);
+                            explicit_uri_fields.insert((uri_key, "username"));
+                        }
+                        "_password" => {
+                            entry.password = Some(value);
+                            explicit_uri_fields.insert((uri_key, "_password"));
+                        }
                         "tokenHelper" | "token-helper" => {
                             // CVE-2025-69262 (pnpm GHSA-2phv-j68v-wwqx)
                             // class: `tokenHelper` is spawned as
@@ -433,11 +438,18 @@ impl NpmConfig {
                                 continue;
                             };
                             entry.token_helper = Some(sanitized);
+                            explicit_uri_fields.insert((uri_key, "tokenHelper"));
                         }
                         "ca" | "ca[]" => entry.tls.ca.push(pem_value(value)),
                         "cafile" | "caFile" => entry.tls.cafile = Some(PathBuf::from(value)),
-                        "cert" => entry.tls.cert = Some(pem_value(value)),
-                        "key" => entry.tls.key = Some(pem_value(value)),
+                        "cert" => {
+                            entry.tls.cert = Some(pem_value(value));
+                            explicit_uri_fields.insert((uri_key, "cert"));
+                        }
+                        "key" => {
+                            entry.tls.key = Some(pem_value(value));
+                            explicit_uri_fields.insert((uri_key, "key"));
+                        }
                         _ => {} // Ignore unknown suffixes for now
                     }
                 }
@@ -458,6 +470,14 @@ impl NpmConfig {
         explicit_uri_field_exists: bool,
         apply: impl FnOnce(&mut AuthConfig),
     ) {
+        if explicit_uri_field_exists {
+            tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_UNSCOPED_AUTH_RESCOPED,
+                "ignoring unscoped {suffix} from {source:?}: URI-scoped `{}:{suffix}` is already configured",
+                registry_uri_key(registry)
+            );
+            return;
+        }
         if matches!(source, NpmrcSource::Env | NpmrcSource::PnpmAuth) {
             tracing::warn!(
                 code = aube_codes::warnings::WARN_AUBE_UNSCOPED_AUTH_RESCOPED,
@@ -474,9 +494,7 @@ impl NpmConfig {
             .auth_by_uri
             .entry(registry_uri_key(registry))
             .or_default();
-        if !explicit_uri_field_exists {
-            apply(entry);
-        }
+        apply(entry);
     }
 }
 

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -138,11 +138,119 @@ impl NpmConfig {
     }
 
     pub(super) fn apply_tagged(&mut self, entries: Vec<(NpmrcSource, String, String)>) {
+        let mut user_registry = "https://registry.npmjs.org/".to_string();
+        let mut pnpm_auth_registry = "https://registry.npmjs.org/".to_string();
+        let mut project_registry = "https://registry.npmjs.org/".to_string();
+        let mut npmrc_auth_file_registry = "https://registry.npmjs.org/".to_string();
+        let mut env_registry = "https://registry.npmjs.org/".to_string();
+
+        for (source, key, value) in &entries {
+            if key == "registry" {
+                *source_registry_mut(
+                    *source,
+                    &mut user_registry,
+                    &mut pnpm_auth_registry,
+                    &mut project_registry,
+                    &mut npmrc_auth_file_registry,
+                    &mut env_registry,
+                ) = normalize_registry_url(value);
+            }
+        }
+
         for (source, key, value) in entries {
             if key == "registry" {
                 self.registry = normalize_registry_url(&value);
             } else if key == "_authToken" {
-                self.global_auth_token = Some(value);
+                let registry = source_registry(
+                    source,
+                    &user_registry,
+                    &pnpm_auth_registry,
+                    &project_registry,
+                    &npmrc_auth_file_registry,
+                    &env_registry,
+                );
+                self.rescope_unscoped_registry_setting(source, registry, "_authToken", |auth| {
+                    auth.auth_token = Some(value)
+                });
+            } else if key == "_auth" {
+                let registry = source_registry(
+                    source,
+                    &user_registry,
+                    &pnpm_auth_registry,
+                    &project_registry,
+                    &npmrc_auth_file_registry,
+                    &env_registry,
+                );
+                self.rescope_unscoped_registry_setting(source, registry, "_auth", |auth| {
+                    auth.auth = Some(value)
+                });
+            } else if key == "username" {
+                let registry = source_registry(
+                    source,
+                    &user_registry,
+                    &pnpm_auth_registry,
+                    &project_registry,
+                    &npmrc_auth_file_registry,
+                    &env_registry,
+                );
+                self.rescope_unscoped_registry_setting(source, registry, "username", |auth| {
+                    auth.username = Some(value)
+                });
+            } else if key == "_password" {
+                let registry = source_registry(
+                    source,
+                    &user_registry,
+                    &pnpm_auth_registry,
+                    &project_registry,
+                    &npmrc_auth_file_registry,
+                    &env_registry,
+                );
+                self.rescope_unscoped_registry_setting(source, registry, "_password", |auth| {
+                    auth.password = Some(value)
+                });
+            } else if matches!(key.as_str(), "cert" | "key") {
+                let suffix = key.clone();
+                let registry = source_registry(
+                    source,
+                    &user_registry,
+                    &pnpm_auth_registry,
+                    &project_registry,
+                    &npmrc_auth_file_registry,
+                    &env_registry,
+                );
+                self.rescope_unscoped_registry_setting(source, registry, &suffix, |auth| {
+                    if suffix == "cert" {
+                        auth.tls.cert = Some(pem_value(value));
+                    } else {
+                        auth.tls.key = Some(pem_value(value));
+                    }
+                });
+            } else if matches!(key.as_str(), "tokenHelper" | "token-helper") {
+                if !source.is_trusted_for_subprocess_settings() {
+                    tracing::warn!(
+                        code = aube_codes::warnings::WARN_AUBE_UNTRUSTED_TOKEN_HELPER,
+                        "ignoring tokenHelper from untrusted source {source:?}: committed `.npmrc` cannot set this"
+                    );
+                    continue;
+                }
+                let Some(sanitized) = sanitize_token_helper(&value) else {
+                    tracing::warn!(
+                        code = aube_codes::warnings::WARN_AUBE_INVALID_TOKEN_HELPER,
+                        "ignoring tokenHelper: value is not a bare absolute path: {value:?}"
+                    );
+                    continue;
+                };
+                let registry = source_registry(
+                    source,
+                    &user_registry,
+                    &pnpm_auth_registry,
+                    &project_registry,
+                    &npmrc_auth_file_registry,
+                    &env_registry,
+                );
+                self.rescope_unscoped_registry_setting(source, registry, "tokenHelper", |auth| {
+                    auth.token_helper = Some(sanitized)
+                });
             } else if matches!(
                 key.as_str(),
                 "https-proxy"
@@ -292,5 +400,58 @@ impl NpmConfig {
             // source list from settings.toml. Add a new branch here
             // only if the key maps to a registry-client concept.
         }
+    }
+
+    fn rescope_unscoped_registry_setting(
+        &mut self,
+        source: NpmrcSource,
+        registry: &str,
+        suffix: &str,
+        apply: impl FnOnce(&mut AuthConfig),
+    ) {
+        tracing::warn!(
+            code = aube_codes::warnings::WARN_AUBE_UNSCOPED_AUTH_RESCOPED,
+            "unscoped {suffix} from {source:?} was pinned to {registry}; write `{}:{suffix}=...` instead",
+            registry_uri_key(registry)
+        );
+        let entry = self
+            .auth_by_uri
+            .entry(registry_uri_key(registry))
+            .or_default();
+        apply(entry);
+    }
+}
+
+fn source_registry<'a>(
+    source: NpmrcSource,
+    user: &'a str,
+    pnpm_auth: &'a str,
+    project: &'a str,
+    npmrc_auth_file: &'a str,
+    env: &'a str,
+) -> &'a str {
+    match source {
+        NpmrcSource::User => user,
+        NpmrcSource::PnpmAuth => pnpm_auth,
+        NpmrcSource::Project => project,
+        NpmrcSource::NpmrcAuthFile => npmrc_auth_file,
+        NpmrcSource::Env => env,
+    }
+}
+
+fn source_registry_mut<'a>(
+    source: NpmrcSource,
+    user: &'a mut String,
+    pnpm_auth: &'a mut String,
+    project: &'a mut String,
+    npmrc_auth_file: &'a mut String,
+    env: &'a mut String,
+) -> &'a mut String {
+    match source {
+        NpmrcSource::User => user,
+        NpmrcSource::PnpmAuth => pnpm_auth,
+        NpmrcSource::Project => project,
+        NpmrcSource::NpmrcAuthFile => npmrc_auth_file,
+        NpmrcSource::Env => env,
     }
 }

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -1,4 +1,5 @@
 use base64::Engine as _;
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use super::env::env_any;
@@ -139,6 +140,7 @@ impl NpmConfig {
         let mut project_registry = "https://registry.npmjs.org/".to_string();
         let mut npmrc_auth_file_registry = "https://registry.npmjs.org/".to_string();
         let mut env_registry = "https://registry.npmjs.org/".to_string();
+        let mut explicit_uri_fields = BTreeSet::new();
 
         for (source, key, value) in &entries {
             if key == "registry" {
@@ -150,6 +152,11 @@ impl NpmConfig {
                     &mut npmrc_auth_file_registry,
                     &mut env_registry,
                 ) = normalize_registry_url(value);
+            } else if key.starts_with("//")
+                && let Some((uri, suffix)) = key.rsplit_once(':')
+                && let Some(suffix) = canonical_rescoped_suffix(suffix)
+            {
+                explicit_uri_fields.insert((normalize_npmrc_uri_key(uri), suffix));
             }
         }
 
@@ -165,11 +172,16 @@ impl NpmConfig {
                     &npmrc_auth_file_registry,
                     &env_registry,
                 );
-                self.rescope_unscoped_registry_setting(source, registry, "_authToken", |auth| {
-                    if auth.auth_token.is_none() {
-                        auth.auth_token = Some(value);
-                    }
-                });
+                self.rescope_unscoped_registry_setting(
+                    source,
+                    registry,
+                    "_authToken",
+                    explicit_uri_fields.contains(&(
+                        registry_uri_key(registry),
+                        canonical_rescoped_suffix("_authToken").unwrap_or("_authToken"),
+                    )),
+                    |auth| auth.auth_token = Some(value),
+                );
             } else if key == "_auth" {
                 let registry = source_registry(
                     source,
@@ -179,11 +191,16 @@ impl NpmConfig {
                     &npmrc_auth_file_registry,
                     &env_registry,
                 );
-                self.rescope_unscoped_registry_setting(source, registry, "_auth", |auth| {
-                    if auth.auth.is_none() {
-                        auth.auth = Some(value);
-                    }
-                });
+                self.rescope_unscoped_registry_setting(
+                    source,
+                    registry,
+                    "_auth",
+                    explicit_uri_fields.contains(&(
+                        registry_uri_key(registry),
+                        canonical_rescoped_suffix("_auth").unwrap_or("_auth"),
+                    )),
+                    |auth| auth.auth = Some(value),
+                );
             } else if key == "username" {
                 let registry = source_registry(
                     source,
@@ -193,11 +210,16 @@ impl NpmConfig {
                     &npmrc_auth_file_registry,
                     &env_registry,
                 );
-                self.rescope_unscoped_registry_setting(source, registry, "username", |auth| {
-                    if auth.username.is_none() {
-                        auth.username = Some(value);
-                    }
-                });
+                self.rescope_unscoped_registry_setting(
+                    source,
+                    registry,
+                    "username",
+                    explicit_uri_fields.contains(&(
+                        registry_uri_key(registry),
+                        canonical_rescoped_suffix("username").unwrap_or("username"),
+                    )),
+                    |auth| auth.username = Some(value),
+                );
             } else if key == "_password" {
                 let registry = source_registry(
                     source,
@@ -207,11 +229,16 @@ impl NpmConfig {
                     &npmrc_auth_file_registry,
                     &env_registry,
                 );
-                self.rescope_unscoped_registry_setting(source, registry, "_password", |auth| {
-                    if auth.password.is_none() {
-                        auth.password = Some(value);
-                    }
-                });
+                self.rescope_unscoped_registry_setting(
+                    source,
+                    registry,
+                    "_password",
+                    explicit_uri_fields.contains(&(
+                        registry_uri_key(registry),
+                        canonical_rescoped_suffix("_password").unwrap_or("_password"),
+                    )),
+                    |auth| auth.password = Some(value),
+                );
             } else if matches!(key.as_str(), "cert" | "key") {
                 let suffix = key.clone();
                 let registry = source_registry(
@@ -222,15 +249,23 @@ impl NpmConfig {
                     &npmrc_auth_file_registry,
                     &env_registry,
                 );
-                self.rescope_unscoped_registry_setting(source, registry, &suffix, |auth| {
-                    if suffix == "cert" {
-                        if auth.tls.cert.is_none() {
+                let explicit_uri_field = explicit_uri_fields.contains(&(
+                    registry_uri_key(registry),
+                    canonical_rescoped_suffix(&suffix).unwrap_or(suffix.as_str()),
+                ));
+                self.rescope_unscoped_registry_setting(
+                    source,
+                    registry,
+                    &suffix,
+                    explicit_uri_field,
+                    |auth| {
+                        if suffix == "cert" {
                             auth.tls.cert = Some(pem_value(value));
+                        } else {
+                            auth.tls.key = Some(pem_value(value));
                         }
-                    } else if auth.tls.key.is_none() {
-                        auth.tls.key = Some(pem_value(value));
-                    }
-                });
+                    },
+                );
             } else if matches!(key.as_str(), "tokenHelper" | "token-helper") {
                 if !source.is_trusted_for_subprocess_settings() {
                     tracing::warn!(
@@ -254,11 +289,16 @@ impl NpmConfig {
                     &npmrc_auth_file_registry,
                     &env_registry,
                 );
-                self.rescope_unscoped_registry_setting(source, registry, "tokenHelper", |auth| {
-                    if auth.token_helper.is_none() {
-                        auth.token_helper = Some(sanitized);
-                    }
-                });
+                self.rescope_unscoped_registry_setting(
+                    source,
+                    registry,
+                    "tokenHelper",
+                    explicit_uri_fields.contains(&(
+                        registry_uri_key(registry),
+                        canonical_rescoped_suffix("tokenHelper").unwrap_or("tokenHelper"),
+                    )),
+                    |auth| auth.token_helper = Some(sanitized),
+                );
             } else if matches!(
                 key.as_str(),
                 "https-proxy"
@@ -415,6 +455,7 @@ impl NpmConfig {
         source: NpmrcSource,
         registry: &str,
         suffix: &str,
+        explicit_uri_field_exists: bool,
         apply: impl FnOnce(&mut AuthConfig),
     ) {
         if matches!(source, NpmrcSource::Env | NpmrcSource::PnpmAuth) {
@@ -433,7 +474,22 @@ impl NpmConfig {
             .auth_by_uri
             .entry(registry_uri_key(registry))
             .or_default();
-        apply(entry);
+        if !explicit_uri_field_exists {
+            apply(entry);
+        }
+    }
+}
+
+fn canonical_rescoped_suffix(suffix: &str) -> Option<&'static str> {
+    match suffix {
+        "_authToken" => Some("_authToken"),
+        "_auth" => Some("_auth"),
+        "username" => Some("username"),
+        "_password" => Some("_password"),
+        "cert" => Some("cert"),
+        "key" => Some("key"),
+        "tokenHelper" | "token-helper" => Some("tokenHelper"),
+        _ => None,
     }
 }
 

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -86,12 +86,8 @@ impl NpmConfig {
 
     /// Get the auth token for a given registry URL.
     pub fn auth_token_for(&self, registry_url: &str) -> Option<&str> {
-        if let Some(auth) = self.registry_config_for(registry_url)
-            && let Some(ref token) = auth.auth_token
-        {
-            return Some(token);
-        }
-        self.global_auth_token.as_deref()
+        self.registry_config_for(registry_url)
+            .and_then(|auth| auth.auth_token.as_deref())
     }
 
     pub fn token_helper_for(&self, registry_url: &str) -> Option<&str> {
@@ -409,11 +405,18 @@ impl NpmConfig {
         suffix: &str,
         apply: impl FnOnce(&mut AuthConfig),
     ) {
-        tracing::warn!(
-            code = aube_codes::warnings::WARN_AUBE_UNSCOPED_AUTH_RESCOPED,
-            "unscoped {suffix} from {source:?} was pinned to {registry}; write `{}:{suffix}=...` instead",
-            registry_uri_key(registry)
-        );
+        if matches!(source, NpmrcSource::Env | NpmrcSource::PnpmAuth) {
+            tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_UNSCOPED_AUTH_RESCOPED,
+                "unscoped {suffix} from {source:?} was pinned to {registry}"
+            );
+        } else {
+            tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_UNSCOPED_AUTH_RESCOPED,
+                "unscoped {suffix} from {source:?} was pinned to {registry}; write `{}:{suffix}=...` instead",
+                registry_uri_key(registry)
+            );
+        }
         let entry = self
             .auth_by_uri
             .entry(registry_uri_key(registry))

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -166,7 +166,9 @@ impl NpmConfig {
                     &env_registry,
                 );
                 self.rescope_unscoped_registry_setting(source, registry, "_authToken", |auth| {
-                    auth.auth_token = Some(value)
+                    if auth.auth_token.is_none() {
+                        auth.auth_token = Some(value);
+                    }
                 });
             } else if key == "_auth" {
                 let registry = source_registry(
@@ -178,7 +180,9 @@ impl NpmConfig {
                     &env_registry,
                 );
                 self.rescope_unscoped_registry_setting(source, registry, "_auth", |auth| {
-                    auth.auth = Some(value)
+                    if auth.auth.is_none() {
+                        auth.auth = Some(value);
+                    }
                 });
             } else if key == "username" {
                 let registry = source_registry(
@@ -190,7 +194,9 @@ impl NpmConfig {
                     &env_registry,
                 );
                 self.rescope_unscoped_registry_setting(source, registry, "username", |auth| {
-                    auth.username = Some(value)
+                    if auth.username.is_none() {
+                        auth.username = Some(value);
+                    }
                 });
             } else if key == "_password" {
                 let registry = source_registry(
@@ -202,7 +208,9 @@ impl NpmConfig {
                     &env_registry,
                 );
                 self.rescope_unscoped_registry_setting(source, registry, "_password", |auth| {
-                    auth.password = Some(value)
+                    if auth.password.is_none() {
+                        auth.password = Some(value);
+                    }
                 });
             } else if matches!(key.as_str(), "cert" | "key") {
                 let suffix = key.clone();
@@ -216,8 +224,10 @@ impl NpmConfig {
                 );
                 self.rescope_unscoped_registry_setting(source, registry, &suffix, |auth| {
                     if suffix == "cert" {
-                        auth.tls.cert = Some(pem_value(value));
-                    } else {
+                        if auth.tls.cert.is_none() {
+                            auth.tls.cert = Some(pem_value(value));
+                        }
+                    } else if auth.tls.key.is_none() {
                         auth.tls.key = Some(pem_value(value));
                     }
                 });
@@ -245,7 +255,9 @@ impl NpmConfig {
                     &env_registry,
                 );
                 self.rescope_unscoped_registry_setting(source, registry, "tokenHelper", |auth| {
-                    auth.token_helper = Some(sanitized)
+                    if auth.token_helper.is_none() {
+                        auth.token_helper = Some(sanitized);
+                    }
                 });
             } else if matches!(
                 key.as_str(),

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -611,26 +611,21 @@ fn top_level_cafile_and_ca_are_parsed() {
 }
 
 #[test]
-fn test_config_global_auth_token() {
+fn unscoped_auth_token_is_pinned_to_same_source_registry() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join(".npmrc"), "_authToken=global-token\n").unwrap();
 
-    // Isolate from the host's real `~/.npmrc` via `load_isolated`:
-    // a developer or CI runner with
-    // `//registry.npmjs.org/:_authToken=...` already logged in
-    // would have that URI-specific token beat our project-level
-    // `_authToken` fallback, since `auth_token_for` checks
-    // per-URI auth before dropping to `global_auth_token`.
+    // Isolate from the host's real `~/.npmrc`: a developer or CI
+    // runner with `//registry.npmjs.org/:_authToken=...` already
+    // logged in would otherwise affect this assertion.
     let config = NpmConfig::load_isolated(dir.path());
     // Unscoped auth is pinned to npmjs at load time. It must not
-    // remain a floating fallback that a later registry override can
-    // pull onto a different host.
+    // remain a floating fallback.
     assert_eq!(
         config.auth_token_for("https://registry.npmjs.org/"),
         Some("global-token")
     );
     assert_eq!(config.auth_token_for("https://registry.example.com/"), None);
-    assert!(config.global_auth_token.is_none());
 }
 
 #[test]
@@ -717,9 +712,9 @@ fn unscoped_tls_client_credentials_are_registry_scoped() {
 fn test_config_defaults() {
     let dir = tempfile::tempdir().unwrap();
     // No .npmrc at all. Same HOME isolation rationale as
-    // `test_config_global_auth_token` — without it this assertion
-    // flakes on any developer box whose `~/.npmrc` has ever been
-    // touched by `npm login`.
+    // `unscoped_auth_token_is_pinned_to_same_source_registry` —
+    // without it this assertion flakes on any developer box whose
+    // `~/.npmrc` has ever been touched by `npm login`.
     let config = NpmConfig::load_isolated(dir.path());
     assert_eq!(config.registry, "https://registry.npmjs.org/");
     assert!(

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -622,10 +622,94 @@ fn test_config_global_auth_token() {
     // `_authToken` fallback, since `auth_token_for` checks
     // per-URI auth before dropping to `global_auth_token`.
     let config = NpmConfig::load_isolated(dir.path());
-    // Global token used as fallback
+    // Unscoped auth is pinned to npmjs at load time. It must not
+    // remain a floating fallback that a later registry override can
+    // pull onto a different host.
     assert_eq!(
         config.auth_token_for("https://registry.npmjs.org/"),
         Some("global-token")
+    );
+    assert_eq!(config.auth_token_for("https://registry.example.com/"), None);
+    assert!(config.global_auth_token.is_none());
+}
+
+#[test]
+fn unscoped_auth_uses_registry_from_same_source() {
+    let home = tempfile::tempdir().unwrap();
+    std::fs::write(
+        home.path().join(".npmrc"),
+        "registry=https://registry.npmjs.org/\n_authToken=user-token\n",
+    )
+    .unwrap();
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(
+        project.path().join(".npmrc"),
+        "registry=https://registry.internal.example/\n",
+    )
+    .unwrap();
+
+    let mut config = NpmConfig::default();
+    config.apply_tagged(load_npmrc_entries_tagged_with_home(
+        Some(home.path()),
+        None,
+        project.path(),
+        None,
+    ));
+
+    assert_eq!(
+        config.registry, "https://registry.internal.example/",
+        "project registry still wins as the effective default"
+    );
+    assert_eq!(
+        config.auth_token_for("https://registry.npmjs.org/"),
+        Some("user-token")
+    );
+    assert_eq!(
+        config.auth_token_for("https://registry.internal.example/"),
+        None,
+        "project registry must not inherit user source's unscoped token"
+    );
+}
+
+#[test]
+fn unscoped_auth_uses_same_source_registry_regardless_of_order() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        "_authToken=private-token\nregistry=https://registry.private.example/\n",
+    )
+    .unwrap();
+
+    let config = NpmConfig::load_isolated(dir.path());
+    assert_eq!(
+        config.auth_token_for("https://registry.private.example/"),
+        Some("private-token")
+    );
+    assert_eq!(config.auth_token_for("https://registry.npmjs.org/"), None);
+}
+
+#[test]
+fn unscoped_tls_client_credentials_are_registry_scoped() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        "registry=https://registry.example.com/\n\
+         cert=-----BEGIN CERTIFICATE-----\\nclient\\n-----END CERTIFICATE-----\n\
+         key=-----BEGIN PRIVATE KEY-----\\nkey\\n-----END PRIVATE KEY-----\n",
+    )
+    .unwrap();
+
+    let config = NpmConfig::load_isolated(dir.path());
+    let tls = &config
+        .registry_config_for("https://registry.example.com/")
+        .unwrap()
+        .tls;
+    assert!(tls.cert.as_deref().unwrap().contains("\nclient\n"));
+    assert!(tls.key.as_deref().unwrap().contains("\nkey\n"));
+    assert!(
+        config
+            .registry_config_for("https://registry.npmjs.org/")
+            .is_none()
     );
 }
 

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::config::types::NpmrcSource;
 use base64::Engine as _;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -705,6 +706,28 @@ fn uri_scoped_auth_beats_later_rescoped_bare_auth() {
     assert_eq!(
         config.auth_token_for("https://registry.npmjs.org/"),
         Some("user-token")
+    );
+}
+
+#[test]
+fn later_bare_auth_can_override_earlier_bare_auth() {
+    let mut config = NpmConfig::default();
+    config.apply_tagged(vec![
+        (
+            NpmrcSource::User,
+            "_authToken".to_string(),
+            "user-token".to_string(),
+        ),
+        (
+            NpmrcSource::Env,
+            "_authToken".to_string(),
+            "env-token".to_string(),
+        ),
+    ]);
+
+    assert_eq!(
+        config.auth_token_for("https://registry.npmjs.org/"),
+        Some("env-token")
     );
 }
 

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -732,6 +732,28 @@ fn later_bare_auth_can_override_earlier_bare_auth() {
 }
 
 #[test]
+fn later_uri_scoped_auth_can_override_earlier_bare_auth() {
+    let mut config = NpmConfig::default();
+    config.apply_tagged(vec![
+        (
+            NpmrcSource::User,
+            "_authToken".to_string(),
+            "user-token".to_string(),
+        ),
+        (
+            NpmrcSource::Project,
+            "//registry.npmjs.org/:_authToken".to_string(),
+            "project-token".to_string(),
+        ),
+    ]);
+
+    assert_eq!(
+        config.auth_token_for("https://registry.npmjs.org/"),
+        Some("project-token")
+    );
+}
+
+#[test]
 fn unscoped_tls_client_credentials_are_registry_scoped() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -684,6 +684,31 @@ fn unscoped_auth_uses_same_source_registry_regardless_of_order() {
 }
 
 #[test]
+fn uri_scoped_auth_beats_later_rescoped_bare_auth() {
+    let home = tempfile::tempdir().unwrap();
+    std::fs::write(
+        home.path().join(".npmrc"),
+        "//registry.npmjs.org/:_authToken=user-token\n",
+    )
+    .unwrap();
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(project.path().join(".npmrc"), "_authToken=project-token\n").unwrap();
+
+    let mut config = NpmConfig::default();
+    config.apply_tagged(load_npmrc_entries_tagged_with_home(
+        Some(home.path()),
+        None,
+        project.path(),
+        None,
+    ));
+
+    assert_eq!(
+        config.auth_token_for("https://registry.npmjs.org/"),
+        Some("user-token")
+    );
+}
+
+#[test]
 fn unscoped_tls_client_credentials_are_registry_scoped() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(

--- a/crates/aube-registry/src/config/types.rs
+++ b/crates/aube-registry/src/config/types.rs
@@ -55,8 +55,6 @@ pub struct NpmConfig {
     pub scoped_registries: BTreeMap<String, String>,
     /// Auth config keyed by registry URL prefix (e.g., "//registry.example.com/")
     pub auth_by_uri: BTreeMap<String, AuthConfig>,
-    /// Global auth token (for default registry, when no URI-specific token exists)
-    pub global_auth_token: Option<String>,
     /// Proxy URL for outgoing HTTPS requests (`https-proxy` / `HTTPS_PROXY`).
     pub https_proxy: Option<String>,
     /// Proxy URL for outgoing HTTP requests (`proxy` / `http-proxy` / `HTTP_PROXY`).
@@ -128,7 +126,6 @@ impl Default for NpmConfig {
             registry: String::new(),
             scoped_registries: BTreeMap::new(),
             auth_by_uri: BTreeMap::new(),
-            global_auth_token: None,
             https_proxy: None,
             http_proxy: None,
             no_proxy: None,

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -519,6 +519,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_UNSCOPED_AUTH_RESCOPED",
+      "category": "Registry config (trust gates)",
+      "description": "An unscoped registry credential was pinned to the registry declared by the same config source.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_UNTRUSTED_TOKEN_HELPER",
       "category": "Registry config (trust gates)",
       "description": "`tokenHelper` came from an untrusted source (CVE-2025-69262 class).",


### PR DESCRIPTION
## Summary
- pin unscoped `_authToken`, `_auth`, `username`/`_password`, `tokenHelper`, `cert`, and `key` to the registry from the same config source
- keep `ca`/`cafile` global, matching pnpm 11.4 behavior
- add a warning code for the compatibility rewrite

## Tests
- PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check
- PATH="$HOME/.cargo/bin:$PATH" cargo test -p aube-registry unscoped
- PATH="$HOME/.cargo/bin:$PATH" cargo test -p aube-registry test_config_global_auth_token
- PATH="$HOME/.cargo/bin:$PATH" cargo test -p aube-codes

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication and credential scoping for all registry traffic; mis-pinned tokens could break private registries or alter who receives secrets.
> 
> **Overview**
> **Unscoped registry credentials are no longer global fallbacks.** During `.npmrc` load, bare `_authToken`, `_auth`, username/password, `tokenHelper`, and client `cert`/`key` are rewritten into URI-scoped `auth_by_uri` entries for the **registry declared in the same config source** (user vs project vs env, etc.), with **`WARN_AUBE_UNSCOPED_AUTH_RESCOPED`** when that happens. Explicit `//host/:…` settings win over later unscoped values from the same layer; `ca` / `cafile` stay global.
> 
> **Runtime auth is tightened to match.** `NpmConfig::global_auth_token` is removed; `auth_token_for` only returns per-registry config. **`RegistryClient::authed` no longer sends a default-registry token to other hosts** (the old `same_host_as_default` / `OnceLock` path is deleted), closing token leakage to scoped registries or malicious tarball URLs.
> 
> Tests cover same-source registry pinning, override order, and TLS cert scoping; error-code docs include the new warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a70e5800d3a1d4923ec2d1938160115a0334db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->