### PR TITLE
fix(lockfile): rebase pnpm workspace link paths

### DIFF
--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -344,16 +344,22 @@ pub(crate) fn plan_importer(
 /// Every placed package is recorded in `placements` so the install
 /// driver can later resolve `dep_path -> on-disk dir` for bin
 /// linking and lifecycle scripts without recomputing the plan.
+pub(crate) struct HoistedImporterDirs<'a> {
+    pub(crate) root: &'a Path,
+    pub(crate) importer: &'a Path,
+}
+
 pub(crate) fn link_hoisted_importer(
     linker: &Linker,
-    root_dir: &Path,
-    importer_dir: &Path,
+    dirs: HoistedImporterDirs<'_>,
     root_deps: &[DirectDep],
     graph: &LockfileGraph,
     package_indices: &BTreeMap<String, PackageIndex>,
     stats: &mut LinkStats,
     placements: &mut HoistedPlacements,
 ) -> Result<(), Error> {
+    let root_dir = dirs.root;
+    let importer_dir = dirs.importer;
     let nm = importer_dir.join(linker.modules_dir_name());
     crate::mkdirp(&nm)?;
 

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -346,6 +346,7 @@ pub(crate) fn plan_importer(
 /// linking and lifecycle scripts without recomputing the plan.
 pub(crate) fn link_hoisted_importer(
     linker: &Linker,
+    root_dir: &Path,
     importer_dir: &Path,
     root_deps: &[DirectDep],
     graph: &LockfileGraph,
@@ -393,14 +394,14 @@ pub(crate) fn link_hoisted_importer(
         // plan above because their target owns its deps. `portal:`
         // packages stay on the materialized-package path so their
         // graph-visible deps are linked like Yarn expects.
-        // `rebase_local` in the resolver already normalized the
-        // relative path to be importer-relative.
+        // `rebase_local` in the resolver (and preserved-lockfile
+        // import) stores local paths relative to the project root.
         if let Some(LocalSource::Link(rel)) = pkg.local_source.as_ref() {
             if let Some(parent) = pkg_dir.parent() {
                 crate::mkdirp(parent)?;
             }
             crate::try_remove_entry(&pkg_dir);
-            let abs_target = importer_dir.join(rel);
+            let abs_target = root_dir.join(rel);
             let link_parent = pkg_dir.parent().unwrap_or(&nm);
             let rel_target = pathdiff::diff_paths(&abs_target, link_parent).unwrap_or(abs_target);
             crate::sys::create_dir_link(&rel_target, &pkg_dir)

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -29,6 +29,7 @@ impl Linker {
             hoisted::link_hoisted_importer(
                 self,
                 project_dir,
+                project_dir,
                 graph.root_deps(),
                 graph,
                 package_indices,
@@ -548,6 +549,7 @@ impl Linker {
                 .collect();
             hoisted::link_hoisted_importer(
                 self,
+                root_dir,
                 &importer_dir,
                 &planner_deps,
                 graph,

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -28,8 +28,10 @@ impl Linker {
             let mut placements = HoistedPlacements::default();
             hoisted::link_hoisted_importer(
                 self,
-                project_dir,
-                project_dir,
+                hoisted::HoistedImporterDirs {
+                    root: project_dir,
+                    importer: project_dir,
+                },
                 graph.root_deps(),
                 graph,
                 package_indices,
@@ -549,8 +551,10 @@ impl Linker {
                 .collect();
             hoisted::link_hoisted_importer(
                 self,
-                root_dir,
-                &importer_dir,
+                hoisted::HoistedImporterDirs {
+                    root: root_dir,
+                    importer: &importer_dir,
+                },
                 &planner_deps,
                 graph,
                 package_indices,

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -409,7 +409,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     }
     // Canonical keys the main loop should ignore — those are the
     // snapshot keys we already absorbed above.
-    let local_canonical_keys: std::collections::HashSet<String> = local_packages
+    let mut local_canonical_keys: std::collections::HashSet<String> = local_packages
         .values()
         .filter_map(|p| {
             p.local_source
@@ -417,6 +417,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 .map(|l| format!("{}@{}", p.name, l.specifier()))
         })
         .collect();
+    local_canonical_keys.extend(local_snapshot_keys.into_values());
 
     let snapshot_keys: Vec<String> = if raw.snapshots.is_empty() {
         raw.packages.keys().cloned().collect()

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -43,6 +43,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     let mut local_packages: BTreeMap<String, LockedPackage> = BTreeMap::new();
     let mut local_importers: BTreeMap<String, String> = BTreeMap::new();
     let mut local_snapshot_keys: BTreeMap<String, String> = BTreeMap::new();
+    let mut all_local_snapshot_keys: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
     let mut skipped_optional_dependencies: BTreeMap<String, BTreeMap<String, String>> =
         BTreeMap::new();
     // pnpm v9 encodes npm-aliases implicitly: the importer key is
@@ -137,7 +139,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             }
             local_snapshot_keys
                 .entry(dep_path)
-                .or_insert_with(|| snapshot_key);
+                .or_insert_with(|| snapshot_key.clone());
+            all_local_snapshot_keys.insert(snapshot_key);
         } else {
             // Detect npm-aliased deps purely from the shape of
             // `version:`. pnpm encodes aliases as
@@ -424,7 +427,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 .map(|l| format!("{}@{}", p.name, l.specifier()))
         })
         .collect();
-    local_canonical_keys.extend(local_snapshot_keys.into_values());
+    local_canonical_keys.extend(all_local_snapshot_keys);
 
     let snapshot_keys: Vec<String> = if raw.snapshots.is_empty() {
         raw.packages.keys().cloned().collect()

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -106,7 +106,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 other => other,
             };
             let snapshot_key = format!("{name}@{}", local.specifier());
-            let should_rebase = importer_path != "." && info.specifier == classify_version;
+            let should_rebase = importer_path != "."
+                && (info.specifier == classify_version || info.specifier.starts_with("workspace:"));
             let local = if should_rebase {
                 rebase_importer_local(local, importer_path)
             } else {

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -6,8 +6,28 @@ use crate::{
     CatalogEntry, DepType, DirectDep, Error, LocalSource, LockedPackage, LockfileGraph,
     PeerDepMeta, git_commits_match,
 };
+use aube_util::path::normalize_lexical;
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+fn rebase_importer_local(local: LocalSource, importer_path: &str) -> LocalSource {
+    fn rebase(path: PathBuf, importer_path: &str) -> PathBuf {
+        if importer_path == "." {
+            path
+        } else {
+            normalize_lexical(&Path::new(importer_path).join(path))
+        }
+    }
+
+    match local {
+        LocalSource::Directory(path) => LocalSource::Directory(rebase(path, importer_path)),
+        LocalSource::Tarball(path) => LocalSource::Tarball(rebase(path, importer_path)),
+        LocalSource::Link(path) => LocalSource::Link(rebase(path, importer_path)),
+        LocalSource::Portal(path) => LocalSource::Portal(rebase(path, importer_path)),
+        LocalSource::Exec(path) => LocalSource::Exec(rebase(path, importer_path)),
+        LocalSource::Git(_) | LocalSource::RemoteTarball(_) => local,
+    }
+}
 
 /// Parse a pnpm-lock.yaml file into a LockfileGraph.
 pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
@@ -21,6 +41,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     // them off the canonical lockfile key.
     let mut importers = BTreeMap::new();
     let mut local_packages: BTreeMap<String, LockedPackage> = BTreeMap::new();
+    let mut local_importers: BTreeMap<String, String> = BTreeMap::new();
+    let mut local_snapshot_keys: BTreeMap<String, String> = BTreeMap::new();
     let mut skipped_optional_dependencies: BTreeMap<String, BTreeMap<String, String>> =
         BTreeMap::new();
     // pnpm v9 encodes npm-aliases implicitly: the importer key is
@@ -35,6 +57,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
 
     let mut push_direct = |deps: &mut Vec<DirectDep>,
                            alias_remaps: &mut Vec<(String, String, String, String)>,
+                           importer_path: &str,
                            name: &str,
                            info: &RawDepSpec,
                            dep_type: DepType| {
@@ -80,6 +103,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 }
                 other => other,
             };
+            let snapshot_key = format!("{name}@{}", local.specifier());
+            let local = rebase_importer_local(local, importer_path);
             let dep_path = local.dep_path(name);
             deps.push(DirectDep {
                 name: name.to_string(),
@@ -96,10 +121,16 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                     dependencies: BTreeMap::new(),
                     peer_dependencies: BTreeMap::new(),
                     peer_dependencies_meta: BTreeMap::new(),
-                    dep_path,
+                    dep_path: dep_path.clone(),
                     local_source: Some(local),
                     ..Default::default()
                 });
+            local_importers
+                .entry(dep_path.clone())
+                .or_insert_with(|| importer_path.to_string());
+            local_snapshot_keys
+                .entry(dep_path)
+                .or_insert_with(|| snapshot_key);
         } else {
             // Detect npm-aliased deps purely from the shape of
             // `version:`. pnpm encodes aliases as
@@ -177,6 +208,7 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 push_direct(
                     &mut deps,
                     &mut alias_remaps,
+                    importer_path,
                     name,
                     info,
                     DepType::Production,
@@ -185,12 +217,26 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         }
         if let Some(ref d) = importer.dev_dependencies {
             for (name, info) in d {
-                push_direct(&mut deps, &mut alias_remaps, name, info, DepType::Dev);
+                push_direct(
+                    &mut deps,
+                    &mut alias_remaps,
+                    importer_path,
+                    name,
+                    info,
+                    DepType::Dev,
+                );
             }
         }
         if let Some(ref d) = importer.optional_dependencies {
             for (name, info) in d {
-                push_direct(&mut deps, &mut alias_remaps, name, info, DepType::Optional);
+                push_direct(
+                    &mut deps,
+                    &mut alias_remaps,
+                    importer_path,
+                    name,
+                    info,
+                    DepType::Optional,
+                );
             }
         }
 
@@ -226,18 +272,32 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     for local_pkg in local_packages.values_mut() {
         if let Some(ref local) = local_pkg.local_source {
             let canonical = format!("{}@{}", local_pkg.name, local.specifier());
+            let snapshot_key = local_snapshot_keys
+                .get(&local_pkg.dep_path)
+                .map(String::as_str)
+                .unwrap_or(canonical.as_str());
             // URL-based direct deps have their peer-context suffix
             // stripped (see `push_direct`), but the matching snapshot
             // entry pnpm wrote still carries the suffix. Fall back to
             // any snapshot whose peer-stripped canonical matches so
             // transitive dependency metadata still flows through.
-            let snap = raw.snapshots.get(&canonical).or_else(|| {
-                raw.snapshots.iter().find_map(|(k, v)| {
-                    parse_dep_path(k)
-                        .filter(|(n, ver)| format!("{n}@{ver}") == canonical)
-                        .map(|_| v)
+            let snap = raw
+                .snapshots
+                .get(snapshot_key)
+                .or_else(|| {
+                    if snapshot_key == canonical {
+                        None
+                    } else {
+                        raw.snapshots.get(&canonical)
+                    }
                 })
-            });
+                .or_else(|| {
+                    raw.snapshots.iter().find_map(|(k, v)| {
+                        parse_dep_path(k)
+                            .filter(|(n, ver)| format!("{n}@{ver}") == canonical)
+                            .map(|_| v)
+                    })
+                });
             if let Some(snap) = snap
                 && let Some(mut deps) = snap.dependencies.clone()
             {
@@ -296,6 +356,9 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 && let Some(ref res) = pkg_info.resolution
                 && let Some(mut ls) = local_source_from_resolution(res)
             {
+                if let Some(importer_path) = local_importers.get(&local_pkg.dep_path) {
+                    ls = rebase_importer_local(ls, importer_path);
+                }
                 if matches!(ls, LocalSource::Git(_) | LocalSource::RemoteTarball(_)) {
                     local_pkg.integrity = res.integrity.clone();
                 }

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -104,7 +104,12 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                 other => other,
             };
             let snapshot_key = format!("{name}@{}", local.specifier());
-            let local = rebase_importer_local(local, importer_path);
+            let should_rebase = importer_path != "." && info.specifier == classify_version;
+            let local = if should_rebase {
+                rebase_importer_local(local, importer_path)
+            } else {
+                local
+            };
             let dep_path = local.dep_path(name);
             deps.push(DirectDep {
                 name: name.to_string(),
@@ -125,9 +130,11 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
                     local_source: Some(local),
                     ..Default::default()
                 });
-            local_importers
-                .entry(dep_path.clone())
-                .or_insert_with(|| importer_path.to_string());
+            if should_rebase {
+                local_importers
+                    .entry(dep_path.clone())
+                    .or_insert_with(|| importer_path.to_string());
+            }
             local_snapshot_keys
                 .entry(dep_path)
                 .or_insert_with(|| snapshot_key);

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -411,6 +411,59 @@ snapshots:
 }
 
 #[test]
+fn parse_aube_written_workspace_local_paths_are_not_rebased_twice() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &lockfile_path,
+        r#"
+lockfileVersion: '9.0'
+
+importers:
+  .: {}
+
+  pkg-a:
+    dependencies:
+      pkg-b:
+        specifier: link:../gems/pkg-b-parent/pkg-b
+        version: link:gems/pkg-b-parent/pkg-b
+
+      pkg-c:
+        specifier: file:../gems/pkg-c
+        version: file:gems/pkg-c
+
+packages:
+  pkg-c@file:gems/pkg-c:
+    resolution: {directory: gems/pkg-c, type: directory}
+
+snapshots:
+  pkg-c@file:gems/pkg-c: {}
+"#,
+    )
+    .unwrap();
+
+    let graph = parse(&lockfile_path).unwrap();
+    let pkg_b = graph
+        .packages
+        .values()
+        .find(|pkg| pkg.name == "pkg-b")
+        .expect("pkg-b");
+    assert_eq!(
+        pkg_b.local_source,
+        Some(LocalSource::Link("gems/pkg-b-parent/pkg-b".into()))
+    );
+    let pkg_c = graph
+        .packages
+        .values()
+        .find(|pkg| pkg.name == "pkg-c")
+        .expect("pkg-c");
+    assert_eq!(
+        pkg_c.local_source,
+        Some(LocalSource::Directory("gems/pkg-c".into()))
+    );
+}
+
+#[test]
 fn parse_transitive_url_entry_uses_pnpm_version_field() {
     // Regression: pnpm writes non-registry transitive entries with
     // the tarball URL in the dep-path key and the real semver in a

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -463,6 +463,43 @@ snapshots:
 }
 
 #[test]
+fn parse_workspace_protocol_link_versions_are_rebased_from_importer() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &lockfile_path,
+        r#"
+lockfileVersion: '9.0'
+
+importers:
+  .: {}
+
+  pkg-a:
+    dependencies:
+      pkg-b:
+        specifier: workspace:*
+        version: link:../pkg-b
+
+  pkg-b: {}
+"#,
+    )
+    .unwrap();
+
+    let graph = parse(&lockfile_path).unwrap();
+    let pkg_b = graph
+        .packages
+        .values()
+        .find(|pkg| pkg.name == "pkg-b")
+        .expect("pkg-b");
+    assert_eq!(pkg_b.local_source, Some(LocalSource::Link("pkg-b".into())));
+    assert_eq!(graph.importers["pkg-a"][0].dep_path, pkg_b.dep_path);
+    assert_eq!(
+        graph.importers["pkg-a"][0].specifier.as_deref(),
+        Some("workspace:*")
+    );
+}
+
+#[test]
 fn parse_aube_written_workspace_local_paths_are_not_rebased_twice() {
     let dir = tempfile::tempdir().unwrap();
     let lockfile_path = dir.path().join("pnpm-lock.yaml");

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -411,6 +411,58 @@ snapshots:
 }
 
 #[test]
+fn parse_multi_importer_local_snapshot_keys_do_not_create_orphans() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &lockfile_path,
+        r#"
+lockfileVersion: '9.0'
+
+importers:
+  .: {}
+
+  pkg-a:
+    dependencies:
+      pkg-b:
+        specifier: link:../gems/pkg-b-parent/pkg-b
+        version: link:../gems/pkg-b-parent/pkg-b
+
+  packages/deep-app:
+    dependencies:
+      pkg-b:
+        specifier: link:../../gems/pkg-b-parent/pkg-b
+        version: link:../../gems/pkg-b-parent/pkg-b
+
+snapshots:
+  pkg-b@link:../gems/pkg-b-parent/pkg-b: {}
+  pkg-b@link:../../gems/pkg-b-parent/pkg-b: {}
+"#,
+    )
+    .unwrap();
+
+    let graph = parse(&lockfile_path).unwrap();
+    let pkg_b_entries: Vec<_> = graph
+        .packages
+        .values()
+        .filter(|pkg| pkg.name == "pkg-b")
+        .collect();
+    assert_eq!(pkg_b_entries.len(), 1);
+    assert_eq!(
+        pkg_b_entries[0].local_source,
+        Some(LocalSource::Link("gems/pkg-b-parent/pkg-b".into()))
+    );
+    assert_eq!(
+        graph.importers["pkg-a"][0].dep_path,
+        pkg_b_entries[0].dep_path
+    );
+    assert_eq!(
+        graph.importers["packages/deep-app"][0].dep_path,
+        pkg_b_entries[0].dep_path
+    );
+}
+
+#[test]
 fn parse_aube_written_workspace_local_paths_are_not_rebased_twice() {
     let dir = tempfile::tempdir().unwrap();
     let lockfile_path = dir.path().join("pnpm-lock.yaml");

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -366,6 +366,51 @@ snapshots:
 }
 
 #[test]
+fn parse_workspace_local_snapshot_keys_do_not_duplicate_rebased_packages() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &lockfile_path,
+        r#"
+lockfileVersion: '9.0'
+
+importers:
+  .: {}
+
+  pkg-a:
+    dependencies:
+      pkg-b:
+        specifier: link:../gems/pkg-b-parent/pkg-b
+        version: link:../gems/pkg-b-parent/pkg-b
+
+packages:
+  pkg-b@link:../gems/pkg-b-parent/pkg-b:
+    resolution: {directory: ../gems/pkg-b-parent/pkg-b, type: directory}
+
+snapshots:
+  pkg-b@link:../gems/pkg-b-parent/pkg-b: {}
+"#,
+    )
+    .unwrap();
+
+    let graph = parse(&lockfile_path).unwrap();
+    let pkg_b_entries: Vec<_> = graph
+        .packages
+        .values()
+        .filter(|pkg| pkg.name == "pkg-b")
+        .collect();
+    assert_eq!(pkg_b_entries.len(), 1);
+    assert_eq!(
+        pkg_b_entries[0].local_source,
+        Some(LocalSource::Link("gems/pkg-b-parent/pkg-b".into()))
+    );
+    assert_eq!(
+        graph.importers["pkg-a"][0].dep_path,
+        pkg_b_entries[0].dep_path
+    );
+}
+
+#[test]
 fn parse_transitive_url_entry_uses_pnpm_version_field() {
     // Regression: pnpm writes non-registry transitive entries with
     // the tarball URL in the dep-path key and the real semver in a

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -183,6 +183,51 @@ EOF
 	assert_output --partial '"version":"9.9.9"'
 }
 
+@test "aube install preserves pnpm workspace link targets relative to importer" {
+	mkdir -p pkg-a gems/pkg-b-parent/pkg-b
+	cat >package.json <<'EOF'
+{"name":"root","version":"0.0.0","private":true}
+EOF
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - "pkg-a"
+  - "gems/pkg-b-parent/pkg-b"
+EOF
+	cat >pkg-a/package.json <<'EOF'
+{"name":"pkg-a","version":"0.0.0","dependencies":{"pkg-b":"link:../gems/pkg-b-parent/pkg-b"}}
+EOF
+	cat >gems/pkg-b-parent/pkg-b/package.json <<'EOF'
+{"name":"pkg-b","version":"0.0.0","main":"index.js"}
+EOF
+	cat >pnpm-lock.yaml <<'EOF'
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  pkg-a:
+    dependencies:
+      pkg-b:
+        specifier: link:../gems/pkg-b-parent/pkg-b
+        version: link:../gems/pkg-b-parent/pkg-b
+
+  gems/pkg-b-parent/pkg-b: {}
+EOF
+
+	run aube install --frozen-lockfile
+	assert_success
+
+	[ -L pkg-a/node_modules/pkg-b ]
+	run readlink pkg-a/node_modules/pkg-b
+	assert_output "../../gems/pkg-b-parent/pkg-b"
+	assert_file_exists pkg-a/node_modules/pkg-b/package.json
+}
+
 @test "aube install honors link: paths in pnpm.overrides as project-root-relative" {
 	# Workspace consumer pinned `@company/bar@1.2.3` (registry version),
 	# but root `pnpm.overrides` rewrites that to `link:./libs/bar`.

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -273,6 +273,51 @@ EOF
 	assert_file_exists pkg-a/node_modules/pkg-b/package.json
 }
 
+@test "aube install preserves pnpm workspace protocol link targets in hoisted mode" {
+	mkdir -p pkg-a pkg-b
+	cat >package.json <<'EOF'
+{"name":"root","version":"0.0.0","private":true}
+EOF
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - "pkg-a"
+  - "pkg-b"
+EOF
+	cat >pkg-a/package.json <<'EOF'
+{"name":"pkg-a","version":"0.0.0","dependencies":{"pkg-b":"workspace:*"}}
+EOF
+	cat >pkg-b/package.json <<'EOF'
+{"name":"pkg-b","version":"0.0.0","main":"index.js"}
+EOF
+	cat >pnpm-lock.yaml <<'EOF'
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  pkg-a:
+    dependencies:
+      pkg-b:
+        specifier: workspace:*
+        version: link:../pkg-b
+
+  pkg-b: {}
+EOF
+
+	run aube install --frozen-lockfile --node-linker=hoisted
+	assert_success
+
+	[ -L pkg-a/node_modules/pkg-b ]
+	run readlink pkg-a/node_modules/pkg-b
+	assert_output "../../pkg-b"
+	assert_file_exists pkg-a/node_modules/pkg-b/package.json
+}
+
 @test "aube install honors link: paths in pnpm.overrides as project-root-relative" {
 	# Workspace consumer pinned `@company/bar@1.2.3` (registry version),
 	# but root `pnpm.overrides` rewrites that to `link:./libs/bar`.

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -228,6 +228,51 @@ EOF
 	assert_file_exists pkg-a/node_modules/pkg-b/package.json
 }
 
+@test "aube install preserves pnpm workspace link targets in hoisted mode" {
+	mkdir -p pkg-a gems/pkg-b-parent/pkg-b
+	cat >package.json <<'EOF'
+{"name":"root","version":"0.0.0","private":true}
+EOF
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - "pkg-a"
+  - "gems/pkg-b-parent/pkg-b"
+EOF
+	cat >pkg-a/package.json <<'EOF'
+{"name":"pkg-a","version":"0.0.0","dependencies":{"pkg-b":"link:../gems/pkg-b-parent/pkg-b"}}
+EOF
+	cat >gems/pkg-b-parent/pkg-b/package.json <<'EOF'
+{"name":"pkg-b","version":"0.0.0","main":"index.js"}
+EOF
+	cat >pnpm-lock.yaml <<'EOF'
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  pkg-a:
+    dependencies:
+      pkg-b:
+        specifier: link:../gems/pkg-b-parent/pkg-b
+        version: link:../gems/pkg-b-parent/pkg-b
+
+  gems/pkg-b-parent/pkg-b: {}
+EOF
+
+	run aube install --frozen-lockfile --node-linker=hoisted
+	assert_success
+
+	[ -L pkg-a/node_modules/pkg-b ]
+	run readlink pkg-a/node_modules/pkg-b
+	assert_output "../../gems/pkg-b-parent/pkg-b"
+	assert_file_exists pkg-a/node_modules/pkg-b/package.json
+}
+
 @test "aube install honors link: paths in pnpm.overrides as project-root-relative" {
 	# Workspace consumer pinned `@company/bar@1.2.3` (registry version),
 	# but root `pnpm.overrides` rewrites that to `link:./libs/bar`.


### PR DESCRIPTION
## Summary
- rebase pnpm importer-local `file:`/`link:` paths to project-root-relative paths when parsing preserved pnpm lockfiles
- preserve original pnpm snapshot keys so local package dependency metadata still imports correctly
- add a frozen-lockfile regression for workspace `link:` symlinks from a non-root importer

Closes https://github.com/endevco/aube/discussions/822

## Verification
- `cargo fmt --check`
- `cargo test -p aube-lockfile pnpm`
- `test/bats/bin/bats --filter 'pnpm workspace link targets' test/local_deps.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lockfile parsing and hoisted install linking for workspace local deps; wrong rebasing or symlink bases would break frozen installs, but scope is localized with new regression tests.
> 
> **Overview**
> When importing a **preserved pnpm lockfile**, workspace importers’ `file:` / `link:` / `workspace:` local paths are **rebased from importer-relative to project-root-relative**, with guards so paths aube already wrote root-relative are not rebased twice. **Original pnpm snapshot keys** are kept for dependency metadata lookup and added to the skip set so the same local package is not parsed twice as orphan snapshots.
> 
> **Hoisted linking** now takes separate **project root** and **importer** directories: `link:` symlinks join targets against the root (matching isolated workspace behavior) instead of the nested importer only.
> 
> Adds **unit tests** in `aube-lockfile` and **Bats** frozen-lockfile cases for workspace `link:` / `workspace:*` in default and hoisted modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3172e17405ebe434e5cc1e1078ddb6cbfd9b398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve importer-relative symlink targets for pnpm workspace links during install.
  * Avoid duplicate workspace-local package entries by improving snapshot lookup and importer-relative rebasing.
  * Ensure hoisted linking resolves workspace `link:` targets relative to the project root so symlinks point correctly.

* **Tests**
  * Added integration and regression tests verifying symlink target preservation and single-entry workspace-local package behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->