### PR TITLE
test: disable trust policy in vlt benchmark fixture

### DIFF
--- a/test/vlt_benchmarks.bats
+++ b/test/vlt_benchmarks.bats
@@ -13,7 +13,7 @@ teardown() {
 _setup_vlt_fixture() {
 	local fixture="$1"
 	cp -R "$PROJECT_ROOT/fixtures/vlt-benchmarks/$fixture/." .
-	printf 'registry=https://registry.npmjs.org/\n' >>.npmrc
+	printf 'registry=https://registry.npmjs.org/\ntrustPolicy=off\n' >>.npmrc
 }
 
 _clean_aube_cache() {


### PR DESCRIPTION
## Summary
- disable trust policy for the live npm-backed VLT Svelte benchmark fixture
- keep the fixture focused on install variation behavior instead of mutable npm trust metadata

## Root cause
The fixture resolves against `registry.npmjs.org`, and current metadata makes `nanoid@3.3.14` fail Aube's default `trustPolicy=no-downgrade` check because a newer release has trusted publisher evidence while that resolved version does not.

## Validation
- `mise run test:bats test/vlt_benchmarks.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture setup change with no production or security behavior changes.
> 
> **Overview**
> The live npm-backed VLT Svelte benchmark fixture now writes **`trustPolicy=off`** into the generated **`.npmrc`** (alongside the existing registry URL), so installs are not gated by Aube’s default **`trustPolicy=no-downgrade`** checks.
> 
> That keeps the benchmark focused on **install variation** behavior instead of failing when registry metadata changes—e.g. **`nanoid@3.3.14`** resolving without trusted-publisher evidence while a newer release has it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5abc208743be71dadacd761852f86e3adfc6eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test fixture configuration for benchmark tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->