### PR TITLE
fix(lockfile): preserve remote tarball integrity

### DIFF
--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -274,13 +274,29 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                             _ => None,
                         })
                 }),
+                LocalSource::RemoteTarball(tarball) => {
+                    raw.packages.iter().find_map(|(key, pkg_info)| {
+                        parse_dep_path(key)
+                            .filter(|(name, _)| name == &local_pkg.name)
+                            .and(pkg_info.resolution.as_ref())
+                            .and_then(local_source_from_resolution)
+                            .and_then(|candidate| match candidate {
+                                LocalSource::RemoteTarball(candidate)
+                                    if candidate.url == tarball.url =>
+                                {
+                                    Some(pkg_info)
+                                }
+                                _ => None,
+                            })
+                    })
+                }
                 _ => None,
             });
             if let Some(pkg_info) = pkg_info
                 && let Some(ref res) = pkg_info.resolution
                 && let Some(mut ls) = local_source_from_resolution(res)
             {
-                if matches!(ls, LocalSource::Git(_)) {
+                if matches!(ls, LocalSource::Git(_) | LocalSource::RemoteTarball(_)) {
                     local_pkg.integrity = res.integrity.clone();
                 }
                 if let LocalSource::Git(ref mut g) = ls

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -2556,6 +2556,51 @@ snapshots:
 }
 
 #[test]
+fn remote_tarball_integrity_survives_lockfile_reuse_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &path,
+        r#"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      demo:
+        specifier: https://registry.example.test/demo/-/demo-1.0.0.tgz
+        version: https://registry.example.test/demo/-/demo-1.0.0.tgz
+packages:
+  demo@https://registry.example.test/demo/-/demo-1.0.0.tgz:
+    resolution: {integrity: sha512-demo, tarball: https://registry.example.test/demo/-/demo-1.0.0.tgz}
+    version: 1.0.0
+snapshots:
+  demo@https://registry.example.test/demo/-/demo-1.0.0.tgz: {}
+"#,
+    )
+    .unwrap();
+
+    let graph = parse(&path).unwrap();
+    let pkg = graph
+        .packages
+        .values()
+        .find(|pkg| pkg.name == "demo")
+        .expect("demo package");
+    assert_eq!(pkg.integrity.as_deref(), Some("sha512-demo"));
+    let Some(LocalSource::RemoteTarball(source)) = &pkg.local_source else {
+        panic!("expected remote tarball source, got {:?}", pkg.local_source);
+    };
+    assert_eq!(source.integrity, "sha512-demo");
+
+    write(&path, &graph, &PackageJson::default()).unwrap();
+    let yaml = std::fs::read_to_string(&path).unwrap();
+    assert!(yaml.contains("integrity: sha512-demo"), "{yaml}");
+    assert!(
+        yaml.contains("tarball: https://registry.example.test/demo/-/demo-1.0.0.tgz"),
+        "{yaml}"
+    );
+}
+
+#[test]
 fn parser_rejects_remote_tarball_with_hosted_git_url_in_query() {
     for tarball in [
         "https://evil.example.com/demo.tgz?ref=://codeload.github.com/acme/demo/tar.gz/abcdef",


### PR DESCRIPTION
## Summary
- hydrate direct remote tarball deps from their pnpm resolution block, matching the existing git hydration path
- preserve both LockedPackage.integrity and RemoteTarballSource.integrity on parse/write round-trip
- add a pnpm v11.5 regression covering HTTPS tarball lockfile reuse

## Tests
- cargo fmt --check
- cargo test -p aube-lockfile pnpm::tests::remote_tarball_integrity_survives_lockfile_reuse_roundtrip
- cargo test -p aube-lockfile pnpm::tests
- git diff --check

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to pnpm lockfile read/hydration for direct remote tarballs; behavior mirrors existing git hydration with a focused regression test.
> 
> **Overview**
> Direct **HTTPS tarball** dependencies in `pnpm-lock.yaml` now pull **`integrity`** (and tarball metadata) from the matching `packages:` **`resolution`** block when the importer entry alone is not enough—using the same lookup pattern already used for **git** deps (match by package name + tarball URL).
> 
> **`LockedPackage.integrity`** and **`RemoteTarballSource.integrity`** are kept on **parse → write** reuse so lockfile regeneration does not drop checksums for registry-style tarball URLs.
> 
> A regression test covers a direct tarball importer spec and asserts the written lockfile still contains **`integrity`** and the **`tarball`** URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 850f2aa7b090b5fc266133e4256eefd371ca09df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->