### PR TITLE
fix(install): stop double-counting link deps in the progress bar

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1580,7 +1580,18 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             let missing_packages: BTreeMap<String, aube_lockfile::LockedPackage> = graph
                 .packages
                 .iter()
-                .filter(|(dep_path, _)| !indices.contains_key(*dep_path))
+                // Only non-local registry tarballs are ever deferred by
+                // the streaming platform-skip above (it fires solely for
+                // `local_source.is_none()`), so the catch-up must scope to
+                // those. Local `file:`/`link:` deps already ran their
+                // `import_local_source` + `inc_reused` up front; link-only
+                // deps legitimately leave no `indices` entry, so a plain
+                // `!indices.contains_key` filter would re-import them and
+                // double-credit `reused` (reused > resolved →
+                // WARN_AUBE_PROGRESS_OVERFLOW).
+                .filter(|(dep_path, pkg)| {
+                    !indices.contains_key(*dep_path) && pkg.local_source.is_none()
+                })
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
             if !missing_packages.is_empty() {

--- a/crates/aube/src/progress/ci.rs
+++ b/crates/aube/src/progress/ci.rs
@@ -339,6 +339,15 @@ impl CiState {
         // complete and the bar should reflect that before the summary
         // line lands.
         snap.phase = 4;
+        // Defensive: keep `reused + downloaded <= resolved` so the final
+        // bar *and* the summary line below stay internally consistent
+        // even if a counter race over-credited `reused`. Trim reused,
+        // never downloaded — downloaded reflects real network work.
+        // Mirrors the live bar's `clamped_completed` clamp and the
+        // `clamp_reused_to` rebase `set_total` applies.
+        snap.reused = snap
+            .reused
+            .min(snap.resolved.saturating_sub(snap.downloaded));
         // Emit one final bar so CI logs end on a complete snapshot
         // even when the last heartbeat was skipped (fast fetch+link
         // between ticks). Skipped if it would duplicate the previous


### PR DESCRIPTION
## Summary

A monorepo install (most visibly after `aube clean`) could finish with the progress numerator past the denominator — emitting `WARN_AUBE_PROGRESS_OVERFLOW` and a final summary like `✓ resolved 2622 · reused 2623`. Every `workspace:` / `link:` dependency was credited to the `reused` bucket **twice**, so the count overshot the resolved total by the number of link deps.

## Root cause

In the streaming resolve→fetch path, link deps resolve to `LocalSource::Link`, and `import_local_source` returns `Ok(None)` (link deps never get a store-backed index — the linker symlinks straight to the target). That arm credits `inc_reused(1)` but inserts nothing into `indices`.

After `filter_graph`, the catch-up fetch — which exists only to grab registry tarballs the streaming platform-skip deferred — selected its work purely with `!indices.contains_key(...)`. Link deps have no `indices` entry, so they looked "missing", got re-imported through `fetch.rs`, and were credited `inc_reused(1)` a second time. The platform-skip only ever defers `local_source.is_none()` packages, so local deps never belong in the catch-up set in the first place.

## Fix

- **Root cause:** scope the catch-up's `missing_packages` to non-local packages (`&& pkg.local_source.is_none()`). Local deps are fully handled in the streaming pass and are never deferred, so this removes both the double-credit and a redundant re-import.
- **Hardening:** in the CI summary (`stop()`), clamp `reused + downloaded <= resolved` before the final bar/stats render — mirroring the live bar's existing `clamped_completed` clamp and `set_total`'s `clamp_reused_to` — so a future counter race can't print an inconsistent `reused N > resolved M`. `downloaded` is never trimmed (it reflects real network work).

## Test plan

- [x] `cargo test -p aube progress::` (22 tests, incl. the overflow + reused clamps)
- [x] `cargo clippy -p aube --all-targets -- -D warnings`
- [x] Manual: `aube clean && aube install` in a workspace with `workspace:` deps on a warm store → no `WARN_AUBE_PROGRESS_OVERFLOW`, and the summary reports `reused == resolved`

*This PR description was drafted by Claude.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined package filtering logic to prevent unintended re-processing of local and link-based dependencies during deferred package operations.
  * Fixed counter consistency in terminal progress display to accurately reflect resolved and reused package counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->