### PR TITLE
security(install): verify lockfile tarball URLs

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -221,16 +221,16 @@ pub const ALL: &[CodeMeta] = &[
         exit_code: Some(32),
     },
     CodeMeta {
-        name: ERR_AUBE_TARBALL_URL_MISMATCH,
-        category: category::TARBALL_STORE,
-        description: "A registry lockfile entry's explicit tarball URL didn't match the registry metadata for that `(name, version)`.",
-        exit_code: Some(34),
-    },
-    CodeMeta {
         name: ERR_AUBE_GIT_ERROR,
         category: category::TARBALL_STORE,
         description: "Git operation failed during a `git:` dep prepare or checkout.",
         exit_code: Some(33),
+    },
+    CodeMeta {
+        name: ERR_AUBE_TARBALL_URL_MISMATCH,
+        category: category::TARBALL_STORE,
+        description: "A registry lockfile entry's explicit tarball URL didn't match the registry metadata for that `(name, version)`.",
+        exit_code: Some(34),
     },
     CodeMeta {
         name: ERR_AUBE_NO_HOME,

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -49,6 +49,7 @@ pub const ERR_AUBE_SECURITY_SCANNER_FAILED: &str = "ERR_AUBE_SECURITY_SCANNER_FA
 pub const ERR_AUBE_TARBALL_INTEGRITY: &str = "ERR_AUBE_TARBALL_INTEGRITY";
 pub const ERR_AUBE_TARBALL_EXTRACT: &str = "ERR_AUBE_TARBALL_EXTRACT";
 pub const ERR_AUBE_PKG_CONTENT_MISMATCH: &str = "ERR_AUBE_PKG_CONTENT_MISMATCH";
+pub const ERR_AUBE_TARBALL_URL_MISMATCH: &str = "ERR_AUBE_TARBALL_URL_MISMATCH";
 pub const ERR_AUBE_NO_HOME: &str = "ERR_AUBE_NO_HOME";
 pub const ERR_AUBE_GIT_ERROR: &str = "ERR_AUBE_GIT_ERROR";
 
@@ -218,6 +219,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::TARBALL_STORE,
         description: "Tarball's `package.json` declared a different `(name, version)` than the resolver expected (`strictStorePkgContentCheck=true`).",
         exit_code: Some(32),
+    },
+    CodeMeta {
+        name: ERR_AUBE_TARBALL_URL_MISMATCH,
+        category: category::TARBALL_STORE,
+        description: "A registry lockfile entry's explicit tarball URL didn't match the registry metadata for that `(name, version)`.",
+        exit_code: Some(34),
     },
     CodeMeta {
         name: ERR_AUBE_GIT_ERROR,

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -787,6 +787,10 @@ where
                 let url = tarball_url_override
                     .clone()
                     .unwrap_or_else(|| client.tarball_url(&registry_name, &version));
+                if let Some(lockfile_url) = tarball_url_override.as_deref() {
+                    verify_lockfile_tarball_url(&client, &registry_name, &version, lockfile_url)
+                        .await?;
+                }
 
                 let dl_start = std::time::Instant::now();
 
@@ -971,6 +975,46 @@ where
     }
 
     Ok((indices, cached_count, fetch_count))
+}
+
+async fn verify_lockfile_tarball_url(
+    client: &aube_registry::client::RegistryClient,
+    registry_name: &str,
+    version: &str,
+    lockfile_url: &str,
+) -> miette::Result<()> {
+    let meta = client
+        .fetch_single_version_metadata(registry_name, version)
+        .await
+        .map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_TARBALL_URL_MISMATCH,
+                "{}@{}: failed to verify lockfile tarball URL against registry metadata: {}",
+                registry_name,
+                version,
+                e
+            )
+        })?;
+    let Some(expected_url) = meta.dist.as_ref().map(|dist| dist.tarball.as_str()) else {
+        return Err(miette!(
+            code = aube_codes::errors::ERR_AUBE_TARBALL_URL_MISMATCH,
+            "{}@{}: registry metadata did not include dist.tarball while lockfile pinned {}",
+            registry_name,
+            version,
+            aube_util::url::redact_url(lockfile_url)
+        ));
+    };
+    if lockfile_url != expected_url {
+        return Err(miette!(
+            code = aube_codes::errors::ERR_AUBE_TARBALL_URL_MISMATCH,
+            "{}@{}: lockfile tarball URL {} does not match registry metadata {}",
+            registry_name,
+            version,
+            aube_util::url::redact_url(lockfile_url),
+            aube_util::url::redact_url(expected_url)
+        ));
+    }
+    Ok(())
 }
 
 /// Pull the canonical version off a dep_path for display purposes. The

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -1004,7 +1004,7 @@ async fn verify_lockfile_tarball_url(
             aube_util::url::redact_url(lockfile_url)
         ));
     };
-    if lockfile_url != expected_url {
+    if !lockfile_tarball_url_matches_metadata(lockfile_url, expected_url) {
         return Err(miette!(
             code = aube_codes::errors::ERR_AUBE_TARBALL_URL_MISMATCH,
             "{}@{}: lockfile tarball URL {} does not match registry metadata {}",
@@ -1015,6 +1015,29 @@ async fn verify_lockfile_tarball_url(
         ));
     }
     Ok(())
+}
+
+fn lockfile_tarball_url_matches_metadata(lockfile_url: &str, expected_url: &str) -> bool {
+    lockfile_url == expected_url
+        || (is_public_npm_registry_tarball(lockfile_url)
+            && tarball_url_path(lockfile_url)
+                .zip(tarball_url_path(expected_url))
+                .is_some_and(|(lockfile_path, expected_path)| lockfile_path == expected_path))
+}
+
+fn is_public_npm_registry_tarball(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_ascii_lowercase))
+        .as_deref()
+        == Some("registry.npmjs.org")
+}
+
+fn tarball_url_path(url: &str) -> Option<String> {
+    let url = reqwest::Url::parse(url).ok()?;
+    let path = url.path();
+    path.contains("/-/")
+        .then_some(path.trim_start_matches('/').to_string())
 }
 
 /// Pull the canonical version off a dep_path for display purposes. The
@@ -1047,4 +1070,48 @@ pub(super) fn remap_indices_to_contextualized(
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lockfile_tarball_url_matches_metadata;
+
+    #[test]
+    fn tarball_url_match_accepts_exact_url() {
+        let url = "https://private.example.com/is-odd/-/is-odd-3.0.1.tgz";
+
+        assert!(lockfile_tarball_url_matches_metadata(url, url));
+    }
+
+    #[test]
+    fn tarball_url_match_accepts_public_npm_lockfile_against_mirror() {
+        assert!(lockfile_tarball_url_matches_metadata(
+            "https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz",
+            "http://localhost:4873/is-odd/-/is-odd-3.0.1.tgz",
+        ));
+    }
+
+    #[test]
+    fn tarball_url_match_accepts_scoped_public_npm_lockfile_against_mirror() {
+        assert!(lockfile_tarball_url_matches_metadata(
+            "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "http://localhost:4873/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+        ));
+    }
+
+    #[test]
+    fn tarball_url_match_rejects_tampered_path() {
+        assert!(!lockfile_tarball_url_matches_metadata(
+            "https://registry.npmjs.org/not-is-odd/-/not-is-odd-3.0.1.tgz",
+            "http://localhost:4873/is-odd/-/is-odd-3.0.1.tgz",
+        ));
+    }
+
+    #[test]
+    fn tarball_url_match_rejects_mirror_match_from_arbitrary_host() {
+        assert!(!lockfile_tarball_url_matches_metadata(
+            "https://example.com/is-odd/-/is-odd-3.0.1.tgz",
+            "http://localhost:4873/is-odd/-/is-odd-3.0.1.tgz",
+        ));
+    }
 }

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -989,7 +989,7 @@ async fn verify_lockfile_tarball_url(
         .map_err(|e| {
             miette!(
                 code = aube_codes::errors::ERR_AUBE_TARBALL_URL_MISMATCH,
-                "{}@{}: failed to verify lockfile tarball URL against registry metadata: {}",
+                "{}@{}: failed to fetch registry metadata to verify lockfile tarball URL: {}",
                 registry_name,
                 version,
                 e

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -103,6 +103,12 @@
       "exit_code": 32
     },
     {
+      "name": "ERR_AUBE_TARBALL_URL_MISMATCH",
+      "category": "Tarball / store",
+      "description": "A registry lockfile entry's explicit tarball URL didn't match the registry metadata for that `(name, version)`.",
+      "exit_code": 34
+    },
+    {
       "name": "ERR_AUBE_GIT_ERROR",
       "category": "Tarball / store",
       "description": "Git operation failed during a `git:` dep prepare or checkout.",

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -103,16 +103,16 @@
       "exit_code": 32
     },
     {
-      "name": "ERR_AUBE_TARBALL_URL_MISMATCH",
-      "category": "Tarball / store",
-      "description": "A registry lockfile entry's explicit tarball URL didn't match the registry metadata for that `(name, version)`.",
-      "exit_code": 34
-    },
-    {
       "name": "ERR_AUBE_GIT_ERROR",
       "category": "Tarball / store",
       "description": "Git operation failed during a `git:` dep prepare or checkout.",
       "exit_code": 33
+    },
+    {
+      "name": "ERR_AUBE_TARBALL_URL_MISMATCH",
+      "category": "Tarball / store",
+      "description": "A registry lockfile entry's explicit tarball URL didn't match the registry metadata for that `(name, version)`.",
+      "exit_code": 34
     },
     {
       "name": "ERR_AUBE_NO_HOME",

--- a/test/lockfile_settings.bats
+++ b/test/lockfile_settings.bats
@@ -128,6 +128,30 @@ teardown() {
 	assert_success
 }
 
+@test "lockfile tarball URLs are verified against registry metadata before fetch" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-tarball-url-mismatch",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "3.0.1" }
+		}
+	EOF
+	cat >>.npmrc <<-'EOF'
+
+		lockfile-include-tarball-url=true
+	EOF
+	run aube install --no-frozen-lockfile
+	assert_success
+
+	perl -0pi -e 's#tarball: .*/is-odd/-/is-odd-3\.0\.1\.tgz#tarball: https://example.com/not-is-odd.tgz#' aube-lock.yaml
+	rm -rf node_modules "$XDG_DATA_HOME/aube/store"
+
+	run aube install --frozen-lockfile
+	assert_failure
+	assert_output --partial "ERR_AUBE_TARBALL_URL_MISMATCH"
+	assert_output --partial "not match registry metadata"
+}
+
 @test "lockfileIncludeTarballUrl=false (default) omits tarball URLs" {
 	cat >package.json <<-'EOF'
 		{


### PR DESCRIPTION
## Summary
- verify explicit registry tarball URLs from lockfiles against per-version registry metadata before fetching
- add ERR_AUBE_TARBALL_URL_MISMATCH and regenerate error-code docs data
- cover tampered lockfile tarball URLs in lockfile settings BATS

## Tests
- cargo fmt --check
- cargo test -p aube-codes
- cargo check -p aube
- cargo build
- test/bats/bin/bats test/lockfile_settings.bats

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a supply-chain guard on the install fetch path with extra registry metadata calls when tarball URLs are pinned; behavior change for tampered lockfiles and npmjs.org mirror URL rules.
> 
> **Overview**
> **Lockfile tarball URL verification** runs during install fetch when the lockfile pins an explicit registry tarball URL (e.g. `lockfile-include-tarball-url=true` or npm-alias entries). Before downloading, install fetches per-version registry metadata and compares `dist.tarball` to the lockfile URL; mismatches abort with **`ERR_AUBE_TARBALL_URL_MISMATCH`** (exit 34).
> 
> Matching allows an exact string match, or—when the lockfile URL is on **`registry.npmjs.org`**—the same `/-/…tgz` path on another host (e.g. Verdaccio mirror) so local mirrors still work. Tampered paths or arbitrary hosts pretending to mirror npm are rejected.
> 
> Docs and **`docs/error-codes.data.json`** include the new code. A BATS test corrupts a lockfile tarball URL and expects frozen install to fail with the new error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a406417094f1cdb86247ba9653ef2272142fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install now validates lockfile tarball URLs against registry metadata; mismatches abort install with error ERR_AUBE_TARBALL_URL_MISMATCH. Mirror-style URLs with matching tarball paths on the public registry are accepted.

* **Tests**
  * Added an integration test that corrupts a lockfile tarball URL and asserts installation fails with ERR_AUBE_TARBALL_URL_MISMATCH.

* **Documentation**
  * Error catalog updated to include ERR_AUBE_TARBALL_URL_MISMATCH and its description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->