### PR TITLE
test(publish): remove smoke cache

### DIFF
--- a/.github/workflows/publish-smoke.yml
+++ b/.github/workflows/publish-smoke.yml
@@ -65,9 +65,10 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] manual dispatch only; writes are limited to main
         with:
-          cache: rust
+          shared-key: publish-smoke
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build aube
         run: cargo build -p aube

--- a/.github/workflows/publish-smoke.yml
+++ b/.github/workflows/publish-smoke.yml
@@ -65,11 +65,6 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] manual dispatch only; writes are limited to main
-        with:
-          shared-key: publish-smoke
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
       - name: Build aube
         run: cargo build -p aube
 


### PR DESCRIPTION
## Summary
- Remove caching from the manual npm publish smoke workflow
- Keep the workflow focused on building aube and exercising the real npm publish paths

## Why
The first merged smoke test run failed before building or publishing because `namespacelabs/nscloud-cache-action` requires Namespace runner cache labels, but the manual smoke workflow runs on `ubuntu-latest`: https://github.com/endevco/aube/actions/runs/26619466525

Because this workflow only runs through `workflow_dispatch`, it does not need cache configuration at all.

## Test
- `mise x actionlint -- actionlint .github/workflows/publish-smoke.yml`

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to a manual smoke workflow; no application, auth, or publish logic is modified.
> 
> **Overview**
> Removes the **`namespacelabs/nscloud-cache-action`** step (including its Rust cache config) from the manual **publish-smoke** workflow.
> 
> That action expects Namespace runner cache labels, but this job runs on **`ubuntu-latest`**, which caused the workflow to fail before **aube** was built or npm publish was exercised. The smoke path is **`workflow_dispatch`** only, so dropping cache keeps the job aligned with a plain GitHub-hosted runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7926785b303f17b66dc82bd619c29fba0e25ee53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->