### PR TITLE
docs: link to all sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://37signals.com">37signals</a>.
+  Sponsored by <a href="https://37signals.com">37signals</a>.<br>
+  <a href="https://en.dev/sponsors.html">View all sponsors</a>.
 </p>
 
 ## Why Try It


### PR DESCRIPTION
## Summary
- add a README link to the full en.dev sponsors page

## Tests
- not run (README-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation change with no runtime or security impact.
> 
> **Overview**
> Updates the README sponsor blurb so readers can see everyone who backs the project, not only the headline sponsor.
> 
> After the existing **37signals** line, it adds a line break and a **View all sponsors** link to `https://en.dev/sponsors.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8282a2a55362cc920a6cebd8f1f24247b8d927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README sponsor section with a refreshed layout for better presentation and added a "View all sponsors" link. This makes it more convenient for users to access and explore the complete list of project sponsors while maintaining clear attribution to primary sponsors. The changes improve both visibility and ease of sponsor information discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->