### PR TITLE
feat(sbom): mark dev-only CycloneDX components

### DIFF
--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -57,7 +57,7 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
 
     let json = match args.format {
         SbomFormat::Cyclonedx => {
-            let dev_only = collect_dev_only_packages(&graph, graph.root_deps());
+            let dev_only = collect_dev_only_packages(&graph, graph.importers.values().flatten());
             render_cyclonedx(&manifest, &closure, &dev_only)?
         }
         SbomFormat::Spdx => render_spdx(&manifest, &graph, filter, &closure)?,
@@ -138,10 +138,13 @@ fn render_cyclonedx(
         .wrap_err("failed to serialize CycloneDX SBOM")
 }
 
-fn collect_dev_only_packages(graph: &LockfileGraph, roots: &[DirectDep]) -> BTreeMap<String, bool> {
+fn collect_dev_only_packages<'a>(
+    graph: &LockfileGraph,
+    roots: impl IntoIterator<Item = &'a DirectDep>,
+) -> BTreeMap<String, bool> {
     let mut out = BTreeMap::new();
     let mut stack: Vec<(String, bool)> = roots
-        .iter()
+        .into_iter()
         .map(|d| (d.dep_path.clone(), matches!(d.dep_type, DepType::Dev)))
         .collect();
 
@@ -435,6 +438,41 @@ mod tests {
         let runtime = collect_dev_only_packages(&graph, &roots);
         assert_eq!(runtime.get("a@1.0.0"), Some(&false));
         assert_eq!(runtime.get("b@1.0.0"), Some(&false));
+    }
+
+    #[test]
+    fn collect_dev_only_packages_uses_all_workspace_importers() {
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            "shared@1.0.0".into(),
+            LockedPackage {
+                name: "shared".into(),
+                version: "1.0.0".into(),
+                dep_path: "shared@1.0.0".into(),
+                ..Default::default()
+            },
+        );
+        graph.importers.insert(
+            ".".into(),
+            vec![DirectDep {
+                name: "shared".into(),
+                dep_path: "shared@1.0.0".into(),
+                dep_type: DepType::Dev,
+                specifier: None,
+            }],
+        );
+        graph.importers.insert(
+            "packages/app".into(),
+            vec![DirectDep {
+                name: "shared".into(),
+                dep_path: "shared@1.0.0".into(),
+                dep_type: DepType::Production,
+                specifier: None,
+            }],
+        );
+
+        let dev_only = collect_dev_only_packages(&graph, graph.importers.values().flatten());
+        assert_eq!(dev_only.get("shared@1.0.0"), Some(&false));
     }
 
     #[test]

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -5,7 +5,7 @@
 //! 1.5 JSON or SPDX 2.3 JSON. Pure read; does not touch `node_modules/` or
 //! take the project lock.
 
-use aube_lockfile::{LockedPackage, LockfileGraph};
+use aube_lockfile::{DepType, DirectDep, LockedPackage, LockfileGraph};
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use std::collections::BTreeMap;
@@ -56,7 +56,10 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
     let closure = super::collect_dep_closure(&graph, filter, false);
 
     let json = match args.format {
-        SbomFormat::Cyclonedx => render_cyclonedx(&manifest, &closure)?,
+        SbomFormat::Cyclonedx => {
+            let dev_only = collect_dev_only_packages(&graph, graph.root_deps());
+            render_cyclonedx(&manifest, &closure, &dev_only)?
+        }
         SbomFormat::Spdx => render_spdx(&manifest, &graph, filter, &closure)?,
     };
 
@@ -68,6 +71,7 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
 fn render_cyclonedx(
     manifest: &aube_manifest::PackageJson,
     closure: &BTreeMap<String, &LockedPackage>,
+    dev_only: &BTreeMap<String, bool>,
 ) -> miette::Result<String> {
     let root_name = manifest.name.clone().unwrap_or_else(|| "(unnamed)".into());
     let root_version = manifest.version.clone().unwrap_or_default();
@@ -81,6 +85,16 @@ fn render_cyclonedx(
         c.insert("name".into(), pkg.name.clone().into());
         c.insert("version".into(), pkg.version.clone().into());
         c.insert("purl".into(), purl(&pkg.name, &pkg.version).into());
+        if dev_only.get(dep_path).copied().unwrap_or(false) {
+            c.insert("scope".into(), "excluded".into());
+            c.insert(
+                "properties".into(),
+                serde_json::json!([{
+                    "name": "cdx:npm:package:development",
+                    "value": "true",
+                }]),
+            );
+        }
         components.push(serde_json::Value::Object(c));
     }
 
@@ -122,6 +136,33 @@ fn render_cyclonedx(
     serde_json::to_string_pretty(&bom)
         .into_diagnostic()
         .wrap_err("failed to serialize CycloneDX SBOM")
+}
+
+fn collect_dev_only_packages(graph: &LockfileGraph, roots: &[DirectDep]) -> BTreeMap<String, bool> {
+    let mut out = BTreeMap::new();
+    let mut stack: Vec<(String, bool)> = roots
+        .iter()
+        .map(|d| (d.dep_path.clone(), matches!(d.dep_type, DepType::Dev)))
+        .collect();
+
+    while let Some((dep_path, dev_only)) = stack.pop() {
+        if matches!(out.get(&dep_path), Some(false)) {
+            continue;
+        }
+        let was_runtime = out.insert(dep_path.clone(), dev_only) == Some(false);
+        if was_runtime {
+            continue;
+        }
+
+        let Some(pkg) = graph.get_package(&dep_path) else {
+            continue;
+        };
+        for (name, version) in &pkg.dependencies {
+            stack.push((format!("{name}@{version}"), dev_only));
+        }
+    }
+
+    out
 }
 
 /// SPDX 2.3 JSON. See https://spdx.github.io/spdx-spec/v2.3/.

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -146,12 +146,12 @@ fn collect_dev_only_packages(graph: &LockfileGraph, roots: &[DirectDep]) -> BTre
         .collect();
 
     while let Some((dep_path, dev_only)) = stack.pop() {
-        if matches!(out.get(&dep_path), Some(false)) {
-            continue;
-        }
-        let was_runtime = out.insert(dep_path.clone(), dev_only) == Some(false);
-        if was_runtime {
-            continue;
+        match out.get(&dep_path).copied() {
+            Some(false) => continue,
+            Some(true) if dev_only => continue,
+            _ => {
+                out.insert(dep_path.clone(), dev_only);
+            }
         }
 
         let Some(pkg) = graph.get_package(&dep_path) else {
@@ -382,6 +382,59 @@ mod tests {
     #[test]
     fn sanitize_spdx_id_strips_unsafe() {
         assert_eq!(sanitize_spdx_id("@babel/core@7.0.0"), "-babel-core-7.0.0");
+    }
+
+    #[test]
+    fn collect_dev_only_packages_handles_cycles_and_runtime_downgrade() {
+        let mut graph = LockfileGraph::default();
+        graph.packages.insert(
+            "a@1.0.0".into(),
+            LockedPackage {
+                name: "a".into(),
+                version: "1.0.0".into(),
+                dep_path: "a@1.0.0".into(),
+                dependencies: BTreeMap::from([("b".into(), "1.0.0".into())]),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "b@1.0.0".into(),
+            LockedPackage {
+                name: "b".into(),
+                version: "1.0.0".into(),
+                dep_path: "b@1.0.0".into(),
+                dependencies: BTreeMap::from([("a".into(), "1.0.0".into())]),
+                ..Default::default()
+            },
+        );
+
+        let roots = vec![DirectDep {
+            name: "a".into(),
+            dep_path: "a@1.0.0".into(),
+            dep_type: DepType::Dev,
+            specifier: None,
+        }];
+        let dev_only = collect_dev_only_packages(&graph, &roots);
+        assert_eq!(dev_only.get("a@1.0.0"), Some(&true));
+        assert_eq!(dev_only.get("b@1.0.0"), Some(&true));
+
+        let roots = vec![
+            DirectDep {
+                name: "a".into(),
+                dep_path: "a@1.0.0".into(),
+                dep_type: DepType::Dev,
+                specifier: None,
+            },
+            DirectDep {
+                name: "b".into(),
+                dep_path: "b@1.0.0".into(),
+                dep_type: DepType::Production,
+                specifier: None,
+            },
+        ];
+        let runtime = collect_dev_only_packages(&graph, &roots);
+        assert_eq!(runtime.get("a@1.0.0"), Some(&false));
+        assert_eq!(runtime.get("b@1.0.0"), Some(&false));
     }
 
     #[test]

--- a/test/sbom.bats
+++ b/test/sbom.bats
@@ -63,7 +63,19 @@ JSON
 	run aube sbom --dev
 	assert_success
 	assert_output --partial '"pkg:npm/is-number@7.0.0"'
+	assert_output --partial '"scope": "excluded"'
+	assert_output --partial '"cdx:npm:package:development"'
 	refute_output --partial 'is-odd@3.0.1'
+}
+
+@test "aube sbom marks only dev-only CycloneDX components as excluded" {
+	_setup_mixed_fixture
+	run bash -c 'aube sbom | jq -e "
+	  any(.components[]; .name == \"is-number\" and .scope == \"excluded\" and any(.properties[]?; .name == \"cdx:npm:package:development\" and .value == \"true\"))
+	  and
+	  any(.components[]; .name == \"is-odd\" and (.scope // \"required\") == \"required\")
+	"'
+	assert_success
 }
 
 @test "aube sbom without a lockfile errors out" {


### PR DESCRIPTION
## Summary
- Mark CycloneDX components reachable only through devDependencies with `scope: excluded`
- Add the `cdx:npm:package:development` property for CycloneDX npm consumers
- Cover dev-only and runtime-reachable components with SBOM tests

## Validation
- `cargo fmt --check`
- `cargo build`
- `mise run test:bats test/sbom.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only SBOM serialization change with no install, auth, or runtime behavior impact; SPDX path untouched.
> 
> **Overview**
> **CycloneDX** output from `aube sbom` now labels packages that are reachable **only** through dev dependency edges (across all workspace importers) with `scope: "excluded"` and the `cdx:npm:package:development` property. Production-reachable packages stay unscoped / required.
> 
> A new **`collect_dev_only_packages`** walk seeds from every importer’s direct deps, propagates a dev-only flag down the graph, and **downgrades** a package to non–dev-only when any root path is production (including cycles and the same package linked as dev in one workspace and prod in another). **SPDX** rendering is unchanged.
> 
> Coverage adds unit tests for cycles, runtime downgrade, and multi-importer behavior, plus Bats checks that dev-only vs prod components get the right CycloneDX fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71292503f89f8b96c5f25dbc625ad314e329ea6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `aube sbom` now correctly identifies and marks development-only packages in CycloneDX output, marking them as excluded and flagged as development packages for improved clarity in software bill of materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->