### PR TITLE
test(resolver): cover alias peer cycle

### DIFF
--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -2530,6 +2530,67 @@ async fn resolve_terminates_on_dependency_cycle() {
     );
 }
 
+// pnpm v11.5.0 fixed a dep-path calculation hang for an npm alias
+// participating in a peer cycle. Keep the fixture small but preserve
+// the shape: root installs `alias-a -> npm:real-a`, `real-a` peers on
+// `b`, and `b` peers back on the alias name while depending on the
+// same alias.
+#[tokio::test]
+async fn resolve_terminates_on_npm_alias_peer_cycle() {
+    let mut real_a = make_packument("real-a", &["1.0.0"], "1.0.0");
+    let real_a_meta = real_a.versions.get_mut("1.0.0").unwrap();
+    real_a_meta
+        .dependencies
+        .insert("b".to_string(), "1.0.0".to_string());
+    real_a_meta
+        .peer_dependencies
+        .insert("b".to_string(), "^1.0.0".to_string());
+
+    let mut b = make_packument("b", &["1.0.0"], "1.0.0");
+    let b_meta = b.versions.get_mut("1.0.0").unwrap();
+    b_meta
+        .dependencies
+        .insert("alias-a".to_string(), "npm:real-a@1.0.0".to_string());
+    b_meta
+        .peer_dependencies
+        .insert("alias-a".to_string(), "1.0.0".to_string());
+
+    // The RegistryClient is never hit because we pre-seed the cache.
+    let client = Arc::new(aube_registry::client::RegistryClient::new(
+        "http://127.0.0.1:0",
+    ));
+    let mut resolver = Resolver::new(client);
+    resolver.cache.insert("real-a".to_string(), real_a);
+    resolver.cache.insert("b".to_string(), b);
+
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("alias-a".to_string(), "npm:real-a@1.0.0".to_string());
+    manifest
+        .dependencies
+        .insert("b".to_string(), "1.0.0".to_string());
+
+    let graph = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        resolver.resolve(&manifest, None),
+    )
+    .await
+    .expect("resolver hung on npm-alias peer cycle")
+    .expect("resolve failed");
+
+    let alias_pkg = graph
+        .packages
+        .values()
+        .find(|pkg| pkg.name == "alias-a")
+        .expect("alias package present");
+    assert_eq!(alias_pkg.alias_of.as_deref(), Some("real-a"));
+    assert!(
+        graph.packages.values().any(|pkg| pkg.name == "b"),
+        "peer package should resolve"
+    );
+}
+
 #[tokio::test]
 async fn auto_install_peers_installs_missing_required_peer() {
     let mut consumer = make_packument("consumer", &["1.0.0"], "1.0.0");

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -2572,19 +2572,34 @@ async fn resolve_terminates_on_npm_alias_peer_cycle() {
         .insert("b".to_string(), "1.0.0".to_string());
 
     let graph = tokio::time::timeout(
-        std::time::Duration::from_secs(2),
+        std::time::Duration::from_secs(5),
         resolver.resolve(&manifest, None),
     )
     .await
     .expect("resolver hung on npm-alias peer cycle")
     .expect("resolve failed");
 
+    let alias_dep_path = graph
+        .importers
+        .get(".")
+        .and_then(|deps| deps.iter().find(|dep| dep.name == "alias-a"))
+        .map(|dep| dep.dep_path.as_str())
+        .expect("root alias dependency should be present");
     let alias_pkg = graph
         .packages
-        .values()
-        .find(|pkg| pkg.name == "alias-a")
-        .expect("alias package present");
+        .get(alias_dep_path)
+        .expect("alias package should be keyed by the alias dep_path");
+    assert_eq!(alias_pkg.name, "alias-a");
+    assert_eq!(alias_pkg.version, "1.0.0");
     assert_eq!(alias_pkg.alias_of.as_deref(), Some("real-a"));
+    assert_eq!(alias_pkg.registry_name(), "real-a");
+    assert!(
+        graph
+            .packages
+            .keys()
+            .all(|dep_path| !dep_path.starts_with("real-a@")),
+        "alias package should not leak a real-name dep_path"
+    );
     assert!(
         graph.packages.values().any(|pkg| pkg.name == "b"),
         "peer package should resolve"


### PR DESCRIPTION
## Summary
- add a timeout-guarded resolver regression for npm aliases participating in a peer cycle
- assert the alias package keeps alias_of while the peer package resolves
- mirrors the pnpm v11.5 dep-path hang shape without adding a large fixture

## Tests
- cargo fmt --check
- cargo test -p aube-resolver resolve_terminates_on_npm_alias_peer_cycle
- cargo test -p aube-resolver resolve_terminates_on
- git diff --check

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in `crates/aube-resolver/src/tests.rs`; no production resolver logic modified in this diff.
> 
> **Overview**
> Adds a **regression test** in `aube-resolver` for resolver behavior when an **npm alias** sits in a **peer dependency cycle**, modeled on the pnpm v11.5 dep-path hang.
> 
> The fixture wires root `alias-a` → `npm:real-a`, `real-a` peers on `b`, and `b` peers back on `alias-a` while depending on the same alias. The test runs `resolve` under a **5s timeout** and asserts the graph finishes without hanging: the alias is keyed by its alias `dep_path`, keeps `alias_of` / `registry_name()`, does not expose a `real-a@…` package key, and still resolves `b`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83045e23d8419a96b357b2288ff609318cf3ef6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->