### PR TITLE
fix(lockfile): reject mismatched resolution shapes

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -15,6 +15,7 @@ use crate::CodeMeta;
 pub const ERR_AUBE_NO_LOCKFILE: &str = "ERR_AUBE_NO_LOCKFILE";
 pub const ERR_AUBE_LOCKFILE_PARSE: &str = "ERR_AUBE_LOCKFILE_PARSE";
 pub const ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT: &str = "ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT";
+pub const ERR_AUBE_RESOLUTION_SHAPE_MISMATCH: &str = "ERR_AUBE_RESOLUTION_SHAPE_MISMATCH";
 
 // ── resolver ─────────────────────────────────────────────────────────
 pub const ERR_AUBE_NO_MATCHING_VERSION: &str = "ERR_AUBE_NO_MATCHING_VERSION";
@@ -133,6 +134,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::LOCKFILE,
         description: "Lockfile filename was recognized but its format isn't supported on this aube version.",
         exit_code: Some(12),
+    },
+    CodeMeta {
+        name: ERR_AUBE_RESOLUTION_SHAPE_MISMATCH,
+        category: category::LOCKFILE,
+        description: "A registry-style lockfile dependency path is backed by a git, local directory, or direct tarball resolution.",
+        exit_code: Some(13),
     },
     // Resolver
     CodeMeta {

--- a/crates/aube-lockfile/src/io.rs
+++ b/crates/aube-lockfile/src/io.rs
@@ -385,7 +385,7 @@ fn parse_one(
                 aube_util::diag::jstr(&display)
             )
         });
-    match kind {
+    let graph = match kind {
         // `aube-lock.yaml` uses the same on-disk format as pnpm v9 for
         // now — same parser, same writer — so we piggyback on the pnpm
         // module. Keeping the variant distinct lets detection/import
@@ -399,7 +399,39 @@ fn parse_one(
         LockfileKind::Yarn | LockfileKind::YarnBerry => yarn::parse(path, manifest),
         LockfileKind::Npm | LockfileKind::NpmShrinkwrap => npm::parse(path),
         LockfileKind::Bun => bun::parse(path),
+    }?;
+    validate_resolution_shapes(path, &graph)?;
+    Ok(graph)
+}
+
+fn validate_resolution_shapes(path: &Path, graph: &LockfileGraph) -> Result<(), Error> {
+    for (dep_path, pkg) in &graph.packages {
+        if pkg.local_source.is_some() && dep_path_has_registry_version(dep_path, &pkg.name) {
+            return Err(Error::ResolutionShapeMismatch {
+                path: path.to_path_buf(),
+                dep_path: dep_path.clone(),
+                source_kind: pkg
+                    .local_source
+                    .as_ref()
+                    .map(|source| source.kind_str())
+                    .unwrap_or("unknown"),
+            });
+        }
     }
+    Ok(())
+}
+
+fn dep_path_has_registry_version(dep_path: &str, name: &str) -> bool {
+    let Some(tail) = dep_path
+        .strip_prefix('/')
+        .unwrap_or(dep_path)
+        .strip_prefix(name)
+        .and_then(|rest| rest.strip_prefix('@'))
+    else {
+        return false;
+    };
+    let version = tail.split('(').next().unwrap_or(tail);
+    node_semver::Version::parse(version).is_ok()
 }
 
 /// Replace `LockfileKind::Yarn` with `LockfileKind::YarnBerry` when
@@ -435,6 +467,20 @@ pub enum Error {
     #[error("failed to parse lockfile {0}: {1}")]
     #[diagnostic(code(ERR_AUBE_LOCKFILE_PARSE))]
     Parse(std::path::PathBuf, String),
+    #[error(
+        "lockfile {path} has registry-style dependency path `{dep_path}` backed by {source_kind} resolution"
+    )]
+    #[diagnostic(
+        code(ERR_AUBE_RESOLUTION_SHAPE_MISMATCH),
+        help(
+            "run `aube install --no-frozen-lockfile` from a trusted manifest to regenerate the lockfile"
+        )
+    )]
+    ResolutionShapeMismatch {
+        path: std::path::PathBuf,
+        dep_path: String,
+        source_kind: &'static str,
+    },
     /// Deserialization failure with a byte offset into the source
     /// content, so miette's `fancy` handler can draw a pointer at the
     /// offending byte of the lockfile. Reuses `aube_manifest`'s
@@ -496,6 +542,7 @@ impl Error {
 #[cfg(test)]
 mod parse_diag_tests {
     use super::*;
+    use crate::{LocalSource, LockedPackage};
     use std::path::Path;
 
     /// Trailing `,` in an otherwise fine JSON lockfile — confirm the
@@ -513,6 +560,79 @@ mod parse_diag_tests {
         let len: usize = pe.span.len();
         assert!(offset + len <= content.len());
         assert_eq!(pe.path, path);
+    }
+
+    #[test]
+    fn validate_resolution_shapes_rejects_local_source_with_registry_dep_path() {
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            "left-pad@1.3.0".to_string(),
+            LockedPackage {
+                name: "left-pad".to_string(),
+                version: "1.3.0".to_string(),
+                dep_path: "left-pad@1.3.0".to_string(),
+                local_source: Some(LocalSource::Directory("vendor/left-pad".into())),
+                ..Default::default()
+            },
+        );
+
+        let err = validate_resolution_shapes(Path::new("pnpm-lock.yaml"), &graph).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ResolutionShapeMismatch {
+                dep_path,
+                source_kind: "file",
+                ..
+            } if dep_path == "left-pad@1.3.0"
+        ));
+    }
+
+    #[test]
+    fn validate_resolution_shapes_rejects_peer_suffixed_registry_dep_path() {
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            "plugin@1.0.0(react@19.0.0)".to_string(),
+            LockedPackage {
+                name: "plugin".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "plugin@1.0.0(react@19.0.0)".to_string(),
+                local_source: Some(LocalSource::RemoteTarball(crate::RemoteTarballSource {
+                    url: "https://example.com/plugin.tgz".to_string(),
+                    integrity: "sha512-test".to_string(),
+                    git_hosted: false,
+                })),
+                ..Default::default()
+            },
+        );
+
+        let err = validate_resolution_shapes(Path::new("pnpm-lock.yaml"), &graph).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ResolutionShapeMismatch {
+                dep_path,
+                source_kind: "url",
+                ..
+            } if dep_path == "plugin@1.0.0(react@19.0.0)"
+        ));
+    }
+
+    #[test]
+    fn validate_resolution_shapes_allows_local_source_dep_path() {
+        let source = LocalSource::Directory("vendor/left-pad".into());
+        let dep_path = source.dep_path("left-pad");
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            dep_path.clone(),
+            LockedPackage {
+                name: "left-pad".to_string(),
+                version: "1.3.0".to_string(),
+                dep_path,
+                local_source: Some(source),
+                ..Default::default()
+            },
+        );
+
+        validate_resolution_shapes(Path::new("pnpm-lock.yaml"), &graph).unwrap();
     }
 
     /// Same story for YAML — yaml_serde reports a `Location` with a

--- a/crates/aube-lockfile/src/io.rs
+++ b/crates/aube-lockfile/src/io.rs
@@ -407,15 +407,14 @@ fn parse_one(
 fn validate_resolution_shapes(path: &Path, graph: &LockfileGraph) -> Result<(), Error> {
     for (dep_path, pkg) in &graph.packages {
         if pkg.local_source.is_some() && dep_path_has_registry_version(dep_path, &pkg.name) {
-            return Err(Error::ResolutionShapeMismatch {
-                path: path.to_path_buf(),
-                dep_path: dep_path.clone(),
-                source_kind: pkg
-                    .local_source
+            return Err(Error::ResolutionShapeMismatch(
+                path.to_path_buf(),
+                dep_path.clone(),
+                pkg.local_source
                     .as_ref()
                     .map(|source| source.kind_str())
                     .unwrap_or("unknown"),
-            });
+            ));
         }
     }
     Ok(())
@@ -538,20 +537,14 @@ pub enum Error {
     #[error("failed to parse lockfile {0}: {1}")]
     #[diagnostic(code(ERR_AUBE_LOCKFILE_PARSE))]
     Parse(std::path::PathBuf, String),
-    #[error(
-        "lockfile {path} has registry-style dependency path `{dep_path}` backed by {source_kind} resolution"
-    )]
+    #[error("lockfile {0} has registry-style dependency path `{1}` backed by {2} resolution")]
     #[diagnostic(
         code(ERR_AUBE_RESOLUTION_SHAPE_MISMATCH),
         help(
             "run `aube install --no-frozen-lockfile` from a trusted manifest to regenerate the lockfile"
         )
     )]
-    ResolutionShapeMismatch {
-        path: std::path::PathBuf,
-        dep_path: String,
-        source_kind: &'static str,
-    },
+    ResolutionShapeMismatch(std::path::PathBuf, String, &'static str),
     /// Deserialization failure with a byte offset into the source
     /// content, so miette's `fancy` handler can draw a pointer at the
     /// offending byte of the lockfile. Reuses `aube_manifest`'s
@@ -650,11 +643,8 @@ mod parse_diag_tests {
         let err = validate_resolution_shapes(Path::new("pnpm-lock.yaml"), &graph).unwrap_err();
         assert!(matches!(
             err,
-            Error::ResolutionShapeMismatch {
-                dep_path,
-                source_kind: "file",
-                ..
-            } if dep_path == "left-pad@1.3.0"
+            Error::ResolutionShapeMismatch(_, dep_path, "file")
+                if dep_path == "left-pad@1.3.0"
         ));
     }
 
@@ -679,11 +669,8 @@ mod parse_diag_tests {
         let err = validate_resolution_shapes(Path::new("pnpm-lock.yaml"), &graph).unwrap_err();
         assert!(matches!(
             err,
-            Error::ResolutionShapeMismatch {
-                dep_path,
-                source_kind: "url",
-                ..
-            } if dep_path == "plugin@1.0.0(react@19.0.0)"
+            Error::ResolutionShapeMismatch(_, dep_path, "url")
+                if dep_path == "plugin@1.0.0(react@19.0.0)"
         ));
     }
 

--- a/crates/aube-lockfile/src/io.rs
+++ b/crates/aube-lockfile/src/io.rs
@@ -434,6 +434,77 @@ fn dep_path_has_registry_version(dep_path: &str, name: &str) -> bool {
     node_semver::Version::parse(version).is_ok()
 }
 
+#[cfg(test)]
+mod tests {
+    use super::dep_path_has_registry_version;
+    use crate::{GitSource, LocalSource, RemoteTarballSource};
+    use proptest::prelude::*;
+    use std::path::PathBuf;
+
+    fn package_name() -> impl Strategy<Value = String> {
+        prop_oneof![
+            "[a-z][a-z0-9-]{0,20}".prop_map(|name| name),
+            ("[a-z][a-z0-9-]{0,10}", "[a-z][a-z0-9-]{0,20}")
+                .prop_map(|(scope, name)| format!("@{scope}/{name}")),
+        ]
+    }
+
+    fn semver() -> impl Strategy<Value = String> {
+        (0u16..1000, 0u16..1000, 0u16..1000)
+            .prop_map(|(major, minor, patch)| format!("{major}.{minor}.{patch}"))
+    }
+
+    fn path_source() -> impl Strategy<Value = LocalSource> {
+        ("[a-z][a-z0-9_-]{0,12}", prop_oneof![0u8..5, 5u8..10]).prop_map(|(path, kind)| {
+            let path = PathBuf::from(format!("./vendor/{path}"));
+            match kind {
+                0 => LocalSource::Directory(path),
+                1 => LocalSource::Tarball(path.with_extension("tgz")),
+                2 => LocalSource::Link(path),
+                3 => LocalSource::Portal(path),
+                _ => LocalSource::Exec(path),
+            }
+        })
+    }
+
+    fn local_source() -> impl Strategy<Value = LocalSource> {
+        prop_oneof![
+            path_source(),
+            "[a-z][a-z0-9-]{0,20}".prop_map(|repo| LocalSource::Git(GitSource {
+                url: format!("https://github.com/acme/{repo}.git"),
+                committish: None,
+                resolved: "0123456789abcdef0123456789abcdef01234567".to_string(),
+                integrity: None,
+                subpath: None,
+            })),
+            "[a-z][a-z0-9-]{0,20}".prop_map(|tarball| LocalSource::RemoteTarball(
+                RemoteTarballSource {
+                    url: format!("https://registry.example/{tarball}.tgz"),
+                    integrity: String::new(),
+                    git_hosted: false,
+                },
+            )),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn dep_path_registry_version_accepts_name_at_semver(name in package_name(), version in semver()) {
+            let dep_path = format!("{name}@{version}");
+            prop_assert!(dep_path_has_registry_version(&dep_path, &name));
+        }
+
+        #[test]
+        fn dep_path_registry_version_rejects_local_source_dep_paths(
+            name in package_name(),
+            source in local_source(),
+        ) {
+            let dep_path = source.dep_path(&name);
+            prop_assert!(!dep_path_has_registry_version(&dep_path, &name));
+        }
+    }
+}
+
 /// Replace `LockfileKind::Yarn` with `LockfileKind::YarnBerry` when
 /// the yarn.lock at `path` is actually a yarn 2+ lockfile. Other
 /// kinds pass through unchanged.

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -19,6 +19,12 @@
       "exit_code": 12
     },
     {
+      "name": "ERR_AUBE_RESOLUTION_SHAPE_MISMATCH",
+      "category": "Lockfile",
+      "description": "A registry-style lockfile dependency path is backed by a git, local directory, or direct tarball resolution.",
+      "exit_code": 13
+    },
+    {
       "name": "ERR_AUBE_NO_MATCHING_VERSION",
       "category": "Resolver",
       "description": "No published version of the named package satisfies the requested range.",


### PR DESCRIPTION
## Summary

Reject lockfiles where a registry-style dependency path is backed by a git, local directory, or direct tarball resolution. This keeps dependency paths trustworthy before install/link/script policy relies on them.

Adds ERR_AUBE_RESOLUTION_SHAPE_MISMATCH and regenerates the error-code data.

## Validation

- cargo test -p aube-codes -p aube-lockfile
- cargo clippy -p aube-lockfile -p aube-codes -- -D warnings

This PR was generated by Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new hard failure on every lockfile read path (install/frozen/import), which can break CI on previously tolerated corrupt lockfiles but improves supply-chain trust in dep paths.
> 
> **Overview**
> Lockfile parsing now **fails closed** when a package entry looks like a registry resolution (`name@semver`, including peer suffixes) but is actually backed by a **non-registry** source (`local_source`: git, file, link, remote tarball, etc.).
> 
> After each format-specific parse in `parse_one`, **`validate_resolution_shapes`** walks the graph and rejects that mismatch via a new **`Error::ResolutionShapeMismatch`** with miette help suggesting `aube install --no-frozen-lockfile`. **`ERR_AUBE_RESOLUTION_SHAPE_MISMATCH`** (exit **13**) is registered in **`aube-codes`** and **`docs/error-codes.data.json`**.
> 
> Coverage adds unit tests for peer-suffixed paths and consistent local dep paths, plus proptest checks that registry-style paths are detected and local-source `dep_path`s are not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 163d199ba370c3305b6c7826fa6cc8fc90f88658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added lockfile validation to detect and error when a registry-style dependency path is paired with a local or alternative resolution source, improving parsing diagnostics.

* **Documentation**
  * Updated error codes reference with a new validation error describing conflicting dependency resolution configurations (includes exit code and guidance).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->