### PR TITLE
fix(lockfile): reject unsafe dependency aliases

### DIFF
--- a/crates/aube-lockfile/src/io.rs
+++ b/crates/aube-lockfile/src/io.rs
@@ -472,6 +472,8 @@ fn validate_dependency_aliases(path: &Path, graph: &LockfileGraph) -> Result<(),
             .keys()
             .chain(pkg.optional_dependencies.keys())
             .chain(pkg.peer_dependencies.keys())
+            .chain(pkg.peer_dependencies_meta.keys())
+            .chain(pkg.declared_dependencies.keys())
         {
             if !is_safe_package_alias(alias) {
                 return Err(Error::parse(
@@ -539,7 +541,9 @@ fn dep_path_has_registry_version(dep_path: &str, name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{dep_path_has_registry_version, validate_dependency_aliases};
-    use crate::{DepType, DirectDep, GitSource, LocalSource, LockedPackage, RemoteTarballSource};
+    use crate::{
+        DepType, DirectDep, GitSource, LocalSource, LockedPackage, PeerDepMeta, RemoteTarballSource,
+    };
     use proptest::prelude::*;
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -599,6 +603,9 @@ mod tests {
             "node_modules",
             "@scope/pkg/extra",
             "\\evil",
+            "foo\0bar",
+            "/etc/passwd",
+            "C:pkg",
         ] {
             let mut graph = crate::LockfileGraph::default();
             graph.importers.insert(
@@ -622,9 +629,7 @@ mod tests {
 
     #[test]
     fn rejects_unsafe_package_dependency_aliases() {
-        let mut graph = crate::LockfileGraph::default();
-        graph.packages.insert(
-            "parent@1.0.0".into(),
+        for package in [
             LockedPackage {
                 name: "parent".into(),
                 version: "1.0.0".into(),
@@ -632,15 +637,35 @@ mod tests {
                 dependencies: BTreeMap::from([("../escape".into(), "1.0.0".into())]),
                 ..LockedPackage::default()
             },
-        );
+            LockedPackage {
+                name: "parent".into(),
+                version: "1.0.0".into(),
+                dep_path: "parent@1.0.0".into(),
+                declared_dependencies: BTreeMap::from([("../escape".into(), "^1.0.0".into())]),
+                ..LockedPackage::default()
+            },
+            LockedPackage {
+                name: "parent".into(),
+                version: "1.0.0".into(),
+                dep_path: "parent@1.0.0".into(),
+                peer_dependencies_meta: BTreeMap::from([(
+                    "../escape".into(),
+                    PeerDepMeta { optional: true },
+                )]),
+                ..LockedPackage::default()
+            },
+        ] {
+            let mut graph = crate::LockfileGraph::default();
+            graph.packages.insert("parent@1.0.0".into(), package);
 
-        let err = validate_dependency_aliases(Path::new("pnpm-lock.yaml"), &graph)
-            .expect_err("unsafe alias must be rejected");
-        assert!(
-            err.to_string()
-                .contains("package parent@1.0.0 has unsafe dependency alias `../escape`"),
-            "unexpected error: {err}"
-        );
+            let err = validate_dependency_aliases(Path::new("pnpm-lock.yaml"), &graph)
+                .expect_err("unsafe alias must be rejected");
+            assert!(
+                err.to_string()
+                    .contains("package parent@1.0.0 has unsafe dependency alias `../escape`"),
+                "unexpected error: {err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/aube-lockfile/src/io.rs
+++ b/crates/aube-lockfile/src/io.rs
@@ -430,6 +430,7 @@ fn parse_one(
 }
 
 fn validate_resolution_shapes(path: &Path, graph: &LockfileGraph) -> Result<(), Error> {
+    validate_dependency_aliases(path, graph)?;
     for (dep_path, pkg) in &graph.packages {
         if pkg.local_source.is_some() && dep_path_has_registry_version(dep_path, &pkg.name) {
             return Err(Error::ResolutionShapeMismatch(
@@ -443,6 +444,83 @@ fn validate_resolution_shapes(path: &Path, graph: &LockfileGraph) -> Result<(), 
         }
     }
     Ok(())
+}
+
+fn validate_dependency_aliases(path: &Path, graph: &LockfileGraph) -> Result<(), Error> {
+    for (importer_path, deps) in &graph.importers {
+        for dep in deps {
+            if !is_safe_package_alias(&dep.name) {
+                return Err(Error::parse(
+                    path,
+                    format!(
+                        "importer {importer_path} has unsafe dependency alias `{}`",
+                        dep.name
+                    ),
+                ));
+            }
+        }
+    }
+    for (dep_path, pkg) in &graph.packages {
+        if !is_safe_package_alias(&pkg.name) {
+            return Err(Error::parse(
+                path,
+                format!("package {dep_path} has unsafe package name `{}`", pkg.name),
+            ));
+        }
+        for alias in pkg
+            .dependencies
+            .keys()
+            .chain(pkg.optional_dependencies.keys())
+            .chain(pkg.peer_dependencies.keys())
+        {
+            if !is_safe_package_alias(alias) {
+                return Err(Error::parse(
+                    path,
+                    format!("package {dep_path} has unsafe dependency alias `{alias}`"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_safe_package_alias(name: &str) -> bool {
+    if name.is_empty()
+        || name.contains('\0')
+        || name.contains('\\')
+        || name.starts_with('/')
+        || matches!(name, ".bin" | ".pnpm" | "node_modules")
+    {
+        return false;
+    }
+    let parts: Vec<&str> = name.split('/').collect();
+    match parts.as_slice() {
+        [bare] => is_safe_package_alias_component(bare),
+        [scope, bare] => {
+            scope.starts_with('@')
+                && scope.len() > 1
+                && is_safe_package_alias_component(scope)
+                && is_safe_package_alias_component(bare)
+        }
+        _ => false,
+    }
+}
+
+fn is_safe_package_alias_component(component: &str) -> bool {
+    if component.is_empty() || matches!(component, "." | "..") {
+        return false;
+    }
+    if component.len() >= 2 && component.as_bytes()[1] == b':' {
+        return false;
+    }
+    !std::path::Path::new(component).components().any(|c| {
+        matches!(
+            c,
+            std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_)
+        )
+    })
 }
 
 fn dep_path_has_registry_version(dep_path: &str, name: &str) -> bool {
@@ -460,10 +538,11 @@ fn dep_path_has_registry_version(dep_path: &str, name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::dep_path_has_registry_version;
-    use crate::{GitSource, LocalSource, RemoteTarballSource};
+    use super::{dep_path_has_registry_version, validate_dependency_aliases};
+    use crate::{DepType, DirectDep, GitSource, LocalSource, LockedPackage, RemoteTarballSource};
     use proptest::prelude::*;
-    use std::path::PathBuf;
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
 
     fn package_name() -> impl Strategy<Value = String> {
         prop_oneof![
@@ -509,6 +588,97 @@ mod tests {
                 },
             )),
         ]
+    }
+
+    #[test]
+    fn rejects_unsafe_importer_dependency_aliases() {
+        for alias in [
+            "../../../escape",
+            ".bin",
+            ".pnpm",
+            "node_modules",
+            "@scope/pkg/extra",
+            "\\evil",
+        ] {
+            let mut graph = crate::LockfileGraph::default();
+            graph.importers.insert(
+                ".".into(),
+                vec![DirectDep {
+                    name: alias.into(),
+                    dep_path: "ok@1.0.0".into(),
+                    dep_type: DepType::Production,
+                    specifier: Some("1.0.0".into()),
+                }],
+            );
+
+            let err = validate_dependency_aliases(Path::new("pnpm-lock.yaml"), &graph)
+                .expect_err("unsafe alias must be rejected");
+            assert!(
+                err.to_string().contains("unsafe dependency alias"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unsafe_package_dependency_aliases() {
+        let mut graph = crate::LockfileGraph::default();
+        graph.packages.insert(
+            "parent@1.0.0".into(),
+            LockedPackage {
+                name: "parent".into(),
+                version: "1.0.0".into(),
+                dep_path: "parent@1.0.0".into(),
+                dependencies: BTreeMap::from([("../escape".into(), "1.0.0".into())]),
+                ..LockedPackage::default()
+            },
+        );
+
+        let err = validate_dependency_aliases(Path::new("pnpm-lock.yaml"), &graph)
+            .expect_err("unsafe alias must be rejected");
+        assert!(
+            err.to_string()
+                .contains("package parent@1.0.0 has unsafe dependency alias `../escape`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_valid_scoped_and_unscoped_dependency_aliases() {
+        let mut graph = crate::LockfileGraph::default();
+        graph.importers.insert(
+            ".".into(),
+            vec![
+                DirectDep {
+                    name: "left-pad".into(),
+                    dep_path: "left-pad@1.3.0".into(),
+                    dep_type: DepType::Production,
+                    specifier: Some("1.3.0".into()),
+                },
+                DirectDep {
+                    name: "@scope/pkg".into(),
+                    dep_path: "@scope/pkg@1.0.0".into(),
+                    dep_type: DepType::Dev,
+                    specifier: Some("1.0.0".into()),
+                },
+            ],
+        );
+        graph.packages.insert(
+            "parent@1.0.0".into(),
+            LockedPackage {
+                name: "parent".into(),
+                version: "1.0.0".into(),
+                dep_path: "parent@1.0.0".into(),
+                dependencies: BTreeMap::from([
+                    ("left-pad".into(), "1.3.0".into()),
+                    ("@scope/pkg".into(), "1.0.0".into()),
+                ]),
+                ..LockedPackage::default()
+            },
+        );
+
+        validate_dependency_aliases(Path::new("pnpm-lock.yaml"), &graph)
+            .expect("valid aliases should pass");
     }
 
     proptest! {


### PR DESCRIPTION
## Summary
- reject unsafe importer and package dependency aliases immediately after parsing lockfiles
- cover path traversal, reserved node_modules slots, and malformed scoped aliases

## Why
A crafted lockfile alias should fail before fetch or linker filesystem work begins, matching the hardening added in pnpm 11.7.0.

## Validation
- cargo fmt --check
- cargo test -p aube-lockfile unsafe_ --lib
- cargo test -p aube-lockfile accepts_valid_scoped_and_unscoped_dependency_aliases --lib

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security hardening on the lockfile parse path; legitimate lockfiles with unusual but valid names are unlikely to be affected, but any edge-case alias shapes could now fail parse.
> 
> **Overview**
> Adds **post-parse validation** so crafted lockfile names cannot reach fetch or linker filesystem work. `validate_resolution_shapes` now calls **`validate_dependency_aliases`** first, scanning importer direct deps, each package’s `name`, and dependency keys across production, optional, peer, and declared dependency maps.
> 
> Unsafe aliases fail with a parse-style error. Rules mirror pnpm 11.7.0-style hardening: reject empty names, null bytes, backslashes, absolute paths, reserved slots (`.bin`, `.pnpm`, `node_modules`), malformed scoped names (only `name` or `@scope/name`), `..` / `.` segments, Windows drive prefixes, and other path components that would escape normal package layout.
> 
> Unit tests cover rejected importer and package aliases (including `declared_dependencies` and `peer_dependencies_meta`) and that valid scoped and unscoped names still pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c467d4639b5b70ad1692282439674f0810407c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for dependency and package alias names to reject unsafe characters and path traversal/absolute-path-style patterns, including invalid disallowed segments.

* **Tests**
  * Added unit tests to verify that invalid importer dependency aliases and invalid package dependency alias keys are rejected, while valid scoped and unscoped aliases are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->