### PR TITLE
fix(install): verify tarball urls against packuments

### DIFF
--- a/crates/aube-registry/src/client/request.rs
+++ b/crates/aube-registry/src/client/request.rs
@@ -636,8 +636,10 @@ mod tests {
 
     #[test]
     fn http_for_package_uses_scoped_tls_client() {
-        let mut config = NpmConfig::default();
-        config.registry = "https://registry.example.com/".to_string();
+        let mut config = NpmConfig {
+            registry: "https://registry.example.com/".to_string(),
+            ..Default::default()
+        };
         let mut scoped = AuthConfig::default();
         scoped.tls.cafile = Some(std::path::PathBuf::from("org-a-ca.pem"));
         config
@@ -660,14 +662,18 @@ mod tests {
     #[test]
     fn tarball_request_uses_scoped_auth_for_path_registry() {
         let mut config = NpmConfig::default();
-        let mut registry_auth = AuthConfig::default();
-        registry_auth.auth_token = Some("registry-token".to_string());
+        let registry_auth = AuthConfig {
+            auth_token: Some("registry-token".to_string()),
+            ..Default::default()
+        };
         config
             .auth_by_uri
             .insert("//registry.example.com/".to_string(), registry_auth);
 
-        let mut scoped_auth = AuthConfig::default();
-        scoped_auth.auth_token = Some("scoped-token".to_string());
+        let scoped_auth = AuthConfig {
+            auth_token: Some("scoped-token".to_string()),
+            ..Default::default()
+        };
         config
             .scoped_auth_by_uri
             .entry("//registry.example.com/npm".to_string())

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -6,7 +6,9 @@ use super::settings::{
     resolve_strict_store_integrity, resolve_strict_store_pkg_content_check,
     resolve_verify_store_integrity,
 };
-use crate::commands::{resolve_virtual_store_dir, resolve_virtual_store_dir_max_length};
+use crate::commands::{
+    packument_cache_dir, resolve_virtual_store_dir, resolve_virtual_store_dir_max_length,
+};
 use crate::progress::InstallProgress;
 use aube_lockfile::dep_path_filename::dep_path_to_filename;
 use miette::{Context, IntoDiagnostic, miette};
@@ -986,8 +988,8 @@ async fn verify_lockfile_tarball_url(
     version: &str,
     lockfile_url: &str,
 ) -> miette::Result<()> {
-    let meta = client
-        .fetch_single_version_metadata(registry_name, version)
+    let packument = client
+        .fetch_packument_cached(registry_name, &packument_cache_dir())
         .await
         .map_err(|e| {
             miette!(
@@ -998,6 +1000,15 @@ async fn verify_lockfile_tarball_url(
                 e
             )
         })?;
+    let Some(meta) = packument.versions.get(version) else {
+        return Err(miette!(
+            code = aube_codes::errors::ERR_AUBE_TARBALL_URL_MISMATCH,
+            "{}@{}: registry metadata did not include this version while lockfile pinned {}",
+            registry_name,
+            version,
+            aube_util::url::redact_url(lockfile_url)
+        ));
+    };
     let Some(expected_url) = meta.dist.as_ref().map(|dist| dist.tarball.as_str()) else {
         return Err(miette!(
             code = aube_codes::errors::ERR_AUBE_TARBALL_URL_MISMATCH,

--- a/test/lockfile_settings.bats
+++ b/test/lockfile_settings.bats
@@ -6,6 +6,10 @@ setup() {
 }
 
 teardown() {
+	if [ -n "${SPLIT_REGISTRY_PID:-}" ]; then
+		kill "$SPLIT_REGISTRY_PID" 2>/dev/null || true
+		wait "$SPLIT_REGISTRY_PID" 2>/dev/null || true
+	fi
 	_common_teardown
 }
 
@@ -150,6 +154,85 @@ teardown() {
 	assert_failure
 	assert_output --partial "ERR_AUBE_TARBALL_URL_MISMATCH"
 	assert_output --partial "not match registry metadata"
+}
+
+@test "lockfile tarball URLs are verified against packument metadata" {
+	mkdir -p package
+	cat >package/package.json <<-'EOF'
+		{
+		  "name": "split-pkg",
+		  "version": "1.0.0"
+		}
+	EOF
+	tar -czf split-pkg-1.0.0.tgz package
+	integrity="$(node -e "const crypto = require('node:crypto'); const fs = require('node:fs'); console.log('sha512-' + crypto.createHash('sha512').update(fs.readFileSync('split-pkg-1.0.0.tgz')).digest('base64'))")"
+
+	cat >split-registry.mjs <<'NODE'
+import http from 'node:http';
+import fs from 'node:fs';
+
+const integrity = process.env.SPLIT_PKG_INTEGRITY;
+const tarball = fs.readFileSync('split-pkg-1.0.0.tgz');
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/split-pkg') {
+    const tarballUrl = `http://${req.headers.host}/split-pkg/-/split-pkg-1.0.0.tgz`;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({
+      name: 'split-pkg',
+      'dist-tags': { latest: '1.0.0' },
+      versions: {
+        '1.0.0': {
+          name: 'split-pkg',
+          version: '1.0.0',
+          dist: { tarball: tarballUrl, integrity }
+        }
+      },
+      time: { '1.0.0': '2024-01-01T00:00:00.000Z' }
+    }));
+    return;
+  }
+  if (req.method === 'GET' && req.url === '/split-pkg/-/split-pkg-1.0.0.tgz') {
+    res.setHeader('content-type', 'application/octet-stream');
+    res.end(tarball);
+    return;
+  }
+  res.statusCode = 404;
+  res.end('{}');
+});
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync('split-registry-port', String(server.address().port));
+});
+NODE
+	SPLIT_PKG_INTEGRITY="$integrity" node split-registry.mjs &
+	SPLIT_REGISTRY_PID=$!
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		[ -f split-registry-port ] && break
+		sleep 0.1
+	done
+	registry="http://127.0.0.1:$(cat split-registry-port)"
+
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-packument-tarball-url",
+		  "version": "1.0.0",
+		  "dependencies": { "split-pkg": "1.0.0" }
+		}
+	EOF
+	cat >.npmrc <<-EOF
+		registry=$registry
+		lockfile-include-tarball-url=true
+	EOF
+
+	run aube install --no-frozen-lockfile
+	assert_success
+
+	rm -rf node_modules "$XDG_DATA_HOME/aube/store" "$XDG_CACHE_HOME/aube/packuments-v1"
+
+	run aube install --frozen-lockfile
+	kill "$SPLIT_REGISTRY_PID"
+	wait "$SPLIT_REGISTRY_PID" 2>/dev/null || true
+	unset SPLIT_REGISTRY_PID
+	assert_success
 }
 
 @test "lockfileIncludeTarballUrl=false (default) omits tarball URLs" {


### PR DESCRIPTION
## Summary
- verify lockfile tarball URLs against package packument metadata instead of the per-version endpoint
- preserve fail-closed `ERR_AUBE_TARBALL_URL_MISMATCH` behavior for missing metadata and mismatches
- add a split-endpoint registry regression where `/split-pkg` works but `/split-pkg/1.0.0` does not
- clean up clippy warnings in registry request tests on current `origin/main`

Fixes Discussion #904.

## Root Cause
The verifier compared explicit lockfile tarball URLs against `{registry}/{name}/{version}` metadata, while resolution and lockfile writing use package-level packument metadata. Registries that expose valid package metadata but have incomplete per-version endpoints could reject valid cold-store installs.

## Validation
- `cargo test -p aube commands::install::fetch`
- `cargo build`
- `mise run test:bats test/lockfile_settings.bats`
- `cargo clippy --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install-time security checks on frozen lockfiles and registry metadata fetching; behavior shifts for registries with incomplete per-version endpoints but should align with resolution and remain fail-closed on mismatches.
> 
> **Overview**
> **Frozen-lockfile installs** now validate pinned `resolution.tarball` URLs against **package packument** metadata (via `fetch_packument_cached` and the on-disk packument cache), not the per-version registry endpoint. That matches how resolution and lockfile writing source tarball URLs, so registries that serve full packuments but broken or missing `/{name}/{version}` routes no longer fail valid cold-store installs.
> 
> **Fail-closed behavior is unchanged:** missing packument fetch, a version absent from the packument, missing `dist.tarball`, or a URL mismatch still surfaces `ERR_AUBE_TARBALL_URL_MISMATCH`.
> 
> A **bats regression** spins up a minimal registry where only the packument route works; after clearing store and packument cache, `--frozen-lockfile` must succeed. Registry request unit tests were adjusted for clippy (`..Default::default()` struct updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 761e97d947d5a8f9f5ee2abaa0888be061c7a59d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->