### PR TITLE
test(lockfile): cover remote tarball fallback lookup

### DIFF
--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -2570,11 +2570,11 @@ importers:
         specifier: https://registry.example.test/demo/-/demo-1.0.0.tgz
         version: https://registry.example.test/demo/-/demo-1.0.0.tgz
 packages:
-  demo@https://registry.example.test/demo/-/demo-1.0.0.tgz:
+  demo@https://registry.example.test/demo/-/demo-1.0.0.tgz(react@18.2.0):
     resolution: {integrity: sha512-demo, tarball: https://registry.example.test/demo/-/demo-1.0.0.tgz}
     version: 1.0.0
 snapshots:
-  demo@https://registry.example.test/demo/-/demo-1.0.0.tgz: {}
+  demo@https://registry.example.test/demo/-/demo-1.0.0.tgz(react@18.2.0): {}
 "#,
     )
     .unwrap();


### PR DESCRIPTION
## Summary
- exercise the remote tarball package fallback with a contextual URL key
- keep the roundtrip integrity assertion in place for the merged parser fix

## Tests
- cargo fmt --check
- cargo test -p aube-lockfile remote_tarball_integrity
- git diff --check origin/main..HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only lockfile fixture change; no production code in this diff.
> 
> **Overview**
> Updates the **`remote_tarball_integrity_survives_lockfile_reuse_roundtrip`** fixture so the remote tarball **`demo`** entry uses pnpm’s **peer-context dep-path** form (`…tgz(react@18.2.0)`) in both **`packages`** and **`snapshots`**, instead of the bare URL key.
> 
> The test still checks that integrity and **`RemoteTarballSource`** survive parse/write, but now also covers **fallback lookup** when the lockfile keys the same tarball URL with a peer suffix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f21614976f23ae96273fb2ae5135fe9cd10a4078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->