### PR TITLE
fix(scripts): require source keys for build approvals

### DIFF
--- a/crates/aube-lockfile/src/graph_hash.rs
+++ b/crates/aube-lockfile/src/graph_hash.rs
@@ -285,16 +285,23 @@ fn transitively_requires_build(
 }
 
 /// `full_pkg_id` — pnpm uses `${pkgIdWithPatchHash}:${resolution}`; we
-/// use `${name}@${version}[:patch:<hex>]:${integrity}`. Packages
-/// without integrity (workspace or git deps in pnpm's lockfile) fall
-/// back to `<no-integrity>` which keeps the hash deterministic
-/// without perfectly encoding identity — good enough until those
-/// sources actually matter.
+/// use `${name}@${version}[:patch:<hex>]:${source?}:${integrity}`.
+/// Source-backed packages fold in their stable specifier so two local
+/// or git dependencies with the same manifest version don't collapse
+/// onto the same graph hash when they point at different bytes.
 fn full_pkg_id(pkg: &LockedPackage, patch_hash: PatchHashFn<'_>) -> String {
     let integrity = pkg.integrity.as_deref().unwrap_or("<no-integrity>");
+    let source = pkg
+        .local_source
+        .as_ref()
+        .map(|source| format!(":source:{}", source.specifier()))
+        .unwrap_or_default();
     match patch_hash(&pkg.name, &pkg.version) {
-        Some(hex) => format!("{}@{}:patch:{hex}:{integrity}", pkg.name, pkg.version),
-        None => format!("{}@{}:{}", pkg.name, pkg.version, integrity),
+        Some(hex) => format!(
+            "{}@{}:patch:{hex}{source}:{integrity}",
+            pkg.name, pkg.version
+        ),
+        None => format!("{}@{}{source}:{}", pkg.name, pkg.version, integrity),
     }
 }
 
@@ -322,7 +329,8 @@ struct DepsHashInput<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DirectDep, LockedPackage, LockfileGraph};
+    use crate::{DirectDep, LocalSource, LockedPackage, LockfileGraph};
+    use std::path::PathBuf;
 
     fn mk_pkg(name: &str, ver: &str, integrity: Option<&str>) -> LockedPackage {
         LockedPackage {
@@ -395,6 +403,40 @@ mod tests {
         let h2 = compute_graph_hashes(&g2, &|_| false, None);
         assert_ne!(h1.node_hash["foo@1.0.0"], h2.node_hash["foo@1.0.0"]);
         assert_ne!(h1.node_hash["bar@1.0.0"], h2.node_hash["bar@1.0.0"]);
+    }
+
+    #[test]
+    fn source_change_cascades_to_parent() {
+        let mut g1 = empty_graph();
+        let mut parent = mk_pkg("parent", "1.0.0", Some("sha512-P"));
+        parent
+            .dependencies
+            .insert("child".into(), "file+aaa".into());
+        g1.packages.insert("parent@1.0.0".into(), parent);
+        let mut child = mk_pkg("child", "1.0.0", None);
+        child.dep_path = "child@file+aaa".into();
+        child.local_source = Some(LocalSource::Directory(PathBuf::from("vendor/a")));
+        g1.packages.insert("child@file+aaa".into(), child);
+
+        let mut g2 = empty_graph();
+        let mut parent = mk_pkg("parent", "1.0.0", Some("sha512-P"));
+        parent
+            .dependencies
+            .insert("child".into(), "file+bbb".into());
+        g2.packages.insert("parent@1.0.0".into(), parent);
+        let mut child = mk_pkg("child", "1.0.0", None);
+        child.dep_path = "child@file+bbb".into();
+        child.local_source = Some(LocalSource::Directory(PathBuf::from("vendor/b")));
+        g2.packages.insert("child@file+bbb".into(), child);
+
+        let h1 = compute_graph_hashes(&g1, &|_| false, None);
+        let h2 = compute_graph_hashes(&g2, &|_| false, None);
+
+        assert_ne!(
+            h1.node_hash["child@file+aaa"],
+            h2.node_hash["child@file+bbb"]
+        );
+        assert_ne!(h1.node_hash["parent@1.0.0"], h2.node_hash["parent@1.0.0"]);
     }
 
     #[test]

--- a/crates/aube-lockfile/src/graph_hash.rs
+++ b/crates/aube-lockfile/src/graph_hash.rs
@@ -38,7 +38,7 @@ use aube_util::collections::FxSet as FxHashSet;
 /// scripts. Implemented by `aube-scripts::BuildPolicy` in practice,
 /// but the hasher stays oblivious to the policy crate so the lockfile
 /// crate doesn't depend on it.
-pub type AllowBuildFn<'a> = &'a dyn Fn(&str, &str) -> bool;
+pub type AllowBuildFn<'a> = &'a dyn Fn(&LockedPackage) -> bool;
 
 /// Engine fingerprint folded into a node's hash when any of its
 /// transitive deps are allowed to build. Callers compute this once
@@ -148,12 +148,7 @@ pub fn compute_graph_hashes_with_patches(
     // allowed to run its scripts. This is the "builds" set.
     let mut builds: FxHashSet<String> = FxHashSet::default();
     for (dep_path, pkg) in &graph.packages {
-        // Feed registry_name to allow_build, not pkg.name. pkg.name
-        // could be an npm: alias from the manifest. Allowlist pins
-        // the real name. Without this, an aliased import smuggles
-        // past the allowlist. Same fix applied at every policy.decide
-        // callsite in aube/ (install/mod.rs, ignored_builds.rs).
-        if allow_build(pkg.registry_name(), &pkg.version) {
+        if allow_build(pkg) {
             builds.insert(dep_path.clone());
         }
     }
@@ -359,8 +354,8 @@ mod tests {
             "foo@1.0.0".into(),
             mk_pkg("foo", "1.0.0", Some("sha512-ABC")),
         );
-        let h1 = compute_graph_hashes(&g, &|_, _| false, None);
-        let h2 = compute_graph_hashes(&g, &|_, _| false, None);
+        let h1 = compute_graph_hashes(&g, &|_| false, None);
+        let h2 = compute_graph_hashes(&g, &|_| false, None);
         assert_eq!(h1.node_hash, h2.node_hash);
     }
 
@@ -372,8 +367,8 @@ mod tests {
         let mut g2 = empty_graph();
         g2.packages
             .insert("foo@1.0.0".into(), mk_pkg("foo", "1.0.0", Some("sha512-B")));
-        let h1 = compute_graph_hashes(&g1, &|_, _| false, None);
-        let h2 = compute_graph_hashes(&g2, &|_, _| false, None);
+        let h1 = compute_graph_hashes(&g1, &|_| false, None);
+        let h2 = compute_graph_hashes(&g2, &|_| false, None);
         assert_ne!(h1.node_hash["foo@1.0.0"], h2.node_hash["foo@1.0.0"]);
     }
 
@@ -396,8 +391,8 @@ mod tests {
             mk_pkg("bar", "1.0.0", Some("sha512-B2")),
         );
 
-        let h1 = compute_graph_hashes(&g1, &|_, _| false, None);
-        let h2 = compute_graph_hashes(&g2, &|_, _| false, None);
+        let h1 = compute_graph_hashes(&g1, &|_| false, None);
+        let h2 = compute_graph_hashes(&g2, &|_| false, None);
         assert_ne!(h1.node_hash["foo@1.0.0"], h2.node_hash["foo@1.0.0"]);
         assert_ne!(h1.node_hash["bar@1.0.0"], h2.node_hash["bar@1.0.0"]);
     }
@@ -419,7 +414,7 @@ mod tests {
             .insert("native".into(), "1.0.0".into());
         g.packages.insert("consumer@1.0.0".into(), consumer);
 
-        let allow_native = |name: &str, _v: &str| name == "native";
+        let allow_native = |pkg: &LockedPackage| pkg.registry_name() == "native";
         let engine_a = EngineName("linux-x64-node20".into());
         let engine_b = EngineName("linux-x64-node22".into());
 
@@ -447,7 +442,7 @@ mod tests {
         g.packages.insert("a@1.0.0".into(), a);
         g.packages.insert("b@1.0.0".into(), b);
 
-        let h = compute_graph_hashes(&g, &|_, _| false, None);
+        let h = compute_graph_hashes(&g, &|_| false, None);
         assert!(h.node_hash.contains_key("a@1.0.0"));
         assert!(h.node_hash.contains_key("b@1.0.0"));
     }

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -389,14 +389,65 @@ impl LockedPackage {
     /// approved by their lockfile identity, with any peer suffix
     /// stripped so the approval survives peer-context reshuffling.
     pub fn source_approval_key(&self) -> Option<&str> {
-        if self.local_source.is_none() && !self.registry_git_hosted {
-            return None;
-        }
+        self.local_source.as_ref()?;
         Some(
             self.dep_path
                 .split_once('(')
                 .map_or(&self.dep_path, |(base, _)| base),
         )
+    }
+}
+
+#[cfg(test)]
+mod locked_package_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn pkg() -> LockedPackage {
+        LockedPackage {
+            name: "pkg".to_string(),
+            version: "1.0.0".to_string(),
+            integrity: Some("sha512-abc".to_string()),
+            dependencies: BTreeMap::new(),
+            optional_dependencies: BTreeMap::new(),
+            peer_dependencies: BTreeMap::new(),
+            peer_dependencies_meta: BTreeMap::new(),
+            dep_path: "pkg@1.0.0".to_string(),
+            local_source: None,
+            os: PlatformList::default(),
+            cpu: PlatformList::default(),
+            libc: PlatformList::default(),
+            bundled_dependencies: Vec::new(),
+            tarball_url: None,
+            registry_git_hosted: false,
+            alias_of: None,
+            yarn_checksum: None,
+            engines: BTreeMap::new(),
+            bin: BTreeMap::new(),
+            declared_dependencies: BTreeMap::new(),
+            license: None,
+            funding_url: None,
+            optional: false,
+            transitive_peer_dependencies: Vec::new(),
+            extra_meta: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn source_approval_key_ignores_registry_git_hosted_packages() {
+        let mut pkg = pkg();
+        pkg.registry_git_hosted = true;
+
+        assert_eq!(pkg.source_approval_key(), None);
+    }
+
+    #[test]
+    fn source_approval_key_strips_peer_suffix_for_local_sources() {
+        let mut pkg = pkg();
+        pkg.dep_path = "pkg@file+abc(peer@1.0.0)".to_string();
+        pkg.local_source = Some(LocalSource::Directory(PathBuf::from("vendor/pkg")));
+
+        assert_eq!(pkg.source_approval_key(), Some("pkg@file+abc"));
     }
 }
 

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -381,6 +381,23 @@ impl LockedPackage {
     pub fn spec_key(&self) -> String {
         format!("{}@{}", self.name, self.version)
     }
+
+    /// Exact approval key for non-registry package sources.
+    ///
+    /// Name-wide build approvals are only trustworthy for packages
+    /// fetched from a registry. Source-backed entries need to be
+    /// approved by their lockfile identity, with any peer suffix
+    /// stripped so the approval survives peer-context reshuffling.
+    pub fn source_approval_key(&self) -> Option<&str> {
+        if self.local_source.is_none() && !self.registry_git_hosted {
+            return None;
+        }
+        Some(
+            self.dep_path
+                .split_once('(')
+                .map_or(&self.dep_path, |(base, _)| base),
+        )
+    }
 }
 
 /// Metadata about a single declared peer dependency. Matches the shape of

--- a/crates/aube-scripts/src/policy.rs
+++ b/crates/aube-scripts/src/policy.rs
@@ -51,6 +51,11 @@ pub struct BuildPolicy {
     /// `name@version` strings (match that specific version).
     allowed: HashSet<String>,
     denied: HashSet<String>,
+    /// Exact source-backed lockfile IDs such as `pkg@file+abc123`.
+    /// These are intentionally separate from normal `name@version`
+    /// entries so a typo like `pkg@latest` still warns.
+    allowed_sources: HashSet<String>,
+    denied_sources: HashSet<String>,
     /// Bare-name patterns containing `*` wildcards. Checked with a
     /// linear scan after the exact-match sets; wildcard rules are rare
     /// enough that the linear pass is cheaper than building an
@@ -94,6 +99,8 @@ impl BuildPolicy {
         }
         let mut allowed = HashSet::new();
         let mut denied = HashSet::new();
+        let mut allowed_sources = HashSet::new();
+        let mut denied_sources = HashSet::new();
         let mut allowed_wildcards = Vec::new();
         let mut denied_wildcards = Vec::new();
         let mut warnings = Vec::new();
@@ -127,7 +134,12 @@ impl BuildPolicy {
                     } else {
                         (&mut denied, &mut denied_wildcards)
                     };
-                    sort_entries(expanded, exact, wild);
+                    let source = if bool_value {
+                        &mut allowed_sources
+                    } else {
+                        &mut denied_sources
+                    };
+                    sort_entries(expanded, exact, source, wild);
                 }
                 Err(e) => warnings.push(e),
             }
@@ -140,13 +152,23 @@ impl BuildPolicy {
         // format.
         for pattern in only_built {
             match expand_spec(pattern) {
-                Ok(expanded) => sort_entries(expanded, &mut allowed, &mut allowed_wildcards),
+                Ok(expanded) => sort_entries(
+                    expanded,
+                    &mut allowed,
+                    &mut allowed_sources,
+                    &mut allowed_wildcards,
+                ),
                 Err(e) => warnings.push(e),
             }
         }
         for pattern in never_built {
             match expand_spec(pattern) {
-                Ok(expanded) => sort_entries(expanded, &mut denied, &mut denied_wildcards),
+                Ok(expanded) => sort_entries(
+                    expanded,
+                    &mut denied,
+                    &mut denied_sources,
+                    &mut denied_wildcards,
+                ),
                 Err(e) => warnings.push(e),
             }
         }
@@ -156,6 +178,8 @@ impl BuildPolicy {
                 allow_all: false,
                 allowed,
                 denied,
+                allowed_sources,
+                denied_sources,
                 allowed_wildcards,
                 denied_wildcards,
             },
@@ -166,11 +190,17 @@ impl BuildPolicy {
     /// Build an allow-all policy with explicit package-pattern denies.
     pub fn denylist(denied_patterns: &[String]) -> (Self, Vec<BuildPolicyError>) {
         let mut denied = HashSet::new();
+        let mut denied_sources = HashSet::new();
         let mut denied_wildcards = Vec::new();
         let mut warnings = Vec::new();
         for pattern in denied_patterns {
             match expand_spec(pattern) {
-                Ok(expanded) => sort_entries(expanded, &mut denied, &mut denied_wildcards),
+                Ok(expanded) => sort_entries(
+                    expanded,
+                    &mut denied,
+                    &mut denied_sources,
+                    &mut denied_wildcards,
+                ),
                 Err(e) => warnings.push(e),
             }
         }
@@ -179,6 +209,8 @@ impl BuildPolicy {
                 allow_all: true,
                 allowed: HashSet::new(),
                 denied,
+                allowed_sources: HashSet::new(),
+                denied_sources,
                 allowed_wildcards: Vec::new(),
                 denied_wildcards,
             },
@@ -189,6 +221,22 @@ impl BuildPolicy {
     /// Decide whether `(name, version)` may run lifecycle scripts.
     /// Explicit denies always win over allows (mirrors pnpm).
     pub fn decide(&self, name: &str, version: &str) -> AllowDecision {
+        self.decide_package(name, version, None)
+    }
+
+    /// Decide whether a package may run lifecycle scripts, with an
+    /// optional source identity for non-registry packages.
+    ///
+    /// Bare package-name approvals only apply to registry packages.
+    /// Source-backed packages (`file:`, `git:`, direct tarball, etc.)
+    /// require an exact source key such as `pkg@file+abc123`; otherwise
+    /// a trusted package name could approve arbitrary untrusted bytes.
+    pub fn decide_package(
+        &self,
+        name: &str,
+        version: &str,
+        source_key: Option<&str>,
+    ) -> AllowDecision {
         // Reusable thread-local buffer for the `name@version` probe key.
         // Avoids a `format!` allocation on every call — ~2k throwaway
         // Strings on a typical install otherwise.
@@ -199,6 +247,11 @@ impl BuildPolicy {
             return AllowDecision::Deny;
         }
         if matches_any_wildcard(name, &self.denied_wildcards) {
+            return AllowDecision::Deny;
+        }
+        if let Some(source_key) = source_key
+            && self.denied_sources.contains(source_key)
+        {
             return AllowDecision::Deny;
         }
         // Build the `name@version` probe key once and answer both the
@@ -217,6 +270,13 @@ impl BuildPolicy {
         if self.allow_all {
             return AllowDecision::Allow;
         }
+        if let Some(source_key) = source_key {
+            return if self.allowed_sources.contains(source_key) {
+                AllowDecision::Allow
+            } else {
+                AllowDecision::Unspecified
+            };
+        }
         if self.allowed.contains(name) || allowed_versioned {
             return AllowDecision::Allow;
         }
@@ -230,7 +290,10 @@ impl BuildPolicy {
     /// allow-all mode. Lets callers cheaply skip the whole dep-script
     /// phase when nothing could possibly run.
     pub fn has_any_allow_rule(&self) -> bool {
-        self.allow_all || !self.allowed.is_empty() || !self.allowed_wildcards.is_empty()
+        self.allow_all
+            || !self.allowed.is_empty()
+            || !self.allowed_sources.is_empty()
+            || !self.allowed_wildcards.is_empty()
     }
 
     /// Merge another resolved policy into this one. Denies from either
@@ -239,6 +302,10 @@ impl BuildPolicy {
         self.allow_all |= other.allow_all;
         self.allowed.extend(other.allowed.iter().cloned());
         self.denied.extend(other.denied.iter().cloned());
+        self.allowed_sources
+            .extend(other.allowed_sources.iter().cloned());
+        self.denied_sources
+            .extend(other.denied_sources.iter().cloned());
         merge_unique(&mut self.allowed_wildcards, &other.allowed_wildcards);
         merge_unique(&mut self.denied_wildcards, &other.denied_wildcards);
     }
@@ -271,12 +338,19 @@ pub fn pattern_matches(pattern: &str, name: &str, version: &str) -> Result<bool,
 /// and the wildcard list. Wildcards are identified by a literal `*` in
 /// the string; since `expand_spec` rejects `wildcard@version`, a `*`
 /// can only appear in a bare name.
-fn sort_entries(entries: Vec<String>, exact: &mut HashSet<String>, wildcards: &mut Vec<String>) {
+fn sort_entries(
+    entries: Vec<String>,
+    exact: &mut HashSet<String>,
+    sources: &mut HashSet<String>,
+    wildcards: &mut Vec<String>,
+) {
     for entry in entries {
         if entry.contains('*') {
             if !wildcards.iter().any(|p| p == &entry) {
                 wildcards.push(entry);
             }
+        } else if is_source_key(&entry) {
+            sources.insert(entry);
         } else {
             exact.insert(entry);
         }
@@ -363,12 +437,27 @@ fn expand_spec(pattern: &str) -> Result<Vec<String>, BuildPolicyError> {
     let mut out = Vec::new();
     for raw in versions_part.split("||") {
         let trimmed = raw.trim();
+        if is_source_version(trimmed) && !versions_part.contains("||") {
+            out.push(format!("{name}@{trimmed}"));
+            return Ok(out);
+        }
         if trimmed.is_empty() || !is_exact_semver(trimmed) {
             return Err(BuildPolicyError::InvalidVersionUnion(pattern.to_string()));
         }
         out.push(format!("{name}@{trimmed}"));
     }
     Ok(out)
+}
+
+fn is_source_key(key: &str) -> bool {
+    let (_, version) = split_name_and_versions(key);
+    is_source_version(version)
+}
+
+fn is_source_version(version: &str) -> bool {
+    ["file+", "link+", "portal+", "exec+", "git+", "url+"]
+        .iter()
+        .any(|prefix| version.starts_with(prefix))
 }
 
 /// Split `pattern` into `(name, version_spec)`, respecting a leading
@@ -423,6 +512,38 @@ mod tests {
         assert_eq!(p.decide("esbuild", "0.19.0"), AllowDecision::Allow);
         assert_eq!(p.decide("esbuild", "0.25.0"), AllowDecision::Allow);
         assert_eq!(p.decide("rollup", "4.0.0"), AllowDecision::Unspecified);
+    }
+
+    #[test]
+    fn bare_name_does_not_allow_source_backed_package() {
+        let p = policy(&[("esbuild", true)]);
+        assert_eq!(
+            p.decide_package("esbuild", "0.25.0", Some("esbuild@file+abc123")),
+            AllowDecision::Unspecified
+        );
+    }
+
+    #[test]
+    fn exact_source_key_allows_source_backed_package() {
+        let p = policy(&[("esbuild@file+abc123", true)]);
+        assert_eq!(
+            p.decide_package("esbuild", "0.25.0", Some("esbuild@file+abc123")),
+            AllowDecision::Allow
+        );
+        assert_eq!(
+            p.decide_package("esbuild", "0.25.0", Some("esbuild@file+def456")),
+            AllowDecision::Unspecified
+        );
+        assert_eq!(p.decide("esbuild", "0.25.0"), AllowDecision::Unspecified);
+    }
+
+    #[test]
+    fn source_backed_package_name_deny_still_wins() {
+        let p = policy(&[("esbuild", false), ("esbuild@file+abc123", true)]);
+        assert_eq!(
+            p.decide_package("esbuild", "0.25.0", Some("esbuild@file+abc123")),
+            AllowDecision::Deny
+        );
     }
 
     #[test]

--- a/crates/aube-scripts/src/policy.rs
+++ b/crates/aube-scripts/src/policy.rs
@@ -455,9 +455,25 @@ fn is_source_key(key: &str) -> bool {
 }
 
 fn is_source_version(version: &str) -> bool {
-    ["file+", "link+", "portal+", "exec+", "git+", "url+"]
-        .iter()
-        .any(|prefix| version.starts_with(prefix))
+    [
+        "file+",
+        "link+",
+        "portal+",
+        "exec+",
+        "git+",
+        "url+",
+        "file:",
+        "link:",
+        "portal:",
+        "exec:",
+        "git:",
+        "http://",
+        "https://",
+        "github:",
+        "workspace:",
+    ]
+    .iter()
+    .any(|prefix| version.starts_with(prefix))
 }
 
 /// Split `pattern` into `(name, version_spec)`, respecting a leading
@@ -535,6 +551,36 @@ mod tests {
             AllowDecision::Unspecified
         );
         assert_eq!(p.decide("esbuild", "0.25.0"), AllowDecision::Unspecified);
+    }
+
+    #[test]
+    fn source_keys_accept_url_and_git_tails() {
+        let p = policy(&[
+            ("native@url+abc123", true),
+            ("gitdep@git+def456", true),
+            ("raw-url@https://example.com/pkg.tgz", true),
+            ("raw-git@github:owner/repo", true),
+        ]);
+        assert_eq!(
+            p.decide_package("native", "1.0.0", Some("native@url+abc123")),
+            AllowDecision::Allow
+        );
+        assert_eq!(
+            p.decide_package("gitdep", "1.0.0", Some("gitdep@git+def456")),
+            AllowDecision::Allow
+        );
+        assert_eq!(
+            p.decide_package(
+                "raw-url",
+                "1.0.0",
+                Some("raw-url@https://example.com/pkg.tgz")
+            ),
+            AllowDecision::Allow
+        );
+        assert_eq!(
+            p.decide_package("raw-git", "1.0.0", Some("raw-git@github:owner/repo")),
+            AllowDecision::Allow
+        );
     }
 
     #[test]

--- a/crates/aube/src/commands/ignored_builds.rs
+++ b/crates/aube/src/commands/ignored_builds.rs
@@ -158,7 +158,7 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
         // real pkg name. npm: alias would sneak past otherwise. Same
         // fix as every other policy.decide callsite.
         if matches!(
-            policy.decide(pkg.registry_name(), &pkg.version),
+            policy.decide_package(pkg.registry_name(), &pkg.version, pkg.source_approval_key()),
             aube_scripts::AllowDecision::Allow
         ) {
             continue;

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -155,10 +155,10 @@ impl JailBuildPolicy {
         )
     }
 
-    fn should_jail(&self, name: &str, version: &str) -> bool {
+    fn should_jail(&self, name: &str, version: &str, source_key: Option<&str>) -> bool {
         self.enabled
             && !matches!(
-                self.denylist.decide(name, version),
+                self.denylist.decide_package(name, version, source_key),
                 aube_scripts::AllowDecision::Deny
             )
     }
@@ -167,10 +167,11 @@ impl JailBuildPolicy {
         &self,
         name: &str,
         version: &str,
+        source_key: Option<&str>,
         package_dir: &std::path::Path,
         project_dir: &std::path::Path,
     ) -> Option<aube_scripts::ScriptJail> {
-        if !self.should_jail(name, version) {
+        if !self.should_jail(name, version, source_key) {
             return None;
         }
         let mut env = Vec::new();
@@ -390,6 +391,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         name: String,
         registry_name: String,
         version: String,
+        source_key: Option<String>,
         package_dir: std::path::PathBuf,
         /// Directory containing the dep package and its sibling
         /// symlinks — i.e. `package_dir`'s enclosing `node_modules/`.
@@ -418,7 +420,11 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             // writes `"h3-safe": "npm:h3@0.19.0"` to sneak a denied pkg
             // through the allowlist. registry_name() strips alias back to
             // real name.
-            match policy.decide(pkg.registry_name(), &pkg.version) {
+            match policy.decide_package(
+                pkg.registry_name(),
+                &pkg.version,
+                pkg.source_approval_key(),
+            ) {
                 aube_scripts::AllowDecision::Allow => {}
                 aube_scripts::AllowDecision::Deny | aube_scripts::AllowDecision::Unspecified => {
                     continue;
@@ -496,6 +502,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             name: pkg.name.clone(),
             registry_name: pkg.registry_name().to_string(),
             version: pkg.version.clone(),
+            source_key: pkg.source_approval_key().map(str::to_owned),
             package_dir,
             dep_modules_dir,
             manifest: dep_manifest,
@@ -577,6 +584,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             let jail = jail_policy.jail_for(
                 &job.registry_name,
                 &job.version,
+                job.source_key.as_deref(),
                 &job.package_dir,
                 &project_dir,
             );
@@ -1104,7 +1112,7 @@ pub(super) fn unreviewed_dep_builds(
     let mut unreviewed = Vec::new();
     for (dep_path, pkg) in &graph.packages {
         if !matches!(
-            policy.decide(pkg.registry_name(), &pkg.version),
+            policy.decide_package(pkg.registry_name(), &pkg.version, pkg.source_approval_key()),
             aube_scripts::AllowDecision::Unspecified
         ) {
             continue;
@@ -1143,7 +1151,9 @@ pub(super) fn unreviewed_dep_builds(
             })?;
         if aube_scripts::has_dep_lifecycle_work(&package_dir, &dep_manifest) {
             unreviewed.push(UnreviewedBuild {
-                spec_key: pkg.spec_key(),
+                spec_key: pkg
+                    .source_approval_key()
+                    .map_or_else(|| pkg.spec_key(), str::to_owned),
                 suspicions: aube_scripts::sniff_lifecycle(&dep_manifest),
             });
         }

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -209,9 +209,13 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
             arc.as_ref().clone()
         } else {
             let engine = node_version.map(aube_lockfile::graph_hash::engine_name_default);
-            let allow = |name: &str, version: &str| {
+            let allow = |pkg: &aube_lockfile::LockedPackage| {
                 matches!(
-                    build_policy.decide(name, version),
+                    build_policy.decide_package(
+                        pkg.registry_name(),
+                        &pkg.version,
+                        pkg.source_approval_key()
+                    ),
                     aube_scripts::AllowDecision::Allow
                 )
             };

--- a/crates/aube/src/commands/install/materialize.rs
+++ b/crates/aube/src/commands/install/materialize.rs
@@ -147,9 +147,13 @@ pub(super) async fn run_gvs_prewarm_materializer(
             aube_util::diag::Category::Materialize,
             "graph_hash_compute",
         );
-        let allow = |name: &str, version: &str| {
+        let allow = |pkg: &aube_lockfile::LockedPackage| {
             matches!(
-                build_policy_for_hash.decide(name, version),
+                build_policy_for_hash.decide_package(
+                    pkg.registry_name(),
+                    &pkg.version,
+                    pkg.source_approval_key()
+                ),
                 aube_scripts::AllowDecision::Allow
             )
         };

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -100,7 +100,7 @@ JSON
 	assert_file_exists packages/app/postinstall.marker
 }
 
-@test "workspace member onlyBuiltDependencies allows member dep postinstall" {
+@test "workspace member onlyBuiltDependencies bare name skips source dep postinstall" {
 	cat >package.json <<'JSON'
 {
   "name": "workspace-build-policy-root",
@@ -135,7 +135,8 @@ JSON
 JSON
 	run aube install
 	assert_success
-	assert_file_exists packages/app/node_modules/member-dep-with-build/built.marker
+	assert_file_not_exists packages/app/node_modules/member-dep-with-build/built.marker
+	assert_output --partial "member-dep-with-build@file+"
 }
 
 @test "requiredScripts enforces root package scripts" {
@@ -184,7 +185,7 @@ JSON
 	run aube install
 	assert_failure
 	assert_output --partial "dependencies with build scripts must be reviewed"
-	assert_output --partial "dep-with-build@1.0.0"
+	assert_output --partial "dep-with-build@file+"
 	# Diverges from pnpm: aube does not auto-seed an `allowBuilds`
 	# placeholder. The manifest is left exactly as the user wrote it.
 	assert_file_not_exists aube-workspace.yaml
@@ -218,7 +219,7 @@ JSON
 	run aube install --config.strict-dep-builds=true
 	assert_failure
 	assert_output --partial "dependencies with build scripts must be reviewed"
-	assert_output --partial "dep-with-build@1.0.0"
+	assert_output --partial "dep-with-build@file+"
 }
 
 @test "strictDepBuilds=false keeps unreviewed dependency build scripts skipped" {
@@ -275,7 +276,7 @@ JSON
   }
 }
 JSON
-	run aube install
+	run aube install --dangerously-allow-all-builds
 	assert_success
 	assert_file_exists node_modules/dep-with-build/built.marker
 	[ ! -e node_modules/side-effects-v1 ]


### PR DESCRIPTION
## Summary
- require exact source approval keys for source-backed dependency builds
- keep bare package-name allowBuilds scoped to registry packages
- carry source-aware build decisions into ignored-builds and GVS hashing

## Tests
- cargo test -p aube-scripts policy
- cargo test -p aube-lockfile graph_hash
- cargo clippy -p aube-scripts -p aube-lockfile -- -D warnings
- cargo clippy -p aube -- -D warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security-sensitive lifecycle script gating and can alter virtual-store graph hashes for local/git deps; installs may skip builds or use new store paths until policies use source keys.
> 
> **Overview**
> **Source-backed dependencies** (`file:`, `git:`, tarballs, etc.) no longer inherit lifecycle build approval from bare package names or `name@semver` pins. They must be explicitly allowed via **exact lockfile source keys** (e.g. `esbuild@file+abc123`), parsed into separate `allowed_sources` / `denied_sources` sets in `BuildPolicy`. `LockedPackage::source_approval_key()` supplies that key (peer suffix stripped); install, ignored-builds, jail checks, and strict-dep-build prompts all call `decide_package` with it.
> 
> **Graph hashing** now takes a full `LockedPackage` in the allow-build callback and folds **local source specifiers** into `full_pkg_id`, so different file/git bytes at the same manifest version get distinct virtual-store hashes (with cascade to parents).
> 
> Integration tests expect workspace `onlyBuiltDependencies` by **name** to skip `file:` postinstalls until a source key is approved, and strict-dep-build messages to reference `pkg@file+…` identities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c00d92aa6104053919147ec4b4ceda3659daebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treats source-backed packages (git/file/local) as distinct exact items and exposes a source-approval key for non-registry packages.

* **Refactor**
  * Source keys are threaded through approval, jail checks, lifecycle steps, and package-aware graph-hash computation/allow checks.

* **Behavior**
  * Graph hashes can change for packages that differ by local source or patch identity.

* **Tests**
  * Updated lifecycle and policy tests to reflect source-key semantics and revised outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->