### PR TITLE
fix(install): align network concurrency default

### DIFF
--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1565,11 +1565,11 @@ examples = []
 [networkConcurrency]
 description = "Maximum concurrent HTTP(S) requests."
 type = "int"
-default = "auto (workers x3 clamped to 16-64)"
+default = "auto (workers x3 clamped to 64-96)"
 docs = """
 Caps the tokio semaphores that gate concurrent tarball downloads
 inside `crates/aube/src/commands/install.rs`. When unset, aube
-matches pnpm's dynamic default: worker count x3, clamped to 16-64.
+matches pnpm's dynamic default: worker count x3, clamped to 64-96.
 Set this value explicitly to override the automatic scaling. The
 resolver's packument fetcher still uses its own internal cap for now;
 plumbing that cap through is tracked as a follow-up.

--- a/crates/aube/src/commands/install/args.rs
+++ b/crates/aube/src/commands/install/args.rs
@@ -69,7 +69,7 @@ pub struct InstallArgs {
     ///
     /// Overrides `network-concurrency` from `.npmrc` /
     /// `aube-workspace.yaml` when set. Falls back to an auto-scaled
-    /// default of worker count x3, clamped to 16-64.
+    /// default of worker count x3, clamped to 64-96.
     #[arg(long, value_name = "N")]
     pub network_concurrency: Option<u64>,
     /// Skip optionalDependencies; don't install optional native modules

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -280,12 +280,7 @@ fn default_network_concurrency() -> usize {
 }
 
 fn network_concurrency_for_workers(workers: usize) -> usize {
-    // 128 ceiling chosen empirically. The npm registry advertises
-    // ~100 concurrent HTTP/2 streams per connection; with prior
-    // knowledge of h2 multiplexing a single TCP connection absorbs
-    // most of this and we never spawn 128 sockets. The old 64 cap
-    // queued the second wave on cold installs >500 packages.
-    workers.saturating_mul(3).clamp(16, 128)
+    workers.saturating_mul(3).clamp(64, 96)
 }
 
 /// Resolve `verifyStoreIntegrity` from cli / env / `.npmrc` /
@@ -1001,11 +996,11 @@ mod network_concurrency_tests {
 
     #[test]
     fn dynamic_default_matches_pnpm_worker_clamp() {
-        assert_eq!(network_concurrency_for_workers(1), 16);
-        assert_eq!(network_concurrency_for_workers(8), 24);
+        assert_eq!(network_concurrency_for_workers(1), 64);
+        assert_eq!(network_concurrency_for_workers(8), 64);
         assert_eq!(network_concurrency_for_workers(24), 72);
-        assert_eq!(network_concurrency_for_workers(64), 128);
-        assert_eq!(network_concurrency_for_workers(usize::MAX), 128);
+        assert_eq!(network_concurrency_for_workers(64), 96);
+        assert_eq!(network_concurrency_for_workers(usize::MAX), 96);
     }
 }
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4960,7 +4960,7 @@
             "name": "network-concurrency",
             "usage": "--network-concurrency <N>",
             "help": "Cap concurrent tarball downloads",
-            "help_long": "Cap concurrent tarball downloads.\n\nOverrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to an auto-scaled default of worker count x3, clamped to 16-64.",
+            "help_long": "Cap concurrent tarball downloads.\n\nOverrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to an auto-scaled default of worker count x3, clamped to 64-96.",
             "help_first_line": "Cap concurrent tarball downloads",
             "short": [],
             "long": [

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -69,7 +69,7 @@ Combines every `aube-lock.<branch>.yaml` file in the project into `aube-lock.yam
 
 Cap concurrent tarball downloads.
 
-Overrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to an auto-scaled default of worker count x3, clamped to 16-64.
+Overrides `network-concurrency` from `.npmrc` / `aube-workspace.yaml` when set. Falls back to an auto-scaled default of worker count x3, clamped to 64-96.
 
 ### `--no-optional`
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1596,7 +1596,7 @@ regardless of which strategy produced it.
 Maximum concurrent HTTP(S) requests.
 
 - Type: `int`
-- Default: `auto (workers x3 clamped to 16-64)`
+- Default: `auto (workers x3 clamped to 64-96)`
 - CLI flags: `network-concurrency`
 - Environment: `npm_config_network_concurrency`, `NPM_CONFIG_NETWORK_CONCURRENCY`, `AUBE_NETWORK_CONCURRENCY`
 - .npmrc keys: `network-concurrency`, `networkConcurrency`
@@ -1604,7 +1604,7 @@ Maximum concurrent HTTP(S) requests.
 
 Caps the tokio semaphores that gate concurrent tarball downloads
 inside `crates/aube/src/commands/install.rs`. When unset, aube
-matches pnpm's dynamic default: worker count x3, clamped to 16-64.
+matches pnpm's dynamic default: worker count x3, clamped to 64-96.
 Set this value explicitly to override the automatic scaling. The
 resolver's packument fetcher still uses its own internal cap for now;
 plumbing that cap through is tracked as a follow-up.
@@ -2947,4 +2947,3 @@ Examples:
 
 - `AUBE_NO_AUTO_INSTALL=1 aube run dev`
 - `echo 'aubeNoAutoInstall=true' >> .npmrc`
-


### PR DESCRIPTION
## Summary
- align the default network concurrency formula with pnpm 11.6.0
- raise the floor to 64 and cap at 96 while preserving `network-concurrency` overrides
- update the clamp regression test

## Tests
- `cargo test -p aube commands::install::settings::network_concurrency_tests::dynamic_default_matches_pnpm_worker_clamp`
- `cargo fmt --check`
- `git diff --check`

Generated by Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default install download parallelism for all users who do not set `network-concurrency`, which can affect registry load and cold-install performance on both low- and high-core hosts.
> 
> **Overview**
> Aligns aube’s **auto `networkConcurrency`** with pnpm 11.6.0: when `network-concurrency` is unset, the default is still `workers × 3`, but the clamp is now **64–96** instead of **16–128** (and the old floor of 16 is gone). That raises concurrency on small machines and caps it lower on very large ones; explicit CLI, env, `.npmrc`, and workspace overrides are unchanged.
> 
> `network_concurrency_for_workers` and its unit test were updated accordingly. User-facing copy for `networkConcurrency` was synced in `settings.toml`, install CLI help, generated CLI JSON, and install/settings docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b97e21311b642cd2537f8327a9a303248f25d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automatic network concurrency scaling: computed default now clamps worker-based values to 64–96 (was 16–64), improving runtime concurrency behavior.

* **Documentation**
  * CLI and settings docs updated to reflect the new 64–96 clamp for the auto-derived network concurrency default.

* **Tests**
  * Unit tests adjusted to match the revised concurrency clamp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->