### PR TITLE
chore(ci): bump pr-closer action

### DIFF
--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -18,4 +18,4 @@ jobs:
       checks: read
       statuses: read
     steps:
-      - uses: jdx/pr-closer@44b9e7859d29e01b4b38e50e2ad6b5c5d00a6973 # v1.0.1
+      - uses: jdx/pr-closer@ddc40dfad5567fc7296a2463880c618344d26055 # v1.1.0


### PR DESCRIPTION
## Summary
- Bump `jdx/pr-closer` from `v1.0.1` to `v1.1.0`.
- Keep the action pinned by full commit SHA.

## Verification
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI action version bump with SHA pinning; no application or auth logic changes.
> 
> **Overview**
> Updates the scheduled **pr-closer** workflow to use **`jdx/pr-closer` v1.1.0** (commit `ddc40df…`) instead of **v1.0.1**, still pinned by full SHA for supply-chain safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ee0a7c93da5e47c2fe0ca5dec1085596528634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request management automation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->