### PR TITLE
fix(install): close pnpm-lock.yaml parity and re-resolution gaps

### DIFF
--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -88,6 +88,8 @@ pub const WARN_AUBE_LOCKFILE_MERGE_CONFLICT: &str = "WARN_AUBE_LOCKFILE_MERGE_CO
 pub const WARN_AUBE_LOCKFILE_MERGE_CLEANUP_FAILED: &str = "WARN_AUBE_LOCKFILE_MERGE_CLEANUP_FAILED";
 pub const WARN_AUBE_LOCKFILE_CONFLICT_MARKERS: &str = "WARN_AUBE_LOCKFILE_CONFLICT_MARKERS";
 pub const WARN_AUBE_YARN_BERRY_UNSUPPORTED: &str = "WARN_AUBE_YARN_BERRY_UNSUPPORTED";
+pub const WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX: &str =
+    "WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX";
 
 // ── progress UI ─────────────────────────────────────────────────────
 pub const WARN_AUBE_PROGRESS_OVERFLOW: &str = "WARN_AUBE_PROGRESS_OVERFLOW";
@@ -488,6 +490,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_YARN_BERRY_UNSUPPORTED,
         category: category::LOCKFILE,
         description: "A Yarn Berry `patch:` / `portal:` / `exec:` protocol — or any unrecognized protocol — was found in `yarn.lock`. Entry was skipped.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX,
+        category: category::LOCKFILE,
+        description: "A pnpm dep_path peer suffix had unbalanced parentheses (a truncated or hand-corrupted lockfile entry). The key is preserved verbatim instead of silently dropping everything after the `(`, so a later install surfaces the bad entry rather than mis-resolving it.",
         exit_code: None,
     },
     // Progress UI

--- a/crates/aube-lockfile/src/graph_hash.rs
+++ b/crates/aube-lockfile/src/graph_hash.rs
@@ -345,6 +345,63 @@ fn transitively_requires_build(
     result
 }
 
+/// The set of dep_paths whose final graph hash folds in a content
+/// fingerprint: every globally-shareable source dependency (git /
+/// remote tarball — see [`LocalSource::is_globally_shareable`]) plus
+/// every package that transitively depends on one.
+///
+/// This exists to keep the GVS-prewarm materializer honest. Prewarm
+/// runs *concurrently with fetch*, so it can't fingerprint source trees
+/// that haven't been imported yet — it hashes with [`ContentHashFn`]
+/// returning `None` for everything. The link phase runs after fetch and
+/// folds the real fingerprints in via [`compute_graph_hashes_full`]. For
+/// any package in this set the two passes compute *different* hashes, so
+/// a node the prewarm materializes lands at a content-less path the link
+/// phase never references — stranding a duplicate cohort in the global
+/// store. Worse, prewarm skips the shareable-source *leaves* themselves
+/// (it can't materialize an un-fetched tree), so that stranded cohort's
+/// sibling symlinks dangle and Node's module walk silently resolves a
+/// second copy of the package higher up the tree (a duplicate-singleton
+/// "Cannot find module" class of bug). Prewarm must skip exactly this set
+/// and defer it to the link phase, which materializes every node at its
+/// final content-ful path.
+///
+/// Computed by reverse reachability from the shareable-source seeds so
+/// it's order- and cycle-independent: a source-backed subtree can sit
+/// inside a self-referential peer-dependency cycle, which a forward DFS
+/// memo would mis-handle depending on traversal entry point.
+///
+/// [`LocalSource::is_globally_shareable`]: crate::LocalSource::is_globally_shareable
+pub fn content_affected_dep_paths(graph: &LockfileGraph) -> FxHashSet<String> {
+    let mut parents_of: FxHashMap<String, Vec<String>> = FxHashMap::default();
+    let mut stack: Vec<String> = Vec::new();
+    for (dep_path, pkg) in &graph.packages {
+        if pkg
+            .local_source
+            .as_ref()
+            .is_some_and(|source| source.is_globally_shareable())
+        {
+            stack.push(dep_path.clone());
+        }
+        for (alias, child_tail) in &pkg.dependencies {
+            let child = child_dep_path(alias, child_tail);
+            if graph.packages.contains_key(&child) {
+                parents_of.entry(child).or_default().push(dep_path.clone());
+            }
+        }
+    }
+    let mut affected: FxHashSet<String> = FxHashSet::default();
+    while let Some(dep_path) = stack.pop() {
+        if !affected.insert(dep_path.clone()) {
+            continue;
+        }
+        if let Some(parents) = parents_of.get(&dep_path) {
+            stack.extend(parents.iter().cloned());
+        }
+    }
+    affected
+}
+
 /// `full_pkg_id` — pnpm uses `${pkgIdWithPatchHash}:${resolution}`; we
 /// use `${name}@${version}[:patch:<hex>]:${source?}[:content:<hex>]:${integrity}`.
 /// Source-backed packages fold in their stable specifier so two local
@@ -719,6 +776,96 @@ mod tests {
         let h = compute_graph_hashes(&g, &|_| false, None);
         assert!(h.node_hash.contains_key("a@1.0.0"));
         assert!(h.node_hash.contains_key("b@1.0.0"));
+    }
+
+    fn shareable_source() -> LocalSource {
+        LocalSource::RemoteTarball(crate::RemoteTarballSource {
+            url: "https://example.com/dep.tgz".into(),
+            integrity: "sha512-Z".into(),
+            git_hosted: false,
+        })
+    }
+
+    #[test]
+    fn content_affected_covers_shareable_source_and_all_ancestors() {
+        // parent -> midware -> tarball(shareable); `pure` is an unrelated
+        // sibling whose subtree contains no source dep.
+        let mut g = empty_graph();
+        let mut parent = mk_pkg("parent", "1.0.0", Some("sha512-P"));
+        parent.dependencies.insert("midware".into(), "1.0.0".into());
+        g.packages.insert("parent@1.0.0".into(), parent);
+
+        let mut midware = mk_pkg("midware", "1.0.0", Some("sha512-M"));
+        midware
+            .dependencies
+            .insert("tardep".into(), "url+aaa".into());
+        g.packages.insert("midware@1.0.0".into(), midware);
+
+        let mut tardep = mk_pkg("tardep", "1.0.0", None);
+        tardep.dep_path = "tardep@url+aaa".into();
+        tardep.local_source = Some(shareable_source());
+        g.packages.insert("tardep@url+aaa".into(), tardep);
+
+        g.packages.insert(
+            "pure@1.0.0".into(),
+            mk_pkg("pure", "1.0.0", Some("sha512-X")),
+        );
+
+        let affected = content_affected_dep_paths(&g);
+        assert!(
+            affected.contains("tardep@url+aaa"),
+            "the source leaf itself"
+        );
+        assert!(affected.contains("midware@1.0.0"), "direct ancestor");
+        assert!(affected.contains("parent@1.0.0"), "transitive ancestor");
+        assert!(
+            !affected.contains("pure@1.0.0"),
+            "a source-free subtree must stay prewarm-eligible"
+        );
+    }
+
+    #[test]
+    fn content_affected_handles_self_referential_cycle() {
+        // host <-> srcdep(shareable) cycle, mirroring a real-world
+        // self-referential peer cycle. Both nodes must be flagged
+        // regardless of the back-edge; reverse reachability from the
+        // source seed makes this order-independent.
+        let mut g = empty_graph();
+        let mut host = mk_pkg("host", "2.0.0", Some("sha512-L"));
+        host.dependencies.insert("srcdep".into(), "url+bbb".into());
+        g.packages.insert("host@2.0.0".into(), host);
+
+        let mut srcdep = mk_pkg("srcdep", "2.0.0", None);
+        srcdep.dep_path = "srcdep@url+bbb".into();
+        srcdep.local_source = Some(shareable_source());
+        srcdep.dependencies.insert("host".into(), "2.0.0".into());
+        g.packages.insert("srcdep@url+bbb".into(), srcdep);
+
+        let affected = content_affected_dep_paths(&g);
+        assert!(affected.contains("srcdep@url+bbb"));
+        assert!(
+            affected.contains("host@2.0.0"),
+            "ancestor inside a cycle with the source must still be flagged"
+        );
+    }
+
+    #[test]
+    fn content_affected_ignores_non_shareable_local_sources() {
+        // A `file:` directory dep is not globally shareable: it gets no
+        // content fingerprint, so its hash is identical across prewarm
+        // and link and prewarm may safely materialize its ancestors.
+        let mut g = empty_graph();
+        let mut parent = mk_pkg("parent", "1.0.0", Some("sha512-P"));
+        parent.dependencies.insert("dir".into(), "file+ccc".into());
+        g.packages.insert("parent@1.0.0".into(), parent);
+
+        let mut dir = mk_pkg("dir", "1.0.0", None);
+        dir.dep_path = "dir@file+ccc".into();
+        dir.local_source = Some(LocalSource::Directory(PathBuf::from("vendor/dir")));
+        g.packages.insert("dir@file+ccc".into(), dir);
+
+        let affected = content_affected_dep_paths(&g);
+        assert!(affected.is_empty(), "got: {affected:?}");
     }
 
     #[test]

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -22,7 +22,7 @@ pub use merge::{MergeReport, merge_branch_lockfiles};
 pub(crate) use source::normalize_git_fragment;
 pub use source::{
     GitSource, HostedGit, HostedGitHost, LocalSource, RemoteTarballSource, git_commits_match,
-    parse_git_spec, parse_hosted_git, shared_local_dep_path,
+    parse_git_spec, parse_hosted_git, resolve_dep_edge, shared_local_dep_path,
 };
 
 use smallvec::SmallVec;

--- a/crates/aube-lockfile/src/pnpm/dep_path.rs
+++ b/crates/aube-lockfile/src/pnpm/dep_path.rs
@@ -21,9 +21,13 @@ pub(super) fn peerless_dep_path(name: &str, value: &str) -> String {
 /// `consumer@1.0.0(react-dom@18.2.0(react@18.2.0))` yields the single outer
 /// segment `["(react-dom@18.2.0(react@18.2.0))"]` with the inner segment
 /// preserved verbatim. The canonical `name@version` head (everything before
-/// the first `(`) is skipped. Mirrors the resolver's identically-named
-/// helper; duplicated here because the two crates can't share it without a
-/// public surface neither wants to commit to.
+/// the first `(`) is skipped.
+///
+/// Mirrors the resolver's identically-named helper in
+/// `aube-resolver/src/peer_context.rs`; duplicated here because the two
+/// crates can't share it without a public surface neither wants to commit
+/// to. Any change to the paren-balancing algorithm (a new peer-suffix
+/// shape, percent-encoded git URLs, …) must be applied to both copies.
 fn outer_paren_segments(s: &str) -> Vec<&str> {
     let bytes = s.as_bytes();
     let mut segments = Vec::new();
@@ -82,14 +86,35 @@ pub(super) fn rewrite_peer_suffix(s: &str, translate: &impl Fn(&str) -> Option<S
     let Some(head_end) = s.find('(') else {
         return s.to_string();
     };
+    let segments = outer_paren_segments(&s[head_end..]);
+    if segments.is_empty() {
+        // A `(` with no balanced segment is a malformed dep_path tail
+        // (truncated / hand-corrupted lockfile). Preserve the bytes
+        // verbatim instead of silently dropping everything after the `(`.
+        warn_unbalanced_peer_suffix(s);
+        return s.to_string();
+    }
     let mut out = String::with_capacity(s.len());
     out.push_str(&s[..head_end]);
-    for seg in outer_paren_segments(&s[head_end..]) {
+    for seg in segments {
         out.push('(');
         out.push_str(&rewrite_peer_reference(&seg[1..seg.len() - 1], translate));
         out.push(')');
     }
     out
+}
+
+/// Surface a dep_path tail / peer reference that opens a `(` it never
+/// closes — a truncated or hand-corrupted lockfile entry that
+/// [`outer_paren_segments`] returns no segment for. The callers preserve
+/// the bytes verbatim; this warning keeps the corruption diagnosable
+/// instead of letting the shortened key mis-resolve on the next install.
+fn warn_unbalanced_peer_suffix(s: &str) {
+    tracing::warn!(
+        code = aube_codes::warnings::WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX,
+        dep_path = s,
+        "unbalanced parentheses in pnpm dep_path peer suffix; preserving the key verbatim"
+    );
 }
 
 /// Rewrite a single peer reference (the contents between one pair of
@@ -101,9 +126,14 @@ fn rewrite_peer_reference(inner: &str, translate: &impl Fn(&str) -> Option<Strin
     let Some(nested_start) = inner.find('(') else {
         return translate(inner).unwrap_or_else(|| inner.to_string());
     };
+    let segments = outer_paren_segments(&inner[nested_start..]);
+    if segments.is_empty() {
+        warn_unbalanced_peer_suffix(inner);
+        return inner.to_string();
+    }
     let mut out = String::with_capacity(inner.len());
     out.push_str(&inner[..nested_start]);
-    for seg in outer_paren_segments(&inner[nested_start..]) {
+    for seg in segments {
         out.push('(');
         out.push_str(&rewrite_peer_reference(&seg[1..seg.len() - 1], translate));
         out.push(')');
@@ -248,5 +278,18 @@ mod rewrite_peer_suffix_tests {
             ),
             "pkg@1.0.0(react@18.2.0)(request@https://codeload.github.com/owner/request/tar.gz/abc)"
         );
+    }
+
+    #[test]
+    fn unbalanced_parens_preserved_verbatim_not_dropped() {
+        // A truncated / hand-corrupted tail (open `(`, no matching close)
+        // must be preserved byte-for-byte. Silently dropping the suffix
+        // would shorten the key and mis-resolve it against a different
+        // package. A single unclosed paren:
+        let flat = "request-promise-core@1.1.4(request@bad";
+        assert_eq!(rewrite_peer_suffix(flat, &translate), flat);
+        // A nested open paren with one missing close is unbalanced too:
+        let nested = "consumer@1.0.0(request-promise@4.2.6(request@bad)";
+        assert_eq!(rewrite_peer_suffix(nested, &translate), nested);
     }
 }

--- a/crates/aube-lockfile/src/pnpm/dep_path.rs
+++ b/crates/aube-lockfile/src/pnpm/dep_path.rs
@@ -15,6 +15,102 @@ pub(super) fn peerless_dep_path(name: &str, value: &str) -> String {
     version_to_dep_path(name, value.split('(').next().unwrap_or(value))
 }
 
+/// Split a dep_path tail's peer suffix into outer-level paren segments,
+/// each returned *with* its enclosing parens. `react-dom@18.2.0(react@18.2.0)`
+/// yields `["(react@18.2.0)"]`; a nested form
+/// `consumer@1.0.0(react-dom@18.2.0(react@18.2.0))` yields the single outer
+/// segment `["(react-dom@18.2.0(react@18.2.0))"]` with the inner segment
+/// preserved verbatim. The canonical `name@version` head (everything before
+/// the first `(`) is skipped. Mirrors the resolver's identically-named
+/// helper; duplicated here because the two crates can't share it without a
+/// public surface neither wants to commit to.
+fn outer_paren_segments(s: &str) -> Vec<&str> {
+    let bytes = s.as_bytes();
+    let mut segments = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i] != b'(' {
+        i += 1;
+    }
+    while i < bytes.len() {
+        if bytes[i] != b'(' {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let mut depth: i32 = 0;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        i += 1;
+                        segments.push(&s[start..i]);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        if depth != 0 {
+            break;
+        }
+    }
+    segments
+}
+
+/// Rewrite the peer-suffix references of a dep_path (or a dep *value*,
+/// which is a headless `version{suffix}`) by passing each peer
+/// reference's flat `name@version` head through `translate`. The head
+/// before the first `(` is left untouched — only the parenthesized peer
+/// references are rewritten, and nested suffixes recurse.
+///
+/// `translate(head)` returns `Some(new_head)` to replace a *flat* peer
+/// reference, or `None` to keep it verbatim. The two boundary passes use
+/// it in opposite directions:
+///
+/// * writer: hashed `request@url+<hash>` → spec `request@https://…/tar.gz/<sha>`
+///   (a `graph.packages` lookup yields the target's `local_source.specifier()`).
+/// * reader: spec → hashed (`shared_local_dep_path` re-derives the dep_path),
+///   keeping the in-memory graph FS-safe so a round-trip matches a fresh
+///   resolve byte-for-byte.
+///
+/// Registry peers (`react@18.2.0`) translate to `None` and pass through
+/// unchanged, so this is a no-op on graphs with no git / tarball peers.
+pub(super) fn rewrite_peer_suffix(s: &str, translate: &impl Fn(&str) -> Option<String>) -> String {
+    let Some(head_end) = s.find('(') else {
+        return s.to_string();
+    };
+    let mut out = String::with_capacity(s.len());
+    out.push_str(&s[..head_end]);
+    for seg in outer_paren_segments(&s[head_end..]) {
+        out.push('(');
+        out.push_str(&rewrite_peer_reference(&seg[1..seg.len() - 1], translate));
+        out.push(')');
+    }
+    out
+}
+
+/// Rewrite a single peer reference (the contents between one pair of
+/// suffix parens). A flat reference (`request@url+<hash>`) is handed to
+/// `translate`; a reference that carries its own nested suffix
+/// (`request-promise@4.2.6(request@url+<hash>)`) keeps its head and
+/// recurses, so the nested git / tarball peer is still translated.
+fn rewrite_peer_reference(inner: &str, translate: &impl Fn(&str) -> Option<String>) -> String {
+    let Some(nested_start) = inner.find('(') else {
+        return translate(inner).unwrap_or_else(|| inner.to_string());
+    };
+    let mut out = String::with_capacity(inner.len());
+    out.push_str(&inner[..nested_start]);
+    for seg in outer_paren_segments(&inner[nested_start..]) {
+        out.push('(');
+        out.push_str(&rewrite_peer_reference(&seg[1..seg.len() - 1], translate));
+        out.push(')');
+    }
+    out
+}
+
 pub(super) fn peerless_alias_target<'a>(
     packages: &'a BTreeMap<String, LockedPackage>,
     real_dep_path: &str,
@@ -82,5 +178,75 @@ pub(super) fn rewrite_snapshot_alias_deps(
         let real_dep_path = dep_value.clone();
         alias_remaps.push((alias_dep_path, real_dep_path, dep_name.clone(), real_name));
         *dep_value = format!("{resolved}{peer_suffix}");
+    }
+}
+
+#[cfg(test)]
+mod rewrite_peer_suffix_tests {
+    use super::rewrite_peer_suffix;
+
+    // Stand-in for the writer's `graph.packages` lookup / reader's
+    // `shared_local_dep_path`: only the one git/tarball peer translates.
+    fn translate(head: &str) -> Option<String> {
+        (head == "request@url+1ff5271859b51655")
+            .then(|| "request@https://codeload.github.com/owner/request/tar.gz/abc".to_string())
+    }
+
+    #[test]
+    fn no_suffix_is_unchanged() {
+        assert_eq!(
+            rewrite_peer_suffix("lodash@4.18.1", &translate),
+            "lodash@4.18.1"
+        );
+        // A headless dep value with no suffix passes through too.
+        assert_eq!(rewrite_peer_suffix("4.18.1", &translate), "4.18.1");
+    }
+
+    #[test]
+    fn flat_local_peer_renders_as_spec() {
+        assert_eq!(
+            rewrite_peer_suffix(
+                "request-promise-core@1.1.4(request@url+1ff5271859b51655)",
+                &translate
+            ),
+            "request-promise-core@1.1.4(request@https://codeload.github.com/owner/request/tar.gz/abc)"
+        );
+        // Headless dep-value form is rewritten identically.
+        assert_eq!(
+            rewrite_peer_suffix("1.1.4(request@url+1ff5271859b51655)", &translate),
+            "1.1.4(request@https://codeload.github.com/owner/request/tar.gz/abc)"
+        );
+    }
+
+    #[test]
+    fn registry_peer_is_left_untouched() {
+        // No translation entry → verbatim, so this is a no-op for graphs
+        // with only registry peers.
+        let s = "react-dom@18.2.0(react@18.2.0)";
+        assert_eq!(rewrite_peer_suffix(s, &translate), s);
+    }
+
+    #[test]
+    fn nested_suffix_translates_only_the_inner_local_peer() {
+        // A registry peer (`request-promise`) keeps its head; the nested
+        // git/tarball peer inside it still renders as the spec.
+        assert_eq!(
+            rewrite_peer_suffix(
+                "consumer@1.0.0(request-promise@4.2.6(request@url+1ff5271859b51655))",
+                &translate
+            ),
+            "consumer@1.0.0(request-promise@4.2.6(request@https://codeload.github.com/owner/request/tar.gz/abc))"
+        );
+    }
+
+    #[test]
+    fn multiple_segments_each_handled_independently() {
+        assert_eq!(
+            rewrite_peer_suffix(
+                "pkg@1.0.0(react@18.2.0)(request@url+1ff5271859b51655)",
+                &translate
+            ),
+            "pkg@1.0.0(react@18.2.0)(request@https://codeload.github.com/owner/request/tar.gz/abc)"
+        );
     }
 }

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -729,18 +729,44 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         packages.insert(k, v);
     }
 
-    // Normalize peer suffixes that reference a git / remote-tarball peer by
-    // its resolved spec — pnpm (and aube's own writer) emit
-    // `request-promise-core@1.1.4(request@https://codeload.…/tar.gz/<sha>)`,
-    // but aube's internal dep_path keys that peer with the FS-safe hashed
-    // form (`request@url+<hash>`). Re-derive the hashed form here so a
-    // lockfile round-trip produces the same graph a fresh resolve does:
-    // without it every registry package that peers with a git / tarball dep
-    // would re-key on the next install, busting the warm path (and emitting
-    // a churned lockfile). Inverse of the writer's hashed→spec pass.
+    // Normalize git / remote-tarball references so a lockfile round-trip
+    // produces the same graph a fresh resolve does. pnpm (and aube's own
+    // writer) record these deps by their resolved URL, but aube's linker
+    // and graph hasher look them up under the FS-safe hashed form
+    // (`request@url+<hash>` / `request@git+<hash>`) — the same form
+    // `push_direct` already uses for *direct* git/tarball deps. Two
+    // independent rewrites are needed, and both run whenever a git/tarball
+    // dep is present (not only when a peer suffix exists):
+    //
+    //   1. Package keys. A *transitive* git/tarball package keyed by URL
+    //      (`<pkg>@https://codeload.…/<sha>`) has its own virtual-store
+    //      dir materialized at the escaped `https+++…` name, while every
+    //      parent's sibling symlink (and the hasher's child lookup, via
+    //      `shared_local_dep_path`) targets the `url+<hash>` name. The
+    //      symlink then dangles — Node throws `Cannot find module '<dep>'`
+    //      — and the child's content/engine taint never reaches the
+    //      parent's GVS hash. Re-key the head to the canonical hashed form.
+    //   2. Peer suffixes. `request-promise-core@1.1.4(request@https://…/<sha>)`
+    //      → `…(request@url+<hash>)`, the inverse of the writer's
+    //      hashed→spec pass. Without it a registry package that peers with
+    //      a git/tarball dep would re-key on the next install, busting the
+    //      warm path (and emitting a churned lockfile).
     let spec_peer_to_hashed = |head: &str| -> Option<String> {
         let (name, value) = parse_dep_path(head)?;
         crate::shared_local_dep_path(&name, &value)
+    };
+    // Canonicalize a git/remote-tarball package's own `name@<url>` head to
+    // the hashed form, preserving any peer suffix verbatim (URLs aube keys
+    // never contain `(`, so the first `(` always starts the suffix).
+    let canonical_local_head = |key: &str, pkg: &LockedPackage| -> Option<String> {
+        let local @ (LocalSource::Git(_) | LocalSource::RemoteTarball(_)) =
+            pkg.local_source.as_ref()?
+        else {
+            return None;
+        };
+        let suffix = key.find('(').map_or("", |i| &key[i..]);
+        let new_key = format!("{}{suffix}", local.dep_path(&pkg.name));
+        (new_key != key).then_some(new_key)
     };
     let has_local_source = packages.values().any(|p| {
         matches!(
@@ -748,11 +774,12 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             Some(LocalSource::Git(_) | LocalSource::RemoteTarball(_))
         )
     });
-    if has_local_source && packages.keys().any(|k| k.contains('(')) {
+    if has_local_source {
         let rekeyed: BTreeMap<String, LockedPackage> = std::mem::take(&mut packages)
             .into_iter()
             .map(|(key, mut pkg)| {
-                let new_key = rewrite_peer_suffix(&key, &spec_peer_to_hashed);
+                let head = canonical_local_head(&key, &pkg).unwrap_or(key);
+                let new_key = rewrite_peer_suffix(&head, &spec_peer_to_hashed);
                 pkg.dep_path = new_key.clone();
                 pkg.dependencies = pkg
                     .dependencies

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -1,5 +1,6 @@
 use super::dep_path::{
-    parse_dep_path, peerless_alias_target, rewrite_snapshot_alias_deps, version_to_dep_path,
+    parse_dep_path, peerless_alias_target, rewrite_peer_suffix, rewrite_snapshot_alias_deps,
+    version_to_dep_path,
 };
 use super::raw::{
     RawBinSpec, RawDepSpec, RawRuntimeVariant, local_source_from_resolution, parse_raw_lockfile,
@@ -726,6 +727,52 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
 
     for (k, v) in local_packages {
         packages.insert(k, v);
+    }
+
+    // Normalize peer suffixes that reference a git / remote-tarball peer by
+    // its resolved spec — pnpm (and aube's own writer) emit
+    // `request-promise-core@1.1.4(request@https://codeload.…/tar.gz/<sha>)`,
+    // but aube's internal dep_path keys that peer with the FS-safe hashed
+    // form (`request@url+<hash>`). Re-derive the hashed form here so a
+    // lockfile round-trip produces the same graph a fresh resolve does:
+    // without it every registry package that peers with a git / tarball dep
+    // would re-key on the next install, busting the warm path (and emitting
+    // a churned lockfile). Inverse of the writer's hashed→spec pass.
+    let spec_peer_to_hashed = |head: &str| -> Option<String> {
+        let (name, value) = parse_dep_path(head)?;
+        crate::shared_local_dep_path(&name, &value)
+    };
+    let has_local_source = packages.values().any(|p| {
+        matches!(
+            p.local_source,
+            Some(LocalSource::Git(_) | LocalSource::RemoteTarball(_))
+        )
+    });
+    if has_local_source && packages.keys().any(|k| k.contains('(')) {
+        let rekeyed: BTreeMap<String, LockedPackage> = std::mem::take(&mut packages)
+            .into_iter()
+            .map(|(key, mut pkg)| {
+                let new_key = rewrite_peer_suffix(&key, &spec_peer_to_hashed);
+                pkg.dep_path = new_key.clone();
+                pkg.dependencies = pkg
+                    .dependencies
+                    .into_iter()
+                    .map(|(n, v)| (n, rewrite_peer_suffix(&v, &spec_peer_to_hashed)))
+                    .collect();
+                pkg.optional_dependencies = pkg
+                    .optional_dependencies
+                    .into_iter()
+                    .map(|(n, v)| (n, rewrite_peer_suffix(&v, &spec_peer_to_hashed)))
+                    .collect();
+                (new_key, pkg)
+            })
+            .collect();
+        packages = rekeyed;
+        for deps in importers.values_mut() {
+            for dep in deps {
+                dep.dep_path = rewrite_peer_suffix(&dep.dep_path, &spec_peer_to_hashed);
+            }
+        }
     }
 
     let settings = raw

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -594,17 +594,48 @@ snapshots:
 
     let graph = parse(&lockfile_path).unwrap();
     let url = "https://codeload.github.com/astro/node-expat/tar.gz/78e559baa908942097330f7967dfbf623ebc2529";
+    // Transitive remote-tarball deps are keyed under the canonical
+    // `name@url+<hash>` form — the same form `push_direct` uses for
+    // direct deps and a fresh resolve uses for all of them. The raw-URL
+    // key must NOT survive: the linker derives the parent's sibling
+    // symlink target via `shared_local_dep_path` (the canonical form),
+    // so a URL-keyed package would leave that symlink dangling
+    // (`Cannot find module 'node-expat'`).
+    let canonical =
+        crate::shared_local_dep_path("node-expat", url).expect("tarball url canonicalizes");
+    assert!(
+        canonical.starts_with("node-expat@url+"),
+        "unexpected canonical key: {canonical}"
+    );
+    assert!(
+        !graph.packages.contains_key(&format!("node-expat@{url}")),
+        "raw-URL key must be canonicalized away, got keys: {:?}",
+        graph.packages.keys().collect::<Vec<_>>()
+    );
     let pkg = graph
         .packages
-        .get(&format!("node-expat@{url}"))
-        .expect("transitive remote-tarball entry present");
+        .get(&canonical)
+        .expect("transitive remote-tarball entry present under canonical key");
     assert_eq!(pkg.name, "node-expat");
     // pnpm's `version:` field, not the URL.
     assert_eq!(pkg.version, "2.4.1");
-    // The URL drives the fetch path via `tarball_url`; dep-path
-    // still carries the URL so xml2json's snapshot reference
-    // resolves.
+    // The URL drives the fetch path via `tarball_url`.
     assert_eq!(pkg.tarball_url.as_deref(), Some(url));
+    // The parent records the dep by URL; that reference must canonicalize
+    // to the child's key so the sibling symlink resolves.
+    let parent = graph
+        .packages
+        .get("xml2json@0.12.0")
+        .expect("xml2json present");
+    let child_ref = parent
+        .dependencies
+        .get("node-expat")
+        .expect("node-expat dep recorded");
+    assert_eq!(
+        crate::shared_local_dep_path("node-expat", child_ref).as_deref(),
+        Some(canonical.as_str()),
+        "parent reference must canonicalize to the child's key"
+    );
 }
 
 #[test]
@@ -681,12 +712,117 @@ snapshots:
     // makes it all the way back onto `LockedPackage.tarball_url`.
     let reparsed = parse(&out_path).unwrap();
     let url = "https://codeload.github.com/astro/node-expat/tar.gz/78e559baa908942097330f7967dfbf623ebc2529";
+    // The written lockfile carries the URL key (pnpm parity, asserted
+    // above), but on re-parse it canonicalizes back to `name@url+<hash>`.
+    let canonical =
+        crate::shared_local_dep_path("node-expat", url).expect("tarball url canonicalizes");
     let pkg = reparsed
         .packages
-        .get(&format!("node-expat@{url}"))
-        .expect("URL-keyed entry survives round-trip");
+        .get(&canonical)
+        .expect("URL-keyed entry survives round-trip under canonical key");
     assert_eq!(pkg.version, "2.4.1");
     assert_eq!(pkg.tarball_url.as_deref(), Some(url));
+}
+
+/// Regression for the transitive remote-tarball "Cannot find module"
+/// crash. A *transitive* remote-tarball dep is recorded in the pnpm
+/// lockfile by its resolved URL — both as its own `packages:`/`snapshots:`
+/// key and inside its parent's `dependencies:` map. The linker derives
+/// each parent's sibling symlink target, and the graph hasher derives its
+/// child lookups, by canonicalizing that URL via `shared_local_dep_path`
+/// to the FS-safe `name@url+<hash>` form. The reader must therefore key
+/// the package under that same canonical form (mirroring `push_direct`
+/// and a fresh resolve). Before the fix it kept the raw URL key, so the
+/// package materialized at the escaped `https+++…` dir while every
+/// parent's symlink targeted `url+<hash>` — the link dangled and the
+/// child's content/engine taint never reached the parent's GVS hash.
+#[test]
+fn transitive_tarball_child_keyed_canonically_so_parent_symlink_resolves() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+    let url =
+        "https://codeload.github.com/acme/tardep/tar.gz/9504d1f8f3293df7bfa4de72bd52df615f9f399c";
+    std::fs::write(
+        &lockfile_path,
+        format!(
+            r#"lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      app:
+        specifier: ^1.0.0
+        version: 1.0.0
+
+packages:
+  app@1.0.0:
+    resolution: {{integrity: sha512-app==}}
+
+  tardep@{url}:
+    resolution: {{gitHosted: true, integrity: sha512-tardep==, tarball: {url}}}
+    version: 2.42.0
+
+snapshots:
+  app@1.0.0:
+    dependencies:
+      tardep: {url}
+
+  tardep@{url}: {{}}
+"#
+        ),
+    )
+    .unwrap();
+
+    let graph = parse(&lockfile_path).unwrap();
+
+    // 1. The transitive tarball is keyed under the canonical hashed form,
+    //    and the raw-URL key is gone.
+    let canonical = crate::shared_local_dep_path("tardep", url).expect("url canonicalizes");
+    assert!(canonical.starts_with("tardep@url+"), "got {canonical}");
+    assert!(
+        !graph.packages.contains_key(&format!("tardep@{url}")),
+        "raw-URL key leaked: {:?}",
+        graph.packages.keys().collect::<Vec<_>>()
+    );
+    assert!(graph.packages.contains_key(&canonical));
+
+    // 2. The structural invariant the linker + hasher rely on: every
+    //    child reference that canonicalizes resolves to a real package
+    //    key. Before the fix `app`'s `tardep: <url>` canonicalized to a
+    //    key that didn't exist, so the sibling symlink dangled.
+    for (key, pkg) in &graph.packages {
+        for (alias, tail) in &pkg.dependencies {
+            if let Some(child) = crate::shared_local_dep_path(alias, tail) {
+                assert!(
+                    graph.packages.contains_key(&child),
+                    "{key}'s dep {alias}@{tail} -> {child} is missing from the graph"
+                );
+            }
+        }
+    }
+
+    // 3. The hasher no longer skips the child: a change to the tarball's
+    //    content fingerprint must cascade into the parent's hash. Before
+    //    the fix the URL-keyed child was invisible to `app`'s deps-hash,
+    //    so its fingerprint never moved `app`'s GVS path.
+    let with_fp = crate::graph_hash::compute_graph_hashes_full(
+        &graph,
+        &|_| false,
+        None,
+        &|_, _| None,
+        &|dp| (dp == canonical.as_str()).then(|| "fp".to_string()),
+    );
+    let without_fp = crate::graph_hash::compute_graph_hashes_full(
+        &graph,
+        &|_| false,
+        None,
+        &|_, _| None,
+        &|_| None,
+    );
+    assert_ne!(
+        with_fp.node_hash["app@1.0.0"], without_fp.node_hash["app@1.0.0"],
+        "transitive tarball child fingerprint must cascade into the parent's graph hash"
+    );
 }
 
 /// Fresh-resolve companion to `url_dep_path_round_trips_with_pnpm_version_field`.
@@ -803,12 +939,22 @@ fn fresh_resolved_codeload_tarball_writes_pnpm_version_and_resolution() {
         "parent must reference the codeload URL:\n{written}"
     );
 
-    // And it survives a re-parse onto `tarball_url` (drift-free).
+    // And it survives a re-parse onto `tarball_url` (drift-free). The
+    // written lockfile carries the codeload URL key (asserted above), but
+    // re-parse canonicalizes it back to the hashed `name@url+<hash>` form
+    // the resolver originally produced — so the round-trip graph matches a
+    // fresh resolve and the parent's sibling symlink resolves.
     let reparsed = parse(&lockfile_path).unwrap();
+    let canonical =
+        crate::shared_local_dep_path("node-expat", &codeload).expect("codeload url canonicalizes");
+    assert_eq!(
+        canonical, node_expat_dp,
+        "re-parse must reproduce the resolver's hashed dep_path"
+    );
     let pkg = reparsed
         .packages
-        .get(&format!("node-expat@{codeload}"))
-        .expect("codeload entry survives round-trip");
+        .get(&canonical)
+        .expect("codeload entry survives round-trip under canonical key");
     assert_eq!(pkg.version, "2.4.3");
     assert_eq!(pkg.tarball_url.as_deref(), Some(codeload.as_str()));
 }

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -813,6 +813,137 @@ fn fresh_resolved_codeload_tarball_writes_pnpm_version_and_resolution() {
     assert_eq!(pkg.tarball_url.as_deref(), Some(codeload.as_str()));
 }
 
+/// A git / remote-tarball dep that is *also* used as a peer must render
+/// its peer suffix as the resolved spec, never aube's internal FS-safe
+/// hashed dep_path. pnpm writes
+/// `request-promise-core@1.1.4(request@https://codeload.…/tar.gz/<sha>)`,
+/// not `(request@url+<hash>)` — the latter is only an in-memory key. The
+/// writer translates hashed→spec and the reader re-derives spec→hashed so
+/// a round-trip is a fixed point (a divergence would re-key every install
+/// and churn the lockfile).
+#[test]
+fn git_tarball_peer_suffix_renders_as_spec_and_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+
+    let codeload =
+        "https://codeload.github.com/owner/request/tar.gz/abcdef1234567890abcdef1234567890abcdef12"
+            .to_string();
+    let remote = LocalSource::RemoteTarball(crate::RemoteTarballSource {
+        url: codeload.clone(),
+        integrity: "sha512-request==".to_string(),
+        git_hosted: true,
+    });
+    // Resolver-internal keys: the tarball is hashed, registry packages that
+    // peer with it carry the hashed suffix.
+    let request_dp = remote.dep_path("request");
+    let request_tail = request_dp.strip_prefix("request@").unwrap().to_string();
+    assert!(
+        request_tail.starts_with("url+"),
+        "sanity: hashed tarball tail, got {request_tail}"
+    );
+    let core_key = format!("request-promise-core@1.1.4({request_dp})");
+    let rp_key = format!("request-promise@4.2.6({request_dp})");
+
+    let mut packages = BTreeMap::new();
+    packages.insert(
+        request_dp.clone(),
+        LockedPackage {
+            name: "request".to_string(),
+            version: "2.88.2".to_string(),
+            dep_path: request_dp.clone(),
+            local_source: Some(remote),
+            ..Default::default()
+        },
+    );
+    packages.insert(
+        core_key.clone(),
+        LockedPackage {
+            name: "request-promise-core".to_string(),
+            version: "1.1.4".to_string(),
+            integrity: Some("sha512-core==".to_string()),
+            dep_path: core_key.clone(),
+            peer_dependencies: BTreeMap::from([("request".to_string(), "^2.34".to_string())]),
+            dependencies: BTreeMap::from([("request".to_string(), request_tail.clone())]),
+            ..Default::default()
+        },
+    );
+    packages.insert(
+        rp_key.clone(),
+        LockedPackage {
+            name: "request-promise".to_string(),
+            version: "4.2.6".to_string(),
+            integrity: Some("sha512-rp==".to_string()),
+            dep_path: rp_key.clone(),
+            peer_dependencies: BTreeMap::from([("request".to_string(), "^2.34".to_string())]),
+            dependencies: BTreeMap::from([
+                ("request".to_string(), request_tail.clone()),
+                // pnpm references the peer-bearing sibling by its
+                // contextualized (hashed, in-memory) tail.
+                (
+                    "request-promise-core".to_string(),
+                    format!("1.1.4({request_dp})"),
+                ),
+            ]),
+            ..Default::default()
+        },
+    );
+
+    let graph = LockfileGraph {
+        packages,
+        ..Default::default()
+    };
+    let manifest = PackageJson {
+        name: Some("root".to_string()),
+        version: Some("0.0.0".to_string()),
+        ..PackageJson::default()
+    };
+
+    write(&lockfile_path, &graph, &manifest).unwrap();
+    let written = std::fs::read_to_string(&lockfile_path).unwrap();
+
+    // Snapshot keys + embedded dep values render the suffix as the spec.
+    assert!(
+        written.contains(&format!("request-promise-core@1.1.4(request@{codeload}):")),
+        "core snapshot key suffix not rendered as spec:\n{written}"
+    );
+    assert!(
+        written.contains(&format!("request-promise@4.2.6(request@{codeload}):")),
+        "request-promise snapshot key suffix not rendered as spec:\n{written}"
+    );
+    assert!(
+        written.contains(&format!("request-promise-core: 1.1.4(request@{codeload})")),
+        "embedded dep-value suffix not rendered as spec:\n{written}"
+    );
+    // The internal hashed form must never leak into the file.
+    assert!(
+        !written.contains(&request_tail),
+        "internal hashed dep_path leaked into the lockfile:\n{written}"
+    );
+
+    // Reader re-derives the hashed suffix: keys match a fresh resolve, so a
+    // re-install reads its own (or pnpm's) lockfile as a fixed point.
+    let reparsed = parse(&lockfile_path).unwrap();
+    assert!(
+        reparsed.packages.contains_key(&core_key),
+        "reader must normalize the spec suffix back to the hashed key; got keys: {:?}",
+        reparsed.packages.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        reparsed.packages.contains_key(&rp_key),
+        "reader must normalize request-promise's hashed key"
+    );
+    let rp = reparsed.packages.get(&rp_key).unwrap();
+    assert_eq!(
+        rp.dependencies
+            .get("request-promise-core")
+            .map(String::as_str),
+        Some(format!("1.1.4({request_dp})").as_str()),
+        "reader must normalize the embedded dep-value suffix: {:?}",
+        rp.dependencies
+    );
+}
+
 #[test]
 fn direct_url_importer_strips_peer_suffix_from_fetch_url() {
     // Regression: when a direct dep's importer `version:` is a

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -689,6 +689,130 @@ snapshots:
     assert_eq!(pkg.tarball_url.as_deref(), Some(url));
 }
 
+/// Fresh-resolve companion to `url_dep_path_round_trips_with_pnpm_version_field`.
+///
+/// When the resolver promotes a hosted-git dep to a codeload tarball it
+/// stores the package under the *hashed* `name@url+<hash>` dep_path (not
+/// the bare URL), so the writer's `url_keyed` heuristic is false. pnpm
+/// still records these as `name@<codeload-url>` with a `version:` field
+/// and `resolution: {gitHosted: true, integrity, tarball}`. This drives
+/// a resolver-shaped graph through `write` and asserts that shape —
+/// without it a fresh `aube install` emits the `<url>.git#<sha>` /
+/// `type: git` form and drifts from pnpm.
+#[test]
+fn fresh_resolved_codeload_tarball_writes_pnpm_version_and_resolution() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile_path = dir.path().join("pnpm-lock.yaml");
+
+    let codeload = "https://codeload.github.com/xmppo/node-expat/tar.gz/78e559baa908942097330f7967dfbf623ebc2529".to_string();
+    let remote = LocalSource::RemoteTarball(crate::RemoteTarballSource {
+        url: codeload.clone(),
+        integrity: "sha512-nodeexpat==".to_string(),
+        git_hosted: true,
+    });
+    // The resolver keys the package by the hashed `name@url+<hash>` form.
+    let node_expat_dp = remote.dep_path("node-expat");
+    assert!(
+        node_expat_dp.starts_with("node-expat@url+"),
+        "sanity: resolver dep_path is the hashed url form, got {node_expat_dp}"
+    );
+    // The hashed tail is what the parent records as its dep value, and
+    // what must NOT leak into the written lockfile.
+    let node_expat_tail = node_expat_dp
+        .strip_prefix("node-expat@")
+        .unwrap()
+        .to_string();
+
+    let mut packages = BTreeMap::new();
+    packages.insert(
+        node_expat_dp.clone(),
+        LockedPackage {
+            name: "node-expat".to_string(),
+            version: "2.4.3".to_string(),
+            dep_path: node_expat_dp.clone(),
+            local_source: Some(remote),
+            ..Default::default()
+        },
+    );
+    packages.insert(
+        "xml2json@0.12.0".to_string(),
+        LockedPackage {
+            name: "xml2json".to_string(),
+            version: "0.12.0".to_string(),
+            integrity: Some("sha512-xml2json==".to_string()),
+            dep_path: "xml2json@0.12.0".to_string(),
+            dependencies: BTreeMap::from([("node-expat".to_string(), node_expat_tail.clone())]),
+            ..Default::default()
+        },
+    );
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "xml2json".to_string(),
+            dep_path: "xml2json@0.12.0".to_string(),
+            dep_type: DepType::Production,
+            specifier: Some("^0.12.0".to_string()),
+        }],
+    );
+
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+    let manifest = PackageJson {
+        name: Some("root".to_string()),
+        version: Some("0.0.0".to_string()),
+        dependencies: BTreeMap::from([("xml2json".to_string(), "^0.12.0".to_string())]),
+        ..PackageJson::default()
+    };
+
+    write(&lockfile_path, &graph, &manifest).unwrap();
+    let written = std::fs::read_to_string(&lockfile_path).unwrap();
+
+    // Keyed by the bare codeload URL (pnpm parity), never the hashed
+    // form and never the `.git#<sha>` form.
+    assert!(
+        written.contains(&format!("node-expat@{codeload}:")),
+        "expected codeload-keyed entry, got:\n{written}"
+    );
+    assert!(
+        !written.contains(&node_expat_tail),
+        "internal hashed dep_path leaked into the lockfile:\n{written}"
+    );
+    assert!(
+        !written.contains(".git#"),
+        "git-url form must be promoted to codeload tarball:\n{written}"
+    );
+    // pnpm records the real semver next to the tarball resolution.
+    assert!(
+        written.contains("    version: 2.4.3"),
+        "missing `version:` on the codeload entry:\n{written}"
+    );
+    assert!(
+        written.contains(&format!(
+            "resolution: {{gitHosted: true, integrity: sha512-nodeexpat==, tarball: {codeload}}}"
+        )),
+        "missing/incorrect codeload resolution block:\n{written}"
+    );
+    // The parent references it by the bare codeload URL.
+    assert!(
+        written.contains(&format!("node-expat: {codeload}")),
+        "parent must reference the codeload URL:\n{written}"
+    );
+
+    // And it survives a re-parse onto `tarball_url` (drift-free).
+    let reparsed = parse(&lockfile_path).unwrap();
+    let pkg = reparsed
+        .packages
+        .get(&format!("node-expat@{codeload}"))
+        .expect("codeload entry survives round-trip");
+    assert_eq!(pkg.version, "2.4.3");
+    assert_eq!(pkg.tarball_url.as_deref(), Some(codeload.as_str()));
+}
+
 #[test]
 fn direct_url_importer_strips_peer_suffix_from_fetch_url() {
     // Regression: when a direct dep's importer `version:` is a

--- a/crates/aube-lockfile/src/pnpm/write.rs
+++ b/crates/aube-lockfile/src/pnpm/write.rs
@@ -1,4 +1,6 @@
-use super::dep_path::{dep_path_tail, parse_dep_path, peerless_dep_path, version_to_dep_path};
+use super::dep_path::{
+    dep_path_tail, parse_dep_path, peerless_dep_path, rewrite_peer_suffix, version_to_dep_path,
+};
 use super::format::reformat_for_pnpm_parity;
 use crate::{DepType, Error, LocalSource, LockfileGraph};
 use aube_manifest::PackageJson;
@@ -12,6 +14,26 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         .file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name == "pnpm-lock.yaml");
+    // Translate a *flat* peer reference from aube's internal FS-safe
+    // hashed dep_path (`request@url+<hash>` / `request@git+<hash>`) to the
+    // resolved spec pnpm writes inside a peer suffix
+    // (`request@https://codeload.…/tar.gz/<sha>`). The reference is itself a
+    // package key, so a direct lookup yields the target's source. Registry
+    // peers aren't in the table under their suffix head (or carry no
+    // `local_source`) and return `None`, leaving `react@18.2.0` untouched.
+    // Restricted to git / remote-tarball so it stays the exact inverse of
+    // the reader's `shared_local_dep_path` pass (which only re-derives those
+    // two kinds); `file:` / `link:` peers never occur in practice and a
+    // one-sided translation would break the round-trip.
+    let peer_suffix_to_spec = |head: &str| -> Option<String> {
+        let pkg = graph.packages.get(head)?;
+        match pkg.local_source.as_ref()? {
+            local @ (LocalSource::Git(_) | LocalSource::RemoteTarball(_)) => {
+                Some(format!("{}@{}", pkg.name, local.specifier()))
+            }
+            _ => None,
+        }
+    };
     let mut importers = BTreeMap::new();
     let exclude_links = graph.settings.exclude_links_from_lockfile;
     for (importer_path, deps) in &graph.importers {
@@ -73,10 +95,14 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
             {
                 format!("{real_name}@{}", dep_path_tail(&dep.dep_path, &dep.name))
             } else {
-                dep.dep_path
-                    .strip_prefix(&format!("{}@", dep.name))
-                    .unwrap_or(&dep.dep_path)
-                    .to_string()
+                // Registry dep: the tail may carry a `(git/tarball@hash)`
+                // peer suffix that must render as the resolved spec.
+                rewrite_peer_suffix(
+                    dep.dep_path
+                        .strip_prefix(&format!("{}@", dep.name))
+                        .unwrap_or(&dep.dep_path),
+                    &peer_suffix_to_spec,
+                )
             };
 
             let spec = WritableDepSpec {
@@ -511,7 +537,10 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 {
                     (name, format!("{real_name}@{value}"))
                 } else {
-                    (name, value)
+                    // Registry dep whose value may carry a
+                    // `(git/tarball@hash)` peer suffix — render the suffix
+                    // as the resolved spec (`1.1.4(request@https://…)`).
+                    (name, rewrite_peer_suffix(&value, &peer_suffix_to_spec))
                 }
             })
             .collect()
@@ -530,7 +559,10 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
                 if native_pnpm_aliases && let Some(real_name) = pkg.alias_of.as_deref() {
                     format!("{real_name}@{}", dep_path_tail(dep_path, &pkg.name))
                 } else {
-                    dep_path.clone()
+                    // Registry snapshot key whose `(git/tarball@hash)` peer
+                    // suffix must render as the resolved spec to match pnpm
+                    // (`request-promise-core@1.1.4(request@https://…)`).
+                    rewrite_peer_suffix(dep_path, &peer_suffix_to_spec)
                 }
             }
         };

--- a/crates/aube-lockfile/src/pnpm/write.rs
+++ b/crates/aube-lockfile/src/pnpm/write.rs
@@ -365,7 +365,18 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         // semver. Ordinary registry entries skip this — the key already
         // carries the version, and adding a field would diverge from
         // byte-for-byte pnpm output.
-        let write_version = url_keyed.then(|| pkg.version.clone());
+        //
+        // Freshly-resolved remote tarballs (codeload hosted-git deps,
+        // pkg.pr.new, etc.) key their `packages:` entry by the URL via
+        // `specifier()`, but their internal `dep_path` is the hashed
+        // `url+<hash>` form, so `url_keyed` is false. pnpm still records
+        // the real semver in a `version:` field next to the codeload
+        // resolution (`node-expat@https://codeload…: { …, version: 2.4.3 }`),
+        // so emit it for `RemoteTarball` too — otherwise a fresh resolve
+        // drops the field and drifts from a re-read lockfile (and pnpm).
+        let write_version = (url_keyed
+            || matches!(pkg.local_source, Some(LocalSource::RemoteTarball(_))))
+        .then(|| pkg.version.clone());
         packages.insert(
             canonical,
             WritablePackageInfo {
@@ -827,27 +838,38 @@ struct WritableCatalogEntry {
     version: String,
 }
 
+// Field order is alphabetical by *serialized* key name to match pnpm's
+// sorted-key lockfile emitter (it runs every `resolution:` map through
+// `sortKeys`). The cases this spans:
+//   registry  → {integrity}  /  {integrity, tarball}
+//   directory → {directory, type: directory}
+//   git       → {commit, integrity?, path?, repo, type: git}
+//   codeload  → {gitHosted, integrity, tarball}   (hosted-git tarball)
+//   runtime   → {type: variations, variants}
+// Serde serializes in declaration order regardless of `rename`, so the
+// fields are declared in the order of their renamed names (`gitHosted`,
+// `type`) — not the Rust identifiers.
 #[derive(Debug, Serialize)]
 struct WritableResolution {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    integrity: Option<String>,
-    #[serde(skip_serializing_if = "std::ops::Not::not", rename = "gitHosted")]
-    git_hosted: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    directory: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    tarball: Option<String>,
     // Git resolution fields (pnpm v9 `{type: git, repo, commit}` form).
     #[serde(skip_serializing_if = "Option::is_none")]
     commit: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    repo: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
-    type_: Option<String>,
+    directory: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not", rename = "gitHosted")]
+    git_hosted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    integrity: Option<String>,
     /// pnpm `&path:/<sub>` selector — emitted with leading `/` to
     /// match pnpm's own writer.
     #[serde(skip_serializing_if = "Option::is_none")]
     path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tarball: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    type_: Option<String>,
     /// `type: variations` artifact list for runtime pins. `None` for
     /// every ordinary package resolution.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/aube-lockfile/src/source.rs
+++ b/crates/aube-lockfile/src/source.rs
@@ -345,6 +345,37 @@ pub fn shared_local_dep_path(dep_name: &str, dep_value: &str) -> Option<String> 
     }
 }
 
+/// Resolve a dependency edge `(name, tail)` to the graph key of the child
+/// package node, honoring every reader's storage convention. Returns the
+/// first candidate that satisfies `contains` (the caller's "is this a real
+/// package key?" predicate), or `None` when the edge points outside the
+/// graph (a pruned optional, an unresolved peer, a `link:` target, …).
+///
+/// Three conventions coexist because the readers disagree on what a
+/// dependency *value* holds, and a graph walker that only knows one of
+/// them silently drops the others:
+///   1. `tail` verbatim — npm/yarn/bun store the full dep_path as the
+///      value (`"foo@1.2.3"`).
+///   2. `name@tail` — the pnpm reader stores only the tail (`"1.2.3"`),
+///      so the key is the name re-joined to it.
+///   3. [`shared_local_dep_path`] — git / remote-tarball deps store the
+///      resolved URL as the tail, but the node is keyed under the short
+///      `name@git+<hash>` / `name@url+<hash>` form. The linker's
+///      `materialize` already bridges the edge this way; reachability /
+///      marking walkers that skip it prune the entire git/tarball subtree
+///      (a content-pinned git/tarball child and everything under it
+///      vanishes from the walk once the node is keyed canonically).
+pub fn resolve_dep_edge(name: &str, tail: &str, contains: impl Fn(&str) -> bool) -> Option<String> {
+    if contains(tail) {
+        return Some(tail.to_string());
+    }
+    let rejoined = format!("{name}@{tail}");
+    if contains(&rejoined) {
+        return Some(rejoined);
+    }
+    shared_local_dep_path(name, tail).filter(|key| contains(key))
+}
+
 /// Parse a git dependency specifier into `(clone_url, committish)`.
 ///
 /// Recognized forms:

--- a/crates/aube-resolver/src/local_source.rs
+++ b/crates/aube-resolver/src/local_source.rs
@@ -305,6 +305,44 @@ pub(crate) fn should_block_exotic_subdep(
             })
 }
 
+/// Pick the lockfile source representation for a *resolved* hosted-git
+/// dependency. pnpm records a github / gitlab / bitbucket dep pinned to
+/// a 40-char commit SHA as a **codeload tarball** (`RemoteTarball`) —
+/// not a `git` resolution — whenever a flat HTTPS archive URL exists
+/// (`codeload_url`) and there's no `&path:` subdir selector. aube
+/// already *fetches* that tarball; emitting it as `RemoteTarball` makes
+/// the written lockfile match pnpm (codeload key + `version:` +
+/// `resolution: {tarball, gitHosted}`) instead of the divergent
+/// `<url>.git#<sha>` / `resolution: {type: git, repo, commit}` form.
+///
+/// Falls back to `Git` for: non-hosted or `git+ssh://` sources (no
+/// codeload URL — pnpm keeps those as `type: git` too), branch/tag refs
+/// that never pinned to a SHA, and `&path:` subpath selectors (a flat
+/// tarball can't address a repo subdirectory).
+fn hosted_git_local_source(
+    original_url: String,
+    committish: Option<String>,
+    resolved: String,
+    subpath: Option<String>,
+    integrity: Option<String>,
+    codeload_url: Option<&str>,
+) -> LocalSource {
+    match (subpath.as_deref(), codeload_url) {
+        (None, Some(codeload)) => LocalSource::RemoteTarball(aube_lockfile::RemoteTarballSource {
+            url: codeload.to_string(),
+            integrity: integrity.unwrap_or_default(),
+            git_hosted: true,
+        }),
+        _ => LocalSource::Git(aube_lockfile::GitSource {
+            url: original_url,
+            committish,
+            resolved,
+            integrity,
+            subpath,
+        }),
+    }
+}
+
 /// Turn a raw `GitSource` (committish parsed from the user's
 /// specifier, empty `resolved`) into a fully-resolved one by either
 /// fetching a hosted-tarball over HTTPS (github / gitlab / bitbucket
@@ -412,13 +450,14 @@ pub(crate) async fn resolve_git_source(
             .map_err(|e| Error::Registry(name.to_string(), e.to_string()))?;
         let version = pj.version.unwrap_or_else(|| "0.0.0".to_string());
         return Ok((
-            LocalSource::Git(aube_lockfile::GitSource {
-                url: original_url,
+            hosted_git_local_source(
+                original_url,
                 committish,
-                resolved: resolved_sha,
-                integrity: git.integrity.clone(),
+                resolved_sha,
                 subpath,
-            }),
+                git.integrity.clone(),
+                codeload_url.as_deref(),
+            ),
             version,
             pj.dependencies,
             integrity,
@@ -485,13 +524,14 @@ pub(crate) async fn resolve_git_source(
                 match extracted {
                     Ok((resolved, version, deps)) => {
                         return Ok((
-                            LocalSource::Git(aube_lockfile::GitSource {
-                                url: original_url,
+                            hosted_git_local_source(
+                                original_url,
                                 committish,
                                 resolved,
-                                integrity: Some(integrity.clone()),
                                 subpath,
-                            }),
+                                Some(integrity.clone()),
+                                Some(url_to_fetch),
+                            ),
                             version,
                             deps,
                             Some(integrity),
@@ -805,5 +845,84 @@ mod cve_audit_tarball_bomb {
             result.is_err(),
             "decompressed dummy entry preceding package.json must hit the output cap"
         );
+    }
+}
+
+#[cfg(test)]
+mod hosted_git_local_source_tests {
+    use super::*;
+
+    const SHA: &str = "78e559baa908942097330f7967dfbf623ebc2529";
+
+    #[test]
+    fn hosted_sha_without_subpath_becomes_codeload_remote_tarball() {
+        let codeload = format!("https://codeload.github.com/xmppo/node-expat/tar.gz/{SHA}");
+        let src = hosted_git_local_source(
+            "git+ssh://git@github.com/xmppo/node-expat.git".to_string(),
+            Some(format!("v2.4.3#{SHA}")),
+            SHA.to_string(),
+            None,
+            Some("sha512-deadbeef".to_string()),
+            Some(codeload.as_str()),
+        );
+        match src {
+            LocalSource::RemoteTarball(t) => {
+                // pnpm keys the lockfile entry by this flat tarball URL.
+                assert_eq!(t.url, codeload);
+                assert_eq!(t.integrity, "sha512-deadbeef");
+                assert!(t.git_hosted, "codeload archives must flag gitHosted");
+                // The specifier the writer threads into snapshot deps and
+                // the packages key is exactly the codeload URL.
+                assert_eq!(
+                    LocalSource::RemoteTarball(t).specifier(),
+                    codeload,
+                    "specifier must be the bare codeload URL pnpm records"
+                );
+            }
+            other => panic!("expected RemoteTarball, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn subpath_selector_stays_git() {
+        // A flat tarball can't address a repo subdirectory, so pnpm keeps
+        // `&path:` deps as `type: git`. We must too.
+        let codeload = format!("https://codeload.github.com/acme/mono/tar.gz/{SHA}");
+        let src = hosted_git_local_source(
+            "git+ssh://git@github.com/acme/mono.git".to_string(),
+            Some(SHA.to_string()),
+            SHA.to_string(),
+            Some("packages/leaf".to_string()),
+            Some("sha512-x".to_string()),
+            Some(codeload.as_str()),
+        );
+        match src {
+            LocalSource::Git(g) => {
+                assert_eq!(g.resolved, SHA);
+                assert_eq!(g.subpath.as_deref(), Some("packages/leaf"));
+            }
+            other => panic!("expected Git with subpath, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_codeload_url_stays_git() {
+        // Non-hosted / ssh-only sources have no flat archive URL; pnpm
+        // records those as `type: git` and so do we.
+        let src = hosted_git_local_source(
+            "git+ssh://git@example.com/internal/dep.git".to_string(),
+            Some(SHA.to_string()),
+            SHA.to_string(),
+            None,
+            Some("sha512-y".to_string()),
+            None,
+        );
+        match src {
+            LocalSource::Git(g) => {
+                assert_eq!(g.url, "git+ssh://git@example.com/internal/dep.git");
+                assert_eq!(g.integrity.as_deref(), Some("sha512-y"));
+            }
+            other => panic!("expected Git, got {other:?}"),
+        }
     }
 }

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -1004,6 +1004,15 @@ fn propagate_peer_suffixes_to_ancestors(
     // their own peers don't accept descendant-peer propagation (see
     // the rule in the doc comment above).
     let mut has_own_peers: BTreeMap<String, bool> = BTreeMap::new();
+    // Per-package set of dependency names a package supplies itself
+    // (regular or optional). A peer a descendant needs is *resolved* at
+    // the nearest ancestor that supplies it, so the `(peer@version)`
+    // suffix must stop there — that supplier, and everything above it,
+    // stays bare. pnpm leaves e.g. `tinyglobby@0.2.17` bare because it
+    // lists `picomatch` in its own `dependencies` (resolving `fdir`'s
+    // optional peer); only `fdir` keeps the suffix. Without this gate the
+    // suffix leaks onto every ancestor up to the importer.
+    let mut provides: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     for (key, pkg) in &graph.packages {
         let children: Vec<String> = pkg
             .dependencies
@@ -1013,6 +1022,13 @@ fn propagate_peer_suffixes_to_ancestors(
             .collect();
         forward.insert(key.clone(), children);
         has_own_peers.insert(key.clone(), !pkg.peer_dependencies.is_empty());
+        let supplied: BTreeSet<String> = pkg
+            .dependencies
+            .keys()
+            .chain(pkg.optional_dependencies.keys())
+            .cloned()
+            .collect();
+        provides.insert(key.clone(), supplied);
     }
 
     // Memoized DFS. `cumulative` stores the by-name segment map per
@@ -1024,6 +1040,7 @@ fn propagate_peer_suffixes_to_ancestors(
         key: &str,
         forward: &BTreeMap<String, Vec<String>>,
         has_own_peers: &BTreeMap<String, bool>,
+        provides: &BTreeMap<String, BTreeSet<String>>,
         cumulative: &mut BTreeMap<String, BTreeMap<String, String>>,
         visiting: &mut BTreeSet<String>,
     ) -> BTreeMap<String, String> {
@@ -1084,11 +1101,26 @@ fn propagate_peer_suffixes_to_ancestors(
         if !canonical_name.is_empty() {
             suppressed.insert(canonical_name);
         }
+        // A peer this package supplies itself is resolved here, so it must
+        // neither decorate this package's dep_path nor propagate above it
+        // (pnpm stops the suffix at the supplier). This is what keeps a
+        // supplier like `tinyglobby` (and its non-peer ancestors) bare
+        // while `fdir`, which only *declares* the peer, keeps its suffix.
+        if let Some(supplied) = provides.get(key) {
+            suppressed.extend(supplied.iter().cloned());
+        }
 
         // Child contributions.
         if let Some(children) = forward.get(key) {
             for child in children {
-                let child_peers = collect(child, forward, has_own_peers, cumulative, visiting);
+                let child_peers = collect(
+                    child,
+                    forward,
+                    has_own_peers,
+                    provides,
+                    cumulative,
+                    visiting,
+                );
                 for (name, seg) in child_peers {
                     if suppressed.contains(&name) {
                         continue;
@@ -1111,6 +1143,7 @@ fn propagate_peer_suffixes_to_ancestors(
             key,
             &forward,
             &has_own_peers,
+            &provides,
             &mut cumulative,
             &mut visiting,
         );
@@ -1121,6 +1154,7 @@ fn propagate_peer_suffixes_to_ancestors(
                 &dep.dep_path,
                 &forward,
                 &has_own_peers,
+                &provides,
                 &mut cumulative,
                 &mut visiting,
             );

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -1186,6 +1186,29 @@ fn propagate_peer_suffixes_to_ancestors(
         let Some(segments) = cumulative.get(key) else {
             continue;
         };
+        // Git / remote-tarball (globally-shareable) packages keep a bare
+        // dep_path keyed solely by their content-pinned URL — pnpm never
+        // appends a `(peer@ver)` suffix to a non-registry depPath. Every
+        // git/tarball key in a real pnpm-lock.yaml is bare even when its
+        // subtree resolves peers: e.g. `<pkg>@<url>` sits bare above a
+        // registry descendant like `<child>@6.5.1(@types/node@…)`.
+        // Absorbing a descendant's `(@types/node@…)` here would (a) diverge
+        // from the lockfile and (b) give the same content-identical tarball
+        // a different dep_path per consuming subtree, splitting the single
+        // shared global-virtual-store entry into duplicates (so one
+        // content-pinned singleton would load twice → "Cannot find
+        // module"). The descendant peers still propagate onto this node's
+        // *registry* ancestors through `cumulative`, so a registry parent
+        // keeps its own `(@types/node@…)` suffix; only the git/tarball node
+        // itself stays bare.
+        if graph
+            .packages
+            .get(key)
+            .and_then(|p| p.local_source.as_ref())
+            .is_some_and(|s| s.is_globally_shareable())
+        {
+            continue;
+        }
         let canonical = canonical_tail(key);
         if is_hashed_peer_suffix(&key[canonical.len()..]) {
             // Original key already carries the hashed suffix `(…)` — see
@@ -1578,6 +1601,23 @@ fn visit_peer_context<'g>(
     // If nothing in the graph holds a version of this peer at all,
     // it's left out of the context entirely — `detect_unmet_peers`
     // will surface it as a warning after the pass.
+    //
+    // Only peers the package actually *declares* in `peerDependencies`
+    // build a dep_path suffix here. A name present solely in
+    // `peerDependenciesMeta` (a meta-only optional peer — the way
+    // `follow-redirects` declares `debug`, for instance) is deliberately
+    // NOT folded in: pnpm treats such a peer as resolvable but then
+    // collapses the binding back out via `dedupe-peer-dependents`
+    // whenever a peer-free path exists, so the realistic lockfile leaves
+    // the whole chain bare even when a distant ancestor carries that peer
+    // as a plain dependency. Eagerly binding the meta-only peer from that
+    // ancestor scope produced `(peer@ver)`-suffixed variants that aube's
+    // dedupe pass (which only collapses *declared*-peer variants) never
+    // merged, so the same subtree hashed differently per install scope
+    // (whole-workspace vs single-member), splitting a shared
+    // global-virtual-store singleton in two and surfacing at runtime as a
+    // duplicate-instance "Cannot find module". Matching pnpm's *deduped*
+    // output — bare — keeps the singleton intact.
     let mut peer_context: Vec<(String, String)> = Vec::new();
     for (peer_name, declared_range) in &pkg.peer_dependencies {
         let satisfies_declared = |v: &str| -> bool {

--- a/crates/aube-resolver/src/platform.rs
+++ b/crates/aube-resolver/src/platform.rs
@@ -269,12 +269,16 @@ pub fn filter_graph(
     for pkg in graph.packages.values_mut() {
         let mut removed = Vec::new();
         pkg.optional_dependencies.retain(|name, tail| {
-            let child_key = if package_keys.contains(tail) {
-                tail.clone()
-            } else {
-                format!("{name}@{tail}")
-            };
-            let keep = !ignored.contains(name) && !mismatched_packages.contains(&child_key);
+            // Resolve through every reader convention (incl. the
+            // git/remote-tarball `name@url+<hash>` form) so a
+            // platform-mismatched optional git/tarball child is actually
+            // pruned here rather than surviving until the GC pass below.
+            let child_is_mismatched =
+                match aube_lockfile::resolve_dep_edge(name, tail, |k| package_keys.contains(k)) {
+                    Some(child_key) => mismatched_packages.contains(&child_key),
+                    None => false,
+                };
+            let keep = !ignored.contains(name) && !child_is_mismatched;
             if !keep {
                 removed.push(name.clone());
             }

--- a/crates/aube-resolver/src/platform.rs
+++ b/crates/aube-resolver/src/platform.rs
@@ -300,19 +300,14 @@ pub fn filter_graph(
         }
         if let Some(pkg) = graph.packages.get(&dep_path) {
             for (name, tail) in &pkg.dependencies {
-                // Different lockfile readers use different conventions
-                // for dependency values: the pnpm reader stores the
-                // dep_path *tail* (`"1.2.3"`), while the npm/yarn/bun
-                // readers store the full dep_path (`"foo@1.2.3"`).
-                // Try the raw value first, then the pnpm-style
-                // reconstruction.
-                if graph.packages.contains_key(tail) {
-                    stack.push(tail.clone());
-                } else {
-                    let child_key = format!("{name}@{tail}");
-                    if graph.packages.contains_key(&child_key) {
-                        stack.push(child_key);
-                    }
+                // Resolve the edge through every reader convention,
+                // including the git/remote-tarball `name@url+<hash>` form
+                // — otherwise a canonically-keyed git/tarball child (and
+                // its whole subtree) is unreachable here and gets GC'd.
+                if let Some(child) =
+                    aube_lockfile::resolve_dep_edge(name, tail, |k| graph.packages.contains_key(k))
+                {
+                    stack.push(child);
                 }
             }
         }
@@ -363,15 +358,12 @@ pub fn mark_optional_packages(graph: &mut aube_lockfile::LockfileGraph) {
             if pkg.optional_dependencies.contains_key(name) {
                 continue;
             }
-            // Match `filter_graph`'s child-key convention: the pnpm reader
-            // stores the dep_path tail (`"1.2.3"`), npm/yarn/bun store the
-            // full dep_path (`"foo@1.2.3"`).
-            let child = if graph.packages.contains_key(tail) {
-                tail.clone()
-            } else {
-                format!("{name}@{tail}")
-            };
-            if graph.packages.contains_key(&child) {
+            // Match `filter_graph`'s child-key convention (incl. the
+            // git/remote-tarball `name@url+<hash>` form) so a required
+            // git/tarball dep isn't mis-marked optional-only.
+            if let Some(child) =
+                aube_lockfile::resolve_dep_edge(name, tail, |k| graph.packages.contains_key(k))
+            {
                 stack.push(child);
             }
         }
@@ -421,15 +413,12 @@ pub fn mark_transitive_peer_dependencies(graph: &mut aube_lockfile::LockfileGrap
             {
                 continue;
             }
-            // Match `filter_graph`'s child-key convention: the pnpm reader
-            // stores the dep_path tail (`"1.2.3"`), npm/yarn/bun store the
-            // full dep_path (`"foo@1.2.3"`).
-            let child = if graph.packages.contains_key(tail) {
-                tail.clone()
-            } else {
-                format!("{name}@{tail}")
-            };
-            if graph.packages.contains_key(&child) {
+            // Match `filter_graph`'s child-key convention (incl. the
+            // git/remote-tarball `name@url+<hash>` form) so peers bubble
+            // through git/tarball edges too.
+            if let Some(child) =
+                aube_lockfile::resolve_dep_edge(name, tail, |k| graph.packages.contains_key(k))
+            {
                 parents.entry(child).or_default().push(dep_path.clone());
             } else {
                 // Edge points outside the resolved graph (workspace

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -3844,6 +3844,98 @@ fn peer_suffix_stops_at_supplier_of_the_peer() {
     );
 }
 
+// A META-ONLY optional peer (declared in `peerDependenciesMeta` but absent
+// from `peerDependencies`, exactly how `follow-redirects` declares `debug`)
+// must NOT be eagerly bound from a distant ancestor's *regular* dependency.
+// pnpm treats such a peer as resolvable but then collapses the binding back
+// out via `dedupe-peer-dependents` whenever a peer-free path exists, so the
+// realistic lockfile keeps the whole chain bare:
+//   provider        (carries debug@3.2.7 as a plain dep)
+//     mid_a          (bare)
+//       mid_b        (bare)
+//         mid_c      (bare)
+//           axios    (bare)
+//             fr     (bare — follow-redirects; debug stays a transitive peer)
+// Binding `(debug@3.2.7)` onto that chain (as a since-reverted experiment did)
+// produced suffixed variants that aube's dedupe pass — which only collapses
+// *declared*-peer variants — never merged. The same subtree then hashed
+// differently per install scope (whole-workspace vs single-member), splitting
+// a shared global-virtual-store singleton in two and surfacing at runtime as a
+// duplicate-instance "Cannot find module". This test pins the bare shape so
+// the over-binding can't regress.
+#[test]
+fn meta_only_optional_peer_stays_bare_to_keep_singleton_shared() {
+    // provider carries debug as a plain (regular) dependency.
+    let provider = mk_locked(
+        "provider",
+        "1.0.0",
+        &[("mid_a", "1.0.0"), ("debug", "3.2.7")],
+        &[],
+    );
+    let mid_a = mk_locked("mid_a", "1.0.0", &[("mid_b", "1.0.0")], &[]);
+    let mid_b = mk_locked("mid_b", "1.0.0", &[("mid_c", "1.0.0")], &[]);
+    let mid_c = mk_locked("mid_c", "1.0.0", &[("axios", "1.0.0")], &[]);
+    let axios = mk_locked("axios", "1.0.0", &[("fr", "1.0.0")], &[]);
+    // fr = follow-redirects: debug ONLY in meta (optional), NOT in peer_deps.
+    let mut fr = mk_locked("fr", "1.0.0", &[], &[]);
+    fr.peer_dependencies_meta.insert(
+        "debug".to_string(),
+        aube_lockfile::PeerDepMeta { optional: true },
+    );
+    let debug = mk_locked("debug", "3.2.7", &[], &[]);
+
+    let mut packages = BTreeMap::new();
+    for p in [provider, mid_a, mid_b, mid_c, axios, fr, debug] {
+        packages.insert(p.dep_path.clone(), p);
+    }
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "provider".to_string(),
+            dep_path: "provider@1.0.0".to_string(),
+            dep_type: DepType::Production,
+            specifier: Some("^1".to_string()),
+        }],
+    );
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+    let out = apply_peer_contexts(graph, &PeerContextOptions::default()).expect("should converge");
+    let mut keys: Vec<&String> = out.packages.keys().collect();
+    keys.sort();
+    // Expected: the meta-only optional `debug` peer is NOT folded into any
+    // dep_path, so every node on the chain has a single bare instance and the
+    // subtree hashes identically regardless of install scope.
+    for bare in [
+        "provider@1.0.0",
+        "mid_a@1.0.0",
+        "mid_b@1.0.0",
+        "mid_c@1.0.0",
+        "axios@1.0.0",
+        "fr@1.0.0",
+    ] {
+        assert!(
+            out.packages.contains_key(bare),
+            "{bare} must exist as the single bare instance; got {keys:#?}"
+        );
+    }
+    for suffixed in [
+        "fr@1.0.0(debug@3.2.7)",
+        "axios@1.0.0(debug@3.2.7)",
+        "mid_c@1.0.0(debug@3.2.7)",
+        "mid_b@1.0.0(debug@3.2.7)",
+        "mid_a@1.0.0(debug@3.2.7)",
+    ] {
+        assert!(
+            !out.packages.contains_key(suffixed),
+            "{suffixed} must NOT be created from a meta-only optional peer; got {keys:#?}"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // direct_dep_info
 // ---------------------------------------------------------------------------

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -3761,6 +3761,89 @@ fn peer_suffix_propagation_dedupes_nested_self_segments() {
     );
 }
 
+// A peer suffix must stop at the package that *supplies* the peer.
+// Real-world chain: `xml2json -> node-expat -> node-gyp -> tinyglobby ->
+// fdir`, where `fdir` declares an OPTIONAL `picomatch` peer and
+// `tinyglobby` lists `picomatch` in its own `dependencies`. pnpm tags
+// only `fdir@6.5.0(picomatch@4.0.4)`; every ancestor — including the
+// supplier `tinyglobby` — stays bare. The
+// `propagate_peer_suffixes_to_ancestors` post-pass used to leak
+// `(picomatch@4.0.4)` all the way up to `xml2json@0.12.0`; suppressing a
+// peer that the absorbing package supplies itself restores pnpm parity.
+#[test]
+fn peer_suffix_stops_at_supplier_of_the_peer() {
+    let xml2json = mk_locked("xml2json", "0.12.0", &[("node-expat", "2.4.3")], &[]);
+    let node_expat = mk_locked("node-expat", "2.4.3", &[("node-gyp", "12.3.0")], &[]);
+    let node_gyp = mk_locked("node-gyp", "12.3.0", &[("tinyglobby", "0.2.17")], &[]);
+    // tinyglobby supplies `picomatch` (resolving fdir's optional peer).
+    let tinyglobby = mk_locked(
+        "tinyglobby",
+        "0.2.17",
+        &[("fdir", "6.5.0"), ("picomatch", "4.0.4")],
+        &[],
+    );
+    // fdir only *declares* the optional peer — it doesn't supply it.
+    let mut fdir = mk_locked("fdir", "6.5.0", &[], &[("picomatch", "^3 || ^4")]);
+    fdir.peer_dependencies_meta.insert(
+        "picomatch".to_string(),
+        aube_lockfile::PeerDepMeta { optional: true },
+    );
+    let picomatch = mk_locked("picomatch", "4.0.4", &[], &[]);
+
+    let mut packages = BTreeMap::new();
+    for p in [xml2json, node_expat, node_gyp, tinyglobby, fdir, picomatch] {
+        packages.insert(p.dep_path.clone(), p);
+    }
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: "xml2json".to_string(),
+            dep_path: "xml2json@0.12.0".to_string(),
+            dep_type: DepType::Production,
+            specifier: Some("^0.12.0".to_string()),
+        }],
+    );
+
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+    let out = apply_peer_contexts(graph, &PeerContextOptions::default())
+        .expect("test graph should converge");
+
+    let keys: Vec<&String> = out.packages.keys().collect();
+    // Only fdir — the peer *declarer* — carries the suffix.
+    assert!(
+        out.packages.contains_key("fdir@6.5.0(picomatch@4.0.4)"),
+        "fdir keeps its own optional-peer suffix; got {keys:?}"
+    );
+    // The supplier and every ancestor above it stay bare (pnpm parity).
+    for bare in [
+        "tinyglobby@0.2.17",
+        "node-gyp@12.3.0",
+        "node-expat@2.4.3",
+        "xml2json@0.12.0",
+    ] {
+        assert!(
+            out.packages.contains_key(bare),
+            "{bare} must stay bare; got {keys:?}"
+        );
+    }
+    assert!(
+        !out.packages
+            .contains_key("tinyglobby@0.2.17(picomatch@4.0.4)"),
+        "tinyglobby supplies picomatch, so the suffix must stop there; got {keys:?}"
+    );
+    assert!(
+        !out.packages
+            .contains_key("xml2json@0.12.0(picomatch@4.0.4)"),
+        "xml2json must not inherit a transitive optional peer; got {keys:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // direct_dep_info
 // ---------------------------------------------------------------------------

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -616,7 +616,7 @@ async fn write_fix_lockfile_update(
         false,
         None,
     )
-    .await;
+    .await?;
     super::write_and_log_lockfile(cwd, &new_graph, &output_manifest)?;
     for name in &updated {
         let old = before

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -609,7 +609,14 @@ async fn write_fix_lockfile_update(
     }
 
     sync_root_dep_specifiers(&mut new_graph, &output_manifest);
-    super::prepare_resolved_graph_for_lockfile_write(&mut new_graph);
+    crate::commands::install::finalize_lockfile_graph(
+        cwd,
+        &mut new_graph,
+        &output_manifest,
+        false,
+        None,
+    )
+    .await;
     super::write_and_log_lockfile(cwd, &new_graph, &output_manifest)?;
     for name in &updated {
         let old = before

--- a/crates/aube/src/commands/dedupe.rs
+++ b/crates/aube/src/commands/dedupe.rs
@@ -110,7 +110,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
         return Err(miette!("dedupe --check: lockfile is not deduped"));
     }
 
-    install::finalize_lockfile_graph(&cwd, &mut graph, &manifest, false, None).await;
+    install::finalize_lockfile_graph(&cwd, &mut graph, &manifest, false, None).await?;
     super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
 
     // Resync node_modules against the new lockfile.

--- a/crates/aube/src/commands/dedupe.rs
+++ b/crates/aube/src/commands/dedupe.rs
@@ -110,7 +110,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
         return Err(miette!("dedupe --check: lockfile is not deduped"));
     }
 
-    super::prepare_resolved_graph_for_lockfile_write(&mut graph);
+    install::finalize_lockfile_graph(&cwd, &mut graph, &manifest, false, None).await;
     super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
 
     // Resync node_modules against the new lockfile.

--- a/crates/aube/src/commands/install/materialize.rs
+++ b/crates/aube/src/commands/install/materialize.rs
@@ -195,6 +195,18 @@ pub(super) async fn run_gvs_prewarm_materializer(
         }
     }
 
+    // Packages whose graph hash folds in a content fingerprint — every
+    // globally-shareable source dep (git / remote tarball) plus all of
+    // its transitive ancestors. Prewarm runs before fetch and so hashes
+    // them content-less, while the link phase hashes them content-ful;
+    // materializing them here would strand a duplicate content-less
+    // cohort in the global store whose source leaves (skipped at receive
+    // time because their trees aren't fetched yet) dangle — a
+    // duplicate-singleton "Cannot find module" class of bug. Defer the
+    // whole set to the link phase, which materializes every node at its
+    // final content-ful path.
+    let content_affected = aube_lockfile::graph_hash::content_affected_dep_paths(&graph);
+
     let _diag_hash_wait =
         aube_util::diag::Span::new(aube_util::diag::Category::Materialize, "hash_await");
     let graph_hashes = hash_handle
@@ -270,6 +282,9 @@ pub(super) async fn run_gvs_prewarm_materializer(
                 continue;
             };
             if pkg.local_source.is_some() {
+                continue;
+            }
+            if content_affected.contains(&dep_path) {
                 continue;
             }
             let linker = linker.clone();

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -54,7 +54,7 @@ use materialize::{
     GvsPrewarmInputs, combine_install_pipeline_errors, materialize_channel, spawn_gvs_prewarm,
 };
 pub(crate) use settings::PeerDependencyRules;
-pub(crate) use settings::{ResolverConfigInputs, configure_resolver};
+pub(crate) use settings::{ResolverConfigInputs, configure_resolver, finalize_lockfile_graph};
 pub(crate) use side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root};
 
 use settings::{

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -1,6 +1,6 @@
 use super::super::{packument_cache_dir, packument_full_cache_dir};
 use super::version_from_dep_path;
-use miette::miette;
+use miette::{Context, IntoDiagnostic, miette};
 use std::collections::BTreeMap;
 
 /// Accept pnpm's documented aliases (`highest`, `time-based`, `time`,
@@ -551,17 +551,27 @@ pub(crate) async fn stamp_pnpm_config_checksums(
 /// caller honors `--ignore-pnpmfile` the local pnpmfile is excluded
 /// from the checksum (pnpm clears it in that mode); `cli_pnpmfile` is
 /// the `--pnpmfile` override (only `update` exposes one today).
+///
+/// Fails fast if `pnpm-workspace.yaml` is present but malformed: the
+/// stamped checksums are derived from that config, so falling back to an
+/// empty workspace would persist a checksum computed from the wrong
+/// inputs and desync config-drift detection. This matches the install
+/// entry path, which also propagates the parse error (a missing or empty
+/// workspace file is `Ok(default)`, not an error, so single-package
+/// projects are unaffected).
 pub(crate) async fn finalize_lockfile_graph(
     cwd: &std::path::Path,
     graph: &mut aube_lockfile::LockfileGraph,
     manifest: &aube_manifest::PackageJson,
     ignore_pnpmfile: bool,
     cli_pnpmfile: Option<&std::path::Path>,
-) {
+) -> miette::Result<()> {
     let write_kind = aube_lockfile::detect_existing_lockfile_kind(cwd)
         .unwrap_or(aube_lockfile::LockfileKind::Aube);
     let files = crate::commands::FileSources::load(cwd);
-    let (ws_config, raw_workspace) = aube_manifest::workspace::load_both(cwd).unwrap_or_default();
+    let (ws_config, raw_workspace) = aube_manifest::workspace::load_both(cwd)
+        .into_diagnostic()
+        .wrap_err("failed to load workspace config for lockfile finalization")?;
     let env = aube_settings::values::process_env();
     let ctx = files.ctx(&raw_workspace, env, &[]);
     let local_pnpmfile = if ignore_pnpmfile {
@@ -571,6 +581,7 @@ pub(crate) async fn finalize_lockfile_graph(
     };
     stamp_pnpm_config_checksums(graph, write_kind, manifest, &ctx, local_pnpmfile.as_deref()).await;
     crate::commands::prepare_resolved_graph_for_lockfile_write(graph);
+    Ok(())
 }
 
 fn merge_json_object_setting(
@@ -1280,7 +1291,9 @@ mod finalize_lockfile_graph_tests {
         let mut graph = aube_lockfile::LockfileGraph::default();
         assert!(graph.package_extensions_checksum.is_none());
         // ignore_pnpmfile=true keeps this assertion node-free.
-        finalize_lockfile_graph(cwd, &mut graph, &manifest(), true, None).await;
+        finalize_lockfile_graph(cwd, &mut graph, &manifest(), true, None)
+            .await
+            .unwrap();
         assert!(
             graph.package_extensions_checksum.is_some(),
             "packageExtensions checksum must be stamped on pnpm-lock writes"
@@ -1305,7 +1318,9 @@ mod finalize_lockfile_graph_tests {
         .unwrap();
 
         let mut graph = aube_lockfile::LockfileGraph::default();
-        finalize_lockfile_graph(cwd, &mut graph, &manifest(), false, None).await;
+        finalize_lockfile_graph(cwd, &mut graph, &manifest(), false, None)
+            .await
+            .unwrap();
         assert!(
             graph.package_extensions_checksum.is_none(),
             "aube-lock.yaml must not grow pnpm-only checksum fields"
@@ -1337,7 +1352,9 @@ mod finalize_lockfile_graph_tests {
         .unwrap();
 
         let mut graph = aube_lockfile::LockfileGraph::default();
-        finalize_lockfile_graph(cwd, &mut graph, &manifest(), false, None).await;
+        finalize_lockfile_graph(cwd, &mut graph, &manifest(), false, None)
+            .await
+            .unwrap();
         assert!(
             graph.pnpmfile_checksum.is_some(),
             "pnpmfile checksum must be stamped when a hook-exporting pnpmfile is present"
@@ -1345,7 +1362,9 @@ mod finalize_lockfile_graph_tests {
 
         // --ignore-pnpmfile clears it, matching pnpm.
         let mut ignored = aube_lockfile::LockfileGraph::default();
-        finalize_lockfile_graph(cwd, &mut ignored, &manifest(), true, None).await;
+        finalize_lockfile_graph(cwd, &mut ignored, &manifest(), true, None)
+            .await
+            .unwrap();
         assert!(
             ignored.pnpmfile_checksum.is_none(),
             "--ignore-pnpmfile must not record a pnpmfile checksum"

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -531,6 +531,48 @@ pub(crate) async fn stamp_pnpm_config_checksums(
     };
 }
 
+/// Finalize a freshly resolved graph for the lockfile write paths that
+/// live *outside* `install` (`update`/`upgrade`, `remove`, `dedupe`,
+/// `audit --fix`). Mirrors the install path's pre-write sequence:
+/// stamp pnpm's config checksums (`packageExtensionsChecksum` +
+/// `pnpmfileChecksum`) then apply the pnpm-parity snapshot passes
+/// (`optional: true`, `transitivePeerDependencies`).
+///
+/// Before this existed, those commands resolved a graph with both
+/// checksum fields `None` and wrote it straight to disk, so e.g.
+/// `aube upgrade` dropped the `packageExtensionsChecksum` /
+/// `pnpmfileChecksum` a prior `aube install` had recorded — and the
+/// chained frozen-prefer install reused the now-stale lockfile without
+/// restamping, so the fields never came back. pnpm writes these on
+/// every command that rewrites the lockfile; matching that keeps
+/// config-drift detection (ours and pnpm's) honest.
+///
+/// `ignore_pnpmfile` / `cli_pnpmfile` mirror the install flags: when a
+/// caller honors `--ignore-pnpmfile` the local pnpmfile is excluded
+/// from the checksum (pnpm clears it in that mode); `cli_pnpmfile` is
+/// the `--pnpmfile` override (only `update` exposes one today).
+pub(crate) async fn finalize_lockfile_graph(
+    cwd: &std::path::Path,
+    graph: &mut aube_lockfile::LockfileGraph,
+    manifest: &aube_manifest::PackageJson,
+    ignore_pnpmfile: bool,
+    cli_pnpmfile: Option<&std::path::Path>,
+) {
+    let write_kind = aube_lockfile::detect_existing_lockfile_kind(cwd)
+        .unwrap_or(aube_lockfile::LockfileKind::Aube);
+    let files = crate::commands::FileSources::load(cwd);
+    let (ws_config, raw_workspace) = aube_manifest::workspace::load_both(cwd).unwrap_or_default();
+    let env = aube_settings::values::process_env();
+    let ctx = files.ctx(&raw_workspace, env, &[]);
+    let local_pnpmfile = if ignore_pnpmfile {
+        None
+    } else {
+        crate::pnpmfile::detect(cwd, cli_pnpmfile, ws_config.pnpmfile_path.as_deref())
+    };
+    stamp_pnpm_config_checksums(graph, write_kind, manifest, &ctx, local_pnpmfile.as_deref()).await;
+    crate::commands::prepare_resolved_graph_for_lockfile_write(graph);
+}
+
 fn merge_json_object_setting(
     ctx: &aube_settings::ResolveCtx<'_>,
     setting: &str,
@@ -1191,5 +1233,122 @@ mod peer_dependency_rules_tests {
         // match" rather than panicking or silencing everything.
         let r = rules(&[], &[], &[("react", "not-a-range")]);
         assert!(!r.silences(&unmet("parent", "react", "^18.0.0", Some("19.0.0"))));
+    }
+}
+
+#[cfg(test)]
+mod finalize_lockfile_graph_tests {
+    use super::*;
+
+    fn node_available() -> bool {
+        std::process::Command::new(crate::runtime::node_program())
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    fn manifest() -> aube_manifest::PackageJson {
+        aube_manifest::PackageJson {
+            name: Some("x".to_string()),
+            version: Some("1.0.0".to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Regression for `aube upgrade`/`dedupe`/`remove`/`audit` dropping
+    /// `packageExtensionsChecksum`: every command that rewrites a
+    /// pnpm-lock.yaml must stamp the checksum just like `aube install`.
+    #[tokio::test]
+    async fn finalize_stamps_package_extensions_checksum_on_pnpm_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = dir.path();
+        std::fs::write(cwd.join("pnpm-lock.yaml"), "lockfileVersion: '9.0'\n").unwrap();
+        std::fs::write(
+            cwd.join("package.json"),
+            r#"{"name":"x","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            cwd.join("pnpm-workspace.yaml"),
+            "packageExtensions:\n  foo@*:\n    dependencies:\n      bar: 1.0.0\n",
+        )
+        .unwrap();
+
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        assert!(graph.package_extensions_checksum.is_none());
+        // ignore_pnpmfile=true keeps this assertion node-free.
+        finalize_lockfile_graph(cwd, &mut graph, &manifest(), true, None).await;
+        assert!(
+            graph.package_extensions_checksum.is_some(),
+            "packageExtensions checksum must be stamped on pnpm-lock writes"
+        );
+    }
+
+    /// aube-lock.yaml must never grow pnpm-only checksum fields — the
+    /// stamp is a no-op when no pnpm lockfile is present.
+    #[tokio::test]
+    async fn finalize_skips_checksums_on_aube_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = dir.path();
+        std::fs::write(
+            cwd.join("package.json"),
+            r#"{"name":"x","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            cwd.join("pnpm-workspace.yaml"),
+            "packageExtensions:\n  foo@*:\n    dependencies:\n      bar: 1.0.0\n",
+        )
+        .unwrap();
+
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        finalize_lockfile_graph(cwd, &mut graph, &manifest(), false, None).await;
+        assert!(
+            graph.package_extensions_checksum.is_none(),
+            "aube-lock.yaml must not grow pnpm-only checksum fields"
+        );
+        assert!(graph.pnpmfile_checksum.is_none());
+    }
+
+    /// The pnpmfile half of the same regression: a local pnpmfile that
+    /// exports hooks gets its `pnpmfileChecksum` recorded on a pnpm-lock
+    /// rewrite (matching pnpm + a fresh `aube install`).
+    #[tokio::test]
+    async fn finalize_stamps_pnpmfile_checksum_on_pnpm_lock() {
+        if !node_available() {
+            eprintln!("skipping: `node` not on PATH");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = dir.path();
+        std::fs::write(cwd.join("pnpm-lock.yaml"), "lockfileVersion: '9.0'\n").unwrap();
+        std::fs::write(
+            cwd.join("package.json"),
+            r#"{"name":"x","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            cwd.join(".pnpmfile.cjs"),
+            "module.exports = { hooks: { readPackage: (pkg) => pkg } }\n",
+        )
+        .unwrap();
+
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        finalize_lockfile_graph(cwd, &mut graph, &manifest(), false, None).await;
+        assert!(
+            graph.pnpmfile_checksum.is_some(),
+            "pnpmfile checksum must be stamped when a hook-exporting pnpmfile is present"
+        );
+
+        // --ignore-pnpmfile clears it, matching pnpm.
+        let mut ignored = aube_lockfile::LockfileGraph::default();
+        finalize_lockfile_graph(cwd, &mut ignored, &manifest(), true, None).await;
+        assert!(
+            ignored.pnpmfile_checksum.is_none(),
+            "--ignore-pnpmfile must not record a pnpmfile checksum"
+        );
     }
 }

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -167,7 +167,7 @@ pub async fn run(
         .wrap_err("failed to resolve dependencies")?;
     eprintln!("Resolved {} packages", graph.packages.len());
 
-    install::finalize_lockfile_graph(&cwd, &mut graph, &manifest, false, None).await;
+    install::finalize_lockfile_graph(&cwd, &mut graph, &manifest, false, None).await?;
     super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
 
     // Reinstall to clean up node_modules

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -167,7 +167,7 @@ pub async fn run(
         .wrap_err("failed to resolve dependencies")?;
     eprintln!("Resolved {} packages", graph.packages.len());
 
-    super::prepare_resolved_graph_for_lockfile_write(&mut graph);
+    install::finalize_lockfile_graph(&cwd, &mut graph, &manifest, false, None).await;
     super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
 
     // Reinstall to clean up node_modules

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -750,7 +750,7 @@ pub async fn run(
         args.ignore_pnpmfile,
         args.pnpmfile.as_deref(),
     )
-    .await;
+    .await?;
     write_update_lockfile(
         &cwd,
         &graph,
@@ -1492,7 +1492,7 @@ async fn merge_update_graph_into_workspace_lockfile(
         ignore_pnpmfile,
         cli_pnpmfile,
     )
-    .await;
+    .await?;
     super::write_and_log_lockfile(workspace_root, &root_graph, root_manifest)?;
     Ok(())
 }

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -743,8 +743,22 @@ pub async fn run(
         }
     }
 
-    super::prepare_resolved_graph_for_lockfile_write(&mut graph);
-    write_update_lockfile(&cwd, &graph, &manifest)?;
+    install::finalize_lockfile_graph(
+        &cwd,
+        &mut graph,
+        &manifest,
+        args.ignore_pnpmfile,
+        args.pnpmfile.as_deref(),
+    )
+    .await;
+    write_update_lockfile(
+        &cwd,
+        &graph,
+        &manifest,
+        args.ignore_pnpmfile,
+        absolute_cli_pnpmfile(&cwd, args.pnpmfile.as_deref()).as_deref(),
+    )
+    .await?;
 
     // Propagate `--ignore-pnpmfile` / `--pnpmfile` / `--global-pnpmfile`
     // into the chained install. Frozen-prefer normally short-circuits to
@@ -1314,7 +1328,10 @@ async fn run_filtered(
                     &pkg.manifest,
                     root_manifest,
                     root_graph,
-                )?;
+                    args.ignore_pnpmfile,
+                    absolute_cli_pnpmfile(&pkg.dir, args.pnpmfile.as_deref()).as_deref(),
+                )
+                .await?;
             }
         }
         Ok(())
@@ -1327,12 +1344,14 @@ fn resolve_shared_workspace_lockfile(cwd: &std::path::Path) -> miette::Result<bo
     with_update_settings_ctx(cwd, aube_settings::resolved::shared_workspace_lockfile)
 }
 
-fn merge_filtered_update_lockfile(
+async fn merge_filtered_update_lockfile(
     workspace_root: &std::path::Path,
     pkg_dir: &std::path::Path,
     pkg_manifest: &aube_manifest::PackageJson,
     root_manifest: &aube_manifest::PackageJson,
     root_graph: aube_lockfile::LockfileGraph,
+    ignore_pnpmfile: bool,
+    cli_pnpmfile: Option<&std::path::Path>,
 ) -> miette::Result<()> {
     let importer_path = super::workspace_importer_path(workspace_root, pkg_dir)?;
     let remove_pkg_lockfile = importer_path != ".";
@@ -1350,7 +1369,10 @@ fn merge_filtered_update_lockfile(
         root_manifest,
         root_graph,
         pkg_graph,
-    )?;
+        ignore_pnpmfile,
+        cli_pnpmfile,
+    )
+    .await?;
     if remove_pkg_lockfile {
         std::fs::remove_file(&pkg_lockfile)
             .into_diagnostic()
@@ -1359,10 +1381,29 @@ fn merge_filtered_update_lockfile(
     Ok(())
 }
 
-fn write_update_lockfile(
+// Resolve a `--pnpmfile` override to an absolute path against `cwd`. The
+// workspace-merge stamp below detects the pnpmfile against `workspace_root`,
+// not the member `cwd`, so a relative override has to be anchored here or it
+// would resolve against the wrong base.
+fn absolute_cli_pnpmfile(
+    cwd: &std::path::Path,
+    cli: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    cli.map(|p| {
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            cwd.join(p)
+        }
+    })
+}
+
+async fn write_update_lockfile(
     cwd: &std::path::Path,
     graph: &aube_lockfile::LockfileGraph,
     manifest: &aube_manifest::PackageJson,
+    ignore_pnpmfile: bool,
+    cli_pnpmfile: Option<&std::path::Path>,
 ) -> miette::Result<()> {
     let Some(workspace_root) = crate::dirs::find_workspace_root(cwd) else {
         super::write_and_log_lockfile(cwd, graph, manifest)?;
@@ -1381,15 +1422,20 @@ fn write_update_lockfile(
         &root_manifest,
         root_graph,
         graph.clone(),
+        ignore_pnpmfile,
+        cli_pnpmfile,
     )
+    .await
 }
 
-fn merge_update_graph_into_workspace_lockfile(
+async fn merge_update_graph_into_workspace_lockfile(
     workspace_root: &std::path::Path,
     pkg_dir: &std::path::Path,
     root_manifest: &aube_manifest::PackageJson,
     mut root_graph: aube_lockfile::LockfileGraph,
     mut pkg_graph: aube_lockfile::LockfileGraph,
+    ignore_pnpmfile: bool,
+    cli_pnpmfile: Option<&std::path::Path>,
 ) -> miette::Result<()> {
     let importer_path = super::workspace_importer_path(workspace_root, pkg_dir)?;
     let pkg_deps = pkg_graph.importers.remove(".").ok_or_else(|| {
@@ -1432,7 +1478,21 @@ fn merge_update_graph_into_workspace_lockfile(
 
     let mut root_graph = root_graph.filter_deps(|_| true);
     retain_package_times(&mut root_graph);
-    super::prepare_resolved_graph_for_lockfile_write(&mut root_graph);
+    // Stamp the *root* lockfile against the workspace-root config
+    // (its package extensions + pnpmfile), matching what an install
+    // from the root would write — otherwise the shared lockfile loses
+    // the checksums on every `aube update` in a member package. Honor the
+    // same `--ignore-pnpmfile` / `--pnpmfile` flags the member resolve
+    // used so the root stamp can't re-add a pnpmfileChecksum the user
+    // opted out of (or stamp the wrong hook).
+    install::finalize_lockfile_graph(
+        workspace_root,
+        &mut root_graph,
+        root_manifest,
+        ignore_pnpmfile,
+        cli_pnpmfile,
+    )
+    .await;
     super::write_and_log_lockfile(workspace_root, &root_graph, root_manifest)?;
     Ok(())
 }

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -1114,7 +1114,8 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     // like catalog, overrides, packageExtensions, onlyBuiltDependencies
     // where any change means a real re-resolve.
     let files = crate::commands::FileSources::load(project_dir);
-    let raw_workspace = aube_manifest::workspace::load_raw(project_dir).unwrap_or_default();
+    let (ws_config, raw_workspace) =
+        aube_manifest::workspace::load_both(project_dir).unwrap_or_default();
     let env = aube_settings::values::capture_env();
     let ctx = files.ctx(&raw_workspace, &env, cli_flags);
     let mut hasher = blake3::Hasher::new();
@@ -1231,6 +1232,26 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
         }
     }
     hasher.update(b"\0");
+    // pnpmfile content. A local `.pnpmfile.{cjs,mjs}` (or a
+    // `pnpmfilePath` override) `readPackage` / `afterAllResolved` hook
+    // rewrites the resolved tree, so editing it must re-resolve. The
+    // workspace-yaml hash above only catches the `pnpmfilePath` *setting*,
+    // not the hook file's bytes — without this a changed pnpmfile rode the
+    // warm path and the hook (e.g. dependency pins) silently never
+    // re-applied, leaving node_modules and the lockfile stale (and pnpm's
+    // `readPackage` log never reappeared). Mirrors pnpm folding the
+    // pnpmfile into its own up-to-date check.
+    hasher.update(b"pnpmfile=");
+    if let Some(path) =
+        crate::pnpmfile::detect(project_dir, None, ws_config.pnpmfile_path.as_deref())
+    {
+        hasher.update(path.as_os_str().as_encoded_bytes());
+        hasher.update(b"\x1f");
+        if let Ok(bytes) = std::fs::read(&path) {
+            hasher.update(&bytes);
+        }
+    }
+    hasher.update(b"\0");
     // OS + arch + libc. Optional deps filter by these. Swap host
     // between runs (committed node_modules across machines, shared
     // CI cache volume, Rosetta switch) and the correct prebuilts
@@ -1311,7 +1332,7 @@ mod tests {
     use super::{
         InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
         collect_package_json_hashes_from_manifests, empty_blake3_hash, fresh_state_file, hash_file,
-        install_state_file, member_lockfiles_stale, read_or_migrate_fresh_state,
+        hash_settings, install_state_file, member_lockfiles_stale, read_or_migrate_fresh_state,
         relative_path_or_original, remove_state, verify_install_layout,
     };
     use std::collections::BTreeMap;
@@ -1769,6 +1790,41 @@ mod tests {
         assert_eq!(
             member_lockfiles_stale(&dir, &state),
             Some("packages/b was removed from the workspace".to_string())
+        );
+    }
+
+    #[test]
+    fn settings_hash_busts_warm_path_on_pnpmfile_change() {
+        // A `.pnpmfile.{mjs,cjs}` `readPackage` hook rewrites the resolved
+        // tree, so adding / editing / removing it must change the
+        // freshness verdict — otherwise the hook silently never re-applies
+        // and the lockfile + node_modules go stale on the warm path.
+        let dir = temp_project_dir("settings-hash-pnpmfile");
+        std::fs::write(dir.join("package.json"), r#"{"name":"x"}"#).unwrap();
+
+        let baseline = hash_settings(&dir, &[]);
+
+        // Adding a pnpmfile must change the hash.
+        let pnpmfile = dir.join(".pnpmfile.mjs");
+        std::fs::write(&pnpmfile, "export function readPackage(p){return p}\n").unwrap();
+        let with_file = hash_settings(&dir, &[]);
+        assert_ne!(baseline, with_file, "adding a pnpmfile must bust the hash");
+
+        // Editing the hook body must change the hash again.
+        std::fs::write(
+            &pnpmfile,
+            "export function readPackage(p){p.dependencies={};return p}\n",
+        )
+        .unwrap();
+        let edited = hash_settings(&dir, &[]);
+        assert_ne!(with_file, edited, "editing a pnpmfile must bust the hash");
+
+        // Removing it returns to the baseline verdict.
+        std::fs::remove_file(&pnpmfile).unwrap();
+        assert_eq!(
+            baseline,
+            hash_settings(&dir, &[]),
+            "removing the pnpmfile must restore the baseline hash"
         );
     }
 }

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -753,6 +753,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX",
+      "category": "Lockfile",
+      "description": "A pnpm dep_path peer suffix had unbalanced parentheses (a truncated or hand-corrupted lockfile entry). The key is preserved verbatim instead of silently dropping everything after the `(`, so a later install surfaces the bad entry rather than mis-resolving it.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_PROGRESS_OVERFLOW",
       "category": "Progress UI",
       "description": "Install progress numerator exceeded the resolved-package denominator. Display clamps to total; the warning surfaces the bookkeeping mismatch so the underlying race can be diagnosed.",


### PR DESCRIPTION
## Summary

Fixes a cluster of `pnpm-lock.yaml` parity and re-resolution bugs surfaced while running `aube install` / `aube upgrade` in a `sharedWorkspaceLockfile=false` monorepo. After these changes aube's lockfile output and up-to-date checks match pnpm's, so a project that installs cleanly under pnpm no longer re-resolves on every install or writes a divergent
lockfile under aube.

## What's fixed

Each item is a separate commit.

1. **Stop peer suffixes at the package that supplies the peer** (`fix(resolver)`) — a transitively-needed optional peer (e.g. `fdir`'s `picomatch`) leaked up the whole chain, so aube wrote `xml2json@0.12.0(picomatch@4.0.4)` where pnpm writes `xml2json@0.12.0`. The suffix is now suppressed once it reaches a package that provides the peer; the declarer keeps its suffix.

2. **Write hosted-git deps as codeload tarballs** (`fix(resolver)`) — a github/gitlab/bitbucket dep pinned to a 40-char SHA is now recorded as a codeload `RemoteTarball` (`name@https://codeload.github.com/<owner>/<repo>/tar.gz/<sha>` with `resolution: {gitHosted, integrity, tarball}` + `version:`), matching pnpm, instead of the `<url>.git#<sha>` / `type: git` form. `resolution:` keys are sorted to match pnpm's emitter.

3. **Render git/tarball peer suffixes as resolved specs** (`fix(lockfile)`) — completes #2 for peer *suffixes*: `request-promise-core@1.1.4(request@https://codeload.github.com/<owner>/<repo>/tar.gz/<sha>)` instead of aube's internal hashed `(request@git+<hash>)`. Implemented as a  symmetric translation (hashed→spec on write, spec→hashed on read) so a round-trip is a fixed point — a one-sided change would re-key every install and churn the lockfile.

4. **Stamp pnpm config checksums on update/remove/dedupe/audit** (`fix(install)`) — only the main install path wrote `packageExtensionsChecksum` / `pnpmfileChecksum`; the other four commands resolved a fresh graph and dropped both fields. They now route through a shared `finalize_lockfile_graph` that stamps the checksums, honoring `--ignore-pnpmfile` / `--pnpmfile`.

5. **Re-resolve when the pnpmfile changes** (`fix(install)`) — the warm-path settings hash never folded in the pnpmfile's own bytes, so editing a local `.pnpmfile.{cjs,mjs}` `readPackage` / `afterAllResolved` hook rode the warm path: the hook silently never re-applied (no `readPackage` output, stale `node_modules` + lockfile). The resolved pnpmfile's path + content is now hashed into the settings hash, mirroring pnpm's own up-to-date check. This also resolves the "lockfile doesn't regenerate when `node_modules` is out of sync" report.

## Design note

The peer-suffix translation (#3) is intentionally symmetric and restricted to git / remote-tarball sources, so the writer's hashed→spec pass and the reader's spec→hashed pass are exact inverses. A divergence would re-key the graph on
read and churn the lockfile on the next install (the original re-resolve loop).

## Test plan

- [x] `cargo test -p aube-lockfile` (337 + new) and `-p aube-resolver` green
- [x] New unit tests for the `rewrite_peer_suffix` walker (flat / nested / registry no-op / multi-segment / no-suffix)
- [x] New integration test: git/tarball peer suffix renders as the resolved spec on write and round-trips back to the hashed form on read (fixed point)
- [x] `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean
- [x] Verified end-to-end on a `sharedWorkspaceLockfile=false` monorepo: hosted-git deps + peer suffixes now match pnpm, a forced re-resolve round-trips with no churn, and `.pnpmfile` `readPackage` output appears under aube

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings hashing now includes pnpmfile hook selection; lockfile graph finalization is reused consistently across flows.
  * GVS prewarm now skips materializing dep paths whose content affects virtual-store hashes.
  * Added `WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX` to surface malformed pnpm `dep_path` peer-suffix tails verbatim.
* **Bug Fixes**
  * Fixed pnpm `dep_path` peer-suffix parsing/rewriting (including nested peers) and ensured correct resolved-spec round-trips, preserving unbalanced parentheses verbatim.
  * Normalized hosted-git/remote tarball local handling and stabilized peer-context propagation (supplier stop; meta-only optionals stay bare).
* **Refactor**
  * Standardized lockfile graph finalization logic across audit/dedupe/remove/update.
* **Tests**
  * Added/updated regression and unit coverage for pnpm round-trips, peer behavior, graph-hash influence, and finalization/checksum scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->