### PR TITLE
fix(update): support global updates

### DIFF
--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -870,8 +870,9 @@ fn select_global_updates(
             .push(raw.clone());
     }
 
-    for name in &missing {
-        eprintln!("Not globally installed: {name}");
+    if !missing.is_empty() {
+        let joined = missing.join(", ");
+        return Err(miette!("not globally installed: {joined}"));
     }
     if by_hash.is_empty() {
         return Err(miette!("no matching global packages were updated"));

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -116,7 +116,6 @@ pub async fn run(
     args.lockfile.install_overrides();
     args.virtual_store.install_overrides();
     let _ = args.ignore_scripts; // parity no-op: dep scripts already gated by allowBuilds
-    let _ = args.global;
     if let Some(depth) = args.depth.as_deref() {
         // pnpm's `--depth Infinity` is the only useful value; the
         // intermediate ones (`--depth 1`, `--depth 2`) have semantics
@@ -127,6 +126,9 @@ pub async fn run(
             "warn: --depth {depth} is ignored; aube only refreshes direct deps. \
              For a full refresh, run `rm aube-lock.yaml && aube install`."
         );
+    }
+    if args.global {
+        return run_global(args).await;
     }
     if !filter.is_empty() {
         // Discussion #602: `aube update -r` is expected to bump the
@@ -769,6 +771,112 @@ pub async fn run(
     install::run(chained).await?;
 
     Ok(())
+}
+
+async fn run_global(args: UpdateArgs) -> miette::Result<()> {
+    reject_unsupported_pkg_specs(&args.packages)?;
+
+    let layout = super::global::GlobalLayout::resolve()?;
+    let packages = super::global::scan_packages(&layout.pkg_dir);
+    if packages.is_empty() {
+        return Err(miette!("no global packages installed"));
+    }
+
+    let selected = select_global_updates(&args.packages, packages)?;
+    let original_cwd = crate::dirs::cwd()?;
+    let result = async {
+        for (info, package_args) in selected {
+            let old_bins = super::global::bin_names_for(&info.install_dir, &info.aliases);
+            super::retarget_cwd(&info.install_dir)?;
+
+            let mut inner = args.clone();
+            inner.global = false;
+            inner.packages = package_args;
+            inner.depth = None;
+            inner.latest = true;
+            inner.exact = true;
+            inner.no_save = false;
+            inner.workspace = false;
+
+            Box::pin(run(
+                inner,
+                aube_workspace::selector::EffectiveFilter::default(),
+            ))
+            .await?;
+
+            let shim_opts = crate::commands::with_settings_ctx(&info.install_dir, |ctx| {
+                aube_linker::BinShimOptions {
+                    extend_node_path: aube_settings::resolved::extend_node_path(ctx),
+                    prefer_symlinked_executables:
+                        aube_settings::resolved::prefer_symlinked_executables(ctx),
+                    hidden_modules_dir: None,
+                }
+            });
+            let linked = super::global::link_bins(
+                &info.install_dir,
+                &layout.bin_dir,
+                &info.aliases,
+                shim_opts,
+            )?;
+            let linked_set: std::collections::BTreeSet<&str> =
+                linked.iter().map(String::as_str).collect();
+            let stale_bins: Vec<String> = old_bins
+                .into_iter()
+                .filter(|name| !linked_set.contains(name.as_str()))
+                .collect();
+            super::global::unlink_bins(&info.install_dir, &layout.bin_dir, &stale_bins);
+            if !linked.is_empty() {
+                eprintln!(
+                    "Linked {} into {}",
+                    pluralizer::pluralize("bin", linked.len() as isize, true),
+                    layout.bin_dir.display()
+                );
+            }
+        }
+        Ok(())
+    }
+    .await;
+    super::finish_filtered_workspace(&original_cwd, result)
+}
+
+fn select_global_updates(
+    requested: &[String],
+    packages: Vec<super::global::GlobalPackageInfo>,
+) -> miette::Result<Vec<(super::global::GlobalPackageInfo, Vec<String>)>> {
+    if requested.is_empty() {
+        return Ok(packages
+            .into_iter()
+            .map(|info| (info, Vec::new()))
+            .collect());
+    }
+
+    let mut by_hash: BTreeMap<String, (super::global::GlobalPackageInfo, Vec<String>)> =
+        BTreeMap::new();
+    let mut missing = Vec::new();
+    for raw in requested {
+        let (name, _) = split_pkg_arg(raw);
+        let Some(info) = packages
+            .iter()
+            .find(|info| info.aliases.iter().any(|alias| alias == name))
+            .cloned()
+        else {
+            missing.push(name.to_string());
+            continue;
+        };
+        by_hash
+            .entry(info.hash.clone())
+            .or_insert_with(|| (info, Vec::new()))
+            .1
+            .push(raw.clone());
+    }
+
+    for name in &missing {
+        eprintln!("Not globally installed: {name}");
+    }
+    if by_hash.is_empty() {
+        return Err(miette!("no matching global packages were updated"));
+    }
+    Ok(by_hash.into_values().collect())
 }
 
 fn workspace_package_versions(cwd: &std::path::Path) -> miette::Result<HashMap<String, String>> {

--- a/test/filter.bats
+++ b/test/filter.bats
@@ -260,11 +260,22 @@ _setup_filter_workspace() {
 	assert_output --partial "other-ran"
 }
 
-@test "aube -F update: --global no-op still preserves workspace filter" {
+@test "aube -F update: --global uses global installs instead of workspace filter" {
 	_setup_filter_workspace
-	node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('packages/lib-a/package.json')); p.dependencies={'is-odd':'^0.1.0'}; fs.writeFileSync('packages/lib-a/package.json', JSON.stringify(p, null, 2));"
+	cat >packages/lib-a/package.json <<-'EOF'
+		{
+		  "name": "@scope/lib-a",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "^0.1.0" },
+		  "scripts": { "hello": "echo lib-a-ran" }
+		}
+	EOF
 
 	run aube -F @scope/lib-a update --global is-odd
+	assert_failure
+	assert_output --partial "no global packages installed"
+
+	run grep -F '"is-odd": "^0.1.0"' packages/lib-a/package.json
 	assert_success
 }
 

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -64,6 +64,23 @@ teardown() {
 	assert_output --partial '"version": "7.7.4"'
 }
 
+@test "aube update -g updates global packages outside a project" {
+	run aube add -g is-positive@1.0.0
+	assert_success
+
+	mkdir -p "$TEST_TEMP_DIR/no-project"
+	cd "$TEST_TEMP_DIR/no-project"
+
+	run aube update -g
+	assert_success
+	refute_output --partial "no package.json found"
+	assert_output --partial "is-positive: 1.0.0 -> 3.1.0"
+
+	run aube list -g
+	assert_success
+	assert_output --partial "is-positive 3.1.0"
+}
+
 @test "aube add -g creates a hash pointer in the pkg dir" {
 	run aube add -g semver@7.7.4
 	assert_success

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -70,15 +70,26 @@ teardown() {
 
 	mkdir -p "$TEST_TEMP_DIR/no-project"
 	cd "$TEST_TEMP_DIR/no-project"
+	assert_file_not_exists package.json
 
 	run aube update -g
 	assert_success
 	refute_output --partial "no package.json found"
-	assert_output --partial "is-positive: 1.0.0 -> 3.1.0"
+	assert_output --partial "is-positive: 1.0.0 ->"
 
 	run aube list -g
 	assert_success
-	assert_output --partial "is-positive 3.1.0"
+	assert_output --partial "is-positive "
+	refute_output --partial "is-positive 1.0.0"
+}
+
+@test "aube update -g fails when any named package is missing" {
+	run aube add -g is-positive@1.0.0
+	assert_success
+
+	run aube update -g is-positive missing-global-package
+	assert_failure
+	assert_output --partial "not globally installed: missing-global-package"
 }
 
 @test "aube add -g creates a hash pointer in the pkg dir" {


### PR DESCRIPTION
## Summary
- Route `aube update --global` through the global install directory instead of project-root discovery.
- Reuse the normal update pipeline inside each global install, keeping global tools pinned exactly while moving them to latest.
- Relink global bin shims after updates and add a regression covering execution outside a project.

Fixes Discussion #839: https://github.com/endevco/aube/discussions/839

## Tests
- `cargo fmt --check`
- `cargo test -p aube global`
- `cargo clippy -p aube --all-targets -- -D warnings`
- `test/bats/bin/bats --filter 'aube update -g updates global packages outside a project' test/global_install.bats`

Note: `mise run test:bats test/global_install.bats` could not start in this environment because GNU `parallel` is missing. Running the whole BATS file directly reached the new regression successfully, then later unrelated lifecycle-script tests failed because `node` is currently a broken `mise` shim here.

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global install layout, bin linking, and reuses the full update resolver inside each global directory; mistakes could break CLI tools on PATH but scope is limited to the global code path.
> 
> **Overview**
> **`aube update --global`** now updates tools from the global install store instead of requiring a project `package.json`, so it works from any directory (including outside a repo).
> 
> When `--global` is set, the command scans installed globals, runs the normal update flow inside each global install directory with **`--latest`** and exact manifest pins, then **relinks** bin shims and removes **stale** executables after version changes. Named packages resolve by alias; missing names fail with **`not globally installed`**. With a workspace **`--filter`**, **`--global` takes precedence** and does not mutate filtered workspace manifests.
> 
> BATS coverage adds global update success outside a project and failure for unknown package names; the filter test expects global routing instead of a no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e98c554e99625b3bec4d2f9522e9816481d01d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `aube update --global` now updates globally installed packages from anywhere, supporting updating all globals or specific packages by name, and ensures binary shims are linked and stale shims removed.
* **Bug Fixes**
  * Named-package updates now error if a specified package is not globally installed.
* **Tests**
  * Added tests for global updates and failure when a named global package is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->