### PR TITLE
fix(install): warn on deprecated override refs

### DIFF
--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -31,6 +31,8 @@ pub const WARN_AUBE_GVS_MODE_CHANGED: &str = "WARN_AUBE_GVS_MODE_CHANGED";
 pub const WARN_AUBE_INVALID_CONCURRENCY: &str = "WARN_AUBE_INVALID_CONCURRENCY";
 pub const WARN_AUBE_INVALID_TRUST_POLICY: &str = "WARN_AUBE_INVALID_TRUST_POLICY";
 pub const WARN_AUBE_OVERRIDE_MISSING_DEP: &str = "WARN_AUBE_OVERRIDE_MISSING_DEP";
+pub const WARN_AUBE_OVERRIDE_DOLLAR_REF_DEPRECATED: &str =
+    "WARN_AUBE_OVERRIDE_DOLLAR_REF_DEPRECATED";
 pub const WARN_AUBE_INVALID_PEER_PATTERN: &str = "WARN_AUBE_INVALID_PEER_PATTERN";
 pub const WARN_AUBE_INVALID_SAVE_PREFIX: &str = "WARN_AUBE_INVALID_SAVE_PREFIX";
 pub const WARN_AUBE_CONCURRENCY_ENV_INVALID: &str = "WARN_AUBE_CONCURRENCY_ENV_INVALID";
@@ -237,6 +239,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_OVERRIDE_MISSING_DEP,
         category: category::SETTINGS_CONFIG,
         description: "An `overrides` `$ref` pointed at a package not in any of the importer's dependency lists.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_OVERRIDE_DOLLAR_REF_DEPRECATED,
+        category: category::SETTINGS_CONFIG,
+        description: "An `overrides` entry used pnpm's deprecated `$` version reference syntax.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -505,6 +505,18 @@ fn merge_string_map_setting(
     }
 }
 
+fn deprecated_dollar_override_refs(overrides: &BTreeMap<String, String>) -> Vec<(&str, &str)> {
+    overrides
+        .iter()
+        .filter_map(|(key, value)| {
+            value
+                .strip_prefix('$')
+                .filter(|dep| !dep.is_empty())
+                .map(|dep| (key.as_str(), dep))
+        })
+        .collect()
+}
+
 fn object_setting_from_npmrc(
     setting: &str,
     entries: &[(String, String)],
@@ -727,6 +739,12 @@ pub(crate) fn configure_resolver(
     };
     let mut effective_overrides = manifest.overrides_map();
     merge_string_map_setting(settings_ctx, "overrides", &mut effective_overrides);
+    for (key, dep) in deprecated_dollar_override_refs(&effective_overrides) {
+        tracing::warn!(
+            code = aube_codes::warnings::WARN_AUBE_OVERRIDE_DOLLAR_REF_DEPRECATED,
+            "override {key:?} uses deprecated $ reference ${dep}; use a catalog entry instead"
+        );
+    }
     let unresolved_refs = manifest.resolve_override_refs(&mut effective_overrides);
     for key in &unresolved_refs {
         tracing::warn!(
@@ -956,6 +974,25 @@ fn compile_peer_patterns(field: &str, raw: &[String]) -> Vec<glob::Pattern> {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod override_tests {
+    use super::*;
+
+    #[test]
+    fn deprecated_dollar_override_refs_reports_only_ref_values() {
+        let overrides = BTreeMap::from([
+            ("left-pad".to_string(), "$left-pad".to_string()),
+            ("react".to_string(), "^19.0.0".to_string()),
+            ("empty".to_string(), "$".to_string()),
+        ]);
+
+        assert_eq!(
+            deprecated_dollar_override_refs(&overrides),
+            vec![("left-pad", "left-pad")]
+        );
+    }
 }
 
 #[cfg(test)]

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -471,6 +471,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_OVERRIDE_DOLLAR_REF_DEPRECATED",
+      "category": "Settings / config validation",
+      "description": "An `overrides` entry used pnpm's deprecated `$` version reference syntax.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_INVALID_PEER_PATTERN",
       "category": "Settings / config validation",
       "description": "A `peerDependencyRules` pattern was unparseable and skipped.",


### PR DESCRIPTION
## Summary
- warn when merged overrides use pnpm's deprecated `` reference syntax
- keep existing resolution/drop behavior unchanged
- add the new warning code to generated error-code docs data

## Tests
- cargo run -p aube-codes --bin generate-error-codes-docs
- cargo test -p aube-codes
- cargo test -p aube deprecated_dollar_override_refs_reports_only_ref_values
- cargo clippy -p aube-codes -p aube -- -D warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Advisory-only tracing during install settings validation; override merge and drop behavior are unchanged.
> 
> **Overview**
> Install now surfaces **pnpm’s deprecated `$` override syntax** as an advisory warning while leaving resolution unchanged.
> 
> After merged `overrides` are built in `configure_resolver`, a new `deprecated_dollar_override_refs` helper flags values that start with `$` (excluding bare `$`) and logs **`WARN_AUBE_OVERRIDE_DOLLAR_REF_DEPRECATED`**, pointing users toward catalog entries. The existing **`WARN_AUBE_OVERRIDE_MISSING_DEP`** path for unresolved `$` refs still runs afterward.
> 
> The warning is registered in **`aube-codes`** and **`docs/error-codes.data.json`**, with a unit test on the detector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3363c30d2c5b134a66b3d31df47499b0939c53a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and warnings for deprecated `$` version reference syntax in package overrides, helping identify and migrate outdated override configurations.

* **Documentation**
  * Updated error codes documentation to include the new override deprecation warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->