### PR TITLE
feat(linker): add hoisting limits

### DIFF
--- a/crates/aube-linker/src/builder.rs
+++ b/crates/aube-linker/src/builder.rs
@@ -5,7 +5,9 @@ use aube_lockfile::graph_hash::GraphHashes;
 use aube_store::Store;
 use std::path::{Path, PathBuf};
 
-use crate::{LinkStrategy, Linker, NodeLinker, Patches, default_linker_parallelism};
+use crate::{
+    HoistingLimits, LinkStrategy, Linker, NodeLinker, Patches, default_linker_parallelism,
+};
 
 impl Linker {
     pub fn new(store: &Store, strategy: LinkStrategy) -> Self {
@@ -32,6 +34,7 @@ impl Linker {
             hoist_patterns: vec![glob::Pattern::new("*").expect("'*' is a valid glob pattern")],
             hoist_negations: Vec::new(),
             hoist_workspace_packages: true,
+            hoisting_limits: HoistingLimits::None,
             dedupe_direct_deps: false,
             node_linker: NodeLinker::Isolated,
             link_concurrency: None,
@@ -197,6 +200,13 @@ impl Linker {
     /// parity).
     pub fn with_hoist_workspace_packages(mut self, on: bool) -> Self {
         self.hoist_workspace_packages = on;
+        self
+    }
+
+    /// Configure pnpm's `hoistingLimits` for `node-linker=hoisted`.
+    /// No-op for the default isolated linker.
+    pub fn with_hoisting_limits(mut self, limits: HoistingLimits) -> Self {
+        self.hoisting_limits = limits;
         self
     }
 

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -297,13 +297,7 @@ pub(crate) fn plan_importer(
         }
         let child_floor = match hoisting_limits {
             HoistingLimits::None | HoistingLimits::Workspaces => plan.root_idx,
-            HoistingLimits::Dependencies => {
-                if requester == plan.root_idx {
-                    outcome.node_idx
-                } else {
-                    floor
-                }
-            }
+            HoistingLimits::Dependencies => outcome.node_idx,
         };
         for (dep_name, dep_tail) in &pkg.dependencies {
             let child_dep_path = format!("{dep_name}@{dep_tail}");
@@ -523,9 +517,13 @@ mod tests {
             "app@1.0.0".into(),
             pkg("app", "1.0.0", &[("left-pad", "1.0.0")]),
         );
+        graph.packages.insert(
+            "left-pad@1.0.0".into(),
+            pkg("left-pad", "1.0.0", &[("repeat", "1.0.0")]),
+        );
         graph
             .packages
-            .insert("left-pad@1.0.0".into(), pkg("left-pad", "1.0.0", &[]));
+            .insert("repeat@1.0.0".into(), pkg("repeat", "1.0.0", &[]));
         let root_deps = vec![dep("app", "app@1.0.0")];
 
         let unlimited = plan_importer(&nm, &root_deps, &graph, HoistingLimits::None).unwrap();
@@ -533,11 +531,16 @@ mod tests {
             package_dir(&unlimited, "left-pad@1.0.0"),
             nm.join("left-pad")
         );
+        assert_eq!(package_dir(&unlimited, "repeat@1.0.0"), nm.join("repeat"));
 
         let limited = plan_importer(&nm, &root_deps, &graph, HoistingLimits::Dependencies).unwrap();
         assert_eq!(
             package_dir(&limited, "left-pad@1.0.0"),
             nm.join("app/node_modules/left-pad")
+        );
+        assert_eq!(
+            package_dir(&limited, "repeat@1.0.0"),
+            nm.join("app/node_modules/left-pad/node_modules/repeat")
         );
     }
 

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -41,7 +41,7 @@
 //! dependency lifecycle scripts can locate a package's on-disk
 //! directory without recomputing the tree.
 
-use crate::{Error, LinkStats, Linker, apply_multi_file_patch};
+use crate::{Error, HoistingLimits, LinkStats, Linker, apply_multi_file_patch};
 use aube_lockfile::{DirectDep, LocalSource, LockfileGraph};
 use aube_store::PackageIndex;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -80,7 +80,7 @@ impl HoistedPlacements {
                 root_dir.join(importer_path)
             };
             let nm = importer_dir.join(modules_dir_name);
-            let plan = plan_importer(&nm, deps, graph)?;
+            let plan = plan_importer(&nm, deps, graph, HoistingLimits::None)?;
             for node in &plan.nodes {
                 let (Some(dep_path), Some(pkg_dir)) = (&node.dep_path, &node.pkg_dir) else {
                     continue;
@@ -144,6 +144,7 @@ struct TreeNode {
     parent: Option<usize>,
     children: BTreeMap<String, usize>,
     dep_path: Option<String>,
+    depth: usize,
 }
 
 /// Arena-backed placement tree.
@@ -165,6 +166,7 @@ impl PlacementPlan {
             parent: None,
             children: BTreeMap::new(),
             dep_path: None,
+            depth: 0,
         };
         Self {
             nodes: vec![root],
@@ -179,13 +181,16 @@ impl PlacementPlan {
     fn place(
         &mut self,
         requester: usize,
+        floor: usize,
         name: &str,
         dep_path: &str,
     ) -> Result<PlaceOutcome, Error> {
         crate::validate_package_link_name(name)?;
+        debug_assert!(is_ancestor_or_self(&self.nodes, floor, requester));
         // Walk up from the requester looking for the shallowest
-        // ancestor that doesn't already host a different version of
-        // `name`. If any ancestor has a matching entry, reuse it.
+        // allowed ancestor that doesn't already host a different
+        // version of `name`. If any allowed ancestor has a matching
+        // entry, reuse it.
         let mut cursor = requester;
         let mut candidate = requester;
         loop {
@@ -200,6 +205,9 @@ impl PlacementPlan {
                 break;
             }
             candidate = cursor;
+            if cursor == floor {
+                break;
+            }
             match self.nodes[cursor].parent {
                 Some(p) => cursor = p,
                 None => break,
@@ -216,6 +224,7 @@ impl PlacementPlan {
             parent: Some(candidate),
             children: BTreeMap::new(),
             dep_path: Some(dep_path.to_string()),
+            depth: self.nodes[candidate].depth + 1,
         });
         self.nodes[candidate]
             .children
@@ -236,14 +245,27 @@ impl PlacementPlan {
     }
 }
 
+fn is_ancestor_or_self(nodes: &[TreeNode], ancestor: usize, mut node: usize) -> bool {
+    loop {
+        if node == ancestor {
+            return true;
+        }
+        let Some(parent) = nodes[node].parent else {
+            return false;
+        };
+        node = parent;
+    }
+}
+
 /// Build a placement plan for a single importer.
 pub(crate) fn plan_importer(
     importer_nm: &Path,
     root_deps: &[DirectDep],
     graph: &LockfileGraph,
+    hoisting_limits: HoistingLimits,
 ) -> Result<PlacementPlan, Error> {
     let mut plan = PlacementPlan::new(importer_nm.to_path_buf());
-    let mut queue: VecDeque<(usize, String, String)> = VecDeque::new();
+    let mut queue: VecDeque<(usize, usize, String, String)> = VecDeque::new();
 
     // Seed the queue with the importer's direct deps in declaration
     // order. BFS makes shallower deps win placement ties over
@@ -252,11 +274,16 @@ pub(crate) fn plan_importer(
         if !graph.packages.contains_key(&dep.dep_path) {
             continue;
         }
-        queue.push_back((plan.root_idx, dep.name.clone(), dep.dep_path.clone()));
+        queue.push_back((
+            plan.root_idx,
+            plan.root_idx,
+            dep.name.clone(),
+            dep.dep_path.clone(),
+        ));
     }
 
-    while let Some((requester, name, dep_path)) = queue.pop_front() {
-        let outcome = plan.place(requester, &name, &dep_path)?;
+    while let Some((requester, floor, name, dep_path)) = queue.pop_front() {
+        let outcome = plan.place(requester, floor, &name, &dep_path)?;
         if !outcome.created {
             continue;
         }
@@ -270,12 +297,27 @@ pub(crate) fn plan_importer(
         if matches!(pkg.local_source.as_ref(), Some(LocalSource::Link(_))) {
             continue;
         }
+        let child_floor = match hoisting_limits {
+            HoistingLimits::None | HoistingLimits::Workspaces => plan.root_idx,
+            HoistingLimits::Dependencies => {
+                if requester == plan.root_idx {
+                    outcome.node_idx
+                } else {
+                    floor
+                }
+            }
+        };
         for (dep_name, dep_tail) in &pkg.dependencies {
             let child_dep_path = format!("{dep_name}@{dep_tail}");
             if !graph.packages.contains_key(&child_dep_path) {
                 continue;
             }
-            queue.push_back((outcome.node_idx, dep_name.clone(), child_dep_path));
+            queue.push_back((
+                outcome.node_idx,
+                child_floor,
+                dep_name.clone(),
+                child_dep_path,
+            ));
         }
     }
 
@@ -307,7 +349,7 @@ pub(crate) fn link_hoisted_importer(
     let nm = importer_dir.join(linker.modules_dir_name());
     crate::mkdirp(&nm)?;
 
-    let plan = plan_importer(&nm, root_deps, graph)?;
+    let plan = plan_importer(&nm, root_deps, graph, linker.hoisting_limits)?;
 
     // Sweep any top-level entries that are no longer claimed by the
     // plan. Dotfiles (`.aube`, `.bin`, …) are preserved — .aube in
@@ -438,4 +480,66 @@ pub(crate) fn link_hoisted_importer(
 
     stats.top_level_linked += plan.nodes[plan.root_idx].children.len();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aube_lockfile::{DepType, LockedPackage};
+
+    fn dep(name: &str, dep_path: &str) -> DirectDep {
+        DirectDep {
+            name: name.to_string(),
+            dep_path: dep_path.to_string(),
+            dep_type: DepType::Production,
+            specifier: None,
+        }
+    }
+
+    fn pkg(name: &str, version: &str, deps: &[(&str, &str)]) -> LockedPackage {
+        LockedPackage {
+            name: name.to_string(),
+            version: version.to_string(),
+            dep_path: format!("{name}@{version}"),
+            dependencies: deps
+                .iter()
+                .map(|(dep_name, tail)| ((*dep_name).to_string(), (*tail).to_string()))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn package_dir(plan: &PlacementPlan, dep_path: &str) -> PathBuf {
+        plan.nodes
+            .iter()
+            .find(|node| node.dep_path.as_deref() == Some(dep_path))
+            .and_then(|node| node.pkg_dir.clone())
+            .unwrap_or_else(|| panic!("{dep_path} was not placed"))
+    }
+
+    #[test]
+    fn dependencies_limit_keeps_transitives_under_their_direct_dep() {
+        let nm = PathBuf::from("/project/node_modules");
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            "app@1.0.0".into(),
+            pkg("app", "1.0.0", &[("left-pad", "1.0.0")]),
+        );
+        graph
+            .packages
+            .insert("left-pad@1.0.0".into(), pkg("left-pad", "1.0.0", &[]));
+        let root_deps = vec![dep("app", "app@1.0.0")];
+
+        let unlimited = plan_importer(&nm, &root_deps, &graph, HoistingLimits::None).unwrap();
+        assert_eq!(
+            package_dir(&unlimited, "left-pad@1.0.0"),
+            nm.join("left-pad")
+        );
+
+        let limited = plan_importer(&nm, &root_deps, &graph, HoistingLimits::Dependencies).unwrap();
+        assert_eq!(
+            package_dir(&limited, "left-pad@1.0.0"),
+            nm.join("app/node_modules/left-pad")
+        );
+    }
 }

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -191,13 +191,16 @@ impl PlacementPlan {
         // prevent placing a new package that high.
         let mut cursor = requester;
         loop {
-            if let Some(&existing) = self.nodes[cursor].children.get(name)
-                && self.nodes[existing].dep_path.as_deref() == Some(dep_path)
-            {
-                return Ok(PlaceOutcome {
-                    node_idx: existing,
-                    created: false,
-                });
+            if let Some(&existing) = self.nodes[cursor].children.get(name) {
+                if self.nodes[existing].dep_path.as_deref() == Some(dep_path) {
+                    return Ok(PlaceOutcome {
+                        node_idx: existing,
+                        created: false,
+                    });
+                }
+                // A nearer same-name package blocks Node from
+                // resolving to any matching package above it.
+                break;
             }
             match self.nodes[cursor].parent {
                 Some(p) => cursor = p,
@@ -580,6 +583,39 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn dependencies_limit_does_not_reuse_above_version_blocker() {
+        let nm = PathBuf::from("/project/node_modules");
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            "app@1.0.0".into(),
+            pkg("app", "1.0.0", &[("shared", "2.0.0"), ("tool", "1.0.0")]),
+        );
+        graph.packages.insert(
+            "tool@1.0.0".into(),
+            pkg("tool", "1.0.0", &[("shared", "1.0.0")]),
+        );
+        graph
+            .packages
+            .insert("shared@1.0.0".into(), pkg("shared", "1.0.0", &[]));
+        graph
+            .packages
+            .insert("shared@2.0.0".into(), pkg("shared", "2.0.0", &[]));
+        let root_deps = vec![dep("shared", "shared@1.0.0"), dep("app", "app@1.0.0")];
+
+        let limited = plan_importer(&nm, &root_deps, &graph, HoistingLimits::Dependencies).unwrap();
+
+        let shared_v1_dirs: Vec<_> = limited
+            .nodes
+            .iter()
+            .filter(|node| node.dep_path.as_deref() == Some("shared@1.0.0"))
+            .filter_map(|node| node.pkg_dir.as_ref())
+            .collect();
+        assert_eq!(shared_v1_dirs.len(), 2);
+        assert!(shared_v1_dirs.contains(&&nm.join("shared")));
+        assert!(shared_v1_dirs.contains(&&nm.join("app/node_modules/tool/node_modules/shared")));
     }
 
     #[test]

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -186,20 +186,32 @@ impl PlacementPlan {
     ) -> Result<PlaceOutcome, Error> {
         crate::validate_package_link_name(name)?;
         debug_assert!(is_ancestor_or_self(&self.nodes, floor, requester));
+        // Reuse a matching package anywhere already visible through
+        // Node's ancestor lookup, even if the hoist limit would
+        // prevent placing a new package that high.
+        let mut cursor = requester;
+        loop {
+            if let Some(&existing) = self.nodes[cursor].children.get(name)
+                && self.nodes[existing].dep_path.as_deref() == Some(dep_path)
+            {
+                return Ok(PlaceOutcome {
+                    node_idx: existing,
+                    created: false,
+                });
+            }
+            match self.nodes[cursor].parent {
+                Some(p) => cursor = p,
+                None => break,
+            }
+        }
+
         // Walk up from the requester looking for the shallowest
         // allowed ancestor that doesn't already host a different
-        // version of `name`. If any allowed ancestor has a matching
-        // entry, reuse it.
+        // version of `name`.
         let mut cursor = requester;
         let mut candidate = requester;
         loop {
-            if let Some(&existing) = self.nodes[cursor].children.get(name) {
-                if self.nodes[existing].dep_path.as_deref() == Some(dep_path) {
-                    return Ok(PlaceOutcome {
-                        node_idx: existing,
-                        created: false,
-                    });
-                }
+            if self.nodes[cursor].children.contains_key(name) {
                 // Conflict: must stay at or below `candidate`.
                 break;
             }
@@ -541,6 +553,32 @@ mod tests {
         assert_eq!(
             package_dir(&limited, "repeat@1.0.0"),
             nm.join("app/node_modules/left-pad/node_modules/repeat")
+        );
+    }
+
+    #[test]
+    fn dependencies_limit_reuses_matching_direct_dependency_above_floor() {
+        let nm = PathBuf::from("/project/node_modules");
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            "app@1.0.0".into(),
+            pkg("app", "1.0.0", &[("shared", "1.0.0")]),
+        );
+        graph
+            .packages
+            .insert("shared@1.0.0".into(), pkg("shared", "1.0.0", &[]));
+        let root_deps = vec![dep("shared", "shared@1.0.0"), dep("app", "app@1.0.0")];
+
+        let limited = plan_importer(&nm, &root_deps, &graph, HoistingLimits::Dependencies).unwrap();
+
+        assert_eq!(package_dir(&limited, "shared@1.0.0"), nm.join("shared"));
+        assert_eq!(
+            limited
+                .nodes
+                .iter()
+                .filter(|node| node.dep_path.as_deref() == Some("shared@1.0.0"))
+                .count(),
+            1
         );
     }
 

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -68,6 +68,7 @@ impl HoistedPlacements {
         root_dir: &Path,
         graph: &LockfileGraph,
         modules_dir_name: &str,
+        hoisting_limits: HoistingLimits,
     ) -> Result<Self, Error> {
         let mut placements = Self::default();
         for (importer_path, deps) in &graph.importers {
@@ -80,7 +81,7 @@ impl HoistedPlacements {
                 root_dir.join(importer_path)
             };
             let nm = importer_dir.join(modules_dir_name);
-            let plan = plan_importer(&nm, deps, graph, HoistingLimits::None)?;
+            let plan = plan_importer(&nm, deps, graph, hoisting_limits)?;
             for node in &plan.nodes {
                 let (Some(dep_path), Some(pkg_dir)) = (&node.dep_path, &node.pkg_dir) else {
                     continue;
@@ -144,7 +145,6 @@ struct TreeNode {
     parent: Option<usize>,
     children: BTreeMap<String, usize>,
     dep_path: Option<String>,
-    depth: usize,
 }
 
 /// Arena-backed placement tree.
@@ -166,7 +166,6 @@ impl PlacementPlan {
             parent: None,
             children: BTreeMap::new(),
             dep_path: None,
-            depth: 0,
         };
         Self {
             nodes: vec![root],
@@ -224,7 +223,6 @@ impl PlacementPlan {
             parent: Some(candidate),
             children: BTreeMap::new(),
             dep_path: Some(dep_path.to_string()),
-            depth: self.nodes[candidate].depth + 1,
         });
         self.nodes[candidate]
             .children
@@ -540,6 +538,40 @@ mod tests {
         assert_eq!(
             package_dir(&limited, "left-pad@1.0.0"),
             nm.join("app/node_modules/left-pad")
+        );
+    }
+
+    #[test]
+    fn from_graph_respects_dependencies_limit() {
+        let root = tempfile::tempdir().unwrap();
+        let nm = root.path().join("node_modules");
+        let app_dir = nm.join("app");
+        let left_pad_dir = app_dir.join("node_modules/left-pad");
+        std::fs::create_dir_all(&left_pad_dir).unwrap();
+
+        let mut graph = LockfileGraph::default();
+        graph
+            .importers
+            .insert(".".into(), vec![dep("app", "app@1.0.0")]);
+        graph.packages.insert(
+            "app@1.0.0".into(),
+            pkg("app", "1.0.0", &[("left-pad", "1.0.0")]),
+        );
+        graph
+            .packages
+            .insert("left-pad@1.0.0".into(), pkg("left-pad", "1.0.0", &[]));
+
+        let placements = HoistedPlacements::from_graph(
+            root.path(),
+            &graph,
+            "node_modules",
+            HoistingLimits::Dependencies,
+        )
+        .unwrap();
+
+        assert_eq!(
+            placements.package_dir("left-pad@1.0.0"),
+            Some(left_pad_dir.as_path())
         );
     }
 }

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -62,6 +62,20 @@ pub enum NodeLinker {
     Hoisted,
 }
 
+/// Limit how far packages may be promoted in `NodeLinker::Hoisted`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum HoistingLimits {
+    /// Hoist as far as possible.
+    #[default]
+    None,
+    /// Aube plans hoisted installs per physical importer, so this is
+    /// currently equivalent to `None`.
+    Workspaces,
+    /// Do not hoist transitives above the direct dependency that
+    /// introduced them.
+    Dependencies,
+}
+
 /// Links packages from the global store into a project's node_modules/.
 ///
 /// Uses pnpm-compatible symlink layout backed by a global virtual store:
@@ -146,6 +160,10 @@ pub struct Linker {
     /// lockfile's workspace protocol, but plain `require('<ws-pkg>')`
     /// from the root stops working. Default true.
     hoist_workspace_packages: bool,
+    /// pnpm's `hoistingLimits` for `node-linker=hoisted`. Isolated
+    /// linking ignores this setting because hidden/public hoisting is
+    /// controlled by the separate `hoist*` family above.
+    pub(crate) hoisting_limits: HoistingLimits,
     /// pnpm's `dedupe-direct-deps`: when true, the linker skips
     /// creating a per-importer `node_modules/<name>` symlink for a
     /// direct dep whose root importer already declares the same

--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -115,6 +115,10 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub hoist_workspace_packages: Option<bool>,
 
+    /// Limit how far packages may be promoted in `nodeLinker=hoisted`.
+    #[serde(default)]
+    pub hoisting_limits: Option<String>,
+
     /// When true, the linker skips a workspace package's per-importer
     /// `node_modules/<name>` symlink if the workspace root already
     /// links the same package at the same resolved version. Default

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -676,6 +676,34 @@ sources.npmrc = ["hoist-workspace-packages", "hoistWorkspacePackages"]
 sources.workspaceYaml = ["hoistWorkspacePackages"]
 examples = []
 
+[hoistingLimits]
+description = "Limit how far dependencies are hoisted in nodeLinker=hoisted installs."
+type = '"none" | "workspaces" | "dependencies"'
+default = "\"none\""
+docs = """
+Controls how far packages can be promoted when `nodeLinker=hoisted` is
+active, mirroring Yarn's `nmHoistingLimits` and pnpm's
+`hoistingLimits` setting:
+
+- `none`: hoist as far as possible (default).
+- `workspaces`: hoist only as far as each workspace package. Aube plans
+  hoisted installs per physical importer, so this currently matches
+  `none`.
+- `dependencies`: hoist only up to each workspace package's direct
+  dependencies. Transitive packages stay under the direct dependency
+  that introduced them instead of being promoted to the importer root.
+
+Ignored by the default isolated linker.
+"""
+sources.cli = []
+sources.env = ["npm_config_hoisting_limits", "NPM_CONFIG_HOISTING_LIMITS", "AUBE_HOISTING_LIMITS"]
+sources.npmrc = ["hoistingLimits", "hoisting-limits"]
+sources.workspaceYaml = ["hoistingLimits"]
+examples = [
+  "echo 'node-linker=hoisted' >> .npmrc",
+  "echo 'hoisting-limits=dependencies' >> .npmrc",
+]
+
 [hoistPattern]
 description = "Packages to hoist to the hidden modules directory."
 type = "list<string>"

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -89,6 +89,15 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     let hoist = aube_settings::resolved::hoist(settings_ctx);
     let hoist_pattern = aube_settings::resolved::hoist_pattern(settings_ctx);
     let hoist_workspace_packages = aube_settings::resolved::hoist_workspace_packages(settings_ctx);
+    let hoisting_limits = match aube_settings::resolved::hoisting_limits(settings_ctx) {
+        aube_settings::resolved::HoistingLimits::None => aube_linker::HoistingLimits::None,
+        aube_settings::resolved::HoistingLimits::Workspaces => {
+            aube_linker::HoistingLimits::Workspaces
+        }
+        aube_settings::resolved::HoistingLimits::Dependencies => {
+            aube_linker::HoistingLimits::Dependencies
+        }
+    };
     let dedupe_direct_deps = aube_settings::resolved::dedupe_direct_deps(settings_ctx);
     let virtual_store_only = aube_settings::resolved::virtual_store_only(settings_ctx);
     // Resolve the layout mode. CLI override wins, then `.npmrc` /
@@ -125,6 +134,7 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         .with_hoist(hoist)
         .with_hoist_pattern(&hoist_pattern)
         .with_hoist_workspace_packages(hoist_workspace_packages)
+        .with_hoisting_limits(hoisting_limits)
         .with_dedupe_direct_deps(dedupe_direct_deps)
         .with_virtual_store_dir_max_length(virtual_store_dir_max_length)
         .with_node_linker(node_linker)

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -89,15 +89,9 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     let hoist = aube_settings::resolved::hoist(settings_ctx);
     let hoist_pattern = aube_settings::resolved::hoist_pattern(settings_ctx);
     let hoist_workspace_packages = aube_settings::resolved::hoist_workspace_packages(settings_ctx);
-    let hoisting_limits = match aube_settings::resolved::hoisting_limits(settings_ctx) {
-        aube_settings::resolved::HoistingLimits::None => aube_linker::HoistingLimits::None,
-        aube_settings::resolved::HoistingLimits::Workspaces => {
-            aube_linker::HoistingLimits::Workspaces
-        }
-        aube_settings::resolved::HoistingLimits::Dependencies => {
-            aube_linker::HoistingLimits::Dependencies
-        }
-    };
+    let hoisting_limits = crate::commands::settings_hoisting_limits_to_linker(
+        aube_settings::resolved::hoisting_limits(settings_ctx),
+    );
     let dedupe_direct_deps = aube_settings::resolved::dedupe_direct_deps(settings_ctx);
     let virtual_store_only = aube_settings::resolved::virtual_store_only(settings_ctx);
     // Resolve the layout mode. CLI override wins, then `.npmrc` /

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -78,6 +78,20 @@ mod settings_context;
 mod workspace_helpers;
 
 pub(crate) use auto_install::ensure_installed;
+
+pub(crate) fn settings_hoisting_limits_to_linker(
+    value: aube_settings::resolved::HoistingLimits,
+) -> aube_linker::HoistingLimits {
+    match value {
+        aube_settings::resolved::HoistingLimits::None => aube_linker::HoistingLimits::None,
+        aube_settings::resolved::HoistingLimits::Workspaces => {
+            aube_linker::HoistingLimits::Workspaces
+        }
+        aube_settings::resolved::HoistingLimits::Dependencies => {
+            aube_linker::HoistingLimits::Dependencies
+        }
+    }
+}
 pub(crate) use catalog_discovery::{CatalogMap, discover_catalogs, load_workspace_catalogs};
 pub(crate) use dep_filter::DepFilter;
 pub(crate) use fs_helpers::{format_virtual_store_display_prefix, remove_existing, symlink_dir};

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -123,15 +123,29 @@ pub async fn run(
             // is parsed out of — no need for a separate fallback on the
             // typed struct field.
             let node_linker_setting = aube_settings::resolved::node_linker(&settings_ctx);
+            let hoisting_limits = match aube_settings::resolved::hoisting_limits(&settings_ctx) {
+                aube_settings::resolved::HoistingLimits::None => aube_linker::HoistingLimits::None,
+                aube_settings::resolved::HoistingLimits::Workspaces => {
+                    aube_linker::HoistingLimits::Workspaces
+                }
+                aube_settings::resolved::HoistingLimits::Dependencies => {
+                    aube_linker::HoistingLimits::Dependencies
+                }
+            };
             let hoisted_placements = match node_linker_setting {
                 aube_settings::resolved::NodeLinker::Pnp => {
                     return Err(miette!(
                         "node-linker=pnp is not supported by aube; use `isolated` (default) or `hoisted`"
                     ));
                 }
-                aube_settings::resolved::NodeLinker::Hoisted => Some(
-                    aube_linker::HoistedPlacements::from_graph(&cwd, &graph, &modules_dir_name)?,
-                ),
+                aube_settings::resolved::NodeLinker::Hoisted => {
+                    Some(aube_linker::HoistedPlacements::from_graph(
+                        &cwd,
+                        &graph,
+                        &modules_dir_name,
+                        hoisting_limits,
+                    )?)
+                }
                 aube_settings::resolved::NodeLinker::Isolated => None,
             };
             let side_effects_cache_root =

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -123,15 +123,9 @@ pub async fn run(
             // is parsed out of — no need for a separate fallback on the
             // typed struct field.
             let node_linker_setting = aube_settings::resolved::node_linker(&settings_ctx);
-            let hoisting_limits = match aube_settings::resolved::hoisting_limits(&settings_ctx) {
-                aube_settings::resolved::HoistingLimits::None => aube_linker::HoistingLimits::None,
-                aube_settings::resolved::HoistingLimits::Workspaces => {
-                    aube_linker::HoistingLimits::Workspaces
-                }
-                aube_settings::resolved::HoistingLimits::Dependencies => {
-                    aube_linker::HoistingLimits::Dependencies
-                }
-            };
+            let hoisting_limits = crate::commands::settings_hoisting_limits_to_linker(
+                aube_settings::resolved::hoisting_limits(&settings_ctx),
+            );
             let hoisted_placements = match node_linker_setting {
                 aube_settings::resolved::NodeLinker::Pnp => {
                     return Err(miette!(

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -958,6 +958,10 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     hasher.update(format!("virtual_store_only={virtual_store_only}\0").as_bytes());
     let hoist_workspace_packages = aube_settings::resolved::hoist_workspace_packages(&ctx);
     hasher.update(format!("hoist_workspace_packages={hoist_workspace_packages}\0").as_bytes());
+    let hoisting_limits = aube_settings::resolved::hoisting_limits(&ctx);
+    hasher.update(b"hoisting_limits=");
+    hasher.update(format!("{hoisting_limits:?}").as_bytes());
+    hasher.update(b"\0");
     let dedupe_direct_deps = aube_settings::resolved::dedupe_direct_deps(&ctx);
     hasher.update(format!("dedupe_direct_deps={dedupe_direct_deps}\0").as_bytes());
     let symlink = aube_settings::resolved::symlink(&ctx);

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -37,6 +37,7 @@ Aube generates this page from [`settings.toml`](https://github.com/endevco/aube/
 | [`registries`](#setting-registries) | `object` | Registry URLs, including scoped registry overrides. |
 | [`hoist`](#setting-hoist) | `bool` | Hoist all dependencies to the hidden modules directory. |
 | [`hoistWorkspacePackages`](#setting-hoistworkspacepackages) | `bool` | Symlink workspace packages into node_modules. |
+| [`hoistingLimits`](#setting-hoistinglimits) | `"none" \| "workspaces" \| "dependencies"` | Limit how far dependencies are hoisted in nodeLinker=hoisted installs. |
 | [`hoistPattern`](#setting-hoistpattern) | `list<string>` | Packages to hoist to the hidden modules directory. |
 | [`publicHoistPattern`](#setting-publichoistpattern) | `list<string>` | Packages to hoist directly to the root node_modules. |
 | [`shamefullyHoist`](#setting-shamefullyhoist) | `bool` | Hoist all dependencies to the root node_modules (shortcut for publicHoistPattern=["*"]). |
@@ -732,6 +733,30 @@ depends on, matching pnpm. When false, those symlinks are omitted —
 cross-importer `workspace:` dependencies still resolve through the
 lockfile, but a top-level `require('<ws-pkg>')` from a package that
 doesn't declare the workspace dep stops working.
+
+### `hoistingLimits` {#setting-hoistinglimits}
+
+Limit how far dependencies are hoisted in nodeLinker=hoisted installs.
+
+- Type: `"none" | "workspaces" | "dependencies"`
+- Default: `"none"`
+- Environment: `npm_config_hoisting_limits`, `NPM_CONFIG_HOISTING_LIMITS`, `AUBE_HOISTING_LIMITS`
+- .npmrc keys: `hoistingLimits`, `hoisting-limits`
+- Workspace YAML keys: `hoistingLimits`
+
+Controls how far packages can be promoted when `nodeLinker=hoisted` is
+active, mirroring Yarn's `nmHoistingLimits` and pnpm's
+`hoistingLimits` setting:
+
+- `none`: hoist as far as possible (default).
+- `workspaces`: hoist only as far as each workspace package. Aube plans
+  hoisted installs per physical importer, so this currently matches
+  `none`.
+- `dependencies`: hoist only up to each workspace package's direct
+  dependencies. Transitive packages stay under the direct dependency
+  that introduced them instead of being promoted to the importer root.
+
+Ignored by the default isolated linker.
 
 ### `hoistPattern` {#setting-hoistpattern}
 
@@ -2837,4 +2862,3 @@ Examples:
 
 - `AUBE_NO_AUTO_INSTALL=1 aube run dev`
 - `echo 'aubeNoAutoInstall=true' >> .npmrc`
-

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -758,6 +758,11 @@ active, mirroring Yarn's `nmHoistingLimits` and pnpm's
 
 Ignored by the default isolated linker.
 
+Examples:
+
+- `echo 'node-linker=hoisted' >> .npmrc`
+- `echo 'hoisting-limits=dependencies' >> .npmrc`
+
 ### `hoistPattern` {#setting-hoistpattern}
 
 Packages to hoist to the hidden modules directory.
@@ -2862,3 +2867,4 @@ Examples:
 
 - `AUBE_NO_AUTO_INSTALL=1 aube run dev`
 - `echo 'aubeNoAutoInstall=true' >> .npmrc`
+


### PR DESCRIPTION
## Summary
- add pnpm-compatible hoistingLimits setting metadata and docs
- wire hoistingLimits into nodeLinker=hoisted planning and install-state hashing
- keep transitive packages under their introducing direct dependency for dependencies mode

## Tests
- cargo fmt --check
- cargo test -p aube-settings
- cargo test -p aube-linker hoisted::tests::dependencies_limit_keeps_transitives_under_their_direct_dep
- cargo test -p aube-manifest workspace::tests::test_settings
- cargo check -p aube

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hoisted `node_modules` layout and install-state hashing; misconfiguration could alter resolution paths for tools expecting maximum hoisting, though isolated installs are unaffected.
> 
> **Overview**
> Adds **pnpm-compatible `hoistingLimits`** for **`nodeLinker=hoisted`**: new setting surface (`.npmrc`, env, workspace YAML, `settings.toml`, docs) and a **`HoistingLimits`** knob on the linker.
> 
> When set to **`dependencies`**, the hoisted placement planner caps how far transitives can be promoted—they stay under the direct dependency that introduced them, while still reusing an already-visible matching install and respecting same-name version blockers. **`none`** / **`workspaces`** keep prior “hoist as far as possible” behavior (workspaces is documented as equivalent to none for aube’s per-importer planning).
> 
> Install and **rebuild** pass the resolved limit into hoisted linking and **`HoistedPlacements::from_graph`**; install-state hashing includes the value so tree layout invalidates when it changes. **Isolated** linking ignores the setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2791206e60c2c47a431f383377f0de411577ddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hoistingLimits` configuration setting to control dependency hoisting behavior. Supports three modes: "none", "workspaces", and "dependencies" (default: "none").
  * New setting can be configured via CLI, environment variables, `.npmrc`, and workspace configuration files.

* **Documentation**
  * Documentation added for the `hoistingLimits` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->