### PR TITLE
chore: use trusted publishing for cargo releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,8 +16,9 @@ jobs:
   # On every push to main: run `release-plz release`. If the current
   # workspace version has no tag yet (because the release PR was just
   # merged), this tags `aube` as `v<version>`, opens a draft GitHub
-  # release, and publishes every workspace crate to crates.io in
-  # dependency order. Otherwise it's a no-op.
+  # release, and publishes every workspace crate to crates.io using
+  # crates.io trusted publishing in dependency order. Otherwise it's a
+  # no-op.
   release-plz-release:
     name: release-plz release
     runs-on: ubuntu-latest
@@ -27,6 +28,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: write
+      id-token: write
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
@@ -43,7 +45,6 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       # The `releases` output is an array of every crate that was
       # published, in dependency order. Since aube depends on all
       # 9 other internal crates, it is the LAST entry — and only it


### PR DESCRIPTION
## Summary
- grant `id-token: write` to the release-plz publish job
- remove the long-lived `CARGO_REGISTRY_TOKEN` from cargo publishing
- update the workflow comment to describe crates.io trusted publishing

## Validation
- `actionlint .github/workflows/release-plz.yml`

Note: the crates.io trusted publisher must be configured for each existing workspace crate to trust `endevco/aube` and `.github/workflows/release-plz.yml`. New crates still need their first publish done manually before trusted publishing can take over.

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Publishing now depends on per-crate crates.io trusted-publisher configuration; misconfiguration would block releases until fixed, though the change is limited to CI credentials.
> 
> **Overview**
> The **release-plz release** job on `main` now publishes workspace crates to crates.io via **OIDC trusted publishing** instead of a long-lived registry secret.
> 
> It adds **`id-token: write`** on that job so GitHub Actions can mint the token crates.io expects, drops **`CARGO_REGISTRY_TOKEN`** from the `release-plz` step env, and updates the workflow comment to describe trusted publishing. **GitHub release tagging and `AUBE_GH_TOKEN` usage are unchanged.**
> 
> Each crate still needs a one-time crates.io trusted-publisher setup for this repo and workflow before publishes succeed without the old secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeaa6a78e76719e9f15035e088bb33d8f390b118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process security by updating publishing workflow to use trusted publishing for crate uploads, eliminating manual token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->