### PR TITLE
fix(registry): honor pnpm url-scoped auth env

### DIFF
--- a/crates/aube-registry/src/config.rs
+++ b/crates/aube-registry/src/config.rs
@@ -20,7 +20,7 @@ pub(crate) use token::run_token_helper;
 pub(crate) use url::lookup_by_uri_prefix;
 
 #[cfg(test)]
-use env::translate_npm_config_env;
+use env::{npm_config_env_entries_from, translate_npm_config_env};
 #[cfg(test)]
 use load::{
     expand_userconfig_path, load_npmrc_entries_tagged_with_home, load_npmrc_entries_with_home,

--- a/crates/aube-registry/src/config/env.rs
+++ b/crates/aube-registry/src/config/env.rs
@@ -7,9 +7,31 @@
 /// aliases. Env entries must be applied *after* `.npmrc` entries so
 /// last-write-wins gives env the higher precedence npm/pnpm document.
 pub(super) fn npm_config_env_entries_from(env: &[(String, String)]) -> Vec<(String, String)> {
-    env.iter()
-        .filter_map(|(n, v)| translate_npm_config_env(n, v))
-        .collect()
+    let mut npm_scoped = Vec::new();
+    let mut pnpm_scoped = Vec::new();
+    let mut out = Vec::new();
+    for (name, value) in env {
+        if value.is_empty() {
+            continue;
+        }
+        match translate_npm_config_env(name, value) {
+            Some((key, value)) if key.starts_with("//") => {
+                if name
+                    .get(.."pnpm_config_".len())
+                    .is_some_and(|p| p.eq_ignore_ascii_case("pnpm_config_"))
+                {
+                    pnpm_scoped.push((key, value));
+                } else {
+                    npm_scoped.push((key, value));
+                }
+            }
+            Some(entry) => out.push(entry),
+            None => {}
+        }
+    }
+    out.extend(npm_scoped);
+    out.extend(pnpm_scoped);
+    out
 }
 
 /// Map a single `npm_config_*` / `NPM_CONFIG_*` env var to the
@@ -20,13 +42,14 @@ pub(super) fn npm_config_env_entries_from(env: &[(String, String)]) -> Vec<(Stri
 pub(super) fn translate_npm_config_env(name: &str, value: &str) -> Option<(String, String)> {
     let suffix = name
         .strip_prefix("npm_config_")
-        .or_else(|| name.strip_prefix("NPM_CONFIG_"))?;
+        .or_else(|| name.strip_prefix("NPM_CONFIG_"))
+        .or_else(|| strip_url_scoped_config_prefix(name))?;
     // Per-URI auth keys (e.g. `//registry.example.com/:_authToken`)
     // already carry `.npmrc` syntax in the env-var name. Pass them
     // through unchanged so `apply`'s `starts_with("//")` arm picks
     // them up and preserves the `_authToken` / `_auth` / `username`
     // casing that the match inside it depends on.
-    if suffix.starts_with("//") {
+    if suffix.starts_with("//") && is_url_scoped_env_auth_key(suffix) {
         return Some((suffix.to_string(), value.to_string()));
     }
     // Scoped-registry keys: `@myorg:REGISTRY` or `@MYORG:registry`,
@@ -58,6 +81,27 @@ pub(super) fn translate_npm_config_env(name: &str, value: &str) -> Option<(Strin
         _ => return None,
     };
     Some((npmrc_key.to_string(), value.to_string()))
+}
+
+fn strip_url_scoped_config_prefix(name: &str) -> Option<&str> {
+    for prefix in ["npm_config_", "pnpm_config_"] {
+        if name
+            .get(..prefix.len())
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
+        {
+            let suffix = &name[prefix.len()..];
+            if suffix.starts_with("//") {
+                return Some(suffix);
+            }
+        }
+    }
+    None
+}
+
+fn is_url_scoped_env_auth_key(key: &str) -> bool {
+    key.rsplit_once(':').is_some_and(|(_, suffix)| {
+        matches!(suffix, "_authToken" | "_auth" | "username" | "_password")
+    })
 }
 /// Return the first set (and non-empty) env var in `names`. Used to
 /// read proxy config from both the upper- and lowercase spellings that

--- a/crates/aube-registry/src/config/load.rs
+++ b/crates/aube-registry/src/config/load.rs
@@ -14,7 +14,9 @@ impl NpmConfig {
     /// the generic settings resolver (`aube_cli::settings_values`) can
     /// never disagree on precedence.
     pub fn load(project_dir: &Path) -> Self {
-        let env: Vec<(String, String)> = std::env::vars().collect();
+        let env: Vec<(String, String)> = std::env::vars_os()
+            .filter_map(|(k, v)| Some((k.into_string().ok()?, v.into_string().ok()?)))
+            .collect();
         Self::load_with_env(project_dir, &env)
     }
 

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -1832,6 +1832,51 @@ fn translate_npm_config_env_passes_uri_auth_through_verbatim() {
 }
 
 #[test]
+fn translate_npm_config_env_passes_pnpm_uri_auth_through_verbatim() {
+    assert_eq!(
+        translate_npm_config_env(
+            "PNPM_CONFIG_//registry.example.com/:_authToken",
+            "secret-token"
+        ),
+        Some((
+            "//registry.example.com/:_authToken".to_string(),
+            "secret-token".to_string()
+        ))
+    );
+}
+
+#[test]
+fn npm_config_env_entries_pnpm_uri_auth_wins_over_npm_uri_auth() {
+    let entries = npm_config_env_entries_from(&[
+        (
+            "npm_config_//registry.example.com/:_authToken".to_string(),
+            "npm-token".to_string(),
+        ),
+        (
+            "pnpm_config_//registry.example.com/:_authToken".to_string(),
+            "pnpm-token".to_string(),
+        ),
+    ]);
+    let mut config = NpmConfig::default();
+    config.apply(entries);
+    assert_eq!(
+        config.auth_token_for("https://registry.example.com/"),
+        Some("pnpm-token")
+    );
+}
+
+#[test]
+fn translate_npm_config_env_ignores_uri_token_helper() {
+    assert_eq!(
+        translate_npm_config_env(
+            "pnpm_config_//registry.example.com/:tokenHelper",
+            "/tmp/helper"
+        ),
+        None
+    );
+}
+
+#[test]
 fn load_with_env_npm_config_registry_overrides_project_file() {
     // Integration-ish: `load_with_env` stitches file config and
     // env together. Project `.npmrc` sets one registry URL; the

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -616,7 +616,9 @@ docs = """
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
 `.npmrc` via `aube_registry::config::NpmConfig` (see
 `crates/aube-registry/src/config.rs`). Bearer tokens and basic auth per
-registry are also parsed from `.npmrc`.
+registry are parsed from `.npmrc` and URL-scoped `npm_config_//...` /
+`pnpm_config_//...` environment variables. `tokenHelper` is only accepted
+from trusted user-level config, not from URL-scoped environment variables.
 """
 sources.cli = []
 sources.env = []
@@ -624,6 +626,7 @@ sources.npmrc = ["registry", "@scope:registry", "//host/:_authToken", "//host/:_
 examples = [
   "registry=https://registry.npmmirror.com/",
   "@mycorp:registry=https://npm.mycorp.internal/",
+  "pnpm_config_//registry.example.com/:_authToken=$NPM_TOKEN aube install",
 ]
 npmShared = true
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -680,12 +680,15 @@ Registry URLs, including scoped registry overrides.
 Maps `default` and `@scope` keys to registry URLs. aube reads these from
 `.npmrc` via `aube_registry::config::NpmConfig` (see
 `crates/aube-registry/src/config.rs`). Bearer tokens and basic auth per
-registry are also parsed from `.npmrc`.
+registry are parsed from `.npmrc` and URL-scoped `npm_config_//...` /
+`pnpm_config_//...` environment variables. `tokenHelper` is only accepted
+from trusted user-level config, not from URL-scoped environment variables.
 
 Examples:
 
 - `registry=https://registry.npmmirror.com/`
 - `@mycorp:registry=https://npm.mycorp.internal/`
+- `pnpm_config_//registry.example.com/:_authToken=$NPM_TOKEN aube install`
 
 ## Dependency Hoisting
 


### PR DESCRIPTION
## Summary
- support `pnpm_config_//...` URL-scoped registry auth env vars in addition to `npm_config_//...`
- make `pnpm_config_` win for duplicate URL-scoped auth keys
- ignore URL-scoped env `tokenHelper` and skip non-UTF-8 env entries while loading registry config

## Tests
- `cargo test -p aube-registry config::tests::`
- `cargo fmt --check`
- `git diff --check`

Generated by Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes registry authentication precedence and env parsing on the install/fetch path; mistaken precedence could pick the wrong token, but scope is limited to env-sourced auth mapping.
> 
> **Overview**
> **Registry auth from environment variables** now recognizes pnpm-style URL-scoped vars (`pnpm_config_//host/:_authToken`, case-insensitive prefix) alongside existing `npm_config_//...` forms. When both set auth for the same registry URI, **pnpm-prefixed entries win** over npm-prefixed ones. Empty env values are skipped, and only recognized auth suffixes (`_authToken`, `_auth`, `username`, `_password`) are accepted for `//...` keys—**URL-scoped `tokenHelper` is ignored** so env cannot trigger token helpers.
> 
> **`NpmConfig::load`** collects environment variables via `vars_os()` and **drops non-UTF-8** names/values instead of failing or passing invalid data through.
> 
> Docs for **registries** note `.npmrc` plus URL-scoped env auth and the `tokenHelper` restriction, with an example using `pnpm_config_//registry.example.com/:_authToken`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09aa343f79052631f54652bef432fc8af7d7ca99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-UTF-8 environment variables during registry config loading.
  * Tightened validation of URL-scoped auth entries so only recognized auth-key suffixes are processed.
  * Deterministic precedence when multiple URL-scoped auth env vars exist.

* **New Features**
  * Support for pnpm-prefixed environment variables for registry auth with defined precedence vs npm-prefixed entries.

* **Tests**
  * Added unit tests covering pnpm per-URI auth handling and precedence.

* **Documentation**
  * Clarified registries docs on how auth is sourced and restrictions for URL-scoped env vars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->