### PR TITLE
docs: clarify contribution fit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,46 @@
-# Contributing to aube
+# Contributing
+
+## Contribution Expectations
+
+Before opening a PR, unless it is something obvious, consider creating a
+discussion or mentioning what you plan to do in
+[Discord](https://discord.gg/UBa7pJUN7Z). The important part is to settle the
+direction before much review happens. aube has a specific scope and design
+taste. I am comfortable saying no to changes that do not clearly fit.
+
+Before I review a PR, CI must be passing and all automated AI review comments
+must be addressed. If those are still open, assume I will wait to look at the
+PR.
+
+If I am on the fence about a contribution, I will probably reject it for that
+reason alone. If I did not do this, aube would suffer from feature bloat. I
+may also reject a PR if the quality is poor enough that I do not have confidence
+the contributor can get it across the finish line. I do not have time to coach
+contributors.
+
+I get hundreds of PRs per week across my projects, so I do not have time to
+respond to every PR with detailed context. A rejection may be brief.
+
+## Code Style
+
+All of these repos use [hk](https://hk.jdx.dev) for linting and formatting.
+Run the checks before opening a PR:
+
+```sh
+hk check --all
+hk fix --all
+```
+
+Some repos also expose wrapper tasks such as `mise run lint` and
+`mise run lint-fix`; prefer those when they exist.
+
+## Commit and PR Titles
+
+Use Conventional Commits for commit messages and PR titles. Examples:
+
+- `fix: handle missing config file`
+- `docs: clarify installation steps`
+- `feat: add quiet output mode`
 
 ## Building and running tests
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -91,6 +91,7 @@ export default defineConfig({
           { text: "Overview", link: "/guide" },
           { text: "Getting Started", link: "/getting-started" },
           { text: "Installation", link: "/installation" },
+          { text: "Contributing", link: "/contributing" },
           { text: "For pnpm users", link: "/pnpm-users" },
           { text: "For npm users", link: "/npm-users" },
           { text: "For yarn users", link: "/yarn-users" },

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md


### PR DESCRIPTION
## Summary
- make repository-root CONTRIBUTING.md the canonical full guide for GitHub contribution surfaces
- symlink docs/contributing.md back to the root guide for VitePress
- keep project-specific feature-bloat wording

## Tests
- not run (documentation-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or build logic changes beyond VitePress nav.
> 
> **Overview**
> **Expands the root `CONTRIBUTING.md`** into the canonical contributor guide: scope/fit expectations (Discord first, CI and AI review gates, brief rejections), **hk**-based lint/format workflow, and **Conventional Commits** for titles—while keeping the existing Cargo/BATS/Verdaccio sections.
> 
> **Wires the docs site to the same source** by adding `docs/contributing.md` that points at the root file and a **Contributing** entry in the VitePress Guide sidebar so GitHub and the site stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dccd647225caee7786f2379ce667e4c52bed004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->