### PR TITLE
fix(lockfile): only write time: under resolution-mode=time-based

### DIFF
--- a/crates/aube-resolver/src/builder.rs
+++ b/crates/aube-resolver/src/builder.rs
@@ -137,16 +137,28 @@ impl Resolver {
     }
 
     /// Whether the resolver should round-trip registry `time:` entries
-    /// into the output graph. pnpm only writes `time:` to its lockfile
-    /// when one of `resolution-mode=time-based` / `minimumReleaseAge`
-    /// is active — otherwise the field is dead weight and, worse, shows
-    /// up as churn in a pnpm ↔ aube diff. Gate the insertion at the
-    /// two `resolved_times.insert` call sites on this predicate so
-    /// Highest-mode installs never populate the map.
+    /// into the output graph (and from there into the lockfile's
+    /// top-level `time:` block).
+    ///
+    /// pnpm writes `time:` to the lockfile *only* under
+    /// `resolution-mode=time-based`. In `resolveDependencies.ts` the
+    /// `time` map is populated solely inside the `if (ctx.resolutionMode
+    /// === 'time-based')` branch, and `updateLockfile` then guards
+    /// `newLockfile.time = …` behind that map being truthy. The
+    /// `minimumReleaseAge` and `trustPolicy=no-downgrade` policies do
+    /// *not* persist `time:` — pnpm enforces them from a separate
+    /// on-disk metadata cache (re-fetching full metadata as needed), so
+    /// its lockfiles stay `time:`-free even with both policies active.
+    ///
+    /// aube mirrors that here: the two policies still drive `needs_time`
+    /// (we fetch the publish dates to enforce them in-memory during the
+    /// resolve), but they no longer leak a `time:` block that pnpm would
+    /// never write. Including them previously produced a spurious `time:`
+    /// block on every default install (aube defaults `trustPolicy` to
+    /// `no-downgrade` and `minimumReleaseAge` to 1440), which showed up
+    /// as churn in a pnpm ↔ aube lockfile diff.
     pub(crate) fn should_record_times(&self) -> bool {
         self.resolution_mode == ResolutionMode::TimeBased
-            || self.minimum_release_age.is_some()
-            || self.dependency_policy.trust_policy == crate::TrustPolicy::NoDowngrade
     }
 
     /// Override the default `auto-install-peers=true` behavior. pnpm reads

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -779,15 +779,18 @@ impl<'a> ResolveDriver<'a> {
         let version = version_meta.version.clone();
         let dep_path = dep_path_for(&task.name, &version);
 
-        // Record publish time for the cutoff / `time:` block
-        // whenever the packument carries one — matches pnpm,
-        // which populates `publishedAt` opportunistically via
-        // `meta.time?.[version]` regardless of resolution mode.
-        // Corgi packuments from npmjs.org omit `time`, so in
-        // Highest mode this is usually a no-op; Verdaccio
-        // (v5.15.1+) and full-packument fetches do include it,
-        // and then we round-trip it into the lockfile just like
-        // pnpm does.
+        // Record the picked version's publish time so (a) the
+        // time-based cutoff computation at the end of wave 0 can
+        // derive `published_by` from the directs and (b) the
+        // lockfile write emits a `time:` block. Gated on
+        // `should_record_times()` — i.e. `resolution-mode=time-based`
+        // only — because that's the sole case pnpm persists `time:`
+        // to the lockfile (see `should_record_times` for the pnpm
+        // source trail). pnpm captures `publishedAt` per-package
+        // opportunistically in memory regardless of mode, but only
+        // aggregates it into the lockfile under time-based resolution,
+        // so Highest-mode installs (incl. `minimumReleaseAge` /
+        // `trustPolicy`) stay `time:`-free here too.
         //
         // Fall back to the prior lockfile's time when the
         // packument doesn't carry one — `aube update` filters

--- a/test/minimum_release_age.bats
+++ b/test/minimum_release_age.bats
@@ -64,6 +64,30 @@ EOF
 	assert_failure
 }
 
+@test "minimumReleaseAge + trustPolicy do not add a time: block under default resolution (pnpm parity)" {
+	# Regression for the reported pnpm <-> aube incoherence: with
+	# `minimumReleaseAge` (and `trustPolicy: no-downgrade`) set but the
+	# default `resolution-mode=highest`, pnpm writes no top-level `time:`
+	# block — it enforces both policies from a separate on-disk metadata
+	# cache, persisting `time:` only under `resolution-mode=time-based`.
+	# aube used to leak a `time:` block here because `should_record_times`
+	# also keyed off these two policies. The fixture packages are years
+	# old, so a one-week cutoff resolves cleanly.
+	_setup_basic_fixture
+	rm aube-lock.yaml
+	cat >pnpm-workspace.yaml <<EOF
+packages:
+  - "."
+minimumReleaseAge: 10080
+trustPolicy: no-downgrade
+EOF
+	run aube install
+	assert_success
+	assert_file_exists aube-lock.yaml
+	run grep -E '^time:' aube-lock.yaml
+	assert_failure
+}
+
 @test "minimumReleaseAgeExclude lets named packages bypass the cutoff" {
 	# With strict mode + an impossible cutoff, the install would fail
 	# unless every range in the dep tree is excluded. Excluding the

--- a/test/pnpm_monorepo_dedupePeers.bats
+++ b/test/pnpm_monorepo_dedupePeers.bats
@@ -119,9 +119,9 @@ _require_registry() {
 
 	# Dedupe parity: extract the snapshots section and count keys that
 	# start with `'@pnpm.e2e/abc@1.0.0` — should be exactly one. The
-	# packages: and time: sections each carry an `'@pnpm.e2e/abc@1.0.0'`
-	# entry without a peer suffix, so we anchor the grep to lines that
-	# follow the `snapshots:` header.
+	# packages: section also carries an `'@pnpm.e2e/abc@1.0.0'` entry
+	# without a peer suffix, so we anchor the grep to lines that follow
+	# the `snapshots:` header.
 	run bash -c "awk '/^snapshots:/{f=1;next} /^[a-z]/{f=0} f' aube-lock.yaml | grep -cE \"^  '@pnpm\\\\.e2e/abc@1\\\\.0\\\\.0(\\\\(|':)\""
 	assert_success
 	assert_output "1"

--- a/test/resolution_mode.bats
+++ b/test/resolution_mode.bats
@@ -29,31 +29,32 @@ teardown() {
 	assert_success
 }
 
-@test "aube install --resolution-mode=highest writes time: when packument carries it" {
+@test "aube install --resolution-mode=highest writes no time: block (pnpm parity)" {
 	_setup_basic_fixture
 	rm aube-lock.yaml
 	run aube install --resolution-mode=highest
 	assert_success
 	assert_file_exists aube-lock.yaml
-	# Matches pnpm's opportunistic `publishedAt` wiring: whenever the
-	# registry metadata carries a `time` map we round-trip it into the
-	# lockfile, regardless of resolution mode. The fixture Verdaccio
-	# ships `time` in its corgi responses, so the block is present here.
-	# (npmjs.org's corgi omits `time`, so real-world default installs
-	# still won't get a `time:` block — matching pnpm's behavior there.)
+	# pnpm aggregates publish times into the lockfile *only* under
+	# resolution-mode=time-based: resolveDependencies.ts populates its
+	# `time` map solely inside the `if (ctx.resolutionMode ===
+	# 'time-based')` branch, and updateLockfile then guards
+	# `newLockfile.time = …` on that map. Highest mode must therefore
+	# stay time:-free even though the fixture Verdaccio ships `time` in
+	# its corgi responses — matching pnpm. (Regression: aube used to
+	# round-trip the field opportunistically in every mode.)
 	run grep -E '^time:' aube-lock.yaml
-	assert_success
+	assert_failure
 }
 
 @test "aube install --resolution-mode rejects unknown values via .npmrc fallback" {
 	_setup_basic_fixture
 	rm aube-lock.yaml
 	# Unknown CLI value silently falls back to the .npmrc/default
-	# path; the install should still succeed with classic highest
-	# resolution. The fixture Verdaccio returns `time` in its corgi
-	# metadata, so the opportunistic `time:` block is expected.
+	# (highest) path; the install should still succeed with classic
+	# highest resolution, which — like pnpm — writes no time: block.
 	run aube install --resolution-mode=bogus
 	assert_success
 	run grep -E '^time:' aube-lock.yaml
-	assert_success
+	assert_failure
 }

--- a/test/update.bats
+++ b/test/update.bats
@@ -323,24 +323,94 @@ EOF
 	assert_success
 }
 
-# Companion regression for discussion #345: `aube update` was dropping
-# `time:` entries for direct deps from the rewritten lockfile because
-# (a) the stripped-down `build_resolver` skipped install-time settings
-# and (b) `aube update`'s `filtered_existing` strips direct deps from
-# `existing.packages` to force a fresh re-resolve, so the lockfile-
-# reuse path's time-carry-forward never fired for them. Transitive
-# deps stayed in `existing.packages`; the writer now prunes transitive
-# publish times for pnpm v11 parity.
-@test "aube update preserves time: entries for direct deps" {
-	# `^0.1.0` is the only spec that exposes the bug cleanly: `>=0.1.0`
-	# would bump is-odd to 3.0.1 and the resolver would (correctly)
-	# write a fresh `time:` entry for the new version, masking the
-	# regression. With `^0.1.0` the highest in-range version equals
-	# the locked one (0.1.2), so the resolver re-resolves to the
-	# same version and the `time:` entry must round-trip.
+# Companion regression for discussion #345: under `resolution-mode=time-based`
+# `aube update` was dropping `time:` entries for direct deps from the
+# rewritten lockfile because (a) the stripped-down `build_resolver`
+# skipped install-time settings and (b) `aube update`'s `filtered_existing`
+# strips direct deps from `existing.packages` to force a fresh re-resolve,
+# so the lockfile-reuse path's time-carry-forward never fired for them.
+# Transitive deps stayed in `existing.packages`; the writer prunes their
+# publish times for pnpm v11 parity. pnpm only persists the `time:` block
+# in time-based mode (resolveDependencies.ts populates `time` solely in the
+# `time-based` branch), so this preservation behavior is asserted there.
+@test "aube update preserves time: entries for direct deps (time-based mode)" {
+	# Use is-odd@^3.0.1 (-> is-number@6.0.0): in time-based mode the
+	# cutoff is derived from the direct dep's publish time, and that
+	# direct must be newer than its transitives or they get filtered
+	# out. is-odd@3.0.1 is newer than is-number@6.0.0 (the inverse
+	# is-odd@0.1.2 -> is-number@3.0.0 tree fails to resolve under the
+	# cutoff). `^3.0.1` pins to the only 3.x in the fixture, so the
+	# re-resolve lands back on 3.0.1 and the `time:` entry round-trips.
 	cat >package.json <<-'JSON'
 		{
 		  "name": "update-time-preserve",
+		  "version": "0.0.0",
+		  "dependencies": {
+		    "is-odd": "^3.0.1"
+		  }
+		}
+	JSON
+	# Append so the registry= line _common_setup wrote stays in place.
+	cat >>.npmrc <<-'EOF'
+		resolution-mode=time-based
+	EOF
+	cat >aube-lock.yaml <<-'EOF'
+		lockfileVersion: '9.0'
+
+		settings:
+		  autoInstallPeers: true
+		  excludeLinksFromLockfile: false
+
+		time:
+		  is-odd@3.0.1: '2099-01-02T00:00:00.000Z'
+		  is-number@6.0.0: '2099-01-03T00:00:00.000Z'
+
+		importers:
+		  .:
+		    dependencies:
+		      is-odd:
+		        specifier: ^3.0.1
+		        version: 3.0.1
+
+		packages:
+		  is-number@6.0.0:
+		    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+		  is-odd@3.0.1:
+		    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+
+		snapshots:
+		  is-number@6.0.0: {}
+		  is-odd@3.0.1:
+		    dependencies:
+		      is-number: 6.0.0
+	EOF
+
+	run aube update
+	assert_success
+
+	# The direct dep must keep a `time:` entry after the rewrite. We
+	# can't pin the timestamp value because the resolver may have
+	# refreshed it from the packument during re-resolve, but the entry
+	# MUST be present. pnpm v11 prunes transitive publish times from the
+	# written lockfile, so the transitive is-number@6.0.0 must be gone.
+	#
+	time_block="$(awk '/^time:/{f=1;next} /^[^[:space:]].*:/{f=0} f' aube-lock.yaml)"
+	run bash -c "grep -E '^  is-odd@3\\.0\\.1: [^[:space:]]' <<<\"\$1\"" _ "$time_block"
+	assert_success
+	run bash -c "grep -E '^  is-number@6\\.0\\.0: [^[:space:]]' <<<\"\$1\"" _ "$time_block"
+	assert_failure
+}
+
+# Default (highest) resolution must drop a stray `time:` block on rewrite,
+# matching pnpm: outside time-based mode pnpm never assigns `newLockfile.time`,
+# so a lockfile that picked up a `time:` block elsewhere (an older aube, a
+# time-based install, a hand edit) is cleaned up on the next update. Guards the
+# fix for the bug where `minimumReleaseAge`/`trustPolicy` leaked a `time:` block
+# into highest-mode lockfiles.
+@test "aube update drops a stray time: block under default resolution (pnpm parity)" {
+	cat >package.json <<-'JSON'
+		{
+		  "name": "update-time-drop",
 		  "version": "0.0.0",
 		  "dependencies": {
 		    "is-odd": "^0.1.0"
@@ -386,18 +456,6 @@ EOF
 
 	run aube update
 	assert_success
-
-	# The direct dep must keep a `time:` entry after the rewrite. We
-	# can't pin the timestamp value because the resolver may have
-	# refreshed it from the packument during re-resolve, but the entry
-	# MUST be present. pnpm v11 prunes transitive publish times from the
-	# written lockfile, so only the importer dep is asserted here.
-	#
-	time_block="$(awk '/^time:/{f=1;next} /^[^[:space:]].*:/{f=0} f' aube-lock.yaml)"
-	run bash -c "grep -E '^  is-odd@0\\.1\\.2: [^[:space:]]' <<<\"\$1\"" _ "$time_block"
-	assert_success
-	run bash -c "grep -E '^  is-number@3\\.0\\.0: [^[:space:]]' <<<\"\$1\"" _ "$time_block"
-	assert_failure
-	run bash -c "grep -E '^  kind-of@3\\.2\\.2: [^[:space:]]' <<<\"\$1\"" _ "$time_block"
+	run grep -E '^time:' aube-lock.yaml
 	assert_failure
 }


### PR DESCRIPTION
## Summary

`aube install` was writing a top-level `time:` block to `pnpm-lock.yaml` whenever `minimumReleaseAge` or `trustPolicy=no-downgrade` was active, even under the default `resolution-mode=highest`. pnpm never does this — running `pnpm install` with the same config produces no `time:` block — so the field showed up as spurious churn in a pnpm ↔ aube diff. Because aube defaults `trustPolicy` to `no-downgrade`, almost every lockfile was affected.

## Root cause

pnpm aggregates publish times into the lockfile **only** for `resolution-mode=time-based`. In `installing/deps-resolver/src/resolveDependencies.ts` the `time` map is populated solely inside the `if (ctx.resolutionMode === 'time-based')` branch, and `index.ts` sets `newLockfile.time` only when that map is truthy. `minimumReleaseAge` / `trustPolicy` are enforced from a separate on-disk metadata cache, so pnpm's lockfiles stay `time:`-free with those policies on.

aube's `should_record_times()` additionally keyed off `minimumReleaseAge` and `trustPolicy`, persisting `time:` where pnpm wouldn't.

## Fix

Narrow `should_record_times()` to `resolution_mode == TimeBased` only. This changes lockfile **persistence** exclusively: both policies still drive `needs_time` and are enforced in-memory during the resolve — they just no longer emit a `time:` block. A stray `time:` block left by an older aube is dropped on the next non-frozen rewrite, matching pnpm.

## Test plan

- [x] `cargo test -p aube-resolver` / `-p aube-lockfile`
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`
- [x] `resolution_mode.bats` — highest / unknown-mode write no `time:`; time-based still does
- [x] `minimum_release_age.bats` — new test: `minimumReleaseAge` + `trustPolicy: no-downgrade` under default resolution writes no `time:`
- [x] `update.bats` — new tests: highest-mode drops a stray `time:` block; time-based preserves direct-dep `time:` and prunes transitives
- [x] `registry_supports_time_field.bats`, `workspace.bats`, `audit.bats`, `pnpm_monorepo_dedupePeers.bats`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unintended `time:` block emission in lockfiles when `minimumReleaseAge` or `trustPolicy=no-downgrade` configuration is used outside of time-based resolution mode.

* **Tests**
  * Expanded test coverage to validate `time:` block generation behavior across all resolution modes for improved standards compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->