### PR TITLE
fix(scripts): match URL source build approvals

### DIFF
--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -386,15 +386,12 @@ impl LockedPackage {
     ///
     /// Name-wide build approvals are only trustworthy for packages
     /// fetched from a registry. Source-backed entries need to be
-    /// approved by their lockfile identity, with any peer suffix
-    /// stripped so the approval survives peer-context reshuffling.
-    pub fn source_approval_key(&self) -> Option<&str> {
-        self.local_source.as_ref()?;
-        Some(
-            self.dep_path
-                .split_once('(')
-                .map_or(&self.dep_path, |(base, _)| base),
-        )
+    /// approved by their source identity as pnpm records it in
+    /// lockfile keys / `allowBuilds` placeholders.
+    pub fn source_approval_key(&self) -> Option<String> {
+        self.local_source
+            .as_ref()
+            .map(|source| format!("{}@{}", self.registry_name(), source.specifier()))
     }
 }
 
@@ -442,12 +439,31 @@ mod locked_package_tests {
     }
 
     #[test]
-    fn source_approval_key_strips_peer_suffix_for_local_sources() {
+    fn source_approval_key_uses_source_spec_for_local_sources() {
         let mut pkg = pkg();
         pkg.dep_path = "pkg@file+abc(peer@1.0.0)".to_string();
         pkg.local_source = Some(LocalSource::Directory(PathBuf::from("vendor/pkg")));
 
-        assert_eq!(pkg.source_approval_key(), Some("pkg@file+abc"));
+        assert_eq!(
+            pkg.source_approval_key(),
+            Some("pkg@file:vendor/pkg".to_string())
+        );
+    }
+
+    #[test]
+    fn source_approval_key_uses_raw_remote_tarball_url() {
+        let mut pkg = pkg();
+        pkg.dep_path = "pkg@url+abc123".to_string();
+        pkg.local_source = Some(LocalSource::RemoteTarball(RemoteTarballSource {
+            url: "https://example.com/pkg.tgz".to_string(),
+            integrity: "sha512-tarball".to_string(),
+            git_hosted: false,
+        }));
+
+        assert_eq!(
+            pkg.source_approval_key(),
+            Some("pkg@https://example.com/pkg.tgz".to_string())
+        );
     }
 }
 

--- a/crates/aube-scripts/src/policy.rs
+++ b/crates/aube-scripts/src/policy.rs
@@ -686,6 +686,32 @@ mod tests {
     }
 
     #[test]
+    fn source_specs_cannot_be_union_members() {
+        let map: BTreeMap<String, AllowBuildRaw> = [(
+            "dependency@https://example.com/dep.tgz || 1.0.0".to_string(),
+            AllowBuildRaw::Bool(true),
+        )]
+        .into_iter()
+        .collect();
+        let (_, errs) = BuildPolicy::from_config(&map, &[], &[], false);
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(errs[0], BuildPolicyError::InvalidVersionUnion(_)));
+    }
+
+    #[test]
+    fn semver_then_source_spec_union_is_also_rejected() {
+        let map: BTreeMap<String, AllowBuildRaw> = [(
+            "dependency@1.0.0 || https://example.com/dep.tgz".to_string(),
+            AllowBuildRaw::Bool(true),
+        )]
+        .into_iter()
+        .collect();
+        let (_, errs) = BuildPolicy::from_config(&map, &[], &[], false);
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(errs[0], BuildPolicyError::InvalidVersionUnion(_)));
+    }
+
+    #[test]
     fn non_bool_value_reports_warning() {
         let map: BTreeMap<String, AllowBuildRaw> =
             [("esbuild".to_string(), AllowBuildRaw::Other("maybe".into()))]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -2229,7 +2229,8 @@ docs = """
 Per-package review map for dependency lifecycle scripts. Read from
 `package.json`'s `pnpm.allowBuilds` field and workspace yaml's
 `allowBuilds`. Keys are package name patterns (`esbuild`, `@scope/*`,
-`pkg@1.0.0 || 2.0.0`); values are `true` to allow `preinstall` /
+`pkg@1.0.0 || 2.0.0`, exact non-registry sources like
+`pkg@https://example.com/pkg.tgz`); values are `true` to allow `preinstall` /
 `install` / `postinstall` scripts for that package or `false` to record
 an intentional skip. Packages not listed are skipped by default, and
 install adds unreviewed build packages to workspace `allowBuilds` as

--- a/crates/aube/src/commands/ignored_builds.rs
+++ b/crates/aube/src/commands/ignored_builds.rs
@@ -157,8 +157,9 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
         // Match on registry_name, not pkg.name. Allowlist pins the
         // real pkg name. npm: alias would sneak past otherwise. Same
         // fix as every other policy.decide callsite.
+        let source_key = pkg.source_approval_key();
         if matches!(
-            policy.decide_package(pkg.registry_name(), &pkg.version, pkg.source_approval_key()),
+            policy.decide_package(pkg.registry_name(), &pkg.version, source_key.as_deref()),
             aube_scripts::AllowDecision::Allow
         ) {
             continue;

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -420,11 +420,8 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             // writes `"h3-safe": "npm:h3@0.19.0"` to sneak a denied pkg
             // through the allowlist. registry_name() strips alias back to
             // real name.
-            match policy.decide_package(
-                pkg.registry_name(),
-                &pkg.version,
-                pkg.source_approval_key(),
-            ) {
+            let source_key = pkg.source_approval_key();
+            match policy.decide_package(pkg.registry_name(), &pkg.version, source_key.as_deref()) {
                 aube_scripts::AllowDecision::Allow => {}
                 aube_scripts::AllowDecision::Deny | aube_scripts::AllowDecision::Unspecified => {
                     continue;
@@ -502,7 +499,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             name: pkg.name.clone(),
             registry_name: pkg.registry_name().to_string(),
             version: pkg.version.clone(),
-            source_key: pkg.source_approval_key().map(str::to_owned),
+            source_key: pkg.source_approval_key(),
             package_dir,
             dep_modules_dir,
             manifest: dep_manifest,
@@ -1111,8 +1108,9 @@ pub(super) fn unreviewed_dep_builds(
 ) -> miette::Result<Vec<UnreviewedBuild>> {
     let mut unreviewed = Vec::new();
     for (dep_path, pkg) in &graph.packages {
+        let source_key = pkg.source_approval_key();
         if !matches!(
-            policy.decide_package(pkg.registry_name(), &pkg.version, pkg.source_approval_key()),
+            policy.decide_package(pkg.registry_name(), &pkg.version, source_key.as_deref()),
             aube_scripts::AllowDecision::Unspecified
         ) {
             continue;
@@ -1151,9 +1149,7 @@ pub(super) fn unreviewed_dep_builds(
             })?;
         if aube_scripts::has_dep_lifecycle_work(&package_dir, &dep_manifest) {
             unreviewed.push(UnreviewedBuild {
-                spec_key: pkg
-                    .source_approval_key()
-                    .map_or_else(|| pkg.spec_key(), str::to_owned),
+                spec_key: pkg.source_approval_key().unwrap_or_else(|| pkg.spec_key()),
                 suspicions: aube_scripts::sniff_lifecycle(&dep_manifest),
             });
         }

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -214,7 +214,7 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
                     build_policy.decide_package(
                         pkg.registry_name(),
                         &pkg.version,
-                        pkg.source_approval_key()
+                        pkg.source_approval_key().as_deref(),
                     ),
                     aube_scripts::AllowDecision::Allow
                 )

--- a/crates/aube/src/commands/install/materialize.rs
+++ b/crates/aube/src/commands/install/materialize.rs
@@ -152,7 +152,7 @@ pub(super) async fn run_gvs_prewarm_materializer(
                 build_policy_for_hash.decide_package(
                     pkg.registry_name(),
                     &pkg.version,
-                    pkg.source_approval_key()
+                    pkg.source_approval_key().as_deref(),
                 ),
                 aube_scripts::AllowDecision::Allow
             )

--- a/docs/package-manager/lifecycle-scripts.md
+++ b/docs/package-manager/lifecycle-scripts.md
@@ -65,7 +65,10 @@ Deny rules win over allow rules. Workspace-yaml entries and
 Entry keys support a bare package name (matches every version), an
 exact version pin (`esbuild@0.19.0`), an exact version union
 (`esbuild@0.19.0 || 0.20.0`), or a `*` wildcard name (`@babel/*`,
-`*-loader`, or bare `*` for everything). Wildcards can't be combined
+`*-loader`, or bare `*` for everything). Exact non-registry source
+keys from pnpm are also honored, such as
+`dep@https://codeload.github.com/example/dep/tar.gz/<sha>`.
+Wildcards can't be combined
 with a version pin — the point of a version pin is to assert a
 specific build was audited, and a wildcard defeats that. Semver
 ranges aren't supported for the same reason.

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -2241,7 +2241,8 @@ Explicitly allow or disallow script execution per package.
 Per-package review map for dependency lifecycle scripts. Read from
 `package.json`'s `pnpm.allowBuilds` field and workspace yaml's
 `allowBuilds`. Keys are package name patterns (`esbuild`, `@scope/*`,
-`pkg@1.0.0 || 2.0.0`); values are `true` to allow `preinstall` /
+`pkg@1.0.0 || 2.0.0`, exact non-registry sources like
+`pkg@https://example.com/pkg.tgz`); values are `true` to allow `preinstall` /
 `install` / `postinstall` scripts for that package or `false` to record
 an intentional skip. Packages not listed are skipped by default, and
 install adds unreviewed build packages to workspace `allowBuilds` as

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -136,7 +136,7 @@ JSON
 	run aube install
 	assert_success
 	assert_file_not_exists packages/app/node_modules/member-dep-with-build/built.marker
-	assert_output --partial "member-dep-with-build@file+"
+	assert_output --partial "member-dep-with-build@file:packages/app/dep-with-build"
 }
 
 @test "requiredScripts enforces root package scripts" {
@@ -185,7 +185,7 @@ JSON
 	run aube install
 	assert_failure
 	assert_output --partial "dependencies with build scripts must be reviewed"
-	assert_output --partial "dep-with-build@file+"
+	assert_output --partial "dep-with-build@file:./dep-with-build"
 	# Diverges from pnpm: aube does not auto-seed an `allowBuilds`
 	# placeholder. The manifest is left exactly as the user wrote it.
 	assert_file_not_exists aube-workspace.yaml
@@ -219,7 +219,7 @@ JSON
 	run aube install --config.strict-dep-builds=true
 	assert_failure
 	assert_output --partial "dependencies with build scripts must be reviewed"
-	assert_output --partial "dep-with-build@file+"
+	assert_output --partial "dep-with-build@file:./dep-with-build"
 }
 
 @test "strictDepBuilds=false keeps unreviewed dependency build scripts skipped" {


### PR DESCRIPTION
## Summary
- make non-registry build approvals use pnpm-style source keys like `dep@https://example.com/pkg.tgz`
- keep install, ignored-builds, and GVS hash policy checks source-aware after the key shape change
- add tests for raw remote-tarball approval keys and both source-spec union orders
- document exact non-registry source keys in lifecycle-script and generated settings docs

## Context
#858 landed the source-specific build approval machinery while this PR was open. This follow-up aligns the approval key with pnpm-authored URL keys and covers the review-requested union-order case.

## Validation
- `mise run render`
- `cargo fmt --check`
- `cargo test -p aube-lockfile source_approval_key`
- `cargo test -p aube-scripts policy`
- `cargo check -p aube`
- `cargo clippy -p aube-lockfile -p aube-scripts -p aube --all-targets -- -D warnings`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how source-backed packages match `allowBuilds`, which is security-sensitive; misaligned keys could skip or run unintended lifecycle scripts until configs are updated to pnpm-style source keys.
> 
> **Overview**
> Non-registry dependency build approvals now use **pnpm-style source keys** (`registry_name@<source specifier>`) instead of lockfile `dep_path` bases with peer suffixes stripped.
> 
> `LockedPackage::source_approval_key()` returns an owned `Option<String>` built from `registry_name()` and `LocalSource::specifier()` (e.g. `pkg@file:vendor/pkg`, `pkg@https://example.com/pkg.tgz`). Install lifecycle policy, ignored-builds, unreviewed-build reporting, and graph-hash allow checks pass that key into `BuildPolicy::decide_package` via `as_deref()` where needed.
> 
> **Build policy** gains tests that **`allowBuilds` keys mixing semver and URL/source specs in a `||` union are rejected** (both orderings).
> 
> **Docs** (`lifecycle-scripts`, generated `allowBuilds` settings) note exact non-registry source keys. **Bats** expectations for strict-dep-builds output use `file:…` paths instead of `file+` lockfile tails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ae746303278bb04493762c59906a5424a9a31f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->