### PR TITLE
chore(ci): use shared coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+remote_config:
+  repository: "jdx/coderabbit"
+  ref: "main"
+  path: ".coderabbit.yaml"


### PR DESCRIPTION
## Summary
- Point this repository's CodeRabbit YAML at the shared `jdx/coderabbit` configuration.
- Keep CodeRabbit settings centralized across the en.dev CLI repositories.

## Validation
- YAML-only configuration change; not run.

*This PR was created by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only addition for a third-party PR review tool; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Centralizes CodeRabbit review settings** by adding a new `.coderabbit.yaml` that uses `remote_config` to load configuration from `jdx/coderabbit` (`ref: main`, path `.coderabbit.yaml`) instead of maintaining a full local ruleset in this repo.
> 
> The file includes the CodeRabbit schema URL for editor validation. No application or CI workflow code changes—only this integration config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e3f20bdebceafdf6125c08e6b37156e52d67924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->