### PR TITLE
fix(ci): fall back for primer package list

### DIFF
--- a/scripts/generate-primer.mjs
+++ b/scripts/generate-primer.mjs
@@ -20,7 +20,11 @@ const versionsArg = args.get('versions') ?? '100'
 const versions = versionsArg === 'all' ? Infinity : Number(versionsArg)
 const out = resolve(args.get('out') ?? `crates/aube-resolver/data/primer-top${top}.json`)
 const namesFile = args.get('names')
-const namesUrl = args.get('names-url') ?? 'https://raw.githubusercontent.com/jdx/aube-primer-packages/main/data/packages.json'
+const namesUrl = args.get('names-url')
+const defaultNamesUrls = [
+  'https://raw.githubusercontent.com/jdx/aube-primer-packages/main/data/packages.json',
+  'https://raw.githubusercontent.com/endevco/aube-primer-packages/main/data/packages.json',
+]
 
 if (!Number.isInteger(top) || top < 1) throw new Error('--top must be a positive integer')
 if (versions !== Infinity && (!Number.isInteger(versions) || versions < 1)) {
@@ -29,7 +33,7 @@ if (versions !== Infinity && (!Number.isInteger(versions) || versions < 1)) {
 
 const names = namesFile
   ? parseNames(await readFile(namesFile, 'utf8'), namesFile)
-  : await fetchPopularNames(namesUrl)
+  : await fetchPopularNames(namesUrl ? [namesUrl] : defaultNamesUrls)
 if (!Array.isArray(names)) throw new Error('package-name source must be a JSON array')
 
 const primer = {}
@@ -200,10 +204,15 @@ function hasProvenance(attestations) {
   return typeof predicate === 'string' && /^https:\/\/slsa\.dev\/provenance\/v\d+$/.test(predicate)
 }
 
-async function fetchPopularNames(url) {
-  const { res, body } = await fetchBodyWithRetry(url, undefined, (res) => res.text())
-  if (!res.ok) throw new Error(`${url}: HTTP ${res.status}`)
-  return parseNames(body, url)
+async function fetchPopularNames(urls) {
+  const failures = []
+  for (const url of urls) {
+    const { res, body } = await fetchBodyWithRetry(url, undefined, (res) => res.text())
+    if (res.ok) return parseNames(body, url)
+    failures.push(`${url}: HTTP ${res.status}`)
+    if (urls.length > 1) console.error(`  package-name source unavailable: HTTP ${res.status}; trying next source`)
+  }
+  throw new Error(failures.join('; '))
 }
 
 // Wrap fetch and body reads to retry transient failures: socket resets /


### PR DESCRIPTION
## Summary
- try the migrated jdx primer package-list URL first, then fall back to the still-live endevco source
- keep explicit --names-url overrides strict so bad custom sources still fail loudly

## Verification
- node scripts/generate-primer.mjs --top 1 --versions 1 --out /tmp/aube-primer-smoke.json

Fixes the release asset job failure from https://github.com/jdx/aube/actions/runs/27174834975/job/80222244838.

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only change to offline primer generation with no impact on runtime resolver behavior; explicit URL overrides remain strict.
> 
> **Overview**
> **Fixes release primer generation** when the primary GitHub-hosted package-name list is unavailable by trying a **second default source** instead of failing on the first HTTP error.
> 
> When `--names-url` is omitted, `generate-primer.mjs` now walks **`defaultNamesUrls`**: the migrated `jdx/aube-primer-packages` URL first, then **`endevco/aube-primer-packages`**. `fetchPopularNames` accepts a URL list, returns on the first successful response, logs a stderr hint when it advances, and only throws after all sources fail (with combined error text). **Explicit `--names-url` stays single-source**—no silent fallback—so custom/broken overrides still fail loudly.
> 
> This unblocks the release workflow’s `generate-primer` job, which invokes the script without `--names-url`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edb999f1aa5edff343d64789a81ffa6dd4d81dd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->