### PR TITLE
fix(dlx): accept allow-build flag

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -630,8 +630,8 @@ cmd dlx help="Fetch a package into a throwaway environment and run its binary" {
         long_help "Install a specific package (repeatable).\n\nOverrides inferring from the command."
         arg <PACKAGE>
     }
-    flag --allow-build help="Allow named packages to run postinstall scripts during the transient install" var=#true {
-        long_help "Allow named packages to run postinstall scripts during the transient install.\n\nRepeatable — pass once per package. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved."
+    flag --allow-build help="Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`" var=#true {
+        long_help "Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`.\n\nRepeatable — pass once per package. The named package's `preinstall` / `install` / `postinstall` scripts execute during the transient install. Requires the equals form (`--allow-build=<pkg>`); space-separated forms are rejected. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved."
         arg <PKG>
     }
     flag --frozen-lockfile help="Error if the lockfile drifts from package.json"

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -630,6 +630,10 @@ cmd dlx help="Fetch a package into a throwaway environment and run its binary" {
         long_help "Install a specific package (repeatable).\n\nOverrides inferring from the command."
         arg <PACKAGE>
     }
+    flag --allow-build help="Allow named packages to run postinstall scripts during the transient install" var=#true {
+        long_help "Allow named packages to run postinstall scripts during the transient install.\n\nRepeatable — pass once per package. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved."
+        arg <PKG>
+    }
     flag --frozen-lockfile help="Error if the lockfile drifts from package.json"
     flag --no-frozen-lockfile help="Always re-resolve, even if the lockfile is up to date"
     flag --prefer-frozen-lockfile help="Use the lockfile when fresh, re-resolve when stale"

--- a/crates/aube/src/commands/add/build_flags.rs
+++ b/crates/aube/src/commands/add/build_flags.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 /// Wording must stay byte-identical to pnpm's: scripts that grep
 /// pnpm's stderr for this exact line continue to work after a swap
 /// to aube.
-pub(super) fn parse_allow_build_value(s: &str) -> Result<String, String> {
+pub(crate) fn parse_allow_build_value(s: &str) -> Result<String, String> {
     if s.is_empty() {
         Err("The --allow-build flag is missing a package name. \
              Please specify the package name(s) that are allowed to run installation scripts."

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -1,4 +1,4 @@
-mod build_flags;
+pub(crate) mod build_flags;
 mod filtered;
 mod global;
 mod manifest;

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -81,6 +81,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         env_snapshot: aube_settings::values::capture_env(),
         git_prepare_depth: 0,
         inherited_build_policy: None,
+        build_policy_override: None,
         workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
         skip_root_lifecycle: false,
         // `aube ci` is the canonical "lockfile is law" path —

--- a/crates/aube/src/commands/create.rs
+++ b/crates/aube/src/commands/create.rs
@@ -58,6 +58,7 @@ pub async fn run(args: CreateArgs) -> miette::Result<()> {
     dlx::run(DlxArgs {
         params: dlx_params,
         package: Vec::new(),
+        allow_build: Vec::new(),
         shell_mode: false,
         lockfile: Default::default(),
         network,

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -327,6 +327,7 @@ pub async fn run(
             env_snapshot: aube_settings::values::capture_env(),
             git_prepare_depth: 0,
             inherited_build_policy: None,
+            build_policy_override: None,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
             skip_root_lifecycle: false,
             // Deploys are lockfile-driven by definition. Don't

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -1,4 +1,5 @@
 use super::install::{FrozenMode, InstallOptions};
+use crate::commands::add::build_flags::parse_allow_build_value;
 use clap::{Args, CommandFactory};
 use miette::{Context, IntoDiagnostic, miette};
 
@@ -37,6 +38,19 @@ pub struct DlxArgs {
     /// Overrides inferring from the command.
     #[arg(short = 'p', long = "package")]
     pub package: Vec<String>,
+    /// Allow named packages to run postinstall scripts during the
+    /// transient install.
+    ///
+    /// Repeatable — pass once per package. Mirrors pnpm's
+    /// `pnpm dlx --allow-build=<pkg>` compatibility surface while
+    /// keeping dlx scripts skipped unless explicitly approved.
+    #[arg(
+        long = "allow-build",
+        value_name = "PKG",
+        require_equals = true,
+        value_parser = parse_allow_build_value,
+    )]
+    pub allow_build: Vec<String>,
     #[command(flatten)]
     pub lockfile: crate::cli_args::LockfileArgs,
     #[command(flatten)]
@@ -65,6 +79,7 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
     let DlxArgs {
         params,
         package,
+        allow_build,
         shell_mode,
         lockfile: _,
         network: _,
@@ -144,26 +159,7 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
         .wrap_err("failed to create dlx scratch dir")?;
     let project_dir = tmp.path().to_path_buf();
 
-    // Minimal package.json. Version specs and dist-tags pass through as-is
-    // — the resolver handles them exactly as it would from a real manifest.
-    let mut deps: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
-    for spec in &install_specs {
-        let (mut name, value) = synthesize_dlx_dep(spec);
-        if deps.contains_key(&name) {
-            let mut suffix = 2usize;
-            while deps.contains_key(&format!("{name}-{suffix}")) {
-                suffix += 1;
-            }
-            name = format!("{name}-{suffix}");
-        }
-        deps.insert(name, serde_json::Value::String(value));
-    }
-    let manifest = serde_json::json!({
-        "name": "aube-dlx",
-        "version": "0.0.0",
-        "private": true,
-        "dependencies": deps,
-    });
+    let manifest = dlx_manifest(&install_specs, &allow_build);
     let manifest_bytes = serde_json::to_vec_pretty(&manifest).into_diagnostic()?;
     aube_util::fs_atomic::atomic_write(&project_dir.join("package.json"), &manifest_bytes)
         .into_diagnostic()
@@ -181,7 +177,7 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
     // otherwise resolve to that workspace and install the wrong tree.
     let prev_cwd = {
         let _cwd_guard = CwdGuard::switch_to(&project_dir)?;
-        let mut opts = dlx_install_options();
+        let mut opts = dlx_install_options(&allow_build);
         opts.project_dir = Some(project_dir.clone());
         let install_result = super::install::run(opts).await;
         let prev = _cwd_guard.original.clone();
@@ -269,7 +265,48 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
     Ok(())
 }
 
-fn dlx_install_options() -> InstallOptions {
+fn dlx_manifest(install_specs: &[String], allow_build: &[String]) -> serde_json::Value {
+    // Minimal package.json. Version specs and dist-tags pass through as-is
+    // — the resolver handles them exactly as it would from a real manifest.
+    let mut deps = serde_json::Map::new();
+    for spec in install_specs {
+        let (mut name, value) = synthesize_dlx_dep(spec);
+        if deps.contains_key(&name) {
+            let mut suffix = 2usize;
+            while deps.contains_key(&format!("{name}-{suffix}")) {
+                suffix += 1;
+            }
+            name = format!("{name}-{suffix}");
+        }
+        deps.insert(name, serde_json::Value::String(value));
+    }
+    let mut manifest = serde_json::Map::from_iter([
+        (
+            "name".to_string(),
+            serde_json::Value::String("aube-dlx".to_string()),
+        ),
+        (
+            "version".to_string(),
+            serde_json::Value::String("0.0.0".to_string()),
+        ),
+        ("private".to_string(), serde_json::Value::Bool(true)),
+        ("dependencies".to_string(), serde_json::Value::Object(deps)),
+    ]);
+    if !allow_build.is_empty() {
+        let allow_builds = serde_json::Map::from_iter(
+            allow_build
+                .iter()
+                .map(|name| (name.clone(), serde_json::Value::Bool(true))),
+        );
+        manifest.insert(
+            "pnpm".to_string(),
+            serde_json::json!({ "allowBuilds": allow_builds }),
+        );
+    }
+    serde_json::Value::Object(manifest)
+}
+
+fn dlx_install_options(allow_build: &[String]) -> InstallOptions {
     let mut opts = InstallOptions::with_mode(FrozenMode::No);
     // `dlx` executes bins from a throwaway project and deletes that project
     // immediately. Keeping package materialization inside the scratch tree is
@@ -284,15 +321,17 @@ fn dlx_install_options() -> InstallOptions {
             "false".to_string(),
         ));
     }
-    // Force ignore-scripts on transient dlx installs. User asked to
-    // run one bin. They did not ask postinstall scripts on fresh
-    // downloaded pkg to run. Without this, a user with
-    // `allowedBuildDependencies=["*"]` in ~/.npmrc (common for
-    // convenience) gets every dlx'd package running arbitrary
-    // postinstall code. That is how supply chain attacks land.
-    // pnpm dlx does the same, match it.
-    opts.cli_flags
-        .push(("ignore-scripts".to_string(), "true".to_string()));
+    if allow_build.is_empty() {
+        // Force ignore-scripts on transient dlx installs. User asked to
+        // run one bin. They did not ask postinstall scripts on fresh
+        // downloaded pkg to run. Without this, a user with
+        // `allowedBuildDependencies=["*"]` in ~/.npmrc (common for
+        // convenience) gets every dlx'd package running arbitrary
+        // postinstall code. That is how supply chain attacks land.
+        opts.ignore_scripts = true;
+        opts.cli_flags
+            .push(("ignore-scripts".to_string(), "true".to_string()));
+    }
     opts
 }
 
@@ -509,7 +548,7 @@ mod tests {
 
     #[test]
     fn dlx_install_disables_global_virtual_store() {
-        let opts = dlx_install_options();
+        let opts = dlx_install_options(&[]);
         let empty_workspace = std::collections::BTreeMap::new();
         let empty_env = Vec::new();
         let ctx = aube_settings::ResolveCtx {
@@ -525,6 +564,46 @@ mod tests {
             aube_settings::resolved::enable_global_virtual_store(&ctx),
             Some(false)
         );
+    }
+
+    #[test]
+    fn dlx_install_skips_scripts_by_default() {
+        let opts = dlx_install_options(&[]);
+        assert!(opts.ignore_scripts);
+        assert!(
+            opts.cli_flags
+                .iter()
+                .any(|(key, value)| { key == "ignore-scripts" && value == "true" })
+        );
+    }
+
+    #[test]
+    fn dlx_install_allows_scripts_when_builds_are_approved() {
+        let allow_build = vec!["esbuild".to_string()];
+        let opts = dlx_install_options(&allow_build);
+        assert!(!opts.ignore_scripts);
+        assert!(
+            !opts
+                .cli_flags
+                .iter()
+                .any(|(key, _)| key == "ignore-scripts")
+        );
+    }
+
+    #[test]
+    fn dlx_manifest_records_allow_build_approvals() {
+        let install_specs = vec!["vite".to_string()];
+        let allow_build = vec!["esbuild".to_string()];
+        let manifest = dlx_manifest(&install_specs, &allow_build);
+        assert_eq!(manifest["dependencies"]["vite"], "latest");
+        assert_eq!(manifest["pnpm"]["allowBuilds"]["esbuild"], true);
+    }
+
+    #[test]
+    fn dlx_manifest_omits_policy_when_no_builds_are_approved() {
+        let install_specs = vec!["vite".to_string()];
+        let manifest = dlx_manifest(&install_specs, &[]);
+        assert!(manifest.get("pnpm").is_none());
     }
 
     fn write_pkg_json(modules_dir: &std::path::Path, pkg_name: &str, pkg_json: serde_json::Value) {

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -41,12 +41,16 @@ pub struct DlxArgs {
     /// Overrides inferring from the command.
     #[arg(short = 'p', long = "package")]
     pub package: Vec<String>,
-    /// Allow named packages to run postinstall scripts during the
-    /// transient install.
+    /// Allow named packages to run lifecycle scripts during the
+    /// transient install. Use `--allow-build=<pkg>`.
     ///
-    /// Repeatable — pass once per package. Mirrors pnpm's
-    /// `pnpm dlx --allow-build=<pkg>` compatibility surface while
-    /// keeping dlx scripts skipped unless explicitly approved.
+    /// Repeatable — pass once per package. The named package's
+    /// `preinstall` / `install` / `postinstall` scripts execute during
+    /// the transient install. Requires the equals form
+    /// (`--allow-build=<pkg>`); space-separated forms are rejected.
+    /// Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility
+    /// surface while keeping dlx scripts skipped unless explicitly
+    /// approved.
     #[arg(
         long = "allow-build",
         value_name = "PKG",

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -335,6 +335,13 @@ fn dlx_install_options(allow_build: &[String]) -> InstallOptions {
         opts.cli_flags
             .push(("ignore-scripts".to_string(), "true".to_string()));
     } else {
+        // The isolated dlx allowlist should skip unapproved transitive
+        // builds, not fail the one-off command because the user's project
+        // has strictDepBuilds/paranoid enabled.
+        opts.cli_flags
+            .push(("strictDepBuilds".to_string(), "false".to_string()));
+        opts.cli_flags
+            .push(("paranoid".to_string(), "false".to_string()));
         opts.build_policy_override = Some(Arc::new(dlx_build_policy(allow_build)));
     }
     opts
@@ -346,7 +353,10 @@ fn dlx_build_policy(allow_build: &[String]) -> aube_scripts::BuildPolicy {
             .iter()
             .map(|name| (name.clone(), AllowBuildRaw::Bool(true))),
     );
-    let (policy, _) = aube_scripts::BuildPolicy::from_config(&allow_builds, &[], &[], false);
+    let (policy, warnings) = aube_scripts::BuildPolicy::from_config(&allow_builds, &[], &[], false);
+    for warning in warnings {
+        crate::progress::safe_eprintln(&format!("warn: --allow-build: {warning}"));
+    }
     policy
 }
 
@@ -598,6 +608,16 @@ mod tests {
         let opts = dlx_install_options(&allow_build);
         assert!(!opts.ignore_scripts);
         assert!(opts.build_policy_override.is_some());
+        assert!(
+            opts.cli_flags
+                .iter()
+                .any(|(key, value)| { key == "strictDepBuilds" && value == "false" })
+        );
+        assert!(
+            opts.cli_flags
+                .iter()
+                .any(|(key, value)| { key == "paranoid" && value == "false" })
+        );
         assert!(
             !opts
                 .cli_flags

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -1,7 +1,10 @@
 use super::install::{FrozenMode, InstallOptions};
 use crate::commands::add::build_flags::parse_allow_build_value;
+use aube_manifest::AllowBuildRaw;
 use clap::{Args, CommandFactory};
 use miette::{Context, IntoDiagnostic, miette};
+use std::collections::BTreeMap;
+use std::sync::Arc;
 
 #[derive(Debug, Args)]
 // dlx forwards everything after `<command>` to the bin it runs, including
@@ -331,8 +334,20 @@ fn dlx_install_options(allow_build: &[String]) -> InstallOptions {
         opts.ignore_scripts = true;
         opts.cli_flags
             .push(("ignore-scripts".to_string(), "true".to_string()));
+    } else {
+        opts.build_policy_override = Some(Arc::new(dlx_build_policy(allow_build)));
     }
     opts
+}
+
+fn dlx_build_policy(allow_build: &[String]) -> aube_scripts::BuildPolicy {
+    let allow_builds = BTreeMap::from_iter(
+        allow_build
+            .iter()
+            .map(|name| (name.clone(), AllowBuildRaw::Bool(true))),
+    );
+    let (policy, _) = aube_scripts::BuildPolicy::from_config(&allow_builds, &[], &[], false);
+    policy
 }
 
 /// RAII guard that swaps the process cwd on construction and restores it
@@ -582,11 +597,26 @@ mod tests {
         let allow_build = vec!["esbuild".to_string()];
         let opts = dlx_install_options(&allow_build);
         assert!(!opts.ignore_scripts);
+        assert!(opts.build_policy_override.is_some());
         assert!(
             !opts
                 .cli_flags
                 .iter()
                 .any(|(key, _)| key == "ignore-scripts")
+        );
+    }
+
+    #[test]
+    fn dlx_build_policy_only_allows_explicit_approvals() {
+        let allow_build = vec!["esbuild".to_string()];
+        let policy = dlx_build_policy(&allow_build);
+        assert_eq!(
+            policy.decide("esbuild", "0.25.0"),
+            aube_scripts::AllowDecision::Allow
+        );
+        assert_eq!(
+            policy.decide("sharp", "0.33.0"),
+            aube_scripts::AllowDecision::Unspecified
         );
     }
 

--- a/crates/aube/src/commands/install/args.rs
+++ b/crates/aube/src/commands/install/args.rs
@@ -283,6 +283,7 @@ impl InstallArgs {
             env_snapshot,
             git_prepare_depth: 0,
             inherited_build_policy: None,
+            build_policy_override: None,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
             // Argumentless `aube install` runs root lifecycle hooks; the
             // chained-call constructor (`with_mode`) is where commands
@@ -387,6 +388,10 @@ pub struct InstallOptions {
     /// scratch clone, but dependency build approval belongs to the outer
     /// project that requested the git package.
     pub inherited_build_policy: Option<std::sync::Arc<aube_scripts::BuildPolicy>>,
+    /// Fully replace the build policy discovered from manifests and
+    /// workspace config. Used by throwaway installs whose trust boundary
+    /// must not inherit ambient project/user approvals.
+    pub build_policy_override: Option<std::sync::Arc<aube_scripts::BuildPolicy>>,
     /// Global `--filter` / `--filter-prod` selectors. Resolution and
     /// lockfile writing still happen at the workspace root; these
     /// selectors narrow only the graph passed to the linker. Prod-only
@@ -445,6 +450,7 @@ impl InstallOptions {
             env_snapshot: aube_settings::values::capture_env(),
             git_prepare_depth: 0,
             inherited_build_policy: None,
+            build_policy_override: None,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
             // pnpm parity: every chained-call site (add / remove / update
             // / dedupe / dlx / patch / ensure_installed / git prepare)

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -289,14 +289,20 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     let ws_package_versions = workspace_plan.ws_package_versions;
     let ws_dirs = workspace_plan.ws_dirs;
     let lifecycle_manifests = workspace_plan.lifecycle_manifests;
-    let (mut build_policy, policy_warnings) = build_policy_from_manifest_sources(
-        lifecycle_manifests.iter().map(|(_, manifest)| manifest),
-        &ws_config_shared,
-        opts.dangerously_allow_all_builds,
-    );
-    if let Some(inherited) = opts.inherited_build_policy.as_deref() {
-        build_policy.merge(inherited);
-    }
+    let (build_policy, policy_warnings) =
+        if let Some(override_policy) = opts.build_policy_override.as_deref() {
+            (override_policy.clone(), Vec::new())
+        } else {
+            let (mut build_policy, policy_warnings) = build_policy_from_manifest_sources(
+                lifecycle_manifests.iter().map(|(_, manifest)| manifest),
+                &ws_config_shared,
+                opts.dangerously_allow_all_builds,
+            );
+            if let Some(inherited) = opts.inherited_build_policy.as_deref() {
+                build_policy.merge(inherited);
+            }
+            (build_policy, policy_warnings)
+        };
     let inherited_build_policy_for_git_prepare = Some(std::sync::Arc::new(build_policy.clone()));
 
     // 1b. Project `preinstall` lifecycle hooks.

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -1127,6 +1127,32 @@ mod cli_spec_tests {
     }
 
     #[test]
+    fn dlx_accepts_allow_build_before_command() {
+        let cli =
+            Cli::try_parse_from(["aube", "dlx", "--allow-build=esbuild", "vite", "--version"])
+                .expect("dlx --allow-build should parse");
+
+        let Some(Commands::Dlx(dlx_args)) = cli.command else {
+            panic!("expected dlx subcommand");
+        };
+        assert_eq!(dlx_args.allow_build, ["esbuild"]);
+        assert_eq!(dlx_args.params, ["vite", "--version"]);
+    }
+
+    #[test]
+    fn dlx_rejects_empty_allow_build_value() {
+        let err = match Cli::try_parse_from(["aube", "dlx", "--allow-build=", "vite"]) {
+            Ok(_) => panic!("empty --allow-build should fail"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("The --allow-build flag is missing a package name"),
+            "{err}"
+        );
+    }
+
+    #[test]
     fn lifter_does_not_eat_lifted_flag_as_kept_flag_value() {
         // Regression: `aube --dir /tmp --frozen-lockfile install` would
         // previously lose `--frozen-lockfile` if `--dir`'s value was

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3420,9 +3420,9 @@
           {
             "name": "allow-build",
             "usage": "--allow-build… <PKG>",
-            "help": "Allow named packages to run postinstall scripts during the transient install",
-            "help_long": "Allow named packages to run postinstall scripts during the transient install.\n\nRepeatable — pass once per package. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved.",
-            "help_first_line": "Allow named packages to run postinstall scripts during the transient install",
+            "help": "Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`",
+            "help_long": "Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`.\n\nRepeatable — pass once per package. The named package's `preinstall` / `install` / `postinstall` scripts execute during the transient install. Requires the equals form (`--allow-build=<pkg>`); space-separated forms are rejected. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved.",
+            "help_first_line": "Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`",
             "short": [],
             "long": [
               "allow-build"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3418,6 +3418,27 @@
             }
           },
           {
+            "name": "allow-build",
+            "usage": "--allow-build… <PKG>",
+            "help": "Allow named packages to run postinstall scripts during the transient install",
+            "help_long": "Allow named packages to run postinstall scripts during the transient install.\n\nRepeatable — pass once per package. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved.",
+            "help_first_line": "Allow named packages to run postinstall scripts during the transient install",
+            "short": [],
+            "long": [
+              "allow-build"
+            ],
+            "var": true,
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "PKG",
+              "usage": "<PKG>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
             "name": "frozen-lockfile",
             "usage": "--frozen-lockfile",
             "help": "Error if the lockfile drifts from package.json",

--- a/docs/cli/dlx.md
+++ b/docs/cli/dlx.md
@@ -29,9 +29,9 @@ Overrides inferring from the command.
 
 ### `--allow-build… <PKG>`
 
-Allow named packages to run postinstall scripts during the transient install.
+Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`.
 
-Repeatable — pass once per package. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved.
+Repeatable — pass once per package. The named package's `preinstall` / `install` / `postinstall` scripts execute during the transient install. Requires the equals form (`--allow-build=<pkg>`); space-separated forms are rejected. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved.
 
 ### `--frozen-lockfile`
 

--- a/docs/cli/dlx.md
+++ b/docs/cli/dlx.md
@@ -27,6 +27,12 @@ Install a specific package (repeatable).
 
 Overrides inferring from the command.
 
+### `--allow-build… <PKG>`
+
+Allow named packages to run postinstall scripts during the transient install.
+
+Repeatable — pass once per package. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved.
+
 ### `--frozen-lockfile`
 
 Error if the lockfile drifts from package.json


### PR DESCRIPTION
## Summary
- parse `aube dlx --allow-build=<pkg>` before the command positional
- write temporary `pnpm.allowBuilds` approvals into the dlx scratch manifest
- keep dlx scripts skipped by default unless an allow-build approval is provided

## Tests
- `cargo fmt --check`
- `cargo test -p aube dlx`
- `cargo clippy --all-targets -- -D warnings`

Fixes discussion #844.

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency lifecycle/build approval during dlx installs; risk is mitigated because scripts stay off unless explicitly named, but approved packages can run install scripts in a throwaway tree.
> 
> **Overview**
> Adds **`aube dlx --allow-build=<pkg>`** (repeatable, equals-only) for pnpm parity, parsing before the command positional and reusing the same **`parse_allow_build_value`** validator as `add`.
> 
> **Default dlx** still skips lifecycle scripts (`ignore-scripts`). When any `--allow-build` is passed, the scratch **`package.json`** gains **`pnpm.allowBuilds`**, scripts are no longer forced off, and install uses an isolated **`BuildPolicy`** via new **`InstallOptions.build_policy_override`** so transient dlx installs do not inherit project/user approvals; **`strictDepBuilds`** / **`paranoid`** are relaxed for that one-off run.
> 
> Install **`run`** now honors **`build_policy_override`** instead of merging manifest/workspace policy when set. CLI metadata and docs (`aube.usage.kdl`, `commands.json`, `dlx.md`) document the flag; unit and clap tests cover parsing, policy, and manifest emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca34d9c545b6483cd63c9b24a62a11958676d7ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable --allow-build flag to dlx to selectively permit postinstall builds for named packages.

* **Tests**
  * Added tests for allow-build parsing, default script-skipping, enabling scripts when approved, and manifest emission of approvals.

* **Refactor**
  * Broadened internal module/function visibility to support cross-module reuse and reorganized manifest/install helpers.

* **Behavior**
  * Install commands now accept an explicit build-policy override to control inheritance of build approvals.

* **Documentation**
  * CLI docs and command metadata updated to document the new --allow-build option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->