### PR TITLE
fix(publish): normalize semver metadata

### DIFF
--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -212,6 +212,8 @@ struct PackedFile {
     rel: String,
     /// File size captured while collecting the packlist.
     size: u64,
+    /// Optional in-memory content used when publish normalizes package.json.
+    data_override: Option<Vec<u8>>,
 }
 
 /// In-memory result of packing a project. Reused by `aube publish`,
@@ -234,6 +236,13 @@ pub(crate) struct BuiltArchive {
 /// `aube pack` (writes the bytes to disk) and the forthcoming
 /// `aube publish` (hashes and uploads them).
 pub(crate) fn build_archive(project_dir: &Path) -> miette::Result<BuiltArchive> {
+    build_archive_with_package_json(project_dir, None)
+}
+
+pub(crate) fn build_archive_with_package_json(
+    project_dir: &Path,
+    package_json: Option<Vec<u8>>,
+) -> miette::Result<BuiltArchive> {
     let manifest = PackageJson::from_path(&project_dir.join("package.json"))
         .map_err(miette::Report::new)
         .wrap_err("failed to read package.json")?;
@@ -248,7 +257,13 @@ pub(crate) fn build_archive(project_dir: &Path) -> miette::Result<BuiltArchive> 
         .ok_or_else(|| miette!("pack: package.json has no `version` field"))?
         .to_string();
 
-    let files = collect_files(project_dir, &manifest)?;
+    let mut files = collect_files(project_dir, &manifest)?;
+    if let Some(package_json) = package_json
+        && let Some(file) = files.iter_mut().find(|f| f.rel == "package.json")
+    {
+        file.size = package_json.len() as u64;
+        file.data_override = Some(package_json);
+    }
     let filename = tarball_filename(&name, &version);
     let unpacked_size = files.iter().map(|f| f.size).sum();
 
@@ -314,7 +329,12 @@ fn collect_files(project_dir: &Path, manifest: &PackageJson) -> miette::Result<V
             .into_diagnostic()
             .wrap_err_with(|| format!("pack: stat {}", abs.display()))?
             .len();
-        out.push(PackedFile { abs, rel, size });
+        out.push(PackedFile {
+            abs,
+            rel,
+            size,
+            data_override: None,
+        });
     }
     out.sort_by(|a, b| a.rel.cmp(&b.rel));
     Ok(out)
@@ -564,9 +584,12 @@ fn write_tarball<W: Write>(files: &[PackedFile], writer: W) -> miette::Result<()
     let mut builder = tar::Builder::new(gz);
 
     for packed in files {
-        let data = std::fs::read(&packed.abs)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to read {}", packed.abs.display()))?;
+        let data = match &packed.data_override {
+            Some(data) => data.clone(),
+            None => std::fs::read(&packed.abs)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("failed to read {}", packed.abs.display()))?,
+        };
         let mut header = tar::Header::new_gnu();
         header.set_size(data.len() as u64);
         header.set_mode(file_mode(&packed.abs));

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -198,7 +198,7 @@ pub(crate) async fn run_root_lifecycle_script(
 
 /// Sanitize a package name into the tarball filename stem.
 /// `@scope/foo` -> `scope-foo`, `foo` -> `foo`.
-fn tarball_filename(name: &str, version: &str) -> String {
+pub(crate) fn tarball_filename(name: &str, version: &str) -> String {
     let sanitized = name.replace('@', "").replace('/', "-");
     format!("{sanitized}-{version}.tgz")
 }

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -28,7 +28,7 @@
 //! "already published" error, leaving the registry itself to decide
 //! whether a republish is allowed.
 
-use crate::commands::pack::{BuiltArchive, build_archive};
+use crate::commands::pack::{BuiltArchive, build_archive, tarball_filename};
 use crate::commands::{encode_package_name, ensure_registry_auth};
 use aube_manifest::PackageJson;
 use aube_registry::client::RegistryClient;
@@ -380,16 +380,12 @@ async fn publish_one(
         .as_deref()
         .ok_or_else(|| miette!("publish: {}/package.json has no `name`", pkg_dir.display()))?
         .to_string();
-    let version = manifest
-        .version
-        .as_deref()
-        .ok_or_else(|| {
-            miette!(
-                "publish: {}/package.json has no `version`",
-                pkg_dir.display()
-            )
-        })?
-        .to_string();
+    let version = normalize_publish_version(manifest.version.as_deref().ok_or_else(|| {
+        miette!(
+            "publish: {}/package.json has no `version`",
+            pkg_dir.display()
+        )
+    })?);
 
     // publishConfig in package.json overrides both registry and tag
     // if the user has not passed CLI flags. pnpm and npm both honor
@@ -428,7 +424,8 @@ async fn publish_one(
         // hitting the registry, matching pnpm. `publish` / `postpublish`
         // are skipped — nothing was actually uploaded.
         run_publish_lifecycle_pre(pkg_dir, &manifest, args.ignore_scripts).await?;
-        let archive = build_archive(pkg_dir)?;
+        let mut archive = build_archive(pkg_dir)?;
+        normalize_archive_for_publish(&mut archive);
         super::pack::run_pack_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
         // `--dry-run --provenance` is a common "does my CI actually have
         // OIDC wired up?" smoke test. Silently skipping the OIDC probe
@@ -478,7 +475,8 @@ async fn publish_one(
     // every package is already on the registry, the loop never reaches
     // this point and the whole fanout is script-free and gzip-free.
     run_publish_lifecycle_pre(pkg_dir, &manifest, args.ignore_scripts).await?;
-    let archive = build_archive(pkg_dir)?;
+    let mut archive = build_archive(pkg_dir)?;
+    normalize_archive_for_publish(&mut archive);
     super::pack::run_pack_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
 
     // Re-read the manifest *after* the pre-pack chain. Publish-time
@@ -578,6 +576,20 @@ async fn publish_one(
         archive: Some(archive),
         status: PublishStatus::Published,
     })
+}
+
+fn normalize_archive_for_publish(archive: &mut BuiltArchive) {
+    let version = normalize_publish_version(&archive.version);
+    if version != archive.version {
+        archive.version = version;
+        archive.filename = tarball_filename(&archive.name, &archive.version);
+    }
+}
+
+fn normalize_publish_version(version: &str) -> String {
+    node_semver::Version::parse(version)
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| version.to_string())
 }
 
 #[derive(Debug, Deserialize)]
@@ -998,6 +1010,7 @@ fn build_publish_body(
     let obj = version_doc
         .as_object_mut()
         .ok_or_else(|| miette!("manifest did not serialize to a JSON object"))?;
+    obj.insert("version".into(), archive.version.clone().into());
     obj.insert(
         "_id".into(),
         format!("{}@{}", archive.name, archive.version).into(),
@@ -1269,6 +1282,52 @@ mod tests {
             json.get("integrity")
                 .and_then(|v| v.as_str())
                 .is_some_and(|s| s.starts_with("sha512-"))
+        );
+    }
+
+    #[test]
+    fn publish_normalizes_v_prefixed_semver_like_npm() {
+        assert_eq!(normalize_publish_version("v2026.5.16"), "2026.5.16");
+        assert_eq!(normalize_publish_version("1.2.3-beta.1"), "1.2.3-beta.1");
+        assert_eq!(normalize_publish_version("not-semver"), "not-semver");
+    }
+
+    #[test]
+    fn publish_body_uses_normalized_version_for_registry_metadata() {
+        let mut archive = BuiltArchive {
+            name: "@jdxcode/mise-linux-x64".to_string(),
+            version: "v2026.5.16".to_string(),
+            filename: "jdxcode-mise-linux-x64-v2026.5.16.tgz".to_string(),
+            files: vec!["package.json".to_string()],
+            unpacked_size: 42,
+            tarball: b"archive bytes".to_vec(),
+        };
+        normalize_archive_for_publish(&mut archive);
+
+        let manifest: PackageJson = serde_json::from_value(serde_json::json!({
+            "name": "@jdxcode/mise-linux-x64",
+            "version": "v2026.5.16"
+        }))
+        .unwrap();
+        let body = build_publish_body(
+            &archive,
+            &manifest,
+            "https://registry.npmjs.org/",
+            "latest",
+            Some("public"),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(archive.version, "2026.5.16");
+        assert_eq!(archive.filename, "jdxcode-mise-linux-x64-2026.5.16.tgz");
+        assert_eq!(body["dist-tags"]["latest"], "2026.5.16");
+        assert!(body["versions"].get("2026.5.16").is_some());
+        assert!(body["versions"].get("v2026.5.16").is_none());
+        assert_eq!(body["versions"]["2026.5.16"]["version"], "2026.5.16");
+        assert_eq!(
+            body["versions"]["2026.5.16"]["_id"],
+            "@jdxcode/mise-linux-x64@2026.5.16"
         );
     }
 

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -28,7 +28,9 @@
 //! "already published" error, leaving the registry itself to decide
 //! whether a republish is allowed.
 
-use crate::commands::pack::{BuiltArchive, build_archive, tarball_filename};
+use crate::commands::pack::{
+    BuiltArchive, build_archive, build_archive_with_package_json, tarball_filename,
+};
 use crate::commands::{encode_package_name, ensure_registry_auth};
 use aube_manifest::PackageJson;
 use aube_registry::client::RegistryClient;
@@ -424,8 +426,7 @@ async fn publish_one(
         // hitting the registry, matching pnpm. `publish` / `postpublish`
         // are skipped — nothing was actually uploaded.
         run_publish_lifecycle_pre(pkg_dir, &manifest, args.ignore_scripts).await?;
-        let mut archive = build_archive(pkg_dir)?;
-        normalize_archive_for_publish(&mut archive);
+        let archive = build_archive_for_publish(pkg_dir)?;
         super::pack::run_pack_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
         // `--dry-run --provenance` is a common "does my CI actually have
         // OIDC wired up?" smoke test. Silently skipping the OIDC probe
@@ -475,8 +476,7 @@ async fn publish_one(
     // every package is already on the registry, the loop never reaches
     // this point and the whole fanout is script-free and gzip-free.
     run_publish_lifecycle_pre(pkg_dir, &manifest, args.ignore_scripts).await?;
-    let mut archive = build_archive(pkg_dir)?;
-    normalize_archive_for_publish(&mut archive);
+    let archive = build_archive_for_publish(pkg_dir)?;
     super::pack::run_pack_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
 
     // Re-read the manifest *after* the pre-pack chain. Publish-time
@@ -584,6 +584,32 @@ fn normalize_archive_for_publish(archive: &mut BuiltArchive) {
         archive.version = version;
         archive.filename = tarball_filename(&archive.name, &archive.version);
     }
+}
+
+fn build_archive_for_publish(pkg_dir: &Path) -> miette::Result<BuiltArchive> {
+    let manifest_path = pkg_dir.join("package.json");
+    let manifest_bytes = std::fs::read(&manifest_path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to read {}", manifest_path.display()))?;
+    let mut manifest_json: serde_json::Value =
+        serde_json::from_slice(&manifest_bytes).into_diagnostic()?;
+    let Some(raw_version) = manifest_json.get("version").and_then(|v| v.as_str()) else {
+        return build_archive(pkg_dir);
+    };
+    let version = normalize_publish_version(raw_version);
+    if version == raw_version {
+        return build_archive(pkg_dir);
+    }
+
+    if let Some(obj) = manifest_json.as_object_mut() {
+        obj.insert("version".into(), version.into());
+    }
+    let mut package_json = serde_json::to_vec_pretty(&manifest_json).into_diagnostic()?;
+    package_json.push(b'\n');
+
+    let mut archive = build_archive_with_package_json(pkg_dir, Some(package_json))?;
+    normalize_archive_for_publish(&mut archive);
+    Ok(archive)
 }
 
 fn normalize_publish_version(version: &str) -> String {
@@ -1329,6 +1355,37 @@ mod tests {
             body["versions"]["2026.5.16"]["_id"],
             "@jdxcode/mise-linux-x64@2026.5.16"
         );
+    }
+
+    #[test]
+    fn publish_archive_embeds_normalized_package_json_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("package.json"),
+            r#"{"name":"@jdxcode/mise-linux-x64","version":"v2026.5.16"}"#,
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("README.md"), "mise").unwrap();
+
+        let archive = build_archive_for_publish(tmp.path()).unwrap();
+        let gz = flate2::read::GzDecoder::new(archive.tarball.as_slice());
+        let mut tar = tar::Archive::new(gz);
+        let mut package_json = None;
+        for entry in tar.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap() == std::path::Path::new("package/package.json") {
+                let mut contents = String::new();
+                std::io::Read::read_to_string(&mut entry, &mut contents).unwrap();
+                package_json = Some(contents);
+                break;
+            }
+        }
+        let package_json: serde_json::Value =
+            serde_json::from_str(&package_json.expect("package.json in tarball")).unwrap();
+
+        assert_eq!(archive.version, "2026.5.16");
+        assert_eq!(archive.filename, "jdxcode-mise-linux-x64-2026.5.16.tgz");
+        assert_eq!(package_json["version"], "2026.5.16");
     }
 
     #[test]

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -808,7 +808,9 @@ fn publish_failure_needs_otp(failure: &PublishHttpFailure) -> bool {
     body.contains("eotp")
         || body.contains("npm-otp")
         || body.contains("one-time password")
+        || body.contains("one-time pass")
         || body.contains("one time password")
+        || body.contains("one time pass")
         || (body.contains("otp") && requires)
         || (two_factor && requires)
 }
@@ -1137,6 +1139,16 @@ mod tests {
         let failure = PublishHttpFailure {
             status: reqwest::StatusCode::UNAUTHORIZED,
             body: r#"{"error":"EOTP","reason":"This operation requires a one-time password."}"#
+                .into(),
+        };
+        assert!(publish_failure_needs_otp(&failure));
+    }
+
+    #[test]
+    fn publish_failure_detects_npm_one_time_pass_challenge() {
+        let failure = PublishHttpFailure {
+            status: reqwest::StatusCode::UNAUTHORIZED,
+            body: r#"{"error":"You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA."}"#
                 .into(),
         };
         assert!(publish_failure_needs_otp(&failure));

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -153,8 +153,8 @@ _setup_workspace_fixture() {
 	run aube deploy --filter @test/lib ./out
 	assert_failure
 	# miette wraps the rendered error at ~80 cols; long temp-dir paths can
-	# split "is not empty", so match the stable tail of the message.
-	assert_output --partial "not empty"
+	# split "is not empty" at different points, so match a stable word.
+	assert_output --partial "empty"
 }
 
 @test "aube deploy: glob filter fans out across every match" {
@@ -189,8 +189,8 @@ _setup_workspace_fixture() {
 	run aube deploy --filter "@test/*" ./out
 	assert_failure
 	# miette wraps the rendered error at ~80 cols; long temp-dir paths can
-	# split "is not empty", so match the stable tail of the message.
-	assert_output --partial "not empty"
+	# split "is not empty" at different points, so match a stable word.
+	assert_output --partial "empty"
 }
 
 # Narrow @test/lib's publish surface to just package.json + index.js so

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -152,9 +152,9 @@ _setup_workspace_fixture() {
 
 	run aube deploy --filter @test/lib ./out
 	assert_failure
-	# miette wraps the rendered error at ~80 cols; "not empty" can split
-	# once the temp-dir path grows a digit, so match "is not" instead.
-	assert_output --partial "is not"
+	# miette wraps the rendered error at ~80 cols; long temp-dir paths can
+	# split "is not empty", so match the stable tail of the message.
+	assert_output --partial "not empty"
 }
 
 @test "aube deploy: glob filter fans out across every match" {
@@ -188,9 +188,9 @@ _setup_workspace_fixture() {
 
 	run aube deploy --filter "@test/*" ./out
 	assert_failure
-	# miette wraps the rendered error at ~80 cols; "not empty" can split
-	# once the temp-dir path grows a digit, so match "is not" instead.
-	assert_output --partial "is not"
+	# miette wraps the rendered error at ~80 cols; long temp-dir paths can
+	# split "is not empty", so match the stable tail of the message.
+	assert_output --partial "not empty"
 }
 
 # Narrow @test/lib's publish surface to just package.json + index.js so


### PR DESCRIPTION
## Summary
- Normalize npm publish-facing semver values before registry checks and PUT metadata
- Rebuild the publish tarball with normalized `package/package.json` bytes when package versions need npm-style cleaning
- Detect npm OTP challenges that say `one-time pass` and retry through the interactive OTP prompt
- Add regression coverage for the mise failure shape and npm OTP wording

## Why
Mise release packages use tags like `v2026.5.16` as `package.json#version`. `npm publish` auto-corrects that to `2026.5.16` in publish metadata and in the packed package JSON, but `aube publish` sent the raw `v...` value and npm rejected it with `New versions must be valid semver.`

The user-reported OTP path also failed because npm returns `You must provide a one-time pass...`, while aube only detected `one-time password` wording.

Latest failed mise run showing the semver regression: https://github.com/jdx/mise/actions/runs/26599017929

Discussion report for the OTP prompt UX: https://github.com/endevco/aube/discussions/345#discussioncomment-17049217

## Test
- `cargo test -p aube commands::publish::tests::`
- Local OTP publish without `--otp` prompted after npm challenge and published `@endevco/aube-publish-otp-smoke@0.0.0-interactive.1780033846`

This PR was generated by an AI coding assistant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes publish tarball contents and registry version keys (behavioral fix aligned with npm); OTP heuristics are slightly broader but still gated on 401/403.
> 
> **Overview**
> **Publish** now normalizes semver the way npm does before registry checks, tarball naming, and PUT metadata. Versions like `v2026.5.16` are parsed with `node_semver` to `2026.5.16`; when that changes the on-disk string, publish rebuilds the archive via `build_archive_with_package_json` so `package/package.json` inside the `.tgz` and `versions.<v>` / dist-tags in the publish body all use the cleaned version (fixes npm’s “New versions must be valid semver” for mise-style tags).
> 
> **Pack** gains optional in-memory `package.json` bytes (`data_override` on packed files) so publish can ship normalized manifest content without rewriting the workspace file.
> 
> **OTP retry** detection now treats npm’s `one-time pass` / `one time pass` challenges like existing `one-time password` wording, so interactive OTP prompt works on current npm 2FA errors.
> 
> **Tests**: unit coverage for normalization, publish body keys, tarball contents, and OTP phrasing; deploy bats assert on `empty` instead of `is not` when miette wraps long paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8242f4eeccbc4d8267876b73d497730e4d8460b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->