### PR TITLE
fix(install): keep nested pnpm-workspace.yaml as a hard workspace boundary

### DIFF
--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -22,8 +22,8 @@ mod yaml_patch;
 
 pub use config::{
     ConfigWriteTarget, JailBuildPermission, SupportedArchitectures, WorkspaceConfig,
-    WorkspaceYamlKind, config_write_target, load_both, load_raw, workspace_yaml_existing,
-    workspace_yaml_kind, workspace_yaml_names, workspace_yaml_target,
+    config_write_target, load_both, load_raw, workspace_yaml_existing, workspace_yaml_names,
+    workspace_yaml_target,
 };
 pub use edits::{
     edit_setting_map, edit_workspace_yaml, remove_map_entry, remove_setting_entry, upsert_map_entry,

--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -632,25 +632,19 @@ impl WorkspaceConfig {
         if let Some(hit) = typed_cache_lookup(project_dir) {
             return Ok(hit);
         }
-        let value = Self::load_present(project_dir)?.unwrap_or_default();
+        let value = Self::load_uncached(project_dir)?;
         typed_cache_insert(project_dir, value.clone());
         Ok(value)
     }
 
-    /// Parse the workspace yaml in `project_dir`, distinguishing an
-    /// *absent* file (`None`) from a *present* one (`Some`, possibly the
-    /// empty default). [`load`](Self::load) folds both into
-    /// `Self::default()`, but workspace-root discovery must tell them
-    /// apart — a present-but-memberless yaml is a settings-only root
-    /// candidate, an absent one is not. See [`workspace_yaml_kind`].
-    fn load_present(project_dir: &Path) -> Result<Option<Self>, crate::Error> {
+    fn load_uncached(project_dir: &Path) -> Result<Self, crate::Error> {
         let Some((path, content)) = find_and_read(project_dir)? else {
-            return Ok(None);
+            return Ok(Self::default());
         };
         if content.trim().is_empty() {
-            return Ok(Some(Self::default()));
+            return Ok(Self::default());
         }
-        Ok(Some(crate::parse_yaml(&path, content)?))
+        crate::parse_yaml(&path, content)
     }
 }
 
@@ -764,75 +758,6 @@ pub fn workspace_yaml_existing(project_dir: &Path) -> Option<PathBuf> {
     None
 }
 
-/// How a directory participates in workspace-root discovery, derived
-/// from its workspace yaml (`aube-workspace.yaml` / `pnpm-workspace.yaml`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WorkspaceYamlKind {
-    /// No workspace yaml in this directory.
-    Absent,
-    /// A yaml exists but declares no members — settings-only:
-    /// per-package config (`minimumReleaseAge`, `pnpmfile`, `catalog`,
-    /// etc.) with no `packages:` list.
-    SettingsOnly,
-    /// A yaml exists and declares members (a non-empty `packages:` list).
-    DeclaresMembers,
-    /// A yaml exists but can't be read or parsed. Discovery must stop
-    /// here rather than walk past it: collapsing this into `SettingsOnly`
-    /// would silently resolve a member command to a parent workspace and
-    /// hide the broken member config. The parse/IO error then surfaces
-    /// when the config is loaded for real.
-    Invalid,
-}
-
-/// Classify `project_dir`'s workspace yaml in a single file probe.
-///
-/// Workspace-root discovery needs four outcomes per directory:
-/// `DeclaresMembers` (stop — this is the root), `SettingsOnly` (remember
-/// as a fallback root, keep walking), `Absent` (keep walking), and
-/// `Invalid` (stop — a present-but-broken yaml must surface, not be
-/// silently skipped). [`WorkspaceConfig::load`] collapses absent and
-/// memberless yamls — both yield an empty `packages` list — so
-/// classifying here lets the ancestor walk use one probe per directory
-/// instead of a memoized load plus a redundant existence stat.
-///
-/// pnpm treats *any* `pnpm-workspace.yaml` as a workspace root, but a
-/// member of an enclosing workspace that drops a settings-only yaml into
-/// its own directory is configuring itself, not declaring a new
-/// workspace. Discovery walks past such a file to the real root so `cd
-/// member && aube install` still targets the workspace the member
-/// belongs to — otherwise the member resolves to itself, its workspace
-/// siblings can't be linked, and the install never settles.
-///
-/// Deliberately does *not* warm the typed cache. `find_workspace_root`'s
-/// ancestor walk runs early and probes many directories through here, but
-/// a command that writes a workspace yaml mid-process (`patch-commit`,
-/// `approve-builds`, catalog edits) and then re-reads through
-/// [`WorkspaceConfig::load`] must see the fresh bytes — not a config this
-/// walk parsed before the write. Caching the pre-write config here made
-/// the post-write read stale (e.g. `patch-commit` recorded a patch but
-/// the in-process reinstall reused a cached config without it and skipped
-/// applying the patch). `WorkspaceConfig::load` still memoizes for its
-/// own direct callers.
-pub fn workspace_yaml_kind(project_dir: &Path) -> WorkspaceYamlKind {
-    match WorkspaceConfig::load_present(project_dir) {
-        Ok(Some(config)) => {
-            if config.packages.is_empty() {
-                WorkspaceYamlKind::SettingsOnly
-            } else {
-                WorkspaceYamlKind::DeclaresMembers
-            }
-        }
-        // An absent yaml is simply `Absent`; nothing to cache.
-        Ok(None) => WorkspaceYamlKind::Absent,
-        // A present-but-unreadable/unparseable yaml is its own state.
-        // Stop discovery here instead of collapsing into `SettingsOnly`
-        // and walking up to a parent workspace, which would silently
-        // ignore the broken member config; the parse/IO error surfaces
-        // when the config is loaded for real.
-        Err(_) => WorkspaceYamlKind::Invalid,
-    }
-}
-
 /// Resolve which workspace-yaml path a writer should mutate in
 /// `project_dir`. Existing `aube-workspace.yaml` wins over
 /// `pnpm-workspace.yaml`; when neither exists, falls back to
@@ -893,109 +818,5 @@ pub fn config_write_target(project_dir: &Path) -> ConfigWriteTarget {
     match workspace_yaml_existing(project_dir) {
         Some(path) => ConfigWriteTarget::WorkspaceYaml(path),
         None => ConfigWriteTarget::PackageJson,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn workspace_yaml_kind_classifies_absent_settings_only_and_members() {
-        // Absent: no workspace yaml at all — discovery keeps walking.
-        let absent = tempfile::tempdir().unwrap();
-        assert_eq!(
-            workspace_yaml_kind(absent.path()),
-            WorkspaceYamlKind::Absent
-        );
-
-        // Settings-only: a yaml with no `packages:` list, i.e. the
-        // per-package config a member drops into its own directory.
-        let settings = tempfile::tempdir().unwrap();
-        std::fs::write(
-            settings.path().join("pnpm-workspace.yaml"),
-            "minimumReleaseAge: 0\nenableGlobalVirtualStore: true\n",
-        )
-        .unwrap();
-        assert_eq!(
-            workspace_yaml_kind(settings.path()),
-            WorkspaceYamlKind::SettingsOnly
-        );
-
-        // Declares members: a non-empty `packages:` list — the real root.
-        let members = tempfile::tempdir().unwrap();
-        std::fs::write(
-            members.path().join("pnpm-workspace.yaml"),
-            "packages:\n  - 'packages/*'\n",
-        )
-        .unwrap();
-        assert_eq!(
-            workspace_yaml_kind(members.path()),
-            WorkspaceYamlKind::DeclaresMembers
-        );
-    }
-
-    #[test]
-    fn workspace_yaml_kind_treats_empty_yaml_as_settings_only() {
-        // A present-but-empty yaml is settings-only, not absent: the file
-        // exists, so it is still a settings-root candidate.
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("pnpm-workspace.yaml"), "\n").unwrap();
-        assert_eq!(
-            workspace_yaml_kind(dir.path()),
-            WorkspaceYamlKind::SettingsOnly
-        );
-    }
-
-    #[test]
-    fn workspace_yaml_kind_treats_unparseable_yaml_as_invalid() {
-        // A present-but-malformed yaml must classify as `Invalid` so
-        // discovery stops at this directory instead of walking past a
-        // broken member config to a parent workspace. A tab as the first
-        // indent char is a spec-level YAML syntax error.
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join("pnpm-workspace.yaml"),
-            "packages:\n\t- pkg\n",
-        )
-        .unwrap();
-        assert_eq!(workspace_yaml_kind(dir.path()), WorkspaceYamlKind::Invalid);
-    }
-
-    #[test]
-    fn workspace_yaml_kind_does_not_cache_pre_write_config() {
-        // Regression: discovery must not warm the typed config cache.
-        // `find_workspace_root` classifies every ancestor through
-        // `workspace_yaml_kind` *before* a command such as `patch-commit`
-        // writes `patchedDependencies` into that same yaml. When the early
-        // pass cached the pre-write config, the in-process
-        // `WorkspaceConfig::load` after the write returned the stale
-        // (patch-less) config, so the reinstall skipped applying the patch.
-        let dir = tempfile::tempdir().unwrap();
-        let yaml = dir.path().join("pnpm-workspace.yaml");
-        std::fs::write(&yaml, "packages:\n  - 'packages/*'\n").unwrap();
-
-        // Discovery-time classification (the early ancestor probe).
-        assert_eq!(
-            workspace_yaml_kind(dir.path()),
-            WorkspaceYamlKind::DeclaresMembers
-        );
-
-        // A command now records a patch in the very same yaml.
-        std::fs::write(
-            &yaml,
-            "packages:\n  - 'packages/*'\npatchedDependencies:\n  is-odd@3.0.1: patches/is-odd@3.0.1.patch\n",
-        )
-        .unwrap();
-
-        // The post-write read must observe the patch, not a cached
-        // pre-write config.
-        let cfg = WorkspaceConfig::load(dir.path()).unwrap();
-        assert_eq!(
-            cfg.patched_dependencies
-                .get("is-odd@3.0.1")
-                .map(String::as_str),
-            Some("patches/is-odd@3.0.1.patch"),
-        );
     }
 }

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -239,33 +239,22 @@ fn bootstrap_blocking(
     // so its workspace-root walk-up stops here instead of escaping
     // upward. `tool_dir` lives under `$XDG_CACHE_HOME/aube/tools/` —
     // i.e. inside the user's HOME and inside any test temp dir set
-    // via `HOME=$TEST_TEMP_DIR`. Without a members-declaring marker,
-    // `find_workspace_root` walks past `$XDG_CACHE_HOME`, discovers an
-    // enclosing project's `pnpm-workspace.yaml` / `package.json#workspaces`,
-    // and runs the recursive install against the *outer* tree —
-    // deadlocking on the outer process's project lock.
-    //
-    // The marker must *declare members* (a non-empty `packages:` list)
-    // so workspace-root discovery classifies `tool_dir` as
-    // `WorkspaceYamlKind::DeclaresMembers` and stops here. A
-    // settings-only (empty) yaml no longer halts the walk — discovery
-    // treats it as per-package config and keeps climbing toward the
-    // enclosing workspace — so an empty marker would re-introduce the
-    // deadlock. The glob is deliberately one that matches nothing under
-    // `tool_dir`, so `find_workspace_packages` returns empty and the
-    // recursive install still runs as a single-package install
-    // (`has_workspace` is false).
+    // via `HOME=$TEST_TEMP_DIR`. Without this stub yaml,
+    // `find_workspace_root` would walk past `$XDG_CACHE_HOME`,
+    // discover the outer project's `pnpm-workspace.yaml`, and run
+    // the recursive install against the *outer* tree — deadlocking
+    // on the outer process's project lock. Any `pnpm-workspace.yaml`
+    // is a hard boundary, so the empty stub hits the first marker
+    // check at the start of the walk, returns `tool_dir`, and the
+    // install runs as a single-package install (`workspace_packages`
+    // is empty so `has_workspace` is false).
     // Use whichever workspace-yaml name this tool's discovery recognizes
     // first (its branded YAML, or the shared `pnpm-workspace.yaml`).
     let marker = aube_manifest::workspace::workspace_yaml_names()
         .first()
         .copied()
         .unwrap_or("pnpm-workspace.yaml");
-    aube_util::fs_atomic::atomic_write(
-        &tool_dir.join(marker),
-        b"packages:\n  - 'aube-node-gyp-bootstrap-has-no-members/*'\n",
-    )
-    .into_diagnostic()?;
+    aube_util::fs_atomic::atomic_write(&tool_dir.join(marker), b"").into_diagnostic()?;
     // Forward the outer project's `.npmrc` so private registries and
     // auth tokens configured at project scope carry through to the
     // recursive install. The subprocess's cwd is `tool_dir`, so

--- a/crates/aube/src/dirs.rs
+++ b/crates/aube/src/dirs.rs
@@ -133,43 +133,27 @@ fn find_workspace_root_uncached(start: &Path) -> Option<PathBuf> {
     // a workspaces field, and attach to that workspace. Cap the walk
     // at $HOME so that never happens.
     let stop = home_stop_boundary();
-    // A *settings-only* `pnpm-workspace.yaml` (no `packages:`) inside a
-    // member of an enclosing workspace configures that member; it does
-    // not declare a new workspace. Walk past it to the real root (the
-    // nearest ancestor that declares members) so `cd member && aube
-    // install` targets the workspace the member belongs to — otherwise
-    // the member resolves to itself, its workspace siblings (e.g.
-    // `@scope/lib`) can't be linked, and the warm path never settles.
-    // Only when no members-declaring root exists above do we fall back
-    // to the nearest settings-only yaml: a standalone single package
-    // that keeps its config in `pnpm-workspace.yaml` is still its own
-    // root. A present-but-broken yaml (`Invalid`) also stops the walk
-    // here — escaping past it to a parent would silently ignore the
-    // member's own (malformed) config; anchoring on it surfaces the
-    // parse/IO error downstream instead.
-    use aube_manifest::workspace::{WorkspaceYamlKind, workspace_yaml_kind};
-    let mut settings_only_root: Option<PathBuf> = None;
+    // Any `pnpm-workspace.yaml` is a hard workspace boundary, matching
+    // pnpm: a file with no `packages:` list configures a single-package
+    // workspace (just the root package) — it does not mean "ignore this
+    // file and keep walking to an enclosing workspace". So `cd member &&
+    // aube install` anchors on the member's own yaml rather than the
+    // outer root; per-member lockfile freshness (tracked in install
+    // state) is what keeps repeat installs warm under
+    // `sharedWorkspaceLockfile=false`.
     for dir in start.ancestors() {
-        // One probe per dir classifies the yaml as members-declaring,
-        // settings-only, absent, or invalid — no separate existence stat.
-        match workspace_yaml_kind(dir) {
-            WorkspaceYamlKind::DeclaresMembers | WorkspaceYamlKind::Invalid => {
-                return Some(dir.to_path_buf());
-            }
-            WorkspaceYamlKind::SettingsOnly if settings_only_root.is_none() => {
-                settings_only_root = Some(dir.to_path_buf());
-            }
-            _ => {}
+        if aube_manifest::workspace::workspace_yaml_existing(dir).is_some() {
+            return Some(dir.to_path_buf());
         }
         let pkg = dir.join("package.json");
         if pkg.is_file() && package_json_has_workspaces(&pkg) {
             return Some(dir.to_path_buf());
         }
         if stop.as_deref() == Some(dir) {
-            break;
+            return None;
         }
     }
-    settings_only_root
+    None
 }
 
 /// Walk upward from `start` looking for the nearest ancestor that
@@ -384,14 +368,13 @@ mod tests {
     }
 
     #[test]
-    fn find_workspace_root_walks_past_settings_only_member_yaml() {
-        // A member of a `packages:`-declaring workspace can drop a
-        // settings-only `pnpm-workspace.yaml` (no `packages:`) in its
-        // own directory to carry per-package config. That file must NOT
-        // make the member look like its own workspace root — discovery
-        // walks past it to the real root, so `cd member && aube install`
-        // targets the enclosing workspace where the member's workspace
-        // siblings actually live (otherwise the install never settles).
+    fn find_workspace_root_stops_at_member_settings_only_yaml() {
+        // A `pnpm-workspace.yaml` is a hard boundary even when it declares
+        // no `packages:` list. pnpm treats a memberless yaml as a
+        // single-package workspace (just the root package), not as "ignore
+        // this file and keep walking to the enclosing workspace". So a
+        // member that drops its own settings-only yaml resolves to
+        // *itself*, not the outer `packages:`-declaring root.
         let dir = tempfile::tempdir().unwrap();
         write(
             &dir.path().join("pnpm-workspace.yaml"),
@@ -404,7 +387,7 @@ mod tests {
             "# per-service settings, no packages:\nenableGlobalVirtualStore: true\n",
         );
 
-        assert_eq!(find_workspace_root(&member).unwrap(), dir.path());
+        assert_eq!(find_workspace_root(&member).unwrap(), member);
     }
 
     #[test]
@@ -425,11 +408,10 @@ mod tests {
 
     #[test]
     fn find_workspace_root_stops_at_member_with_broken_yaml() {
-        // A member that carries a *malformed* `pnpm-workspace.yaml` must
-        // anchor discovery on itself rather than silently escaping to the
-        // enclosing members-declaring workspace. Walking past the broken
-        // file would hide the member's own (unparseable) config; stopping
-        // here surfaces the parse error when the config is loaded.
+        // A `pnpm-workspace.yaml` is a hard boundary regardless of whether
+        // it parses: its mere presence anchors discovery on this directory
+        // rather than the enclosing members-declaring workspace, and the
+        // parse error surfaces later when the config is loaded for real.
         let dir = tempfile::tempdir().unwrap();
         write(
             &dir.path().join("pnpm-workspace.yaml"),

--- a/test/shared_workspace_lockfile_warm_path.bats
+++ b/test/shared_workspace_lockfile_warm_path.bats
@@ -106,41 +106,6 @@ _setup_no_shared_workspace() {
 	assert_equal "$(cat node_modules/.aube-state/state.json)" "$root_state_before"
 }
 
-@test "sharedWorkspaceLockfile=false: settings-only nested member yaml resolves to the parent root" {
-	_setup_no_shared_workspace
-
-	# The member drops a *settings-only* pnpm-workspace.yaml (no
-	# `packages:`) into its own dir. That configures the member; it does
-	# not declare a new workspace. Workspace-root discovery must walk
-	# past it to the real root — otherwise `cd member && aube install`
-	# resolves to the member-as-its-own-root, which can't see its
-	# `workspace:*` sibling and re-resolves the whole graph every run.
-	cat >packages/service-name/pnpm-workspace.yaml <<-'YAML'
-		minimumReleaseAge: 0
-	YAML
-
-	run aube install
-	assert_success
-	# The root install links the workspace sibling into the member.
-	assert_link_exists packages/service-name/node_modules/@ws/lib-a
-
-	cd packages/service-name
-	run aube install
-	assert_success
-	cd ../..
-
-	# Warm fast path: bare "Already up to date", no "(N packages)" count.
-	assert_output --partial "Already up to date"
-	refute_output --partial "up to date ("
-
-	# Resolved to the parent root: the member grew no install state of
-	# its own, and its workspace sibling is still linked (a member-rooted
-	# resolve would have dropped the sibling and rebuilt the member).
-	run test -e packages/service-name/node_modules/.aube-state
-	assert_failure
-	assert_link_exists packages/service-name/node_modules/@ws/lib-a
-}
-
 @test "sharedWorkspaceLockfile=false: deleting a member node_modules relinks on the next root install" {
 	_setup_no_shared_workspace
 


### PR DESCRIPTION
## Summary

Per @jdx's review, this backs out the workspace-root discovery change so a nested `pnpm-workspace.yaml` is once again a **hard** workspace boundary — matching pnpm. A `pnpm-workspace.yaml` with no `packages:` list configures a single-package workspace (just the root package); it does not mean "ignore this file and keep walking to an enclosing workspace". Treating a member's settings-only yaml as member-local config was a surprising divergence from aube's drop-in pnpm compatibility story.

The per-member lockfile freshness fix — the part jdx agreed with — already landed on `main` via #891. That install-state member-lockfile fingerprinting is what keeps repeat installs warm under `sharedWorkspaceLockfile=false`, so no discovery divergence is needed.

## Changes

- `aube` (dirs): `find_workspace_root` treats any `pnpm-workspace.yaml` as a hard boundary again — no walk-past, no settings-only fallback scan.
- `aube-manifest`: drop `WorkspaceYamlKind` / `workspace_yaml_kind` and the `load_present` split; restore `WorkspaceConfig::load` → `load_uncached`.
- `aube` (node-gyp bootstrap): restore the empty stub marker — any `pnpm-workspace.yaml` halts discovery, so it no longer needs a dummy `packages:` glob.
- tests: drop the now-invalid walk-past regression; unit tests assert the hard-boundary semantics (a member's settings-only yaml resolves to itself; a standalone settings-only yaml resolves to itself).

## Test plan

- `cargo fmt --check`
- `cargo clippy -p aube -p aube-manifest --all-targets -- -D warnings`
- `cargo test -p aube find_workspace_root` (8 passed)
- `cargo test -p aube-manifest workspace` (48 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified workspace root detection to stop at the first recognized workspace YAML file name, treating its presence as a hard boundary.
  * Improved workspace configuration loading to distinguish absent YAML vs present-but-empty/whitespace YAML, while keeping typed caching behavior safe.
  * Adjusted the node-gyp bootstrap workspace marker to use an empty stub YAML.
* **New Features**
  * Added a public API to classify workspace YAML state: Absent, SettingsOnly, or DeclaresMembers.
* **Tests**
  * Updated workspace root discovery tests for the new hard-boundary behavior.
  * Removed the outdated regression test covering settings-only nested member YAML handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->