### PR TITLE
chore: add cmake to `mise.toml`

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -71,6 +71,38 @@ url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/ca
 checksum = "sha256:89706aa5215c164d8d091597a470fee72308ac87e8553af395ea77db844a888c"
 url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-pc-windows-msvc.zip"
 
+[[tools.cmake]]
+version = "4.3.2"
+backend = "aqua:Kitware/CMake"
+
+[tools.cmake."platforms.linux-arm64"]
+checksum = "sha256:377079ab739f5765176f427609d9a2015b756ea20d5cba908d279c3731a2f481"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-linux-aarch64.tar.gz"
+
+[tools.cmake."platforms.linux-arm64-musl"]
+checksum = "sha256:377079ab739f5765176f427609d9a2015b756ea20d5cba908d279c3731a2f481"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-linux-aarch64.tar.gz"
+
+[tools.cmake."platforms.linux-x64"]
+checksum = "sha256:791ae3604841ca03cb3889a3ad89165346e4b180ae3448efd4b0caa9ef46d245"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-linux-x86_64.tar.gz"
+
+[tools.cmake."platforms.linux-x64-musl"]
+checksum = "sha256:791ae3604841ca03cb3889a3ad89165346e4b180ae3448efd4b0caa9ef46d245"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-linux-x86_64.tar.gz"
+
+[tools.cmake."platforms.macos-arm64"]
+checksum = "sha256:808ab43a0db04c8eec9ed7db12b90d7be1c8e2e75f4a060724d604a2043ccaf7"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-macos-universal.tar.gz"
+
+[tools.cmake."platforms.macos-x64"]
+checksum = "sha256:808ab43a0db04c8eec9ed7db12b90d7be1c8e2e75f4a060724d604a2043ccaf7"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-macos-universal.tar.gz"
+
+[tools.cmake."platforms.windows-x64"]
+checksum = "sha256:83d20c23f5c5f64b3b328785e35b23c532e33057a97ed6294acaca3781b78a01"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-windows-x86_64.zip"
+
 [[tools.communique]]
 version = "1.1.2"
 backend = "github:jdx/communique"

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@ _.path = ["./bin"]
 [tools]
 actionlint = "latest"
 cargo-binstall = "latest"
+cmake = "latest"
 communique = "latest"
 "github:bnjbvr/cargo-machete" = "latest"
 "github:foresterre/cargo-msrv" = "latest"


### PR DESCRIPTION
aube requires cmake env for the first time building:

```console
$ cargo check -p aube 2>&1
Updating crates.io index
 Downloading crates ...
  Downloaded sha1 v0.11.0
  Downloaded sigstore-crypto v0.8.0
  Downloaded palette_derive v0.7.6
  Downloaded mimalloc v0.1.52
  Downloaded sigstore-sign v0.8.0
  Downloaded sigstore-types v0.8.0
  Downloaded sigstore-merkle v0.8.0
  Downloaded sigstore-tsa v0.8.0
  Downloaded sigstore-rekor v0.8.0
  Downloaded sigstore-fulcio v0.8.0
  Downloaded ratatui-crossterm v0.1.1
  Downloaded lru v0.18.0
  Downloaded fast-srgb8 v1.0.0
  Downloaded sigstore-bundle v0.8.0
  Downloaded sigstore-trust-root v0.8.0
  Downloaded prefix-trie v0.8.4
  Downloaded jiff-static v0.2.25
  Downloaded ignore v0.4.26
  Downloaded hickory-net v0.26.1
  Downloaded hickory-resolver v0.26.1
  Downloaded diffy v0.5.0
  Downloaded sigstore-oidc v0.8.0
  Downloaded ratatui v0.30.1
  Downloaded clx v2.1.0
  Downloaded winnow v1.0.3
  Downloaded ratatui-core v0.1.1
  Downloaded ratatui-widgets v0.3.1
  Downloaded palette v0.7.6
  Downloaded hickory-proto v0.26.1
  Downloaded libmimalloc-sys v0.1.49
  Downloaded jiff v0.2.25
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.45
   Compiling unicode-ident v1.0.24
   Compiling libc v0.2.186
    Checking cfg-if v1.0.4
   Compiling serde_core v1.0.228
   Compiling find-msvc-tools v0.1.9
   Compiling shlex v1.3.0
   Compiling serde v1.0.228
    Checking memchr v2.8.0
    Checking equivalent v1.0.2
    Checking allocator-api2 v0.2.21
    Checking foldhash v0.2.0
    Checking bitflags v2.13.0
    Checking log v0.4.32
    Checking itoa v1.0.18
   Compiling portable-atomic v1.13.1
   Compiling autocfg v1.5.0
    Checking hashbrown v0.17.1
   Compiling zmij v1.0.21
    Checking critical-section v1.2.0
   Compiling serde_json v1.0.150
   Compiling thiserror v2.0.18
    Checking pin-project-lite v0.2.17
   Compiling parking_lot_core v0.9.12
    Checking scopeguard v1.2.0
   Compiling num-traits v0.2.19
    Checking stable_deref_trait v1.2.1
    Checking lock_api v0.4.14
    Checking bytes v1.11.1
    Checking core-foundation-sys v0.8.7
   Compiling crossbeam-utils v0.8.21
    Checking typenum v1.20.0
   Compiling version_check v0.9.5
    Checking simd-adler32 v0.3.9
    Checking either v1.15.0
   Compiling fs_extra v1.3.0
   Compiling dunce v1.0.5
   Compiling pkg-config v0.3.33
    Checking adler2 v2.0.1
    Checking miniz_oxide v0.8.9
    Checking percent-encoding v2.3.2
    Checking futures-core v0.3.32
   Compiling getrandom v0.4.2
    Checking rand_core v0.10.1
   Compiling aws-lc-rs v1.17.0
    Checking litemap v0.8.2
    Checking writeable v0.6.3
   Compiling zstd-safe v7.2.4
   Compiling icu_normalizer_data v2.2.0
    Checking indexmap v2.14.0
    Checking utf8_iter v1.0.4
   Compiling icu_properties_data v2.2.0
    Checking ryu v1.0.23
    Checking untrusted v0.7.1
    Checking slab v0.4.12
   Compiling syn v2.0.117
   Compiling crc32fast v1.5.0
    Checking errno v0.3.14
    Checking signal-hook-registry v1.4.8
    Checking mio v1.2.0
   Compiling jobserver v0.1.34
    Checking socket2 v0.6.3
   Compiling cc v1.2.62
    Checking chacha20 v0.10.0
    Checking http v1.4.0
    Checking aho-corasick v1.1.4
   Compiling cmake v0.1.58
   Compiling synstructure v0.13.2
    Checking regex-syntax v0.8.10
   Compiling zstd-sys v2.0.16+zstd.1.5.7
   Compiling aws-lc-sys v0.41.0
   Compiling libz-ng-sys v1.1.28
    Checking futures-task v0.3.32
   Compiling serde_derive v1.0.228
   Compiling zeroize_derive v1.4.3
    Checking once_cell v1.21.4
   Compiling thiserror-impl v2.0.18
   Compiling zerofrom-derive v0.1.7
   Compiling yoke-derive v0.8.2
    Checking zeroize v1.8.2
   Compiling zerovec-derive v0.11.3
    Checking tracing-core v0.1.36
    Checking zerofrom v0.1.8
   Compiling displaydoc v0.2.5
   Compiling tracing-attributes v0.1.31
   Compiling tokio-macros v2.7.0
   Compiling futures-macro v0.3.32
    Checking tracing v0.1.44
   Compiling zerocopy v0.8.48
    Checking base64 v0.22.1
    Checking futures-util v0.3.32
    Checking crossbeam-epoch v0.9.18
    Checking regex-automata v0.4.14
    Checking rand v0.10.1
    Checking form_urlencoded v1.2.2
   Compiling system-configuration-sys v0.6.0
    Checking futures-sink v0.3.32
    Checking alloc-no-stdlib v2.0.4
    Checking alloc-stdlib v0.2.2
    Checking http-body v1.0.1
    Checking futures-channel v0.3.32
   Compiling getrandom v0.3.4
   Compiling httparse v1.10.1
    Checking zlib-rs v0.6.3
   Compiling rustls v0.23.40
    Checking untrusted v0.9.0
    Checking rustls-pki-types v1.14.1
    Checking brotli-decompressor v5.0.0
    Checking core-foundation v0.9.4
    Checking atomic-waker v1.1.2
    Checking try-lock v0.2.5
    Checking tinyvec_macros v0.1.1
    Checking unicode-width v0.2.2
    Checking tower-service v0.3.3
    Checking fnv v1.0.7
    Checking subtle v2.6.1
   Compiling rustix v1.1.4
    Checking tinyvec v1.11.0
    Checking want v0.3.1
    Checking yoke v0.8.2
    Checking brotli v8.0.2
    Checking data-encoding v2.11.0
    Checking smallvec v1.15.1
    Checking ipnet v2.12.0
    Checking prefix-trie v0.8.4
    Checking parking_lot v0.12.5
    Checking tokio v1.52.3
    Checking compression-core v0.4.32
    Checking uuid v1.23.1
    Checking crossbeam-channel v0.5.15
   Compiling async-trait v0.1.89
    Checking security-framework-sys v2.17.0
    Checking core-foundation v0.10.1
    Checking getrandom v0.2.17
    Checking sync_wrapper v1.0.2
    Checking tower-layer v0.3.3
    Checking tagptr v0.2.0
    Checking futures-io v0.3.32
    Checking moka v0.12.15
    Checking rand_core v0.6.4
    Checking security-framework v3.7.0
    Checking http-body-util v0.1.3
   Compiling generic-array v0.14.7
    Checking resolv-conf v0.7.6
    Checking serde_urlencoded v0.7.1
    Checking regex v1.12.3
    Checking crossbeam-deque v0.8.6
error: failed to run custom build command for `libz-ng-sys v1.1.28`
Caused by:
  process didn't exit successfully: `/Users/bytedance/Projects/aube/target/debug/build/libz-ng-sys-588b23c37eb87059/build-script-cmake` (exit status: 101)
  --- stdout
  CMAKE_TOOLCHAIN_FILE_aarch64-apple-darwin = None
  CMAKE_TOOLCHAIN_FILE_aarch64_apple_darwin = None
  HOST_CMAKE_TOOLCHAIN_FILE = None
  CMAKE_TOOLCHAIN_FILE = None
  CMAKE_GENERATOR_aarch64-apple-darwin = None
  CMAKE_GENERATOR_aarch64_apple_darwin = None
  HOST_CMAKE_GENERATOR = None
  CMAKE_GENERATOR = None
  CMAKE_PREFIX_PATH_aarch64-apple-darwin = None
  CMAKE_PREFIX_PATH_aarch64_apple_darwin = None
  HOST_CMAKE_PREFIX_PATH = None
  CMAKE_PREFIX_PATH = None
  CMAKE_aarch64-apple-darwin = None
  CMAKE_aarch64_apple_darwin = None
  HOST_CMAKE = None
  CMAKE = None
  --- stderr
  running: cd "/Users/bytedance/Projects/aube/target/debug/build/libz-ng-sys-f6753399a25c44fe/out/build" && CMAKE_PREFIX_PATH="" LC_ALL="C" "cmake" "/Users/bytedance/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libz-ng-sys-1.1.28/src/zlib-ng" "-B" "/Users/bytedance/Projects/aube/target/debug/build/libz-ng-sys-f6753399a25c44fe/out/build" "-DCMAKE_OSX_ARCHITECTURES=arm64" "-DBUILD_SHARED_LIBS=OFF" "-DZLIB_COMPAT=OFF" "-DZLIB_ENABLE_TESTS=OFF" "-DWITH_GZFILEOP=ON" "-DCMAKE_INSTALL_LIBDIR=lib" "-DCMAKE_INSTALL_PREFIX=/Users/bytedance/Projects/aube/target/debug/build/libz-ng-sys-f6753399a25c44fe/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC --target=arm64-apple-macosx -mmacosx-version-min=26.2 -w" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC --target=arm64-apple-macosx -mmacosx-version-min=26.2 -w" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC --target=arm64-apple-macosx -mmacosx-version-min=26.2 -w" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Debug"
  thread 'main' (1598609) panicked at /Users/bytedance/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cmake-0.1.58/src/lib.rs:1132:5:
  failed to execute command: No such file or directory (os error 2)
  is `cmake` not installed?
  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```