### PR TITLE
fix(install): enforce release age during frozen installs

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -15,6 +15,7 @@ use crate::CodeMeta;
 pub const ERR_AUBE_NO_LOCKFILE: &str = "ERR_AUBE_NO_LOCKFILE";
 pub const ERR_AUBE_LOCKFILE_PARSE: &str = "ERR_AUBE_LOCKFILE_PARSE";
 pub const ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT: &str = "ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT";
+pub const ERR_AUBE_LOCKFILE_POLICY: &str = "ERR_AUBE_LOCKFILE_POLICY";
 
 // ── resolver ─────────────────────────────────────────────────────────
 pub const ERR_AUBE_NO_MATCHING_VERSION: &str = "ERR_AUBE_NO_MATCHING_VERSION";
@@ -131,6 +132,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::LOCKFILE,
         description: "Lockfile filename was recognized but its format isn't supported on this aube version.",
         exit_code: Some(12),
+    },
+    CodeMeta {
+        name: ERR_AUBE_LOCKFILE_POLICY,
+        category: category::LOCKFILE,
+        description: "Lockfile entries failed an active supply-chain policy check.",
+        exit_code: Some(13),
     },
     // Resolver
     CodeMeta {

--- a/crates/aube/src/commands/install/lockfile_policy.rs
+++ b/crates/aube/src/commands/install/lockfile_policy.rs
@@ -57,13 +57,21 @@ pub(super) async fn verify_frozen_lockfile_policy(
             });
         }
         while let Some(result) = tasks.join_next().await {
-            let (_name, versions, fetched_times) = result.into_diagnostic()??;
+            let (name, versions, fetched_times) = result.into_diagnostic()??;
+            let mut unresolved_versions = Vec::new();
             for key in versions {
-                if let Some((_, version)) = key.rsplit_once('@')
-                    && let Some(published_at) = fetched_times.get(version)
-                {
-                    times.insert(key, published_at.clone());
+                if let Some((_, version)) = key.rsplit_once('@') {
+                    if let Some(published_at) = fetched_times.get(version) {
+                        times.insert(key, published_at.clone());
+                    } else {
+                        unresolved_versions.push(version.to_string());
+                    }
                 }
+            }
+            if !unresolved_versions.is_empty() {
+                unresolved_versions.sort();
+                unresolved_versions.dedup();
+                return Err(unverifiable_times_error(&name, &unresolved_versions));
             }
         }
     }
@@ -104,6 +112,21 @@ fn missing_times_error(name: &str, count: usize) -> miette::Report {
     )
 }
 
+fn unverifiable_times_error(name: &str, versions: &[String]) -> miette::Report {
+    let shown = versions.iter().take(12).cloned().collect::<Vec<_>>();
+    let mut detail = shown.join(", ");
+    if versions.len() > shown.len() {
+        detail.push_str(&format!(", ... and {} more", versions.len() - shown.len()));
+    }
+    miette!(
+        code = aube_codes::errors::ERR_AUBE_LOCKFILE_POLICY,
+        help = "check whether the configured registry publishes per-version time metadata, or set minimumReleaseAge=0 to disable this policy",
+        "cannot verify minimumReleaseAge for {name}: registry metadata has no publish time for version{} {}",
+        if versions.len() == 1 { "" } else { "s" },
+        detail,
+    )
+}
+
 fn missing_time_entries(
     graph: &LockfileGraph,
     mra: &MinimumReleaseAge,
@@ -114,12 +137,11 @@ fn missing_time_entries(
         if pkg.local_source.is_some() || is_excluded(mra, pkg.name.as_str(), pkg.registry_name()) {
             continue;
         }
-        let key = time_key(pkg.registry_name(), &pkg.version);
-        if !times.contains_key(&key) {
+        if locked_time(times, pkg.name.as_str(), pkg.registry_name(), &pkg.version).is_none() {
             missing
                 .entry(pkg.registry_name().to_string())
                 .or_default()
-                .insert(key);
+                .insert(time_key(pkg.name.as_str(), &pkg.version));
         }
     }
     missing
@@ -137,11 +159,13 @@ fn minimum_release_age_violations(
         if pkg.local_source.is_some() || is_excluded(mra, pkg.name.as_str(), pkg.registry_name()) {
             continue;
         }
-        let key = time_key(pkg.registry_name(), &pkg.version);
-        if !seen.insert(key.clone()) {
+        let dedupe_key = time_key(pkg.name.as_str(), &pkg.version);
+        if !seen.insert(dedupe_key) {
             continue;
         }
-        let Some(published_at) = times.get(&key) else {
+        let Some(published_at) =
+            locked_time(times, pkg.name.as_str(), pkg.registry_name(), &pkg.version)
+        else {
             continue;
         };
         if published_at.as_str() > cutoff {
@@ -153,6 +177,17 @@ fn minimum_release_age_violations(
         }
     }
     violations
+}
+
+fn locked_time<'a>(
+    times: &'a BTreeMap<String, String>,
+    display_name: &str,
+    registry_name: &str,
+    version: &str,
+) -> Option<&'a String> {
+    times
+        .get(&time_key(display_name, version))
+        .or_else(|| times.get(&time_key(registry_name, version)))
 }
 
 fn time_key(name: &str, version: &str) -> String {
@@ -209,5 +244,21 @@ mod tests {
         let violations =
             minimum_release_age_violations(&graph, &mra, "2026-05-25T17:04:21.482Z", &graph.times);
         assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn alias_uses_display_name_time_key() {
+        let mut graph = graph_with("demo-alias", "1.0.0", "2026-05-28T08:12:56.230Z");
+        graph.packages.get_mut("demo-alias@1.0.0").unwrap().alias_of = Some("demo".to_string());
+        let mra = MinimumReleaseAge {
+            minutes: 1,
+            exclude: BTreeSet::new().into_iter().collect(),
+            strict: false,
+        };
+        assert!(missing_time_entries(&graph, &mra, &graph.times).is_empty());
+        let violations =
+            minimum_release_age_violations(&graph, &mra, "2026-05-25T17:04:21.482Z", &graph.times);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].name, "demo");
     }
 }

--- a/crates/aube/src/commands/install/lockfile_policy.rs
+++ b/crates/aube/src/commands/install/lockfile_policy.rs
@@ -1,0 +1,191 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use aube_lockfile::LockfileGraph;
+use aube_resolver::MinimumReleaseAge;
+use miette::{Context, IntoDiagnostic, miette};
+use tokio::task::JoinSet;
+
+use super::settings;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AgeViolation {
+    name: String,
+    version: String,
+    published_at: String,
+}
+
+pub(super) async fn verify_frozen_lockfile_policy(
+    cwd: &std::path::Path,
+    graph: &LockfileGraph,
+    settings_ctx: &aube_settings::ResolveCtx<'_>,
+    network_mode: aube_registry::NetworkMode,
+) -> miette::Result<()> {
+    let Some(mra) = settings::resolve_minimum_release_age(settings_ctx, None) else {
+        return Ok(());
+    };
+    let Some(cutoff) = mra.cutoff() else {
+        return Ok(());
+    };
+
+    let mut times = graph.times.clone();
+    let missing = missing_time_entries(graph, &mra, &times);
+    if !missing.is_empty() {
+        let client =
+            std::sync::Arc::new(crate::commands::make_client(cwd).with_network_mode(network_mode));
+        let cache_dir = crate::commands::packument_full_cache_dir();
+        let mut tasks = JoinSet::new();
+        for (name, versions) in missing {
+            let client = client.clone();
+            let cache_dir = cache_dir.clone();
+            tasks.spawn(async move {
+                let packument = client
+                    .fetch_packument_with_time_cached(&name, &cache_dir)
+                    .await
+                    .wrap_err_with(|| format!("failed to fetch metadata for {name}"))?;
+                Ok::<_, miette::Report>((name, versions, packument.time))
+            });
+        }
+        while let Some(result) = tasks.join_next().await {
+            let (_name, versions, fetched_times) = result.into_diagnostic()??;
+            for key in versions {
+                if let Some((_, version)) = key.rsplit_once('@')
+                    && let Some(published_at) = fetched_times.get(version)
+                {
+                    times.insert(key, published_at.clone());
+                }
+            }
+        }
+    }
+
+    let violations = minimum_release_age_violations(graph, &mra, &cutoff, &times);
+    if violations.is_empty() {
+        return Ok(());
+    }
+
+    let mut lines = Vec::with_capacity(violations.len().min(12) + 1);
+    for v in violations.iter().take(12) {
+        lines.push(format!(
+            "  {}@{} was published at {}, within the minimumReleaseAge cutoff ({cutoff})",
+            v.name, v.version, v.published_at
+        ));
+    }
+    if violations.len() > lines.len() {
+        lines.push(format!("  ... and {} more", violations.len() - lines.len()));
+    }
+    Err(miette!(
+        code = aube_codes::errors::ERR_AUBE_LOCKFILE_POLICY,
+        help = "inspect recent lockfile changes before trusting them; if expected, regenerate the lockfile from a fresh resolution or relax minimumReleaseAge",
+        "lockfile failed supply-chain policy check ({} entr{}):\n{}",
+        violations.len(),
+        if violations.len() == 1 { "y" } else { "ies" },
+        lines.join("\n")
+    ))
+}
+
+fn missing_time_entries(
+    graph: &LockfileGraph,
+    mra: &MinimumReleaseAge,
+    times: &BTreeMap<String, String>,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut missing: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for pkg in graph.packages.values() {
+        if pkg.local_source.is_some() || is_excluded(mra, pkg.name.as_str(), pkg.registry_name()) {
+            continue;
+        }
+        let key = time_key(pkg.registry_name(), &pkg.version);
+        if !times.contains_key(&key) {
+            missing
+                .entry(pkg.registry_name().to_string())
+                .or_default()
+                .insert(key);
+        }
+    }
+    missing
+}
+
+fn minimum_release_age_violations(
+    graph: &LockfileGraph,
+    mra: &MinimumReleaseAge,
+    cutoff: &str,
+    times: &BTreeMap<String, String>,
+) -> Vec<AgeViolation> {
+    let mut seen = BTreeSet::new();
+    let mut violations = Vec::new();
+    for pkg in graph.packages.values() {
+        if pkg.local_source.is_some() || is_excluded(mra, pkg.name.as_str(), pkg.registry_name()) {
+            continue;
+        }
+        let key = time_key(pkg.registry_name(), &pkg.version);
+        if !seen.insert(key.clone()) {
+            continue;
+        }
+        let Some(published_at) = times.get(&key) else {
+            continue;
+        };
+        if published_at.as_str() > cutoff {
+            violations.push(AgeViolation {
+                name: pkg.registry_name().to_string(),
+                version: pkg.version.clone(),
+                published_at: published_at.clone(),
+            });
+        }
+    }
+    violations
+}
+
+fn time_key(name: &str, version: &str) -> String {
+    format!("{name}@{version}")
+}
+
+fn is_excluded(mra: &MinimumReleaseAge, display_name: &str, registry_name: &str) -> bool {
+    mra.exclude.contains(display_name) || mra.exclude.contains(registry_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aube_lockfile::LockedPackage;
+
+    fn graph_with(name: &str, version: &str, published_at: &str) -> LockfileGraph {
+        let mut graph = LockfileGraph::default();
+        let dep_path = format!("{name}@{version}");
+        graph.packages.insert(
+            dep_path.clone(),
+            LockedPackage {
+                name: name.to_string(),
+                version: version.to_string(),
+                dep_path: dep_path.clone(),
+                ..LockedPackage::default()
+            },
+        );
+        graph.times.insert(dep_path, published_at.to_string());
+        graph
+    }
+
+    #[test]
+    fn flags_locked_package_inside_cutoff() {
+        let graph = graph_with("demo", "1.0.0", "2026-05-28T08:12:56.230Z");
+        let mra = MinimumReleaseAge {
+            minutes: 1,
+            exclude: BTreeSet::new().into_iter().collect(),
+            strict: false,
+        };
+        let violations =
+            minimum_release_age_violations(&graph, &mra, "2026-05-25T17:04:21.482Z", &graph.times);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].name, "demo");
+    }
+
+    #[test]
+    fn exclude_skips_locked_package() {
+        let graph = graph_with("demo", "1.0.0", "2026-05-28T08:12:56.230Z");
+        let mra = MinimumReleaseAge {
+            minutes: 1,
+            exclude: ["demo".to_string()].into_iter().collect(),
+            strict: false,
+        };
+        let violations =
+            minimum_release_age_violations(&graph, &mra, "2026-05-25T17:04:21.482Z", &graph.times);
+        assert!(violations.is_empty());
+    }
+}

--- a/crates/aube/src/commands/install/lockfile_policy.rs
+++ b/crates/aube/src/commands/install/lockfile_policy.rs
@@ -1,0 +1,213 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use aube_lockfile::LockfileGraph;
+use aube_resolver::MinimumReleaseAge;
+use miette::{IntoDiagnostic, miette};
+use tokio::task::JoinSet;
+
+use super::settings;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AgeViolation {
+    name: String,
+    version: String,
+    published_at: String,
+}
+
+pub(super) async fn verify_frozen_lockfile_policy(
+    cwd: &std::path::Path,
+    graph: &LockfileGraph,
+    settings_ctx: &aube_settings::ResolveCtx<'_>,
+    network_mode: aube_registry::NetworkMode,
+) -> miette::Result<()> {
+    let Some(mra) = settings::resolve_minimum_release_age(settings_ctx, None) else {
+        return Ok(());
+    };
+    let Some(cutoff) = mra.cutoff() else {
+        return Ok(());
+    };
+
+    // `minimumReleaseAgeStrict=false` is a resolver fallback knob: when every
+    // satisfying candidate is too new, fresh resolution may pick the lowest
+    // satisfying version. Frozen installs do not have candidate ranges in hand
+    // and cannot re-resolve safely, so the lockfile verification mirrors pnpm's
+    // CI policy check and treats locked versions after the cutoff as rejected.
+    let mut times = graph.times.clone();
+    let missing = missing_time_entries(graph, &mra, &times);
+    if !missing.is_empty() {
+        let client =
+            std::sync::Arc::new(crate::commands::make_client(cwd).with_network_mode(network_mode));
+        let cache_dir = crate::commands::packument_full_cache_dir();
+        let mut tasks = JoinSet::new();
+        for (name, versions) in missing {
+            let client = client.clone();
+            let cache_dir = cache_dir.clone();
+            tasks.spawn(async move {
+                let packument = client
+                    .fetch_packument_with_time_cached(&name, &cache_dir)
+                    .await
+                    .map_err(|err| match err {
+                        aube_registry::Error::Offline(_) => {
+                            missing_times_error(&name, versions.len())
+                        }
+                        other => miette::Report::new(other)
+                            .wrap_err(format!("failed to fetch metadata for {name}")),
+                    })?;
+                Ok::<_, miette::Report>((name, versions, packument.time))
+            });
+        }
+        while let Some(result) = tasks.join_next().await {
+            let (_name, versions, fetched_times) = result.into_diagnostic()??;
+            for key in versions {
+                if let Some((_, version)) = key.rsplit_once('@')
+                    && let Some(published_at) = fetched_times.get(version)
+                {
+                    times.insert(key, published_at.clone());
+                }
+            }
+        }
+    }
+
+    let violations = minimum_release_age_violations(graph, &mra, &cutoff, &times);
+    if violations.is_empty() {
+        return Ok(());
+    }
+
+    let mut lines = Vec::with_capacity(violations.len().min(12) + 1);
+    for v in violations.iter().take(12) {
+        lines.push(format!(
+            "  {}@{} was published at {}, within the minimumReleaseAge cutoff ({cutoff})",
+            v.name, v.version, v.published_at
+        ));
+    }
+    if violations.len() > lines.len() {
+        lines.push(format!("  ... and {} more", violations.len() - lines.len()));
+    }
+    Err(miette!(
+        code = aube_codes::errors::ERR_AUBE_LOCKFILE_POLICY,
+        help = "inspect recent lockfile changes before trusting them; if expected, regenerate the lockfile from a fresh resolution or relax minimumReleaseAge",
+        "lockfile failed supply-chain policy check ({} entr{}):\n{}",
+        violations.len(),
+        if violations.len() == 1 { "y" } else { "ies" },
+        lines.join("\n")
+    ))
+}
+
+fn missing_times_error(name: &str, count: usize) -> miette::Report {
+    miette!(
+        code = aube_codes::errors::ERR_AUBE_LOCKFILE_POLICY,
+        help = "run once with network access so aube can verify publish times, or set minimumReleaseAge=0 to disable this policy",
+        "cannot verify minimumReleaseAge for {name}: lockfile is missing publish time{} for {} entr{} and network mode is offline",
+        if count == 1 { "" } else { "s" },
+        count,
+        if count == 1 { "y" } else { "ies" },
+    )
+}
+
+fn missing_time_entries(
+    graph: &LockfileGraph,
+    mra: &MinimumReleaseAge,
+    times: &BTreeMap<String, String>,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut missing: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for pkg in graph.packages.values() {
+        if pkg.local_source.is_some() || is_excluded(mra, pkg.name.as_str(), pkg.registry_name()) {
+            continue;
+        }
+        let key = time_key(pkg.registry_name(), &pkg.version);
+        if !times.contains_key(&key) {
+            missing
+                .entry(pkg.registry_name().to_string())
+                .or_default()
+                .insert(key);
+        }
+    }
+    missing
+}
+
+fn minimum_release_age_violations(
+    graph: &LockfileGraph,
+    mra: &MinimumReleaseAge,
+    cutoff: &str,
+    times: &BTreeMap<String, String>,
+) -> Vec<AgeViolation> {
+    let mut seen = BTreeSet::new();
+    let mut violations = Vec::new();
+    for pkg in graph.packages.values() {
+        if pkg.local_source.is_some() || is_excluded(mra, pkg.name.as_str(), pkg.registry_name()) {
+            continue;
+        }
+        let key = time_key(pkg.registry_name(), &pkg.version);
+        if !seen.insert(key.clone()) {
+            continue;
+        }
+        let Some(published_at) = times.get(&key) else {
+            continue;
+        };
+        if published_at.as_str() > cutoff {
+            violations.push(AgeViolation {
+                name: pkg.registry_name().to_string(),
+                version: pkg.version.clone(),
+                published_at: published_at.clone(),
+            });
+        }
+    }
+    violations
+}
+
+fn time_key(name: &str, version: &str) -> String {
+    format!("{name}@{version}")
+}
+
+fn is_excluded(mra: &MinimumReleaseAge, display_name: &str, registry_name: &str) -> bool {
+    mra.exclude.contains(display_name) || mra.exclude.contains(registry_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aube_lockfile::LockedPackage;
+
+    fn graph_with(name: &str, version: &str, published_at: &str) -> LockfileGraph {
+        let mut graph = LockfileGraph::default();
+        let dep_path = format!("{name}@{version}");
+        graph.packages.insert(
+            dep_path.clone(),
+            LockedPackage {
+                name: name.to_string(),
+                version: version.to_string(),
+                dep_path: dep_path.clone(),
+                ..LockedPackage::default()
+            },
+        );
+        graph.times.insert(dep_path, published_at.to_string());
+        graph
+    }
+
+    #[test]
+    fn rejects_package_published_after_cutoff() {
+        let graph = graph_with("demo", "1.0.0", "2026-05-28T08:12:56.230Z");
+        let mra = MinimumReleaseAge {
+            minutes: 1,
+            exclude: BTreeSet::new().into_iter().collect(),
+            strict: false,
+        };
+        let violations =
+            minimum_release_age_violations(&graph, &mra, "2026-05-25T17:04:21.482Z", &graph.times);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].name, "demo");
+    }
+
+    #[test]
+    fn exclude_skips_locked_package() {
+        let graph = graph_with("demo", "1.0.0", "2026-05-28T08:12:56.230Z");
+        let mra = MinimumReleaseAge {
+            minutes: 1,
+            exclude: ["demo".to_string()].into_iter().collect(),
+            strict: false,
+        };
+        let violations =
+            minimum_release_age_violations(&graph, &mra, "2026-05-25T17:04:21.482Z", &graph.times);
+        assert!(violations.is_empty());
+    }
+}

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -19,6 +19,7 @@ mod layout;
 mod lifecycle;
 mod link;
 mod lockfile_dir;
+mod lockfile_policy;
 mod materialize;
 pub(crate) mod node_gyp_bootstrap;
 mod resolve;
@@ -571,6 +572,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // each package's ancestor path.
             crate::dep_chain::set_active(&graph);
             aube_registry::slow_metadata::flush_summary();
+
+            if matches!(mode, FrozenMode::Frozen) {
+                lockfile_policy::verify_frozen_lockfile_policy(
+                    &cwd,
+                    &graph,
+                    &settings_ctx,
+                    opts.network_mode,
+                )
+                .await?;
+            }
 
             // Post-resolve OSV `MAL-*` routing — lockfile-found
             // branch. `fresh_resolution = false` here because the

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -573,7 +573,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             crate::dep_chain::set_active(&graph);
             aube_registry::slow_metadata::flush_summary();
 
-            if matches!(mode, FrozenMode::Frozen) {
+            if matches!(mode, FrozenMode::Frozen | FrozenMode::Prefer) {
                 lockfile_policy::verify_frozen_lockfile_policy(
                     &cwd,
                     &graph,

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -74,7 +74,7 @@ fn map_resolution_mode(
 /// build-time-generated typed accessors in `aube_settings::resolved`
 /// — `.npmrc` first, then `pnpm-workspace.yaml`. CLI override
 /// (currently always `None`, no flag yet) wins over both.
-fn resolve_minimum_release_age(
+pub(super) fn resolve_minimum_release_age(
     ctx: &aube_settings::ResolveCtx<'_>,
     cli_minutes: Option<u64>,
 ) -> Option<aube_resolver::MinimumReleaseAge> {

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -19,6 +19,12 @@
       "exit_code": 12
     },
     {
+      "name": "ERR_AUBE_LOCKFILE_POLICY",
+      "category": "Lockfile",
+      "description": "Lockfile entries failed an active supply-chain policy check.",
+      "exit_code": 13
+    },
+    {
       "name": "ERR_AUBE_NO_MATCHING_VERSION",
       "category": "Resolver",
       "description": "No published version of the named package satisfies the requested range.",


### PR DESCRIPTION
## Summary
- verify frozen lockfile installs against active minimumReleaseAge policy
- fetch full packument metadata for missing lockfile time entries before checking the cutoff
- add ERR_AUBE_LOCKFILE_POLICY for rejected lockfile policy violations

## Tests
- cargo test -p aube lockfile_policy
- cargo test -p aube-codes
- cargo check -p aube
- cargo clippy -p aube --all-targets -- -D warnings
- cargo fmt --check

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI/frozen install behavior when minimumReleaseAge is enabled: installs can fail on otherwise-valid lockfiles or require network for missing publish times, though policy is skipped when the setting is off.
> 
> **Overview**
> **Frozen and prefer-lockfile installs** now run a **minimumReleaseAge** check on the parsed lockfile before fetch, aligned with pnpm-style CI policy: locked versions published after the cutoff fail even when `minimumReleaseAgeStrict=false` (that flag only affects fresh resolution fallback).
> 
> A new **`lockfile_policy`** module walks locked packages (skipping local sources and excluded names), compares publish times to the cutoff, and **fetches full packuments in parallel** when `time` entries are missing. Failures use **`ERR_AUBE_LOCKFILE_POLICY`** (exit **13**), including offline installs that cannot backfill times and registries without per-version `time` metadata.
> 
> **`resolve_minimum_release_age`** is exposed as `pub(super)` so the verifier shares the same settings resolution as the resolver. Error registry and **`docs/error-codes.data.json`** document the new code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee4b73d606c56498f005e97000e64f2d391f6d21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->