### PR TITLE
feat(scripts): match pnpm's full npm_* env for lifecycle & run scripts

### DIFF
--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -488,6 +488,51 @@ impl PackageJson {
         out
     }
 
+    /// pnpm-compatible `npm_package_*` environment pairs for lifecycle
+    /// scripts. Mirrors what pnpm exports from a manifest: `name`,
+    /// `version`, plus the deep-flattened `engines`, `config`, and
+    /// `bin` fields (string `bin` → unsuffixed `npm_package_bin`).
+    /// Other fields (`description`, `main`, `license`, `author`, …)
+    /// are intentionally **not** exported — pnpm dropped whole-manifest
+    /// flattening, and matching its exact allowlist keeps scripts that
+    /// sniff these vars (`husky`, `node-pre-gyp`, …) behaving
+    /// identically under aube.
+    ///
+    /// The `npm_package_json` path is set by the caller, which knows
+    /// where the manifest lives on disk.
+    ///
+    /// Keys are "envified" the npm way: every character outside
+    /// `[A-Za-z0-9_]` becomes `_`, so `config.my-key` →
+    /// `npm_package_config_my_key`. Returned in a stable order
+    /// (name, version, then engines/config/bin in key order) so the
+    /// emitted environment is deterministic.
+    pub fn npm_package_env(&self) -> Vec<(String, String)> {
+        let mut out = Vec::new();
+        if let Some(name) = &self.name {
+            out.push(("npm_package_name".to_string(), name.clone()));
+        }
+        if let Some(version) = &self.version {
+            out.push(("npm_package_version".to_string(), version.clone()));
+        }
+        for (key, value) in &self.engines {
+            out.push((
+                format!("npm_package_engines_{}", envify_env_key(key)),
+                value.clone(),
+            ));
+        }
+        if let Some(config) = self.extra.get("config") {
+            flatten_json_env("npm_package_config", config, &mut out);
+        }
+        if let Some(bin) = self.extra.get("bin") {
+            // Generic flatten, same as `config`: a string `bin` →
+            // unsuffixed `npm_package_bin`, an object → `npm_package_bin_<key>`.
+            // This mirrors pnpm exactly (verified against 11.5); npm instead
+            // normalizes a string `bin` to the package's unscoped name first.
+            flatten_json_env("npm_package_bin", bin, &mut out);
+        }
+        out
+    }
+
     /// Extract `pnpm.catalog` / `aube.catalog` — a default catalog
     /// defined inline in package.json under the `pnpm`/`aube` object.
     /// pnpm itself reads catalogs only from `pnpm-workspace.yaml`, but
@@ -936,6 +981,43 @@ fn push_unique_strs(dst: &mut Vec<String>, arr: &[serde_json::Value]) {
     }
 }
 
+/// npm/pnpm "envify": replace every character that is not
+/// `[A-Za-z0-9_]` with `_`, leaving case untouched. Used to build the
+/// `npm_package_*` env-var keys from manifest field names.
+fn envify_env_key(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Deep-flatten a JSON value into `prefix`-rooted `npm_package_*`
+/// pairs, npm-style: objects recurse with `_`-joined keys, arrays
+/// index with `_<i>`, scalars stringify, `null` is skipped.
+fn flatten_json_env(prefix: &str, value: &serde_json::Value, out: &mut Vec<(String, String)>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (k, v) in map {
+                flatten_json_env(&format!("{prefix}_{}", envify_env_key(k)), v, out);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for (i, v) in arr.iter().enumerate() {
+                flatten_json_env(&format!("{prefix}_{i}"), v, out);
+            }
+        }
+        serde_json::Value::String(s) => out.push((prefix.to_string(), s.clone())),
+        serde_json::Value::Number(n) => out.push((prefix.to_string(), n.to_string())),
+        serde_json::Value::Bool(b) => out.push((prefix.to_string(), b.to_string())),
+        serde_json::Value::Null => {}
+    }
+}
+
 /// Union of `package.json`'s `{pnpm,aube}.supportedArchitectures.*` and
 /// `pnpm-workspace.yaml`'s `supportedArchitectures.*`. pnpm v10 treats
 /// the workspace yaml as the canonical home for shared platform
@@ -1180,6 +1262,87 @@ mod tests {
 
     fn parse(json: &str) -> PackageJson {
         serde_json::from_str(json).unwrap()
+    }
+
+    /// `npm_package_env` mirrors pnpm's exact flattening: name, version,
+    /// and deep `engines`/`config`/`bin` — and nothing else.
+    #[test]
+    fn npm_package_env_matches_pnpm_allowlist() {
+        let pkg = parse(
+            r#"{
+                "name": "@scope/envprobe",
+                "version": "4.5.6",
+                "description": "ignored",
+                "main": "index.js",
+                "type": "module",
+                "private": true,
+                "os": ["darwin"],
+                "engines": { "node": ">=18", "npm": ">=9" },
+                "config": { "port": "8080", "nested": { "deep-key": "x" } },
+                "bin": { "probe": "./cli.js" }
+            }"#,
+        );
+        let env: std::collections::BTreeMap<String, String> =
+            pkg.npm_package_env().into_iter().collect();
+
+        assert_eq!(
+            env.get("npm_package_name").map(String::as_str),
+            Some("@scope/envprobe")
+        );
+        assert_eq!(
+            env.get("npm_package_version").map(String::as_str),
+            Some("4.5.6")
+        );
+        assert_eq!(
+            env.get("npm_package_engines_node").map(String::as_str),
+            Some(">=18")
+        );
+        assert_eq!(
+            env.get("npm_package_engines_npm").map(String::as_str),
+            Some(">=9")
+        );
+        assert_eq!(
+            env.get("npm_package_config_port").map(String::as_str),
+            Some("8080")
+        );
+        // Nested objects flatten with `_`-joined, envified keys.
+        assert_eq!(
+            env.get("npm_package_config_nested_deep_key")
+                .map(String::as_str),
+            Some("x")
+        );
+        assert_eq!(
+            env.get("npm_package_bin_probe").map(String::as_str),
+            Some("./cli.js")
+        );
+        // Fields pnpm does not export must be absent.
+        for absent in [
+            "npm_package_description",
+            "npm_package_main",
+            "npm_package_type",
+            "npm_package_private",
+            "npm_package_os_0",
+        ] {
+            assert!(!env.contains_key(absent), "{absent} should not be exported");
+        }
+    }
+
+    /// A bare-string `bin` flattens to the unsuffixed `npm_package_bin`
+    /// (pnpm verified against 11.5) — the same generic flattening as
+    /// `config`, not npm's normalize-to-unscoped-name behavior.
+    #[test]
+    fn npm_package_env_string_bin_is_unsuffixed() {
+        let pkg = parse(r#"{ "name": "@scope/tool", "version": "1.0.0", "bin": "./cli.js" }"#);
+        let env: std::collections::BTreeMap<String, String> =
+            pkg.npm_package_env().into_iter().collect();
+        assert_eq!(
+            env.get("npm_package_bin").map(String::as_str),
+            Some("./cli.js")
+        );
+        assert!(
+            !env.keys().any(|k| k.starts_with("npm_package_bin_")),
+            "string bin must stay unsuffixed: {env:?}"
+        );
     }
 
     /// Pre-npm-2.x publishes (e.g. `extsprintf@1.4.1`, `coffee-script@1.3.3`)

--- a/crates/aube-runtime/src/discover.rs
+++ b/crates/aube-runtime/src/discover.rs
@@ -150,22 +150,30 @@ pub(crate) fn is_executable_file(path: &Path) -> bool {
     true
 }
 
+/// The platform's `node` executable file name: `node.exe` on Windows,
+/// `node` everywhere else. Single source of truth for the spots that
+/// build or look up the node binary by name.
+pub(crate) const fn node_exe_name() -> &'static str {
+    if cfg!(windows) { "node.exe" } else { "node" }
+}
+
 /// Per-OS layout of a native Node install: unix puts `node` under
 /// `bin/`, Windows puts `node.exe` at the root (mise mirrors both).
 pub(crate) fn node_paths_in(dir: &Path) -> (PathBuf, PathBuf) {
+    let exe_name = node_exe_name();
     if cfg!(windows) {
         // Windows zips have node.exe at the archive root, but mise
         // (and some mirrors' layouts) use bin\node.exe — accept both.
-        let root_exe = dir.join("node.exe");
+        let root_exe = dir.join(exe_name);
         if root_exe.is_file() {
             return (dir.to_path_buf(), root_exe);
         }
         let bin = dir.join("bin");
-        let exe = bin.join("node.exe");
+        let exe = bin.join(exe_name);
         (bin, exe)
     } else {
         let bin = dir.join("bin");
-        let exe = bin.join("node");
+        let exe = bin.join(exe_name);
         (bin, exe)
     }
 }
@@ -180,7 +188,7 @@ pub fn probe_path_node() -> Option<(node_semver::Version, PathBuf)> {
 }
 
 fn probe_path_node_uncached() -> Option<(node_semver::Version, PathBuf)> {
-    let exe = find_on_path(if cfg!(windows) { "node.exe" } else { "node" })?;
+    let exe = find_on_path(node_exe_name())?;
     let output = std::process::Command::new(&exe)
         .arg("--version")
         .output()
@@ -191,6 +199,16 @@ fn probe_path_node_uncached() -> Option<(node_semver::Version, PathBuf)> {
     let raw = String::from_utf8(output.stdout).ok()?;
     let version = node_semver::Version::parse(raw.trim().trim_start_matches('v')).ok()?;
     Some((version, exe))
+}
+
+/// Locate a `node` executable on `PATH` without spawning it (unlike
+/// [`probe_path_node`], which runs `node --version`). Cheap enough to
+/// call on the hot install/run path to populate `npm_node_execpath` /
+/// `NODE` for lifecycle scripts when no runtime switch is active.
+/// Returns the absolute path of the first `node` (`node.exe` on
+/// Windows) found in `PATH`.
+pub fn node_on_path() -> Option<PathBuf> {
+    find_on_path(node_exe_name())
 }
 
 /// Minimal PATH walk (std-only). Returns the first existing,
@@ -231,7 +249,7 @@ mod tests {
             dir.join("bin")
         };
         std::fs::create_dir_all(&bin).unwrap();
-        let exe = bin.join(if cfg!(windows) { "node.exe" } else { "node" });
+        let exe = bin.join(node_exe_name());
         std::fs::write(&exe, "#!/bin/sh\necho v0.0.0\n").unwrap();
         #[cfg(unix)]
         {

--- a/crates/aube-runtime/src/discover.rs
+++ b/crates/aube-runtime/src/discover.rs
@@ -161,21 +161,19 @@ pub(crate) const fn node_exe_name() -> &'static str {
 /// `bin/`, Windows puts `node.exe` at the root (mise mirrors both).
 pub(crate) fn node_paths_in(dir: &Path) -> (PathBuf, PathBuf) {
     let exe_name = node_exe_name();
+    // Windows zips put node.exe at the archive root; mise (and some
+    // mirror layouts) use bin\node.exe instead. Prefer the root copy
+    // when it exists, otherwise fall through to the shared bin/ layout
+    // used on every OS.
     if cfg!(windows) {
-        // Windows zips have node.exe at the archive root, but mise
-        // (and some mirrors' layouts) use bin\node.exe — accept both.
         let root_exe = dir.join(exe_name);
         if root_exe.is_file() {
             return (dir.to_path_buf(), root_exe);
         }
-        let bin = dir.join("bin");
-        let exe = bin.join(exe_name);
-        (bin, exe)
-    } else {
-        let bin = dir.join("bin");
-        let exe = bin.join(exe_name);
-        (bin, exe)
     }
+    let bin = dir.join("bin");
+    let exe = bin.join(exe_name);
+    (bin, exe)
 }
 
 /// Find `node` on PATH and probe its version (`node --version`).

--- a/crates/aube-runtime/src/discover.rs
+++ b/crates/aube-runtime/src/discover.rs
@@ -203,10 +203,21 @@ fn probe_path_node_uncached() -> Option<(node_semver::Version, PathBuf)> {
 /// [`probe_path_node`], which runs `node --version`). Cheap enough to
 /// call on the hot install/run path to populate `npm_node_execpath` /
 /// `NODE` for lifecycle scripts when no runtime switch is active.
-/// Returns the absolute path of the first `node` (`node.exe` on
-/// Windows) found in `PATH`.
+/// Returns the first `node` (`node.exe` on Windows) on `PATH` as an
+/// absolute, executable path, or `None` if none qualifies.
 pub fn node_on_path() -> Option<PathBuf> {
-    find_on_path(node_exe_name())
+    let node = find_on_path(node_exe_name())?;
+    // `npm_node_execpath` / `NODE` are contracted to be an absolute,
+    // runnable node. `find_on_path` only guarantees an existing file,
+    // and a relative `PATH` segment yields a relative match, so make
+    // the path absolute and require the exec bit — better to leave the
+    // vars unset than hand tools a path they can't run.
+    let node = if node.is_absolute() {
+        node
+    } else {
+        std::env::current_dir().ok()?.join(node)
+    };
+    is_executable_file(&node).then_some(node)
 }
 
 /// Minimal PATH walk (std-only). Returns the first existing,

--- a/crates/aube-runtime/src/lib.rs
+++ b/crates/aube-runtime/src/lib.rs
@@ -26,7 +26,8 @@ mod sources;
 mod spec;
 
 pub use discover::{
-    InstallOrigin, InstalledNode, list_installed, mise_node_installs_dir, probe_path_node,
+    InstallOrigin, InstalledNode, list_installed, mise_node_installs_dir, node_on_path,
+    probe_path_node,
 };
 pub use error::Error;
 pub use mise::mise_on_path;

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -44,6 +44,18 @@ pub struct ScriptSettings {
     /// The resolved node executable, exported as `npm_node_execpath` /
     /// `NODE` (npm parity) for every script.
     pub node_exe: Option<PathBuf>,
+    /// The top-level package-manager command, exported as `npm_command`
+    /// (npm/pnpm parity): `"run-script"` for `aube run`, `"install"`
+    /// for install lifecycle hooks, `"rebuild"`, `"pack"`, etc. `None`
+    /// leaves `npm_command` unset.
+    pub command: Option<String>,
+    /// Path to a runnable `node-gyp` stand-in, exported as
+    /// `npm_config_node_gyp` (npm/pnpm parity). npm/pnpm point this at
+    /// their bundled `node-gyp/bin/node-gyp.js`; aube bootstraps node-gyp
+    /// lazily, so this is a tiny shim that resolves (and bootstraps on
+    /// first use) the real node-gyp and forwards argv. `None` leaves
+    /// `npm_config_node_gyp` unset.
+    pub node_gyp_js: Option<PathBuf>,
 }
 
 /// Native build jail applied to dependency lifecycle scripts.
@@ -495,6 +507,38 @@ fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &Scrip
     // spawn time) so it flows through both the jailed and the
     // non-jailed paths.
     cmd.env("npm_config_user_agent", aube_user_agent());
+    // `npm_execpath`: the package-manager binary that drove the script.
+    // Tools (and pnpm's own `$npm_execpath run …` postinstalls) read it
+    // to re-invoke the *same* PM. `current_exe()` is the aube binary;
+    // ignore the rare resolution failure rather than abort the script.
+    if let Ok(exe) = std::env::current_exe() {
+        cmd.env("npm_execpath", exe);
+    }
+    // `npm_node_execpath` / `NODE`: the node binary scripts should use
+    // — the switched runtime's node, or the ambient `node` on PATH.
+    // Set here (not at spawn) so it survives the jail's `env_clear`.
+    if let Some(node_exe) = settings.node_exe.as_deref() {
+        cmd.env("npm_node_execpath", node_exe).env("NODE", node_exe);
+    }
+    // `npm_command`: the top-level PM command (run-script / install / …).
+    if let Some(command) = settings.command.as_deref() {
+        cmd.env("npm_command", command);
+    }
+    // `npm_config_node_gyp`: path to a runnable node-gyp. npm/pnpm bundle
+    // node-gyp and point this at its `bin/node-gyp.js`; aube hands out a
+    // lazy shim that resolves the bootstrapped node-gyp on first use.
+    // The shim self-resolves via `AUBE_NODE_GYP_EXE` (the aube binary),
+    // so stamp that too unless a caller (e.g. `aube run`) already set a
+    // more specific value. `AUBE_NODE_GYP_PROJECT_DIR` is optional — the
+    // shim falls back to the script's cwd.
+    if let Some(node_gyp_js) = settings.node_gyp_js.as_deref() {
+        cmd.env("npm_config_node_gyp", node_gyp_js);
+        if std::env::var_os("AUBE_NODE_GYP_EXE").is_none()
+            && let Ok(exe) = std::env::current_exe()
+        {
+            cmd.env("AUBE_NODE_GYP_EXE", exe);
+        }
+    }
     if let Some(node_options) = settings.node_options.as_deref() {
         cmd.env("NODE_OPTIONS", node_options);
     }
@@ -506,6 +550,27 @@ fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &Scrip
     }
     if settings.shell_emulator {
         cmd.env("npm_config_shell_emulator", "true");
+    }
+}
+
+/// Apply the manifest-derived `npm_package_*` env (name, version,
+/// absolute `npm_package_json` path, and the deep-flattened
+/// `engines`/`config`/`bin`) plus `npm_lifecycle_script` (the raw
+/// script body) to a lifecycle command. Called last in `run_script`
+/// so the values land *after* any jail `env_clear` and override a
+/// parent aube invocation's leaked `npm_package_*` on the unjailed
+/// path. `script_dir` is the directory the script runs in, whose
+/// `package.json` is the manifest being executed.
+fn apply_npm_manifest_env(
+    cmd: &mut tokio::process::Command,
+    manifest: &PackageJson,
+    script_dir: &Path,
+    script_cmd: &str,
+) {
+    cmd.env("npm_lifecycle_script", script_cmd);
+    cmd.env("npm_package_json", script_dir.join("package.json"));
+    for (key, value) in manifest.npm_package_env() {
+        cmd.env(key, value);
     }
 }
 
@@ -884,11 +949,6 @@ pub async fn run_script(
         .stderr(child_stderr())
         .env("PATH", &new_path)
         .env("npm_lifecycle_event", script_name);
-    // Set after the jail's env_clear (builder env calls compose in
-    // order), so jailed builds see the pinned node too.
-    if let Some(node_exe) = &settings.node_exe {
-        cmd.env("npm_node_execpath", node_exe).env("NODE", node_exe);
-    }
 
     // Pass INIT_CWD the way npm/pnpm do — the directory the user
     // invoked the package manager from, *not* the script's own cwd.
@@ -900,12 +960,6 @@ pub async fn run_script(
         cmd.env("INIT_CWD", project_root);
     }
 
-    if let Some(ref name) = manifest.name {
-        cmd.env("npm_package_name", name);
-    }
-    if let Some(ref version) = manifest.version {
-        cmd.env("npm_package_version", version);
-    }
     if let (Some(jail), Some(home)) = (jail, jail_home.as_deref()) {
         apply_jail_env(
             &mut cmd,
@@ -918,6 +972,11 @@ pub async fn run_script(
         );
         apply_script_settings_env(&mut cmd, &settings);
     }
+
+    // npm-compat manifest env, applied last so it survives the jail's
+    // `env_clear`: name/version/json plus the deep-flattened
+    // engines/config/bin, and the raw script body (`npm_lifecycle_script`).
+    apply_npm_manifest_env(&mut cmd, manifest, script_dir, script_cmd);
 
     tracing::debug!("lifecycle: {script_name} → {script_cmd}");
     let status = run_command_killing_descendants(cmd, script_name).await?;

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -511,7 +511,9 @@ fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &Scrip
     // Tools (and pnpm's own `$npm_execpath run …` postinstalls) read it
     // to re-invoke the *same* PM. `current_exe()` is the aube binary;
     // ignore the rare resolution failure rather than abort the script.
-    if let Ok(exe) = std::env::current_exe() {
+    // Reused below for `AUBE_NODE_GYP_EXE` (same binary), so resolve once.
+    let aube_exe = std::env::current_exe().ok();
+    if let Some(exe) = aube_exe.as_deref() {
         cmd.env("npm_execpath", exe);
     }
     // `npm_node_execpath` / `NODE`: the node binary scripts should use
@@ -526,16 +528,17 @@ fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &Scrip
     }
     // `npm_config_node_gyp`: path to a runnable node-gyp. npm/pnpm bundle
     // node-gyp and point this at its `bin/node-gyp.js`; aube hands out a
-    // lazy shim that resolves the bootstrapped node-gyp on first use.
-    // The shim self-resolves via `AUBE_NODE_GYP_EXE` (the aube binary),
-    // so stamp that too unless a caller (e.g. `aube run`) already set a
-    // more specific value. `AUBE_NODE_GYP_PROJECT_DIR` is optional — the
-    // shim falls back to the script's cwd.
+    // lazy shim that resolves the bootstrapped node-gyp on first use. The
+    // shim trampolines back into aube via `AUBE_NODE_GYP_EXE`, so always
+    // stamp the running aube — it must be a real aube that implements
+    // `__node-gyp-bootstrap`, never an inherited/user-set value (which
+    // could be stale or wrong). `aube run` stamps the same value at its
+    // own spawn site; keeping both unconditional holds the two paths in
+    // lockstep. `AUBE_NODE_GYP_PROJECT_DIR` is optional — the shim falls
+    // back to the script's cwd.
     if let Some(node_gyp_js) = settings.node_gyp_js.as_deref() {
         cmd.env("npm_config_node_gyp", node_gyp_js);
-        if std::env::var_os("AUBE_NODE_GYP_EXE").is_none()
-            && let Ok(exe) = std::env::current_exe()
-        {
+        if let Some(exe) = aube_exe.as_deref() {
             cmd.env("AUBE_NODE_GYP_EXE", exe);
         }
     }
@@ -556,18 +559,33 @@ fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &Scrip
 /// Apply the manifest-derived `npm_package_*` env (name, version,
 /// absolute `npm_package_json` path, and the deep-flattened
 /// `engines`/`config`/`bin`) plus `npm_lifecycle_script` (the raw
-/// script body) to a lifecycle command. Called last in `run_script`
-/// so the values land *after* any jail `env_clear` and override a
-/// parent aube invocation's leaked `npm_package_*` on the unjailed
-/// path. `script_dir` is the directory the script runs in, whose
-/// `package.json` is the manifest being executed.
-fn apply_npm_manifest_env(
+/// script body) to a lifecycle or `aube run` command. Call last so the
+/// values land *after* any jail `env_clear`. `script_dir` is the
+/// directory the script runs in, whose `package.json` is the manifest
+/// being executed; `lifecycle_script` is the raw script body exported
+/// as `npm_lifecycle_script`.
+///
+/// pnpm rebuilds the `npm_package_*` namespace per package: it drops
+/// every inherited `npm_package_*` key and stamps only the running
+/// manifest's allowlist. We mirror that — scrub first, then re-stamp —
+/// so a script never sees a parent/sibling package's fields (verified
+/// against pnpm 11.5). Without the scrub, non-allowlisted inherited
+/// keys (e.g. an outer `npm run`'s `npm_package_description`) would
+/// leak through on the unjailed path and break allowlist parity. On
+/// the jailed path the prior `env_clear` already dropped them, so the
+/// scrub is a harmless no-op there.
+pub fn apply_npm_manifest_env(
     cmd: &mut tokio::process::Command,
     manifest: &PackageJson,
     script_dir: &Path,
-    script_cmd: &str,
+    lifecycle_script: &str,
 ) {
-    cmd.env("npm_lifecycle_script", script_cmd);
+    for (key, _) in std::env::vars_os() {
+        if key.to_str().is_some_and(|k| k.starts_with("npm_package_")) {
+            cmd.env_remove(&key);
+        }
+    }
+    cmd.env("npm_lifecycle_script", lifecycle_script);
     cmd.env("npm_package_json", script_dir.join("package.json"));
     for (key, value) in manifest.npm_package_env() {
         cmd.env(key, value);

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -215,7 +215,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         crate::runtime::lockfile_node_pin(&cwd, &manifest).as_ref(),
     )
     .await?;
-    super::configure_script_settings(&settings_ctx);
+    super::configure_script_settings(&settings_ctx, Some("install"));
 
     let layout::InstallLayoutConfig {
         lockfile_dir,

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -122,6 +122,23 @@ pub(crate) fn lazy_shim_bin_dir(project_bin_dir: &Path) -> miette::Result<Option
     Ok(Some(shim_dir))
 }
 
+/// Path to the lazy `node-gyp.js` shim, exported as `npm_config_node_gyp`
+/// for parity with npm/pnpm (which point it at their bundled
+/// `node-gyp/bin/node-gyp.js`). Unlike [`lazy_shim_bin_dir`], this is
+/// returned unconditionally — `npm_config_node_gyp` is a separate channel
+/// from `PATH`, and npm/pnpm always set it even when a system node-gyp
+/// exists. Writing the shim is cheap (a few tiny files) and never
+/// bootstraps; the real node-gyp install is deferred until a tool runs
+/// `node $npm_config_node_gyp`. Rewritten on every call (like
+/// [`lazy_shim_bin_dir`]) so a shipped shim fix self-heals rather than
+/// being pinned to whatever first landed in the cache.
+pub(crate) fn lazy_js_shim_path() -> miette::Result<PathBuf> {
+    let shim_dir = tool_root()?.join("lazy-bin");
+    std::fs::create_dir_all(&shim_dir).into_diagnostic()?;
+    write_lazy_shims(&shim_dir)?;
+    Ok(shim_dir.join("node-gyp.js"))
+}
+
 pub(crate) async fn print_bootstrapped_binary(project_dir: &Path) -> miette::Result<()> {
     let bin_dir = ensure_cached(project_dir).await?;
     println!("{}", bin_dir.join(primary_binary_name()).display());
@@ -140,6 +157,45 @@ exec "$real" "$@"
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&sh_path, std::fs::Permissions::from_mode(0o755))
+            .into_diagnostic()?;
+    }
+
+    // `node-gyp.js`: the value of `npm_config_node_gyp`. Consumers run it
+    // as `node $npm_config_node_gyp …`, so it must be a Node script (not
+    // the shell `node-gyp` shim above). It resolves the real node-gyp the
+    // same way — via the hidden `__node-gyp-bootstrap` subcommand — then
+    // forwards argv. Falls back to a `node-gyp` on PATH when aube's env
+    // markers are absent (e.g. a script spawned outside aube's wrappers).
+    let js = r#"#!/usr/bin/env node
+"use strict";
+// aube lazy node-gyp stand-in for npm_config_node_gyp. Resolves (and
+// bootstraps on first use) aube's node-gyp, then forwards argv. Kept
+// dependency-free; writing this file is free, the bootstrap only fires
+// when something actually invokes it. Bare `require` (no `node:` prefix)
+// so the shim runs under any Node the user drives, including pre-16.
+const { execFileSync, spawnSync } = require("child_process");
+const isWin = process.platform === "win32";
+let real;
+const exe = process.env.AUBE_NODE_GYP_EXE;
+if (exe) {
+  const dir = process.env.AUBE_NODE_GYP_PROJECT_DIR || process.cwd();
+  real = execFileSync(exe, ["__node-gyp-bootstrap", dir], { encoding: "utf8" }).trim();
+} else {
+  real = isWin ? "node-gyp.cmd" : "node-gyp";
+}
+const result = spawnSync(real, process.argv.slice(2), { stdio: "inherit", shell: isWin });
+if (result.error) {
+  console.error("aube: failed to run node-gyp (" + real + "): " + result.error.message);
+  process.exit(1);
+}
+process.exit(result.status === null ? 1 : result.status);
+"#;
+    let js_path = shim_dir.join("node-gyp.js");
+    aube_util::fs_atomic::atomic_write(&js_path, js.as_bytes()).into_diagnostic()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&js_path, std::fs::Permissions::from_mode(0o755))
             .into_diagnostic()?;
     }
 

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -187,7 +187,7 @@ pub(crate) async fn run_root_lifecycle_script(
     if !manifest.scripts.contains_key(script_name) {
         return Ok(());
     }
-    super::configure_script_settings_for_cwd(project_root)?;
+    super::configure_script_settings_for_cwd(project_root, Some("pack"))?;
     let modules_dir_name = super::resolve_modules_dir_name_for_cwd(project_root);
     tracing::debug!("lifecycle: {script_name}");
     aube_scripts::run_root_script_by_name(project_root, &modules_dir_name, manifest, script_name)

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -54,7 +54,7 @@ pub async fn run(
         .wrap_err("failed to load workspace config")?;
     let env_snapshot = aube_settings::values::capture_env();
     let settings_ctx = files.ctx(&raw_workspace, &env_snapshot, &[]);
-    super::configure_script_settings(&settings_ctx);
+    super::configure_script_settings(&settings_ctx, Some("rebuild"));
 
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
         Ok(graph) => Some(graph),

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -929,8 +929,6 @@ async fn build_script_command(
         )
         .env("AUBE_NODE_GYP_PROJECT_DIR", node_gyp_project_dir)
         .env("npm_lifecycle_event", script)
-        .env("npm_lifecycle_script", &lifecycle_script)
-        .env("npm_package_json", script_dir.join("package.json"))
         // `npm_command` is "run-script" for every script-running command
         // (run/test/start/stop/restart). `spawn_shell` already stamped it
         // from the process-global ScriptSettings, but a preceding
@@ -939,9 +937,10 @@ async fn build_script_command(
         // authoritative spawn site rather than depend on call ordering.
         .env("npm_command", "run-script")
         .stderr(aube_scripts::child_stderr());
-    for (key, value) in manifest.npm_package_env() {
-        command.env(key, value);
-    }
+    // name/version/engines/config/bin + npm_package_json +
+    // npm_lifecycle_script, scrubbing any inherited npm_package_* first
+    // so a nested `aube run` matches pnpm's per-package allowlist.
+    aube_scripts::apply_npm_manifest_env(&mut command, manifest, &script_dir, &lifecycle_script);
     // INIT_CWD is the dir the user invoked aube from, NOT the
     // project root. node-gyp and prebuild-install key their
     // caches by INIT_CWD to locate the invoking project. Pulling

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -819,7 +819,7 @@ fn configure_script_settings_for_project(cwd: &Path) -> miette::Result<bool> {
     let env_snapshot = aube_settings::values::capture_env();
     let ctx = files.ctx(&raw_workspace, &env_snapshot, &[]);
     let enable_pre_post_scripts = aube_settings::resolved::enable_pre_post_scripts(&ctx);
-    super::configure_script_settings(&ctx);
+    super::configure_script_settings(&ctx, Some("run-script"));
     Ok(enable_pre_post_scripts)
 }
 
@@ -863,6 +863,11 @@ async fn build_script_command(
     args: &[String],
     node_args: &[String],
 ) -> miette::Result<tokio::process::Command> {
+    // Raw script body as written in package.json, exported as
+    // `npm_lifecycle_script` (pnpm parity). Captured before node-arg
+    // injection and arg quoting so it mirrors the manifest, not the
+    // spliced shell command line.
+    let lifecycle_script = cmd.to_string();
     let cmd = inject_node_args(cmd, node_args);
     let shell_cmd = if args.is_empty() {
         cmd
@@ -906,14 +911,15 @@ async fn build_script_command(
     let node_gyp_project_dir =
         crate::dirs::find_workspace_root(&script_dir).unwrap_or_else(|| script_dir.clone());
 
-    // npm-compat env vars. Lifecycle path sets these in
-    // aube-scripts::run_root_hook, `aube run` was bare env before.
-    // Build scripts that stamp `$npm_package_version` or branch on
-    // `$npm_lifecycle_event` got empty strings under `aube run`
-    // while working fine under `aube install` postinstall. npm
-    // and pnpm set these on every script exec.
+    // npm-compat env vars. `spawn_shell` already stamped the
+    // invocation-level vars (`npm_execpath`, `npm_node_execpath` /
+    // `NODE`, `npm_command`, `npm_config_user_agent`) from the
+    // process-global ScriptSettings configured for this run. Here we
+    // add the per-script + manifest vars so build scripts that branch
+    // on `$npm_lifecycle_event`, stamp `$npm_package_version`, or read
+    // `$npm_package_engines_node` behave the same under `aube run` as
+    // under `aube install` postinstall.
     let mut command = aube_scripts::spawn_shell(&shell_cmd);
-    crate::runtime::apply_child_env(&mut command);
     command
         .env("PATH", &new_path)
         .current_dir(cwd)
@@ -923,12 +929,18 @@ async fn build_script_command(
         )
         .env("AUBE_NODE_GYP_PROJECT_DIR", node_gyp_project_dir)
         .env("npm_lifecycle_event", script)
+        .env("npm_lifecycle_script", &lifecycle_script)
+        .env("npm_package_json", script_dir.join("package.json"))
+        // `npm_command` is "run-script" for every script-running command
+        // (run/test/start/stop/restart). `spawn_shell` already stamped it
+        // from the process-global ScriptSettings, but a preceding
+        // `ensure_installed` reconfigures those settings to "install"
+        // (its own `npm_command`), so re-assert the run value here at the
+        // authoritative spawn site rather than depend on call ordering.
+        .env("npm_command", "run-script")
         .stderr(aube_scripts::child_stderr());
-    if let Some(ref name) = manifest.name {
-        command.env("npm_package_name", name);
-    }
-    if let Some(ref version) = manifest.version {
-        command.env("npm_package_version", version);
+    for (key, value) in manifest.npm_package_env() {
+        command.env(key, value);
     }
     // INIT_CWD is the dir the user invoked aube from, NOT the
     // project root. node-gyp and prebuild-install key their

--- a/crates/aube/src/commands/script_settings.rs
+++ b/crates/aube/src/commands/script_settings.rs
@@ -4,7 +4,10 @@ use miette::{Context, IntoDiagnostic};
 
 use super::FileSources;
 
-pub(crate) fn configure_script_settings(ctx: &aube_settings::ResolveCtx<'_>) {
+pub(crate) fn configure_script_settings(
+    ctx: &aube_settings::ResolveCtx<'_>,
+    command: Option<&str>,
+) {
     let node_options = aube_settings::resolved::node_options(ctx).and_then(non_empty_string);
     let script_shell = aube_settings::resolved::script_shell(ctx)
         .and_then(|s| non_empty_string(s).map(Into::into));
@@ -14,7 +17,9 @@ pub(crate) fn configure_script_settings(ctx: &aube_settings::ResolveCtx<'_>) {
     // this for lifecycle scripts to see the pinned node — the install
     // driver resolves the runtime early, then configures script
     // settings. When no context exists (or no switching is active)
-    // these stay `None` and scripts inherit PATH untouched.
+    // `node_bin_dir` stays `None` (PATH untouched); `node_exe` still
+    // falls back to the ambient `node` on PATH so `npm_node_execpath` /
+    // `NODE` are populated for lifecycle scripts the way pnpm/npm do.
     let runtime = crate::runtime::current();
     aube_scripts::set_script_settings(aube_scripts::ScriptSettings {
         node_options,
@@ -22,7 +27,15 @@ pub(crate) fn configure_script_settings(ctx: &aube_settings::ResolveCtx<'_>) {
         unsafe_perm,
         shell_emulator,
         node_bin_dir: runtime.and_then(|r| r.bin_dir.clone()),
-        node_exe: runtime.and_then(|r| r.node_bin.clone()),
+        node_exe: runtime
+            .and_then(|r| r.node_bin.clone())
+            .or_else(aube_runtime::node_on_path),
+        command: command.map(str::to_string),
+        // `npm_config_node_gyp` parity: hand every lifecycle script a
+        // runnable node-gyp stand-in. The shim is written once into
+        // aube's cache; a write failure here is non-fatal (the var just
+        // stays unset, matching pre-parity behavior).
+        node_gyp_js: super::install::node_gyp_bootstrap::lazy_js_shim_path().ok(),
     });
 }
 
@@ -30,14 +43,19 @@ pub(crate) fn configure_script_settings(ctx: &aube_settings::ResolveCtx<'_>) {
 /// process-wide script settings snapshot. Used by commands that run
 /// lifecycle hooks (pack/publish/version) outside the install path,
 /// which already does this via `configure_script_settings` directly.
-pub(crate) fn configure_script_settings_for_cwd(cwd: &Path) -> miette::Result<()> {
+/// `command` is the npm-compat command label exported as
+/// `npm_command` (e.g. `"pack"`).
+pub(crate) fn configure_script_settings_for_cwd(
+    cwd: &Path,
+    command: Option<&str>,
+) -> miette::Result<()> {
     let files = FileSources::load(cwd);
     let (_, raw_workspace) = aube_manifest::workspace::load_both(cwd)
         .into_diagnostic()
         .wrap_err("failed to load workspace config")?;
     let env_snapshot = aube_settings::values::capture_env();
     let ctx = files.ctx(&raw_workspace, &env_snapshot, &[]);
-    configure_script_settings(&ctx);
+    configure_script_settings(&ctx, command);
     Ok(())
 }
 

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -114,14 +114,21 @@ pub fn path_entries() -> Vec<PathBuf> {
         .collect()
 }
 
-/// Set the npm-compat env vars naming the selected node on a child
+/// Set the npm-compat env vars naming the node binary on a child
 /// command (`npm_node_execpath`, and `NODE` which npm also exports).
+///
+/// Prefers the switched runtime's node; when no switch is active,
+/// falls back to the ambient `node` resolved on `PATH` so these vars
+/// are populated on every spawn — pnpm/npm always set them, and tools
+/// (`node-gyp`, `node-pre-gyp`, re-spawners) read `npm_node_execpath`
+/// to locate the exact node that drove the package manager.
 pub fn apply_child_env(cmd: &mut tokio::process::Command) {
-    if let Some(ctx) = current()
-        && let Some(node_bin) = &ctx.node_bin
-    {
-        cmd.env("npm_node_execpath", node_bin);
-        cmd.env("NODE", node_bin);
+    let node_bin = current()
+        .and_then(|ctx| ctx.node_bin.clone())
+        .or_else(aube_runtime::node_on_path);
+    if let Some(node_bin) = node_bin {
+        cmd.env("npm_node_execpath", &node_bin);
+        cmd.env("NODE", &node_bin);
     }
 }
 

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -542,6 +542,38 @@ JSON
 	assert_output --regexp "UA=aube/[0-9]+\.[0-9]+\.[0-9]+"
 }
 
+@test "aube install: lifecycle hooks export the full npm_* env set (pnpm parity)" {
+	# Companion to the run-path test in run.bats: install lifecycle hooks
+	# must see the same npm_* surface pnpm provides — npm_execpath,
+	# npm_node_execpath, npm_package_json, npm_command (=install here),
+	# npm_config_node_gyp, the deep-flattened engines/config/bin, and the
+	# raw npm_lifecycle_script. Tools like node-pre-gyp / husky branch on
+	# these during a dependency build.
+	cat >package.json <<'JSON'
+{
+  "name": "@scope/install-env-probe",
+  "version": "4.5.6",
+  "engines": { "node": ">=18.0.0" },
+  "config": { "port": "8080" },
+  "bin": { "probe-cli": "./cli.js" },
+  "scripts": {
+    "postinstall": "node -e 'for (const k of [\"npm_execpath\",\"npm_node_execpath\",\"npm_package_json\",\"npm_command\",\"npm_config_node_gyp\",\"npm_package_engines_node\",\"npm_package_config_port\",\"npm_package_bin_probe_cli\",\"npm_lifecycle_script\"]) console.log(k + \"=\" + (process.env[k] || \"\"))'"
+  }
+}
+JSON
+	run aube install
+	assert_success
+	assert_output --partial "npm_command=install"
+	assert_output --regexp "npm_execpath=[^[:space:]]*aube"
+	assert_output --regexp "npm_node_execpath=[^[:space:]]+"
+	assert_output --regexp "npm_package_json=[^[:space:]]*package\.json"
+	assert_output --regexp "npm_config_node_gyp=[^[:space:]]*node-gyp\.js"
+	assert_output --partial "npm_package_engines_node=>=18.0.0"
+	assert_output --partial "npm_package_config_port=8080"
+	assert_output --partial "npm_package_bin_probe_cli=./cli.js"
+	assert_output --regexp "npm_lifecycle_script=.*node -e"
+}
+
 @test "aube add: root postinstall is NOT triggered when adding a named dep" {
 	# Ported from pnpm/test/install/lifecycleScripts.ts:69
 	# ('postinstall is not executed after named installation').

--- a/test/node_gyp_bootstrap.bats
+++ b/test/node_gyp_bootstrap.bats
@@ -198,5 +198,8 @@ JSON
 	run aube test --no-install
 	assert_success
 	assert_file_exists project-node-gyp
-	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp"
+	# No *bootstrap* (the `v12/` bucket) — the project's own node-gyp was
+	# used. A cheap network-free lazy shim under `lazy-bin/` (backing
+	# `npm_config_node_gyp`) may exist; it never triggers an install.
+	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp/v12"
 }

--- a/test/node_gyp_rebuild.bats
+++ b/test/node_gyp_rebuild.bats
@@ -215,8 +215,11 @@ JSON
 	assert_success
 	# The shim wrote the marker, proving the on-PATH copy was used.
 	assert_file_exists node-gyp.marker
-	# And the aube cache must NOT have a bootstrapped node-gyp dir.
-	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp"
+	# And the aube cache must NOT have a *bootstrapped* node-gyp (the
+	# `v12/` bucket). A cheap network-free lazy shim (`lazy-bin/`) may
+	# exist — it backs `npm_config_node_gyp` and never bootstraps unless
+	# something executes it — so assert specifically on the bootstrap dir.
+	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp/v12"
 }
 
 @test "--ignore-scripts suppresses the implicit node-gyp rebuild" {

--- a/test/run.bats
+++ b/test/run.bats
@@ -407,6 +407,42 @@ JSON
 	assert_file_exists shell.log
 }
 
+@test "aube run exports the full npm_* env set (pnpm parity)" {
+	# A pnpm/aube bridge keys off these npm_* vars to detect the running
+	# PM (npm_execpath) and read package metadata. aube used to omit
+	# npm_execpath, npm_node_execpath, npm_package_json, npm_command,
+	# npm_config_node_gyp, npm_package_engines_*, and npm_lifecycle_script
+	# on the `run` path; assert they're all present and well-formed now.
+	cat >package.json <<'JSON'
+{
+  "name": "@scope/run-env-probe",
+  "version": "2.0.1",
+  "engines": { "node": ">=18.0.0" },
+  "scripts": {
+    "probe": "node -e 'for (const k of [\"npm_execpath\",\"npm_node_execpath\",\"npm_package_json\",\"npm_command\",\"npm_config_node_gyp\",\"npm_package_engines_node\",\"npm_package_name\",\"npm_package_version\",\"npm_lifecycle_script\"]) console.log(k + \"=\" + (process.env[k] || \"\"))'"
+  }
+}
+JSON
+	run aube run probe
+	assert_success
+	# npm_command is "run-script" for every script-running command.
+	assert_output --partial "npm_command=run-script"
+	# npm_execpath points back at the aube binary that drove the script.
+	assert_output --regexp "npm_execpath=[^[:space:]]*aube"
+	# npm_node_execpath / NODE resolve to a node binary (non-empty).
+	assert_output --regexp "npm_node_execpath=[^[:space:]]+"
+	# Absolute path to the package.json being run.
+	assert_output --regexp "npm_package_json=[^[:space:]]*package\.json"
+	# Lazy node-gyp stand-in for npm_config_node_gyp parity.
+	assert_output --regexp "npm_config_node_gyp=[^[:space:]]*node-gyp\.js"
+	# Deep-flattened manifest fields.
+	assert_output --partial "npm_package_engines_node=>=18.0.0"
+	assert_output --partial "npm_package_name=@scope/run-env-probe"
+	assert_output --partial "npm_package_version=2.0.1"
+	# Raw script body (pnpm exports this for tools that re-run it).
+	assert_output --regexp "npm_lifecycle_script=.*node -e"
+}
+
 # discussion #228: a package's own `bin` should resolve from its own
 # scripts without `npx`, matching yarn/pnpm behavior.
 @test "aube run resolves package's own bin (string form)" {


### PR DESCRIPTION
## Summary
- Lifecycle and `aube run` scripts now receive the same `npm_*` environment pnpm/npm export, so PM-detection bridges and build tooling behave identically under aube. Previously aube omitted `npm_execpath`, `npm_node_execpath`, `npm_package_json`, `npm_command`, `npm_config_node_gyp`, `npm_package_engines_*`, and `npm_lifecycle_script`.

- Adds `PackageJson::npm_package_env()` — pnpm's exact allowlist (`name`, `version`, deep-flattened `engines`/`config`/`bin`), envified the npm way (non-`[A-Za-z0-9_]` → `_`, case preserved). String `bin` flattens to the unsuffixed `npm_package_bin`, matching pnpm (not npm's unscoped-name rule).

- `npm_command` is stamped per command family (`run-script`, `install`, `rebuild`, `pack`); re-asserted at the run spawn site so a preceding auto-install doesn't clobber it.

- `npm_config_node_gyp` points at a lazy, dependency-free node-gyp stand-in written into aube's cache. It bootstraps the real node-gyp only when a tool actually executes it — no eager install — and self-heals on each write.

- `npm_node_execpath`/`NODE` fall back to the ambient `node` on `PATH` when no runtime switch is active, so they're always populated.

## Implementation notes
- Manifest-derived vars are applied last in `run_script`, after the build jail's `env_clear`, so jailed dependency builds see them too.

- Dedups the `node.exe`/`node` selection in `aube-runtime/discover.rs` behind a
  single `node_exe_name()` and adds a process-free `node_on_path()` PATH lookup.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Unit tests: `aube-manifest`, `aube-scripts`, `aube-runtime`
- [x] bats: `run`, `lifecycle_scripts` (new pnpm-parity tests), `node_gyp_bootstrap`, `node_gyp_rebuild`
- [x] Empirically diffed the full `npm_package_*` set against pnpm 11.5 — byte-for-byte identical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced npm lifecycle environment parity: deterministic export of npm_package_* (flattened package fields), npm_lifecycle_script, npm_execpath, npm_node_execpath and npm_command; lifecycle env now survives jailed env_clear
  * Improved script runtime selection so scripts use the pinned runtime or PATH-resolved node when needed
  * Added lazy shim support and npm_config_node_gyp support for node-gyp bootstrapping

* **Tests**
  * Added and tightened tests validating npm lifecycle env export, run/install behavior, and node-gyp bootstrap handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->