### PR TITLE
security(lockfile): require remote tarball integrity

### DIFF
--- a/crates/aube-lockfile/src/pnpm/mod.rs
+++ b/crates/aube-lockfile/src/pnpm/mod.rs
@@ -26,12 +26,13 @@ fn http_url_host_and_path(url: &str) -> Option<(String, &str)> {
     let rest = url
         .strip_prefix("https://")
         .or_else(|| url.strip_prefix("http://"))?;
-    let before_query = rest
-        .split_once('?')
-        .map_or(rest, |(before, _)| before)
+    let before_query = rest.split_once('?').map_or(rest, |(before, _)| before);
+    let before_fragment = before_query
         .split_once('#')
-        .map_or(rest, |(before, _)| before);
-    let (authority, path) = before_query.split_once('/').unwrap_or((before_query, ""));
+        .map_or(before_query, |(before, _)| before);
+    let (authority, path) = before_fragment
+        .split_once('/')
+        .unwrap_or((before_fragment, ""));
     let host_port = authority
         .rsplit_once('@')
         .map_or(authority, |(_, host)| host);

--- a/crates/aube-lockfile/src/pnpm/mod.rs
+++ b/crates/aube-lockfile/src/pnpm/mod.rs
@@ -9,3 +9,39 @@ mod tests;
 
 pub use read::parse;
 pub use write::write;
+
+pub(super) fn tarball_url_is_hosted_git(url: &str) -> bool {
+    let Some((host, path)) = http_url_host_and_path(url) else {
+        return false;
+    };
+    match host.as_str() {
+        "codeload.github.com" | "npm.pkg.github.com" => true,
+        "gitlab.com" => path.contains("/-/archive/"),
+        "bitbucket.org" => path.contains("/get/"),
+        _ => false,
+    }
+}
+
+fn http_url_host_and_path(url: &str) -> Option<(String, &str)> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let before_query = rest
+        .split_once('?')
+        .map_or(rest, |(before, _)| before)
+        .split_once('#')
+        .map_or(rest, |(before, _)| before);
+    let (authority, path) = before_query.split_once('/').unwrap_or((before_query, ""));
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    let host = host_port
+        .split_once(':')
+        .map_or(host_port, |(host, _)| host)
+        .to_ascii_lowercase();
+    if host.is_empty() {
+        None
+    } else {
+        Some((host, path))
+    }
+}

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -661,12 +661,23 @@ fn resolution_requires_integrity(
         | Some(LocalSource::Portal(_))
         | Some(LocalSource::Git(_))
         | Some(LocalSource::Exec(_)) => false,
-        Some(LocalSource::RemoteTarball(t)) => !t.git_hosted,
+        Some(LocalSource::RemoteTarball(t)) => !t.git_hosted && !tarball_url_is_hosted_git(&t.url),
         None => resolution
             .tarball
             .as_deref()
-            .is_none_or(|t| t.starts_with("http://") || t.starts_with("https://")),
+            .is_some_and(|t| is_http_url(t) && !tarball_url_is_hosted_git(t)),
     }
+}
+
+fn is_http_url(url: &str) -> bool {
+    url.starts_with("http://") || url.starts_with("https://")
+}
+
+fn tarball_url_is_hosted_git(url: &str) -> bool {
+    url.contains("://codeload.github.com/")
+        || url.contains("://npm.pkg.github.com/")
+        || (url.contains("://gitlab.com/") && url.contains("/-/archive/"))
+        || (url.contains("://bitbucket.org/") && url.contains("/get/"))
 }
 
 fn git_commit_from_dep_path_version(version: &str) -> Option<&str> {

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -661,23 +661,18 @@ fn resolution_requires_integrity(
         | Some(LocalSource::Portal(_))
         | Some(LocalSource::Git(_))
         | Some(LocalSource::Exec(_)) => false,
-        Some(LocalSource::RemoteTarball(t)) => !t.git_hosted && !tarball_url_is_hosted_git(&t.url),
+        Some(LocalSource::RemoteTarball(t)) => {
+            !t.git_hosted && !super::tarball_url_is_hosted_git(&t.url)
+        }
         None => resolution
             .tarball
             .as_deref()
-            .is_some_and(|t| is_http_url(t) && !tarball_url_is_hosted_git(t)),
+            .is_some_and(|t| is_http_url(t) && !super::tarball_url_is_hosted_git(t)),
     }
 }
 
 fn is_http_url(url: &str) -> bool {
     url.starts_with("http://") || url.starts_with("https://")
-}
-
-fn tarball_url_is_hosted_git(url: &str) -> bool {
-    url.contains("://codeload.github.com/")
-        || url.contains("://npm.pkg.github.com/")
-        || (url.contains("://gitlab.com/") && url.contains("/-/archive/"))
-        || (url.contains("://bitbucket.org/") && url.contains("/get/"))
 }
 
 fn git_commit_from_dep_path_version(version: &str) -> Option<&str> {

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -493,6 +493,19 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             Some(LocalSource::RemoteTarball(_)) if !version_is_http_url => None,
             other => other,
         };
+        if integrity.is_none()
+            && resolution_requires_integrity(
+                pkg_info.and_then(|p| p.resolution.as_ref()),
+                &local_source,
+            )
+        {
+            return Err(Error::parse(
+                path,
+                format!(
+                    "lockfile entry {dep_path:?} has a remote tarball resolution without integrity"
+                ),
+            ));
+        }
 
         packages.insert(
             dep_path.clone(),
@@ -629,6 +642,31 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         extra_fields: BTreeMap::new(),
         workspace_extra_fields: BTreeMap::new(),
     })
+}
+
+fn resolution_requires_integrity(
+    resolution: Option<&super::raw::Resolution>,
+    local_source: &Option<LocalSource>,
+) -> bool {
+    let Some(resolution) = resolution else {
+        return false;
+    };
+    if resolution.integrity.is_some() || resolution.git_hosted {
+        return false;
+    }
+    match local_source {
+        Some(LocalSource::Tarball(_))
+        | Some(LocalSource::Directory(_))
+        | Some(LocalSource::Link(_))
+        | Some(LocalSource::Portal(_))
+        | Some(LocalSource::Git(_))
+        | Some(LocalSource::Exec(_)) => false,
+        Some(LocalSource::RemoteTarball(t)) => !t.git_hosted,
+        None => resolution
+            .tarball
+            .as_deref()
+            .is_none_or(|t| t.starts_with("http://") || t.starts_with("https://")),
+    }
 }
 
 fn git_commit_from_dep_path_version(version: &str) -> Option<&str> {

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -2556,6 +2556,36 @@ snapshots:
 }
 
 #[test]
+fn parser_rejects_remote_tarball_with_hosted_git_url_in_query() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &path,
+        r#"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      demo:
+        specifier: 1.0.0
+        version: 1.0.0
+packages:
+  demo@1.0.0:
+    resolution: {tarball: https://evil.example.com/demo.tgz?ref=://codeload.github.com/acme/demo/tar.gz/abcdef}
+snapshots:
+  demo@1.0.0: {}
+"#,
+    )
+    .unwrap();
+
+    let err = parse(&path).unwrap_err().to_string();
+    assert!(
+        err.contains("remote tarball resolution without integrity"),
+        "{err}"
+    );
+}
+
+#[test]
 fn parser_allows_git_hosted_tarball_resolution_without_integrity() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("pnpm-lock.yaml");

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -2557,11 +2557,16 @@ snapshots:
 
 #[test]
 fn parser_rejects_remote_tarball_with_hosted_git_url_in_query() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("pnpm-lock.yaml");
-    std::fs::write(
-        &path,
-        r#"
+    for tarball in [
+        "https://evil.example.com/demo.tgz?ref=://codeload.github.com/acme/demo/tar.gz/abcdef",
+        "https://gitlab.com/acme/demo/demo.tgz?redirect=/-/archive/main",
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &path,
+            format!(
+                r#"
 lockfileVersion: '9.0'
 importers:
   .:
@@ -2571,18 +2576,20 @@ importers:
         version: 1.0.0
 packages:
   demo@1.0.0:
-    resolution: {tarball: https://evil.example.com/demo.tgz?ref=://codeload.github.com/acme/demo/tar.gz/abcdef}
+    resolution: {{tarball: {tarball}}}
 snapshots:
-  demo@1.0.0: {}
+  demo@1.0.0: {{}}
 "#,
-    )
-    .unwrap();
+            ),
+        )
+        .unwrap();
 
-    let err = parse(&path).unwrap_err().to_string();
-    assert!(
-        err.contains("remote tarball resolution without integrity"),
-        "{err}"
-    );
+        let err = parse(&path).unwrap_err().to_string();
+        assert!(
+            err.contains("remote tarball resolution without integrity"),
+            "{tarball}: {err}"
+        );
+    }
 }
 
 #[test]

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -2523,11 +2523,13 @@ snapshots:
 
 #[test]
 fn parser_rejects_remote_tarball_resolution_without_integrity() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("pnpm-lock.yaml");
-    std::fs::write(
-        &path,
-        r#"
+    for scheme in ["http", "https"] {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pnpm-lock.yaml");
+        std::fs::write(
+            &path,
+            format!(
+                r#"
 lockfileVersion: '9.0'
 importers:
   .:
@@ -2537,18 +2539,20 @@ importers:
         version: 1.0.0
 packages:
   demo@1.0.0:
-    resolution: {tarball: https://registry.npmjs.org/demo/-/demo-1.0.0.tgz}
+    resolution: {{tarball: {scheme}://registry.npmjs.org/demo/-/demo-1.0.0.tgz}}
 snapshots:
-  demo@1.0.0: {}
+  demo@1.0.0: {{}}
 "#,
-    )
-    .unwrap();
+            ),
+        )
+        .unwrap();
 
-    let err = parse(&path).unwrap_err().to_string();
-    assert!(
-        err.contains("remote tarball resolution without integrity"),
-        "{err}"
-    );
+        let err = parse(&path).unwrap_err().to_string();
+        assert!(
+            err.contains("remote tarball resolution without integrity"),
+            "{scheme}: {err}"
+        );
+    }
 }
 
 #[test]

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -2522,6 +2522,62 @@ snapshots:
 }
 
 #[test]
+fn parser_rejects_remote_tarball_resolution_without_integrity() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &path,
+        r#"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      demo:
+        specifier: 1.0.0
+        version: 1.0.0
+packages:
+  demo@1.0.0:
+    resolution: {tarball: https://registry.npmjs.org/demo/-/demo-1.0.0.tgz}
+snapshots:
+  demo@1.0.0: {}
+"#,
+    )
+    .unwrap();
+
+    let err = parse(&path).unwrap_err().to_string();
+    assert!(
+        err.contains("remote tarball resolution without integrity"),
+        "{err}"
+    );
+}
+
+#[test]
+fn parser_allows_git_hosted_tarball_resolution_without_integrity() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &path,
+        r#"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      demo:
+        specifier: 1.0.0
+        version: 1.0.0
+packages:
+  demo@1.0.0:
+    resolution: {tarball: https://codeload.github.com/acme/demo/tar.gz/abcdef, gitHosted: true}
+snapshots:
+  demo@1.0.0: {}
+"#,
+    )
+    .unwrap();
+
+    parse(&path).unwrap();
+}
+
+#[test]
 fn parser_expands_transitive_git_resolution_commit_from_dep_path() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("pnpm-lock.yaml");

--- a/crates/aube-lockfile/src/pnpm/write.rs
+++ b/crates/aube-lockfile/src/pnpm/write.rs
@@ -271,7 +271,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 } else {
                     Some(t.integrity.clone())
                 },
-                git_hosted: t.git_hosted || tarball_url_is_hosted_git(&t.url),
+                git_hosted: t.git_hosted || super::tarball_url_is_hosted_git(&t.url),
                 directory: None,
                 tarball: Some(t.url.clone()),
                 commit: None,
@@ -291,7 +291,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                         || pkg
                             .tarball_url
                             .as_deref()
-                            .is_some_and(tarball_url_is_hosted_git),
+                            .is_some_and(super::tarball_url_is_hosted_git),
                     directory: None,
                     tarball: pkg.tarball_url.clone(),
                     commit: None,
@@ -306,7 +306,7 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                     || pkg
                         .tarball_url
                         .as_deref()
-                        .is_some_and(tarball_url_is_hosted_git),
+                        .is_some_and(super::tarball_url_is_hosted_git),
                 directory: None,
                 // Emit the full registry tarball URL when the setting
                 // opts in. JSR packages are the exception: npm.jsr.io
@@ -531,13 +531,6 @@ fn registry_tarball_url_is_not_derivable(
         .split_once('#')
         .map_or(path_only, |(path, _)| path);
     !path_only.ends_with(&expected_suffix)
-}
-
-fn tarball_url_is_hosted_git(url: &str) -> bool {
-    url.contains("://codeload.github.com/")
-        || url.contains("://npm.pkg.github.com/")
-        || (url.contains("://gitlab.com/") && url.contains("/-/archive/"))
-        || (url.contains("://bitbucket.org/") && url.contains("/get/"))
 }
 
 fn pruned_time_entries(


### PR DESCRIPTION
## Summary
- reject pnpm/aube lockfile entries that resolve remote HTTP tarballs without `integrity`
- keep git-hosted tarball resolutions exempt because their commit anchors the bytes

## Tests
- PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check
- PATH="$HOME/.cargo/bin:$PATH" cargo test -p aube-lockfile parser_rejects_remote_tarball_resolution_without_integrity
- PATH="$HOME/.cargo/bin:$PATH" cargo test -p aube-lockfile parser_allows_git_hosted_tarball_resolution_without_integrity

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes lockfile acceptance rules for supply-chain security; misclassification of hosted-git vs registry tarballs could reject valid lockfiles or still allow bad entries.
> 
> **Overview**
> **pnpm lockfile parsing now fails** when a package resolves to a remote **HTTP/HTTPS tarball** without an **`integrity`** field, so installs cannot trust unverified registry (or arbitrary URL) bytes from the lockfile alone.
> 
> **Git-hosted tarballs stay allowed** without integrity when `gitHosted` is set or the tarball URL is recognized as hosted Git (e.g. `codeload.github.com`, `npm.pkg.github.com`, GitLab `/-/archive/`, Bitbucket `/get/`). Detection was **centralized** in `pnpm/mod.rs` with proper URL host/path parsing (query/fragment stripped) instead of naive substring checks in the writer—closing cases where a malicious URL smuggles a hosted-git pattern in the query.
> 
> Writer paths now call the shared **`tarball_url_is_hosted_git`** helper. Tests cover rejection of bare registry tarballs, query-string bypass attempts, and acceptance of explicit `gitHosted` resolutions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d93aa52d1ba433eca8fcc5410bc5c1c75e6db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->