### PR TITLE
fix(outdated): support global packages

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1195,6 +1195,7 @@ cmd logout help="Remove a registry auth token from the user's ~/.npmrc" {
 cmd outdated help="Report dependencies whose installed version lags behind the registry" {
     after_long_help "Examples:\n\n  $ aube outdated\n  Package     Current  Wanted   Latest\n  lodash      4.17.20  4.17.21  4.17.21\n  typescript  5.3.3    5.3.3    5.4.5\n  zod         3.22.4   3.22.4   3.23.8\n\n  # Also print the package.json specifier and dep type\n  $ aube outdated --long\n  Package     Current  Wanted   Latest\n  lodash      4.17.20  4.17.21  4.17.21\n  typescript  5.3.3    5.3.3    5.4.5\n\n    lodash (dependencies): ^4.17.20\n    typescript (devDependencies): ^5.3.0\n\n  # Filter by prefix\n  $ aube outdated '@babel/*'\n\n  # Machine-readable (pnpm-compatible shape)\n  $ aube outdated --json\n  {\n    \"lodash\": {\n      \"current\": \"4.17.20\",\n      \"wanted\": \"4.17.21\",\n      \"latest\": \"4.17.21\"\n    }\n  }\n\n  # Nothing to report exits 0\n  $ aube outdated\n  All dependencies up to date.\n"
     flag "-D --dev" help="Show only devDependencies"
+    flag "-g --global" help="Check globally-installed packages instead of the current project"
     flag --json help="Emit a JSON object keyed by package name instead of the default table"
     flag --long help="Also show deps whose `wanted` version matches the installed version"
     flag "-P --prod --production" help="Show only production dependencies (skip devDependencies)"

--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -90,6 +90,7 @@ pub const WARN_AUBE_LOCKFILE_CONFLICT_MARKERS: &str = "WARN_AUBE_LOCKFILE_CONFLI
 pub const WARN_AUBE_YARN_BERRY_UNSUPPORTED: &str = "WARN_AUBE_YARN_BERRY_UNSUPPORTED";
 pub const WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX: &str =
     "WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX";
+pub const WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE: &str = "WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE";
 
 // ── progress UI ─────────────────────────────────────────────────────
 pub const WARN_AUBE_PROGRESS_OVERFLOW: &str = "WARN_AUBE_PROGRESS_OVERFLOW";
@@ -496,6 +497,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_LOCKFILE_MALFORMED_PEER_SUFFIX,
         category: category::LOCKFILE,
         description: "A pnpm dep_path peer suffix had unbalanced parentheses (a truncated or hand-corrupted lockfile entry). The key is preserved verbatim instead of silently dropping everything after the `(`, so a later install surfaces the bad entry rather than mis-resolving it.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE,
+        category: category::LOCKFILE,
+        description: "`aube outdated -g` found a global install without a lockfile and skipped that install.",
         exit_code: None,
     },
     // Progress UI

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -239,11 +239,18 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
     let mut rows = Vec::new();
     let mut matched_any = false;
     for info in packages {
+        if let Some(pattern) = args.pattern.as_deref()
+            && !info.aliases.iter().any(|alias| alias.starts_with(pattern))
+        {
+            continue;
+        }
+
         let manifest = super::load_manifest(&info.install_dir.join("package.json"))?;
         let graph = match aube_lockfile::parse_lockfile(&info.install_dir, &manifest) {
             Ok(g) => g,
             Err(aube_lockfile::Error::NotFound(_)) => {
                 tracing::warn!(
+                    code = aube_codes::warnings::WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE,
                     "global install at {} has no lockfile; skipping outdated check",
                     info.install_dir.display()
                 );

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -656,11 +656,24 @@ fn render_table(rows: &[Row], long: bool) {
 
 fn render_json(rows: &[Row]) -> miette::Result<()> {
     // Emit a pnpm-compatible shape: `{ "<name>": { current, wanted, latest } }`.
+    // If malformed global state presents duplicate root names, keep every
+    // row by promoting that one key to an array instead of overwriting.
     use serde_json::{Map, Value};
     let mut map: Map<String, Value> = Map::new();
     for row in rows {
         let v = serde_json::to_value(row).into_diagnostic()?;
-        map.insert(row.name.clone(), v);
+        match map.remove(&row.name) {
+            None => {
+                map.insert(row.name.clone(), v);
+            }
+            Some(Value::Array(mut values)) => {
+                values.push(v);
+                map.insert(row.name.clone(), Value::Array(values));
+            }
+            Some(existing) => {
+                map.insert(row.name.clone(), Value::Array(vec![existing, v]));
+            }
+        }
     }
     let out = serde_json::to_string_pretty(&Value::Object(map)).into_diagnostic()?;
     println!("{out}");
@@ -669,7 +682,8 @@ fn render_json(rows: &[Row]) -> miette::Result<()> {
 
 #[cfg(test)]
 mod colorize_tests {
-    use super::colorize_diff;
+    use super::{Row, colorize_diff};
+    use aube_lockfile::DepType;
 
     fn strip_ansi(s: &str) -> String {
         // Strip CSI sequences for assertion purposes — the renderer
@@ -737,5 +751,49 @@ mod colorize_tests {
         // skip colorization rather than panic. Width still applies.
         let painted = colorize_diff("1.2.3", "latest", 8);
         assert_eq!(painted, "latest  ");
+    }
+
+    #[test]
+    fn json_duplicate_names_promote_to_array() {
+        let rows = vec![
+            Row {
+                name: "same".to_string(),
+                current: "1.0.0".to_string(),
+                wanted: "1.0.1".to_string(),
+                latest: "1.0.1".to_string(),
+                dep_type: DepType::Production,
+                latest_known: true,
+                specifier: Some("^1.0.0".to_string()),
+                importer: None,
+            },
+            Row {
+                name: "same".to_string(),
+                current: "2.0.0".to_string(),
+                wanted: "2.0.1".to_string(),
+                latest: "2.0.1".to_string(),
+                dep_type: DepType::Production,
+                latest_known: true,
+                specifier: Some("^2.0.0".to_string()),
+                importer: None,
+            },
+        ];
+        let mut map = serde_json::Map::new();
+        for row in rows {
+            let value = serde_json::to_value(&row).unwrap();
+            match map.remove(&row.name) {
+                None => {
+                    map.insert(row.name, value);
+                }
+                Some(serde_json::Value::Array(mut values)) => {
+                    values.push(value);
+                    map.insert(row.name, serde_json::Value::Array(values));
+                }
+                Some(existing) => {
+                    map.insert(row.name, serde_json::Value::Array(vec![existing, value]));
+                }
+            }
+        }
+
+        assert_eq!(map["same"].as_array().unwrap().len(), 2);
     }
 }

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -62,6 +62,10 @@ pub struct OutdatedArgs {
     #[arg(short = 'D', long, conflicts_with = "prod")]
     pub dev: bool,
 
+    /// Check globally-installed packages instead of the current project.
+    #[arg(short = 'g', long, conflicts_with = "workspace_root")]
+    pub global: bool,
+
     /// Emit a JSON object keyed by package name instead of the default table
     #[arg(long)]
     pub json: bool,
@@ -124,6 +128,10 @@ pub async fn run(
     mut filter: aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<Option<i32>> {
     args.network.install_overrides();
+    if args.global {
+        return run_global(args).await;
+    }
+
     let mut cwd = crate::dirs::project_root()?;
     if !filter.is_empty() {
         // Discussion #602: include the workspace root in `outdated -r`
@@ -214,6 +222,68 @@ async fn run_filtered(
     Ok(None)
 }
 
+async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
+    let layout = super::global::GlobalLayout::resolve()?;
+    let mut packages = super::global::scan_packages(&layout.pkg_dir);
+    packages.sort_by(|a, b| a.aliases.first().cmp(&b.aliases.first()));
+
+    if packages.is_empty() {
+        if args.json {
+            println!("{{}}");
+        } else {
+            println!("(no global packages installed)");
+        }
+        return Ok(None);
+    }
+
+    let mut rows = Vec::new();
+    let mut matched_any = false;
+    for info in packages {
+        let manifest = super::load_manifest(&info.install_dir.join("package.json"))?;
+        let graph = match aube_lockfile::parse_lockfile(&info.install_dir, &manifest) {
+            Ok(g) => g,
+            Err(aube_lockfile::Error::NotFound(_)) => {
+                tracing::warn!(
+                    "global install at {} has no lockfile; skipping outdated check",
+                    info.install_dir.display()
+                );
+                continue;
+            }
+            Err(e) => {
+                return Err(miette::Report::new(e)).wrap_err_with(|| {
+                    format!(
+                        "failed to parse global lockfile in {}",
+                        info.install_dir.display()
+                    )
+                });
+            }
+        };
+        let (mut package_rows, matched) = collect_rows(
+            &info.install_dir,
+            args.clone_for_fanout(),
+            &graph,
+            graph.root_deps(),
+        )
+        .await?;
+        if matched {
+            matched_any = true;
+        }
+        rows.append(&mut package_rows);
+    }
+
+    rows.sort_by(|a, b| a.name.cmp(&b.name));
+    let has_drift = has_drift(&rows);
+    if args.json {
+        render_json(&rows)?;
+    } else if rows.is_empty() && !matched_any {
+        println!("(no matching dependencies)");
+    } else {
+        render_table(&rows, args.long);
+    }
+
+    if has_drift { Ok(Some(1)) } else { Ok(None) }
+}
+
 async fn run_one(cwd: &Path, args: OutdatedArgs, importer: Option<String>) -> miette::Result<bool> {
     let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
@@ -239,6 +309,35 @@ async fn run_graph(
     roots: &[DirectDep],
     importer: Option<String>,
 ) -> miette::Result<bool> {
+    let (mut rows, matched_any) = collect_rows(cwd, args.clone_for_fanout(), graph, roots).await?;
+    rows.sort_by(|a, b| a.name.cmp(&b.name));
+    let has_drift = has_drift(&rows);
+    for row in &mut rows {
+        row.importer.clone_from(&importer);
+    }
+
+    if args.json {
+        render_json(&rows)?;
+    } else if rows.is_empty() && !matched_any {
+        println!("(no matching dependencies)");
+    } else {
+        render_table(&rows, args.long);
+    }
+
+    // Return the drift flag to the caller. The single-project caller (`run`)
+    // maps `true` to exit code 1 (pnpm parity: `aube outdated || exit 1`),
+    // and the recursive caller (`run_filtered`) aggregates drift across
+    // importers — the exit decision lives at the top so the command layer
+    // stays embed-safe (no in-place `std::process::exit`).
+    Ok(has_drift)
+}
+
+async fn collect_rows(
+    cwd: &Path,
+    args: OutdatedArgs,
+    graph: &aube_lockfile::LockfileGraph,
+    roots: &[DirectDep],
+) -> miette::Result<(Vec<Row>, bool)> {
     let filter = DepFilter::from_flags(args.prod, args.dev);
     let roots: Vec<&DirectDep> = roots
         .iter()
@@ -250,12 +349,7 @@ async fn run_graph(
         .collect();
 
     if roots.is_empty() {
-        if !args.json {
-            println!("(no matching dependencies)");
-        } else {
-            println!("{{}}");
-        }
-        return Ok(false);
+        return Ok((Vec::new(), false));
     }
     let roots: Vec<&DirectDep> = roots
         .into_iter()
@@ -266,12 +360,7 @@ async fn run_graph(
         })
         .collect();
     if roots.is_empty() {
-        if args.json {
-            println!("{{}}");
-        } else {
-            println!("(no matching dependencies)");
-        }
-        return Ok(false);
+        return Ok((Vec::new(), false));
     }
 
     let client = std::sync::Arc::new(make_client(cwd));
@@ -339,34 +428,22 @@ async fn run_graph(
                 dep_type: dep.dep_type,
                 latest_known,
                 specifier: dep.specifier.clone(),
-                importer: importer.clone(),
+                importer: None,
             });
         }
     }
 
-    rows.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok((rows, true))
+}
 
+fn has_drift(rows: &[Row]) -> bool {
     // Hide "up-to-date but only because --long" rows from the non-empty check
     // so `--long` alone doesn't cause a pnpm CI pipeline to flip to exit 1.
     // A row only counts as drift when its latest is known AND differs from
     // current, or its wanted version diverges from current — a missing
     // `latest` dist-tag must never flip the exit code.
-    let has_drift = rows
-        .iter()
-        .any(|r| (r.latest_known && r.current != r.latest) || r.current != r.wanted);
-
-    if args.json {
-        render_json(&rows)?;
-    } else {
-        render_table(&rows, args.long);
-    }
-
-    // Return the drift flag to the caller. The single-project caller (`run`)
-    // maps `true` to exit code 1 (pnpm parity: `aube outdated || exit 1`),
-    // and the recursive caller (`run_filtered`) aggregates drift across
-    // importers — the exit decision lives at the top so the command layer
-    // stays embed-safe (no in-place `std::process::exit`).
-    Ok(has_drift)
+    rows.iter()
+        .any(|r| (r.latest_known && r.current != r.latest) || r.current != r.wanted)
 }
 
 impl OutdatedArgs {
@@ -374,6 +451,7 @@ impl OutdatedArgs {
         Self {
             pattern: self.pattern.clone(),
             dev: self.dev,
+            global: self.global,
             json: self.json,
             long: self.long,
             prod: self.prod,

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -129,6 +129,12 @@ pub async fn run(
 ) -> miette::Result<Option<i32>> {
     args.network.install_overrides();
     if args.global {
+        if !filter.is_empty() {
+            return Err(miette::miette!(
+                "{}: --global cannot be used with --recursive or --filter",
+                aube_util::cmd("outdated")
+            ));
+        }
         return run_global(args).await;
     }
 
@@ -239,6 +245,8 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
     let mut rows = Vec::new();
     let mut matched_any = false;
     let mut matched_install = false;
+    let mut parsed_install = false;
+    let mut skipped_lockfile = false;
     for info in packages {
         if let Some(pattern) = args.pattern.as_deref()
             && !info.aliases.iter().any(|alias| alias.starts_with(pattern))
@@ -251,6 +259,7 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
         let graph = match aube_lockfile::parse_lockfile(&info.install_dir, &manifest) {
             Ok(g) => g,
             Err(aube_lockfile::Error::NotFound(_)) => {
+                skipped_lockfile = true;
                 tracing::warn!(
                     code = aube_codes::warnings::WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE,
                     "global install at {} has no lockfile; skipping outdated check",
@@ -267,13 +276,11 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
                 });
             }
         };
-        let (mut package_rows, matched) = collect_rows(
-            &info.install_dir,
-            args.clone_for_fanout(),
-            &graph,
-            graph.root_deps(),
-        )
-        .await?;
+        parsed_install = true;
+        let mut collect_args = args.clone_for_fanout();
+        collect_args.pattern = None;
+        let (mut package_rows, matched) =
+            collect_rows(&info.install_dir, collect_args, &graph, graph.root_deps()).await?;
         if matched {
             matched_any = true;
         }
@@ -284,7 +291,7 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
     let has_drift = has_drift(&rows);
     if args.json {
         render_json(&rows)?;
-    } else if rows.is_empty() && matched_install && !matched_any {
+    } else if rows.is_empty() && matched_install && !parsed_install && skipped_lockfile {
         println!("(no checkable global dependencies)");
     } else if rows.is_empty() && !matched_any {
         println!("(no matching dependencies)");

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -305,9 +305,15 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
 
     rows.sort_by(|a, b| a.name.cmp(&b.name));
     let has_drift = has_drift(&rows);
+    let no_checkable_global_dependencies =
+        rows.is_empty() && matched_install && !parsed_install && skipped_lockfile;
     if args.json {
-        render_json(&rows)?;
-    } else if rows.is_empty() && matched_install && !parsed_install && skipped_lockfile {
+        if no_checkable_global_dependencies {
+            render_no_checkable_global_json()?;
+        } else {
+            render_json(&rows)?;
+        }
+    } else if no_checkable_global_dependencies {
         println!("(no checkable global dependencies)");
     } else if rows.is_empty() && !matched_any {
         println!("(no matching dependencies)");
@@ -692,6 +698,17 @@ fn render_json(rows: &[Row]) -> miette::Result<()> {
         }
     }
     let out = serde_json::to_string_pretty(&Value::Object(map)).into_diagnostic()?;
+    println!("{out}");
+    Ok(())
+}
+
+fn render_no_checkable_global_json() -> miette::Result<()> {
+    let out = serde_json::to_string_pretty(&serde_json::json!({
+        "checked": false,
+        "code": aube_codes::warnings::WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE,
+        "message": "no checkable global dependencies"
+    }))
+    .into_diagnostic()?;
     println!("{out}");
     Ok(())
 }

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -238,12 +238,14 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
 
     let mut rows = Vec::new();
     let mut matched_any = false;
+    let mut matched_install = false;
     for info in packages {
         if let Some(pattern) = args.pattern.as_deref()
             && !info.aliases.iter().any(|alias| alias.starts_with(pattern))
         {
             continue;
         }
+        matched_install = true;
 
         let manifest = super::load_manifest(&info.install_dir.join("package.json"))?;
         let graph = match aube_lockfile::parse_lockfile(&info.install_dir, &manifest) {
@@ -282,6 +284,8 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
     let has_drift = has_drift(&rows);
     if args.json {
         render_json(&rows)?;
+    } else if rows.is_empty() && matched_install && !matched_any {
+        println!("(no checkable global dependencies)");
     } else if rows.is_empty() && !matched_any {
         println!("(no matching dependencies)");
     } else {

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -248,9 +248,13 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
     let mut parsed_install = false;
     let mut skipped_lockfile = false;
     for info in packages {
-        if let Some(pattern) = args.pattern.as_deref()
-            && !info.aliases.iter().any(|alias| alias.starts_with(pattern))
-        {
+        let matched_aliases: Option<Vec<&str>> = args.pattern.as_deref().map(|pattern| {
+            info.aliases
+                .iter()
+                .filter_map(|alias| alias.starts_with(pattern).then_some(alias.as_str()))
+                .collect()
+        });
+        if matched_aliases.as_ref().is_some_and(Vec::is_empty) {
             continue;
         }
         matched_install = true;
@@ -279,8 +283,20 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
         parsed_install = true;
         let mut collect_args = args.clone_for_fanout();
         collect_args.pattern = None;
+        let selected_roots;
+        let roots = if let Some(aliases) = matched_aliases {
+            selected_roots = graph
+                .root_deps()
+                .iter()
+                .filter(|dep| aliases.iter().any(|alias| dep.name == *alias))
+                .cloned()
+                .collect::<Vec<_>>();
+            selected_roots.as_slice()
+        } else {
+            graph.root_deps()
+        };
         let (mut package_rows, matched) =
-            collect_rows(&info.install_dir, collect_args, &graph, graph.root_deps()).await?;
+            collect_rows(&info.install_dir, collect_args, &graph, roots).await?;
         if matched {
             matched_any = true;
         }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6720,6 +6720,20 @@
             "global": false
           },
           {
+            "name": "global",
+            "usage": "-g --global",
+            "help": "Check globally-installed packages instead of the current project",
+            "help_first_line": "Check globally-installed packages instead of the current project",
+            "short": [
+              "g"
+            ],
+            "long": [
+              "global"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "json",
             "usage": "--json",
             "help": "Emit a JSON object keyed by package name instead of the default table",

--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -17,6 +17,10 @@ Optional package name (prefix match) to filter the report
 
 Show only devDependencies
 
+### `-g --global`
+
+Check globally-installed packages instead of the current project
+
 ### `--json`
 
 Emit a JSON object keyed by package name instead of the default table

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -759,6 +759,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE",
+      "category": "Lockfile",
+      "description": "`aube outdated -g` found a global install without a lockfile and skipped that install.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_PROGRESS_OVERFLOW",
       "category": "Progress UI",
       "description": "Install progress numerator exceeded the resolved-package denominator. Display clamps to total; the warning surfaces the bookkeeping mismatch so the underlying race can be diagnosed.",

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -106,6 +106,11 @@ teardown() {
 	assert_success
 	assert_output --partial "(no matching dependencies)"
 	refute_output --partial "is-odd"
+
+	run aube outdated -g is-odd -D
+	assert_success
+	assert_output --partial "(no matching dependencies)"
+	refute_output --partial "(no checkable global dependencies)"
 }
 
 @test "aube outdated -g reports uncheckable globals without lockfiles" {
@@ -120,6 +125,12 @@ teardown() {
 	assert_success
 	assert_output --partial "(no checkable global dependencies)"
 	refute_output --partial "(no matching dependencies)"
+}
+
+@test "aube outdated -g rejects workspace selectors" {
+	run aube --filter foo outdated -g
+	assert_failure
+	assert_output --partial "--global cannot be used with --recursive or --filter"
 }
 
 @test "aube update -g fails when any named package is missing" {

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -108,6 +108,20 @@ teardown() {
 	refute_output --partial "is-odd"
 }
 
+@test "aube outdated -g reports uncheckable globals without lockfiles" {
+	run aube add -g is-odd@0.1.2
+	assert_success
+
+	pkg_dir="$AUBE_HOME/global-aube"
+	install_dir="$(find "$pkg_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+	rm "$install_dir/aube-lock.yaml"
+
+	run aube outdated -g
+	assert_success
+	assert_output --partial "(no checkable global dependencies)"
+	refute_output --partial "(no matching dependencies)"
+}
+
 @test "aube update -g fails when any named package is missing" {
 	run aube add -g is-positive@1.0.0
 	assert_success

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -83,6 +83,28 @@ teardown() {
 	refute_output --partial "is-positive 1.0.0"
 }
 
+@test "aube outdated -g reports stale global packages outside a project" {
+	run aube add -g is-odd@0.1.2
+	assert_success
+
+	mkdir -p "$TEST_TEMP_DIR/no-project"
+	cd "$TEST_TEMP_DIR/no-project"
+	assert_file_not_exists package.json
+
+	run aube outdated -g
+	assert_failure
+	[ "$status" -eq 1 ]
+	assert_output --partial "Package"
+	assert_output --partial "is-odd"
+	assert_output --partial "0.1.2"
+	assert_output --partial "3.0.1"
+
+	run aube outdated -g is-odd
+	assert_failure
+	[ "$status" -eq 1 ]
+	assert_output --partial "is-odd"
+}
+
 @test "aube update -g fails when any named package is missing" {
 	run aube add -g is-positive@1.0.0
 	assert_success

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -92,17 +92,20 @@ teardown() {
 	assert_file_not_exists package.json
 
 	run aube outdated -g
-	assert_failure
-	[ "$status" -eq 1 ]
+	assert_failure 1
 	assert_output --partial "Package"
 	assert_output --partial "is-odd"
 	assert_output --partial "0.1.2"
 	assert_output --partial "3.0.1"
 
 	run aube outdated -g is-odd
-	assert_failure
-	[ "$status" -eq 1 ]
+	assert_failure 1
 	assert_output --partial "is-odd"
+
+	run aube outdated -g definitely-not-global
+	assert_success
+	assert_output --partial "(no matching dependencies)"
+	refute_output --partial "is-odd"
 }
 
 @test "aube update -g fails when any named package is missing" {

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -113,6 +113,20 @@ teardown() {
 	refute_output --partial "(no checkable global dependencies)"
 }
 
+@test "aube outdated -g filters multi-package installs by alias" {
+	run aube add -g is-odd@0.1.2 is-even@0.1.2
+	assert_success
+
+	mkdir -p "$TEST_TEMP_DIR/no-project"
+	cd "$TEST_TEMP_DIR/no-project"
+	assert_file_not_exists package.json
+
+	run aube outdated -g is-odd
+	assert_failure 1
+	assert_output --partial "is-odd"
+	refute_output --partial "is-even"
+}
+
 @test "aube outdated -g reports uncheckable globals without lockfiles" {
 	run aube add -g is-odd@0.1.2
 	assert_success

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -139,6 +139,12 @@ teardown() {
 	assert_success
 	assert_output --partial "(no checkable global dependencies)"
 	refute_output --partial "(no matching dependencies)"
+
+	run aube outdated -g --json
+	assert_success
+	assert_output --partial '"checked": false'
+	assert_output --partial '"code": "WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE"'
+	refute_output --partial '{}'
 }
 
 @test "aube outdated -g rejects workspace selectors" {


### PR DESCRIPTION
## Summary

- add `-g/--global` support to `aube outdated`
- scan global installs and reuse the existing outdated row rendering/exit behavior
- cover `aube outdated -g` and package-filtered global checks in BATS

## Context

Fixes the missing global-package path reported in discussion #906. `aube outdated -g` now works outside a project and reports stale globally installed packages instead of being rejected by clap.

## Validation

- `cargo check -p aube`
- `cargo fmt --check`
- `mise run test:bats test/global_install.bats`
- `mise run test:bats test/outdated.bats`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI feature reusing existing global scan and outdated logic; main edge case is skipped lockless globals, which is explicit and tested.
> 
> **Overview**
> Adds **`aube outdated -g`**, so stale globally installed packages can be checked **without a project** (e.g. from an empty directory), using the same table/JSON output and **exit code 1 on drift** as project mode.
> 
> The command scans global installs via existing **`GlobalLayout`** / **`scan_packages`**, parses each install’s lockfile, and reuses the shared row collection path after refactoring **`run_graph`** into **`collect_rows`** + **`has_drift`**. **`--global`** conflicts with **`--filter` / `--recursive`**; optional **`PATTERN`** filters by alias prefix (including multi-package global installs).
> 
> Global installs **without a lockfile** are skipped with warning **`WARN_AUBE_GLOBAL_OUTDATED_NO_LOCKFILE`** and user-facing “no checkable global dependencies” (dedicated **`--json`** shape with `checked: false`). **`render_json`** now promotes duplicate package names to an **array** instead of overwriting. CLI/docs and BATS in **`test/global_install.bats`** cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995a116cb0d5323a19be089e940ecf4afef6f596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--global` (`-g`) flag to `aube outdated` to check globally-installed packages instead of workspace dependencies.
* **Bug Fixes**
  * When running `aube outdated -g`, installs without a lockfile are now skipped and reported via a dedicated warning.
* **Documentation**
  * Updated CLI help and command documentation for the new `--global` flag.
* **Tests**
  * Added coverage for global `aube outdated -g`, including missing lockfiles, alias filtering, and invalid flag combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->