### PR TITLE
feat(registry): support scope-specific auth tokens

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -57,6 +57,7 @@ const AUDIT_BODY_CAP: u64 = 256 << 20;
 pub struct RegistryClient {
     http: reqwest::Client,
     http_by_uri: BTreeMap<String, reqwest::Client>,
+    http_by_uri_scope: BTreeMap<String, BTreeMap<String, reqwest::Client>>,
     /// HTTP/1.1-only client used for tarball body downloads. See
     /// [`build_http_tarball_client`] for the rationale (h2 stream
     /// queueing on a single connection vs h1's parallel TCP per

--- a/crates/aube-registry/src/client/endpoints.rs
+++ b/crates/aube-registry/src/client/endpoints.rs
@@ -60,7 +60,7 @@ impl RegistryClient {
         let url = format!("{packument_url}/{version}");
         let resp = self
             .send_metadata_with_retry(&format!("version {name}@{version}"), || {
-                self.authed_get(&url, registry_url)
+                self.authed_get_for_package(&url, registry_url, name)
                     .header("Accept", "application/json")
             })
             .await?;
@@ -85,7 +85,7 @@ impl RegistryClient {
         let (url, registry_url) = self.packument_url(name);
         let resp = self
             .send_metadata_with_retry(&format!("packument {name}"), || {
-                self.authed_get(&url, registry_url)
+                self.authed_get_for_package(&url, registry_url, name)
                     .header("Accept", PACKUMENT_FULL_ACCEPT)
             })
             .await?;
@@ -113,12 +113,13 @@ impl RegistryClient {
     ) -> Result<serde_json::Value, Error> {
         let (url, registry_url) = self.packument_url(name);
 
-        let mut req = self.authed(
+        let mut req = self.authed_for_package(
             self.http_for(registry_url)
                 .put(&url)
                 .header("Content-Type", "application/json")
                 .json(body),
             registry_url,
+            name,
         );
         if let Some(code) = otp {
             req = req.header("npm-otp", code);
@@ -163,7 +164,7 @@ impl RegistryClient {
         let url = dist_tag_root_url(registry_url, name);
         let resp = self
             .send_metadata_with_retry(&format!("dist-tags {name}"), || {
-                self.authed_get(&url, registry_url)
+                self.authed_get_for_package(&url, registry_url, name)
             })
             .await?;
         check_dist_tag_status(&resp, name)?;
@@ -204,7 +205,10 @@ impl RegistryClient {
         } else {
             req
         };
-        let resp = self.authed(req, registry_url).send().await?;
+        let resp = self
+            .authed_for_package(req, registry_url, name)
+            .send()
+            .await?;
         check_dist_tag_status(&resp, name)?;
         resp.error_for_status()?;
         Ok(())
@@ -229,7 +233,10 @@ impl RegistryClient {
         } else {
             req
         };
-        let resp = self.authed(req, registry_url).send().await?;
+        let resp = self
+            .authed_for_package(req, registry_url, name)
+            .send()
+            .await?;
         // 404 here is ambiguous: package doesn't exist vs tag doesn't
         // exist on this package. Surface the `name@tag` form so the
         // caller can render it either way.

--- a/crates/aube-registry/src/client/endpoints.rs
+++ b/crates/aube-registry/src/client/endpoints.rs
@@ -114,7 +114,7 @@ impl RegistryClient {
         let (url, registry_url) = self.packument_url(name);
 
         let mut req = self.authed_for_package(
-            self.http_for(registry_url)
+            self.http_for_package(registry_url, name)
                 .put(&url)
                 .header("Content-Type", "application/json")
                 .json(body),
@@ -193,7 +193,7 @@ impl RegistryClient {
         let body = serde_json::to_string(version).map_err(std::io::Error::other)?;
 
         let mut req = self
-            .http_for(registry_url)
+            .http_for_package(registry_url, name)
             .put(&url)
             .header("Content-Type", "application/json")
             .body(body);
@@ -224,7 +224,7 @@ impl RegistryClient {
     ) -> Result<(), Error> {
         let registry_url = self.registry_url_for(name);
         let url = dist_tag_url(registry_url, name, tag);
-        let mut req = self.http_for(registry_url).delete(&url);
+        let mut req = self.http_for_package(registry_url, name).delete(&url);
         if self.config.is_public_npmjs(name) {
             req = req.header("npm-auth-type", "web");
         }

--- a/crates/aube-registry/src/client/lifecycle.rs
+++ b/crates/aube-registry/src/client/lifecycle.rs
@@ -39,11 +39,7 @@ impl RegistryClient {
         let http_tarball = build_http_tarball_client(&config, None, &fetch_policy);
         let mut http_by_uri = BTreeMap::new();
         for (uri, registry) in &config.auth_by_uri {
-            if registry.tls.ca.is_empty()
-                && registry.tls.cafile.is_none()
-                && registry.tls.cert.is_none()
-                && registry.tls.key.is_none()
-            {
+            if !registry.has_tls_material() {
                 continue;
             }
             http_by_uri.insert(
@@ -51,10 +47,26 @@ impl RegistryClient {
                 build_http_client(&config, Some(registry), &fetch_policy),
             );
         }
+        let mut http_by_uri_scope = BTreeMap::new();
+        for (uri, by_scope) in &config.scoped_auth_by_uri {
+            for (scope, registry) in by_scope {
+                if !registry.has_tls_material() {
+                    continue;
+                }
+                http_by_uri_scope
+                    .entry(uri.clone())
+                    .or_insert_with(BTreeMap::new)
+                    .insert(
+                        scope.clone(),
+                        build_http_client(&config, Some(registry), &fetch_policy),
+                    );
+            }
+        }
 
         Self {
             http,
             http_by_uri,
+            http_by_uri_scope,
             http_tarball,
             token_helper_cache: Mutex::new(BTreeMap::new()),
             auth_token_by_url: Mutex::new(BTreeMap::new()),

--- a/crates/aube-registry/src/client/packument.rs
+++ b/crates/aube-registry/src/client/packument.rs
@@ -179,7 +179,7 @@ impl RegistryClient {
             let is_last = attempt + 1 >= max_attempts;
             match {
                 let mut req = self
-                    .authed_get(&url, registry_url)
+                    .authed_get_for_package(&url, registry_url, name)
                     .header("Accept", PACKUMENT_FULL_ACCEPT)
                     // RFC 9218: packument metadata is resolver-blocking,
                     // mark Critical so H2-aware origins prioritize it
@@ -403,7 +403,7 @@ impl RegistryClient {
             let is_last = attempt + 1 >= max_attempts;
             match {
                 let mut req = self
-                    .authed_get(&url, registry_url)
+                    .authed_get_for_package(&url, registry_url, name)
                     .header("Accept", PACKUMENT_FULL_ACCEPT);
                 if let Some(ref etag) = cached.etag {
                     req = req.header("If-None-Match", etag);
@@ -565,7 +565,7 @@ impl RegistryClient {
             let _attempt_send_t0 = std::time::Instant::now();
             match {
                 let req = self
-                    .authed_get(&url, registry_url)
+                    .authed_get_for_package(&url, registry_url, name)
                     // RFC 9218: packument metadata is resolver-blocking,
                     // mark Critical so Cloudflare/Fastly H2 schedulers
                     // prioritize it ahead of pending tarball frames on
@@ -764,13 +764,15 @@ impl RegistryClient {
         for attempt in 0..max_attempts {
             let is_last = attempt + 1 >= max_attempts;
             match {
-                let mut req = self.authed_get(&url, registry_url).header(
-                    "Priority",
-                    aube_util::http::priority::header_value(
-                        aube_util::http::priority::Urgency::Critical,
-                        false,
-                    ),
-                );
+                let mut req = self
+                    .authed_get_for_package(&url, registry_url, name)
+                    .header(
+                        "Priority",
+                        aube_util::http::priority::header_value(
+                            aube_util::http::priority::Urgency::Critical,
+                            false,
+                        ),
+                    );
                 if !force_full_packument() {
                     req = req.header("Accept", PACKUMENT_ACCEPT);
                 }

--- a/crates/aube-registry/src/client/request.rs
+++ b/crates/aube-registry/src/client/request.rs
@@ -656,4 +656,51 @@ mod tests {
         assert_ne!(org_client, default_client);
         assert_eq!(other_client, default_client);
     }
+
+    #[test]
+    fn tarball_request_uses_scoped_auth_for_path_registry() {
+        let mut config = NpmConfig::default();
+        let mut registry_auth = AuthConfig::default();
+        registry_auth.auth_token = Some("registry-token".to_string());
+        config
+            .auth_by_uri
+            .insert("//registry.example.com/".to_string(), registry_auth);
+
+        let mut scoped_auth = AuthConfig::default();
+        scoped_auth.auth_token = Some("scoped-token".to_string());
+        config
+            .scoped_auth_by_uri
+            .entry("//registry.example.com/npm".to_string())
+            .or_default()
+            .insert("@myorg".to_string(), scoped_auth);
+        let client = RegistryClient::from_config(config);
+
+        let req = client
+            .authed_tarball_get(
+                "https://registry.example.com/npm/@myorg/pkg/-/pkg-1.0.0.tgz",
+                "https://registry.example.com/npm/@myorg/pkg/-/pkg-1.0.0.tgz",
+            )
+            .build()
+            .unwrap();
+        assert_eq!(
+            req.headers().get(reqwest::header::AUTHORIZATION),
+            Some(&reqwest::header::HeaderValue::from_static(
+                "Bearer scoped-token"
+            )),
+        );
+
+        let req = client
+            .authed_tarball_get(
+                "https://registry.example.com/npm-release/@myorg/pkg/-/pkg-1.0.0.tgz",
+                "https://registry.example.com/npm-release/@myorg/pkg/-/pkg-1.0.0.tgz",
+            )
+            .build()
+            .unwrap();
+        assert_eq!(
+            req.headers().get(reqwest::header::AUTHORIZATION),
+            Some(&reqwest::header::HeaderValue::from_static(
+                "Bearer registry-token"
+            )),
+        );
+    }
 }

--- a/crates/aube-registry/src/client/request.rs
+++ b/crates/aube-registry/src/client/request.rs
@@ -72,7 +72,8 @@ impl RegistryClient {
         package_name: &str,
     ) -> reqwest::RequestBuilder {
         self.authed_for_package(
-            self.http_for(registry_url).request(method, url),
+            self.http_for_package(registry_url, package_name)
+                .request(method, url),
             registry_url,
             package_name,
         )
@@ -209,6 +210,24 @@ impl RegistryClient {
         crate::config::lookup_by_uri_prefix(&self.http_by_uri, &uri_key).unwrap_or(&self.http)
     }
 
+    pub(super) fn http_for_package(
+        &self,
+        registry_url: &str,
+        package_name: &str,
+    ) -> &reqwest::Client {
+        if let Some((prefix, scope, _)) = self
+            .config
+            .scoped_tls_config_for_package(registry_url, package_name)
+            && let Some(client) = self
+                .http_by_uri_scope
+                .get(prefix)
+                .and_then(|by_scope| by_scope.get(scope))
+        {
+            return client;
+        }
+        self.http_for(registry_url)
+    }
+
     /// Pick the right HTTP client for tarball body downloads. The
     /// default registry uses the dedicated h1 client. Per-uri
     /// authed registries (corporate Artifactory, GitHub Packages)
@@ -221,6 +240,24 @@ impl RegistryClient {
             .unwrap_or(&self.http_tarball)
     }
 
+    pub(super) fn http_tarball_for_package(
+        &self,
+        registry_url: &str,
+        package_name: &str,
+    ) -> &reqwest::Client {
+        if let Some((prefix, scope, _)) = self
+            .config
+            .scoped_tls_config_for_package(registry_url, package_name)
+            && let Some(client) = self
+                .http_by_uri_scope
+                .get(prefix)
+                .and_then(|by_scope| by_scope.get(scope))
+        {
+            return client;
+        }
+        self.http_tarball_for(registry_url)
+    }
+
     /// Authed RequestBuilder routed through the tarball-specific
     /// client. Mirrors [`Self::authed_get`] but picks
     /// [`Self::http_tarball_for`] instead of [`Self::http_for`].
@@ -229,12 +266,15 @@ impl RegistryClient {
         url: &str,
         registry_url: &str,
     ) -> reqwest::RequestBuilder {
-        let req = self
-            .http_tarball_for(registry_url)
-            .request(reqwest::Method::GET, url);
         if let Some(package_name) = package_name_from_tarball_url(url) {
+            let req = self
+                .http_tarball_for_package(registry_url, &package_name)
+                .request(reqwest::Method::GET, url);
             self.authed_for_package(req, registry_url, &package_name)
         } else {
+            let req = self
+                .http_tarball_for(registry_url)
+                .request(reqwest::Method::GET, url);
             self.authed(req, registry_url)
         }
     }
@@ -556,7 +596,8 @@ fn package_name_from_tarball_url(url: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::package_name_from_tarball_url;
+    use super::{RegistryClient, package_name_from_tarball_url};
+    use crate::config::{AuthConfig, NpmConfig};
 
     #[test]
     fn package_name_from_tarball_url_handles_scoped_paths() {
@@ -591,5 +632,28 @@ mod tests {
             .as_deref(),
             Some("lodash")
         );
+    }
+
+    #[test]
+    fn http_for_package_uses_scoped_tls_client() {
+        let mut config = NpmConfig::default();
+        config.registry = "https://registry.example.com/".to_string();
+        let mut scoped = AuthConfig::default();
+        scoped.tls.cafile = Some(std::path::PathBuf::from("org-a-ca.pem"));
+        config
+            .scoped_auth_by_uri
+            .entry("//registry.example.com/".to_string())
+            .or_default()
+            .insert("@org-a".to_string(), scoped);
+        let client = RegistryClient::from_config(config);
+
+        let default_client = client.http_for("https://registry.example.com/") as *const _;
+        let org_client =
+            client.http_for_package("https://registry.example.com/", "@org-a/pkg") as *const _;
+        let other_client =
+            client.http_for_package("https://registry.example.com/", "@org-b/pkg") as *const _;
+
+        assert_ne!(org_client, default_client);
+        assert_eq!(other_client, default_client);
     }
 }

--- a/crates/aube-registry/src/client/request.rs
+++ b/crates/aube-registry/src/client/request.rs
@@ -163,10 +163,11 @@ impl RegistryClient {
         {
             return cached.clone();
         }
-        let resolved = if let Some(auth) = package_name
-            .and_then(|name| self.config.registry_config_for_package(registry_url, name))
-            .or_else(|| self.config.registry_config_for(registry_url))
-        {
+        let auth_config = match package_name {
+            Some(name) => self.config.registry_config_for_package(registry_url, name),
+            None => self.config.registry_config_for(registry_url),
+        };
+        let resolved = if let Some(auth) = auth_config {
             if let Some(token) = auth.auth_token.as_ref() {
                 Some(token.to_string())
             } else if let Some(helper) = auth.token_helper.as_deref() {
@@ -523,6 +524,20 @@ impl RegistryClient {
 fn package_name_from_tarball_url(url: &str) -> Option<String> {
     let parsed = reqwest::Url::parse(url).ok()?;
     let segments: Vec<&str> = parsed.path_segments()?.collect();
+    if let Some(dash_idx) = segments.iter().position(|segment| *segment == "-")
+        && dash_idx >= 1
+    {
+        let name = segments[dash_idx - 1];
+        if let Some((scope, name)) = name.split_once("%2F").or_else(|| name.split_once("%2f"))
+            && scope.starts_with('@')
+        {
+            return Some(format!("{scope}/{name}"));
+        }
+        if dash_idx >= 2 && segments[dash_idx - 2].starts_with('@') {
+            return Some(format!("{}/{}", segments[dash_idx - 2], name));
+        }
+        return Some(name.to_string());
+    }
     for (idx, segment) in segments.iter().enumerate() {
         if let Some((scope, name)) = segment
             .split_once("%2F")
@@ -567,6 +582,13 @@ mod tests {
         assert_eq!(
             package_name_from_tarball_url("https://registry.example.com/lodash/-/lodash-1.0.0.tgz")
                 .as_deref(),
+            Some("lodash")
+        );
+        assert_eq!(
+            package_name_from_tarball_url(
+                "https://registry.example.com/npm/lodash/-/lodash-1.0.0.tgz"
+            )
+            .as_deref(),
             Some("lodash")
         );
     }

--- a/crates/aube-registry/src/client/request.rs
+++ b/crates/aube-registry/src/client/request.rs
@@ -41,9 +41,13 @@ impl RegistryClient {
         (url, registry_url)
     }
 
-    /// Build a GET request with auth headers for the given registry URL.
-    pub(super) fn authed_get(&self, url: &str, registry_url: &str) -> reqwest::RequestBuilder {
-        self.authed_request(reqwest::Method::GET, url, registry_url)
+    pub(super) fn authed_get_for_package(
+        &self,
+        url: &str,
+        registry_url: &str,
+        package_name: &str,
+    ) -> reqwest::RequestBuilder {
+        self.authed_request_for_package(reqwest::Method::GET, url, registry_url, package_name)
     }
 
     /// Build an HTTP request using this registry's configured TLS client
@@ -57,6 +61,20 @@ impl RegistryClient {
         self.authed(
             self.http_for(registry_url).request(method, url),
             registry_url,
+        )
+    }
+
+    pub fn authed_request_for_package(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        registry_url: &str,
+        package_name: &str,
+    ) -> reqwest::RequestBuilder {
+        self.authed_for_package(
+            self.http_for(registry_url).request(method, url),
+            registry_url,
+            package_name,
         )
     }
 
@@ -76,6 +94,15 @@ impl RegistryClient {
     pub fn has_resolved_auth_for(&self, registry_url: &str) -> bool {
         self.registry_auth_token_for(registry_url).is_some()
             || self.config.basic_auth_for(registry_url).is_some()
+    }
+
+    pub fn has_resolved_auth_for_package(&self, registry_url: &str, package_name: &str) -> bool {
+        self.registry_auth_token_for_package(registry_url, Some(package_name))
+            .is_some()
+            || self
+                .config
+                .basic_auth_for_package(registry_url, package_name)
+                .is_some()
     }
 
     /// Attach auth headers to any `RequestBuilder` keyed off the registry
@@ -98,14 +125,48 @@ impl RegistryClient {
     }
 
     fn registry_auth_token_for(&self, registry_url: &str) -> Option<String> {
+        self.registry_auth_token_for_package(registry_url, None)
+    }
+
+    pub(super) fn authed_for_package(
+        &self,
+        req: reqwest::RequestBuilder,
+        registry_url: &str,
+        package_name: &str,
+    ) -> reqwest::RequestBuilder {
+        if let Some(token) = self.registry_auth_token_for_package(registry_url, Some(package_name))
+        {
+            req.bearer_auth(token)
+        } else if let Some(auth) = self
+            .config
+            .basic_auth_for_package(registry_url, package_name)
+        {
+            req.header("Authorization", format!("Basic {auth}"))
+        } else {
+            req
+        }
+    }
+
+    fn registry_auth_token_for_package(
+        &self,
+        registry_url: &str,
+        package_name: Option<&str>,
+    ) -> Option<String> {
+        let cache_key = match package_name {
+            Some(name) => format!("{registry_url}\0{name}"),
+            None => registry_url.to_string(),
+        };
         // Fast path: memoized result. Hit on the second-and-later
         // request to the same registry URL within one process.
         if let Ok(cache) = self.auth_token_by_url.lock()
-            && let Some(cached) = cache.get(registry_url)
+            && let Some(cached) = cache.get(&cache_key)
         {
             return cached.clone();
         }
-        let resolved = if let Some(auth) = self.config.registry_config_for(registry_url) {
+        let resolved = if let Some(auth) = package_name
+            .and_then(|name| self.config.registry_config_for_package(registry_url, name))
+            .or_else(|| self.config.registry_config_for(registry_url))
+        {
             if let Some(token) = auth.auth_token.as_ref() {
                 Some(token.to_string())
             } else if let Some(helper) = auth.token_helper.as_deref() {
@@ -117,7 +178,7 @@ impl RegistryClient {
             None
         };
         if let Ok(mut cache) = self.auth_token_by_url.lock() {
-            cache.insert(registry_url.to_string(), resolved.clone());
+            cache.insert(cache_key, resolved.clone());
         }
         resolved
     }
@@ -167,11 +228,14 @@ impl RegistryClient {
         url: &str,
         registry_url: &str,
     ) -> reqwest::RequestBuilder {
-        self.authed(
-            self.http_tarball_for(registry_url)
-                .request(reqwest::Method::GET, url),
-            registry_url,
-        )
+        let req = self
+            .http_tarball_for(registry_url)
+            .request(reqwest::Method::GET, url);
+        if let Some(package_name) = package_name_from_tarball_url(url) {
+            self.authed_for_package(req, registry_url, &package_name)
+        } else {
+            self.authed(req, registry_url)
+        }
     }
 
     /// Same as [`Self::send_with_retry`] but also returns wall-clock
@@ -453,5 +517,57 @@ impl RegistryClient {
             }
         }
         unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
+    }
+}
+
+fn package_name_from_tarball_url(url: &str) -> Option<String> {
+    let parsed = reqwest::Url::parse(url).ok()?;
+    let segments: Vec<&str> = parsed.path_segments()?.collect();
+    for (idx, segment) in segments.iter().enumerate() {
+        if let Some((scope, name)) = segment
+            .split_once("%2F")
+            .or_else(|| segment.split_once("%2f"))
+            && scope.starts_with('@')
+        {
+            return Some(format!("{scope}/{name}"));
+        }
+        if segment.starts_with('@') {
+            let name = segments.get(idx + 1)?;
+            return Some(format!("{segment}/{name}"));
+        }
+    }
+    segments.first().map(|segment| (*segment).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::package_name_from_tarball_url;
+
+    #[test]
+    fn package_name_from_tarball_url_handles_scoped_paths() {
+        assert_eq!(
+            package_name_from_tarball_url("https://registry.example.com/@org/pkg/-/pkg-1.0.0.tgz")
+                .as_deref(),
+            Some("@org/pkg")
+        );
+        assert_eq!(
+            package_name_from_tarball_url(
+                "https://registry.example.com/@org%2Fpkg/-/pkg-1.0.0.tgz"
+            )
+            .as_deref(),
+            Some("@org/pkg")
+        );
+        assert_eq!(
+            package_name_from_tarball_url(
+                "https://registry.example.com/npm/@org/pkg/-/pkg-1.0.0.tgz"
+            )
+            .as_deref(),
+            Some("@org/pkg")
+        );
+        assert_eq!(
+            package_name_from_tarball_url("https://registry.example.com/lodash/-/lodash-1.0.0.tgz")
+                .as_deref(),
+            Some("lodash")
+        );
     }
 }

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -146,7 +146,7 @@ impl NpmConfig {
                 .scoped_auth_by_uri
                 .iter()
                 .filter_map(|(prefix, auth_by_scope)| {
-                    if uri_key.starts_with(prefix.as_str()) {
+                    if uri_key_matches_prefix(&uri_key, prefix) {
                         auth_by_scope.get(&scope).map(|auth| (prefix.len(), auth))
                     } else {
                         None
@@ -624,6 +624,15 @@ fn has_credential_material(auth: &AuthConfig) -> bool {
         || auth.auth.is_some()
         || auth.token_helper.is_some()
         || (auth.username.is_some() && auth.password.is_some())
+}
+
+fn uri_key_matches_prefix(uri_key: &str, prefix: &str) -> bool {
+    if uri_key == prefix || (uri_key.starts_with(prefix) && prefix.ends_with('/')) {
+        return true;
+    }
+    uri_key
+        .strip_prefix(prefix)
+        .is_some_and(|rest| rest.starts_with('/'))
 }
 
 fn auth_entry_for_uri<'a>(

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -152,8 +152,8 @@ impl NpmConfig {
                         None
                     }
                 })
-                .max_by_key(|(prefix_len, _)| *prefix_len)
                 .filter(|(_, auth)| has_credential_material(auth))
+                .max_by_key(|(prefix_len, _)| *prefix_len)
             {
                 return Some(auth);
             }

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -445,35 +445,50 @@ impl NpmConfig {
                     // produces on the lookup side after stripping the
                     // scheme's default port.
                     let uri_key = normalize_npmrc_uri_key(uri);
-                    let entry = if let Some(scope) = scope {
-                        self.scoped_auth_by_uri
-                            .entry(uri_key.clone())
-                            .or_default()
-                            .entry(scope.to_lowercase())
-                            .or_default()
-                    } else {
-                        self.auth_by_uri.entry(uri_key.clone()).or_default()
-                    };
                     match suffix {
                         "_authToken" => {
+                            let entry = auth_entry_for_uri(
+                                &mut self.auth_by_uri,
+                                &mut self.scoped_auth_by_uri,
+                                &uri_key,
+                                scope,
+                            );
                             entry.auth_token = Some(value);
                             if scope.is_none() {
                                 explicit_uri_fields.insert((uri_key, "_authToken"));
                             }
                         }
                         "_auth" => {
+                            let entry = auth_entry_for_uri(
+                                &mut self.auth_by_uri,
+                                &mut self.scoped_auth_by_uri,
+                                &uri_key,
+                                scope,
+                            );
                             entry.auth = Some(value);
                             if scope.is_none() {
                                 explicit_uri_fields.insert((uri_key, "_auth"));
                             }
                         }
                         "username" => {
+                            let entry = auth_entry_for_uri(
+                                &mut self.auth_by_uri,
+                                &mut self.scoped_auth_by_uri,
+                                &uri_key,
+                                scope,
+                            );
                             entry.username = Some(value);
                             if scope.is_none() {
                                 explicit_uri_fields.insert((uri_key, "username"));
                             }
                         }
                         "_password" => {
+                            let entry = auth_entry_for_uri(
+                                &mut self.auth_by_uri,
+                                &mut self.scoped_auth_by_uri,
+                                &uri_key,
+                                scope,
+                            );
                             entry.password = Some(value);
                             if scope.is_none() {
                                 explicit_uri_fields.insert((uri_key, "_password"));
@@ -502,20 +517,54 @@ impl NpmConfig {
                                 );
                                 continue;
                             };
+                            let entry = auth_entry_for_uri(
+                                &mut self.auth_by_uri,
+                                &mut self.scoped_auth_by_uri,
+                                &uri_key,
+                                scope,
+                            );
                             entry.token_helper = Some(sanitized);
                             if scope.is_none() {
                                 explicit_uri_fields.insert((uri_key, "tokenHelper"));
                             }
                         }
-                        "ca" | "ca[]" => entry.tls.ca.push(pem_value(value)),
-                        "cafile" | "caFile" => entry.tls.cafile = Some(PathBuf::from(value)),
+                        "ca" | "ca[]" => {
+                            let entry = auth_entry_for_uri(
+                                &mut self.auth_by_uri,
+                                &mut self.scoped_auth_by_uri,
+                                &uri_key,
+                                scope,
+                            );
+                            entry.tls.ca.push(pem_value(value));
+                        }
+                        "cafile" | "caFile" => {
+                            let entry = auth_entry_for_uri(
+                                &mut self.auth_by_uri,
+                                &mut self.scoped_auth_by_uri,
+                                &uri_key,
+                                scope,
+                            );
+                            entry.tls.cafile = Some(PathBuf::from(value));
+                        }
                         "cert" => {
+                            let entry = auth_entry_for_uri(
+                                &mut self.auth_by_uri,
+                                &mut self.scoped_auth_by_uri,
+                                &uri_key,
+                                scope,
+                            );
                             entry.tls.cert = Some(pem_value(value));
                             if scope.is_none() {
                                 explicit_uri_fields.insert((uri_key, "cert"));
                             }
                         }
                         "key" => {
+                            let entry = auth_entry_for_uri(
+                                &mut self.auth_by_uri,
+                                &mut self.scoped_auth_by_uri,
+                                &uri_key,
+                                scope,
+                            );
                             entry.tls.key = Some(pem_value(value));
                             if scope.is_none() {
                                 explicit_uri_fields.insert((uri_key, "key"));
@@ -566,6 +615,26 @@ impl NpmConfig {
             .entry(registry_uri_key(registry))
             .or_default();
         apply(entry);
+    }
+}
+
+fn auth_entry_for_uri<'a>(
+    auth_by_uri: &'a mut std::collections::BTreeMap<String, AuthConfig>,
+    scoped_auth_by_uri: &'a mut std::collections::BTreeMap<
+        String,
+        std::collections::BTreeMap<String, AuthConfig>,
+    >,
+    uri_key: &str,
+    scope: Option<&str>,
+) -> &'a mut AuthConfig {
+    if let Some(scope) = scope {
+        scoped_auth_by_uri
+            .entry(uri_key.to_string())
+            .or_default()
+            .entry(scope.to_lowercase())
+            .or_default()
+    } else {
+        auth_by_uri.entry(uri_key.to_string()).or_default()
     }
 }
 

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -139,26 +139,56 @@ impl NpmConfig {
         registry_url: &str,
         package_name: &str,
     ) -> Option<&AuthConfig> {
+        if let Some((_, _, auth)) =
+            self.scoped_config_for_package_matching(registry_url, package_name, |auth| {
+                has_credential_material(auth)
+            })
+        {
+            return Some(auth);
+        }
+        self.registry_config_for(registry_url)
+    }
+
+    pub(crate) fn scoped_tls_config_for_package(
+        &self,
+        registry_url: &str,
+        package_name: &str,
+    ) -> Option<(&str, &str, &AuthConfig)> {
+        self.scoped_config_for_package_matching(
+            registry_url,
+            package_name,
+            AuthConfig::has_tls_material,
+        )
+    }
+
+    fn scoped_config_for_package_matching(
+        &self,
+        registry_url: &str,
+        package_name: &str,
+        matches: impl Fn(&AuthConfig) -> bool,
+    ) -> Option<(&str, &str, &AuthConfig)> {
         if let Some(scope) = package_scope(package_name) {
             let scope = scope.to_lowercase();
             let uri_key = registry_uri_key(registry_url);
-            if let Some((_, auth)) = self
+            if let Some((_, prefix, scope, auth)) = self
                 .scoped_auth_by_uri
                 .iter()
                 .filter_map(|(prefix, auth_by_scope)| {
                     if uri_key_matches_prefix(&uri_key, prefix) {
-                        auth_by_scope.get(&scope).map(|auth| (prefix.len(), auth))
+                        auth_by_scope.get_key_value(&scope).map(|(scope, auth)| {
+                            (prefix.len(), prefix.as_str(), scope.as_str(), auth)
+                        })
                     } else {
                         None
                     }
                 })
-                .filter(|(_, auth)| has_credential_material(auth))
-                .max_by_key(|(prefix_len, _)| *prefix_len)
+                .filter(|(_, _, _, auth)| matches(auth))
+                .max_by_key(|(prefix_len, _, _, _)| *prefix_len)
             {
-                return Some(auth);
+                return Some((prefix, scope, auth));
             }
         }
-        self.registry_config_for(registry_url)
+        None
     }
 
     /// Test-only compatibility shim. Production code must go through

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -91,6 +91,14 @@ impl NpmConfig {
             .and_then(|auth| auth.auth_token.as_deref())
     }
 
+    /// Get the auth token for a package request, preferring
+    /// scope-specific credentials when `.npmrc` configured
+    /// `//registry/:@scope:_authToken=...`.
+    pub fn auth_token_for_package(&self, registry_url: &str, package_name: &str) -> Option<&str> {
+        self.registry_config_for_package(registry_url, package_name)
+            .and_then(|auth| auth.auth_token.as_deref())
+    }
+
     pub fn token_helper_for(&self, registry_url: &str) -> Option<&str> {
         self.registry_config_for(registry_url)
             .and_then(|auth| auth.token_helper.as_deref())
@@ -98,7 +106,14 @@ impl NpmConfig {
 
     /// Get the basic auth (_auth) for a given registry URL.
     pub fn basic_auth_for(&self, registry_url: &str) -> Option<String> {
-        let auth = self.registry_config_for(registry_url)?;
+        self.basic_auth_from_config(self.registry_config_for(registry_url)?)
+    }
+
+    pub fn basic_auth_for_package(&self, registry_url: &str, package_name: &str) -> Option<String> {
+        self.basic_auth_from_config(self.registry_config_for_package(registry_url, package_name)?)
+    }
+
+    fn basic_auth_from_config(&self, auth: &AuthConfig) -> Option<String> {
         if let Some(ref a) = auth.auth {
             return Some(a.clone());
         }
@@ -117,6 +132,21 @@ impl NpmConfig {
     pub fn registry_config_for(&self, registry_url: &str) -> Option<&AuthConfig> {
         let uri_key = registry_uri_key(registry_url);
         lookup_by_uri_prefix(&self.auth_by_uri, &uri_key)
+    }
+
+    pub fn registry_config_for_package(
+        &self,
+        registry_url: &str,
+        package_name: &str,
+    ) -> Option<&AuthConfig> {
+        if let Some(scope) = package_scope(package_name)
+            && let Some(auth_by_scope) =
+                lookup_by_uri_prefix(&self.scoped_auth_by_uri, &registry_uri_key(registry_url))
+            && let Some(auth) = auth_by_scope.get(&scope.to_lowercase())
+        {
+            return Some(auth);
+        }
+        self.registry_config_for(registry_url)
     }
 
     /// Test-only compatibility shim. Production code must go through
@@ -398,28 +428,45 @@ impl NpmConfig {
             } else if key.starts_with("//") {
                 // URI-specific config: //registry.url/:_authToken=TOKEN
                 if let Some((uri, suffix)) = key.rsplit_once(':') {
+                    let (uri, scope) = split_uri_scope_key(uri);
                     // Normalize so `//host:443/x/` and `//host/x/` collapse
                     // to the same key — matches what `registry_uri_key`
                     // produces on the lookup side after stripping the
                     // scheme's default port.
                     let uri_key = normalize_npmrc_uri_key(uri);
-                    let entry = self.auth_by_uri.entry(uri_key.clone()).or_default();
+                    let entry = if let Some(scope) = scope {
+                        self.scoped_auth_by_uri
+                            .entry(uri_key.clone())
+                            .or_default()
+                            .entry(scope.to_lowercase())
+                            .or_default()
+                    } else {
+                        self.auth_by_uri.entry(uri_key.clone()).or_default()
+                    };
                     match suffix {
                         "_authToken" => {
                             entry.auth_token = Some(value);
-                            explicit_uri_fields.insert((uri_key, "_authToken"));
+                            if scope.is_none() {
+                                explicit_uri_fields.insert((uri_key, "_authToken"));
+                            }
                         }
                         "_auth" => {
                             entry.auth = Some(value);
-                            explicit_uri_fields.insert((uri_key, "_auth"));
+                            if scope.is_none() {
+                                explicit_uri_fields.insert((uri_key, "_auth"));
+                            }
                         }
                         "username" => {
                             entry.username = Some(value);
-                            explicit_uri_fields.insert((uri_key, "username"));
+                            if scope.is_none() {
+                                explicit_uri_fields.insert((uri_key, "username"));
+                            }
                         }
                         "_password" => {
                             entry.password = Some(value);
-                            explicit_uri_fields.insert((uri_key, "_password"));
+                            if scope.is_none() {
+                                explicit_uri_fields.insert((uri_key, "_password"));
+                            }
                         }
                         "tokenHelper" | "token-helper" => {
                             // CVE-2025-69262 (pnpm GHSA-2phv-j68v-wwqx)
@@ -445,17 +492,23 @@ impl NpmConfig {
                                 continue;
                             };
                             entry.token_helper = Some(sanitized);
-                            explicit_uri_fields.insert((uri_key, "tokenHelper"));
+                            if scope.is_none() {
+                                explicit_uri_fields.insert((uri_key, "tokenHelper"));
+                            }
                         }
                         "ca" | "ca[]" => entry.tls.ca.push(pem_value(value)),
                         "cafile" | "caFile" => entry.tls.cafile = Some(PathBuf::from(value)),
                         "cert" => {
                             entry.tls.cert = Some(pem_value(value));
-                            explicit_uri_fields.insert((uri_key, "cert"));
+                            if scope.is_none() {
+                                explicit_uri_fields.insert((uri_key, "cert"));
+                            }
                         }
                         "key" => {
                             entry.tls.key = Some(pem_value(value));
-                            explicit_uri_fields.insert((uri_key, "key"));
+                            if scope.is_none() {
+                                explicit_uri_fields.insert((uri_key, "key"));
+                            }
                         }
                         _ => {} // Ignore unknown suffixes for now
                     }
@@ -503,6 +556,17 @@ impl NpmConfig {
             .or_default();
         apply(entry);
     }
+}
+
+fn split_uri_scope_key(uri: &str) -> (&str, Option<&str>) {
+    if let Some((base, scope)) = uri.rsplit_once(':')
+        && scope.starts_with('@')
+        && scope.len() > 1
+        && !scope.contains('/')
+    {
+        return (base, Some(scope));
+    }
+    (uri, None)
 }
 
 fn canonical_rescoped_suffix(suffix: &str) -> Option<&'static str> {

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -139,12 +139,23 @@ impl NpmConfig {
         registry_url: &str,
         package_name: &str,
     ) -> Option<&AuthConfig> {
-        if let Some(scope) = package_scope(package_name)
-            && let Some(auth_by_scope) =
-                lookup_by_uri_prefix(&self.scoped_auth_by_uri, &registry_uri_key(registry_url))
-            && let Some(auth) = auth_by_scope.get(&scope.to_lowercase())
-        {
-            return Some(auth);
+        if let Some(scope) = package_scope(package_name) {
+            let scope = scope.to_lowercase();
+            let uri_key = registry_uri_key(registry_url);
+            if let Some((_, auth)) = self
+                .scoped_auth_by_uri
+                .iter()
+                .filter_map(|(prefix, auth_by_scope)| {
+                    if uri_key.starts_with(prefix.as_str()) {
+                        auth_by_scope.get(&scope).map(|auth| (prefix.len(), auth))
+                    } else {
+                        None
+                    }
+                })
+                .max_by_key(|(prefix_len, _)| *prefix_len)
+            {
+                return Some(auth);
+            }
         }
         self.registry_config_for(registry_url)
     }

--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -153,6 +153,7 @@ impl NpmConfig {
                     }
                 })
                 .max_by_key(|(prefix_len, _)| *prefix_len)
+                .filter(|(_, auth)| has_credential_material(auth))
             {
                 return Some(auth);
             }
@@ -616,6 +617,13 @@ impl NpmConfig {
             .or_default();
         apply(entry);
     }
+}
+
+fn has_credential_material(auth: &AuthConfig) -> bool {
+    auth.auth_token.is_some()
+        || auth.auth.is_some()
+        || auth.token_helper.is_some()
+        || (auth.username.is_some() && auth.password.is_some())
 }
 
 fn auth_entry_for_uri<'a>(

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -2087,6 +2087,29 @@ fn scoped_tls_config_does_not_shadow_registry_token() {
 }
 
 #[test]
+fn longer_scoped_tls_config_does_not_shadow_shorter_scoped_token() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        "registry=https://registry.example.com/npm/\n\
+         //registry.example.com/:_authToken=registry-token\n\
+         //registry.example.com/:@org-a:_authToken=org-a-token\n\
+         //registry.example.com/npm/:@org-a:cafile=/etc/ssl/org-a.pem\n",
+    )
+    .unwrap();
+
+    let config = NpmConfig::load_isolated(dir.path());
+
+    assert_eq!(
+        config.auth_token_for_package(
+            "https://registry.example.com/npm/@org-a/pkg/-/pkg-1.0.0.tgz",
+            "@org-a/pkg"
+        ),
+        Some("org-a-token")
+    );
+}
+
+#[test]
 fn scoped_auth_token_honors_path_scoped_registry_prefix() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -467,6 +467,35 @@ fn auth_token_resolves_for_path_scoped_registry_with_default_port() {
 }
 
 #[test]
+fn scoped_auth_token_resolves_for_full_tarball_url_under_path_registry() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        "registry=https://registry.example.com/\n\
+             //registry.example.com/:_authToken=registry-token\n\
+             //registry.example.com/npm:@myorg:_authToken=scoped-token\n",
+    )
+    .unwrap();
+
+    let config = NpmConfig::load_isolated(dir.path());
+
+    assert_eq!(
+        config.auth_token_for_package(
+            "https://registry.example.com/npm/@myorg/pkg/-/pkg-1.0.0.tgz",
+            "@myorg/pkg",
+        ),
+        Some("scoped-token"),
+    );
+    assert_eq!(
+        config.auth_token_for_package(
+            "https://registry.example.com/npm-release/@myorg/pkg/-/pkg-1.0.0.tgz",
+            "@myorg/pkg",
+        ),
+        Some("registry-token"),
+    );
+}
+
+#[test]
 fn npmrc_key_with_default_port_is_normalized_on_ingest() {
     // User wrote `:443` explicitly in `.npmrc`. Lookups that don't
     // carry the port must still resolve.

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -2012,3 +2012,55 @@ fn fetch_policy_clamps_giant_retry_counts_into_u32() {
     let p = FetchPolicy::from_ctx(&ctx);
     assert_eq!(p.retries, u32::MAX);
 }
+
+#[test]
+fn scoped_auth_token_overrides_registry_token_for_matching_scope() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        "registry=https://npm.pkg.github.com/\n\
+         //npm.pkg.github.com/:_authToken=registry-token\n\
+         //npm.pkg.github.com/:@org-a:_authToken=org-a-token\n",
+    )
+    .unwrap();
+
+    let config = NpmConfig::load_isolated(dir.path());
+
+    assert_eq!(
+        config.auth_token_for_package("https://npm.pkg.github.com/", "@org-a/pkg"),
+        Some("org-a-token")
+    );
+    assert_eq!(
+        config.auth_token_for_package("https://npm.pkg.github.com/", "@org-b/pkg"),
+        Some("registry-token")
+    );
+}
+
+#[test]
+fn scoped_auth_token_honors_path_scoped_registry_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        "@org-a:registry=https://registry.example.com/npm/\n\
+         //registry.example.com/npm/:@org-a:_authToken=org-a-token\n\
+         //registry.example.com/:_authToken=root-token\n",
+    )
+    .unwrap();
+
+    let config = NpmConfig::load_isolated(dir.path());
+
+    assert_eq!(
+        config.auth_token_for_package(
+            "https://registry.example.com/npm/@org-a/pkg/-/pkg-1.0.0.tgz",
+            "@org-a/pkg"
+        ),
+        Some("org-a-token")
+    );
+    assert_eq!(
+        config.auth_token_for_package(
+            "https://registry.example.com/other/@org-a/pkg/-/pkg-1.0.0.tgz",
+            "@org-a/pkg"
+        ),
+        Some("root-token")
+    );
+}

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -605,6 +605,37 @@ fn token_helper_from_project_npmrc_is_refused() {
 }
 
 #[test]
+fn untrusted_scoped_token_helper_does_not_shadow_registry_token() {
+    let home = tempfile::tempdir().unwrap();
+    std::fs::write(
+        home.path().join(".npmrc"),
+        "//npm.pkg.github.com/:_authToken=broad-token\n",
+    )
+    .unwrap();
+
+    let project = tempfile::tempdir().unwrap();
+    std::fs::write(
+        project.path().join(".npmrc"),
+        "//npm.pkg.github.com/:@myorg:tokenHelper=/tmp/evil.sh\n",
+    )
+    .unwrap();
+
+    let mut config = NpmConfig::default();
+    config.apply_tagged(load_npmrc_entries_tagged_with_home(
+        Some(home.path()),
+        None,
+        project.path(),
+        None,
+    ));
+
+    assert_eq!(
+        config.auth_token_for_package("https://npm.pkg.github.com/", "@myorg/pkg"),
+        Some("broad-token"),
+        "ignored project tokenHelper must not create an empty scoped auth entry"
+    );
+}
+
+#[test]
 fn token_helper_from_user_npmrc_is_accepted() {
     // The user's own `~/.npmrc` is the only file trusted to
     // configure subprocess execution. A valid bare absolute

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -2068,6 +2068,25 @@ fn scoped_auth_token_overrides_registry_token_for_matching_scope() {
 }
 
 #[test]
+fn scoped_tls_config_does_not_shadow_registry_token() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        "registry=https://npm.pkg.github.com/\n\
+         //npm.pkg.github.com/:_authToken=registry-token\n\
+         //npm.pkg.github.com/:@org-a:ca=-----BEGIN CERTIFICATE-----\\nca\\n-----END CERTIFICATE-----\n",
+    )
+    .unwrap();
+
+    let config = NpmConfig::load_isolated(dir.path());
+
+    assert_eq!(
+        config.auth_token_for_package("https://npm.pkg.github.com/", "@org-a/pkg"),
+        Some("registry-token")
+    );
+}
+
+#[test]
 fn scoped_auth_token_honors_path_scoped_registry_prefix() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -2064,3 +2064,24 @@ fn scoped_auth_token_honors_path_scoped_registry_prefix() {
         Some("root-token")
     );
 }
+
+#[test]
+fn scoped_auth_lookup_checks_shorter_prefixes_before_unscoped_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        "//registry.example.com/npm/private/:_authToken=private-root-token\n\
+         //registry.example.com/npm/:@org-a:_authToken=org-a-token\n",
+    )
+    .unwrap();
+
+    let config = NpmConfig::load_isolated(dir.path());
+
+    assert_eq!(
+        config.auth_token_for_package(
+            "https://registry.example.com/npm/private/@org-a/pkg/-/pkg-1.0.0.tgz",
+            "@org-a/pkg"
+        ),
+        Some("org-a-token")
+    );
+}

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -2116,6 +2116,34 @@ fn scoped_auth_token_honors_path_scoped_registry_prefix() {
 }
 
 #[test]
+fn scoped_auth_token_requires_path_prefix_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        "//registry.example.com/npm:@org-a:_authToken=org-a-token\n\
+         //registry.example.com/:_authToken=root-token\n",
+    )
+    .unwrap();
+
+    let config = NpmConfig::load_isolated(dir.path());
+
+    assert_eq!(
+        config.auth_token_for_package(
+            "https://registry.example.com/npm/@org-a/pkg/-/pkg-1.0.0.tgz",
+            "@org-a/pkg"
+        ),
+        Some("org-a-token")
+    );
+    assert_eq!(
+        config.auth_token_for_package(
+            "https://registry.example.com/npm-release/@org-a/pkg/-/pkg-1.0.0.tgz",
+            "@org-a/pkg"
+        ),
+        Some("root-token")
+    );
+}
+
+#[test]
 fn scoped_auth_lookup_checks_shorter_prefixes_before_unscoped_fallback() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(

--- a/crates/aube-registry/src/config/types.rs
+++ b/crates/aube-registry/src/config/types.rs
@@ -65,6 +65,9 @@ pub struct NpmConfig {
     pub scoped_registries: BTreeMap<String, String>,
     /// Auth config keyed by registry URL prefix (e.g., "//registry.example.com/")
     pub auth_by_uri: BTreeMap<String, AuthConfig>,
+    /// Scope-specific auth config keyed by registry URL prefix, then
+    /// package scope (e.g., "//npm.pkg.github.com/" -> "@org").
+    pub scoped_auth_by_uri: BTreeMap<String, BTreeMap<String, AuthConfig>>,
     /// Proxy URL for outgoing HTTPS requests (`https-proxy` / `HTTPS_PROXY`).
     pub https_proxy: Option<String>,
     /// Proxy URL for outgoing HTTP requests (`proxy` / `http-proxy` / `HTTP_PROXY`).
@@ -136,6 +139,7 @@ impl Default for NpmConfig {
             registry: String::new(),
             scoped_registries: BTreeMap::new(),
             auth_by_uri: BTreeMap::new(),
+            scoped_auth_by_uri: BTreeMap::new(),
             https_proxy: None,
             http_proxy: None,
             no_proxy: None,

--- a/crates/aube-registry/src/config/types.rs
+++ b/crates/aube-registry/src/config/types.rs
@@ -119,6 +119,15 @@ pub struct AuthConfig {
     pub tls: TlsConfig,
 }
 
+impl AuthConfig {
+    pub(crate) fn has_tls_material(&self) -> bool {
+        !self.tls.ca.is_empty()
+            || self.tls.cafile.is_some()
+            || self.tls.cert.is_some()
+            || self.tls.key.is_some()
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct TlsConfig {
     pub ca: Vec<String>,

--- a/crates/aube/src/commands/login.rs
+++ b/crates/aube/src/commands/login.rs
@@ -62,9 +62,11 @@ pub async fn run(args: LoginArgs) -> miette::Result<()> {
 
     let path = user_npmrc_path()?;
     let mut edit = NpmrcEdit::load(&path)?;
-    edit.set(&format!("{host_key}:_authToken"), &token);
     if let Some(scope) = &args.scope {
+        edit.set(&format!("{host_key}:{scope}:_authToken"), &token);
         edit.set(&format!("{scope}:registry"), &registry);
+    } else {
+        edit.set(&format!("{host_key}:_authToken"), &token);
     }
     edit.save(&path)?;
 

--- a/crates/aube/src/commands/login.rs
+++ b/crates/aube/src/commands/login.rs
@@ -63,6 +63,7 @@ pub async fn run(args: LoginArgs) -> miette::Result<()> {
     let path = user_npmrc_path()?;
     let mut edit = NpmrcEdit::load(&path)?;
     if let Some(scope) = &args.scope {
+        let scope = scope.to_ascii_lowercase();
         edit.set(&format!("{host_key}:{scope}:_authToken"), &token);
         edit.set(&format!("{scope}:registry"), &registry);
     } else {

--- a/crates/aube/src/commands/logout.rs
+++ b/crates/aube/src/commands/logout.rs
@@ -37,7 +37,14 @@ pub async fn run(args: LogoutArgs) -> miette::Result<()> {
 
     let mut edit = NpmrcEdit::load(&path)?;
     let removed_token = match &args.scope {
-        Some(scope) => edit.remove(&format!("{host_key}:{scope}:_authToken")),
+        Some(scope) => {
+            let scoped_token_prefix = format!("{host_key}:");
+            edit.remove_matching(|key| {
+                key.strip_prefix(&scoped_token_prefix)
+                    .and_then(|rest| rest.strip_suffix(":_authToken"))
+                    .is_some_and(|stored_scope| stored_scope.eq_ignore_ascii_case(scope))
+            })
+        }
         None => {
             let unscoped_token_key = format!("{host_key}:_authToken");
             let scoped_token_prefix = format!("{host_key}:@");
@@ -48,7 +55,10 @@ pub async fn run(args: LogoutArgs) -> miette::Result<()> {
         }
     };
     let removed_scope = match &args.scope {
-        Some(scope) => edit.remove(&format!("{scope}:registry")),
+        Some(scope) => edit.remove_matching(|key| {
+            key.strip_suffix(":registry")
+                .is_some_and(|stored_scope| stored_scope.eq_ignore_ascii_case(scope))
+        }),
         None => false,
     };
 

--- a/crates/aube/src/commands/logout.rs
+++ b/crates/aube/src/commands/logout.rs
@@ -1,8 +1,9 @@
 //! `aube logout` — remove a registry auth token from the user's `~/.npmrc`.
 //!
-//! Inverse of `aube login`. Strips `//host/:_authToken` (and, when a
-//! `--scope` is passed, the matching `@scope:registry` mapping) from the
-//! user-level `.npmrc` in place, leaving every other entry untouched.
+//! Inverse of `aube login`. Strips `//host/:_authToken` or
+//! `//host/:@scope:_authToken` (and, when a `--scope` is passed, the
+//! matching `@scope:registry` mapping) from the user-level `.npmrc` in
+//! place, leaving every other entry untouched.
 
 use crate::commands::npmrc::{NpmrcEdit, registry_host_key, resolve_registry, user_npmrc_path};
 use clap::Args;
@@ -35,7 +36,10 @@ pub async fn run(args: LogoutArgs) -> miette::Result<()> {
     }
 
     let mut edit = NpmrcEdit::load(&path)?;
-    let removed_token = edit.remove(&format!("{host_key}:_authToken"));
+    let removed_token = match &args.scope {
+        Some(scope) => edit.remove(&format!("{host_key}:{scope}:_authToken")),
+        None => edit.remove(&format!("{host_key}:_authToken")),
+    };
     let removed_scope = match &args.scope {
         Some(scope) => edit.remove(&format!("{scope}:registry")),
         None => false,

--- a/crates/aube/src/commands/logout.rs
+++ b/crates/aube/src/commands/logout.rs
@@ -38,7 +38,14 @@ pub async fn run(args: LogoutArgs) -> miette::Result<()> {
     let mut edit = NpmrcEdit::load(&path)?;
     let removed_token = match &args.scope {
         Some(scope) => edit.remove(&format!("{host_key}:{scope}:_authToken")),
-        None => edit.remove(&format!("{host_key}:_authToken")),
+        None => {
+            let unscoped_token_key = format!("{host_key}:_authToken");
+            let scoped_token_prefix = format!("{host_key}:@");
+            edit.remove_matching(|key| {
+                key == unscoped_token_key.as_str()
+                    || (key.starts_with(&scoped_token_prefix) && key.ends_with(":_authToken"))
+            })
+        }
     };
     let removed_scope = match &args.scope {
         Some(scope) => edit.remove(&format!("{scope}:registry")),

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -108,10 +108,10 @@ pub(crate) use project_lock::take_project_lock;
 pub(crate) use script_settings::{configure_script_settings, configure_script_settings_for_cwd};
 pub(crate) use settings_context::{
     FileSources, GlobalOutputFlags, build_resolver, chained_frozen_mode, ensure_registry_auth,
-    expand_setting_path, global_frozen_override, global_output_flags, global_virtual_store_flags,
-    load_npm_config, make_client, open_store, packument_cache_dir, packument_full_cache_dir,
-    project_modules_dir, resolve_fetch_policy, resolve_modules_dir_name_for_cwd,
-    resolve_virtual_store_dir, resolve_virtual_store_dir_for_cwd,
+    ensure_registry_auth_for_package, expand_setting_path, global_frozen_override,
+    global_output_flags, global_virtual_store_flags, load_npm_config, make_client, open_store,
+    packument_cache_dir, packument_full_cache_dir, project_modules_dir, resolve_fetch_policy,
+    resolve_modules_dir_name_for_cwd, resolve_virtual_store_dir, resolve_virtual_store_dir_for_cwd,
     resolve_virtual_store_dir_max_length, resolve_virtual_store_dir_max_length_for_cwd,
     resolved_cache_dir, run_pnpmfile_pre_resolution, set_fetch_cli_overrides,
     set_global_frozen_override, set_global_output_flags, set_global_virtual_store_flags,

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -107,7 +107,7 @@ pub(crate) use package_spec::{
 pub(crate) use project_lock::take_project_lock;
 pub(crate) use script_settings::{configure_script_settings, configure_script_settings_for_cwd};
 pub(crate) use settings_context::{
-    FileSources, GlobalOutputFlags, build_resolver, chained_frozen_mode, ensure_registry_auth,
+    FileSources, GlobalOutputFlags, build_resolver, chained_frozen_mode,
     ensure_registry_auth_for_package, expand_setting_path, global_frozen_override,
     global_output_flags, global_virtual_store_flags, load_npm_config, make_client, open_store,
     packument_cache_dir, packument_full_cache_dir, project_modules_dir, resolve_fetch_policy,

--- a/crates/aube/src/commands/npmrc.rs
+++ b/crates/aube/src/commands/npmrc.rs
@@ -96,9 +96,15 @@ impl NpmrcEdit {
     /// Remove all entries matching `key`. Returns `true` if any were
     /// removed.
     pub fn remove(&mut self, key: &str) -> bool {
+        self.remove_matching(|k| k == key)
+    }
+
+    /// Remove all entries whose key satisfies `predicate`. Returns
+    /// `true` if any were removed.
+    pub fn remove_matching(&mut self, predicate: impl Fn(&str) -> bool) -> bool {
         let before = self.lines.len();
         self.lines.retain(|line| match line {
-            Line::Entry { key: k, .. } => k != key,
+            Line::Entry { key: k, .. } => !predicate(k),
             Line::Raw(_) => true,
         });
         before != self.lines.len()

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -31,7 +31,7 @@
 use crate::commands::pack::{
     BuiltArchive, build_archive, build_archive_with_package_json, tarball_filename,
 };
-use crate::commands::{encode_package_name, ensure_registry_auth};
+use crate::commands::{encode_package_name, ensure_registry_auth_for_package};
 use aube_manifest::PackageJson;
 use aube_registry::client::RegistryClient;
 use aube_registry::config::{NpmConfig, normalize_registry_url_pub};
@@ -542,13 +542,14 @@ async fn publish_one(
     let url = put_url(&registry_url, &archive.name);
     let trusted_publish_token = trusted_publish_token(client, &registry_url, &archive.name).await?;
     if trusted_publish_token.is_none() {
-        ensure_registry_auth(client, &registry_url)?;
+        ensure_registry_auth_for_package(client, &registry_url, &archive.name)?;
     }
     let body_bytes = serde_json::to_vec(&body).into_diagnostic()?;
     match send_publish_put(
         client,
         &url,
         &registry_url,
+        &archive.name,
         body_bytes.clone(),
         trusted_publish_token.as_deref(),
         args.otp.as_deref(),
@@ -562,6 +563,7 @@ async fn publish_one(
                 client,
                 &url,
                 &registry_url,
+                &archive.name,
                 body_bytes,
                 trusted_publish_token.as_deref(),
                 Some(&otp),
@@ -763,6 +765,7 @@ async fn send_publish_put(
     client: &RegistryClient,
     url: &str,
     registry_url: &str,
+    name: &str,
     body: Vec<u8>,
     trusted_publish_token: Option<&str>,
     otp: Option<&str>,
@@ -772,7 +775,7 @@ async fn send_publish_put(
             .request(reqwest::Method::PUT, url, registry_url)
             .bearer_auth(token)
     } else {
-        client.authed_request(reqwest::Method::PUT, url, registry_url)
+        client.authed_request_for_package(reqwest::Method::PUT, url, registry_url, name)
     }
     .header("content-type", "application/json")
     .body(body);
@@ -898,7 +901,7 @@ async fn version_on_registry(
 ) -> bool {
     let url = put_url(registry_url, name);
     let Ok(resp) = client
-        .authed_request(reqwest::Method::GET, &url, registry_url)
+        .authed_request_for_package(reqwest::Method::GET, &url, registry_url, name)
         .send()
         .await
     else {

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -170,12 +170,13 @@ pub(crate) fn ensure_registry_auth_for_package(
     if client.has_resolved_auth_for_package(registry_url, package_name) {
         Ok(())
     } else {
+        let login_cmd = aube_util::cmd("login");
         let login_hint = package_name
             .split_once('/')
             .map(|(scope, _)| scope)
             .filter(|scope| scope.starts_with('@'))
-            .map(|scope| format!("aube login --registry {registry_url} --scope {scope}"))
-            .unwrap_or_else(|| format!("aube login --registry {registry_url}"));
+            .map(|scope| format!("{login_cmd} --registry {registry_url} --scope {scope}"))
+            .unwrap_or_else(|| format!("{login_cmd} --registry {registry_url}"));
         Err(miette!(
             "no auth token for {registry_url} package {package_name}. Run `{login_hint}` first."
         ))

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -162,20 +162,6 @@ pub(crate) fn chained_frozen_mode(default: install::FrozenMode) -> install::Froz
     }
 }
 
-pub(crate) fn ensure_registry_auth(
-    client: &RegistryClient,
-    registry_url: &str,
-) -> miette::Result<()> {
-    if client.has_resolved_auth_for(registry_url) {
-        Ok(())
-    } else {
-        Err(miette!(
-            "no auth token for {registry_url}. Run `{} --registry {registry_url}` first.",
-            aube_util::cmd("login")
-        ))
-    }
-}
-
 pub(crate) fn ensure_registry_auth_for_package(
     client: &RegistryClient,
     registry_url: &str,
@@ -184,8 +170,14 @@ pub(crate) fn ensure_registry_auth_for_package(
     if client.has_resolved_auth_for_package(registry_url, package_name) {
         Ok(())
     } else {
+        let login_hint = package_name
+            .split_once('/')
+            .map(|(scope, _)| scope)
+            .filter(|scope| scope.starts_with('@'))
+            .map(|scope| format!("aube login --registry {registry_url} --scope {scope}"))
+            .unwrap_or_else(|| format!("aube login --registry {registry_url}"));
         Err(miette!(
-            "no auth token for {registry_url} package {package_name}. Run `aube login --registry {registry_url} --scope <scope>` first."
+            "no auth token for {registry_url} package {package_name}. Run `{login_hint}` first."
         ))
     }
 }

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -176,6 +176,20 @@ pub(crate) fn ensure_registry_auth(
     }
 }
 
+pub(crate) fn ensure_registry_auth_for_package(
+    client: &RegistryClient,
+    registry_url: &str,
+    package_name: &str,
+) -> miette::Result<()> {
+    if client.has_resolved_auth_for_package(registry_url, package_name) {
+        Ok(())
+    } else {
+        Err(miette!(
+            "no auth token for {registry_url} package {package_name}. Run `aube login --registry {registry_url} --scope <scope>` first."
+        ))
+    }
+}
+
 /// Open the global content-addressable store, honoring a `storeDir`
 /// override from `.npmrc` or `pnpm-workspace.yaml` in `cwd`. Falls
 /// back to the aube-owned default under `$XDG_DATA_HOME/aube/store/`

--- a/crates/aube/src/commands/unpublish.rs
+++ b/crates/aube/src/commands/unpublish.rs
@@ -25,7 +25,7 @@
 //! Auth and per-registry TLS follow the same `RegistryClient` path as
 //! `aube publish` / `aube dist-tag`.
 
-use crate::commands::{encode_package_name, ensure_registry_auth, split_name_spec};
+use crate::commands::{encode_package_name, ensure_registry_auth_for_package, split_name_spec};
 use aube_manifest::PackageJson;
 use aube_registry::client::RegistryClient;
 use aube_registry::config::{NpmConfig, normalize_registry_url_pub};
@@ -107,7 +107,7 @@ pub async fn run(args: UnpublishArgs) -> miette::Result<()> {
 
     let policy = crate::commands::resolve_fetch_policy(&cwd);
     let client = RegistryClient::from_config_with_policy(config, policy);
-    ensure_registry_auth(&client, &registry_url)?;
+    ensure_registry_auth_for_package(&client, &registry_url, &target.name)?;
 
     match target.version {
         Some(version) => {
@@ -176,7 +176,8 @@ async fn unpublish_package(
         encode_package_name(name),
         rev
     );
-    let mut req = client.authed_request(reqwest::Method::DELETE, &url, registry_url);
+    let mut req =
+        client.authed_request_for_package(reqwest::Method::DELETE, &url, registry_url, name);
     if let Some(otp) = otp {
         req = req.header("npm-otp", otp);
     }
@@ -215,7 +216,7 @@ async fn unpublish_version(
         rev
     );
     let mut req = client
-        .authed_request(reqwest::Method::PUT, &put_url, registry_url)
+        .authed_request_for_package(reqwest::Method::PUT, &put_url, registry_url, name)
         .header("content-type", "application/json")
         .body(serde_json::to_vec(&packument).into_diagnostic()?);
     if let Some(otp) = otp {
@@ -273,7 +274,8 @@ async fn unpublish_version(
         tarball_path,
         new_rev
     );
-    let mut req = client.authed_request(reqwest::Method::DELETE, &del_url, registry_url);
+    let mut req =
+        client.authed_request_for_package(reqwest::Method::DELETE, &del_url, registry_url, name);
     if let Some(otp) = otp {
         req = req.header("npm-otp", otp);
     }
@@ -310,7 +312,7 @@ async fn fetch_packument(
         encode_package_name(name)
     );
     let resp = client
-        .authed_request(reqwest::Method::GET, &url, registry_url)
+        .authed_request_for_package(reqwest::Method::GET, &url, registry_url, name)
         .send()
         .await
         .into_diagnostic()

--- a/test/login.bats
+++ b/test/login.bats
@@ -163,6 +163,22 @@ teardown() {
 	refute_output --partial "@myorg:registry"
 }
 
+@test "aube logout without scope removes scoped tokens for the registry" {
+	printf '%s\n' \
+		'@myorg:registry=https://myorg.example.com/' \
+		'//myorg.example.com/:@myorg:_authToken=scoped' \
+		'//myorg.example.com/:_authToken=unscoped' >"$HOME/.npmrc"
+
+	run aube logout --registry=https://myorg.example.com/
+	assert_success
+	assert_output --partial "Logged out of https://myorg.example.com/"
+
+	run cat "$HOME/.npmrc"
+	assert_success
+	refute_output --partial "_authToken"
+	assert_output --partial "@myorg:registry=https://myorg.example.com/"
+}
+
 @test "aube logout is a no-op when no credentials exist" {
 	run aube logout --registry=https://r.example.com/
 	assert_success

--- a/test/login.bats
+++ b/test/login.bats
@@ -152,7 +152,7 @@ teardown() {
 @test "aube logout --scope strips the scope mapping too" {
 	printf '%s\n' \
 		'@myorg:registry=https://myorg.example.com/' \
-		'//myorg.example.com/:_authToken=tok' >"$HOME/.npmrc"
+		'//myorg.example.com/:@myorg:_authToken=tok' >"$HOME/.npmrc"
 
 	run aube logout --scope=@myorg --registry=https://myorg.example.com/
 	assert_success

--- a/test/login.bats
+++ b/test/login.bats
@@ -63,7 +63,9 @@ teardown() {
 		--registry=https://myorg.example.com/ \
 		--scope=@myorg
 	assert_success
-	assert_file_contains "$HOME/.npmrc" "//myorg.example.com/:_authToken=scoped"
+	run cat "$HOME/.npmrc"
+	assert_success
+	assert_output --partial "//myorg.example.com/:@myorg:_authToken=scoped"
 	assert_file_contains "$HOME/.npmrc" "@myorg:registry=https://myorg.example.com/"
 }
 
@@ -108,8 +110,10 @@ teardown() {
 		--registry="http://127.0.0.1:$MOCK_WEB_LOGIN_PORT/" \
 		--scope=@myorg
 	assert_success
-	assert_file_contains "$HOME/.npmrc" \
-		"//127.0.0.1:$MOCK_WEB_LOGIN_PORT/:_authToken=mock-web-token"
+	run cat "$HOME/.npmrc"
+	assert_success
+	assert_output --partial \
+		"//127.0.0.1:$MOCK_WEB_LOGIN_PORT/:@myorg:_authToken=mock-web-token"
 	assert_file_contains "$HOME/.npmrc" \
 		"@myorg:registry=http://127.0.0.1:$MOCK_WEB_LOGIN_PORT/"
 }

--- a/test/login.bats
+++ b/test/login.bats
@@ -69,6 +69,18 @@ teardown() {
 	assert_file_contains "$HOME/.npmrc" "@myorg:registry=https://myorg.example.com/"
 }
 
+@test "aube login normalizes scope casing" {
+	AUBE_AUTH_TOKEN=scoped run aube login \
+		--registry=https://myorg.example.com/ \
+		--scope=@MyOrg
+	assert_success
+	run cat "$HOME/.npmrc"
+	assert_success
+	assert_output --partial "//myorg.example.com/:@myorg:_authToken=scoped"
+	assert_output --partial "@myorg:registry=https://myorg.example.com/"
+	refute_output --partial "@MyOrg"
+}
+
 @test "aube login replaces an existing token" {
 	printf '%s\n' \
 		'registry=https://r.example.com/' \
@@ -161,6 +173,20 @@ teardown() {
 	assert_success
 	refute_output --partial "_authToken"
 	refute_output --partial "@myorg:registry"
+}
+
+@test "aube logout --scope matches scope casing insensitively" {
+	printf '%s\n' \
+		'@MyOrg:registry=https://myorg.example.com/' \
+		'//myorg.example.com/:@MyOrg:_authToken=tok' >"$HOME/.npmrc"
+
+	run aube logout --scope=@myorg --registry=https://myorg.example.com/
+	assert_success
+
+	run cat "$HOME/.npmrc"
+	assert_success
+	refute_output --partial "_authToken"
+	refute_output --partial "@MyOrg:registry"
 }
 
 @test "aube logout without scope removes scoped tokens for the registry" {


### PR DESCRIPTION
## Summary
- parse pnpm-style scope-specific auth keys such as `//npm.pkg.github.com/:@org:_authToken=...`
- prefer scoped credentials for package metadata, tarball, dist-tag, deprecate, and publish requests
- make `aube login --scope` write scoped token keys instead of broad registry tokens

## Why
GitHub Packages and similar registries can host multiple scopes behind the same registry URL. Scope-specific tokens avoid leaking one org token to another scope while matching pnpm 11.7.0 behavior.

## Validation
- cargo fmt --check
- cargo test -p aube-registry scoped_auth_token --lib
- cargo test -p aube-registry package_name_from_tarball_url --lib
- cargo test -p aube --no-default-features --lib publish --no-run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential selection across install, publish, and tarball paths; mistakes could send the wrong token or break multi-org registries, but behavior is heavily tested and falls back to registry-wide auth when no scoped credentials exist.
> 
> **Overview**
> **Adds scope-specific registry credentials** for one registry URL hosting multiple orgs (e.g. GitHub Packages). `.npmrc` keys like `//host/:@scope:_authToken` are parsed into `scoped_auth_by_uri`; lookups use longest matching URI prefix and only override the broad registry token when the scoped entry has real credentials (TLS-only scoped config does not steal auth).
> 
> **Registry traffic is package-aware**: metadata, dist-tags, packument writes, publish/unpublish, and tarball GETs resolve auth via `authed_*_for_package` / `http_*_for_package`, with per-scope TLS `reqwest` clients and tarball URLs parsed to infer package name for scoped tokens.
> 
> **CLI**: `aube login --scope` writes `//host/:@scope:_authToken` (normalized scope) plus `@scope:registry`; `logout` removes the right scoped or all scoped tokens for a registry. Auth-missing errors suggest `login --scope` when applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da385c183ffe3e95d79efff2d50e6348a17572f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added package-scoped authentication for registry requests, selecting credentials using the package name/scope.
  * `aube login` now writes scope-specific `.npmrc` entries (auth token plus `scope:registry`) when `--scope` is provided.

* **Improvements**
  * `aube publish` and `aube unpublish` now use package-scoped registry authentication when available.
  * `aube logout` now removes the correct scoped token; logout can also clear scoped tokens for a registry when using `--registry`.

* **Tests**
  * Expanded coverage for scope vs registry precedence and `.npmrc` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->