### PR TITLE
fix(add): check exact pins with versioned OSV gate

### DIFF
--- a/crates/aube/src/commands/add/supply_chain.rs
+++ b/crates/aube/src/commands/add/supply_chain.rs
@@ -99,7 +99,7 @@ fn registry_bound_inputs_for_supply_chain(
         // API doesn't index them), so the prompt naturally skips
         // them — no per-name special case needed in the gate.
         inputs.download_names.push(spec.name.clone());
-        if spec.has_explicit_range && node_semver::Version::parse(&spec.range).is_ok() {
+        if spec.has_explicit_range && is_full_exact_version(&spec.range) {
             inputs.exact_advisory_pairs.push((spec.name, spec.range));
         } else {
             inputs.name_only_advisory_names.push(spec.name);
@@ -112,6 +112,28 @@ fn registry_bound_inputs_for_supply_chain(
     inputs.download_names.sort();
     inputs.download_names.dedup();
     inputs
+}
+
+fn is_full_exact_version(range: &str) -> bool {
+    let suffix_start = range.find(['-', '+']).unwrap_or(range.len());
+    let core = &range[..suffix_start];
+    let mut parts = core.split('.');
+    let Some(major) = parts.next() else {
+        return false;
+    };
+    let Some(minor) = parts.next() else {
+        return false;
+    };
+    let Some(patch) = parts.next() else {
+        return false;
+    };
+    if parts.next().is_some() {
+        return false;
+    }
+    [major, minor, patch]
+        .into_iter()
+        .all(|part| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()))
+        && node_semver::Version::parse(range).is_ok()
 }
 
 #[cfg(test)]
@@ -136,18 +158,47 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let inputs = registry_bound_inputs_for_supply_chain(
             tmp.path(),
-            &["nx@^23".into(), "vite@latest".into(), "react".into()],
+            &[
+                "nx@^23".into(),
+                "pkg-major@4".into(),
+                "pkg-minor@1.2".into(),
+                "react".into(),
+                "vite@latest".into(),
+            ],
         );
 
         assert_eq!(
             inputs.name_only_advisory_names,
-            vec!["nx".to_string(), "react".to_string(), "vite".to_string()],
+            vec![
+                "nx".to_string(),
+                "pkg-major".to_string(),
+                "pkg-minor".to_string(),
+                "react".to_string(),
+                "vite".to_string(),
+            ],
         );
         assert!(inputs.exact_advisory_pairs.is_empty());
         assert_eq!(
             inputs.download_names,
-            vec!["nx".to_string(), "react".to_string(), "vite".to_string()],
+            vec![
+                "nx".to_string(),
+                "pkg-major".to_string(),
+                "pkg-minor".to_string(),
+                "react".to_string(),
+                "vite".to_string(),
+            ],
         );
+    }
+
+    #[test]
+    fn full_exact_version_requires_major_minor_patch() {
+        assert!(is_full_exact_version("1.2.3"));
+        assert!(is_full_exact_version("1.2.3-beta.1"));
+        assert!(is_full_exact_version("1.2.3+build.7"));
+        assert!(!is_full_exact_version("1"));
+        assert!(!is_full_exact_version("1.2"));
+        assert!(!is_full_exact_version("^1.2.3"));
+        assert!(!is_full_exact_version("latest"));
     }
 
     #[test]

--- a/crates/aube/src/commands/add/supply_chain.rs
+++ b/crates/aube/src/commands/add/supply_chain.rs
@@ -7,7 +7,7 @@ pub(super) async fn run_cli_name_gates(
     packages: &[String],
     allow_low_downloads: bool,
 ) -> miette::Result<()> {
-    let registry_names = registry_bound_names_for_supply_chain(cwd, packages);
+    let registry_inputs = registry_bound_inputs_for_supply_chain(cwd, packages);
     let (advisory_check, low_download_threshold, allowed_unpopular) =
         crate::commands::with_settings_ctx(cwd, |ctx| {
             let policy = if aube_settings::resolved::paranoid(ctx) {
@@ -22,7 +22,9 @@ pub(super) async fn run_cli_name_gates(
             )
         });
     crate::commands::add_supply_chain::run_gates(
-        &registry_names,
+        &registry_inputs.name_only_advisory_names,
+        &registry_inputs.exact_advisory_pairs,
+        &registry_inputs.download_names,
         advisory_check,
         low_download_threshold,
         allow_low_downloads,
@@ -31,8 +33,22 @@ pub(super) async fn run_cli_name_gates(
     .await
 }
 
-fn registry_bound_names_for_supply_chain(cwd: &Path, packages: &[String]) -> Vec<String> {
-    let mut names = Vec::with_capacity(packages.len());
+#[derive(Default)]
+struct RegistryBoundSupplyChainInputs {
+    name_only_advisory_names: Vec<String>,
+    exact_advisory_pairs: Vec<(String, String)>,
+    download_names: Vec<String>,
+}
+
+fn registry_bound_inputs_for_supply_chain(
+    cwd: &Path,
+    packages: &[String],
+) -> RegistryBoundSupplyChainInputs {
+    let mut inputs = RegistryBoundSupplyChainInputs {
+        name_only_advisory_names: Vec::with_capacity(packages.len()),
+        exact_advisory_pairs: Vec::with_capacity(packages.len()),
+        download_names: Vec::with_capacity(packages.len()),
+    };
     let workspace_versions = collect_workspace_versions(cwd);
     // Scope→registry overrides + the default registry tell us which
     // names route through public npmjs. Anything else (a swapped-out
@@ -82,9 +98,68 @@ fn registry_bound_names_for_supply_chain(cwd: &Path, packages: &[String]) -> Vec
         // packages into `DownloadCount::Unknown` (npm's downloads
         // API doesn't index them), so the prompt naturally skips
         // them — no per-name special case needed in the gate.
-        names.push(spec.name);
+        inputs.download_names.push(spec.name.clone());
+        if spec.has_explicit_range && node_semver::Version::parse(&spec.range).is_ok() {
+            inputs.exact_advisory_pairs.push((spec.name, spec.range));
+        } else {
+            inputs.name_only_advisory_names.push(spec.name);
+        }
     }
-    names.sort();
-    names.dedup();
-    names
+    inputs.name_only_advisory_names.sort();
+    inputs.name_only_advisory_names.dedup();
+    inputs.exact_advisory_pairs.sort();
+    inputs.exact_advisory_pairs.dedup();
+    inputs.download_names.sort();
+    inputs.download_names.dedup();
+    inputs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_bound_inputs_use_versioned_osv_for_exact_versions() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let inputs = registry_bound_inputs_for_supply_chain(tmp.path(), &["nx@23.0.0".into()]);
+
+        assert_eq!(
+            inputs.exact_advisory_pairs,
+            vec![("nx".to_string(), "23.0.0".to_string())],
+        );
+        assert!(inputs.name_only_advisory_names.is_empty());
+        assert_eq!(inputs.download_names, vec!["nx".to_string()]);
+    }
+
+    #[test]
+    fn registry_bound_inputs_keep_ranges_and_tags_name_only() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let inputs = registry_bound_inputs_for_supply_chain(
+            tmp.path(),
+            &["nx@^23".into(), "vite@latest".into(), "react".into()],
+        );
+
+        assert_eq!(
+            inputs.name_only_advisory_names,
+            vec!["nx".to_string(), "react".to_string(), "vite".to_string()],
+        );
+        assert!(inputs.exact_advisory_pairs.is_empty());
+        assert_eq!(
+            inputs.download_names,
+            vec!["nx".to_string(), "react".to_string(), "vite".to_string()],
+        );
+    }
+
+    #[test]
+    fn registry_bound_inputs_version_alias_checks_real_package() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let inputs =
+            registry_bound_inputs_for_supply_chain(tmp.path(), &["nx-stable@npm:nx@23.0.0".into()]);
+
+        assert_eq!(
+            inputs.exact_advisory_pairs,
+            vec![("nx".to_string(), "23.0.0".to_string())],
+        );
+        assert_eq!(inputs.download_names, vec!["nx".to_string()]);
+    }
 }

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -20,7 +20,7 @@
 //! checks because the public-registry signal doesn't apply. Names
 //! whose resolved registry isn't `registry.npmjs.org` (per
 //! `NpmConfig::is_public_npmjs`) are filtered out upstream in
-//! `registry_bound_names_for_supply_chain`.
+//! `registry_bound_inputs_for_supply_chain`.
 
 use aube_codes::errors::{
     ERR_AUBE_ADVISORY_CHECK_FAILED, ERR_AUBE_LOW_DOWNLOAD_PACKAGE, ERR_AUBE_MALICIOUS_PACKAGE,
@@ -104,7 +104,13 @@ pub async fn run_gates(
         }
     };
     osv_gate(&client, name_only_advisory_names, advisory_check).await?;
-    osv_gate_versioned(&client, exact_advisory_pairs, advisory_check).await?;
+    osv_gate_versioned(
+        &client,
+        exact_advisory_pairs,
+        advisory_check,
+        "refusing to add malicious package(s):",
+    )
+    .await?;
     if !allow_low_downloads && low_download_threshold > 0 {
         let patterns = compile_allowed_unpopular(allowed_unpopular_globs);
         let gated: Vec<String> = download_names
@@ -216,7 +222,13 @@ pub async fn run_transitive_osv_gate(
             return Ok(());
         }
     };
-    osv_gate_versioned(&client, &pairs, policy).await
+    osv_gate_versioned(
+        &client,
+        &pairs,
+        policy,
+        "refusing to install malicious package(s):",
+    )
+    .await
 }
 
 /// Mirror-backed transitive OSV `MAL-*` check for plain reinstalls.
@@ -460,8 +472,14 @@ pub async fn run_transitive_osv_gate_via_bloom(
     // `advisoryCheck` — `osv_gate_versioned_with_bypass` threads
     // that setting name through to the `ERR_AUBE_MALICIOUS_PACKAGE`
     // footer and the required-failure message.
-    osv_gate_versioned_with_bypass(&live_client, &bloom_hits, live_policy, "advisoryBloomCheck")
-        .await
+    osv_gate_versioned_with_bypass(
+        &live_client,
+        &bloom_hits,
+        live_policy,
+        "refusing to install malicious package(s):",
+        "advisoryBloomCheck",
+    )
+    .await
 }
 
 /// True when the resolved graph contains at least one
@@ -510,7 +528,7 @@ pub fn lockfile_has_new_picks(
 
 /// Distinct public-npmjs `(registry_name, version)` pairs in
 /// `graph`, filtered to match the CLI-name gate's
-/// `registry_bound_names_for_supply_chain` shape so a scoped
+/// `registry_bound_inputs_for_supply_chain` shape so a scoped
 /// registry override (`@myorg:registry=...`) or a swapped default
 /// registry doesn't ship internal package names to OSV. Workspace /
 /// `link:` / `file:` entries drop out via
@@ -576,8 +594,9 @@ async fn osv_gate_versioned(
     client: &reqwest::Client,
     pairs: &[(String, String)],
     policy: AdvisoryCheck,
+    refusal_header: &str,
 ) -> miette::Result<()> {
-    osv_gate_versioned_with_bypass(client, pairs, policy, "advisoryCheck").await
+    osv_gate_versioned_with_bypass(client, pairs, policy, refusal_header, "advisoryCheck").await
 }
 
 /// Versioned-OSV gate with an overridable bypass-setting name.
@@ -590,6 +609,7 @@ async fn osv_gate_versioned_with_bypass(
     client: &reqwest::Client,
     pairs: &[(String, String)],
     policy: AdvisoryCheck,
+    refusal_header: &str,
     bypass_setting: &str,
 ) -> miette::Result<()> {
     if matches!(policy, AdvisoryCheck::Off) {
@@ -598,7 +618,7 @@ async fn osv_gate_versioned_with_bypass(
     handle_osv_result(
         fetch_malicious_advisories_versioned(client, pairs).await,
         policy,
-        "refusing to install malicious package(s):",
+        refusal_header,
         bypass_setting,
     )
 }
@@ -932,6 +952,25 @@ mod tests {
         assert!(msg.contains("- evil ("), "name-only hit keeps bare name");
         assert!(msg.starts_with("header:"));
         assert!(msg.ends_with("footer."));
+    }
+
+    #[test]
+    fn add_exact_pin_refusal_uses_add_header() {
+        let err = handle_osv_result(
+            Ok(vec![MaliciousAdvisory {
+                package: "nx".to_string(),
+                advisory_id: "MAL-2025-41443".to_string(),
+                version: Some("20.9.0".to_string()),
+            }]),
+            AdvisoryCheck::On,
+            "refusing to add malicious package(s):",
+            "advisoryCheck",
+        )
+        .expect_err("malicious hit should fail");
+        let rendered = err.to_string();
+        assert!(rendered.contains("refusing to add malicious package(s):"));
+        assert!(!rendered.contains("refusing to install malicious package(s):"));
+        assert!(rendered.contains("nx@20.9.0"));
     }
 
     #[test]

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -39,10 +39,12 @@ use aube_settings::resolved::{AdvisoryBloomCheck, AdvisoryCheck, AdvisoryCheckOn
 use miette::miette;
 use std::io::{BufRead, IsTerminal, Write};
 
-/// Run both supply-chain gates against the registry-bound names the
-/// user passed to `aube add`. `names` should already be filtered to
-/// names that resolve via the public npm registry — workspace, git,
-/// and local specs are not in scope.
+/// Run both supply-chain gates against the registry-bound specs the
+/// user passed to `aube add`. Inputs should already be filtered to
+/// packages that resolve via the public npm registry — workspace, git,
+/// and local specs are not in scope. Exact pins can use OSV's
+/// version-aware query; ranges and dist-tags stay on the name-only
+/// query until the resolver picks a concrete version.
 ///
 /// `allow_low_downloads` is the per-invocation `--allow-low-downloads`
 /// override; when `true` the download gate is skipped entirely (the
@@ -51,16 +53,21 @@ use std::io::{BufRead, IsTerminal, Write};
 /// `allowed_unpopular_globs` are the `allowedUnpopularPackages`
 /// setting entries: full-name globs that exempt matching names from
 /// the downloads gate only. The advisory check still runs against
-/// every name regardless — exempting confirmed-malicious advisories
+/// every package regardless — exempting confirmed-malicious advisories
 /// is not what this list is for.
 pub async fn run_gates(
-    names: &[String],
+    name_only_advisory_names: &[String],
+    exact_advisory_pairs: &[(String, String)],
+    download_names: &[String],
     advisory_check: AdvisoryCheck,
     low_download_threshold: u64,
     allow_low_downloads: bool,
     allowed_unpopular_globs: &[String],
 ) -> miette::Result<()> {
-    if names.is_empty() {
+    if name_only_advisory_names.is_empty()
+        && exact_advisory_pairs.is_empty()
+        && download_names.is_empty()
+    {
         return Ok(());
     }
     // One client shared across both gates and every per-package
@@ -96,10 +103,11 @@ pub async fn run_gates(
             return Ok(());
         }
     };
-    osv_gate(&client, names, advisory_check).await?;
+    osv_gate(&client, name_only_advisory_names, advisory_check).await?;
+    osv_gate_versioned(&client, exact_advisory_pairs, advisory_check).await?;
     if !allow_low_downloads && low_download_threshold > 0 {
         let patterns = compile_allowed_unpopular(allowed_unpopular_globs);
-        let gated: Vec<String> = names
+        let gated: Vec<String> = download_names
             .iter()
             .filter(|n| !patterns.iter().any(|p| p.matches(n)))
             .cloned()
@@ -778,7 +786,7 @@ mod tests {
         // registry-name list. The function must be a no-op in that
         // case (no network, no error) so those code paths stay free.
         assert!(
-            run_gates(&[], AdvisoryCheck::Required, 1000, false, &[])
+            run_gates(&[], &[], &[], AdvisoryCheck::Required, 1000, false, &[])
                 .await
                 .is_ok()
         );


### PR DESCRIPTION
## Summary
- Route exact `aube add` pins such as `nx@23.0.0` through OSV's version-aware query instead of the name-only malicious-package gate.
- Keep ranges and dist-tags on the existing name-only pre-resolve check, and keep download-count checks name-based.
- Add focused tests for exact pins, ranges/tags, and npm aliases.

## Root Cause
The pre-resolve `aube add` supply-chain gate only queried OSV by package name. For advisories like `MAL-2025-41443`, OSV flags `nx` name-only but does not flag unaffected concrete versions such as `nx@23.0.0`, causing global installs from mise to fail unless users disabled advisory checks entirely.

## Validation
- `cargo fmt --check`
- `cargo test -p aube supply_chain`
- `cargo clippy -p aube --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-add malicious-package blocking logic and OSV query shape; incorrect exact-version detection could miss or over-block installs, but scope is limited to `aube add` supply-chain gates with added test coverage.
> 
> **Overview**
> Fixes false blocks on **`aube add`** when OSV has a **name-level** `MAL-*` hit but the user pins a **safe concrete version** (e.g. `nx@23.0.0`).
> 
> Pre-resolve supply-chain input is split into **name-only** advisory names, **exact `(name, version)`** pairs, and **download** names. Full semver pins (including via `npm:` aliases) go through **`fetch_malicious_advisories_versioned`**; ranges, tags, and bare names stay on the name-only OSV query. Download checks remain name-based.
> 
> **`run_gates`** now runs both advisory paths and threads a **`refusal_header`** so add-time failures say *refusing to add* while install/bloom paths keep *refusing to install*. Unit tests cover classification, `is_full_exact_version`, and the add header on exact-pin refusals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28da435ee796de4f6494be48c2726690886dbe28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved supply chain vulnerability gating by splitting advisory checks into name-only lookups, exact version pair checks, and weekly-download probing.
  * Added accurate “full exact version” detection so explicit semver ranges are handled as exact pins, with results sorted and deduplicated.
  * Updated low-download gating and refined refusal messaging to clearly reflect the “add” context.
* **Tests**
  * Added unit tests covering exact-version classification, allow/reject behavior, alias resolution, and the “refusing to add malicious package(s):” header for exact-pin flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->