### PR TITLE
fix(embedder): honor the embedder profile in the install banner and cache/name sites

### DIFF
--- a/crates/aube-linker/src/builder.rs
+++ b/crates/aube-linker/src/builder.rs
@@ -98,16 +98,19 @@ impl Linker {
         self
     }
 
-    /// Compute the effective `.aube/` path for `project_dir`.
+    /// Compute the effective virtual-store path for `project_dir`.
     /// Consults the override installed by `with_aube_dir_override` if
-    /// any; otherwise falls back to `<project_dir>/<modules_dir>/.aube`.
+    /// any; otherwise falls back to `<project_dir>/<modules_dir>/.<name>`.
     /// Used internally by `link_all`; also called by the install
     /// driver's "already linked" fast path so both sites land on the
     /// same directory when the user has overridden `virtualStoreDir`.
     pub fn aube_dir_for(&self, project_dir: &Path) -> PathBuf {
-        self.aube_dir_override
-            .clone()
-            .unwrap_or_else(|| project_dir.join(&self.modules_dir_name).join(".aube"))
+        self.aube_dir_override.clone().unwrap_or_else(|| {
+            // Virtual-store leaf from the active embedder's name: `.<name>`.
+            // Standalone aube → `.aube`.
+            let leaf = format!(".{}", aube_util::embedder().name);
+            project_dir.join(&self.modules_dir_name).join(leaf)
+        })
     }
 
     /// Override the package-level linker worker count. Values below 1

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -197,11 +197,12 @@ pub struct Linker {
     /// pnpm's `virtual-store-dir`: absolute path of the per-project
     /// virtual store (what pnpm calls `node_modules/.pnpm`). `None`
     /// means "derive from `modules_dir_name` at link time":
-    /// `<project_dir>/<modules_dir_name>/.aube`, matching the default
-    /// behavior every caller expected before this knob existed. When
-    /// set by the install driver via `with_aube_dir_override`, it
-    /// overrides that derivation — the linker writes its
-    /// `.aube/<dep_path>/` tree into the supplied path instead. The
+    /// `<project_dir>/<modules_dir_name>/.<name>` (standalone aube →
+    /// `.aube`), matching the default behavior every caller expected
+    /// before this knob existed. When set by the install driver via
+    /// `with_aube_dir_override`, it overrides that derivation — the
+    /// linker writes its `.<name>/<dep_path>/` tree into the supplied
+    /// path instead. The
     /// path is *absolute*; relative overrides from `.npmrc` /
     /// `pnpm-workspace.yaml` get resolved against the project dir by
     /// the caller (see

--- a/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -23,6 +23,7 @@ static MYTOOL: Embedder = Embedder {
     workspace_yaml: Some("mytool-workspace.yaml"),
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),
+    config_env_prefix: Some("MYTOOL"),
     cache_namespace: "mytool",
     data_namespace: "mytool",
     canonical_lockfile_always_wins: true,

--- a/crates/aube-manifest/src/workspace/edits.rs
+++ b/crates/aube-manifest/src/workspace/edits.rs
@@ -144,8 +144,8 @@ where
     // An embedder whose `manifest_namespace` is `""` ("manifest root") writes
     // the setting at the **manifest root** unconditionally — `allowBuilds` /
     // `patchedDependencies` become top-level `package.json` keys, matching how
-    // the embedder's own migration writer emits them (e.g. nub's
-    // `apply_manifest_edits`) and where the read side looks. It must NOT divert
+    // the embedder's own migration writer emits them (e.g. an embedder's
+    // own `apply_manifest_edits`) and where the read side looks. It must NOT divert
     // to a pre-existing foreign-brand (`pnpm`) namespace, because under such an
     // embedder the read side gates that namespace off, so a nested write would
     // be orphaned. The empty namespace is signalled by `chosen_ns == None`.
@@ -184,8 +184,8 @@ where
 
     match chosen_ns {
         // Manifest-root target: read/insert/remove the setting key directly at
-        // top level. Matches the embedder's migration writer (e.g. nub's
-        // `apply_manifest_edits`, which writes `allowBuilds`/`patchedDependencies`
+        // top level. Matches the embedder's migration writer (e.g. an embedder's
+        // own `apply_manifest_edits`, which writes `allowBuilds`/`patchedDependencies`
         // at root and removes the `pnpm` object) and the read side, which skips
         // the empty self-namespace and (under a non-pnpm incumbent) the pnpm
         // namespace too — so a nested write would orphan.

--- a/crates/aube-registry/src/client/http.rs
+++ b/crates/aube-registry/src/client/http.rs
@@ -265,5 +265,7 @@ fn build_http_client_inner(
 /// or accidentally-set empty value won't silently balloon registry
 /// traffic on end-user machines.
 pub(super) fn force_full_packument() -> bool {
-    std::env::var("AUBE_INTERNAL_FORCE_FULL_PACKUMENT").as_deref() == Ok("1")
+    aube_util::env::embedder_env("INTERNAL_FORCE_FULL_PACKUMENT")
+        .as_deref()
+        .is_some_and(|v| v == "1")
 }

--- a/crates/aube-registry/tests/user_agent_product.rs
+++ b/crates/aube-registry/tests/user_agent_product.rs
@@ -25,6 +25,7 @@ static MYTOOL: Embedder = Embedder {
     workspace_yaml: Some("mytool-workspace.yaml"),
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),
+    config_env_prefix: Some("MYTOOL"),
     cache_namespace: "mytool",
     data_namespace: "mytool",
     canonical_lockfile_always_wins: true,

--- a/crates/aube-resolver/src/primer.rs
+++ b/crates/aube-resolver/src/primer.rs
@@ -266,7 +266,10 @@ fn primer_cache_dir() -> Option<PathBuf> {
     if let Some(base) = std::env::var_os("AUBE_CACHE_DIR") {
         return Some(PathBuf::from(base).join("primer"));
     }
-    cache_base_dir().map(|p| p.join("aube").join("primer"))
+    // Active embedder's `cache_namespace` (standalone aube → "aube"), not a literal,
+    // so the primer lands beside the packument cache in aube-store's `cache_dir`
+    // rather than under an aube-named path in a host embedder's $XDG_CACHE.
+    cache_base_dir().map(|p| p.join(aube_util::embedder().cache_namespace).join("primer"))
 }
 
 #[cfg(unix)]

--- a/crates/aube-resolver/src/primer.rs
+++ b/crates/aube-resolver/src/primer.rs
@@ -263,7 +263,11 @@ fn random_byte() -> u8 {
 }
 
 fn primer_cache_dir() -> Option<PathBuf> {
-    if let Some(base) = std::env::var_os("AUBE_CACHE_DIR") {
+    // First-class config knob, read under the active embedder's brand
+    // (`AUBE_CACHE_DIR` for standalone aube, `<BRAND>_CACHE_DIR` for an embedder
+    // with its own `config_env_prefix`) via `config_env` — never the branded
+    // `AUBE_*` form under such a host.
+    if let Some(base) = aube_util::env::config_env("CACHE_DIR") {
         return Some(PathBuf::from(base).join("primer"));
     }
     // Active embedder's `cache_namespace` (standalone aube → "aube"), not a literal,

--- a/crates/aube-runtime/src/discover.rs
+++ b/crates/aube-runtime/src/discover.rs
@@ -15,7 +15,7 @@ pub enum InstallOrigin {
 impl InstallOrigin {
     pub fn label(self) -> &'static str {
         match self {
-            InstallOrigin::Aube => "aube",
+            InstallOrigin::Aube => aube_util::embedder().name,
             InstallOrigin::Mise => "mise",
         }
     }

--- a/crates/aube-runtime/src/paths.rs
+++ b/crates/aube-runtime/src/paths.rs
@@ -49,17 +49,19 @@ pub(crate) fn locks_dir() -> Option<PathBuf> {
     runtime_dir().map(|d| d.join(".locks"))
 }
 
-/// Cache directory shared with the rest of aube
-/// (`$XDG_CACHE_HOME/aube`), mirroring `aube-store`'s `cache_dir`.
+/// Cache directory shared with the rest of aube, mirroring `aube-store`'s
+/// `cache_dir`. Uses the active embedder's `cache_namespace` (standalone aube →
+/// `"aube"`) under `$XDG_CACHE_HOME`, `%LOCALAPPDATA%`, or `~/.cache`.
 pub(crate) fn cache_dir() -> Option<PathBuf> {
+    let ns = aube_util::embedder().cache_namespace;
     if let Some(xdg) = aube_util::env::xdg_cache_home() {
-        return Some(xdg.join("aube"));
+        return Some(xdg.join(ns));
     }
     #[cfg(windows)]
     if let Ok(local) = std::env::var("LOCALAPPDATA") {
-        return Some(PathBuf::from(local).join("aube"));
+        return Some(PathBuf::from(local).join(ns));
     }
-    aube_util::env::home_dir().map(|h| h.join(".cache/aube"))
+    aube_util::env::home_dir().map(|h| h.join(".cache").join(ns))
 }
 
 /// Disk cache for the dist index, segmented by mirror origin so two

--- a/crates/aube-runtime/src/paths.rs
+++ b/crates/aube-runtime/src/paths.rs
@@ -4,7 +4,7 @@
 //! in the CAS machinery for three path joins).
 //!
 //! ```text
-//! $XDG_DATA_HOME/aube/nodejs/
+//! $XDG_DATA_HOME/<data_namespace>/nodejs/
 //! ├── 24.1.0/              # native layout: unix bin/node, win node.exe
 //! ├── .downloads/          # in-flight archive downloads
 //! ├── .tmp/                # extraction staging (rename source)
@@ -14,22 +14,24 @@
 use std::path::PathBuf;
 
 /// Root of aube-managed Node installs. `AUBE_RUNTIME_DIR` overrides
-/// for tests and unusual setups.
+/// for tests and unusual setups. The data namespace comes from the
+/// active embedder (standalone aube → `"aube"`).
 pub fn runtime_dir() -> Option<PathBuf> {
     if let Some(dir) = std::env::var_os("AUBE_RUNTIME_DIR")
         && !dir.is_empty()
     {
         return Some(PathBuf::from(dir));
     }
+    let ns = aube_util::embedder().data_namespace;
     #[cfg(windows)]
     if let Ok(local) = std::env::var("LOCALAPPDATA") {
-        return Some(PathBuf::from(local).join("aube/nodejs"));
+        return Some(PathBuf::from(local).join(ns).join("nodejs"));
     }
     let data_home = match aube_util::env::xdg_data_home() {
         Some(xdg) => xdg,
         None => aube_util::env::home_dir()?.join(".local/share"),
     };
-    Some(data_home.join("aube/nodejs"))
+    Some(data_home.join(ns).join("nodejs"))
 }
 
 /// The install dir for an exact version: `<runtime_dir>/24.1.0/`.

--- a/crates/aube-runtime/src/paths.rs
+++ b/crates/aube-runtime/src/paths.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 /// for tests and unusual setups. The data namespace comes from the
 /// active embedder (standalone aube → `"aube"`).
 pub fn runtime_dir() -> Option<PathBuf> {
-    if let Some(dir) = std::env::var_os("AUBE_RUNTIME_DIR")
+    if let Some(dir) = aube_util::env::embedder_env("RUNTIME_DIR")
         && !dir.is_empty()
     {
         return Some(PathBuf::from(dir));

--- a/crates/aube-runtime/src/self_install.rs
+++ b/crates/aube-runtime/src/self_install.rs
@@ -56,7 +56,7 @@ pub struct InstalledAube {
 /// aube's own versions dir (`$XDG_DATA_HOME/aube/self`).
 /// `AUBE_SELF_DIR` overrides for tests.
 pub fn self_dir() -> Option<PathBuf> {
-    if let Some(dir) = std::env::var_os("AUBE_SELF_DIR")
+    if let Some(dir) = aube_util::env::embedder_env("SELF_DIR")
         && !dir.is_empty()
     {
         return Some(PathBuf::from(dir));
@@ -197,16 +197,16 @@ pub fn release_target_triple() -> Result<String, Error> {
 }
 
 fn release_base() -> String {
-    std::env::var("AUBE_SELF_DOWNLOAD_BASE")
-        .ok()
+    aube_util::env::embedder_env("SELF_DOWNLOAD_BASE")
+        .and_then(|s| s.into_string().ok())
         .filter(|s| !s.trim().is_empty())
         .map(|s| s.trim_end_matches('/').to_string())
         .unwrap_or_else(|| RELEASE_BASE.to_string())
 }
 
 fn versions_host() -> String {
-    std::env::var("AUBE_VERSIONS_HOST")
-        .ok()
+    aube_util::env::embedder_env("VERSIONS_HOST")
+        .and_then(|s| s.into_string().ok())
         .filter(|s| !s.trim().is_empty())
         .map(|s| s.trim_end_matches('/').to_string())
         .unwrap_or_else(|| VERSIONS_HOST.to_string())
@@ -235,8 +235,8 @@ pub async fn available_aube_versions(retries: u32) -> Result<Vec<node_semver::Ve
             tracing::debug!(%list_url, error = %e, "versions host unreachable; falling back");
         }
     }
-    let url = std::env::var("AUBE_SELF_VERSION_URL")
-        .ok()
+    let url = aube_util::env::embedder_env("SELF_VERSION_URL")
+        .and_then(|s| s.into_string().ok())
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| VERSION_URL.to_string());
     let text = fetch_text(&http, &url).await?;
@@ -456,17 +456,17 @@ async fn fetch_release_digest(
     version: &node_semver::Version,
     archive_name: &str,
 ) -> Option<[u8; 32]> {
-    let api_override = std::env::var("AUBE_SELF_API_BASE")
-        .ok()
+    let api_override = aube_util::env::embedder_env("SELF_API_BASE")
+        .and_then(|s| s.into_string().ok())
         .filter(|s| !s.trim().is_empty())
         .map(|s| s.trim_end_matches('/').to_string());
-    let host_override = std::env::var_os("AUBE_VERSIONS_HOST").is_some();
+    let host_override = aube_util::env::embedder_env("VERSIONS_HOST").is_some();
     // Custom download mirrors may serve different bytes than GitHub's
     // archives; digests describing GitHub's copies don't apply unless
     // a test override says otherwise.
     if api_override.is_none()
         && !host_override
-        && std::env::var_os("AUBE_SELF_DOWNLOAD_BASE").is_some()
+        && aube_util::env::embedder_env("SELF_DOWNLOAD_BASE").is_some()
     {
         return None;
     }

--- a/crates/aube-scripts/tests/user_agent_product.rs
+++ b/crates/aube-scripts/tests/user_agent_product.rs
@@ -19,6 +19,7 @@ static MYTOOL: Embedder = Embedder {
     workspace_yaml: Some("mytool-workspace.yaml"),
     manifest_namespace: "mytool",
     env_prefix: Some("MYTOOL"),
+    config_env_prefix: Some("MYTOOL"),
     cache_namespace: "mytool",
     data_namespace: "mytool",
     canonical_lockfile_always_wins: true,

--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -139,8 +139,9 @@ impl Store {
                 {
                     static O_TMPFILE_DISABLED: std::sync::OnceLock<bool> =
                         std::sync::OnceLock::new();
-                    let disabled = *O_TMPFILE_DISABLED
-                        .get_or_init(|| std::env::var_os("AUBE_DISABLE_O_TMPFILE").is_some());
+                    let disabled = *O_TMPFILE_DISABLED.get_or_init(|| {
+                        aube_util::env::embedder_env("DISABLE_O_TMPFILE").is_some()
+                    });
                     if !disabled {
                         match try_o_tmpfile_publish(path, bytes) {
                             Ok(outcome) => return Ok(outcome),
@@ -530,15 +531,20 @@ const CAS_SMALL_FILE_THRESHOLD_DEFAULT: usize = 64 * 1024;
 #[cfg(target_os = "linux")]
 fn cas_small_file_threshold() -> usize {
     static THRESHOLD: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *THRESHOLD.get_or_init(|| match std::env::var("AUBE_CAS_SMALL_FILE_THRESHOLD") {
-        Err(_) => CAS_SMALL_FILE_THRESHOLD_DEFAULT,
-        Ok(raw) => raw.parse::<usize>().unwrap_or_else(|_| {
-            warn!(
-                "AUBE_CAS_SMALL_FILE_THRESHOLD={raw:?} is not a non-negative integer; \
-                 falling back to default {CAS_SMALL_FILE_THRESHOLD_DEFAULT}"
-            );
-            CAS_SMALL_FILE_THRESHOLD_DEFAULT
-        }),
+    *THRESHOLD.get_or_init(|| {
+        match aube_util::env::embedder_env("CAS_SMALL_FILE_THRESHOLD")
+            .as_deref()
+            .map(|s| s.to_string_lossy().into_owned())
+        {
+            None => CAS_SMALL_FILE_THRESHOLD_DEFAULT,
+            Some(raw) => raw.parse::<usize>().unwrap_or_else(|_| {
+                warn!(
+                    "CAS_SMALL_FILE_THRESHOLD={raw:?} is not a non-negative integer; \
+                     falling back to default {CAS_SMALL_FILE_THRESHOLD_DEFAULT}"
+                );
+                CAS_SMALL_FILE_THRESHOLD_DEFAULT
+            }),
+        }
     })
 }
 

--- a/crates/aube-store/src/tarball.rs
+++ b/crates/aube-store/src/tarball.rs
@@ -131,8 +131,8 @@ impl Store {
          * regression debugging.
          */
         const PIPELINE_CHUNK_SIZE: usize = 64;
-        let pipelined_disabled = std::env::var_os("AUBE_DISABLE_PIPELINED_IMPORT").is_some();
-        let parallel_disabled = std::env::var_os("AUBE_DISABLE_PARALLEL_IMPORT").is_some();
+        let pipelined_disabled = aube_util::env::embedder_env("DISABLE_PIPELINED_IMPORT").is_some();
+        let parallel_disabled = aube_util::env::embedder_env("DISABLE_PARALLEL_IMPORT").is_some();
         let mut staged: Vec<(String, Vec<u8>, bool)> = Vec::new();
         let mut entries_seen: usize = 0;
         let mut total_uncompressed: u64 = 0;

--- a/crates/aube-util/src/adaptive.rs
+++ b/crates/aube-util/src/adaptive.rs
@@ -988,35 +988,35 @@ fn read_snapshot(path: &Path) -> Option<PersistedSnapshot> {
 
 /**
  * Default location for the global persistent adaptive state file.
- * Honors `XDG_CACHE_HOME` first, then falls back to
- * `~/.cache/aube/adaptive-state.json` on Linux,
- * `~/Library/Caches/aube/adaptive-state.json` on macOS, and
- * `%LOCALAPPDATA%\aube\adaptive-state.json` on Windows.
+ * Honors `XDG_CACHE_HOME` first, then falls back to `~/.cache`,
+ * `~/Library/Caches`, or `%LOCALAPPDATA%`. The cache namespace is the active
+ * embedder's `cache_namespace` (standalone aube → `"aube"`), not a literal.
  */
 pub fn default_persistent_state_path() -> Option<PathBuf> {
+    let ns = crate::embedder().cache_namespace;
     if let Ok(xdg) = std::env::var("XDG_CACHE_HOME")
         && !xdg.is_empty()
     {
-        return Some(PathBuf::from(xdg).join("aube").join("adaptive-state.json"));
+        return Some(PathBuf::from(xdg).join(ns).join("adaptive-state.json"));
     }
     if cfg!(windows) {
         std::env::var("LOCALAPPDATA")
             .ok()
             .filter(|s| !s.is_empty())
-            .map(|p| PathBuf::from(p).join("aube").join("adaptive-state.json"))
+            .map(|p| PathBuf::from(p).join(ns).join("adaptive-state.json"))
     } else if cfg!(target_os = "macos") {
         std::env::var("HOME").ok().map(|h| {
             PathBuf::from(h)
                 .join("Library")
                 .join("Caches")
-                .join("aube")
+                .join(ns)
                 .join("adaptive-state.json")
         })
     } else {
         std::env::var("HOME").ok().map(|h| {
             PathBuf::from(h)
                 .join(".cache")
-                .join("aube")
+                .join(ns)
                 .join("adaptive-state.json")
         })
     }

--- a/crates/aube-util/src/concurrency.rs
+++ b/crates/aube-util/src/concurrency.rs
@@ -1,31 +1,35 @@
 //! Concurrency configuration helpers shared across aube crates.
 //!
-//! Today this module exposes one thing: the
-//! `AUBE_CONCURRENCY=<N>` env override that lets users pin the
-//! tarball-fetch fan-out when the default 128 in-flight requests
-//! trigger 429/503 throttling on slow private registries
-//! (Artifactory, Nexus). The override is a knob, not a probe — when
-//! AIMD ramping lands it will live alongside the semaphore in
+//! Today this module exposes one thing: a first-class env override that
+//! lets users pin the tarball-fetch fan-out when the default 128
+//! in-flight requests trigger 429/503 throttling on slow private
+//! registries (Artifactory, Nexus). Read under the active embedder's
+//! config-env brand via [`config_env`](crate::env::config_env) — so it's
+//! `AUBE_CONCURRENCY` for standalone aube and `<BRAND>_CONCURRENCY` for an
+//! embedder with its own `config_env_prefix`, and the branded `AUBE_*`
+//! form is never read under such a host. The override is a knob, not a
+//! probe — when AIMD ramping lands it will live alongside the semaphore in
 //! `aube-registry::concurrency` (the layer that owns retry signals).
 //!
 //! Range-clamped to `[CONCURRENCY_FLOOR, CONCURRENCY_CEILING]` so a
 //! hostile or typo'd value can't exhaust file descriptors on Windows
 //! (default ulimit 8192).
 
-/// Lower bound on `AUBE_CONCURRENCY`. A degenerate slow link still
+/// Lower bound on the concurrency override. A degenerate slow link still
 /// makes progress with 8 in-flight fetches.
 pub const CONCURRENCY_FLOOR: u32 = 8;
 
-/// Upper bound on `AUBE_CONCURRENCY`. Picked so a pathological env
+/// Upper bound on the concurrency override. Picked so a pathological env
 /// value cannot exhaust the Windows default fd ulimit.
 pub const CONCURRENCY_CEILING: u32 = 256;
 
-/// Read `AUBE_CONCURRENCY` as a clamped integer override.
+/// Read the `{config_env_prefix}_CONCURRENCY` override (`AUBE_CONCURRENCY`
+/// under standalone aube) as a clamped integer.
 /// Returns `None` when the variable is unset, missing, or outside
 /// the range — callers fall back to the default (npmrc / setting /
 /// hard-coded). Out-of-range and non-numeric values warn.
 pub fn parse_concurrency_env() -> Option<u32> {
-    let raw = std::env::var_os("AUBE_CONCURRENCY")?;
+    let raw = crate::env::config_env("CONCURRENCY")?;
     if let Some(s) = raw.to_str()
         && let Ok(n) = s.parse::<u32>()
         && (CONCURRENCY_FLOOR..=CONCURRENCY_CEILING).contains(&n)
@@ -37,7 +41,7 @@ pub fn parse_concurrency_env() -> Option<u32> {
         value = ?raw,
         floor = CONCURRENCY_FLOOR,
         ceiling = CONCURRENCY_CEILING,
-        "AUBE_CONCURRENCY ignored: must be an integer in [floor, ceiling]; using default"
+        "concurrency override ignored: must be an integer in [floor, ceiling]; using default"
     );
     None
 }

--- a/crates/aube-util/src/diag.rs
+++ b/crates/aube-util/src/diag.rs
@@ -267,15 +267,16 @@ impl DiagConfig {
      * per-event log is the costly bit.
      */
     pub fn from_env() -> Option<Self> {
-        let file = std::env::var_os("AUBE_DIAG_FILE").map(PathBuf::from);
-        let print = std::env::var_os("AUBE_DIAG_PRINT").is_some();
-        let summary_env = std::env::var_os("AUBE_DIAG_SUMMARY").is_some();
-        let critpath_env = std::env::var_os("AUBE_DIAG_CRITPATH").is_some();
+        let file = crate::env::embedder_env("DIAG_FILE").map(PathBuf::from);
+        let print = crate::env::embedder_env("DIAG_PRINT").is_some();
+        let summary_env = crate::env::embedder_env("DIAG_SUMMARY").is_some();
+        let critpath_env = crate::env::embedder_env("DIAG_CRITPATH").is_some();
         if file.is_none() && !print && !summary_env && !critpath_env {
             return None;
         }
-        let threshold_ms = std::env::var("AUBE_DIAG_THRESHOLD_MS")
-            .ok()
+        let threshold_ms = crate::env::embedder_env("DIAG_THRESHOLD_MS")
+            .as_deref()
+            .and_then(|s| s.to_str())
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(0);
         Some(Self {

--- a/crates/aube-util/src/diag_kernel.rs
+++ b/crates/aube-util/src/diag_kernel.rs
@@ -84,7 +84,7 @@ pub fn snapshot() -> Option<KernelSnapshot> {
  * other platforms.
  */
 pub fn enabled() -> bool {
-    std::env::var_os("AUBE_DIAG_KERNEL").is_some() && snapshot().is_some()
+    crate::env::embedder_env("DIAG_KERNEL").is_some() && snapshot().is_some()
 }
 
 /**

--- a/crates/aube-util/src/env.rs
+++ b/crates/aube-util/src/env.rs
@@ -174,17 +174,32 @@ mod tests {
     /// registers a real non-aube profile in its own process.
     #[test]
     fn embedder_and_config_env_read_aube_prefixed_under_default_profile() {
+        // RAII guard so a panic in `f()` still restores the prior value —
+        // a bare restore-after-`f()` would leak the var on panic and flake
+        // the next serial test.
+        struct EnvGuard {
+            key: String,
+            prev: Option<std::ffi::OsString>,
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                // SAFETY: tests run serially via RUST_TEST_THREADS=1.
+                unsafe {
+                    match &self.prev {
+                        Some(v) => std::env::set_var(&self.key, v),
+                        None => std::env::remove_var(&self.key),
+                    }
+                }
+            }
+        }
         fn with_var<F: FnOnce()>(key: &str, value: &str, f: F) {
-            let prev = std::env::var_os(key);
+            let _guard = EnvGuard {
+                key: key.to_string(),
+                prev: std::env::var_os(key),
+            };
             // SAFETY: tests run serially via RUST_TEST_THREADS=1.
             unsafe { std::env::set_var(key, value) };
             f();
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
         }
 
         with_var("AUBE_DISABLE_CLONEDIR", "1", || {

--- a/crates/aube-util/src/env.rs
+++ b/crates/aube-util/src/env.rs
@@ -62,6 +62,43 @@ fn looks_branded(alias: &str) -> bool {
     }
 }
 
+/// Read a tool-prefixed *non-settings, non-user-facing* env toggle through the
+/// active embedder's [`env_prefix`](crate::identity::Embedder::env_prefix). For
+/// standalone aube (`Some("AUBE")`) `embedder_env("DISABLE_CLONEDIR")` reads
+/// `AUBE_DISABLE_CLONEDIR`; for an embedder with `env_prefix = None` (a host
+/// that exposes no branded debug surface) it reads nothing and returns `None`,
+/// so no branded debug/perf/diag toggle leaks under the embedding host's brand.
+///
+/// This is for the dev/debug/perf-bisect/diagnostic toggles that are NOT
+/// user-facing config — `AUBE_DISABLE_*`, `AUBE_DIAG_*`, `AUBE_CAS_*`,
+/// `AUBE_INTERNAL_*`, `AUBE_BENCH_*`, the self-update endpoints, … User-facing
+/// config knobs go through [`config_env`] instead, and settings-table branded
+/// aliases through [`branded_env_alias_enabled`]. Additive and no-op for
+/// standalone aube: an embedder that registers nothing reads exactly the
+/// `AUBE_*` forms it read before.
+pub fn embedder_env(suffix: &str) -> Option<std::ffi::OsString> {
+    let prefix = embedder().env_prefix?;
+    std::env::var_os(format!("{prefix}_{suffix}"))
+}
+
+/// Read one of the tool's *first-class config* env knobs through the active
+/// embedder's [`config_env_prefix`](crate::identity::Embedder::config_env_prefix).
+/// For standalone aube (`Some("AUBE")`) `config_env("CACHE_DIR")` reads
+/// `AUBE_CACHE_DIR`; for an embedder with `config_env_prefix = Some("NUB")` it
+/// reads `NUB_CACHE_DIR`. `None` reads nothing.
+///
+/// This is the deliberate, minimal exception to the debug-toggle gate: the
+/// handful of knobs a host legitimately wants under its OWN brand — the cache
+/// dir, the fetch concurrency — rather than hidden. Distinct from
+/// [`embedder_env`]: that family vanishes under an embedder with no
+/// `env_prefix`; this family follows the host's `config_env_prefix`, so a host
+/// reads its own brand for exactly these knobs and the branded `AUBE_*` form is
+/// never read under it.
+pub fn config_env(suffix: &str) -> Option<std::ffi::OsString> {
+    let prefix = embedder().config_env_prefix?;
+    std::env::var_os(format!("{prefix}_{suffix}"))
+}
+
 pub fn is_ci() -> bool {
     std::env::var_os("CI").is_some()
 }
@@ -120,6 +157,48 @@ mod tests {
         assert!(branded_env_alias_enabled("CI"));
         assert!(branded_env_alias_enabled("HTTP_PROXY"));
         assert!(branded_env_alias_enabled("NODE_OPTIONS"));
+    }
+
+    /// Under the default (AUBE) profile — `env_prefix = Some("AUBE")`,
+    /// `config_env_prefix = Some("AUBE")` — both helpers compose the prefix onto
+    /// the suffix and read the resulting `AUBE_*` var. This is the
+    /// standalone-neutrality contract: a binary that registers no profile reads
+    /// exactly the `AUBE_*` forms it read before the helpers existed. Tests run
+    /// serially (`RUST_TEST_THREADS=1`) and restore the prior value so they
+    /// don't bleed into the next test.
+    ///
+    /// The `None`-prefix branch (an embedder that hides a family → the helper
+    /// returns `None`) can't be exercised here without `set_embedder`, which
+    /// would flip the process-global fallback the default-profile tests rely on;
+    /// it's covered by the `embedder_env_brand_gate` integration test, which
+    /// registers a real non-aube profile in its own process.
+    #[test]
+    fn embedder_and_config_env_read_aube_prefixed_under_default_profile() {
+        fn with_var<F: FnOnce()>(key: &str, value: &str, f: F) {
+            let prev = std::env::var_os(key);
+            // SAFETY: tests run serially via RUST_TEST_THREADS=1.
+            unsafe { std::env::set_var(key, value) };
+            f();
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+
+        with_var("AUBE_DISABLE_CLONEDIR", "1", || {
+            assert_eq!(
+                embedder_env("DISABLE_CLONEDIR").as_deref(),
+                Some(std::ffi::OsStr::new("1")),
+            );
+        });
+        with_var("AUBE_CACHE_DIR", "/tmp/x", || {
+            assert_eq!(
+                config_env("CACHE_DIR").as_deref(),
+                Some(std::ffi::OsStr::new("/tmp/x")),
+            );
+        });
     }
 
     /// `looks_branded` separates the tool-branded `<UPPER>_<NAME>` shape from

--- a/crates/aube-util/src/hash.rs
+++ b/crates/aube-util/src/hash.rs
@@ -236,8 +236,10 @@ where
     *hasher.finalize().as_bytes()
 }
 
+/// Manifest fields, other than the tool's own namespace, that shape the
+/// install. The active embedder's `manifest_namespace` is folded in at the
+/// digest site (it sorts ahead of these for standalone aube → `"aube"`).
 pub const INSTALL_SHAPE_FIELDS: &[&str] = &[
-    "aube",
     "bundleDependencies",
     "bundledDependencies",
     "catalog",
@@ -264,8 +266,17 @@ pub fn manifest_install_shape_digest(manifest: &serde_json::Value) -> [u8; 32] {
     };
     let mut hasher = blake3::Hasher::new();
     hasher.update(b"aube-manifest-v1\n");
-    for field in INSTALL_SHAPE_FIELDS {
-        if let Some(v) = obj.get(*field) {
+    // The tool's own manifest namespace shapes the install too, but it's
+    // embedder-derived rather than fixed. Hash it ahead of the static fields
+    // so standalone aube (`manifest_namespace == "aube"`) reproduces the
+    // historical order; an embedder with no namespace (`""`) skips it, and a
+    // switch self-heals — the digest invalidates once, forcing one re-derive.
+    let namespace = crate::embedder().manifest_namespace;
+    let fields = std::iter::once(namespace)
+        .filter(|ns| !ns.is_empty())
+        .chain(INSTALL_SHAPE_FIELDS.iter().copied());
+    for field in fields {
+        if let Some(v) = obj.get(field) {
             hasher.update(field.as_bytes());
             hasher.update(b"=");
             canonical_json(v, &mut hasher);

--- a/crates/aube-util/src/hash.rs
+++ b/crates/aube-util/src/hash.rs
@@ -195,7 +195,7 @@ fn blake3_streaming(path: &Path, mut hasher: blake3::Hasher) -> io::Result<[u8; 
 }
 
 fn mmap_disabled() -> bool {
-    std::env::var_os("AUBE_DISABLE_MMAP_BLAKE3").is_some()
+    crate::env::embedder_env("DISABLE_MMAP_BLAKE3").is_some()
 }
 
 pub fn ordered_seq_hash<I, T>(iter: I) -> u64

--- a/crates/aube-util/src/http/prewarm.rs
+++ b/crates/aube-util/src/http/prewarm.rs
@@ -19,7 +19,7 @@ const PREWARM_TIMEOUT: Duration = Duration::from_secs(5);
 /// Returns true when the speculative TLS prewarm is disabled.
 #[inline]
 pub fn is_disabled() -> bool {
-    std::env::var_os("AUBE_DISABLE_SPECULATIVE_TLS").is_some()
+    crate::env::embedder_env("DISABLE_SPECULATIVE_TLS").is_some()
 }
 
 /// Spawn a fire-and-forget HEAD against each `(client, url)` pair on

--- a/crates/aube-util/src/http/race.rs
+++ b/crates/aube-util/src/http/race.rs
@@ -20,7 +20,7 @@ const DEFAULT_RACE_TIMEOUT: Duration = Duration::from_secs(10);
 /// Returns true when speculative request racing is disabled.
 #[inline]
 pub fn is_disabled() -> bool {
-    std::env::var_os("AUBE_DISABLE_REQUEST_RACING").is_some()
+    crate::env::embedder_env("DISABLE_REQUEST_RACING").is_some()
 }
 
 /// Race the given `(client, url)` candidates in parallel. The first

--- a/crates/aube-util/src/http/resolve.rs
+++ b/crates/aube-util/src/http/resolve.rs
@@ -20,7 +20,7 @@ const DEFAULT_RESOLVE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Returns true when DNS pre-resolution is disabled.
 #[inline]
 pub fn is_disabled() -> bool {
-    std::env::var_os("AUBE_DISABLE_DNS_PRERESOLVE").is_some()
+    crate::env::embedder_env("DISABLE_DNS_PRERESOLVE").is_some()
 }
 
 /// Pre-resolve `(host, port)` pairs in parallel via tokio's runtime,

--- a/crates/aube-util/src/http/ticket_cache.rs
+++ b/crates/aube-util/src/http/ticket_cache.rs
@@ -45,7 +45,7 @@ const FORMAT_MAGIC: &str = "aube-tls-tickets/v1";
 /// Returns true when the on-disk ticket cache is disabled.
 #[inline]
 pub fn is_disabled() -> bool {
-    std::env::var_os("AUBE_DISABLE_TLS_TICKET_CACHE").is_some()
+    crate::env::embedder_env("DISABLE_TLS_TICKET_CACHE").is_some()
 }
 
 /// One serialized ticket entry. `ticket` is opaque to this module —

--- a/crates/aube-util/src/identity.rs
+++ b/crates/aube-util/src/identity.rs
@@ -41,6 +41,10 @@ use std::sync::OnceLock;
 pub struct Embedder {
     /// Tool name, lowercase (e.g. `"aube"`). The proper noun users type and
     /// see in output, and the clap command name driving help/usage/errors.
+    /// Must be filesystem- and command-safe (no spaces, slashes, or shell
+    /// metacharacters); it is used verbatim in on-disk sidecar paths (e.g.
+    /// `.<name>_patch_state.json`, `.<name>-deploy-injected/`) and in command
+    /// invocations, so the embedder is responsible for supplying a safe slug.
     pub name: &'static str,
     /// High-visibility display name shown in the progress banner (e.g.
     /// `"aube"`). Usually equal to [`name`](Self::name); split out so an

--- a/crates/aube-util/src/identity.rs
+++ b/crates/aube-util/src/identity.rs
@@ -89,9 +89,26 @@ pub struct Embedder {
     /// manifest **root** as top-level `package.json` keys — never under a
     /// foreign brand's namespace, and never as a literal `""` key.
     pub manifest_namespace: &'static str,
-    /// Env-var prefix for tool-specific variables, e.g. `Some("AUBE")` →
-    /// `AUBE_*`. `None` means the tool reads no branded env family.
+    /// Env-var prefix for the tool's *internal* debug / diagnostic / perf-bisect
+    /// toggles, read through [`embedder_env`](crate::env::embedder_env), e.g.
+    /// `Some("AUBE")` → `AUBE_DISABLE_CLONEDIR`, `AUBE_DIAG_PRINT`, … `None`
+    /// means the tool exposes *no* branded debug-toggle family — every such
+    /// toggle is simply unreadable, so an embedding host's brand never sprouts a
+    /// dozen `<HOST>_DISABLE_*` perf switches. This gates the non-settings,
+    /// non-user-facing toggle family only; the few user-facing config knobs go
+    /// through [`config_env_prefix`](Self::config_env_prefix), and the settings
+    /// table's branded aliases go through
+    /// [`branded_env_alias_enabled`](crate::env::branded_env_alias_enabled).
     pub env_prefix: Option<&'static str>,
+    /// Env-var prefix for the tool's small set of *first-class config* knobs —
+    /// the cache dir and the fetch concurrency — read through
+    /// [`config_env`](crate::env::config_env), e.g. `Some("AUBE")` →
+    /// `AUBE_CACHE_DIR` / `AUBE_CONCURRENCY`, `Some("NUB")` → `NUB_CACHE_DIR` /
+    /// `NUB_CONCURRENCY`. Distinct from [`env_prefix`](Self::env_prefix): these
+    /// few knobs ARE legitimate config the host wants under its own brand,
+    /// whereas the debug toggles vanish under an embedder that hides them.
+    /// `None` reads no first-class config env.
+    pub config_env_prefix: Option<&'static str>,
     /// Leaf directory name under the OS cache root, e.g. `"aube"` →
     /// `<XDG_CACHE_HOME>/aube`.
     pub cache_namespace: &'static str,
@@ -139,6 +156,7 @@ pub const AUBE: Embedder = Embedder {
     workspace_yaml: Some("aube-workspace.yaml"),
     manifest_namespace: "aube",
     env_prefix: Some("AUBE"),
+    config_env_prefix: Some("AUBE"),
     cache_namespace: "aube",
     data_namespace: "aube",
     canonical_lockfile_always_wins: true,
@@ -227,6 +245,7 @@ mod tests {
         assert_eq!(id.workspace_yaml, Some("aube-workspace.yaml"));
         assert_eq!(id.manifest_namespace, "aube");
         assert_eq!(id.env_prefix, Some("AUBE"));
+        assert_eq!(id.config_env_prefix, Some("AUBE"));
         assert_eq!(id.cache_namespace, "aube");
         assert_eq!(id.data_namespace, "aube");
         assert!(id.canonical_lockfile_always_wins);

--- a/crates/aube-util/src/identity.rs
+++ b/crates/aube-util/src/identity.rs
@@ -218,6 +218,47 @@ pub fn embedder() -> &'static Embedder {
     ACTIVE.get().copied().unwrap_or(&AUBE)
 }
 
+/// The active tool's program name for *user-facing* output — the proper noun a
+/// user types and reads (e.g. `"aube"` under the default profile, the host's
+/// brand under an embedder).
+///
+/// This is the source-branding seam jdx approved over post-processing rendered
+/// output: instead of an embedder string-rewriting `"aube"` out of finished
+/// banners and error text, user-facing emission sites compose the program name
+/// at the source via `prog()` / [`cmd`], so a library consumer (nub) gets its
+/// own brand without any post-pass. Use it for bare program-name references in
+/// `miette!` / `bail!` / `eprintln!` / `println!` strings (banners, "re-exec
+/// into pinned {prog} version", …). For an `aube <verb>` command reference use
+/// [`cmd`] instead, which also brands the verb's program prefix.
+///
+/// Default-preserving: under the default [`AUBE`] profile this returns exactly
+/// `"aube"` byte-for-byte, so standalone aube's output is unchanged. Returns
+/// [`Embedder::name`] — the command-safe slug, matching what the clap command
+/// name and on-disk sidecars already use, so a user reads one consistent name.
+pub fn prog() -> &'static str {
+    embedder().name
+}
+
+/// A *user-facing* `"{prog} <verb>"` command reference, e.g. `cmd("install")`
+/// renders `"aube install"` under the default profile and `"nub install"` under
+/// a `nub`-branded embedder.
+///
+/// Use this wherever a user-facing `miette!` / `bail!` / `eprintln!` /
+/// `println!` string tells the user to run a command — `"run `{}` first"` with
+/// `cmd("install")`, `"`{}`: package has no script"` with `cmd("run")`, help
+/// hints, and so on — so the program prefix follows the active brand instead of
+/// being hardcoded to `aube`. The `verb` is the command spelling exactly as the
+/// CLI accepts it (`"install"`, `"patch-commit"`, `"store prune"`); it is not
+/// re-branded, only the leading program name is.
+///
+/// Default-preserving: under the default [`AUBE`] profile `cmd("install")` is
+/// exactly `"aube install"` byte-for-byte, so standalone aube's error and help
+/// text is unchanged. Allocates a `String`; for the bare program name with no
+/// verb use [`prog`], which borrows.
+pub fn cmd(verb: &str) -> String {
+    format!("{} {verb}", prog())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -252,5 +293,22 @@ mod tests {
         assert!(id.runtime_switching);
         assert!(id.self_engines_check);
         assert!(id.self_update_enabled);
+    }
+
+    /// Under the default (AUBE) profile the source-branding helpers reproduce
+    /// aube's hardcoded user-facing strings byte-for-byte: `prog()` is `"aube"`
+    /// and `cmd("install")` is `"aube install"`. This is the default-preserving
+    /// contract for the helpers jdx approved — converting a literal `"aube
+    /// install"` site to `cmd("install")` changes nothing for standalone aube.
+    /// (The non-aube branch — a host brand flowing through `prog`/`cmd` — is
+    /// covered by the `source_branding_brand_gate` integration test, which
+    /// registers a real profile in its own process; doing it here would flip
+    /// the process-global fallback the default-profile tests depend on.)
+    #[test]
+    fn prog_and_cmd_render_aube_under_default_profile() {
+        assert_eq!(prog(), "aube");
+        assert_eq!(cmd("install"), "aube install");
+        assert_eq!(cmd("patch-commit"), "aube patch-commit");
+        assert_eq!(cmd("store prune"), "aube store prune");
     }
 }

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -19,7 +19,7 @@ pub mod io;
 
 // Convenience re-exports so consumers can reference `aube_util::Embedder`
 // / `aube_util::embedder()` without naming the module.
-pub use identity::{AUBE, Embedder, embedder, set_embedder};
+pub use identity::{AUBE, Embedder, cmd, embedder, prog, set_embedder};
 pub mod path;
 pub mod pkg;
 pub mod snapshot;

--- a/crates/aube-util/src/snapshot.rs
+++ b/crates/aube-util/src/snapshot.rs
@@ -54,7 +54,7 @@ struct WalkState {
 }
 
 fn snapshots_disabled() -> bool {
-    std::env::var_os("AUBE_DISABLE_SNAPSHOTS").is_some()
+    crate::env::embedder_env("DISABLE_SNAPSHOTS").is_some()
 }
 
 fn walk(src: &Path, dst: &Path, state: &mut WalkState) -> io::Result<()> {

--- a/crates/aube-util/src/snapshot.rs
+++ b/crates/aube-util/src/snapshot.rs
@@ -3,8 +3,9 @@
 //! Portable per-file reflink walker. On CoW filesystems (APFS,
 //! btrfs, XFS-with-reflinks, ReFS) produces an O(extent-tree)
 //! snapshot via the `reflink-copy` crate; falls through to
-//! `std::fs::copy` per file otherwise. `AUBE_DISABLE_SNAPSHOTS=1`
-//! forces the buffered-copy path for byte-identity diffs.
+//! `std::fs::copy` per file otherwise. `<ENV_PREFIX>_DISABLE_SNAPSHOTS=1`
+//! (default profile: `AUBE_DISABLE_SNAPSHOTS=1`) forces the
+//! buffered-copy path for byte-identity diffs.
 
 use std::fs;
 use std::io;
@@ -28,7 +29,8 @@ pub enum SnapshotOutcome {
 /// target (relative or absolute, copied verbatim). Files use
 /// `reflink_or_copy`; directories are walked depth-first.
 ///
-/// `AUBE_DISABLE_SNAPSHOTS=1` forces every file through `fs::copy`
+/// `<ENV_PREFIX>_DISABLE_SNAPSHOTS=1` (default profile:
+/// `AUBE_DISABLE_SNAPSHOTS=1`) forces every file through `fs::copy`
 /// even when reflinks are available, for use as a regression
 /// killswitch.
 pub fn clone_tree(src: &Path, dst: &Path) -> io::Result<SnapshotOutcome> {

--- a/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -1,0 +1,92 @@
+//! Integration test for the env-prefix brand boundary under a nub-shaped
+//! embedder — `env_prefix = None` (no branded debug-toggle family) but
+//! `config_env_prefix = Some("NUB")` (the first-class config knobs read under
+//! the host's own brand).
+//!
+//! Lives in its own integration-test binary (= its own process) because the
+//! active `Embedder` is once-per-process (`set_embedder` is first-write-wins):
+//! registering a non-default profile here would flip the fallback the other
+//! crates' unit tests rely on. The default (AUBE) side — `embedder_env` /
+//! `config_env` reading `AUBE_*` — is covered by `aube-util`'s lib unit test
+//! `env::tests::embedder_and_config_env_read_aube_prefixed_under_default_profile`,
+//! which runs under the default profile in a different binary.
+
+use aube_util::Embedder;
+use aube_util::env::{config_env, embedder_env};
+
+/// A nub-shaped embedder: hides the branded debug-toggle family
+/// (`env_prefix = None`) but owns the first-class config knobs under its own
+/// brand (`config_env_prefix = Some("NUB")`).
+static NUBLIKE: Embedder = Embedder {
+    name: "nublike",
+    display_name: "nublike",
+    vendor: None,
+    version: "1.0.0",
+    user_agent: "nublike/1.0.0",
+    self_names: &["nublike"],
+    compatible_names: &["pnpm"],
+    lockfile_basename: "lock.yaml",
+    workspace_yaml: None,
+    manifest_namespace: "",
+    env_prefix: None,
+    config_env_prefix: Some("NUB"),
+    cache_namespace: "nublike",
+    data_namespace: "nublike",
+    canonical_lockfile_always_wins: false,
+    runtime_switching: false,
+    self_engines_check: false,
+    self_update_enabled: false,
+};
+
+/// Restore the previous value of an env var around a closure. Integration-test
+/// binaries are single-test here, but be a good citizen anyway.
+fn with_var<F: FnOnce()>(key: &str, value: &str, f: F) {
+    let prev = std::env::var_os(key);
+    // SAFETY: this binary runs one test, single-threaded.
+    unsafe { std::env::set_var(key, value) };
+    f();
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+}
+
+#[test]
+fn nub_profile_hides_debug_toggles_and_reads_nub_config() {
+    aube_util::set_embedder(&NUBLIKE);
+
+    // Debug-toggle family (`env_prefix = None`): a branded `AUBE_*` toggle is
+    // UNREADABLE under the nub-shaped profile — the brand never leaks. (And the
+    // profile exposes no `NUBLIKE_*` debug family either, since `env_prefix` is
+    // `None`, not `Some("NUB")`.)
+    with_var("AUBE_DISABLE_CLONEDIR", "1", || {
+        assert!(
+            embedder_env("DISABLE_CLONEDIR").is_none(),
+            "AUBE_DISABLE_CLONEDIR must be ignored under env_prefix = None"
+        );
+    });
+
+    // First-class config (`config_env_prefix = Some(\"NUB\")`): the `NUB_*`
+    // form is read, and the branded `AUBE_*` form is NOT — even when both are
+    // set in the environment, only the host's own brand wins.
+    with_var("NUB_CACHE_DIR", "/nub/cache", || {
+        with_var("AUBE_CACHE_DIR", "/aube/cache", || {
+            assert_eq!(
+                config_env("CACHE_DIR").as_deref(),
+                Some(std::ffi::OsStr::new("/nub/cache")),
+                "config_env must read NUB_CACHE_DIR and ignore AUBE_CACHE_DIR under nub"
+            );
+        });
+    });
+
+    // The same first-class knob, with ONLY the branded `AUBE_*` form set, must
+    // read nothing under nub — the AUBE brand is fully off nub's surface.
+    with_var("AUBE_CONCURRENCY", "32", || {
+        assert!(
+            config_env("CONCURRENCY").is_none(),
+            "AUBE_CONCURRENCY must be ignored under config_env_prefix = Some(\"NUB\")"
+        );
+    });
+}

--- a/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -1,0 +1,59 @@
+//! Integration test for the source-branding helpers (`prog` / `cmd`) under a
+//! non-aube embedder. These are the helpers jdx approved over post-processing
+//! rendered output: a user-facing string composes the program name at the
+//! source, so a library consumer (nub) gets its own brand in errors/banners
+//! without any post-pass.
+//!
+//! Lives in its own integration-test binary (= its own process) because the
+//! active `Embedder` is once-per-process (`set_embedder` is first-write-wins):
+//! registering a non-default profile here would flip the fallback the other
+//! crates' unit tests rely on. The default (AUBE) side — `prog()` == `"aube"`,
+//! `cmd("install")` == `"aube install"` — is covered by `aube-util`'s lib unit
+//! test `identity::tests::prog_and_cmd_render_aube_under_default_profile`,
+//! which runs under the default profile in a different binary.
+
+use aube_util::{Embedder, cmd, prog};
+
+/// A nub-shaped embedder: its own brand name flows through the source-branding
+/// helpers.
+static NUBLIKE: Embedder = Embedder {
+    name: "nublike",
+    display_name: "nublike",
+    vendor: None,
+    version: "1.0.0",
+    user_agent: "nublike/1.0.0",
+    self_names: &["nublike"],
+    compatible_names: &["pnpm"],
+    lockfile_basename: "lock.yaml",
+    workspace_yaml: None,
+    manifest_namespace: "",
+    env_prefix: None,
+    config_env_prefix: Some("NUB"),
+    cache_namespace: "nublike",
+    data_namespace: "nublike",
+    canonical_lockfile_always_wins: false,
+    runtime_switching: false,
+    self_engines_check: false,
+    self_update_enabled: false,
+};
+
+#[test]
+fn prog_and_cmd_follow_the_embedder_brand() {
+    aube_util::set_embedder(&NUBLIKE);
+
+    // The bare program name is the host's brand, not "aube".
+    assert_eq!(prog(), "nublike");
+
+    // A command reference brands the program prefix and leaves the verb verbatim
+    // — so a user under the nub-shaped embedder is told to run the host command,
+    // never `aube install`.
+    assert_eq!(cmd("install"), "nublike install");
+    assert_eq!(cmd("patch-commit"), "nublike patch-commit");
+    assert_eq!(cmd("store prune"), "nublike store prune");
+
+    // No "aube" leaks through the composed command reference.
+    assert!(
+        !cmd("install").contains("aube"),
+        "a user-facing command reference must carry the host brand, not aube"
+    );
+}

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -724,7 +724,8 @@ async fn downloads_gate(
         if !prompt_continue(name, weekly, threshold)? {
             return Err(miette!(
                 code = ERR_AUBE_LOW_DOWNLOAD_PACKAGE,
-                "user aborted `aube add {name}`"
+                "user aborted `{} {name}`",
+                aube_util::cmd("add")
             ));
         }
     }

--- a/crates/aube/src/commands/approve_builds.rs
+++ b/crates/aube/src/commands/approve_builds.rs
@@ -137,7 +137,8 @@ fn run_global(args: ApproveBuildsArgs) -> miette::Result<()> {
 
     println!("Approved {approved} package(s) across {written_dirs} global install(s).");
     println!(
-        "Run `{} -C <global-install-dir> install` (or `rebuild`) to execute their scripts.",
+        "Run `{} -C <global-install-dir> install` (or `{} -C <global-install-dir> rebuild`) to execute their scripts.",
+        aube_util::prog(),
         aube_util::prog()
     );
     Ok(())

--- a/crates/aube/src/commands/approve_builds.rs
+++ b/crates/aube/src/commands/approve_builds.rs
@@ -73,7 +73,11 @@ fn run_project(cwd: &Path, all: bool, packages: Vec<String>) -> miette::Result<(
     for name in &selected {
         println!("  {name}");
     }
-    println!("Run `aube install` (or `aube rebuild`) to execute their scripts.");
+    println!(
+        "Run `{}` (or `{}`) to execute their scripts.",
+        aube_util::cmd("install"),
+        aube_util::cmd("rebuild")
+    );
     Ok(())
 }
 
@@ -132,7 +136,10 @@ fn run_global(args: ApproveBuildsArgs) -> miette::Result<()> {
     }
 
     println!("Approved {approved} package(s) across {written_dirs} global install(s).");
-    println!("Run `aube -C <global-install-dir> install` (or `rebuild`) to execute their scripts.");
+    println!(
+        "Run `{} -C <global-install-dir> install` (or `rebuild`) to execute their scripts.",
+        aube_util::prog()
+    );
     Ok(())
 }
 
@@ -158,8 +165,9 @@ fn select_project(
             .collect();
         if !unknown.is_empty() {
             return Err(miette!(
-                "not in the ignored-builds set: {}. Run `aube ignored-builds` to see candidates.",
-                unknown.join(", ")
+                "not in the ignored-builds set: {}. Run `{}` to see candidates.",
+                unknown.join(", "),
+                aube_util::cmd("ignored-builds")
             ));
         }
         return Ok(dedupe(packages));
@@ -215,8 +223,9 @@ fn select_global_packages(
         .collect();
     if !unknown.is_empty() {
         return Err(miette!(
-            "not in the ignored-builds set: {}. Run `aube ignored-builds -g` to see candidates.",
-            unknown.join(", ")
+            "not in the ignored-builds set: {}. Run `{} -g` to see candidates.",
+            unknown.join(", "),
+            aube_util::cmd("ignored-builds")
         ));
     }
 

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -146,7 +146,11 @@ pub async fn run(args: AuditArgs) -> miette::Result<()> {
     let graph = super::load_graph(
         &cwd,
         &manifest,
-        "no lockfile found — run `aube install` before `aube audit`",
+        &format!(
+            "no lockfile found — run `{}` before `{}`",
+            aube_util::cmd("install"),
+            aube_util::cmd("audit")
+        ),
     )?;
 
     let filter = DepFilter::from_flags(args.prod, args.dev);

--- a/crates/aube/src/commands/auto_install.rs
+++ b/crates/aube/src/commands/auto_install.rs
@@ -72,7 +72,9 @@ pub(crate) async fn ensure_installed(no_install: bool) -> miette::Result<()> {
         }
         VerifyDepsBeforeRun::Error => {
             return Err(miette!(
-                "dependencies need install before run: {reason}\nRun `aube install`, or set verifyDepsBeforeRun=install to let aube do it automatically."
+                "dependencies need install before run: {reason}\nRun `{}`, or set verifyDepsBeforeRun=install to let {} do it automatically.",
+                aube_util::cmd("install"),
+                aube_util::prog()
             ));
         }
         VerifyDepsBeforeRun::Install => {}

--- a/crates/aube/src/commands/cache.rs
+++ b/crates/aube/src/commands/cache.rs
@@ -269,9 +269,11 @@ fn view(args: ViewArgs) -> miette::Result<()> {
 
     if !found {
         return Err(miette!(
-            "no cached metadata for `{}`\nhelp: run `aube view {}` or `aube install` first to populate the cache",
+            "no cached metadata for `{}`\nhelp: run `{} {}` or `{}` first to populate the cache",
             args.name,
+            aube_util::cmd("view"),
             args.name,
+            aube_util::cmd("install"),
         ));
     }
     Ok(())

--- a/crates/aube/src/commands/cat_file.rs
+++ b/crates/aube/src/commands/cat_file.rs
@@ -53,8 +53,9 @@ pub async fn run(args: CatFileArgs) -> miette::Result<()> {
 
     if !path.exists() {
         return Err(miette!(
-            "no file with hash {} in store\nhelp: install the owning package first, or check the hash against `aube store path`",
-            args.hash
+            "no file with hash {} in store\nhelp: install the owning package first, or check the hash against `{}`",
+            args.hash,
+            aube_util::cmd("store path")
         ));
     }
 

--- a/crates/aube/src/commands/cat_index.rs
+++ b/crates/aube/src/commands/cat_index.rs
@@ -72,7 +72,9 @@ pub async fn run(args: CatIndexArgs) -> miette::Result<()> {
     let index_path = match matches.as_slice() {
         [] => {
             return Err(miette!(
-                "no cached index for {name}@{version}\nhelp: run `aube fetch` or `aube install` to populate the store first"
+                "no cached index for {name}@{version}\nhelp: run `{}` or `{}` to populate the store first",
+                aube_util::cmd("fetch"),
+                aube_util::cmd("install")
             ));
         }
         [p] => p.clone(),
@@ -90,9 +92,10 @@ pub async fn run(args: CatIndexArgs) -> miette::Result<()> {
                 msg.push_str(&p.display().to_string());
                 msg.push('\n');
             }
-            msg.push_str(
-                "help: read the specific file directly, or re-run `aube fetch` in the project whose tarball you want.",
-            );
+            msg.push_str(&format!(
+                "help: read the specific file directly, or re-run `{}` in the project whose tarball you want.",
+                aube_util::cmd("fetch")
+            ));
             return Err(miette!("{msg}"));
         }
     };
@@ -102,7 +105,8 @@ pub async fn run(args: CatIndexArgs) -> miette::Result<()> {
         .into_diagnostic()
         .map_err(|e| {
             miette!(
-                "cached index for {name}@{version} is corrupt: {e}\nhelp: re-run `aube fetch` to regenerate it"
+                "cached index for {name}@{version} is corrupt: {e}\nhelp: re-run `{}` to regenerate it",
+                aube_util::cmd("fetch")
             )
         })?;
 

--- a/crates/aube/src/commands/completion.rs
+++ b/crates/aube/src/commands/completion.rs
@@ -9,14 +9,17 @@ pub struct CompletionArgs {
 }
 
 pub async fn run(args: CompletionArgs) -> Result<()> {
+    // Command name from the active embedder (standalone aube → "aube").
+    let name = aube_util::embedder().name;
+    let usage_cmd = format!("{name} usage");
     let output = Command::new("usage")
         .args([
             "g",
             "completion",
             &args.shell,
-            "aube",
+            name,
             "--usage-cmd",
-            "aube usage",
+            &usage_cmd,
             "--cache-key",
             env!("CARGO_PKG_VERSION"),
         ])

--- a/crates/aube/src/commands/config/aube_config.rs
+++ b/crates/aube/src/commands/config/aube_config.rs
@@ -69,7 +69,7 @@ impl AubeConfigEdit {
     pub(super) fn save(&self, path: &Path) -> miette::Result<()> {
         let out = toml::to_string_pretty(&self.table)
             .into_diagnostic()
-            .wrap_err("failed to serialize aube config")?;
+            .wrap_err(format!("failed to serialize {} config", aube_util::prog()))?;
         // Follow symlinks so a user-managed `~/.config/aube/config.toml`
         // pointing at e.g. a dotfiles repo keeps its symlink intact;
         // atomic_write renames a sibling temp over the path, which
@@ -86,7 +86,10 @@ pub(crate) fn user_aube_config_path() -> miette::Result<PathBuf> {
         return Ok(dir.join("aube").join("config.toml"));
     }
     let home = aube_util::env::home_dir().ok_or_else(|| {
-        miette!("could not locate home directory. set HOME or USERPROFILE to point at aube config")
+        miette!(
+            "could not locate home directory. set HOME or USERPROFILE to point at {} config",
+            aube_util::prog()
+        )
     })?;
     Ok(home.join(".config").join("aube").join("config.toml"))
 }

--- a/crates/aube/src/commands/config/aube_config.rs
+++ b/crates/aube/src/commands/config/aube_config.rs
@@ -118,7 +118,11 @@ fn load_entries_at(path: &Path) -> Vec<(String, String)> {
     match AubeConfigEdit::load(path) {
         Ok(edit) => edit.entries(),
         Err(err) => {
-            tracing::warn!("failed to load aube config at {}: {err}", path.display());
+            tracing::warn!(
+                "failed to load {} config at {}: {err}",
+                aube_util::prog(),
+                path.display()
+            );
             Vec::new()
         }
     }

--- a/crates/aube/src/commands/config/delete.rs
+++ b/crates/aube/src/commands/config/delete.rs
@@ -104,8 +104,9 @@ pub fn run(args: DeleteArgs) -> miette::Result<()> {
             ));
         }
         return Err(miette!(
-            "{} not set in aube config or {}",
+            "{} not set in {} config or {}",
             args.key,
+            aube_util::prog(),
             npmrc_path.display()
         ));
     }
@@ -146,8 +147,10 @@ fn try_delete_aube_map_entry(key: &str, location: Location) -> miette::Result<Op
 
     if !matches!(location, Location::Project) {
         return Err(miette!(
-            "`{key}` only applies at project scope: `{prefix}` is read from `pnpm-workspace.yaml` / `package.json#<pnpm|aube>.{prefix}`, not user-scope aube config.\n\
-             use `aube config delete --local {prefix}.{entry}` to remove it from the project workspace yaml / `package.json`.",
+            "`{key}` only applies at project scope: `{prefix}` is read from `pnpm-workspace.yaml` / `package.json#<pnpm|aube>.{prefix}`, not user-scope {} config.\n\
+             use `{} --local {prefix}.{entry}` to remove it from the project workspace yaml / `package.json`.",
+            aube_util::prog(),
+            aube_util::cmd("config delete"),
         ));
     }
 
@@ -185,9 +188,10 @@ fn missing_aube_key_error(
             "{key} is not set in {} but an entry exists in {}.\n\
              aube doesn't modify `.npmrc` for aube-only settings (it's shared with \
              npm/pnpm/yarn) — edit that file directly to remove it, or run \
-             `aube config set {key} <value>` to override it from {}.",
+             `{} {key} <value>` to override it from {}.",
             config_path.display(),
             npmrc_path.display(),
+            aube_util::cmd("config set"),
             config_path.display(),
         );
     }

--- a/crates/aube/src/commands/config/explain.rs
+++ b/crates/aube/src/commands/config/explain.rs
@@ -11,8 +11,9 @@ pub struct ExplainArgs {
 pub fn run(args: ExplainArgs) -> miette::Result<()> {
     let Some(meta) = setting_for_key(&args.key) else {
         return Err(miette!(
-            "unknown setting `{}`; try `aube config find <words>`",
-            args.key
+            "unknown setting `{}`; try `{} <words>`",
+            args.key,
+            aube_util::cmd("config find")
         ));
     };
 

--- a/crates/aube/src/commands/config/mod.rs
+++ b/crates/aube/src/commands/config/mod.rs
@@ -165,7 +165,11 @@ pub async fn run(args: ConfigArgs) -> miette::Result<()> {
 fn reject_parent_list_args(args: &list::ListArgs, subcommand: &str) -> miette::Result<()> {
     if args.has_parent_overrides() {
         Err(miette!(
-            "`aube config` list flags must be used with `aube config` or `aube config list`, not `aube config {subcommand}`"
+            "`{}` list flags must be used with `{}` or `{}`, not `{} {subcommand}`",
+            aube_util::cmd("config"),
+            aube_util::cmd("config"),
+            aube_util::cmd("config list"),
+            aube_util::cmd("config")
         ))
     } else {
         Ok(())
@@ -178,7 +182,8 @@ mod tui {
 
     pub fn run() -> miette::Result<()> {
         Err(miette!(
-            "`aube config tui` was not enabled in this build; rebuild with the `config-tui` feature"
+            "`{}` was not enabled in this build; rebuild with the `config-tui` feature",
+            aube_util::cmd("config tui")
         ))
     }
 }

--- a/crates/aube/src/commands/config/set.rs
+++ b/crates/aube/src/commands/config/set.rs
@@ -163,9 +163,11 @@ fn try_set_aube_map_entry(
         return Err(miette!(
             code = aube_codes::errors::ERR_AUBE_CONFIG_NESTED_AUBE_KEY,
             help = format!(
-                "use `aube config set --local {prefix}.{entry} {value}` to edit `pnpm-workspace.yaml#{prefix}.{entry}` (or `package.json#aube.{prefix}.{entry}` if no workspace yaml exists). Aube doesn't read user-scope `{prefix}` today.",
+                "use `{} --local {prefix}.{entry} {value}` to edit `pnpm-workspace.yaml#{prefix}.{entry}` (or `package.json#aube.{prefix}.{entry}` if no workspace yaml exists). Aube doesn't read user-scope `{prefix}` today.",
+                aube_util::cmd("config set"),
             ),
-            "`{key}` only applies at project scope: `{prefix}` is read from `pnpm-workspace.yaml` / `package.json#<pnpm|aube>.{prefix}`, not user-scope aube config."
+            "`{key}` only applies at project scope: `{prefix}` is read from `pnpm-workspace.yaml` / `package.json#<pnpm|aube>.{prefix}`, not user-scope {} config.",
+            aube_util::prog()
         ));
     }
 
@@ -253,7 +255,8 @@ fn reject_aube_map_key(key: &str, meta: &aube_settings::meta::SettingMeta) -> mi
     miette!(
         code = aube_codes::errors::ERR_AUBE_CONFIG_NESTED_AUBE_KEY,
         help = format!(
-            "set a single entry with `aube config set --local {key}.<entry> <value>`, or edit `{key}:` directly in `pnpm-workspace.yaml` / `aube.{key}` in `package.json`.",
+            "set a single entry with `{} --local {key}.<entry> <value>`, or edit `{key}:` directly in `pnpm-workspace.yaml` / `aube.{key}` in `package.json`.",
+            aube_util::cmd("config set"),
         ),
         "`{key}` is an aube map setting (type `{}`) and can't be set as a single scalar — set one entry at a time, or edit the map structurally.",
         meta.type_,
@@ -320,8 +323,11 @@ fn reject_scalar_nested_key(key: &str) -> miette::Result<()> {
     Err(miette!(
         code = aube_codes::errors::ERR_AUBE_CONFIG_NESTED_AUBE_KEY,
         help = format!(
-            "`{}` is type `{}` — set it directly with `aube config set {} <value>`.",
-            meta.name, meta.type_, meta.name,
+            "`{}` is type `{}` — set it directly with `{} {} <value>`.",
+            meta.name,
+            meta.type_,
+            aube_util::cmd("config set"),
+            meta.name,
         ),
         "`{key}` is not a writable config key: `{}` is a scalar aube setting and has no nested namespace.",
         meta.name,

--- a/crates/aube/src/commands/config/tui.rs
+++ b/crates/aube/src/commands/config/tui.rs
@@ -204,7 +204,8 @@ impl ConfigTui {
 pub fn run() -> miette::Result<()> {
     if !io::stdout().is_terminal() {
         return Err(miette!(
-            "`aube config tui` requires an interactive terminal"
+            "`{}` requires an interactive terminal",
+            aube_util::cmd("config tui")
         ));
     }
 
@@ -729,8 +730,11 @@ fn edit_target(meta: &settings_meta::SettingMeta) -> Option<EditTarget> {
 fn edit_unavailable_message(meta: &settings_meta::SettingMeta) -> String {
     if !is_tui_editable_type(meta.type_) {
         return format!(
-            "`{}` uses `{}` values, which this TUI editor cannot write yet. Use `aube config explain {}` for the accepted shape, then edit the config file manually.",
-            meta.name, meta.type_, meta.name
+            "`{}` uses `{}` values, which this TUI editor cannot write yet. Use `{} {}` for the accepted shape, then edit the config file manually.",
+            meta.name,
+            meta.type_,
+            aube_util::cmd("config explain"),
+            meta.name
         );
     }
 
@@ -743,15 +747,18 @@ fn edit_unavailable_message(meta: &settings_meta::SettingMeta) -> String {
     }
     if !meta.npmrc_keys.is_empty() || !meta.workspace_yaml_keys.is_empty() {
         actions.push(format!(
-            "run `aube config explain {}` to see the supported config-file keys",
+            "run `{} {}` to see the supported config-file keys",
+            aube_util::cmd("config explain"),
             meta.name
         ));
     }
 
     if actions.is_empty() {
         format!(
-            "`{}` has no writable .npmrc or workspace YAML key. Run `aube config explain {}` to see where it can be set.",
-            meta.name, meta.name
+            "`{}` has no writable .npmrc or workspace YAML key. Run `{} {}` to see where it can be set.",
+            meta.name,
+            aube_util::cmd("config explain"),
+            meta.name
         )
     } else {
         format!(

--- a/crates/aube/src/commands/deploy/injection.rs
+++ b/crates/aube/src/commands/deploy/injection.rs
@@ -56,7 +56,10 @@ pub(super) fn plan_injections(
     ws_index: &BTreeMap<String, (PathBuf, Option<String>)>,
     args: &DeployArgs,
 ) -> miette::Result<InjectionPlan> {
-    let injected_root = target_root.join(".aube-deploy-injected");
+    // Injected-deps staging leaf from the active embedder's name:
+    // `.<name>-deploy-injected`. Standalone aube → `.aube-deploy-injected`.
+    let injected_root =
+        target_root.join(format!(".{}-deploy-injected", aube_util::embedder().name));
     let mut plan: InjectionPlan = BTreeMap::new();
     // Track id collisions so a second sibling with the same encoded
     // name gets a `_2`, `_3`, ... suffix. Keyed by the encoded id.

--- a/crates/aube/src/commands/deploy/injection.rs
+++ b/crates/aube/src/commands/deploy/injection.rs
@@ -2,7 +2,8 @@
 //!
 //! Workspace siblings + `file:` / `link:` / `portal:` targets reachable
 //! from the deployed package land at
-//! `<target>/.aube-deploy-injected/<id>/`. [`plan_injections`] BFS-walks
+//! `<target>/.<name>-deploy-injected/<id>/` (derived from the embedder name;
+//! standalone aube: `<target>/.aube-deploy-injected/<id>/`). [`plan_injections`] BFS-walks
 //! the deployed manifest plus every bundled sibling's manifest, records
 //! one [`Injection`] per distinct local-ref target,
 //! [`materialize_injections`] copies the bytes, and the rewrite layer
@@ -17,7 +18,8 @@ use std::collections::{BTreeMap, VecDeque};
 use std::path::{Path, PathBuf};
 
 /// Where a bundled local ref ends up under
-/// `<target>/.aube-deploy-injected/`. Distinct sources with distinct
+/// `<target>/.<name>-deploy-injected/` (derived from the embedder name;
+/// standalone aube: `.aube-deploy-injected/`). Distinct sources with distinct
 /// canonical paths each get their own entry — siblings shared between
 /// multiple parents bundle once.
 #[derive(Debug, Clone)]
@@ -66,7 +68,7 @@ pub(super) fn plan_injections(
     let mut used_ids: BTreeMap<String, u32> = BTreeMap::new();
     // Don't bundle the deployed package itself: a sibling B with a
     // back-dep `"@deployed-pkg": "workspace:*"` would otherwise duplicate
-    // the deploy root under `.aube-deploy-injected/` and break runtime
+    // the deploy root under the injected-deps dir and break runtime
     // singleton assumptions (two distinct module instances). The
     // rewriter handles back-refs separately.
     let deployed_canonical = super::canonicalize(deployed_pkg_dir);
@@ -213,10 +215,11 @@ fn iter_strippable_deps(manifest: &PackageJson, strip: StripFields) -> Vec<(Stri
     out
 }
 
-/// Pick a filesystem-safe id under `.aube-deploy-injected/`. Starts
-/// from `seed` (with `/` and any other unsafe characters sanitized) and
-/// disambiguates collisions with `_2`, `_3`, ... — collisions are rare
-/// and the suffix keeps the staged path readable when debugging.
+/// Pick a filesystem-safe id under the `.<name>-deploy-injected/` dir
+/// (standalone aube: `.aube-deploy-injected/`). Starts from `seed` (with `/`
+/// and any other unsafe characters sanitized) and disambiguates collisions with
+/// `_2`, `_3`, ... — collisions are rare and the suffix keeps the staged path
+/// readable when debugging.
 fn unique_id(seed: &str, used: &mut BTreeMap<String, u32>) -> String {
     let cleaned: String = seed
         .chars()

--- a/crates/aube/src/commands/deploy/injection.rs
+++ b/crates/aube/src/commands/deploy/injection.rs
@@ -91,7 +91,8 @@ pub(super) fn plan_injections(
             if aube_util::pkg::is_workspace_spec(&dep_spec) {
                 let Some((sibling_dir, _)) = ws_index.get(&dep_name) else {
                     return Err(miette!(
-                        "aube deploy: {} declares `{dep_name}: {dep_spec}` but no workspace package named {dep_name:?} was found",
+                        "{}: {} declares `{dep_name}: {dep_spec}` but no workspace package named {dep_name:?} was found",
+                        aube_util::cmd("deploy"),
                         manifest_path.display()
                     ));
                 };

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -130,7 +130,8 @@ pub async fn run(
     args.virtual_store.install_overrides();
     if filter.is_empty() {
         return Err(miette!(
-            "aube deploy: --filter/-F is required to pick a workspace package"
+            "{}: --filter/-F is required to pick a workspace package",
+            aube_util::cmd("deploy")
         ));
     }
     let source_root = crate::dirs::cwd().wrap_err("failed to read current directory")?;
@@ -163,8 +164,9 @@ pub async fn run(
         .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
     if workspace_pkgs.is_empty() {
         return Err(miette!(
-            "aube deploy: no workspace packages found. \
+            "{}: no workspace packages found. \
              `deploy` requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at {}",
+            aube_util::cmd("deploy"),
             source_root.display()
         ));
     }
@@ -192,7 +194,8 @@ pub async fn run(
     if matches.is_empty() {
         let names: Vec<&str> = ws_index.keys().map(String::as_str).collect();
         return Err(miette!(
-            "aube deploy: --filter {:?} did not match any workspace package. Known: {}",
+            "{}: --filter {:?} did not match any workspace package. Known: {}",
+            aube_util::cmd("deploy"),
             filter,
             names.join(", ")
         ));
@@ -229,14 +232,16 @@ pub async fn run(
                 .map(str::to_string)
                 .ok_or_else(|| {
                     miette!(
-                        "aube deploy: workspace package {} has no directory name",
+                        "{}: workspace package {} has no directory name",
+                        aube_util::cmd("deploy"),
                         src.display()
                     )
                 })?;
             if let Some(prev) = used.insert(base.clone(), name.clone()) {
                 return Err(miette!(
-                    "aube deploy: workspace packages {prev:?} and {name:?} both live in a directory named {base:?}; \
-                     multi-package deploy uses the source basename as the target subdir, so these would collide"
+                    "{}: workspace packages {prev:?} and {name:?} both live in a directory named {base:?}; \
+                     multi-package deploy uses the source basename as the target subdir, so these would collide",
+                    aube_util::cmd("deploy")
                 ));
             }
             v.push((name, src, target_root.join(&base)));

--- a/crates/aube/src/commands/deploy/rewrite.rs
+++ b/crates/aube/src/commands/deploy/rewrite.rs
@@ -67,28 +67,32 @@ fn resolve_catalog_for_rewrite(
         .map(|n| if n.is_empty() { "default" } else { n })
         .ok_or_else(|| {
             miette!(
-                "aube deploy: internal error — resolve_catalog_for_rewrite called on non-catalog spec {spec:?}"
+                "{}: internal error — resolve_catalog_for_rewrite called on non-catalog spec {spec:?}",
+                aube_util::cmd("deploy")
             )
         })?;
     let Some(catalog) = catalogs.get(catalog_name) else {
         return Err(miette!(
             code = aube_codes::errors::ERR_AUBE_UNKNOWN_CATALOG,
             help = "define the catalog in `pnpm-workspace.yaml` or under `pnpm.catalog` / `workspaces.catalog` in `package.json`",
-            "aube deploy: {} declares `{pkg_name}: {spec}` but catalog `{catalog_name}` is not defined in the source workspace",
+            "{}: {} declares `{pkg_name}: {spec}` but catalog `{catalog_name}` is not defined in the source workspace",
+            aube_util::cmd("deploy"),
             manifest_path.display(),
         ));
     };
     let Some(value) = catalog.get(pkg_name) else {
         return Err(miette!(
             code = aube_codes::errors::ERR_AUBE_UNKNOWN_CATALOG_ENTRY,
-            "aube deploy: {} declares `{pkg_name}: {spec}` but catalog `{catalog_name}` has no entry for {pkg_name:?}",
+            "{}: {} declares `{pkg_name}: {spec}` but catalog `{catalog_name}` has no entry for {pkg_name:?}",
+            aube_util::cmd("deploy"),
             manifest_path.display(),
         ));
     };
     if aube_util::pkg::is_catalog_spec(value) {
         return Err(miette!(
             code = aube_codes::errors::ERR_AUBE_UNKNOWN_CATALOG_ENTRY,
-            "aube deploy: catalog `{catalog_name}` entry for {pkg_name:?} is itself a catalog reference ({value:?}); catalogs cannot chain",
+            "{}: catalog `{catalog_name}` entry for {pkg_name:?} is itself a catalog reference ({value:?}); catalogs cannot chain",
+            aube_util::cmd("deploy"),
         ));
     }
     Ok(value.clone())
@@ -190,7 +194,8 @@ pub(super) fn rewrite_local_refs(
             if aube_util::pkg::is_workspace_spec(spec) {
                 let Some((sibling_dir, sibling_version)) = ws_index.get(name) else {
                     return Err(miette!(
-                        "aube deploy: {} declares `{name}: {spec}` but no workspace package named {name:?} was found",
+                        "{}: {} declares `{name}: {spec}` but no workspace package named {name:?} was found",
+                        aube_util::cmd("deploy"),
                         manifest_path.display()
                     ));
                 };
@@ -216,7 +221,8 @@ pub(super) fn rewrite_local_refs(
                     if *field == "peerDependencies" {
                         let Some(sibling_version) = sibling_version else {
                             return Err(miette!(
-                                "aube deploy: workspace package {name:?} has no `version` field, required to rewrite `{name}: {spec}` in {}",
+                                "{}: workspace package {name:?} has no `version` field, required to rewrite `{name}: {spec}` in {}",
+                                aube_util::cmd("deploy"),
                                 manifest_path.display()
                             ));
                         };
@@ -227,7 +233,8 @@ pub(super) fn rewrite_local_refs(
                         continue;
                     }
                     return Err(miette!(
-                        "aube deploy: bundling plan missing entry for workspace sibling {name:?} declared in {}",
+                        "{}: bundling plan missing entry for workspace sibling {name:?} declared in {}",
+                        aube_util::cmd("deploy"),
                         manifest_path.display()
                     ));
                 };
@@ -261,11 +268,13 @@ pub(super) fn rewrite_local_refs(
                     // whose paths resolve nowhere at runtime.
                     if *field == "peerDependencies" {
                         return Err(miette!(
-                            "aube deploy: peerDependencies cannot reference a local `file:`/`link:` target ({name:?} -> {spec:?}) — peers aren't bundled into the deploy and the relative path won't resolve under the target. Promote the peer to a regular dependency or drop the local path."
+                            "{}: peerDependencies cannot reference a local `file:`/`link:` target ({name:?} -> {spec:?}) — peers aren't bundled into the deploy and the relative path won't resolve under the target. Promote the peer to a regular dependency or drop the local path.",
+                            aube_util::cmd("deploy")
                         ));
                     }
                     return Err(miette!(
-                        "aube deploy: bundling plan missing entry for `{name}: {spec}` declared in {}",
+                        "{}: bundling plan missing entry for `{name}: {spec}` declared in {}",
+                        aube_util::cmd("deploy"),
                         manifest_path.display()
                     ));
                 };

--- a/crates/aube/src/commands/deploy/staging.rs
+++ b/crates/aube/src/commands/deploy/staging.rs
@@ -217,7 +217,8 @@ pub(super) fn ensure_target_writable(target: &Path) -> miette::Result<()> {
         Ok(mut entries) => {
             if entries.next().is_some() {
                 return Err(miette!(
-                    "aube deploy: target directory {} is not empty",
+                    "{}: target directory {} is not empty",
+                    aube_util::cmd("deploy"),
                     target.display()
                 ));
             }
@@ -225,7 +226,8 @@ pub(super) fn ensure_target_writable(target: &Path) -> miette::Result<()> {
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(miette!(
-            "aube deploy: failed to inspect {}: {e}",
+            "{}: failed to inspect {}: {e}",
+            aube_util::cmd("deploy"),
             target.display()
         )),
     }

--- a/crates/aube/src/commands/deprecations.rs
+++ b/crates/aube/src/commands/deprecations.rs
@@ -55,7 +55,10 @@ pub async fn run(args: DeprecationsArgs) -> miette::Result<Option<i32>> {
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
-            eprintln!("No lockfile found. Run `aube install` first.");
+            eprintln!(
+                "No lockfile found. Run `{}` first.",
+                aube_util::cmd("install")
+            );
             return Ok(Some(0));
         }
         Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),

--- a/crates/aube/src/commands/dist_tag.rs
+++ b/crates/aube/src/commands/dist_tag.rs
@@ -84,7 +84,8 @@ async fn add(spec: &str, tag: Option<&str>, otp: Option<&str>) -> miette::Result
     let (name, version) = split_name_spec(spec);
     let version = version.ok_or_else(|| {
         miette!(
-            "expected `name@version`, got `{spec}`\nhelp: `aube dist-tag add` needs an exact version, e.g. `react@18.2.0`"
+            "expected `name@version`, got `{spec}`\nhelp: `{}` needs an exact version, e.g. `react@18.2.0`",
+            aube_util::cmd("dist-tag add")
         )
     })?;
     if version.is_empty() {
@@ -103,7 +104,8 @@ async fn add(spec: &str, tag: Option<&str>, otp: Option<&str>) -> miette::Result
         .map_err(|e| match e {
             aube_registry::Error::NotFound(n) => miette!("package not found: {n}"),
             aube_registry::Error::Unauthorized => miette!(
-                "authentication required for {name}\nhelp: run `aube login` first, then retry"
+                "authentication required for {name}\nhelp: run `{}` first, then retry",
+                aube_util::cmd("login")
             ),
             other => miette!("failed to set {name}@{tag} -> {version}: {other}"),
         })?;
@@ -116,7 +118,8 @@ async fn rm(package: &str, tag: &str, otp: Option<&str>) -> miette::Result<()> {
     let (name, version_spec) = split_name_spec(package);
     if version_spec.is_some() {
         return Err(miette!(
-            "expected a bare package name, got `{package}`\nhelp: `aube dist-tag rm` takes just the package name — the tag to remove is a separate argument"
+            "expected a bare package name, got `{package}`\nhelp: `{}` takes just the package name — the tag to remove is a separate argument",
+            aube_util::cmd("dist-tag rm")
         ));
     }
 
@@ -131,7 +134,8 @@ async fn rm(package: &str, tag: &str, otp: Option<&str>) -> miette::Result<()> {
                 miette!("no such tag: {name}@{tag}")
             }
             aube_registry::Error::Unauthorized => miette!(
-                "authentication required for {name}\nhelp: run `aube login` first, then retry"
+                "authentication required for {name}\nhelp: run `{}` first, then retry",
+                aube_util::cmd("login")
             ),
             other => miette!("failed to remove {name}@{tag}: {other}"),
         })?;
@@ -151,7 +155,8 @@ async fn ls(package: Option<&str>) -> miette::Result<()> {
             let (n, version_spec) = split_name_spec(pkg);
             if version_spec.is_some() {
                 return Err(miette!(
-                    "expected a bare package name, got `{pkg}`\nhelp: `aube dist-tag ls` takes just the package name"
+                    "expected a bare package name, got `{pkg}`\nhelp: `{}` takes just the package name",
+                    aube_util::cmd("dist-tag ls")
                 ));
             }
             n.to_string()
@@ -163,7 +168,8 @@ async fn ls(package: Option<&str>) -> miette::Result<()> {
                 .wrap_err_with(|| format!("failed to read {}", manifest_path.display()))?;
             manifest.name.ok_or_else(|| {
                 miette!(
-                    "package.json has no `name` field\nhelp: pass a package name explicitly (`aube dist-tag ls <name>`)"
+                    "package.json has no `name` field\nhelp: pass a package name explicitly (`{} <name>`)",
+                    aube_util::cmd("dist-tag ls")
                 )
             })?
         }
@@ -173,7 +179,10 @@ async fn ls(package: Option<&str>) -> miette::Result<()> {
     let tags = client.fetch_dist_tags(&name).await.map_err(|e| match e {
         aube_registry::Error::NotFound(n) => miette!("package not found: {n}"),
         aube_registry::Error::Unauthorized => {
-            miette!("authentication required for {name}\nhelp: run `aube login` first, then retry")
+            miette!(
+                "authentication required for {name}\nhelp: run `{}` first, then retry",
+                aube_util::cmd("login")
+            )
         }
         other => miette!("failed to fetch dist-tags for {name}: {other}"),
     })?;

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -252,7 +252,8 @@ pub async fn run(args: DlxArgs) -> miette::Result<()> {
         if !bin_path.exists() {
             return Err(miette!(
                 "dlx: binary not found after install: {resolved_bin_name}\n\
-                 help: the package may ship the binary under a different name — try `aube dlx -p <package> <bin>`"
+                 help: the package may ship the binary under a different name — try `{} -p <package> <bin>`",
+                aube_util::cmd("dlx")
             ));
         }
         // The linker writes three shims for every bin on Windows:

--- a/crates/aube/src/commands/doctor.rs
+++ b/crates/aube/src/commands/doctor.rs
@@ -127,7 +127,8 @@ fn build_report(anchor: &Path, in_project: bool) -> miette::Result<Report> {
 
 fn version_section() -> Section {
     let mut s = Section::new("version");
-    s.push("aube", env!("CARGO_PKG_VERSION"));
+    let id = aube_util::embedder();
+    s.push(id.name, id.version);
     s.push(
         "build-profile",
         if cfg!(debug_assertions) {
@@ -211,6 +212,8 @@ fn project_section(anchor: &Path, report: &mut Report) -> Section {
             };
             s.push("package", label);
             // Self-version pin (packageManager / devEngines.packageManager).
+            // Tool name from the active embedder (standalone aube → "aube").
+            let name = aube_util::embedder().name;
             let self_pin = manifest
                 .dev_engines
                 .as_ref()
@@ -222,11 +225,11 @@ fn project_section(anchor: &Path, report: &mut Report) -> Section {
                         .extra
                         .get("packageManager")
                         .and_then(|v| v.as_str())
-                        .and_then(|raw| raw.strip_prefix("aube@"))
+                        .and_then(|raw| raw.strip_prefix(&format!("{name}@")))
                         .map(|v| (v.to_string(), "packageManager"))
                 });
             if let Some((pin, source)) = self_pin {
-                s.push("aube-pin", format!("{pin} (via {source})"));
+                s.push(format!("{name}-pin"), format!("{pin} (via {source})"));
             }
             if let Some(range) = manifest.engines.get("node")
                 && let Some(node) = crate::engines::effective_node_version(None)

--- a/crates/aube/src/commands/doctor.rs
+++ b/crates/aube/src/commands/doctor.rs
@@ -351,14 +351,18 @@ fn check_foreign_package_manager_dirs(anchor: &Path, report: &mut Report) {
 fn check_virtual_store_links(anchor: &Path, report: &mut Report) -> miette::Result<()> {
     let links = super::check::run_report(anchor).wrap_err("failed to walk the virtual store")?;
     if !links.issues.is_empty() {
+        // The virtual-store leaf is `.{embedder().name}` (see
+        // `aube-linker`'s `aube_dir`), so route the reported path through
+        // the profile. Standalone aube → `node_modules/.aube/`.
         report.errors.push(format!(
-            "{} broken {} in node_modules/.aube/ (run `aube check` for details)",
+            "{} broken {} in node_modules/.{}/ (run `aube check` for details)",
             links.issues.len(),
             if links.issues.len() == 1 {
                 "dependency link"
             } else {
                 "dependency links"
-            }
+            },
+            aube_util::embedder().name,
         ));
     }
     Ok(())

--- a/crates/aube/src/commands/doctor.rs
+++ b/crates/aube/src/commands/doctor.rs
@@ -148,10 +148,10 @@ fn runtime_section(warnings: &mut Vec<String>) -> Section {
         Some(v) => s.push("node", format!("v{v}")),
         None => {
             s.push("node", "(not found)");
-            warnings.push(
-                "`node` is not available on PATH — lifecycle scripts and `aube run` will fail"
-                    .to_string(),
-            );
+            warnings.push(format!(
+                "`node` is not available on PATH — lifecycle scripts and `{}` will fail",
+                aube_util::cmd("run")
+            ));
         }
     }
     if let Some(ctx) = crate::runtime::current() {
@@ -306,7 +306,8 @@ fn check_install_state(anchor: &Path, report: &mut Report) {
         let modules_dir = super::project_modules_dir(anchor);
         if modules_dir.exists() {
             report.warnings.push(format!(
-                "node_modules is stale: {reason}. Run `aube install`."
+                "node_modules is stale: {reason}. Run `{}`.",
+                aube_util::cmd("install")
             ));
         }
     }
@@ -355,7 +356,7 @@ fn check_virtual_store_links(anchor: &Path, report: &mut Report) -> miette::Resu
         // `aube-linker`'s `aube_dir`), so route the reported path through
         // the profile. Standalone aube → `node_modules/.aube/`.
         report.errors.push(format!(
-            "{} broken {} in node_modules/.{}/ (run `aube check` for details)",
+            "{} broken {} in node_modules/.{}/ (run `{}` for details)",
             links.issues.len(),
             if links.issues.len() == 1 {
                 "dependency link"
@@ -363,6 +364,7 @@ fn check_virtual_store_links(anchor: &Path, report: &mut Report) -> miette::Resu
                 "dependency links"
             },
             aube_util::embedder().name,
+            aube_util::cmd("check"),
         ));
     }
     Ok(())

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -177,7 +177,8 @@ async fn run_filtered_parallel(
                     .as_deref()
                     .unwrap_or_else(|| pkg.dir.to_str().unwrap_or("<unknown>"));
                 return Err(miette!(
-                    "binary not found in {name}: {bin}\nTry running `aube install` first, or check that the package providing '{bin}' is in its dependencies."
+                    "binary not found in {name}: {bin}\nTry running `{}` first, or check that the package providing '{bin}' is in its dependencies.",
+                    aube_util::cmd("install")
                 ));
             }
         }
@@ -251,7 +252,10 @@ async fn run_filtered_parallel(
                 if !status.success() && first_exit.is_none() {
                     let code = aube_scripts::exit_code_from_status(status);
                     first_exit = Some(code);
-                    first_err = Some(miette!("aube exec: `{bin}` failed in {name} (exit {code})"));
+                    first_err = Some(miette!(
+                        "{}: `{bin}` failed in {name} (exit {code})",
+                        aube_util::cmd("exec")
+                    ));
                 }
             }
             Ok(Err(e)) if first_err.is_none() => first_err = Some(e),
@@ -289,7 +293,8 @@ pub(crate) async fn exec_bin_with_node_args(
 ) -> miette::Result<()> {
     if !shell_mode && !bin_path.exists() {
         return Err(miette!(
-            "binary not found: {bin}\nTry running `aube install` first, or check that the package providing '{bin}' is in your dependencies."
+            "binary not found: {bin}\nTry running `{}` first, or check that the package providing '{bin}' is in your dependencies.",
+            aube_util::cmd("install")
         ));
     }
 
@@ -351,7 +356,8 @@ pub(crate) async fn exec_bin_status_with_node_args(
 ) -> miette::Result<std::process::ExitStatus> {
     if !shell_mode && !bin_path.exists() {
         return Err(miette!(
-            "binary not found: {bin}\nTry running `aube install` first, or check that the package providing '{bin}' is in your dependencies."
+            "binary not found: {bin}\nTry running `{}` first, or check that the package providing '{bin}' is in your dependencies.",
+            aube_util::cmd("install")
         ));
     }
 

--- a/crates/aube/src/commands/fetch.rs
+++ b/crates/aube/src/commands/fetch.rs
@@ -54,8 +54,9 @@ pub async fn run(args: FetchArgs) -> miette::Result<()> {
         Ok(pair) => pair,
         Err(aube_lockfile::Error::NotFound(_)) => {
             return Err(miette!(
-                "no lockfile found — aube fetch requires a lockfile \
-                 (pnpm-lock.yaml, yarn.lock, package-lock.json, npm-shrinkwrap.json, or bun.lock)"
+                "no lockfile found — {} requires a lockfile \
+                 (pnpm-lock.yaml, yarn.lock, package-lock.json, npm-shrinkwrap.json, or bun.lock)",
+                aube_util::cmd("fetch")
             ));
         }
         Err(e) => {

--- a/crates/aube/src/commands/find_hash.rs
+++ b/crates/aube/src/commands/find_hash.rs
@@ -83,8 +83,10 @@ pub async fn run(args: FindHashArgs) -> miette::Result<()> {
     let index_dir = store.index_dir();
     if !index_dir.exists() {
         return Err(miette!(
-            "index cache is empty at {}\nhelp: run `aube install` or `aube fetch` first to populate the store",
-            index_dir.display()
+            "index cache is empty at {}\nhelp: run `{}` or `{}` first to populate the store",
+            index_dir.display(),
+            aube_util::cmd("install"),
+            aube_util::cmd("fetch")
         ));
     }
 

--- a/crates/aube/src/commands/global.rs
+++ b/crates/aube/src/commands/global.rs
@@ -46,7 +46,7 @@ impl GlobalLayout {
         // `bin_dir` and `pkg_dir` are independent: `globalBinDir` controls
         // where bin symlinks go (on PATH), `globalDir` controls where
         // package installs live. Neither inherits from the other — both
-        // fall back to the default home (AUBE_HOME → PNPM_HOME → platform).
+        // fall back to the default home (<PREFIX>_HOME → PNPM_HOME → platform).
         let (setting_bin, setting_pkg) = super::with_settings_ctx(&cwd, |ctx| {
             let bin = aube_settings::resolved::global_bin_dir(ctx)
                 .and_then(|raw| super::expand_setting_path(&raw, &cwd));
@@ -56,20 +56,25 @@ impl GlobalLayout {
         });
 
         let bin_dir = setting_bin.map_or_else(resolve_home, Ok)?;
+        // Package-install subdir named after the active embedder so we never
+        // step on a sibling pnpm install. Standalone aube → `global-aube`.
+        let pkg_subdir = format!("global-{}", aube_util::embedder().name);
         let pkg_dir = setting_pkg.map_or_else(
-            || resolve_home().map(|h| h.join("global-aube")),
-            |p| Ok(p.join("global-aube")),
+            || resolve_home().map(|h| h.join(&pkg_subdir)),
+            |p| Ok(p.join(&pkg_subdir)),
         )?;
 
         Ok(Self { bin_dir, pkg_dir })
     }
 }
 
-/// Resolve the PATH-visible root. Honors `AUBE_HOME`, then `PNPM_HOME` (so
-/// existing pnpm users already have the right dir on PATH), then a
-/// platform-specific pnpm-style default.
+/// Resolve the PATH-visible root. Honors the branded `<PREFIX>_HOME`
+/// (standalone aube → `AUBE_HOME`), then `PNPM_HOME` (so existing pnpm users
+/// already have the right dir on PATH), then a platform-specific pnpm-style
+/// default. An embedder with no `env_prefix` skips the branded var.
 fn resolve_home() -> miette::Result<PathBuf> {
-    if let Ok(v) = std::env::var("AUBE_HOME")
+    if let Some(prefix) = aube_util::embedder().env_prefix
+        && let Ok(v) = std::env::var(format!("{prefix}_HOME"))
         && !v.is_empty()
     {
         return Ok(PathBuf::from(v));

--- a/crates/aube/src/commands/init.rs
+++ b/crates/aube/src/commands/init.rs
@@ -95,10 +95,13 @@ fn render(name: &str, args: &InitArgs) -> String {
     push(&mut out, &mut first, "\"version\": \"1.0.0\"");
 
     if args.init_package_manager {
+        // packageManager pin from the active embedder (standalone aube →
+        // "aube@<version>").
+        let id = aube_util::embedder();
         push(
             &mut out,
             &mut first,
-            &format!("\"packageManager\": \"aube@{}\"", env!("CARGO_PKG_VERSION")),
+            &format!("\"packageManager\": \"{}@{}\"", id.name, id.version),
         );
     }
 

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -357,7 +357,8 @@ pub(super) async fn import_local_source(
                 tracing::warn!(
                     code = aube_codes::warnings::WARN_AUBE_MISSING_INTEGRITY,
                     url = %aube_util::url::redact_url(&t.url),
-                    "remote tarball lockfile entry has no integrity field; importing fetched bytes without verification (run `aube install --no-frozen-lockfile` to refresh the lockfile)",
+                    "remote tarball lockfile entry has no integrity field; importing fetched bytes without verification (run `{} --no-frozen-lockfile` to refresh the lockfile)",
+                    aube_util::cmd("install"),
                 );
             } else {
                 aube_store::verify_integrity(&bytes, &t.integrity)

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -707,7 +707,7 @@ where
     // their lockfile-discovery order; only the natives jump ahead.
     // `AUBE_DISABLE_CRITICAL_PATH=1` reverts to the previous order
     // for byte-identity comparison runs.
-    if std::env::var_os("AUBE_DISABLE_CRITICAL_PATH").is_none() {
+    if aube_util::env::embedder_env("DISABLE_CRITICAL_PATH").is_none() {
         to_fetch
             .sort_by_key(|(_, _, registry_name, _, _, _)| !is_likely_native_build(registry_name));
     }
@@ -756,8 +756,10 @@ where
         // Hoist env-driven flags out of the per-tarball closure so
         // the libc lock fires once instead of N times on a 1000-pkg
         // install.
-        let streaming_sha512_enabled = std::env::var_os("AUBE_DISABLE_STREAMING_SHA512").is_none();
-        let tarball_stream_enabled = std::env::var_os("AUBE_DISABLE_TARBALL_STREAM").is_none();
+        let streaming_sha512_enabled =
+            aube_util::env::embedder_env("DISABLE_STREAMING_SHA512").is_none();
+        let tarball_stream_enabled =
+            aube_util::env::embedder_env("DISABLE_TARBALL_STREAM").is_none();
         // JoinSet so a first-error path aborts the sibling fetches
         // instead of detaching them into the background. Detached
         // tasks keep writing to the CAS after the install command

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -88,7 +88,7 @@ struct InstallPhaseTimings {
 impl InstallPhaseTimings {
     fn from_env() -> Self {
         Self {
-            path: std::env::var_os("AUBE_BENCH_PHASES_FILE").map(std::path::PathBuf::from),
+            path: aube_util::env::embedder_env("BENCH_PHASES_FILE").map(std::path::PathBuf::from),
             phases_ms: BTreeMap::new(),
             last_kernel_snap: aube_util::diag_kernel::snapshot(),
         }
@@ -130,7 +130,8 @@ impl InstallPhaseTimings {
         };
         let payload = serde_json::json!({
             "cwd": cwd,
-            "scenario": std::env::var("AUBE_BENCH_SCENARIO").ok(),
+            "scenario": aube_util::env::embedder_env("BENCH_SCENARIO")
+                .and_then(|s| s.into_string().ok()),
             "total_ms": total.as_millis(),
             "packages": packages,
             "cached": cached,
@@ -922,9 +923,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 let persistent_for_save = persistent.clone();
                 // Hoist env-driven flags out of the per-tarball loop.
                 let streaming_sha512_enabled =
-                    std::env::var_os("AUBE_DISABLE_STREAMING_SHA512").is_none();
+                    aube_util::env::embedder_env("DISABLE_STREAMING_SHA512").is_none();
                 let tarball_stream_enabled =
-                    std::env::var_os("AUBE_DISABLE_TARBALL_STREAM").is_none();
+                    aube_util::env::embedder_env("DISABLE_TARBALL_STREAM").is_none();
                 // JoinSet over bare Vec<JoinHandle>. If the first
                 // fetch errors and we return via `?`, a plain Vec
                 // drops the remaining JoinHandles which detaches the

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1677,7 +1677,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             return Err(miette!(
                 "no lockfile found and --frozen-lockfile is set\n\
                  help: commit pnpm-lock.yaml to your repository, or run \
-                 `aube install --no-frozen-lockfile` to generate one"
+                 `{} --no-frozen-lockfile` to generate one",
+                aube_util::cmd("install")
             ));
         }
         Err(e) => {

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -283,13 +283,18 @@ fn bootstrap_blocking(
         .current_dir(tool_dir)
         .status()
         .into_diagnostic()
-        .wrap_err("failed to spawn recursive aube install for node-gyp bootstrap")?;
+        .wrap_err(format!(
+            "failed to spawn recursive {} for node-gyp bootstrap",
+            aube_util::cmd("install")
+        ))?;
     if !status.success() {
         return Err(miette!(
-            "recursive aube install failed while bootstrapping node-gyp (exit {:?}) — \
-             pre-populate {} or run `aube install` once while online",
+            "recursive {} failed while bootstrapping node-gyp (exit {:?}) — \
+             pre-populate {} or run `{}` once while online",
+            aube_util::cmd("install"),
             status.code(),
-            tool_dir.display()
+            tool_dir.display(),
+            aube_util::cmd("install")
         ));
     }
     if !node_gyp_bin_exists(bin_dir) {

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -398,7 +398,8 @@ pub(super) fn select_lockfile_result(
                     return Err(miette!(
                         "lockfile is out of date with package.json: {reason}\n\
                          help: run without --frozen-lockfile to update the lockfile, \
-                         or run `aube install --no-frozen-lockfile` to regenerate it"
+                         or run `{} --no-frozen-lockfile` to regenerate it",
+                        aube_util::cmd("install")
                     ));
                 }
             }

--- a/crates/aube/src/commands/install/unreviewed_builds.rs
+++ b/crates/aube/src/commands/install/unreviewed_builds.rs
@@ -44,9 +44,10 @@ pub(super) fn emit_warning(unreviewed: &[UnreviewedBuild]) {
         code = aube_codes::warnings::WARN_AUBE_IGNORED_BUILD_SCRIPTS,
         count = unreviewed.len(),
         packages = ?spec_keys,
-        "ignored build scripts for {} package(s): {}. Run `aube approve-builds` to review and enable them, or set `strictDepBuilds=true` to fail installs that have unreviewed builds.",
+        "ignored build scripts for {} package(s): {}. Run `{}` to review and enable them, or set `strictDepBuilds=true` to fail installs that have unreviewed builds.",
         unreviewed.len(),
-        list
+        list,
+        aube_util::cmd("approve-builds")
     );
     for build in unreviewed {
         if build.suspicions.is_empty() {

--- a/crates/aube/src/commands/install/workspace.rs
+++ b/crates/aube/src/commands/install/workspace.rs
@@ -127,7 +127,8 @@ pub(super) fn filter_graph_to_workspace_selection(
     .map_err(|e| miette!("invalid --filter selector: {e}"))?;
     if selected.is_empty() {
         return Err(miette!(
-            "aube install: filter {filters:?} did not match any workspace package"
+            "{}: filter {filters:?} did not match any workspace package",
+            aube_util::cmd("install")
         ));
     }
     let mut keep_importers = std::collections::BTreeSet::new();

--- a/crates/aube/src/commands/install_test.rs
+++ b/crates/aube/src/commands/install_test.rs
@@ -20,8 +20,11 @@ pub async fn run(script_args: ScriptArgs) -> miette::Result<()> {
     } = script_args;
 
     eprintln!(
-        "aube: `install-test` is redundant — aube auto-installs before scripts, \
-         so `aube test` on its own does the same thing."
+        "{}: `install-test` is redundant — {} auto-installs before scripts, \
+         so `{}` on its own does the same thing.",
+        aube_util::prog(),
+        aube_util::prog(),
+        aube_util::cmd("test")
     );
 
     // Fail fast when there's no `test` script so a project with a large

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -93,7 +93,10 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
-            eprintln!("No lockfile found. Run `aube install` first.");
+            eprintln!(
+                "No lockfile found. Run `{}` first.",
+                aube_util::cmd("install")
+            );
             return Ok(());
         }
         Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),

--- a/crates/aube/src/commands/link.rs
+++ b/crates/aube/src/commands/link.rs
@@ -87,7 +87,8 @@ pub async fn run(args: LinkArgs) -> miette::Result<()> {
             if source.symlink_metadata().is_err() {
                 return Err(miette!(
                     "package {name} is not linked globally\n\
-                     Run `aube link` in the package directory first"
+                     Run `{}` in the package directory first",
+                    aube_util::cmd("link")
                 ));
             }
 

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -201,7 +201,8 @@ pub async fn run(
             .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
         if workspace_pkgs.is_empty() {
             return Err(miette!(
-                "aube list: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
+                "{}: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
+                aube_util::cmd("list"),
                 cwd.display()
             ));
         }
@@ -217,7 +218,8 @@ pub async fn run(
                     .map(String::as_str)
                     .collect();
                 return Err(miette!(
-                    "aube list: filter {shown:?} did not match any workspace package"
+                    "{}: filter {shown:?} did not match any workspace package",
+                    aube_util::cmd("list")
                 ));
             }
             if format == ListFormat::Default {
@@ -242,7 +244,10 @@ pub async fn run(
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
-            eprintln!("No lockfile found. Run `aube install` to populate node_modules.");
+            eprintln!(
+                "No lockfile found. Run `{}` to populate node_modules.",
+                aube_util::cmd("install")
+            );
             return Ok(());
         }
         Err(e) => {

--- a/crates/aube/src/commands/login.rs
+++ b/crates/aube/src/commands/login.rs
@@ -75,14 +75,17 @@ pub async fn run(args: LoginArgs) -> miette::Result<()> {
     Ok(())
 }
 
-/// Read the auth token from `$AUBE_AUTH_TOKEN`, then piped stdin, and
-/// finally an interactive `demand` prompt — in that order. The env var is
-/// the escape hatch for CI; the piped case is for
-/// `echo $TOKEN | aube login`; the prompt is the human path, rendered as
-/// a masked password field so the token doesn't echo to the terminal or
-/// end up in shell scrollback.
+/// Read the auth token from the branded `<PREFIX>_AUTH_TOKEN` env var
+/// (standalone aube → `$AUBE_AUTH_TOKEN`), then piped stdin, and finally an
+/// interactive `demand` prompt — in that order. The env var is the escape
+/// hatch for CI; the piped case is for `echo $TOKEN | … login`; the prompt is
+/// the human path, rendered as a masked password field so the token doesn't
+/// echo to the terminal or end up in shell scrollback. An embedder with no
+/// `env_prefix` reads no branded var and falls straight through to stdin.
 fn read_token() -> miette::Result<String> {
-    if let Ok(tok) = std::env::var("AUBE_AUTH_TOKEN") {
+    if let Some(prefix) = aube_util::embedder().env_prefix
+        && let Ok(tok) = std::env::var(format!("{prefix}_AUTH_TOKEN"))
+    {
         let tok = tok.trim();
         if !tok.is_empty() {
             return Ok(tok.to_string());
@@ -122,8 +125,8 @@ fn read_token() -> miette::Result<String> {
 /// 1. POST `{registry}-/v1/login` with `{hostname}`. The registry replies
 ///    with `{loginUrl, doneUrl}`.
 /// 2. Print `loginUrl` and — if we're on an interactive TTY and the user
-///    hasn't opted out via `AUBE_NO_BROWSER` — try to open it in the
-///    default browser.
+///    hasn't opted out via the branded `<PREFIX>_NO_BROWSER` (standalone
+///    aube → `AUBE_NO_BROWSER`) — try to open it in the default browser.
 /// 3. Poll `doneUrl`. The registry returns 202 (with optional
 ///    `Retry-After`) while the user hasn't finished, and 200 with
 ///    `{token}` once login succeeds. Give up after five minutes so a
@@ -137,14 +140,14 @@ async fn web_login(registry: &str) -> miette::Result<String> {
     let login_endpoint = format!("{base}-/v1/login");
 
     let client = aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
-        .user_agent(concat!("aube/", env!("CARGO_PKG_VERSION")))
+        .user_agent(aube_util::embedder().user_agent)
         .build()
         .into_diagnostic()
         .map_err(|e| miette!("failed to build http client: {e}"))?;
 
     let hostname = std::env::var("HOSTNAME")
         .or_else(|_| std::env::var("COMPUTERNAME"))
-        .unwrap_or_else(|_| "aube".to_string());
+        .unwrap_or_else(|_| aube_util::embedder().name.to_string());
 
     let resp = client
         .post(&login_endpoint)
@@ -180,7 +183,12 @@ async fn web_login(registry: &str) -> miette::Result<String> {
 
     eprintln!("Open this URL in your browser to sign in:");
     eprintln!("  {login_url}");
-    if std::io::stderr().is_terminal() && std::env::var_os("AUBE_NO_BROWSER").is_none() {
+    // Branded opt-out `<PREFIX>_NO_BROWSER` (standalone aube → AUBE_NO_BROWSER);
+    // an embedder with no env_prefix has no such knob, so it never opts out.
+    let no_browser = aube_util::embedder()
+        .env_prefix
+        .is_some_and(|prefix| std::env::var_os(format!("{prefix}_NO_BROWSER")).is_some());
+    if std::io::stderr().is_terminal() && !no_browser {
         let _ = open_browser(&login_url);
     }
     eprintln!("Waiting for authentication...");

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -158,7 +158,10 @@ async fn run_filtered(
     let graph = match aube_lockfile::parse_lockfile(&root, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
-            eprintln!("No lockfile found. Run `aube install` first.");
+            eprintln!(
+                "No lockfile found. Run `{}` first.",
+                aube_util::cmd("install")
+            );
             return Ok(());
         }
         Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
@@ -208,7 +211,10 @@ async fn run_one(cwd: &Path, args: OutdatedArgs, importer: Option<String>) -> mi
     let graph = match aube_lockfile::parse_lockfile(cwd, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
-            eprintln!("No lockfile found. Run `aube install` first.");
+            eprintln!(
+                "No lockfile found. Run `{}` first.",
+                aube_util::cmd("install")
+            );
             return Ok(false);
         }
         Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),

--- a/crates/aube/src/commands/patch.rs
+++ b/crates/aube/src/commands/patch.rs
@@ -39,6 +39,14 @@ pub struct PatchArgs {
     pub ignore_existing: bool,
 }
 
+/// The patch-state sidecar filename, derived from the active embedder's
+/// name: `.<name>_patch_state.json`. Standalone aube:
+/// `.aube_patch_state.json`. Used by both the writer (`run`) and the
+/// reader (`read_state`), so they stay paired.
+fn patch_state_filename() -> String {
+    format!(".{}_patch_state.json", aube_util::embedder().name)
+}
+
 pub async fn run(args: PatchArgs) -> Result<()> {
     // Mirror install's resolution: workspace-first so `aube patch`
     // from a workspace member finds the shared `.aube/` store at the
@@ -91,7 +99,7 @@ pub async fn run(args: PatchArgs) -> Result<()> {
         "project": cwd.display().to_string(),
     });
     std::fs::write(
-        parent.join(".aube_patch_state.json"),
+        parent.join(patch_state_filename()),
         serde_json::to_string_pretty(&state).unwrap(),
     )
     .into_diagnostic()
@@ -196,7 +204,7 @@ pub fn read_state(edit_dir: &Path) -> Result<PatchState> {
     let parent = edit_dir
         .parent()
         .ok_or_else(|| miette!("edit dir {} has no parent", edit_dir.display()))?;
-    let state_path = parent.join(".aube_patch_state.json");
+    let state_path = parent.join(patch_state_filename());
     let raw = std::fs::read_to_string(&state_path)
         .into_diagnostic()
         .map_err(|e| {

--- a/crates/aube/src/commands/patch.rs
+++ b/crates/aube/src/commands/patch.rs
@@ -5,8 +5,10 @@
 //! Mirrors `pnpm patch`. Two directories are created under a unique
 //! temp parent: `source/` (the original, immutable, used as the diff
 //! base) and `user/` (the writable copy printed to the user). A
-//! `.aube_patch_state.json` sidecar carries the package identity so
-//! `patch-commit` can locate the source dir given just the user dir.
+//! `.<name>_patch_state.json` sidecar (derived from the embedder name via
+//! `patch_state_filename()`; standalone aube: `.aube_patch_state.json`) carries
+//! the package identity so `patch-commit` can locate the source dir given just
+//! the user dir.
 
 use crate::patches::copy_dir_all;
 use clap::Args;
@@ -197,9 +199,10 @@ fn default_edit_parent(name: &str, version: &str) -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// Read the `.aube_patch_state.json` sidecar that `aube patch` writes
-/// next to a user-edit dir. `patch-commit` calls this to recover the
-/// package identity (name, version) and the matching source dir.
+/// Read the `.<name>_patch_state.json` sidecar (standalone aube:
+/// `.aube_patch_state.json`) that `patch` writes next to a user-edit dir.
+/// `patch-commit` calls this to recover the package identity (name, version)
+/// and the matching source dir.
 pub fn read_state(edit_dir: &Path) -> Result<PatchState> {
     let parent = edit_dir
         .parent()

--- a/crates/aube/src/commands/patch.rs
+++ b/crates/aube/src/commands/patch.rs
@@ -112,7 +112,8 @@ pub async fn run(args: PatchArgs) -> Result<()> {
         user_dir.display()
     );
     println!(
-        "Once you're done with your changes, run \"aube patch-commit '{}'\"",
+        "Once you're done with your changes, run \"{} '{}'\"",
+        aube_util::cmd("patch-commit"),
         user_dir.display()
     );
     Ok(())
@@ -174,15 +175,16 @@ fn find_pnpm_entry(
         }
     }
     Err(miette!(
-        "package {name}@{version} is not installed (looked under {}). Run `aube install` first.",
-        pnpm_dir.display()
+        "package {name}@{version} is not installed (looked under {}). Run `{}` first.",
+        pnpm_dir.display(),
+        aube_util::cmd("install")
     ))
 }
 
 fn parse_spec(input: &str) -> Result<(String, String)> {
     let (name, ver) = crate::commands::split_name_spec(input);
     let ver = ver.ok_or_else(|| {
-        miette!("`aube patch` requires `<name>@<version>` (got {input:?}); a bare name is ambiguous because the same package can be installed at multiple versions")
+        miette!("`{}` requires `<name>@<version>` (got {input:?}); a bare name is ambiguous because the same package can be installed at multiple versions", aube_util::cmd("patch"))
     })?;
     Ok((name.to_string(), ver.to_string()))
 }
@@ -212,8 +214,9 @@ pub fn read_state(edit_dir: &Path) -> Result<PatchState> {
         .into_diagnostic()
         .map_err(|e| {
             miette!(
-                "{} is not a directory created by `aube patch` (no state sidecar: {e})",
-                edit_dir.display()
+                "{} is not a directory created by `{}` (no state sidecar: {e})",
+                edit_dir.display(),
+                aube_util::cmd("patch")
             )
         })?;
     let v: serde_json::Value = serde_json::from_str(&raw)

--- a/crates/aube/src/commands/peers.rs
+++ b/crates/aube/src/commands/peers.rs
@@ -69,7 +69,10 @@ async fn check(args: PeersCheckArgs) -> miette::Result<()> {
     let graph = super::load_graph(
         &cwd,
         &manifest,
-        "no lockfile found\nhelp: run `aube install` first",
+        &format!(
+            "no lockfile found\nhelp: run `{}` first",
+            aube_util::cmd("install")
+        ),
     )?;
 
     let issues = collect_issues(&graph);

--- a/crates/aube/src/commands/project_lock.rs
+++ b/crates/aube/src/commands/project_lock.rs
@@ -68,7 +68,13 @@ pub(crate) fn take_project_lock(cwd: &std::path::Path) -> miette::Result<Project
     let nm_path = super::project_modules_dir(cwd);
     let lock = xx::fslock::FSLock::new(&nm_path)
         .with_callback(|_| {
-            eprintln!("Waiting for another aube process to finish in this project...");
+            // Raw, uncaptured stderr write fired by `xx::fslock` when the
+            // lock is contended, so route the process name through the
+            // embedder profile. Standalone aube → "aube".
+            eprintln!(
+                "Waiting for another {} process to finish in this project...",
+                aube_util::embedder().name
+            );
         })
         .lock()
         .map_err(|e| miette!("failed to acquire project lock: {e}"))?;

--- a/crates/aube/src/commands/prune.rs
+++ b/crates/aube/src/commands/prune.rs
@@ -45,7 +45,10 @@ pub async fn run(args: PruneArgs) -> miette::Result<()> {
 
     let graph = aube_lockfile::parse_lockfile(&cwd, &manifest)
         .map_err(miette::Report::new)
-        .wrap_err("failed to read lockfile — run `aube install` first")?;
+        .wrap_err(format!(
+            "failed to read lockfile — run `{}` first",
+            aube_util::cmd("install")
+        ))?;
 
     // Build the filtered graph via the existing BFS helper.
     let filtered = graph.filter_deps(|dep| {

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -182,8 +182,9 @@ fn enforce_git_checks(cwd: &Path) -> miette::Result<()> {
     let dirty = String::from_utf8_lossy(&status.stdout);
     if !dirty.trim().is_empty() {
         return Err(miette!(
-            "aube publish: working tree has uncommitted changes:\n{}\n\
+            "{}: working tree has uncommitted changes:\n{}\n\
              help: commit or stash them, or pass --no-git-checks to override",
+            aube_util::cmd("publish"),
             dirty.trim_end()
         ));
     }
@@ -225,8 +226,9 @@ fn enforce_git_checks(cwd: &Path) -> miette::Result<()> {
         || is_version_branch(&branch, "release");
     if !ok {
         return Err(miette!(
-            "aube publish: current branch `{branch}` is not a release branch\n\
-             help: switch to main/master or pass --no-git-checks to override"
+            "{}: current branch `{branch}` is not a release branch\n\
+             help: switch to main/master or pass --no-git-checks to override",
+            aube_util::cmd("publish")
         ));
     }
     Ok(())
@@ -245,8 +247,9 @@ async fn run_recursive(
         .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
     if workspace_pkgs.is_empty() {
         return Err(miette!(
-            "aube publish: no workspace packages found. \
+            "{}: no workspace packages found. \
              `--recursive` / `--filter` requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at {}",
+            aube_util::cmd("publish"),
             source_root.display()
         ));
     }
@@ -255,12 +258,14 @@ async fn run_recursive(
     if selected.is_empty() {
         if !filter.is_empty() {
             return Err(miette!(
-                "aube publish: --filter {:?} did not match any workspace package",
+                "{}: --filter {:?} did not match any workspace package",
+                aube_util::cmd("publish"),
                 filter
             ));
         }
         return Err(miette!(
-            "aube publish: no publishable workspace packages (all private or empty)"
+            "{}: no publishable workspace packages (all private or empty)",
+            aube_util::cmd("publish")
         ));
     }
 
@@ -300,7 +305,8 @@ async fn run_recursive(
             .collect::<Vec<_>>()
             .join("\n");
         return Err(miette!(
-            "aube publish: {} failed:\n{joined}",
+            "{}: {} failed:\n{joined}",
+            aube_util::cmd("publish"),
             pluralizer::pluralize("package", failures.len() as isize, true)
         ));
     }
@@ -466,8 +472,9 @@ async fn publish_one(
             });
         }
         return Err(miette!(
-            "aube publish: {name}@{version} is already on {registry_url}\n\
-             help: pass --force to republish (the registry must allow it; npm's public registry does not)"
+            "{}: {name}@{version} is already on {registry_url}\n\
+             help: pass --force to republish (the registry must allow it; npm's public registry does not)",
+            aube_util::cmd("publish")
         ));
     }
 

--- a/crates/aube/src/commands/query.rs
+++ b/crates/aube/src/commands/query.rs
@@ -83,7 +83,10 @@ pub async fn run(
     let graph = match aube_lockfile::parse_lockfile(&read_from, &manifest) {
         Ok(graph) => graph,
         Err(aube_lockfile::Error::NotFound(_)) => {
-            eprintln!("No lockfile found. Run `aube install` first.");
+            eprintln!(
+                "No lockfile found. Run `{}` first.",
+                aube_util::cmd("install")
+            );
             return Ok(());
         }
         Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
@@ -119,7 +122,8 @@ fn selected_importers(
         .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
     if workspace_pkgs.is_empty() {
         return Err(miette!(
-            "aube query: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
+            "{}: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
+            aube_util::cmd("query"),
             root.display()
         ));
     }
@@ -128,7 +132,8 @@ fn selected_importers(
             .map_err(|e| miette!("invalid --filter selector: {e}"))?;
     if selected.is_empty() {
         return Err(miette!(
-            "aube query: filter {filter:?} did not match any workspace package"
+            "{}: filter {filter:?} did not match any workspace package",
+            aube_util::cmd("query")
         ));
     }
 

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -68,8 +68,9 @@ pub async fn run(
     // exit Ok with no scripts run and no diagnostic — invisible in CI.
     if selected.is_some() && graph.is_none() {
         return Err(miette!(
-            "no lockfile found at {} — run `aube install` before targeting specific packages",
-            cwd.display()
+            "no lockfile found at {} — run `{}` before targeting specific packages",
+            cwd.display(),
+            aube_util::cmd("install")
         ));
     }
 

--- a/crates/aube/src/commands/recursive.rs
+++ b/crates/aube/src/commands/recursive.rs
@@ -20,7 +20,7 @@ pub struct RecursiveGlobals {
 /// parses and dispatches this in-process.
 pub fn argv(args: RecursiveArgs, globals: RecursiveGlobals) -> miette::Result<Vec<String>> {
     if args.args.is_empty() {
-        return Err(miette!("aube recursive: missing command"));
+        return Err(miette!("{}: missing command", aube_util::cmd("recursive")));
     }
 
     let mut argv = vec!["aube".to_string()];

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -265,9 +265,17 @@ fn run_global(packages: &[String]) -> miette::Result<()> {
 fn prune_sidecar_entries_json(obj: &mut serde_json::Map<String, serde_json::Value>, name: &str) {
     // shift_remove (not remove → swap_remove) keeps the surrounding
     // keys in their original on-disk position. Same rationale as the
-    // dep-section pruning above: `aube remove` must not reshuffle the
-    // user's manifest as a side effect.
-    for ns_key in ["pnpm", "aube"] {
+    // dep-section pruning above: `remove` must not reshuffle the user's
+    // manifest as a side effect.
+    // Compat namespaces plus the embedder's own (standalone aube →
+    // ["pnpm", "aube"]); an embedder with no namespace ("") skips it.
+    let id = aube_util::embedder();
+    let ns_keys = id
+        .compatible_names
+        .iter()
+        .copied()
+        .chain(std::iter::once(id.manifest_namespace).filter(|ns| !ns.is_empty()));
+    for ns_key in ns_keys {
         let remove_ns = if let Some(ns) = obj.get_mut(ns_key).and_then(|v| v.as_object_mut()) {
             for map_key in ["allowBuilds", "overrides", "peerDependencyRules"] {
                 if let Some(inner) = ns.get_mut(map_key).and_then(|v| v.as_object_mut()) {
@@ -321,8 +329,16 @@ fn prune_sidecar_entries_json(obj: &mut serde_json::Map<String, serde_json::Valu
 /// namespace block if its last entry was the one we just dropped.
 /// Safe no-op if the manifest has none of these fields.
 fn prune_sidecar_entries(manifest: &mut aube_manifest::PackageJson, name: &str) {
-    // Namespaced (pnpm.* / aube.*) allowlists, overrides, denylists.
-    for ns_key in ["pnpm", "aube"] {
+    // Namespaced allowlists, overrides, denylists: the compat namespaces
+    // plus the embedder's own (standalone aube → pnpm.* / aube.*); an
+    // embedder with no namespace ("") skips it.
+    let id = aube_util::embedder();
+    let ns_keys = id
+        .compatible_names
+        .iter()
+        .copied()
+        .chain(std::iter::once(id.manifest_namespace).filter(|ns| !ns.is_empty()));
+    for ns_key in ns_keys {
         let Some(ns) = manifest.extra.get_mut(ns_key) else {
             continue;
         };

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -272,7 +272,8 @@ fn prompt_for_script() -> miette::Result<String> {
     if !std::io::stdin().is_terminal() {
         let names: Vec<&str> = scripts.iter().map(|(n, _)| n.as_str()).collect();
         return Err(miette!(
-            "aube run: script name required when stdin is not a TTY. Available scripts: {}",
+            "{}: script name required when stdin is not a TTY. Available scripts: {}",
+            aube_util::cmd("run"),
             names.join(", ")
         ));
     }
@@ -516,7 +517,10 @@ async fn run_script_filtered(
             if if_present {
                 continue;
             }
-            return Err(miette!("aube run: package {name} has no `{script}` script"));
+            return Err(miette!(
+                "{}: package {name} has no `{script}` script",
+                aube_util::cmd("run")
+            ));
         }
         if !silent {
             tracing::info!("aube run: {name} -> {script}");
@@ -658,7 +662,8 @@ async fn run_filtered_parallel(
                     .clone()
                     .unwrap_or_else(|| pkg.dir.display().to_string());
                 Some(Err(miette!(
-                    "aube run: package {name} has no `{script}` script"
+                    "{}: package {name} has no `{script}` script",
+                    aube_util::cmd("run")
                 )))
             }
         })
@@ -786,7 +791,8 @@ async fn run_filtered_parallel(
                     let code = aube_scripts::exit_code_from_status(status);
                     first_exit = Some(code);
                     first_err = Some(miette!(
-                        "aube run: `{script}` failed in {name} (exit {code})"
+                        "{}: `{script}` failed in {name} (exit {code})",
+                        aube_util::cmd("run")
                     ));
                 }
             }

--- a/crates/aube/src/commands/runtime.rs
+++ b/crates/aube/src/commands/runtime.rs
@@ -62,7 +62,8 @@ pub async fn run(args: RuntimeArgs) -> miette::Result<()> {
 async fn run_set(args: RuntimeSetArgs) -> miette::Result<()> {
     if args.name != "node" {
         return Err(miette!(
-            "aube only manages the `node` runtime (got `{}`); deno/bun pins are not supported",
+            "{} only manages the `node` runtime (got `{}`); deno/bun pins are not supported",
+            aube_util::prog(),
             args.name
         ));
     }
@@ -108,7 +109,8 @@ async fn run_set(args: RuntimeSetArgs) -> miette::Result<()> {
 
     let project_dir = crate::dirs::find_project_root(&cwd).ok_or_else(|| {
         miette!(
-            "aube runtime set: no package.json found in {}",
+            "{}: no package.json found in {}",
+            aube_util::cmd("runtime set"),
             cwd.display()
         )
     })?;
@@ -221,8 +223,11 @@ async fn run_set_global(
     }
     if let Some(bin_dir) = &resolution.bin_dir {
         println!(
-            "aube has no shims — projects running through aube pick it up automatically;\n\
-             to use it outside aube, add it to PATH: export PATH=\"{}:$PATH\"",
+            "{} has no shims — projects running through {} pick it up automatically;\n\
+             to use it outside {}, add it to PATH: export PATH=\"{}:$PATH\"",
+            aube_util::prog(),
+            aube_util::prog(),
+            aube_util::prog(),
             bin_dir.display()
         );
     }

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -46,7 +46,10 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
     let graph = super::load_graph(
         &cwd,
         &manifest,
-        "no lockfile found — run `aube install` before generating an SBOM",
+        &format!(
+            "no lockfile found — run `{}` before generating an SBOM",
+            aube_util::cmd("install")
+        ),
     )?;
 
     let filter = DepFilter::from_flags(args.prod, args.dev);

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -493,7 +493,10 @@ pub(crate) fn resolve_virtual_store_dir(
 ) -> std::path::PathBuf {
     let default_from_modules_dir = || {
         let modules_dir = aube_settings::resolved::modules_dir(ctx);
-        project_dir.join(modules_dir).join(".aube")
+        // Virtual-store leaf from the active embedder's name: `.<name>`.
+        // Standalone aube → `.aube`.
+        let leaf = format!(".{}", aube_util::embedder().name);
+        project_dir.join(modules_dir).join(leaf)
     };
     let has_explicit_npmrc = [
         ctx.project_aube_config,

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -170,7 +170,8 @@ pub(crate) fn ensure_registry_auth(
         Ok(())
     } else {
         Err(miette!(
-            "no auth token for {registry_url}. Run `aube login --registry {registry_url}` first."
+            "no auth token for {registry_url}. Run `{} --registry {registry_url}` first.",
+            aube_util::cmd("login")
         ))
     }
 }

--- a/crates/aube/src/commands/unlink.rs
+++ b/crates/aube/src/commands/unlink.rs
@@ -52,7 +52,8 @@ pub async fn run(args: UnlinkArgs) -> miette::Result<()> {
             // not user-created links. Remove via the shared guard so scope cleanup still runs.
             if !remove_if_external_symlink(&cwd, &link_path)? {
                 return Err(miette!(
-                    "{name} is not a linked package (points into .aube — run `aube install` to restore)"
+                    "{name} is not a linked package (points into .aube — run `{}` to restore)",
+                    aube_util::cmd("install")
                 ));
             }
             eprintln!("Unlinked {name}");
@@ -118,8 +119,9 @@ pub async fn run(args: UnlinkArgs) -> miette::Result<()> {
                 eprintln!("No linked packages found");
             } else {
                 eprintln!(
-                    "Unlinked {unlinked} package{}. Run `aube install` to restore from registry.",
-                    if unlinked == 1 { "" } else { "s" }
+                    "Unlinked {unlinked} package{}. Run `{}` to restore from registry.",
+                    if unlinked == 1 { "" } else { "s" },
+                    aube_util::cmd("install")
                 );
             }
         }

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -124,7 +124,8 @@ pub async fn run(
         // workaround for the genuine refresh-transitives case.
         eprintln!(
             "warn: --depth {depth} is ignored; aube only refreshes direct deps. \
-             For a full refresh, run `rm aube-lock.yaml && aube install`."
+             For a full refresh, run `rm aube-lock.yaml && {}`.",
+            aube_util::cmd("install")
         );
     }
     if args.global {
@@ -933,7 +934,8 @@ async fn pick_update_interactively(
 ) -> miette::Result<BTreeSet<String>> {
     if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
         return Err(miette!(
-            "`aube update --interactive` requires stdin and stderr to be TTYs; pass package names explicitly to update non-interactively"
+            "`{} --interactive` requires stdin and stderr to be TTYs; pass package names explicitly to update non-interactively",
+            aube_util::cmd("update")
         ));
     }
 

--- a/crates/aube/src/commands/why.rs
+++ b/crates/aube/src/commands/why.rs
@@ -89,7 +89,10 @@ pub async fn run(
     let graph = match aube_lockfile::parse_lockfile(&cwd, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
-            eprintln!("No lockfile found. Run `aube install` first.");
+            eprintln!(
+                "No lockfile found. Run `{}` first.",
+                aube_util::cmd("install")
+            );
             return Ok(());
         }
         Err(e) => {
@@ -124,7 +127,8 @@ fn run_filtered(
 ) -> miette::Result<()> {
     let workspace_root = crate::dirs::find_workspace_root(cwd).ok_or_else(|| {
         miette!(
-            "aube why: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
+            "{}: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at or above {}",
+            aube_util::cmd("why"),
             cwd.display()
         )
     })?;
@@ -134,7 +138,10 @@ fn run_filtered(
     let graph = match aube_lockfile::parse_lockfile(&workspace_root, &manifest) {
         Ok(g) => g,
         Err(aube_lockfile::Error::NotFound(_)) => {
-            eprintln!("No lockfile found. Run `aube install` first.");
+            eprintln!(
+                "No lockfile found. Run `{}` first.",
+                aube_util::cmd("install")
+            );
             return Ok(());
         }
         Err(e) => {
@@ -146,7 +153,8 @@ fn run_filtered(
         .map_err(|e| miette!("failed to discover workspace packages: {e}"))?;
     if workspace_pkgs.is_empty() {
         return Err(miette!(
-            "aube why: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at {}",
+            "{}: --filter requires a workspace root (aube-workspace.yaml, pnpm-workspace.yaml, or package.json with a `workspaces` field) at {}",
+            aube_util::cmd("why"),
             workspace_root.display()
         ));
     }
@@ -159,7 +167,8 @@ fn run_filtered(
     .map_err(|e| miette!("invalid --filter selector: {e}"))?;
     if selected.is_empty() {
         return Err(miette!(
-            "aube why: filter {workspace_filter:?} did not match any workspace package"
+            "{}: filter {workspace_filter:?} did not match any workspace package",
+            aube_util::cmd("why")
         ));
     }
 

--- a/crates/aube/src/deprecations.rs
+++ b/crates/aube/src/deprecations.rs
@@ -129,8 +129,12 @@ fn write_warn_line(r: &DeprecationRecord) {
 fn write_transitive_count_line(count: usize) {
     let pkgs = pluralizer::pluralize("transitive package", count as isize, true);
     let verb = if count == 1 { "has" } else { "have" };
+    // Product name from the active embedder (standalone aube → "aube"), not a
+    // literal: this hint streams to stderr mid-install, so it must be branded at
+    // the emit site — a host embedder's later output-capture rewrite never sees it.
+    let product = aube_util::embedder().name;
     let msg = format!(
-        "{pkgs} {verb} deprecation warnings. Run `aube deprecations --transitive` to see them."
+        "{pkgs} {verb} deprecation warnings. Run `{product} deprecations --transitive` to see them."
     );
     let _ = writeln!(std::io::stderr(), "{}", style::edim(msg));
 }
@@ -138,10 +142,12 @@ fn write_transitive_count_line(count: usize) {
 fn write_count_line(count: usize, has_transitive: bool) {
     let pkgs = pluralizer::pluralize("package", count as isize, true);
     let verb = if count == 1 { "has" } else { "have" };
+    // See `write_transitive_count_line`: streamed line, brand at emit.
+    let product = aube_util::embedder().name;
     let cmd = if has_transitive {
-        "aube deprecations --transitive"
+        format!("{product} deprecations --transitive")
     } else {
-        "aube deprecations"
+        format!("{product} deprecations")
     };
     let msg = format!("{pkgs} {verb} deprecation warnings. Run `{cmd}` to see them.");
     let _ = writeln!(std::io::stderr(), "{}", style::edim(msg));

--- a/crates/aube/src/engines.rs
+++ b/crates/aube/src/engines.rs
@@ -47,11 +47,13 @@ pub enum Engine {
 }
 
 impl Engine {
-    /// The literal key as it appears under `engines.<key>` in package.json.
+    /// The key as it appears under `engines.<key>` in package.json. The
+    /// tool's own key is the active embedder's manifest namespace
+    /// (standalone aube → `"aube"`).
     pub fn key(self) -> &'static str {
         match self {
             Self::Node => "node",
-            Self::Aube => "aube",
+            Self::Aube => aube_util::embedder().manifest_namespace,
         }
     }
 }
@@ -178,7 +180,7 @@ fn check_manifest_engines(
             current: node_v.to_string(),
         });
     }
-    if let Some(declared) = check_engine_field(&manifest.engines, "aube", aube_v) {
+    if let Some(declared) = check_engine_field(&manifest.engines, Engine::Aube.key(), aube_v) {
         out.push(Mismatch {
             engine: Engine::Aube,
             package: label.to_string(),

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -969,7 +969,8 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
                 Some(_) | None => {
                     return Err(miette::miette!(
                         code = aube_codes::errors::ERR_AUBE_RECURSIVE_NOT_SUPPORTED,
-                        "aube recursive: command does not support recursive execution"
+                        "{} recursive: command does not support recursive execution",
+                        aube_util::embedder().name,
                     ));
                 }
             }

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -524,12 +524,14 @@ enum Commands {
 /// This is the whole embedding API: register-then-run in one call, so a host
 /// never has to separately wire identity and defaults.
 ///
-/// **Takes over the process.** This is intended to be the program's entire
-/// `main`: it parses argv, runs the selected command, and may terminate the
-/// process directly (e.g. `std::process::exit` on a non-zero command result).
-/// Do not call it expecting control to return normally for further work.
-pub fn cli_main(embedder: &'static aube_util::Embedder) {
-    cli_main_with_defaults(embedder, Vec::new());
+/// **Returns the exit code; it does not terminate the process.** It parses
+/// argv, runs the selected command, renders any diagnostic to stderr, and
+/// hands back the code the binary's `main` should exit with. Returning rather
+/// than calling `std::process::exit` keeps it embed-safe: a host that drives
+/// it in-process is not hard-killed by a non-zero result or an error. The
+/// standalone binary does `std::process::exit(cli_main(..))`.
+pub fn cli_main(embedder: &'static aube_util::Embedder) -> i32 {
+    cli_main_with_defaults(embedder, Vec::new())
 }
 
 /// The clap [`Command`](clap::Command) for the CLI, with its version reset to
@@ -554,7 +556,7 @@ pub fn command() -> clap::Command {
 pub fn cli_main_with_defaults(
     embedder: &'static aube_util::Embedder,
     defaults: Vec<(String, String)>,
-) {
+) -> i32 {
     // Register the binary's embedder profile before anything reads branding,
     // and its setting defaults before anything resolves settings. Both are
     // idempotent — a no-op if already set (e.g. a test harness that
@@ -563,10 +565,10 @@ pub fn cli_main_with_defaults(
     aube_settings::set_embedder_defaults(defaults);
 
     // Two-phase wrapper: `inner_main` runs the real CLI and returns
-    // `Result<(), miette::Report>`. On Err we render via miette's
-    // fancy handler (matching the previous `Termination` behavior),
-    // then look up the diagnostic's `code()` against
-    // `aube_codes::exit::EXIT_TABLE` to pick a bespoke exit code.
+    // `Result<i32, miette::Report>` — the command's exit code on Ok. On
+    // Err we render via miette's fancy handler (matching the previous
+    // `Termination` behavior), then look up the diagnostic's `code()`
+    // against `aube_codes::exit::EXIT_TABLE` to pick a bespoke exit code.
     // Codes outside the table fall through to `EXIT_GENERIC` (1).
     //
     // Chain a panic hook that flushes the diag buffer before the
@@ -587,9 +589,17 @@ pub fn cli_main_with_defaults(
     // etc. — never hit that path and would otherwise silently lose
     // their slow-fetch warnings to the accumulator.
     aube_registry::slow_metadata::flush_summary();
-    if let Err(report) = result {
-        eprintln!("{report:?}");
-        std::process::exit(report_exit_code(&report));
+    // Return the exit code rather than terminating: only the binary's
+    // `main` calls `std::process::exit`, so a host embedding the command
+    // layer in-process isn't hard-killed by a non-zero result or an
+    // error. The diagnostic still renders to stderr here (matching the
+    // previous `Termination` behavior); only the exit itself moves out.
+    match result {
+        Ok(code) => code,
+        Err(report) => {
+            eprintln!("{report:?}");
+            report_exit_code(&report)
+        }
     }
 }
 
@@ -606,7 +616,7 @@ fn report_exit_code(report: &miette::Report) -> i32 {
     aube_codes::exit::EXIT_GENERIC
 }
 
-fn inner_main() -> miette::Result<()> {
+fn inner_main() -> miette::Result<i32> {
     let mut argv: Vec<OsString> = std::env::args_os().collect();
     // pnpm-compat: pull `--config.<key>[=<value>]` out of argv before
     // clap parses it. Stripping here means the rest of the binary sees
@@ -730,10 +740,13 @@ fn inner_main() -> miette::Result<()> {
         .wrap_err("failed to build tokio runtime")?;
     let exit_code = runtime.block_on(async_main(cli))?;
     drop(runtime);
-    if let Some(exit_code) = exit_code {
-        std::process::exit(exit_code);
-    }
-    Ok(())
+    // Return the command's exit code rather than terminating here: a
+    // non-zero result (e.g. `run`/`exec` propagating a child's status)
+    // must travel back up to the binary's `main`, which owns the single
+    // `std::process::exit`. Exiting here would hard-kill a host that
+    // embeds the command layer in-process. `None` means "no explicit
+    // code" — the normal success exit of 0.
+    Ok(exit_code.unwrap_or(0))
 }
 
 async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -530,6 +530,13 @@ enum Commands {
 /// than calling `std::process::exit` keeps it embed-safe: a host that drives
 /// it in-process is not hard-killed by a non-zero result or an error. The
 /// standalone binary does `std::process::exit(cli_main(..))`.
+///
+/// `#[must_use]`: the `i32` is the exit code, not a side effect. An
+/// embedder migrating off the old `process::exit` entrypoint that drops
+/// it would silently exit 0 on every failure — Rust won't warn on an
+/// ignored return — so the lint nudges them to
+/// `std::process::exit(cli_main(..))`.
+#[must_use]
 pub fn cli_main(embedder: &'static aube_util::Embedder) -> i32 {
     cli_main_with_defaults(embedder, Vec::new())
 }
@@ -553,6 +560,10 @@ pub fn command() -> clap::Command {
 /// (Embedder-*fixed* behavior lives on [`aube_util::Embedder`] itself, not
 /// here.) Standalone aube passes an empty vec, so per-setting built-in
 /// defaults apply unchanged.
+///
+/// `#[must_use]` for the same reason as [`cli_main`]: the returned `i32`
+/// is the exit code the embedder must hand to `std::process::exit`.
+#[must_use]
 pub fn cli_main_with_defaults(
     embedder: &'static aube_util::Embedder,
     defaults: Vec<(String, String)>,

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -39,7 +39,10 @@ fn main() {
         return;
     }
 
-    aube::cli_main(embedder)
+    // The binary owns the single `std::process::exit`: `cli_main` returns the
+    // code so the library stays embed-safe (a host driving it in-process is
+    // never hard-killed), and the standalone binary terminates with it here.
+    std::process::exit(aube::cli_main(embedder));
 }
 
 /// True for a standalone `aube usage` invocation: argv[0] resolves to the

--- a/crates/aube/src/progress/ci.rs
+++ b/crates/aube/src/progress/ci.rs
@@ -196,22 +196,12 @@ impl CiState {
 
     /// Render the one-line header banner that prints once above the
     /// first heartbeat-emitted progress line. Plain whitespace
-    /// alignment, no frame: `aube VERSION by jdx.dev`.
+    /// alignment, no frame: `aube VERSION by jdx.dev` for standalone
+    /// aube, `<display_name> VERSION` for an embedder. The vendor
+    /// attribution is gated by `product_banner` so the engine brand
+    /// never leaks into a host's install output.
     fn render_header() -> String {
-        let id = aube_util::embedder();
-        match id.vendor {
-            Some(vendor) => format!(
-                "{} {} {}",
-                style::emagenta(id.display_name).bold(),
-                style::edim(crate::version::VERSION.as_str()),
-                style::edim(vendor),
-            ),
-            None => format!(
-                "{} {}",
-                style::emagenta(id.display_name).bold(),
-                style::edim(crate::version::VERSION.as_str()),
-            ),
-        }
+        super::product_banner("")
     }
 
     pub(super) fn spawn_heartbeat(state: &Arc<Self>) {

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -83,23 +83,51 @@ fn env_truthy(name: &str) -> bool {
     })
 }
 
-/// Build the standard `aube VERSION by jdx.dev · <msg>` one-line
-/// header used by the no-op and fast-mode summaries. Centralizes the
-/// header shape so the install-finished, already-up-to-date, and
-/// fast-mode-summary paths all read consistently.
-pub(crate) fn aube_prefix_line(msg: &str) -> String {
+/// Whether the vendor attribution (`by jdx.dev`) may render into the banner.
+/// The vendor tag is aube's own credit, so it shows only when the active
+/// embedder is standalone aube; any other embedder suppresses it, so the
+/// engine's vendor brand never leaks into a host's user-facing install output.
+/// Keyed on name matching standalone aube's, since `embedder()` returns a
+/// copied profile with no stable pointer to compare against `AUBE`.
+fn banner_vendor() -> Option<&'static str> {
     let id = aube_util::embedder();
-    let vendor = id
-        .vendor
-        .map(|v| format!("{} ", style::edim(v)))
-        .unwrap_or_default();
-    format!(
-        "{} {} {}{} {msg}",
-        style::emagenta(id.display_name).bold(),
-        style::edim(crate::version::VERSION.as_str()),
-        vendor,
-        style::edim("·"),
-    )
+    if id.name == aube_util::AUBE.name {
+        id.vendor
+    } else {
+        None
+    }
+}
+
+/// Render the product banner — `<display_name> <VERSION>[ <vendor>]` —
+/// used by the install-progress headers and the no-op/fast-mode
+/// summaries. The optional vendor attribution is gated by
+/// [`banner_vendor`] so the engine's brand never leaks into an
+/// embedder's install output. Trailing `suffix` (already styled) is
+/// appended verbatim — `" · ✓ msg"` for the summary lines, empty for
+/// the bare header.
+fn product_banner(suffix: &str) -> String {
+    let id = aube_util::embedder();
+    match banner_vendor() {
+        Some(vendor) => format!(
+            "{} {} {}{suffix}",
+            style::emagenta(id.display_name).bold(),
+            style::edim(crate::version::VERSION.as_str()),
+            style::edim(vendor),
+        ),
+        None => format!(
+            "{} {}{suffix}",
+            style::emagenta(id.display_name).bold(),
+            style::edim(crate::version::VERSION.as_str()),
+        ),
+    }
+}
+
+/// Build the standard `<product banner> · <msg>` one-line header used
+/// by the no-op and fast-mode summaries. Centralizes the header shape
+/// so the install-finished, already-up-to-date, and fast-mode-summary
+/// paths all read consistently.
+pub(crate) fn aube_prefix_line(msg: &str) -> String {
+    product_banner(&format!(" {} {msg}", style::edim("·")))
 }
 
 /// Install-time progress UI. Cheap to clone (internally `Arc`).
@@ -223,24 +251,13 @@ impl InstallProgress {
     }
 
     fn new_tty() -> Self {
-        // Colored header: magenta bold display name, dim version, dim vendor.
-        // Mirrors the `mise VERSION by @jdx` / `hk VERSION by @jdx` convention
-        // for visual parity across the trio. An embedder with `vendor: None`
-        // drops the trailing attribution.
-        let id = aube_util::embedder();
-        let header = match id.vendor {
-            Some(vendor) => format!(
-                "{} {} {}",
-                style::emagenta(id.display_name).bold(),
-                style::edim(crate::version::VERSION.as_str()),
-                style::edim(vendor),
-            ),
-            None => format!(
-                "{} {}",
-                style::emagenta(id.display_name).bold(),
-                style::edim(crate::version::VERSION.as_str()),
-            ),
-        };
+        // Colored header: magenta bold display name, dim version, dim
+        // vendor. Mirrors the `mise VERSION by @jdx` / `hk VERSION by
+        // @jdx` convention for visual parity across the trio. The vendor
+        // attribution renders only for standalone aube (see
+        // `product_banner`); an embedder drops it so the engine brand
+        // never leaks into the host's install output.
+        let header = product_banner("");
         // Layout: header, animated bar, count segment, optional bytes
         // segment (running download, with `/ ~estimated` when
         // available), phase-gated rate, ETA. Mirrors the CI-mode

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -88,9 +88,9 @@ fn env_truthy(name: &str) -> bool {
 /// embedder is standalone aube; any other embedder suppresses it, so the
 /// engine's vendor brand never leaks into a host's user-facing install output.
 /// Keyed on name matching standalone aube's, since `embedder()` returns a
-/// copied profile with no stable pointer to compare against `AUBE`.
-fn banner_vendor() -> Option<&'static str> {
-    let id = aube_util::embedder();
+/// copied profile with no stable pointer to compare against `AUBE`. Takes the
+/// caller's already-fetched profile so the banner resolves it once.
+fn banner_vendor(id: &'static aube_util::Embedder) -> Option<&'static str> {
     if id.name == aube_util::AUBE.name {
         id.vendor
     } else {
@@ -107,7 +107,7 @@ fn banner_vendor() -> Option<&'static str> {
 /// the bare header.
 fn product_banner(suffix: &str) -> String {
     let id = aube_util::embedder();
-    match banner_vendor() {
+    match banner_vendor(id) {
         Some(vendor) => format!(
             "{} {} {}{suffix}",
             style::emagenta(id.display_name).bold(),

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -46,7 +46,7 @@ impl RuntimeProvenance {
     pub fn label(self) -> &'static str {
         match self {
             RuntimeProvenance::Mise => "mise",
-            RuntimeProvenance::AubeManaged => "aube",
+            RuntimeProvenance::AubeManaged => aube_util::embedder().name,
             RuntimeProvenance::System => "system",
         }
     }
@@ -558,7 +558,7 @@ impl CliProgress {
     }
 
     pub(crate) fn aube() -> Self {
-        Self::for_tool("aube")
+        Self::for_tool(aube_util::embedder().name)
     }
 
     fn for_tool(tool: &'static str) -> Self {

--- a/crates/aube/src/self_version.rs
+++ b/crates/aube/src/self_version.rs
@@ -38,6 +38,8 @@ pub(crate) async fn maybe_switch(settings: &crate::startup::StartupSettings) -> 
     if !settings.manage_package_manager_versions {
         return Ok(());
     }
+    // Product name for user-facing messages (standalone aube → "aube").
+    let name = aube_util::embedder().name;
     let cwd = std::env::current_dir().into_diagnostic()?;
     let Some(root) = crate::dirs::find_workspace_root(&cwd)
         .filter(|root| root.join("package.json").is_file())
@@ -86,7 +88,7 @@ pub(crate) async fn maybe_switch(settings: &crate::startup::StartupSettings) -> 
                                 .cloned();
                             best.ok_or_else(|| {
                                 format!(
-                                    "no published aube satisfies {} (newest release: {})",
+                                    "no published {name} satisfies {} (newest release: {})",
                                     pin.raw,
                                     published
                                         .iter()
@@ -109,7 +111,7 @@ pub(crate) async fn maybe_switch(settings: &crate::startup::StartupSettings) -> 
                                             aube_codes::warnings::WARN_AUBE_RUNTIME_VERSION_MISMATCH,
                                         requested = pin.raw,
                                         running = running_version(),
-                                        "{detail}; continuing on this aube"
+                                        "{detail}; continuing on this {name}"
                                     );
                                     Ok(())
                                 }
@@ -134,7 +136,7 @@ pub(crate) async fn maybe_switch(settings: &crate::startup::StartupSettings) -> 
             requested = pin.raw,
             running = running_version(),
             target = %target,
-            "switched aube binary still does not satisfy the project's pin; continuing"
+            "switched {name} binary still does not satisfy the project's pin; continuing"
         );
         return Ok(());
     }
@@ -151,14 +153,14 @@ pub(crate) async fn maybe_switch(settings: &crate::startup::StartupSettings) -> 
                     requested = pin.raw,
                     running = running_version(),
                     source = pin.source,
-                    "project pins a different aube version (onFail: warn); continuing on this one"
+                    "project pins a different {name} version (onFail: warn); continuing on this one"
                 );
                 return Ok(());
             }
             aube_manifest::OnFail::Error => {
                 return self_pin_unsatisfied(
                     &pin,
-                    format!("aube@{target} is not installed and onFail is \"error\""),
+                    format!("{name}@{target} is not installed and onFail is \"error\""),
                 );
             }
             aube_manifest::OnFail::Download => {
@@ -173,7 +175,7 @@ pub(crate) async fn maybe_switch(settings: &crate::startup::StartupSettings) -> 
                     retries: 2,
                 };
                 crate::progress::safe_eprintln(&format!(
-                    "Switching to aube@{target} (pinned by {})…",
+                    "Switching to {name}@{target} (pinned by {})…",
                     pin.source
                 ));
                 aube_runtime::install_aube(&cfg, &target, &crate::runtime::CliProgress::aube())
@@ -187,10 +189,15 @@ pub(crate) async fn maybe_switch(settings: &crate::startup::StartupSettings) -> 
 }
 
 fn self_pin_unsatisfied(pin: &SelfPin, detail: String) -> miette::Result<()> {
+    // Product name in the spec syntax shown to the user (standalone aube →
+    // "aube"): the pin reads `packageManager: "<name>@<version>"`.
+    let name = aube_util::embedder().name;
     Err(miette!(
         code = aube_codes::errors::ERR_AUBE_RUNTIME_VERSION_UNSATISFIED,
-        help = "pin an exact released version (e.g. `packageManager: \"aube@<version>\"`), or set managePackageManagerVersions=false to skip switching",
-        "the project pins aube@{} via {}, but this is aube@{} and {detail}",
+        help = format!(
+            "pin an exact released version (e.g. `packageManager: \"{name}@<version>\"`), or set managePackageManagerVersions=false to skip switching"
+        ),
+        "the project pins {name}@{} via {}, but this is {name}@{} and {detail}",
         pin.raw,
         pin.source,
         running_version(),
@@ -222,7 +229,7 @@ fn extract_pin(manifest: &aube_manifest::PackageJson) -> Option<SelfPin> {
     }
     let raw = manifest.extra.get("packageManager")?.as_str()?;
     let (name, version) = raw.rsplit_once('@')?;
-    if name != "aube" {
+    if !aube_util::embedder().self_names.contains(&name) {
         return None;
     }
     // Strip a corepack `+<hash>` suffix.

--- a/crates/aube/src/update_check.rs
+++ b/crates/aube/src/update_check.rs
@@ -45,7 +45,8 @@ pub async fn check_and_notify(cwd: &Path) {
     if !enabled {
         return;
     }
-    let current = aube_util::embedder().version;
+    let id = aube_util::embedder();
+    let current = id.version;
     let Some(latest) = latest_version(cwd).await else {
         return;
     };
@@ -53,7 +54,7 @@ pub async fn check_and_notify(cwd: &Path) {
         return;
     }
     eprintln!();
-    eprintln!("  aube {latest} is available (current: {current})");
+    eprintln!("  {} {latest} is available (current: {current})", id.name);
     eprintln!("  upgrade: https://aube.jdx.dev");
 }
 

--- a/crates/aube/src/update_check.rs
+++ b/crates/aube/src/update_check.rs
@@ -62,7 +62,7 @@ fn should_check() -> bool {
     if aube_util::env::is_ci() {
         return false;
     }
-    if std::env::var_os("AUBE_NO_UPDATE_CHECK").is_some() {
+    if aube_util::env::embedder_env("NO_UPDATE_CHECK").is_some() {
         return false;
     }
     true

--- a/crates/aube/tests/brand_literal_lint.rs
+++ b/crates/aube/tests/brand_literal_lint.rs
@@ -52,6 +52,9 @@ use std::path::{Path, PathBuf};
 /// (those words aren't commands), keeping the lint conservative.
 const VERBS: &[&str] = &[
     "install",
+    "install-test",
+    "it",
+    "test",
     "i",
     "ci",
     "add",

--- a/crates/aube/tests/brand_literal_lint.rs
+++ b/crates/aube/tests/brand_literal_lint.rs
@@ -1,0 +1,284 @@
+//! Conservative brand-literal lint — flags newly-introduced hardcoded
+//! `aube <verb>` command references in user-facing runtime strings, steering
+//! them to [`aube_util::cmd`] instead.
+//!
+//! Why this exists: an embedding host (the headline being nub, which embeds
+//! aube as a library and rebrands its output) needs every *user-facing*
+//! `aube install` / `aube run` / … reference to follow the active brand, not
+//! be hardcoded to `aube`. The source-branding helpers `aube_util::prog()` /
+//! `aube_util::cmd(verb)` are the seam: under the default profile they render
+//! exactly `"aube"` / `"aube install"` byte-for-byte, and under an embedder
+//! they carry the host's brand. This lint keeps future code on that seam — a
+//! freshly-added `"aube install"` literal in a `miette!`/`bail!`/`eprintln!`
+//! string trips it.
+//!
+//! Deliberately CONSERVATIVE (low false-positive). It only scans the command
+//! layer (`src/commands/`), only flags string-literal lines (a `"` on the
+//! line), only matches `aube <verb>` where `<verb>` is a real CLI command, and
+//! skips everything that is legitimately not a runtime command reference:
+//! doc/line comments, `tracing::*` internal logs, branded filenames
+//! (`aube-lock.yaml`, `aube-workspace.yaml` use `aube-`, never `aube `),
+//! manifest keys (`package.json#aube`, `aube.<key>`), sentence-start
+//! capitalized prose ("Aube …"), and — importantly — **clap help text**, which
+//! is the one user-facing surface that genuinely *cannot* use the runtime
+//! helper. `#[command(after_long_help = ...)]` and `long_about` take a
+//! `&'static str` resolved at clap-definition time, so a help const can't call
+//! `cmd()`; the lint exempts the `pub const ..._HELP` blocks and the
+//! `$ aube <verb>` shell-example lines they contain. (Branding help text is a
+//! separate, clap-level concern tracked as a follow-up.) An explicit
+//! [`ALLOWLIST`] covers any remaining one-off intentional mention.
+//!
+//! ## How to satisfy this lint
+//! Replace the hardcoded reference with the helper:
+//!
+//! ```ignore
+//! // before — hardcoded brand, wrong under an embedder:
+//! return Err(miette!("no lockfile found — run `aube install` first"));
+//! // after — follows the active brand, byte-for-byte identical for standalone aube:
+//! return Err(miette!("no lockfile found — run `{}` first", aube_util::cmd("install")));
+//! ```
+//!
+//! For a bare program-name reference (not a `verb`) use `aube_util::prog()`.
+//! If a flagged line is a genuine, intentional exception (a foreign-tool
+//! example, a sentence whose rewrite would hurt clarity), add it to
+//! [`ALLOWLIST`] below with a comment explaining why — keep that list short.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Real CLI command verbs (and the leading word of multi-word subcommand
+/// chains). A `aube <word>` literal only trips the lint when `<word>` is one of
+/// these — so prose like "aube has no shims" or "let aube do it" never trips
+/// (those words aren't commands), keeping the lint conservative.
+const VERBS: &[&str] = &[
+    "install",
+    "i",
+    "ci",
+    "add",
+    "remove",
+    "rm",
+    "update",
+    "up",
+    "run",
+    "exec",
+    "dlx",
+    "import",
+    "dedupe",
+    "patch",
+    "patch-commit",
+    "patch-remove",
+    "approve-builds",
+    "ignored-builds",
+    "store",
+    "outdated",
+    "why",
+    "list",
+    "ls",
+    "ll",
+    "la",
+    "pack",
+    "publish",
+    "init",
+    "create",
+    "setup",
+    "config",
+    "rebuild",
+    "prune",
+    "purge",
+    "link",
+    "unlink",
+    "fetch",
+    "login",
+    "logout",
+    "doctor",
+    "audit",
+    "deprecate",
+    "undeprecate",
+    "view",
+    "node",
+    "runtime",
+    "deploy",
+    "completion",
+    "recursive",
+    "peers",
+    "check",
+    "query",
+    "sbom",
+    "licenses",
+    "token",
+    "owner",
+    "search",
+    "whoami",
+    "root",
+    "bin",
+    "get",
+    "set",
+    "dist-tag",
+    "clean",
+    "stage",
+    "pkg",
+];
+
+/// Intentional exceptions: `crate/path` substrings or exact source lines where
+/// an `aube <verb>`-shaped literal is deliberately left as-is. Keep this SHORT
+/// — each entry is a place the embedder brand will NOT follow, so it must be a
+/// genuine non-command-reference (prose, a foreign example) and not a missed
+/// conversion. Match is by `line.contains(entry)`.
+const ALLOWLIST: &[&str] = &[
+    // A provenance/origin *data value* (the `RuntimeRequest::origin` PathBuf
+    // recording where a Node pin came from), not user-facing emission text.
+    // It's diagnostic metadata, the byte string is matched elsewhere, and it's
+    // built where a `&str`/`PathBuf` is expected — not a place a runtime helper
+    // belongs.
+    "PathBuf::from(\"aube runtime set",
+];
+
+fn commands_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src/commands")
+}
+
+fn rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("read_dir commands") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            rs_files(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Opens a clap help-text const block: `pub const <NAME>_HELP: &str = "..."`
+/// (the `AFTER_LONG_HELP` / `CHECK_AFTER_LONG_HELP` convention). The string
+/// runs across many lines until a `";` terminator.
+fn is_help_const_open(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with("pub const ") && t.contains("_HELP") && t.contains(": &str")
+}
+
+/// A line is exempt when it can't be a *runtime* user-facing command
+/// reference. `in_help_const` is the region flag for the clap help-text blocks
+/// (see [`scan_file`]).
+fn is_exempt(line: &str, in_help_const: bool) -> bool {
+    let t = line.trim_start();
+    // Comments (line + doc).
+    if t.starts_with("//") {
+        return true;
+    }
+    // Internal logging is not user-facing.
+    if t.contains("tracing::") {
+        return true;
+    }
+    // Clap help text — a `&'static str` resolved at definition time, can't call
+    // the runtime helper. The whole `pub const ..._HELP` block is exempt, plus
+    // any `$ aube <verb>` shell-example line (the canonical help-example shape).
+    if in_help_const || t.contains("$ aube ") {
+        return true;
+    }
+    // Must be a string literal to be emitted text at all.
+    if !line.contains('"') {
+        return true;
+    }
+    for skip in ALLOWLIST {
+        if line.contains(skip) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Does this line contain a hardcoded `aube <verb>` command reference that
+/// should be `aube_util::cmd(...)`? Returns the offending verb if so.
+fn offending_verb(line: &str) -> Option<&'static str> {
+    let bytes = line.as_bytes();
+    let mut search_from = 0;
+    while let Some(rel) = line[search_from..].find("aube ") {
+        let at = search_from + rel;
+        search_from = at + 5;
+        // Reject branded *filenames* / manifest keys: `aube-lock.yaml` and
+        // friends use `aube-`, never `aube ` (space), so the "aube " match
+        // already excludes them. But also reject when the char *before* the
+        // match is alphanumeric (`...aube ` inside another word/path) — keep it
+        // a word boundary.
+        if at > 0 {
+            let prev = bytes[at - 1];
+            if prev.is_ascii_alphanumeric() || prev == b'-' || prev == b'.' {
+                continue;
+            }
+        }
+        // The word after "aube ".
+        let rest = &line[at + 5..];
+        let word: String = rest
+            .chars()
+            .take_while(|c| c.is_ascii_lowercase() || *c == '-')
+            .collect();
+        if let Some(v) = VERBS.iter().find(|&&v| v == word) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// The command layer must not hardcode `aube <verb>` in user-facing strings —
+/// use `aube_util::cmd(verb)` so the reference follows the active embedder
+/// brand. See this file's module docs for how to satisfy the lint.
+#[test]
+fn no_hardcoded_aube_verb_in_user_facing_strings() {
+    let mut files = Vec::new();
+    rs_files(&commands_dir(), &mut files);
+    assert!(
+        !files.is_empty(),
+        "found no command-layer source files to lint"
+    );
+
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut hits = Vec::new();
+    for file in &files {
+        let src = fs::read_to_string(file).expect("read source");
+        // Region flags. A `pub const ..._HELP: &str = "..."` clap help block and
+        // a multi-line `tracing::<level>!(...)` internal-log call both span
+        // several lines; their inner string lines are exempt (help can't use the
+        // runtime helper; tracing is internal). Track whether we're inside one.
+        let mut in_help_const = false;
+        let mut in_tracing = false;
+        for (i, line) in src.lines().enumerate() {
+            if !in_help_const && is_help_const_open(line) {
+                in_help_const = true;
+            }
+            if !in_tracing && line.contains("tracing::") && !line.trim_end().contains(';') {
+                in_tracing = true;
+            }
+            let exempt = is_exempt(line, in_help_const || in_tracing);
+            // A help block ends on its closing `";`; a tracing call ends on the
+            // line that closes its statement with `;`.
+            if in_help_const && line.contains("\";") {
+                in_help_const = false;
+            }
+            if in_tracing && line.trim_end().ends_with(';') {
+                in_tracing = false;
+            }
+            if exempt {
+                continue;
+            }
+            if let Some(verb) = offending_verb(line) {
+                let rel = file.strip_prefix(manifest).unwrap_or(file);
+                hits.push(format!(
+                    "{}:{}: hardcoded `aube {verb}` — use `aube_util::cmd(\"{verb}\")`\n    {}",
+                    rel.display(),
+                    i + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        hits.is_empty(),
+        "hardcoded `aube <verb>` command reference(s) in user-facing strings — \
+         replace with `aube_util::cmd(<verb>)` so the brand follows the active \
+         embedder (it renders `aube <verb>` byte-for-byte under standalone aube). \
+         If a hit is a genuine non-command-reference, allowlist it in \
+         brand_literal_lint.rs with a justifying comment.\n\n{}",
+        hits.join("\n")
+    );
+}

--- a/crates/aube/tests/brand_literal_lint.rs
+++ b/crates/aube/tests/brand_literal_lint.rs
@@ -16,7 +16,8 @@
 //! layer (`src/commands/`), only flags string-literal lines (a `"` on the
 //! line), only matches `aube <verb>` where `<verb>` is a real CLI command, and
 //! skips everything that is legitimately not a runtime command reference:
-//! doc/line comments, `tracing::*` internal logs, branded filenames
+//! doc/line comments, *non-user-facing* `tracing::` logs (`debug!`/`trace!`/
+//! `info!` — see the severity split below), branded filenames
 //! (`aube-lock.yaml`, `aube-workspace.yaml` use `aube-`, never `aube `),
 //! manifest keys (`package.json#aube`, `aube.<key>`), sentence-start
 //! capitalized prose ("Aube …"), and — importantly — **clap help text**, which
@@ -27,6 +28,22 @@
 //! `$ aube <verb>` shell-example lines they contain. (Branding help text is a
 //! separate, clap-level concern tracked as a follow-up.) An explicit
 //! [`ALLOWLIST`] covers any remaining one-off intentional mention.
+//!
+//! ## `tracing::` severity split — why `warn!`/`error!` ARE scanned
+//! Not all `tracing::` lines are internal. `tracing::debug!` / `trace!` /
+//! `info!` are developer logs the user never sees on a normal run, so they may
+//! contain `aube <verb>` freely and stay exempt. But `tracing::warn!` and
+//! `tracing::error!` SURFACE to the user (the default subscriber prints them),
+//! so a command hint inside one — ``"Run `aube approve-builds`"``,
+//! ``"run `aube install --no-frozen-lockfile`"`` — is exactly as user-facing as
+//! the same hint in a `bail!`/`eprintln!`, and is held to the same `cmd()`
+//! contract. The lint therefore scans `warn!`/`error!` with the identical
+//! `aube <verb>` verb matcher (NOT a blanket "contains aube" — a `warn!` that
+//! mentions `aube` for a non-command reason, e.g. a path or proper noun, never
+//! trips because the word after `aube ` isn't a CLI verb), and exempts only the
+//! lower severities. The macro a line is judged under is the one whose
+//! statement it sits inside (a multi-line `warn!(...)` is scanned across all of
+//! its lines; the leading-word severity governs the whole call).
 //!
 //! ## How to satisfy this lint
 //! Replace the hardcoded reference with the helper:
@@ -159,23 +176,47 @@ fn is_help_const_open(line: &str) -> bool {
     t.starts_with("pub const ") && t.contains("_HELP") && t.contains(": &str")
 }
 
+/// `tracing::` severities that are *not* user-facing: developer logs that the
+/// default subscriber doesn't surface on a normal run. Lines inside one of
+/// these (and their multi-line continuations) are exempt — they may contain
+/// `aube <verb>` freely. Conversely `warn!` / `error!` DO surface to the user
+/// and are scanned like any other emission macro (see module docs, severity
+/// split). Returns the level word if `line` opens a `tracing::<level>!` call.
+fn tracing_level(line: &str) -> Option<&str> {
+    let rest = line.split_once("tracing::")?.1;
+    let level: &str = rest
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .next()?;
+    (!level.is_empty()).then_some(level)
+}
+
+/// Is this `tracing::<level>` an internal (non-user-facing) log? `debug`,
+/// `trace`, `info` — everything that is NOT `warn`/`error`. A `tracing::warn!`
+/// or `tracing::error!` is user-facing and must be scanned.
+fn is_internal_tracing_level(level: &str) -> bool {
+    !matches!(level, "warn" | "error")
+}
+
 /// A line is exempt when it can't be a *runtime* user-facing command
-/// reference. `in_help_const` is the region flag for the clap help-text blocks
-/// (see [`scan_file`]).
-fn is_exempt(line: &str, in_help_const: bool) -> bool {
+/// reference. `in_exempt_region` is the region flag for the clap help-text
+/// blocks and internal (`debug`/`trace`/`info`) multi-line tracing calls (see
+/// the scan loop in [`no_hardcoded_aube_verb_in_user_facing_strings`]).
+fn is_exempt(line: &str, in_exempt_region: bool) -> bool {
     let t = line.trim_start();
     // Comments (line + doc).
     if t.starts_with("//") {
         return true;
     }
-    // Internal logging is not user-facing.
-    if t.contains("tracing::") {
+    // Internal logging is not user-facing — but only the lower severities.
+    // `tracing::warn!` / `tracing::error!` surface to the user and ARE scanned.
+    if tracing_level(line).is_some_and(is_internal_tracing_level) {
         return true;
     }
     // Clap help text — a `&'static str` resolved at definition time, can't call
     // the runtime helper. The whole `pub const ..._HELP` block is exempt, plus
     // any `$ aube <verb>` shell-example line (the canonical help-example shape).
-    if in_help_const || t.contains("$ aube ") {
+    // Also covers internal multi-line tracing (`debug`/`trace`/`info`) regions.
+    if in_exempt_region || t.contains("$ aube ") {
         return true;
     }
     // Must be a string literal to be emitted text at all.
@@ -239,26 +280,34 @@ fn no_hardcoded_aube_verb_in_user_facing_strings() {
     for file in &files {
         let src = fs::read_to_string(file).expect("read source");
         // Region flags. A `pub const ..._HELP: &str = "..."` clap help block and
-        // a multi-line `tracing::<level>!(...)` internal-log call both span
-        // several lines; their inner string lines are exempt (help can't use the
-        // runtime helper; tracing is internal). Track whether we're inside one.
+        // a multi-line *internal* `tracing::{debug,trace,info}!(...)` call both
+        // span several lines; their inner string lines are exempt (help can't
+        // use the runtime helper; low-severity tracing is internal). A
+        // multi-line `tracing::warn!`/`error!` is NOT exempt — it surfaces to
+        // the user — so its continuation lines are scanned normally. Track
+        // whether we're inside an exempt region.
         let mut in_help_const = false;
-        let mut in_tracing = false;
+        let mut in_internal_tracing = false;
         for (i, line) in src.lines().enumerate() {
             if !in_help_const && is_help_const_open(line) {
                 in_help_const = true;
             }
-            if !in_tracing && line.contains("tracing::") && !line.trim_end().contains(';') {
-                in_tracing = true;
+            // Open an internal-tracing region only for the non-user-facing
+            // severities; `warn!`/`error!` deliberately do not start one.
+            if !in_internal_tracing
+                && !line.trim_end().contains(';')
+                && tracing_level(line).is_some_and(is_internal_tracing_level)
+            {
+                in_internal_tracing = true;
             }
-            let exempt = is_exempt(line, in_help_const || in_tracing);
+            let exempt = is_exempt(line, in_help_const || in_internal_tracing);
             // A help block ends on its closing `";`; a tracing call ends on the
             // line that closes its statement with `;`.
             if in_help_const && line.contains("\";") {
                 in_help_const = false;
             }
-            if in_tracing && line.trim_end().ends_with(';') {
-                in_tracing = false;
+            if in_internal_tracing && line.trim_end().ends_with(';') {
+                in_internal_tracing = false;
             }
             if exempt {
                 continue;

--- a/crates/aube/tests/brand_literal_lint.rs
+++ b/crates/aube/tests/brand_literal_lint.rs
@@ -60,84 +60,47 @@
 //! example, a sentence whose rewrite would hurt clarity), add it to
 //! [`ALLOWLIST`] below with a comment explaining why — keep that list short.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
-/// Real CLI command verbs (and the leading word of multi-word subcommand
-/// chains). A `aube <word>` literal only trips the lint when `<word>` is one of
-/// these — so prose like "aube has no shims" or "let aube do it" never trips
-/// (those words aren't commands), keeping the lint conservative.
-const VERBS: &[&str] = &[
-    "install",
-    "install-test",
-    "it",
-    "test",
-    "i",
-    "ci",
-    "add",
-    "remove",
-    "rm",
-    "update",
-    "up",
-    "run",
-    "exec",
-    "dlx",
-    "import",
-    "dedupe",
-    "patch",
-    "patch-commit",
-    "patch-remove",
-    "approve-builds",
-    "ignored-builds",
-    "store",
-    "outdated",
-    "why",
-    "list",
-    "ls",
-    "ll",
-    "la",
-    "pack",
-    "publish",
-    "init",
-    "create",
-    "setup",
-    "config",
-    "rebuild",
-    "prune",
-    "purge",
-    "link",
-    "unlink",
-    "fetch",
-    "login",
-    "logout",
-    "doctor",
-    "audit",
-    "deprecate",
-    "undeprecate",
-    "view",
-    "node",
-    "runtime",
-    "deploy",
-    "completion",
-    "recursive",
-    "peers",
-    "check",
-    "query",
-    "sbom",
-    "licenses",
-    "token",
-    "owner",
-    "search",
-    "whoami",
-    "root",
-    "bin",
-    "get",
-    "set",
-    "dist-tag",
-    "clean",
-    "stage",
-    "pkg",
-];
+/// The set of real CLI command verbs, **derived from the clap command tree**
+/// (`aube::command()`) rather than hand-maintained. A `aube <word>` literal
+/// only trips the lint when `<word>` is one of these — so prose like "aube has
+/// no shims" or "let aube do it" never trips (those words aren't commands),
+/// keeping the lint conservative.
+///
+/// Deriving from clap is the whole point: the command surface is the single
+/// source of truth, so adding/renaming a verb (or an alias) updates the lint
+/// automatically — no second list to keep in sync. We walk the command tree
+/// recursively, so nested subcommands (`store prune`, `config get`, …) and the
+/// leading word of multi-word chains are all covered, and we include every
+/// subcommand's visible *and* hidden aliases (`i`/`install`, `rm`/`remove`,
+/// `it`/`install-test`, `t`/`test`, …) since a hardcoded `aube <alias>` is just
+/// as much a brand leak as the canonical spelling.
+static VERBS: LazyLock<BTreeSet<String>> = LazyLock::new(|| {
+    let mut verbs = BTreeSet::new();
+    collect_verbs(&aube::command(), &mut verbs);
+    verbs
+});
+
+/// Walk the clap command tree, collecting every subcommand name plus all of its
+/// aliases (visible and hidden), recursing into nested subcommands so the whole
+/// surface — top-level verbs, their aliases, and nested chains — is covered.
+/// The `external_subcommand` catch-all has no fixed name and contributes
+/// nothing; names carrying chars the `aube <verb>` matcher can't reach (e.g. the
+/// hidden `__node-gyp-bootstrap`) are harmless — they simply never match a
+/// literal.
+fn collect_verbs(cmd: &clap::Command, out: &mut BTreeSet<String>) {
+    for sub in cmd.get_subcommands() {
+        out.insert(sub.get_name().to_string());
+        for alias in sub.get_all_aliases() {
+            out.insert(alias.to_string());
+        }
+        collect_verbs(sub, out);
+    }
+}
 
 /// Intentional exceptions: `crate/path` substrings or exact source lines where
 /// an `aube <verb>`-shaped literal is deliberately left as-is. Keep this SHORT
@@ -233,7 +196,7 @@ fn is_exempt(line: &str, in_exempt_region: bool) -> bool {
 
 /// Does this line contain a hardcoded `aube <verb>` command reference that
 /// should be `aube_util::cmd(...)`? Returns the offending verb if so.
-fn offending_verb(line: &str) -> Option<&'static str> {
+fn offending_verb(line: &str) -> Option<String> {
     let bytes = line.as_bytes();
     let mut search_from = 0;
     while let Some(rel) = line[search_from..].find("aube ") {
@@ -256,8 +219,8 @@ fn offending_verb(line: &str) -> Option<&'static str> {
             .chars()
             .take_while(|c| c.is_ascii_lowercase() || *c == '-')
             .collect();
-        if let Some(v) = VERBS.iter().find(|&&v| v == word) {
-            return Some(v);
+        if VERBS.contains(&word) {
+            return Some(word);
         }
     }
     None
@@ -333,4 +296,81 @@ fn no_hardcoded_aube_verb_in_user_facing_strings() {
          brand_literal_lint.rs with a justifying comment.\n\n{}",
         hits.join("\n")
     );
+}
+
+/// The clap-derived verb set is non-empty and covers the canonical core verbs.
+/// Guards against a future refactor that silently breaks the derivation (e.g.
+/// `aube::command()` no longer exposing subcommands) and leaves the lint matching
+/// nothing — which would pass vacuously while catching zero real leaks.
+#[test]
+fn derived_verbs_cover_the_core_surface() {
+    assert!(
+        VERBS.len() > 20,
+        "expected the clap-derived verb set to be substantial, got {} — \
+         did `aube::command()` stop exposing subcommands?",
+        VERBS.len()
+    );
+    // Spot-check the verbs jdx specifically flagged (`test`, `install-test`) plus
+    // a representative spread of canonical names, visible aliases, and the
+    // multi-word/nested chains the old hand-list had to track by hand.
+    for expect in [
+        "install",
+        "i",
+        "add",
+        "a",
+        "remove",
+        "rm",
+        "test",
+        "t",
+        "install-test",
+        "it",
+        "run",
+        "patch-commit",
+        "approve-builds",
+        "store",
+        "prune",
+        "config",
+        "get",
+    ] {
+        assert!(
+            VERBS.contains(expect),
+            "clap-derived verb set is missing `{expect}` — the derivation lost a \
+             verb the lint must catch"
+        );
+    }
+}
+
+/// A planted `aube <verb>` literal trips the matcher (positive control), and a
+/// non-command `aube <word>` does not (conservativeness control).
+#[test]
+fn offending_verb_catches_planted_leak() {
+    assert_eq!(
+        offending_verb(r#"bail!("run `aube install` first")"#).as_deref(),
+        Some("install")
+    );
+    // A word that isn't a CLI verb must not trip — keeps the lint low-false-positive.
+    assert_eq!(offending_verb(r#"eprintln!("aube has no shims")"#), None);
+}
+
+/// The payoff of deriving from clap: a real CLI verb that was **never** in the
+/// old hand-maintained list is now caught automatically. `version`, `cache`,
+/// `diag`, and `sponsors` are all genuine subcommands the previous hardcoded
+/// `VERBS` array omitted — under the static list a hardcoded `aube version`
+/// brand leak would have slipped through; the dynamic derivation catches it,
+/// proving the new approach is strictly stronger than the manual one.
+#[test]
+fn derivation_catches_verbs_the_old_hardcoded_list_missed() {
+    for verb in ["version", "cache", "diag", "sponsors"] {
+        assert!(
+            VERBS.contains(verb),
+            "`{verb}` is a real clap subcommand but the derived set lacks it"
+        );
+        let planted = format!(r#"bail!("see `aube {verb}` output")"#);
+        assert_eq!(
+            offending_verb(&planted).as_deref(),
+            Some(verb),
+            "dynamic lint should catch `aube {verb}` — a verb the old hardcoded \
+             VERBS list did not contain"
+        );
+    }
 }


### PR DESCRIPTION
Completes the `Embedder` profile wiring from #862. The remaining hardcoded `aube` identity/path/namespace literals now resolve through `embedder()`, so an embedder gets its own without patching aube. No-op for standalone aube — every site resolves to the existing `"aube"` under the default profile.

- **Banner** (`progress/`): the `by jdx.dev` vendor tag renders only for standalone aube. Three render sites consolidated into one `product_banner` helper.
- **Paths & namespaces**: cache dirs (resolver primer, runtime, adaptive-state), the virtual-store leaf (`.aube` → `.<name>`), the Node-install root, and the install-shape digest now derive from the profile instead of the literal.
- **Embed-safe entrypoint**: `cli_main`/`cli_main_with_defaults` return the exit code instead of calling `std::process::exit`, which would tear down a host that embeds aube in-process. `main` owns the exit now; `#[must_use]` flags the change for existing callers. (The #862 follow-up.)
- Routes `doctor`'s virtual-store check and the project-lock contention message through the profile too.

Standalone aube is byte-for-byte unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added branded environment-variable handling (brand-specific config and toggles) plus `prog()`/`cmd()` helpers for consistent CLI branding in messages.
* **Refactor**
  * Updated on-disk directories, cache/primer locations, virtual-store paths, progress/product banners, and command/help text to derive from the active embedder.
  * Improved workspace staging/sidecar naming and standardized install/command suggestions across commands.
* **Bug Fixes**
  * Corrected `doctor` guidance to reference the embedder-specific virtual-store location.
* **Tests**
  * Added/expanded branding-gate and branding-literal checks, plus embedder environment integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->