### PR TITLE
feat(install): add dry-run resolution preview

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -874,6 +874,7 @@ cmd install help="Install all dependencies" {
     flag --dangerously-allow-all-builds help="Allow every dependency's lifecycle scripts to run" {
         long_help "Allow every dependency's lifecycle scripts to run.\n\nBypasses the `allowBuilds` allowlist. Do not use in CI."
     }
+    flag --dry-run help="Resolve and report what would happen without writing the lockfile or linking node_modules"
     flag --fix-lockfile help="Re-resolve lockfile entries whose spec drifted from package.json" {
         long_help "Re-resolve lockfile entries whose spec drifted from package.json.\n\nLeaves everything else pinned at its locked version. Unchanged specs keep their existing version and integrity hash; only drifted entries (and any new transitives they pull in) get re-resolved."
     }

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -70,6 +70,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         pnpmfile: None,
         global_pnpmfile: None,
         ignore_scripts,
+        dry_run: false,
         lockfile_only: false,
         merge_git_branch_lockfiles: false,
         dangerously_allow_all_builds: false,

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -321,6 +321,7 @@ pub async fn run(
             pnpmfile: None,
             global_pnpmfile: None,
             ignore_scripts: false,
+            dry_run: false,
             lockfile_only: false,
             merge_git_branch_lockfiles: false,
             dangerously_allow_all_builds: false,

--- a/crates/aube/src/commands/install/args.rs
+++ b/crates/aube/src/commands/install/args.rs
@@ -13,6 +13,10 @@ pub struct InstallArgs {
     /// Bypasses the `allowBuilds` allowlist. Do not use in CI.
     #[arg(long)]
     pub dangerously_allow_all_builds: bool,
+    /// Resolve and report what would happen without writing the lockfile
+    /// or linking node_modules.
+    #[arg(long, conflicts_with = "lockfile_only")]
+    pub dry_run: bool,
     /// Re-resolve lockfile entries whose spec drifted from package.json.
     ///
     /// Leaves everything else pinned at its locked version. Unchanged
@@ -28,10 +32,6 @@ pub struct InstallArgs {
     /// pnpm's `install --force`.
     #[arg(long)]
     pub force: bool,
-    /// Resolve and report what would happen without writing the lockfile
-    /// or linking node_modules.
-    #[arg(long, conflicts_with = "lockfile_only")]
-    pub dry_run: bool,
     /// Add a global pnpmfile that runs before the local one.
     ///
     /// Mirrors pnpm's `--global-pnpmfile <path>`. Relative paths

--- a/crates/aube/src/commands/install/args.rs
+++ b/crates/aube/src/commands/install/args.rs
@@ -28,6 +28,10 @@ pub struct InstallArgs {
     /// pnpm's `install --force`.
     #[arg(long)]
     pub force: bool,
+    /// Resolve and report what would happen without writing the lockfile
+    /// or linking node_modules.
+    #[arg(long, conflicts_with = "lockfile_only")]
+    pub dry_run: bool,
     /// Add a global pnpmfile that runs before the local one.
     ///
     /// Mirrors pnpm's `--global-pnpmfile <path>`. Relative paths
@@ -272,6 +276,7 @@ impl InstallArgs {
             pnpmfile: self.pnpmfile,
             global_pnpmfile: self.global_pnpmfile,
             ignore_scripts: self.ignore_scripts,
+            dry_run: self.dry_run,
             lockfile_only: self.lockfile_only,
             merge_git_branch_lockfiles: self.merge_git_branch_lockfiles,
             dangerously_allow_all_builds: self.dangerously_allow_all_builds,
@@ -328,6 +333,10 @@ pub struct InstallOptions {
     /// `install`, `postinstall`, `prepare`) *and* every dependency's
     /// lifecycle scripts, regardless of `allowBuilds`.
     pub ignore_scripts: bool,
+    /// `--dry-run`: resolve dependencies and report the planned lockfile
+    /// shape without writing lockfiles, node_modules, install state, or
+    /// lifecycle outputs.
+    pub dry_run: bool,
     /// `--lockfile-only`: resolve and write the lockfile, but skip
     /// linking `node_modules` and running lifecycle scripts. Useful
     /// for CI workflows that only need to refresh the lockfile.
@@ -439,6 +448,7 @@ impl InstallOptions {
             pnpmfile: None,
             global_pnpmfile: None,
             ignore_scripts: false,
+            dry_run: false,
             lockfile_only: false,
             merge_git_branch_lockfiles: false,
             dangerously_allow_all_builds: false,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -165,8 +165,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     aube_util::diag::instant(aube_util::diag::Category::Install, "begin", None);
     let _diag_install = aube_util::diag::Span::new(aube_util::diag::Category::Install, "total");
 
-    apply_force_state_reset(&cwd, &opts)?;
-    if try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd)) {
+    if !opts.dry_run {
+        apply_force_state_reset(&cwd, &opts)?;
+    }
+    if !opts.dry_run
+        && try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))
+    {
         return Ok(());
     }
 
@@ -232,17 +236,19 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         &cwd,
         &manifest,
         &settings_ctx,
-        opts.lockfile_only,
+        opts.lockfile_only || opts.dry_run,
         opts.strict_no_lockfile,
     )?;
 
-    merge_branch_lockfiles_if_needed(
-        &cwd,
-        &manifest,
-        &settings_ctx,
-        lockfile_enabled,
-        opts.merge_git_branch_lockfiles,
-    )?;
+    if !opts.dry_run {
+        merge_branch_lockfiles_if_needed(
+            &cwd,
+            &manifest,
+            &settings_ctx,
+            lockfile_enabled,
+            opts.merge_git_branch_lockfiles,
+        )?;
+    }
 
     // Resolve the install-wide networking / integrity knobs once up
     // front so every downstream fetch site (the lockfile path, the
@@ -335,7 +341,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     //     that will be linked, matching pnpm's recursive install
     //     behavior. Runs before the progress UI starts so script output
     //     cannot collide with the progress display.
-    if !opts.ignore_scripts && !lockfile_only_effective && !opts.skip_root_lifecycle {
+    if !opts.dry_run
+        && !opts.ignore_scripts
+        && !lockfile_only_effective
+        && !opts.skip_root_lifecycle
+    {
         let phase_start = std::time::Instant::now();
         for (importer_path, importer_manifest) in &lifecycle_manifests {
             let project_dir = importer_project_dir(&cwd, importer_path);
@@ -456,6 +466,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             minimum_release_age_override: opts.minimum_release_age_override,
             ws_package_versions: &ws_package_versions,
             ignore_scripts: opts.ignore_scripts,
+            write_lockfile: !opts.dry_run,
             prog_ref,
         })
         .await?;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -443,7 +443,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // and report path without writing the lockfile; unlike
     // `--lockfile-only`, explicit frozen mode still validates drift.
     if lockfile_only_effective || opts.dry_run {
-        if opts.dry_run && matches!(mode, FrozenMode::Frozen) {
+        if opts.dry_run && opts.strict_no_lockfile && matches!(mode, FrozenMode::Frozen) {
             match resolve::select_lockfile_result(resolve::SelectLockfileInput {
                 lockfile_enabled,
                 mode,
@@ -458,7 +458,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 lockfile_pre_parse: lockfile_pre_parse.as_ref(),
             })? {
                 Ok(_) => {}
-                Err(aube_lockfile::Error::NotFound(_)) if opts.strict_no_lockfile => {
+                Err(aube_lockfile::Error::NotFound(_)) => {
                     return Err(miette!(
                         "no lockfile found and --frozen-lockfile is set\n\
                          help: commit pnpm-lock.yaml to your repository, or run \
@@ -466,7 +466,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         aube_util::cmd("install")
                     ));
                 }
-                Err(aube_lockfile::Error::NotFound(_)) => {}
                 Err(e) => {
                     return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile");
                 }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -214,13 +214,15 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     if opts.network_mode == aube_registry::NetworkMode::Offline {
         runtime_settings.network = aube_runtime::NetworkMode::Offline;
     }
-    crate::runtime::ensure(
-        &cwd,
-        Some(&manifest),
-        runtime_settings,
-        crate::runtime::lockfile_node_pin(&cwd, &manifest).as_ref(),
-    )
-    .await?;
+    if !opts.dry_run {
+        crate::runtime::ensure(
+            &cwd,
+            Some(&manifest),
+            runtime_settings,
+            crate::runtime::lockfile_node_pin(&cwd, &manifest).as_ref(),
+        )
+        .await?;
+    }
     super::configure_script_settings(&settings_ctx, Some("install"));
 
     let layout::InstallLayoutConfig {
@@ -236,7 +238,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         &cwd,
         &manifest,
         &settings_ctx,
-        opts.lockfile_only || opts.dry_run,
+        opts.lockfile_only,
         opts.strict_no_lockfile,
     )?;
 
@@ -431,14 +433,44 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
 
     // `--lockfile-only` short-circuit. Resolves (or reuses a fresh
     // lockfile), writes the new lockfile, and exits before any tarball
-    // fetch / link / lifecycle work. Runs *before* the FrozenMode
-    // match so it bypasses drift hard-errors entirely — pnpm's
-    // `--lockfile-only` regenerates regardless of frozen mode, and
-    // we'd otherwise be preempted by the auto-CI Frozen default.
+    // fetch / link / lifecycle work. Runs *before* the FrozenMode match
+    // so lockfile-only bypasses drift hard-errors entirely — pnpm's
+    // `--lockfile-only` regenerates regardless of frozen mode, and we'd
+    // otherwise be preempted by the auto-CI Frozen default.
     // `enableModulesDir=false` follows the same short-circuit so
     // projects that persistently disable node_modules materialization
-    // share the exact same control flow.
-    if lockfile_only_effective {
+    // share the exact same control flow. `--dry-run` reuses the resolve
+    // and report path without writing the lockfile; unlike
+    // `--lockfile-only`, explicit frozen mode still validates drift.
+    if lockfile_only_effective || opts.dry_run {
+        if opts.dry_run && matches!(mode, FrozenMode::Frozen) {
+            match resolve::select_lockfile_result(resolve::SelectLockfileInput {
+                lockfile_enabled,
+                mode,
+                cwd: &cwd,
+                lockfile_dir: &lockfile_dir,
+                lockfile_importer_key: &lockfile_importer_key,
+                manifest: &manifest,
+                manifests: &manifests,
+                ws_config: &ws_config_shared,
+                workspace_catalogs: &workspace_catalogs,
+                is_workspace_project,
+                lockfile_pre_parse: lockfile_pre_parse.as_ref(),
+            })? {
+                Ok(_) => {}
+                Err(aube_lockfile::Error::NotFound(_)) => {
+                    return Err(miette!(
+                        "no lockfile found and --frozen-lockfile is set\n\
+                         help: commit pnpm-lock.yaml to your repository, or run \
+                         `{} --no-frozen-lockfile` to generate one",
+                        aube_util::cmd("install")
+                    ));
+                }
+                Err(e) => {
+                    return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile");
+                }
+            }
+        }
         resolve::run_lockfile_only(resolve::LockfileOnlyInput {
             cwd: &cwd,
             mode,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -458,7 +458,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 lockfile_pre_parse: lockfile_pre_parse.as_ref(),
             })? {
                 Ok(_) => {}
-                Err(aube_lockfile::Error::NotFound(_)) => {
+                Err(aube_lockfile::Error::NotFound(_)) if opts.strict_no_lockfile => {
                     return Err(miette!(
                         "no lockfile found and --frozen-lockfile is set\n\
                          help: commit pnpm-lock.yaml to your repository, or run \
@@ -466,6 +466,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         aube_util::cmd("install")
                     ));
                 }
+                Err(aube_lockfile::Error::NotFound(_)) => {}
                 Err(e) => {
                     return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile");
                 }

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -177,6 +177,12 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         if let Some(p) = prog_ref {
             p.finish(true);
         }
+        if !write_lockfile {
+            eprintln!(
+                "Dry run: lockfile is up to date; fetch/link steps were not run and node_modules were not modified"
+            );
+            return Ok(());
+        }
         eprintln!("Lockfile is up to date, resolution step is skipped");
         return Ok(());
     }

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -62,6 +62,7 @@ pub(super) struct LockfileOnlyInput<'a> {
     pub minimum_release_age_override: Option<u64>,
     pub ws_package_versions: &'a HashMap<String, String>,
     pub ignore_scripts: bool,
+    pub write_lockfile: bool,
     pub prog_ref: Option<&'a InstallProgress>,
 }
 
@@ -93,6 +94,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         minimum_release_age_override,
         ws_package_versions,
         ignore_scripts,
+        write_lockfile,
         prog_ref,
     } = input;
 
@@ -292,6 +294,16 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
     // (`optional: true`, `transitivePeerDependencies`) so `--lockfile-only`
     // output stays byte-identical to a regular install.
     crate::commands::prepare_resolved_graph_for_lockfile_write(&mut graph);
+    if !write_lockfile {
+        if let Some(p) = prog_ref {
+            p.finish(true);
+        }
+        eprintln!(
+            "Dry run: resolved {} package(s); lockfile and node_modules were not modified",
+            graph.packages.len()
+        );
+        return Ok(());
+    }
     if shared_workspace_lockfile || !has_workspace {
         let lo_written = write_lockfile_dir_remapped(
             lockfile_dir,

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4842,6 +4842,18 @@
             "global": false
           },
           {
+            "name": "dry-run",
+            "usage": "--dry-run",
+            "help": "Resolve and report what would happen without writing the lockfile or linking node_modules",
+            "help_first_line": "Resolve and report what would happen without writing the lockfile or linking node_modules",
+            "short": [],
+            "long": [
+              "dry-run"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "fix-lockfile",
             "usage": "--fix-lockfile",
             "help": "Re-resolve lockfile entries whose spec drifted from package.json",

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -21,6 +21,10 @@ Allow every dependency's lifecycle scripts to run.
 
 Bypasses the `allowBuilds` allowlist. Do not use in CI.
 
+### `--dry-run`
+
+Resolve and report what would happen without writing the lockfile or linking node_modules
+
 ### `--fix-lockfile`
 
 Re-resolve lockfile entries whose spec drifted from package.json.

--- a/test/install.bats
+++ b/test/install.bats
@@ -917,6 +917,15 @@ JSON
 	assert [ ! -e node_modules ]
 }
 
+@test "aube install --dry-run resolves without writing lockfile or node_modules" {
+	echo '{"name":"test","version":"1.0.0","dependencies":{"is-odd":"^3.0.1"}}' >package.json
+	run aube install --dry-run
+	assert_success
+	assert_output --partial "Dry run: resolved"
+	assert [ ! -e aube-lock.yaml ]
+	assert [ ! -e node_modules ]
+}
+
 @test "aube install --lockfile-only is a no-op when lockfile is fresh" {
 	_setup_basic_fixture
 	# Lockfile already exists in fixture; --lockfile-only should detect

--- a/test/install.bats
+++ b/test/install.bats
@@ -944,6 +944,21 @@ JSON
 	assert [ ! -e node_modules ]
 }
 
+@test "aube install --dry-run in CI resolves drifted lockfile" {
+	_setup_basic_fixture
+	node -e '
+		const fs = require("fs");
+		const pkg = JSON.parse(fs.readFileSync("package.json"));
+		pkg.dependencies["is-number"] = "^7.0.0";
+		fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));
+	'
+	CI=1 run aube install --dry-run
+	assert_success
+	assert_output --partial "Dry run: resolved"
+	refute_output --partial "lockfile is out of date"
+	assert [ ! -e node_modules ]
+}
+
 @test "aube install --dry-run with fresh lockfile still reports skipped fetch and link" {
 	_setup_basic_fixture
 	rm -rf node_modules

--- a/test/install.bats
+++ b/test/install.bats
@@ -944,6 +944,17 @@ JSON
 	assert [ ! -e node_modules ]
 }
 
+@test "aube install --dry-run with fresh lockfile still reports skipped fetch and link" {
+	_setup_basic_fixture
+	rm -rf node_modules
+	run aube install --dry-run
+	assert_success
+	assert_output --partial "Dry run: lockfile is up to date"
+	assert_output --partial "fetch/link steps were not run"
+	refute_output --partial "resolution step is skipped"
+	assert [ ! -e node_modules ]
+}
+
 @test "aube install --lockfile-only is a no-op when lockfile is fresh" {
 	_setup_basic_fixture
 	# Lockfile already exists in fixture; --lockfile-only should detect

--- a/test/install.bats
+++ b/test/install.bats
@@ -926,6 +926,15 @@ JSON
 	assert [ ! -e node_modules ]
 }
 
+@test "aube install --dry-run --frozen-lockfile fails without lockfile" {
+	echo '{"name":"test","version":"1.0.0","dependencies":{"is-odd":"^3.0.1"}}' >package.json
+	run aube install --dry-run --frozen-lockfile
+	assert_failure
+	assert_output --partial "no lockfile found and --frozen-lockfile is set"
+	assert [ ! -e aube-lock.yaml ]
+	assert [ ! -e node_modules ]
+}
+
 @test "aube install --lockfile-only is a no-op when lockfile is fresh" {
 	_setup_basic_fixture
 	# Lockfile already exists in fixture; --lockfile-only should detect

--- a/test/install.bats
+++ b/test/install.bats
@@ -935,6 +935,15 @@ JSON
 	assert [ ! -e node_modules ]
 }
 
+@test "aube install --dry-run in CI resolves without lockfile" {
+	echo '{"name":"test","version":"1.0.0","dependencies":{"is-odd":"^3.0.1"}}' >package.json
+	CI=1 run aube install --dry-run
+	assert_success
+	assert_output --partial "Dry run: resolved"
+	assert [ ! -e aube-lock.yaml ]
+	assert [ ! -e node_modules ]
+}
+
 @test "aube install --lockfile-only is a no-op when lockfile is fresh" {
 	_setup_basic_fixture
 	# Lockfile already exists in fixture; --lockfile-only should detect

--- a/test/lockfile_settings.bats
+++ b/test/lockfile_settings.bats
@@ -80,6 +80,28 @@ teardown() {
 	assert_output --partial 'incompatible with lockfile=false'
 }
 
+@test "lockfile=false + --dry-run resolves without lockfile-only conflict" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-dry-run-no-lockfile",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "3.0.1" }
+		}
+	EOF
+	cat >>.npmrc <<-'EOF'
+
+		lockfile=false
+	EOF
+	run aube install --dry-run
+	assert_success
+	assert_output --partial "Dry run: resolved"
+	refute_output --partial "--lockfile-only is incompatible with lockfile=false"
+	run test -e aube-lock.yaml
+	assert_failure
+	run test -e node_modules
+	assert_failure
+}
+
 # `--frozen-lockfile` ("fail hard if the lockfile doesn't match") makes
 # no sense without a lockfile. Without this check the install falls
 # through to the catch-all Err(NotFound) arm and errors with the


### PR DESCRIPTION
## Summary
- Add `aube install --dry-run` as a no-write resolution preview
- Reuse the lockfile-only resolver path with lockfile writes disabled
- Skip install fast-path mutation, force state reset, branch-lockfile merge, lifecycle hooks, fetch, link, and finalize work in dry-run mode

## Validation
- `cargo build`
- `cargo fmt --check`
- `mise run test:bats test/install.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the central install command path and frozen/CI interaction semantics, but dry-run is explicitly no-write and is covered by new integration tests.
> 
> **Overview**
> Adds **`aube install --dry-run`** to resolve dependencies and print what would happen **without** writing the lockfile, linking `node_modules`, or running install side effects. The flag conflicts with `--lockfile-only` and is documented in CLI usage and install docs.
> 
> Dry-run threads through **`InstallOptions.dry_run`** and reuses the existing lockfile-only resolve path with **`write_lockfile: false`**. The main install flow skips force/state reset, the install fast path, Node runtime ensure, branch-lockfile merge, and root **`preinstall`** hooks when dry-run is set.
> 
> Behavior differs from **`--lockfile-only`** in a few ways: explicit **`--frozen-lockfile`** still fails when no lockfile exists (and validates drift before resolve), while CI-style dry-run can resolve without a lockfile or when the lockfile is drifted. When the lockfile is already fresh, output uses dry-run-specific messages instead of the lockfile-only “resolution step is skipped” line.
> 
> **`ci`** and **`deploy`** continue to pass **`dry_run: false`**. Bats coverage asserts no `aube-lock.yaml` / `node_modules` and checks frozen/CI/fresh-lockfile cases, including **`lockfile=false`** projects that can dry-run without the lockfile-only conflict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9427906acc13b13cf28b9b00e953734d63f275b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` to `aube install` to resolve and report planned changes without writing the lockfile, creating `node_modules`, or running lifecycle scripts.
* **Behavior Changes**
  * `--dry-run` is incompatible with `--lockfile-only`.
  * In frozen scenarios, dry-run validates lockfile constraints and fails with clear errors when a lockfile is required but missing; otherwise it reports an “up to date” outcome without applying changes.
* **Documentation**
  * Updated CLI help and `install` docs for `--dry-run`.
* **Tests**
  * Added Bats coverage to confirm no `aube-lock.yaml` or `node_modules` are created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->