### PR TITLE
feat(resolver): trust staged publishes

### DIFF
--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -291,6 +291,11 @@ pub struct VersionMetadata {
     /// Deprecation message from the registry, if this version is deprecated.
     #[serde(default, deserialize_with = "deprecated_string")]
     pub deprecated: Option<String>,
+    /// npm staged-publish approval metadata. When present, the
+    /// resolver treats it as the strongest trust evidence because the
+    /// publish went through a registry-side approval flow.
+    #[serde(default)]
+    pub approver: Option<serde_json::Value>,
     /// `_npmUser` block from the packument, when present. The
     /// trust-policy check reads `_npmUser.trustedPublisher` as the
     /// strongest trust-evidence signal (npm's "trusted publishers"
@@ -355,6 +360,8 @@ struct VersionMetadataRaw {
     has_install_script: bool,
     #[serde(default, deserialize_with = "deprecated_string")]
     deprecated: Option<String>,
+    #[serde(default)]
+    approver: Option<serde_json::Value>,
     #[serde(default, rename = "_npmUser", deserialize_with = "npm_user_tolerant")]
     npm_user: Option<NpmUser>,
 }
@@ -380,6 +387,7 @@ impl From<VersionMetadataRaw> for VersionMetadata {
             bin: raw.bin,
             has_install_script: raw.has_install_script,
             deprecated: raw.deprecated,
+            approver: raw.approver,
             npm_user: raw.npm_user,
         }
     }
@@ -835,6 +843,24 @@ mod tests {
     }
 
     #[test]
+    fn approver_metadata_is_extracted() {
+        let v = parse(
+            r#"{
+                "name":"x",
+                "version":"1.0.0",
+                "approver":{"name":"release-manager"}
+            }"#,
+        );
+        assert_eq!(
+            v.approver
+                .as_ref()
+                .and_then(|a| a.get("name"))
+                .and_then(serde_json::Value::as_str),
+            Some("release-manager")
+        );
+    }
+
+    #[test]
     fn bin_normalizes_packument_shapes() {
         let missing = parse(r#"{"name":"x","version":"1.0.0"}"#);
         assert!(missing.bin.is_empty(), "missing bin → empty map");
@@ -881,6 +907,7 @@ mod tests {
             bin,
             has_install_script: false,
             deprecated: None,
+            approver: None,
             npm_user: None,
         };
         let json = serde_json::to_string(&v).unwrap();

--- a/crates/aube-resolver/src/primer.rs
+++ b/crates/aube-resolver/src/primer.rs
@@ -88,6 +88,7 @@ impl PrimerVersionMetadata {
             bin: self.bin.clone(),
             has_install_script: self.has_install_script,
             deprecated: self.deprecated.clone(),
+            approver: None,
             npm_user: self.trusted_publisher.then(|| NpmUser {
                 trusted_publisher: Some(serde_json::json!({"id": "npm-primer"})),
             }),

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -591,6 +591,7 @@ fn make_version(name: &str, version: &str) -> VersionMetadata {
         bin: BTreeMap::new(),
         has_install_script: false,
         deprecated: None,
+        approver: None,
         npm_user: None,
     }
 }

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -79,7 +79,12 @@ fn is_approver(v: &serde_json::Value) -> bool {
         serde_json::Value::String(s) => !s.is_empty(),
         serde_json::Value::Array(a) => !a.is_empty(),
         serde_json::Value::Object(o) => !o.is_empty(),
-        serde_json::Value::Bool(_) | serde_json::Value::Number(_) => true,
+        serde_json::Value::Bool(b) => *b,
+        serde_json::Value::Number(n) => {
+            n.as_i64().is_some_and(|i| i != 0)
+                || n.as_u64().is_some_and(|u| u != 0)
+                || n.as_f64().is_some_and(|f| f != 0.0)
+        }
     }
 }
 
@@ -630,7 +635,10 @@ mod tests {
     fn evidence_empty_approver_is_none() {
         let mut v = version("foo", "1.0.0");
         for malformed in [
+            serde_json::Value::Bool(false),
             serde_json::Value::Null,
+            serde_json::json!(0),
+            serde_json::json!(0.0),
             serde_json::json!(""),
             serde_json::json!([]),
             serde_json::json!({}),
@@ -640,6 +648,23 @@ mod tests {
                 evidence_for(&v),
                 None,
                 "{malformed:?} should not count as staged-publish evidence"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_truthy_scalar_approver_counts() {
+        let mut v = version("foo", "1.0.0");
+        for approver in [
+            serde_json::Value::Bool(true),
+            serde_json::json!(1),
+            serde_json::json!("release-manager"),
+        ] {
+            v.approver = Some(approver.clone());
+            assert_eq!(
+                evidence_for(&v),
+                Some(TrustEvidence::StagedPublish),
+                "{approver:?} should count as staged-publish evidence"
             );
         }
     }

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -2,17 +2,18 @@
 //!
 //! Mirrors pnpm's `failIfTrustDowngraded`
 //! (resolving/npm-resolver/src/trustChecks.ts), verified against pnpm's
-//! own test suite. Two trust-evidence sources, ranked
-//! `TrustedPublisher (2) > Provenance (1)`. aube only accepts the
-//! structured metadata shapes npm emits after server-side checks:
-//! `_npmUser.trustedPublisher` must name a publisher id, and
-//! `dist.attestations.provenance` must name an SLSA provenance predicate.
-//! This is metadata-shape validation, not install-time cryptographic
-//! verification of the attestation bundle. The check runs immediately
-//! after a version is picked from a packument: if any strictly older
-//! version of the same package had stronger trust evidence, the install
-//! fails. Pre-2010 packuments without per-version `time` entries error
-//! when the picked version isn't excluded — same as pnpm.
+//! own test suite. Three trust-evidence sources, ranked
+//! `StagedPublish (3) > TrustedPublisher (2) > Provenance (1)`. aube
+//! only accepts the structured metadata shapes npm emits after
+//! server-side checks: `approver` must be present, `_npmUser.trustedPublisher`
+//! must name a publisher id, and `dist.attestations.provenance` must
+//! name an SLSA provenance predicate. This is metadata-shape validation,
+//! not install-time cryptographic verification of the attestation bundle.
+//! The check runs immediately after a version is picked from a packument:
+//! if any strictly older version of the same package had stronger trust
+//! evidence, the install fails. Pre-2010 packuments without per-version
+//! `time` entries error when the picked version isn't excluded — same as
+//! pnpm.
 
 use aube_registry::{Packument, VersionMetadata};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -22,6 +23,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// rank order, so callers must go through [`Self::rank`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrustEvidence {
+    StagedPublish,
     TrustedPublisher,
     Provenance,
 }
@@ -29,6 +31,7 @@ pub enum TrustEvidence {
 impl TrustEvidence {
     pub fn rank(self) -> u8 {
         match self {
+            Self::StagedPublish => 3,
             Self::TrustedPublisher => 2,
             Self::Provenance => 1,
         }
@@ -36,6 +39,7 @@ impl TrustEvidence {
 
     pub fn label(self) -> &'static str {
         match self {
+            Self::StagedPublish => "staged publish approval",
             Self::TrustedPublisher => "trusted publisher",
             Self::Provenance => "provenance attestation",
         }
@@ -43,8 +47,12 @@ impl TrustEvidence {
 }
 
 /// Strongest trust evidence carried by a single version's metadata.
-/// `_npmUser.trustedPublisher` outranks `dist.attestations.provenance`.
+/// `approver` outranks `_npmUser.trustedPublisher`, which outranks
+/// `dist.attestations.provenance`.
 pub fn evidence_for(meta: &VersionMetadata) -> Option<TrustEvidence> {
+    if meta.approver.as_ref().is_some_and(is_approver) {
+        return Some(TrustEvidence::StagedPublish);
+    }
     if meta
         .npm_user
         .as_ref()
@@ -63,6 +71,16 @@ pub fn evidence_for(meta: &VersionMetadata) -> Option<TrustEvidence> {
         return Some(TrustEvidence::Provenance);
     }
     None
+}
+
+fn is_approver(v: &serde_json::Value) -> bool {
+    match v {
+        serde_json::Value::Null => false,
+        serde_json::Value::String(s) => !s.is_empty(),
+        serde_json::Value::Array(a) => !a.is_empty(),
+        serde_json::Value::Object(o) => !o.is_empty(),
+        serde_json::Value::Bool(_) | serde_json::Value::Number(_) => true,
+    }
 }
 
 fn is_trusted_publisher(v: &serde_json::Value) -> bool {
@@ -194,7 +212,7 @@ pub fn check_no_downgrade(
             }
             _ => {}
         }
-        if matches!(best, Some((TrustEvidence::TrustedPublisher, _))) {
+        if matches!(best, Some((TrustEvidence::StagedPublish, _))) {
             break;
         }
     }
@@ -513,6 +531,7 @@ mod tests {
             bin: BTreeMap::new(),
             has_install_script: false,
             deprecated: None,
+            approver: None,
             npm_user: None,
         }
     }
@@ -531,6 +550,11 @@ mod tests {
         v.npm_user = Some(NpmUser {
             trusted_publisher: Some(serde_json::json!({"id": "gh"})),
         });
+        v
+    }
+
+    fn with_staged_publish(mut v: VersionMetadata) -> VersionMetadata {
+        v.approver = Some(serde_json::json!({"name": "release-manager"}));
         v
     }
 
@@ -553,6 +577,14 @@ mod tests {
     fn evidence_trusted_publisher_outranks_provenance() {
         let v = with_trusted_publisher(with_provenance(version("foo", "1.0.0")));
         assert_eq!(evidence_for(&v), Some(TrustEvidence::TrustedPublisher));
+    }
+
+    #[test]
+    fn evidence_staged_publish_outranks_trusted_publisher() {
+        let v = with_staged_publish(with_trusted_publisher(with_provenance(version(
+            "foo", "1.0.0",
+        ))));
+        assert_eq!(evidence_for(&v), Some(TrustEvidence::StagedPublish));
     }
 
     #[test]
@@ -590,6 +622,24 @@ mod tests {
                 evidence_for(&v),
                 None,
                 "{malformed:?} should not count as trusted-publisher evidence"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_empty_approver_is_none() {
+        let mut v = version("foo", "1.0.0");
+        for malformed in [
+            serde_json::Value::Null,
+            serde_json::json!(""),
+            serde_json::json!([]),
+            serde_json::json!({}),
+        ] {
+            v.approver = Some(malformed.clone());
+            assert_eq!(
+                evidence_for(&v),
+                None,
+                "{malformed:?} should not count as staged-publish evidence"
             );
         }
     }
@@ -729,6 +779,59 @@ mod tests {
             }
             _ => panic!("expected Downgrade"),
         }
+    }
+
+    #[test]
+    fn downgrade_staged_publish_to_trusted_publisher_fails() {
+        let p = packument(
+            "foo",
+            vec![
+                ("1.0.0", "2025-01-01T00:00:00.000Z", version("foo", "1.0.0")),
+                (
+                    "2.0.0",
+                    "2025-02-01T00:00:00.000Z",
+                    with_staged_publish(version("foo", "2.0.0")),
+                ),
+                (
+                    "3.0.0",
+                    "2025-03-01T00:00:00.000Z",
+                    with_trusted_publisher(version("foo", "3.0.0")),
+                ),
+            ],
+        );
+        let picked = p.versions.get("3.0.0").unwrap();
+        let err = check_no_downgrade(&p, "3.0.0", picked, &TrustExcludeRules::default(), None)
+            .expect_err("staged publish → trusted publisher is a downgrade");
+        match err {
+            TrustCheckError::Downgrade(d) => {
+                assert_eq!(d.prior_evidence, TrustEvidence::StagedPublish);
+                assert_eq!(d.prior_version, "2.0.0");
+                assert_eq!(d.current_evidence, Some(TrustEvidence::TrustedPublisher));
+            }
+            _ => panic!("expected Downgrade"),
+        }
+    }
+
+    #[test]
+    fn staged_publish_after_trusted_publisher_passes() {
+        let p = packument(
+            "foo",
+            vec![
+                (
+                    "1.0.0",
+                    "2025-01-01T00:00:00.000Z",
+                    with_trusted_publisher(version("foo", "1.0.0")),
+                ),
+                (
+                    "2.0.0",
+                    "2025-02-01T00:00:00.000Z",
+                    with_staged_publish(version("foo", "2.0.0")),
+                ),
+            ],
+        );
+        let picked = p.versions.get("2.0.0").unwrap();
+        let result = check_no_downgrade(&p, "2.0.0", picked, &TrustExcludeRules::default(), None);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -77,8 +77,8 @@ fn is_approver(v: &serde_json::Value) -> bool {
     match v {
         serde_json::Value::Null => false,
         serde_json::Value::String(s) => !s.is_empty(),
-        serde_json::Value::Array(a) => !a.is_empty(),
-        serde_json::Value::Object(o) => !o.is_empty() && o.values().any(|v| !v.is_null()),
+        serde_json::Value::Array(a) => a.iter().any(is_approver),
+        serde_json::Value::Object(o) => o.values().any(is_approver),
         serde_json::Value::Bool(b) => *b,
         serde_json::Value::Number(n) => {
             n.as_i64().is_some_and(|i| i != 0)
@@ -641,9 +641,15 @@ mod tests {
             serde_json::json!(0.0),
             serde_json::json!(""),
             serde_json::json!([]),
+            serde_json::json!([null]),
+            serde_json::json!([false]),
+            serde_json::json!([""]),
+            serde_json::json!([[], {}]),
             serde_json::json!({}),
             serde_json::json!({"name": null}),
             serde_json::json!({"name": null, "email": null}),
+            serde_json::json!({"name": ""}),
+            serde_json::json!({"nested": {}}),
         ] {
             v.approver = Some(malformed.clone());
             assert_eq!(
@@ -661,6 +667,8 @@ mod tests {
             serde_json::Value::Bool(true),
             serde_json::json!(1),
             serde_json::json!("release-manager"),
+            serde_json::json!(["release-manager"]),
+            serde_json::json!({"name": "release-manager"}),
         ] {
             v.approver = Some(approver.clone());
             assert_eq!(

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -78,7 +78,7 @@ fn is_approver(v: &serde_json::Value) -> bool {
         serde_json::Value::Null => false,
         serde_json::Value::String(s) => !s.is_empty(),
         serde_json::Value::Array(a) => !a.is_empty(),
-        serde_json::Value::Object(o) => !o.is_empty(),
+        serde_json::Value::Object(o) => !o.is_empty() && o.values().any(|v| !v.is_null()),
         serde_json::Value::Bool(b) => *b,
         serde_json::Value::Number(n) => {
             n.as_i64().is_some_and(|i| i != 0)
@@ -642,6 +642,8 @@ mod tests {
             serde_json::json!(""),
             serde_json::json!([]),
             serde_json::json!({}),
+            serde_json::json!({"name": null}),
+            serde_json::json!({"name": null, "email": null}),
         ] {
             v.approver = Some(malformed.clone());
             assert_eq!(

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -549,12 +549,13 @@ default = "\"no-downgrade\""
 docs = """
 When `no-downgrade` (the default), aube rejects a version that carries weaker
 trust evidence than any earlier-published version of the same package.
-Recognized evidence: structured npm trusted-publisher metadata
-(`_npmUser.trustedPublisher.id`) outranks structured SLSA provenance metadata
-(`dist.attestations.provenance.predicateType`). Set to `off` to disable, or
-use `trustPolicyExclude` to whitelist specific packages or versions. This
-policy validates registry metadata shape; it does not cryptographically verify
-the attached attestation bundle.
+Recognized evidence: npm staged-publish approval metadata (`approver`)
+outranks structured npm trusted-publisher metadata
+(`_npmUser.trustedPublisher.id`), which outranks structured SLSA provenance
+metadata (`dist.attestations.provenance.predicateType`). Set to `off` to
+disable, or use `trustPolicyExclude` to whitelist specific packages or
+versions. This policy validates registry metadata shape; it does not
+cryptographically verify the attached attestation bundle.
 """
 sources.cli = []
 sources.env = ["npm_config_trust_policy", "NPM_CONFIG_TRUST_POLICY", "AUBE_TRUST_POLICY"]

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -1056,6 +1056,7 @@ mod tests {
                     bin: BTreeMap::new(),
                     has_install_script: false,
                     deprecated: None,
+                    approver: None,
                     npm_user: None,
                 },
             );

--- a/docs/security.md
+++ b/docs/security.md
@@ -125,9 +125,11 @@ Full reference: [Jailed builds](/package-manager/jailed-builds).
 trust evidence than any earlier-published version of the same package. aube
 only counts the structured metadata shape npm emits after registry-side checks:
 
-1. **npm trusted-publisher** — package was published via OIDC from a trusted
+1. **npm staged publish approval** — package metadata carries an `approver`
+   field from the registry-side approval flow.
+2. **npm trusted-publisher** — package was published via OIDC from a trusted
    CI provider (`_npmUser.trustedPublisher.id`).
-2. **Sigstore provenance** — package was published with `npm publish
+3. **Sigstore provenance** — package was published with `npm publish
    --provenance` (`dist.attestations.provenance.predicateType` with an SLSA
    provenance URI).
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -2838,3 +2838,4 @@ Examples:
 
 - `AUBE_NO_AUTO_INSTALL=1 aube run dev`
 - `echo 'aubeNoAutoInstall=true' >> .npmrc`
+

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -616,12 +616,13 @@ Fail install when a package's trust evidence weakens between releases.
 
 When `no-downgrade` (the default), aube rejects a version that carries weaker
 trust evidence than any earlier-published version of the same package.
-Recognized evidence: structured npm trusted-publisher metadata
-(`_npmUser.trustedPublisher.id`) outranks structured SLSA provenance metadata
-(`dist.attestations.provenance.predicateType`). Set to `off` to disable, or
-use `trustPolicyExclude` to whitelist specific packages or versions. This
-policy validates registry metadata shape; it does not cryptographically verify
-the attached attestation bundle.
+Recognized evidence: npm staged-publish approval metadata (`approver`)
+outranks structured npm trusted-publisher metadata
+(`_npmUser.trustedPublisher.id`), which outranks structured SLSA provenance
+metadata (`dist.attestations.provenance.predicateType`). Set to `off` to
+disable, or use `trustPolicyExclude` to whitelist specific packages or
+versions. This policy validates registry metadata shape; it does not
+cryptographically verify the attached attestation bundle.
 
 ### `trustPolicyExclude` {#setting-trustpolicyexclude}
 
@@ -2837,4 +2838,3 @@ Examples:
 
 - `AUBE_NO_AUTO_INSTALL=1 aube run dev`
 - `echo 'aubeNoAutoInstall=true' >> .npmrc`
-


### PR DESCRIPTION
## Summary
- parse npm staged-publish approver metadata from version packuments
- rank staged publish approval above trusted publishers and provenance in trustPolicy=no-downgrade
- document the expanded trust-evidence order

## Tests
- cargo fmt --check
- cargo test -p aube-registry approver_metadata_is_extracted
- cargo test -p aube-resolver trust::tests
- git diff --check
- cargo check -p aube

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time trust enforcement and may block installs when newer versions lack `approver` but older releases had staged approval; behavior is covered by expanded trust tests and docs.
> 
> **Overview**
> Adds **npm staged-publish** support to trust policy: packument parsing now keeps an optional **`approver`** field on version metadata, and **`trustPolicy=no-downgrade`** treats it as the strongest signal (**staged publish** &gt; trusted publisher &gt; provenance).
> 
> The resolver’s **`evidence_for`** / **`check_no_downgrade`** logic ranks **`StagedPublish`** first, validates **`approver`** with tolerant shape checks (empty/null objects do not count), and stops scanning older versions early once staged publish is found. Primer-sourced metadata still sets **`approver: None`**. Settings and security docs describe the new evidence order; tests cover parsing, ranking, downgrades, and malformed approver values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844f7be6ad286bfddcbc41b9fcc007962738f6c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->