### PR TITLE
fix(registry): keep project npmrc env refs literal

### DIFF
--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -50,6 +50,7 @@ pub const WARN_AUBE_UNTRUSTED_STRICT_SSL_DISABLE: &str = "WARN_AUBE_UNTRUSTED_ST
 pub const WARN_AUBE_INVALID_LOCAL_ADDRESS: &str = "WARN_AUBE_INVALID_LOCAL_ADDRESS";
 pub const WARN_AUBE_INVALID_MAXSOCKETS: &str = "WARN_AUBE_INVALID_MAXSOCKETS";
 pub const WARN_AUBE_UNSCOPED_AUTH_RESCOPED: &str = "WARN_AUBE_UNSCOPED_AUTH_RESCOPED";
+pub const WARN_AUBE_UNTRUSTED_AUTH_ENV: &str = "WARN_AUBE_UNTRUSTED_AUTH_ENV";
 pub const WARN_AUBE_UNTRUSTED_TOKEN_HELPER: &str = "WARN_AUBE_UNTRUSTED_TOKEN_HELPER";
 pub const WARN_AUBE_INVALID_TOKEN_HELPER: &str = "WARN_AUBE_INVALID_TOKEN_HELPER";
 pub const WARN_AUBE_TOKEN_HELPER_SPAWN_FAILED: &str = "WARN_AUBE_TOKEN_HELPER_SPAWN_FAILED";
@@ -311,6 +312,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_UNSCOPED_AUTH_RESCOPED,
         category: category::REGISTRY_CONFIG,
         description: "An unscoped registry credential was pinned to the registry declared by the same config source.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_UNTRUSTED_AUTH_ENV,
+        category: category::REGISTRY_CONFIG,
+        description: "An auth setting from project-controlled `.npmrc` contained an environment variable reference and was ignored.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -27,7 +27,7 @@ use load::{
     userconfig_override_from_env,
 };
 #[cfg(test)]
-use npmrc::{parse_npmrc, substitute_env};
+use npmrc::{parse_npmrc, parse_npmrc_untrusted, substitute_env};
 #[cfg(test)]
 use token::sanitize_token_helper;
 #[cfg(test)]

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -156,6 +156,13 @@ impl NpmConfig {
 
         let mut explicit_uri_fields = BTreeSet::new();
         for (source, key, value) in entries {
+            if source.is_project_controlled() && auth_entry_contains_env_ref(&key, &value) {
+                tracing::warn!(
+                    code = aube_codes::warnings::WARN_AUBE_UNTRUSTED_AUTH_ENV,
+                    "ignoring auth setting {key:?} from untrusted source {source:?}: project-controlled `.npmrc` cannot expand environment variables in auth config"
+                );
+                continue;
+            }
             if key == "registry" {
                 self.registry = normalize_registry_url(&value);
             } else if key == "_authToken" {
@@ -523,7 +530,7 @@ fn source_registry<'a>(
         NpmrcSource::User => user,
         NpmrcSource::PnpmAuth => pnpm_auth,
         NpmrcSource::Project => project,
-        NpmrcSource::NpmrcAuthFile => npmrc_auth_file,
+        NpmrcSource::UserNpmrcAuthFile | NpmrcSource::ProjectNpmrcAuthFile => npmrc_auth_file,
         NpmrcSource::Env => env,
     }
 }
@@ -540,7 +547,33 @@ fn source_registry_mut<'a>(
         NpmrcSource::User => user,
         NpmrcSource::PnpmAuth => pnpm_auth,
         NpmrcSource::Project => project,
-        NpmrcSource::NpmrcAuthFile => npmrc_auth_file,
+        NpmrcSource::UserNpmrcAuthFile | NpmrcSource::ProjectNpmrcAuthFile => npmrc_auth_file,
         NpmrcSource::Env => env,
     }
+}
+
+fn auth_entry_contains_env_ref(key: &str, value: &str) -> bool {
+    auth_suffix(key).is_some_and(|suffix| {
+        matches!(
+            suffix,
+            "_authToken" | "_auth" | "username" | "_password" | "cert" | "key"
+        ) && (contains_env_ref(key) || contains_env_ref(value))
+    })
+}
+
+fn auth_suffix(key: &str) -> Option<&str> {
+    if matches!(
+        key,
+        "_authToken" | "_auth" | "username" | "_password" | "cert" | "key"
+    ) {
+        return Some(key);
+    }
+    key.rsplit_once(':').map(|(_, suffix)| suffix)
+}
+
+fn contains_env_ref(value: &str) -> bool {
+    value.contains("${")
+        && value
+            .split_once("${")
+            .is_some_and(|(_, rest)| rest.contains('}'))
 }

--- a/crates/aube-registry/src/config/load.rs
+++ b/crates/aube-registry/src/config/load.rs
@@ -124,8 +124,10 @@ pub fn load_npmrc_entries_split(project_dir: &Path) -> SplitNpmrcEntries {
     let mut split = SplitNpmrcEntries::default();
     for (src, k, v) in tagged {
         match src {
-            NpmrcSource::User | NpmrcSource::PnpmAuth => split.user.push((k, v)),
-            NpmrcSource::Project | NpmrcSource::NpmrcAuthFile => split.project.push((k, v)),
+            NpmrcSource::User | NpmrcSource::PnpmAuth | NpmrcSource::UserNpmrcAuthFile => {
+                split.user.push((k, v));
+            }
+            NpmrcSource::Project | NpmrcSource::ProjectNpmrcAuthFile => split.project.push((k, v)),
             // Env-derived entries (npm_config_*) aren't loaded by the
             // tagged file walker, so this arm is unreachable here.
             NpmrcSource::Env => continue,
@@ -246,20 +248,20 @@ pub(super) fn load_npmrc_entries_tagged_with_home(
                 .map(|(k, v)| (NpmrcSource::Project, k, v)),
         );
     }
-    // Resolve `npmrc-auth-file` by borrowing the tagged entries we
-    // already parsed. No clone, the iterator just drops the tag.
-    if let Some(auth_path) = resolve_npmrc_auth_file(
-        home,
-        project_dir,
-        out.iter().map(|(_, k, v)| (k.as_str(), v.as_str())),
-    ) && auth_path.exists()
-        && let Ok(entries) = parse_npmrc_untrusted(&auth_path)
+    if let Some((auth_path, auth_source)) = resolve_npmrc_auth_file_tagged(home, project_dir, &out)
+        && auth_path.exists()
+        && let Ok(entries) = if auth_source.is_project_controlled() {
+            parse_npmrc_untrusted(&auth_path)
+        } else {
+            parse_npmrc(&auth_path)
+        }
     {
-        out.extend(
-            entries
-                .into_iter()
-                .map(|(k, v)| (NpmrcSource::NpmrcAuthFile, k, v)),
-        );
+        let source = if auth_source.is_project_controlled() {
+            NpmrcSource::ProjectNpmrcAuthFile
+        } else {
+            NpmrcSource::UserNpmrcAuthFile
+        };
+        out.extend(entries.into_iter().map(|(k, v)| (source, k, v)));
     }
     out
 }
@@ -273,74 +275,20 @@ pub(super) fn load_npmrc_entries_with_home(
     project_dir: &Path,
     user_rc_override: Option<&Path>,
 ) -> Vec<(String, String)> {
-    let mut out = Vec::new();
-    // User-level rc: explicit override (from `NPM_CONFIG_USERCONFIG`)
-    // wins over `$HOME/.npmrc`. When the override is set, the default
-    // path is skipped entirely — matching npm/pnpm, which treat the
-    // env var as "this is where the user rc lives," not "also read
-    // this file on top of the default."
-    let user_rc = user_rc_override
-        .map(PathBuf::from)
-        .or_else(|| home.map(|h| h.join(".npmrc")));
-    if let Some(user_rc) = user_rc
-        && user_rc.exists()
-        && let Ok(entries) = parse_npmrc(&user_rc)
-    {
-        out.extend(entries);
-    }
-    if let Some(home) = home {
-        // pnpm's global auth file: `~/.config/pnpm/auth.ini`. Same
-        // `key=value` grammar as `.npmrc`, but lives under the pnpm
-        // config dir so a user can keep registry credentials out of
-        // `~/.npmrc` (which tooling like `npm login` rewrites). Loaded
-        // after the user rc so it overrides any stale token there but
-        // before the project rc, which still wins for per-repo pins.
-        let auth_ini = pnpm_global_auth_ini_path(home, xdg_config_home);
-        if auth_ini.exists()
-            && let Ok(entries) = parse_npmrc(&auth_ini)
-        {
-            out.extend(entries);
-        }
-    }
-    let project_rc = project_dir.join(".npmrc");
-    if project_rc.exists()
-        && let Ok(entries) = parse_npmrc_untrusted(&project_rc)
-    {
-        out.extend(entries);
-    }
-    // pnpm's `npmrcAuthFile` setting points at an out-of-tree file
-    // (typically a CI secret mount or a per-user override) that holds
-    // auth tokens. Load it last so anything declared there wins —
-    // users who put auth tokens in this file expect them to take
-    // precedence over whatever happens to be in `~/.npmrc`.
-    if let Some(auth_path) = resolve_npmrc_auth_file(
-        home,
-        project_dir,
-        out.iter().map(|(k, v)| (k.as_str(), v.as_str())),
-    ) && auth_path.exists()
-        && let Ok(entries) = parse_npmrc_untrusted(&auth_path)
-    {
-        out.extend(entries);
-    }
-    out
+    load_npmrc_entries_tagged_with_home(home, xdg_config_home, project_dir, user_rc_override)
+        .into_iter()
+        .map(|(_, k, v)| (k, v))
+        .collect()
 }
 
-/// Walk the loaded `.npmrc` entries (last-write-wins) for an
-/// `npmrcAuthFile` / `npmrc-auth-file` key and resolve it to an
-/// absolute path. `~` expands against `home`; relative paths resolve
-/// against the project root, matching the storeDir convention.
-pub(super) fn resolve_npmrc_auth_file<'a, I>(
+/// Resolve an `npmrcAuthFile` / `npmrc-auth-file` value to an absolute
+/// path. `~` expands against `home`; relative paths resolve against the
+/// project root, matching the storeDir convention.
+fn resolve_npmrc_auth_file_path(
     home: Option<&Path>,
     project_dir: &Path,
-    entries: I,
-) -> Option<PathBuf>
-where
-    I: DoubleEndedIterator<Item = (&'a str, &'a str)>,
-{
-    let raw = entries
-        .rev()
-        .find(|(k, _)| matches!(*k, "npmrcAuthFile" | "npmrc-auth-file"))
-        .map(|(_, v)| v)?;
+    raw: &str,
+) -> Option<PathBuf> {
     let expanded = if let Some(rest) = raw.strip_prefix("~/") {
         home.map(|h| h.join(rest))?
     } else if raw == "~" {
@@ -355,10 +303,23 @@ where
     }
 }
 
+fn resolve_npmrc_auth_file_tagged(
+    home: Option<&Path>,
+    project_dir: &Path,
+    entries: &[(NpmrcSource, String, String)],
+) -> Option<(PathBuf, NpmrcSource)> {
+    let (source, _, raw) = entries
+        .iter()
+        .rev()
+        .find(|(_, k, _)| matches!(k.as_str(), "npmrcAuthFile" | "npmrc-auth-file"))?;
+    let path = resolve_npmrc_auth_file_path(home, project_dir, raw)?;
+    Some((path, *source))
+}
+
 /// Expand a raw `userconfig` / `NPM_CONFIG_USERCONFIG` value into a
 /// concrete path, applying the same tilde-expansion rules
-/// [`resolve_npmrc_auth_file`] uses so both env-var and `.npmrc`-derived
-/// path overrides behave the same way. Empty (after trim) returns
+/// `npmrc-auth-file` uses so both env-var and `.npmrc`-derived path
+/// overrides behave the same way. Empty (after trim) returns
 /// `None` so callers can skip a pointless file probe. Relative paths
 /// are returned verbatim and resolve against the process cwd when
 /// later fed to `exists()` / `parse_npmrc` — matching npm's behavior.

--- a/crates/aube-registry/src/config/load.rs
+++ b/crates/aube-registry/src/config/load.rs
@@ -238,6 +238,17 @@ pub(super) fn load_npmrc_entries_tagged_with_home(
             );
         }
     }
+    if let Some((auth_path, auth_source)) = resolve_npmrc_auth_file_tagged(home, project_dir, &out)
+        && !auth_source.is_project_controlled()
+        && auth_path.exists()
+        && let Ok(entries) = parse_npmrc(&auth_path)
+    {
+        out.extend(
+            entries
+                .into_iter()
+                .map(|(k, v)| (NpmrcSource::UserNpmrcAuthFile, k, v)),
+        );
+    }
     let project_rc = project_dir.join(".npmrc");
     if project_rc.exists()
         && let Ok(entries) = parse_npmrc_untrusted(&project_rc)
@@ -249,19 +260,15 @@ pub(super) fn load_npmrc_entries_tagged_with_home(
         );
     }
     if let Some((auth_path, auth_source)) = resolve_npmrc_auth_file_tagged(home, project_dir, &out)
+        && auth_source.is_project_controlled()
         && auth_path.exists()
-        && let Ok(entries) = if auth_source.is_project_controlled() {
-            parse_npmrc_untrusted(&auth_path)
-        } else {
-            parse_npmrc(&auth_path)
-        }
+        && let Ok(entries) = parse_npmrc_untrusted(&auth_path)
     {
-        let source = if auth_source.is_project_controlled() {
-            NpmrcSource::ProjectNpmrcAuthFile
-        } else {
-            NpmrcSource::UserNpmrcAuthFile
-        };
-        out.extend(entries.into_iter().map(|(k, v)| (source, k, v)));
+        out.extend(
+            entries
+                .into_iter()
+                .map(|(k, v)| (NpmrcSource::ProjectNpmrcAuthFile, k, v)),
+        );
     }
     out
 }

--- a/crates/aube-registry/src/config/load.rs
+++ b/crates/aube-registry/src/config/load.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use super::env::npm_config_env_entries_from;
-use super::npmrc::parse_npmrc;
+use super::npmrc::{parse_npmrc, parse_npmrc_untrusted};
 use super::types::{NpmConfig, NpmrcSource};
 
 impl NpmConfig {
@@ -238,7 +238,7 @@ pub(super) fn load_npmrc_entries_tagged_with_home(
     }
     let project_rc = project_dir.join(".npmrc");
     if project_rc.exists()
-        && let Ok(entries) = parse_npmrc(&project_rc)
+        && let Ok(entries) = parse_npmrc_untrusted(&project_rc)
     {
         out.extend(
             entries
@@ -253,7 +253,7 @@ pub(super) fn load_npmrc_entries_tagged_with_home(
         project_dir,
         out.iter().map(|(_, k, v)| (k.as_str(), v.as_str())),
     ) && auth_path.exists()
-        && let Ok(entries) = parse_npmrc(&auth_path)
+        && let Ok(entries) = parse_npmrc_untrusted(&auth_path)
     {
         out.extend(
             entries
@@ -304,7 +304,7 @@ pub(super) fn load_npmrc_entries_with_home(
     }
     let project_rc = project_dir.join(".npmrc");
     if project_rc.exists()
-        && let Ok(entries) = parse_npmrc(&project_rc)
+        && let Ok(entries) = parse_npmrc_untrusted(&project_rc)
     {
         out.extend(entries);
     }
@@ -318,7 +318,7 @@ pub(super) fn load_npmrc_entries_with_home(
         project_dir,
         out.iter().map(|(k, v)| (k.as_str(), v.as_str())),
     ) && auth_path.exists()
-        && let Ok(entries) = parse_npmrc(&auth_path)
+        && let Ok(entries) = parse_npmrc_untrusted(&auth_path)
     {
         out.extend(entries);
     }

--- a/crates/aube-registry/src/config/npmrc.rs
+++ b/crates/aube-registry/src/config/npmrc.rs
@@ -1,13 +1,31 @@
 use std::path::Path;
 
-/// Parse a .npmrc file into key=value pairs.
-/// Supports environment variable substitution (${VAR}) and backslash
-/// line continuation. npm's `ini` parser treats a trailing `\` as
-/// "continue value on next physical line", used for long auth
-/// tokens or multi-value arrays. Without this aube would silently
-/// truncate the value at the first line break and reparse the
-/// continuation as a bogus key.
+/// Parse a trusted .npmrc file into key=value pairs.
+///
+/// User/global config may use npm's environment variable substitution
+/// (`${VAR}`) for dynamic registry hosts or tokens. Project-controlled
+/// files must use [`parse_npmrc_untrusted`] so a cloned repository
+/// cannot expand the caller's environment into registry destinations
+/// or credentials.
 pub(super) fn parse_npmrc(path: &Path) -> Result<Vec<(String, String)>, std::io::Error> {
+    parse_npmrc_inner(path, true)
+}
+
+/// Parse a repository-controlled .npmrc file without `${VAR}` expansion.
+pub(super) fn parse_npmrc_untrusted(path: &Path) -> Result<Vec<(String, String)>, std::io::Error> {
+    parse_npmrc_inner(path, false)
+}
+
+/// Parse a .npmrc file into key=value pairs.
+/// Supports backslash line continuation. npm's `ini` parser treats a
+/// trailing `\` as "continue value on next physical line", used for
+/// long auth tokens or multi-value arrays. Without this aube would
+/// silently truncate the value at the first line break and reparse the
+/// continuation as a bogus key.
+fn parse_npmrc_inner(
+    path: &Path,
+    expand_env: bool,
+) -> Result<Vec<(String, String)>, std::io::Error> {
     let raw_content = std::fs::read_to_string(path)?;
     let content = raw_content.strip_prefix('\u{feff}').unwrap_or(&raw_content);
     let mut entries = Vec::new();
@@ -36,21 +54,21 @@ pub(super) fn parse_npmrc(path: &Path) -> Result<Vec<(String, String)>, std::io:
         }
 
         if let Some((key, value)) = line.split_once('=') {
-            // Expand env vars on both sides. pnpm/npm both substitute
-            // `${VAR}` in keys as well as values, which lets users
-            // template the registry-prefix portion of per-URI auth
-            // keys like `${NEXUS_URL}:_auth=${TOKEN}` (common for
-            // Nexus / Artifactory setups where the registry host is
-            // injected by sops/CI). Without key-side expansion the
-            // entry lands in `auth_by_uri` keyed by the literal
-            // `${NEXUS_URL}` and never matches the real tarball URL.
-            let key = substitute_env(key.trim());
-            let value = substitute_env(strip_matched_quotes(value.trim()));
+            let key = maybe_substitute_env(key.trim(), expand_env);
+            let value = maybe_substitute_env(strip_matched_quotes(value.trim()), expand_env);
             entries.push((key, value));
         }
     }
 
     Ok(entries)
+}
+
+fn maybe_substitute_env(value: &str, expand_env: bool) -> String {
+    if expand_env {
+        substitute_env(value)
+    } else {
+        value.to_string()
+    }
 }
 
 /// Strip a single layer of matched surrounding `"` or `'` from `value`.

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -146,15 +146,7 @@ fn parse_npmrc_expands_env_in_keys_for_per_uri_auth() {
     // cleanup can't leak these names into the rest of the test
     // run (the harness runs cases in parallel threads on shared
     // process-wide env).
-    struct EnvVars(&'static [&'static str]);
-    impl Drop for EnvVars {
-        fn drop(&mut self) {
-            for name in self.0 {
-                unsafe { std::env::remove_var(name) };
-            }
-        }
-    }
-    let _vars = EnvVars(&["AUBE_TEST_NEXUS_HOST_CFG", "AUBE_TEST_NEXUS_TOKEN_CFG"]);
+    let _vars = ScopedEnvVars(&["AUBE_TEST_NEXUS_HOST_CFG", "AUBE_TEST_NEXUS_TOKEN_CFG"]);
     unsafe {
         std::env::set_var(
             "AUBE_TEST_NEXUS_HOST_CFG",
@@ -241,8 +233,8 @@ fn project_npmrc_does_not_expand_env_into_auth() {
 
     assert_eq!(
         config.auth_token_for("https://registry.example.com/"),
-        Some("${AUBE_TEST_PROJECT_TOKEN_CFG}"),
-        "project .npmrc must not expand env vars into credentials",
+        None,
+        "project .npmrc auth env refs must be ignored instead of stored literally",
     );
 }
 
@@ -303,8 +295,42 @@ fn npmrc_auth_file_does_not_expand_env_into_auth() {
 
     assert_eq!(
         config.auth_token_for("https://registry.example.com/"),
-        Some("${AUBE_TEST_AUTH_FILE_TOKEN_CFG}"),
-        "auth file loaded through project config inherits project trust",
+        None,
+        "auth file loaded through project config inherits project trust and ignores auth env refs",
+    );
+}
+
+#[test]
+fn user_declared_npmrc_auth_file_expands_env_into_auth() {
+    let _vars = ScopedEnvVars(&["AUBE_TEST_USER_AUTH_FILE_TOKEN_CFG"]);
+    unsafe { std::env::set_var("AUBE_TEST_USER_AUTH_FILE_TOKEN_CFG", "secret-token") };
+
+    let home = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let auth_file = home.path().join("auth.npmrc");
+    std::fs::write(
+        &auth_file,
+        "//registry.example.com/:_authToken=${AUBE_TEST_USER_AUTH_FILE_TOKEN_CFG}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        home.path().join(".npmrc"),
+        format!("npmrc-auth-file={}\n", auth_file.display()),
+    )
+    .unwrap();
+
+    let mut config = NpmConfig::default();
+    config.apply_tagged(load_npmrc_entries_tagged_with_home(
+        Some(home.path()),
+        None,
+        project.path(),
+        None,
+    ));
+
+    assert_eq!(
+        config.auth_token_for("https://registry.example.com/"),
+        Some("secret-token"),
+        "auth file loaded through user config keeps trusted env substitution",
     );
 }
 

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -4,6 +4,16 @@ use base64::Engine as _;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+struct ScopedEnvVars(&'static [&'static str]);
+
+impl Drop for ScopedEnvVars {
+    fn drop(&mut self) {
+        for name in self.0 {
+            unsafe { std::env::remove_var(name) };
+        }
+    }
+}
+
 #[test]
 fn parse_npmrc_strips_utf8_bom() {
     let dir = tempfile::tempdir().unwrap();
@@ -178,6 +188,123 @@ fn parse_npmrc_expands_env_in_keys_for_per_uri_auth() {
             .basic_auth_for("https://nexus.example.com/repository/npm/@scope/pkg/-/pkg-1.0.0.tgz"),
         Some("dXNlcjpwYXNz".to_string()),
         "tarball URL under the env-templated host must pick up _auth",
+    );
+}
+
+#[test]
+fn parse_npmrc_untrusted_preserves_env_refs_in_keys_and_values() {
+    let _vars = ScopedEnvVars(&["AUBE_TEST_PROJECT_HOST_CFG", "AUBE_TEST_PROJECT_TOKEN_CFG"]);
+    unsafe {
+        std::env::set_var("AUBE_TEST_PROJECT_HOST_CFG", "//registry.example.com/");
+        std::env::set_var("AUBE_TEST_PROJECT_TOKEN_CFG", "secret-token");
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let rc = dir.path().join(".npmrc");
+    std::fs::write(
+        &rc,
+        "${AUBE_TEST_PROJECT_HOST_CFG}:_authToken=${AUBE_TEST_PROJECT_TOKEN_CFG}\n",
+    )
+    .unwrap();
+
+    let entries = parse_npmrc_untrusted(&rc).unwrap();
+
+    assert_eq!(
+        entries,
+        vec![(
+            "${AUBE_TEST_PROJECT_HOST_CFG}:_authToken".to_string(),
+            "${AUBE_TEST_PROJECT_TOKEN_CFG}".to_string(),
+        )]
+    );
+}
+
+#[test]
+fn project_npmrc_does_not_expand_env_into_auth() {
+    let _vars = ScopedEnvVars(&["AUBE_TEST_PROJECT_TOKEN_CFG"]);
+    unsafe { std::env::set_var("AUBE_TEST_PROJECT_TOKEN_CFG", "secret-token") };
+
+    let home = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(
+        project.path().join(".npmrc"),
+        "//registry.example.com/:_authToken=${AUBE_TEST_PROJECT_TOKEN_CFG}\n",
+    )
+    .unwrap();
+
+    let mut config = NpmConfig::default();
+    config.apply_tagged(load_npmrc_entries_tagged_with_home(
+        Some(home.path()),
+        None,
+        project.path(),
+        None,
+    ));
+
+    assert_eq!(
+        config.auth_token_for("https://registry.example.com/"),
+        Some("${AUBE_TEST_PROJECT_TOKEN_CFG}"),
+        "project .npmrc must not expand env vars into credentials",
+    );
+}
+
+#[test]
+fn user_npmrc_still_expands_env_into_auth() {
+    let _vars = ScopedEnvVars(&["AUBE_TEST_USER_TOKEN_CFG"]);
+    unsafe { std::env::set_var("AUBE_TEST_USER_TOKEN_CFG", "secret-token") };
+
+    let home = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(
+        home.path().join(".npmrc"),
+        "//registry.example.com/:_authToken=${AUBE_TEST_USER_TOKEN_CFG}\n",
+    )
+    .unwrap();
+
+    let mut config = NpmConfig::default();
+    config.apply_tagged(load_npmrc_entries_tagged_with_home(
+        Some(home.path()),
+        None,
+        project.path(),
+        None,
+    ));
+
+    assert_eq!(
+        config.auth_token_for("https://registry.example.com/"),
+        Some("secret-token"),
+        "user .npmrc keeps trusted env substitution",
+    );
+}
+
+#[test]
+fn npmrc_auth_file_does_not_expand_env_into_auth() {
+    let _vars = ScopedEnvVars(&["AUBE_TEST_AUTH_FILE_TOKEN_CFG"]);
+    unsafe { std::env::set_var("AUBE_TEST_AUTH_FILE_TOKEN_CFG", "secret-token") };
+
+    let home = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let auth_file = project.path().join("auth.npmrc");
+    std::fs::write(
+        &auth_file,
+        "//registry.example.com/:_authToken=${AUBE_TEST_AUTH_FILE_TOKEN_CFG}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project.path().join(".npmrc"),
+        format!("npmrc-auth-file={}\n", auth_file.display()),
+    )
+    .unwrap();
+
+    let mut config = NpmConfig::default();
+    config.apply_tagged(load_npmrc_entries_tagged_with_home(
+        Some(home.path()),
+        None,
+        project.path(),
+        None,
+    ));
+
+    assert_eq!(
+        config.auth_token_for("https://registry.example.com/"),
+        Some("${AUBE_TEST_AUTH_FILE_TOKEN_CFG}"),
+        "auth file loaded through project config inherits project trust",
     );
 }
 

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -335,6 +335,38 @@ fn user_declared_npmrc_auth_file_expands_env_into_auth() {
 }
 
 #[test]
+fn user_declared_npmrc_auth_file_loses_to_project_npmrc() {
+    let home = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let auth_file = home.path().join("auth.npmrc");
+    std::fs::write(
+        &auth_file,
+        "//registry.example.com/:_authToken=user-auth-file-token\n",
+    )
+    .unwrap();
+    std::fs::write(
+        home.path().join(".npmrc"),
+        format!("npmrc-auth-file={}\n", auth_file.display()),
+    )
+    .unwrap();
+    std::fs::write(
+        project.path().join(".npmrc"),
+        "//registry.example.com/:_authToken=project-token\n",
+    )
+    .unwrap();
+
+    let entries = load_npmrc_entries_with_home(Some(home.path()), None, project.path(), None);
+    let mut config = NpmConfig::default();
+    config.apply(entries);
+
+    assert_eq!(
+        config.auth_token_for("https://registry.example.com/"),
+        Some("project-token"),
+        "user-declared auth file entries should stay in the user precedence layer",
+    );
+}
+
+#[test]
 fn test_package_scope() {
     assert_eq!(package_scope("@myorg/pkg"), Some("@myorg"));
     assert_eq!(package_scope("lodash"), None);

--- a/crates/aube-registry/src/config/types.rs
+++ b/crates/aube-registry/src/config/types.rs
@@ -19,10 +19,13 @@ pub(crate) enum NpmrcSource {
     /// therefore attacker controlled when the project came from a
     /// hostile clone.
     Project,
-    /// A file pointed at by the `npmrc-auth-file` setting. The path
-    /// itself can be declared from a project `.npmrc`, so the
-    /// file's contents inherit the project trust level.
-    NpmrcAuthFile,
+    /// A file pointed at by a user/global `npmrc-auth-file` setting.
+    /// Trusted because the user chose the file location.
+    UserNpmrcAuthFile,
+    /// A file pointed at by a project `npmrc-auth-file` setting. The
+    /// path itself came from committed config, so the file's contents
+    /// inherit the project trust level.
+    ProjectNpmrcAuthFile,
     /// Environment variable. `npm_config_*` / `NPM_CONFIG_*`.
     /// Trusted because the developer or their CI pipeline has to
     /// set them explicitly in the shell that invoked aube.
@@ -32,10 +35,17 @@ pub(crate) enum NpmrcSource {
 impl NpmrcSource {
     /// Whether a setting from this source is allowed to configure
     /// subprocess spawning (e.g. `tokenHelper`). `Project` and
-    /// `NpmrcAuthFile` both return false since both are reachable
-    /// from a hostile repo clone.
+    /// `ProjectNpmrcAuthFile` both return false since both are
+    /// reachable from a hostile repo clone.
     pub(super) fn is_trusted_for_subprocess_settings(self) -> bool {
-        matches!(self, Self::User | Self::PnpmAuth | Self::Env)
+        matches!(
+            self,
+            Self::User | Self::PnpmAuth | Self::UserNpmrcAuthFile | Self::Env
+        )
+    }
+
+    pub(super) fn is_project_controlled(self) -> bool {
+        matches!(self, Self::Project | Self::ProjectNpmrcAuthFile)
     }
 }
 

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -537,6 +537,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_UNTRUSTED_AUTH_ENV",
+      "category": "Registry config (trust gates)",
+      "description": "An auth setting from project-controlled `.npmrc` contained an environment variable reference and was ignored.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_UNTRUSTED_TOKEN_HELPER",
       "category": "Registry config (trust gates)",
       "description": "`tokenHelper` came from an untrusted source (CVE-2025-69262 class).",


### PR DESCRIPTION
## Summary

Stop expanding `${VAR}` references from repository-controlled `.npmrc` sources before registry/auth config is applied. User/global `.npmrc` and env-derived config keep trusted substitution, while project `.npmrc` and project-reachable `npmrc-auth-file` entries now preserve env references literally.

This prevents cloned repositories from turning the caller's environment into registry destinations or credentials.

## Validation

- cargo test -p aube-registry npmrc -- --nocapture
- cargo test -p aube-registry
- cargo clippy -p aube-registry -- -D warnings

This PR was generated by Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes trusted vs untrusted registry auth parsing and credential application—security-critical—and may break projects that relied on env-expanded auth in committed `.npmrc`.
> 
> **Overview**
> Hardens registry auth so **repository-controlled** `.npmrc` cannot turn the caller's environment into registry URLs or credentials.
> 
> Project `.npmrc` and project-reachable `npmrc-auth-file` content are parsed with **`parse_npmrc_untrusted`**, which leaves `${VAR}` literals in keys and values. During **`apply_tagged`**, auth entries from project-controlled sources that still contain env references are **dropped** and **`WARN_AUBE_UNTRUSTED_AUTH_ENV`** is logged. User/global sources (`~/.npmrc`, pnpm `auth.ini`, user-declared auth files) keep full `${…}` expansion.
> 
> **`NpmrcSource::NpmrcAuthFile`** is split into **`UserNpmrcAuthFile`** vs **`ProjectNpmrcAuthFile`** according to which layer set `npmrc-auth-file`, with matching trust for subprocess settings and load order. Tests and the error-code catalog document the new warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a26162a0e83584b3b0f6edca64292f5d0762be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Project-scoped .npmrc and project-referenced auth files are now treated as untrusted: environment-variable placeholders in auth entries are ignored; user-level .npmrc continues to expand env vars.
* **New Features**
  * Distinguishes user vs project origins for auth-file entries so trust rules are applied correctly.
* **Warnings**
  * New warning emitted when a project-controlled auth entry contains an environment-variable reference and is ignored.
* **Tests**
  * Added tests covering trusted vs untrusted .npmrc parsing and auth handling.
* **Documentation**
  * Error-code catalog updated with the new warning entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->