### PR TITLE
fix(packaging): restore endevco npm scope

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,8 +4,8 @@ name: publish-npm
 # release-plz flow flips the draft to non-draft and all prebuilt
 # binaries are already attached to the release). Downloads the
 # per-target archives that `release.yml` produced, then publishes
-# each `@jdx/aube-<os>-<arch>` followed by the root
-# `@jdx/aube`.
+# each `@endevco/aube-<os>-<arch>` followed by the root
+# `@endevco/aube`.
 #
 # Decoupled from `release-plz.yml` on purpose: a failed npm publish
 # doesn't block crates.io or the GitHub release, and re-runs can be
@@ -40,7 +40,7 @@ jobs:
       # Required for npm Trusted Publishing (OIDC). GitHub mints a
       # short-lived OIDC token that npm exchanges for a one-shot
       # publish token — no NPM_TOKEN secret to rotate or leak.
-      # Each @jdx/aube* package must have this repo + workflow
+      # Each @endevco/aube* package must have this repo + workflow
       # configured as a Trusted Publisher on npmjs.com (org level
       # default covers new packages under the scope).
       id-token: write
@@ -66,7 +66,7 @@ jobs:
           # Manual dispatch path: id-token: write on this workflow means npm
           # Trusted Publishing will accept whatever the checked-out tag's
           # publish.mjs does. Require the tag to be reachable from main so
-          # an unreviewed ref can't push an @jdx/aube* package.
+          # an unreviewed ref can't push an @endevco/aube* package.
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             STATUS=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${TAG}" --jq '.status' 2>/dev/null || echo "missing")
             if [ "$STATUS" != "identical" ] && [ "$STATUS" != "behind" ]; then
@@ -89,7 +89,7 @@ jobs:
       # workflow doesn't break if Node's bundled npm drifts behind.
       - name: Ensure npm supports Trusted Publishing
         run: npm install -g npm@latest
-      - name: Publish @jdx/aube and platform packages
+      - name: Publish @endevco/aube and platform packages
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: node npm/scripts/publish.mjs

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ mise use aube
 aube is also published on npm:
 
 ```sh
-npm install -g --ignore-scripts=false @jdx/aube
-npx --ignore-scripts=false @jdx/aube --version
+npm install -g --ignore-scripts=false @endevco/aube
+npx --ignore-scripts=false @endevco/aube --version
 ```
 
 The npm package uses an install script to fetch native binaries for

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,11 +49,11 @@ The tap formula builds from source and installs shell completions.
 
 ## From npm
 
-aube is also published on npm as `@jdx/aube`:
+aube is also published on npm as `@endevco/aube`:
 
 ```sh
-npm install -g --ignore-scripts=false @jdx/aube
-npx --ignore-scripts=false @jdx/aube --version
+npm install -g --ignore-scripts=false @endevco/aube
+npx --ignore-scripts=false @endevco/aube --version
 ```
 
 ::: warning

--- a/npm/installArchSpecificPackage.js
+++ b/npm/installArchSpecificPackage.js
@@ -1,4 +1,4 @@
-// Fetch the platform-matching @jdx/aube-<os>-<arch> sub-package at
+// Fetch the platform-matching @endevco/aube-<os>-<arch> sub-package at
 // install time and hardlink (or copy) its three binaries into ./bin so
 // npm's `bin` wrapper resolves directly to the native executable. The root
 // package's bin targets are stable `./bin/<name>` paths so npm/npx can create
@@ -21,7 +21,7 @@ function main() {
     var version = pjson.version;
 
     // Nested `npm install` must stay local; otherwise it'd try to write
-    // into the global prefix when the user ran `npm i -g @jdx/aube`.
+    // into the global prefix when the user ran `npm i -g @endevco/aube`.
     process.env.npm_config_global = 'false';
 
     var platform = process.platform; // darwin | linux | win32
@@ -35,12 +35,12 @@ function main() {
         try { glibc = process.report.getReport().header.glibcVersionRuntime || ''; } catch (_) {}
         if (!glibc) suffix = '-musl';
     }
-    var subpkgName = '@jdx/aube-' + platform + '-' + arch + suffix;
+    var subpkgName = '@endevco/aube-' + platform + '-' + arch + suffix;
 
     var npmCmd = platform === 'win32' ? 'npm.cmd' : 'npm';
     // --ignore-scripts: platform packages are passive binary carriers;
     // a compromised mirror/registry must not get RCE via lifecycle hooks
-    // when the user installs the trusted root @jdx/aube.
+    // when the user installs the trusted root @endevco/aube.
     var args = ['install', '--no-save', '--no-package-lock', '--ignore-scripts', subpkgName + '@' + version];
 
     var cp = spawn(npmCmd, args, { stdio: 'inherit', shell: true });
@@ -49,7 +49,7 @@ function main() {
         // OOM). `process.exit(null)` coerces to 0, which would tell
         // npm the preinstall succeeded — surface it as failure.
         if (signal || code === null) {
-            console.error('[@jdx/aube] preinstall: `npm install ' + subpkgName + '` killed by ' + (signal || 'signal'));
+            console.error('[@endevco/aube] preinstall: `npm install ' + subpkgName + '` killed by ' + (signal || 'signal'));
             process.exit(1);
             return;
         }
@@ -61,7 +61,7 @@ function main() {
             linkSubpkgBins(subpkgName, platform);
             process.exit(0);
         } catch (e) {
-            console.error('[@jdx/aube] preinstall failed: ' + (e && e.message ? e.message : e));
+            console.error('[@endevco/aube] preinstall failed: ' + (e && e.message ? e.message : e));
             process.exit(1);
         }
     });

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jdx/aube",
+  "name": "@endevco/aube",
   "version": "0.0.0-placeholder",
   "description": "A fast Node.js package manager that drops into existing projects.",
   "homepage": "https://aube.jdx.dev",

--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Build and publish the @jdx/aube npm packages for a given tag.
+// Build and publish the @endevco/aube npm packages for a given tag.
 //
 // For each release target this:
 //   1. downloads `aube-<tag>-<target>.{tar.gz,zip}` directly from the
@@ -7,9 +7,9 @@
 //   2. extracts the three binary entries (aube, aubr, aubx) into a
 //      staging dir,
 //   3. generates a platform-scoped package.json and publishes it as
-//      `@jdx/aube-<os>-<arch>`.
+//      `@endevco/aube-<os>-<arch>`.
 // Then rewrites the root `npm/package.json` version and publishes
-// `@jdx/aube` last, so the preinstall script can resolve every
+// `@endevco/aube` last, so the preinstall script can resolve every
 // sub-package it might want to install.
 //
 // Env:
@@ -61,7 +61,7 @@ function run(cmd, args, opts = {}) {
 // package name.
 function platformPkgName(target) {
     const suffix = target.libc === 'musl' ? '-musl' : '';
-    return `@jdx/aube-${target.os}-${target.cpu}${suffix}`;
+    return `@endevco/aube-${target.os}-${target.cpu}${suffix}`;
 }
 
 // Returns true when <pkg>@<version> is already on the registry, so a
@@ -161,7 +161,7 @@ async function buildPlatformPackage(repo, tag, version, target) {
     const pkgJson = {
         name: pkgName,
         version,
-        description: 'Platform binaries for aube — do not install directly, see @jdx/aube.',
+        description: 'Platform binaries for aube — do not install directly, see @endevco/aube.',
         homepage: 'https://aube.jdx.dev',
         repository: { type: 'git', url: 'https://github.com/jdx/aube' },
         license: 'MIT',
@@ -214,7 +214,7 @@ async function main() {
     }
 
     if (!skipRoot) {
-        console.log(`\n[publish] --- @jdx/aube (root) ---`);
+        console.log(`\n[publish] --- @endevco/aube (root) ---`);
         const rootPkgPath = resolve(npmDir, 'package.json');
         const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf8'));
         rootPkg.version = version;


### PR DESCRIPTION
## Summary

- restore the published npm root package name to `@endevco/aube`
- restore generated platform package names and preinstall lookup to `@endevco/aube-*`
- update npm install docs and publish workflow labels to match

## Why

The package was renamed to `@jdx/aube` in the v1.18.2 release path, but that package is not published on npm. Recent `publish-npm` runs have failed, while `@endevco/aube` remains the existing npm package users install.

## Validation

- `node --check npm/scripts/publish.mjs`
- `node --check npm/installArchSpecificPackage.js`
- `npm pack --dry-run` in `npm/`, which reports `@endevco/aube@0.0.0-placeholder`

---

Generated by Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope and documentation-only packaging fix with no runtime or security logic changes; main operational note is ensuring npm Trusted Publishing still covers the @endevco scope.
> 
> **Overview**
> Reverts the npm publish/install identity from **`@jdx/aube`** back to **`@endevco/aube`**, matching the package that actually exists on the registry and unblocking **`publish-npm`** after the mistaken rename in the v1.18.2 path.
> 
> The root **`npm/package.json`** name, preinstall lookup in **`installArchSpecificPackage.js`** (including **`@endevco/aube-<os>-<arch>`** sub-packages and log prefixes), and **`publish.mjs`** platform package naming/descriptions are aligned on **`@endevco`**. **`README.md`**, **`docs/installation.md`**, and **`.github/workflows/publish-npm.yml`** comments and step labels are updated so install docs and CI text match what gets published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ed8e101671b96851426c6e4f60ff69ea57044ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated npm package installation instructions in README and installation documentation to reflect the new package scope.

* **Chores**
  * Updated package scope in npm configuration, GitHub publishing workflows, preinstall scripts, and platform-specific package naming across distribution files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->