### PR TITLE
fix(ci): create bats multicall shims atomically

### DIFF
--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -11,14 +11,23 @@ _common_setup() {
 	# Ensure the multicall shims (`aubr`, `aubx`) exist alongside `aube`.
 	# Local `cargo build` produces all three as real binaries, but CI only
 	# uploads `target/debug/aube` as an artifact; the bats shards then
-	# download just that one file. Materialize the shims as hardlinks to
-	# the shared `aube` inode so the argv[0] dispatch in `main.rs` resolves
-	# correctly. `ln -f` is idempotent — it refreshes if `aube` was rebuilt
-	# and is a no-op if the hardlinks already point at the same inode.
+	# download just that one file. Materialize the shims via temp files and
+	# atomic renames so parallel BATS workers never observe a missing shim.
 	local _aube_bin="$PROJECT_ROOT/target/debug/aube"
 	if [ -x "$_aube_bin" ]; then
-		ln -f "$_aube_bin" "$PROJECT_ROOT/target/debug/aubr" 2>/dev/null || true
-		ln -f "$_aube_bin" "$PROJECT_ROOT/target/debug/aubx" 2>/dev/null || true
+		for _shim in aubr aubx; do
+			local _shim_bin="$PROJECT_ROOT/target/debug/$_shim"
+			local _shim_tmp="$PROJECT_ROOT/target/debug/.$_shim.$$.$RANDOM"
+			if ! ln "$_aube_bin" "$_shim_tmp" 2>/dev/null; then
+				cp "$_aube_bin" "$_shim_tmp"
+			fi
+			chmod +x "$_shim_tmp"
+			if [ "$_shim_tmp" -ef "$_shim_bin" ]; then
+				rm -f "$_shim_tmp"
+			else
+				mv -f "$_shim_tmp" "$_shim_bin"
+			fi
+		done
 	fi
 
 	TEST_TEMP_DIR="$(temp_make)"


### PR DESCRIPTION
## Summary
- create `aubr`/`aubx` BATS shims through temp files and atomic renames
- keep repeated setup calls idempotent when the shim already hardlinks to `aube`
- fall back to copying if hardlink creation is unavailable

## Verification
- `bash -n test/test_helper/common_setup.bash`
- `git diff --check`
- `cargo build`
- `rm -f target/debug/aubr target/debug/aubx && ./test/bats/bin/bats test/runtime.bats`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness-only change with no production code paths; risk is limited to BATS/CI shim creation behavior.
> 
> **Overview**
> **BATS setup** now builds `aubr` and `aubx` from the CI-only `aube` artifact using per-shim temp paths and an atomic `mv`, so parallel workers don’t briefly see a missing or half-updated shim.
> 
> Each shim tries a hardlink to `aube`, falls back to `cp` if linking fails, ensures execute bits, then either drops the temp file when it’s already the same inode as the target or renames it into place. Comments were updated to describe the race fix instead of idempotent `ln -f`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1730b10707a2f3c5c5340856c1ca2517724f856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup reliability by updating the initialization process to use atomic file operations for creating internal test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->