### PR TITLE
fix(run): honor recursive no-bail exits

### DIFF
--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -113,6 +113,7 @@ pub async fn run(
             resume_from,
             workspace_concurrency,
             reporter_hide_prefix,
+            no_bail: false,
         };
         return run_filtered(&cwd, &bin, &args, shell_mode, parallel, &filter, recursive).await;
     }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -761,9 +761,9 @@ async fn run_filtered_parallel(
             // signaled `true` (= finished, regardless of outcome).
             // pnpm's default `--no-bail=false` aborts the whole run on
             // first failure anyway, so the "wait for failed dep too"
-            // case only fires under `--no-bail` (parsed but not yet
-            // wired) and degrades to "dependent runs against possibly
-            // stale dep state" — same as pnpm. A `changed()` Err means
+            // case only fires under `--no-bail` and degrades to
+            // "dependent runs against possibly stale dep state" — same
+            // as pnpm. A `changed()` Err means
             // the prereq's sender was dropped without sending (panic
             // or aborted JoinHandle); break so dependents unblock
             // instead of hanging — only reachable because each task

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -143,7 +143,7 @@ pub async fn run(
         inspect,
         inspect_brk,
         parallel,
-        no_bail: _,
+        no_bail,
         report_summary: _,
         reporter_hide_prefix,
         resume_from,
@@ -182,6 +182,7 @@ pub async fn run(
         resume_from,
         workspace_concurrency,
         reporter_hide_prefix,
+        no_bail,
     };
     run_script_with(
         &script, &args, &node_args, no_install, if_present, parallel, silent, &filter, recursive,
@@ -214,6 +215,10 @@ pub(crate) struct RecursiveOpts {
     /// a `<package>: ` prefix. Matches pnpm's `--reporter-hide-prefix`.
     /// Sequential runs ignore this — they always inherit stdio.
     pub reporter_hide_prefix: bool,
+    /// Continue sequential recursive runs after a script exits non-zero,
+    /// then return the first failing exit code after every matched package
+    /// has had a chance to run.
+    pub no_bail: bool,
 }
 
 impl Default for RecursiveOpts {
@@ -224,6 +229,7 @@ impl Default for RecursiveOpts {
             resume_from: None,
             workspace_concurrency: None,
             reporter_hide_prefix: false,
+            no_bail: false,
         }
     }
 }
@@ -504,6 +510,7 @@ async fn run_script_filtered(
         .await;
     }
 
+    let mut first_exit: Option<i32> = None;
     for pkg in &matched {
         let name = pkg
             .name
@@ -525,7 +532,10 @@ async fn run_script_filtered(
                 )
                 .await?
                 {
-                    return Ok(Some(code));
+                    if !recursive.no_bail {
+                        return Ok(Some(code));
+                    }
+                    first_exit.get_or_insert(code);
                 }
                 continue;
             }
@@ -550,10 +560,13 @@ async fn run_script_filtered(
         )
         .await?
         {
-            return Ok(Some(code));
+            if !recursive.no_bail {
+                return Ok(Some(code));
+            }
+            first_exit.get_or_insert(code);
         }
     }
-    Ok(None)
+    Ok(first_exit)
 }
 
 /// Apply topo sort, reverse, and resume-from to a matched-package list.

--- a/test/yaml_only_root.bats
+++ b/test/yaml_only_root.bats
@@ -75,6 +75,28 @@ _setup_yaml_only_workspace() {
 	assert_output --partial "hello-from-b"
 }
 
+@test "aube run -r --no-bail returns failure after running remaining members" {
+	_setup_yaml_only_workspace
+	node -e '
+		const fs = require("fs");
+		for (const name of ["a", "b"]) {
+			const path = `packages/${name}/package.json`;
+			const pkg = JSON.parse(fs.readFileSync(path));
+			pkg.scripts.check = name === "a"
+				? "node -e \"console.log(\\\"check-from-a\\\"); process.exit(7)\""
+				: "echo check-from-b";
+			fs.writeFileSync(path, JSON.stringify(pkg, null, 2));
+		}
+	'
+	run aube install
+	assert_success
+
+	run aube run -r --no-bail check
+	assert_failure
+	assert_output --partial "check-from-a"
+	assert_output --partial "check-from-b"
+}
+
 @test "aube query from yaml-only root matches sub-package deps" {
 	_setup_yaml_only_workspace
 	run aube install

--- a/test/yaml_only_root.bats
+++ b/test/yaml_only_root.bats
@@ -80,7 +80,7 @@ _setup_yaml_only_workspace() {
 	node -e '
 		const fs = require("fs");
 		for (const name of ["a", "b"]) {
-			const path = `packages/${name}/package.json`;
+			const path = "packages/" + name + "/package.json";
 			const pkg = JSON.parse(fs.readFileSync(path));
 			pkg.scripts.check = name === "a"
 				? "node -e \"console.log(\\\"check-from-a\\\"); process.exit(7)\""
@@ -93,6 +93,7 @@ _setup_yaml_only_workspace() {
 
 	run aube run -r --no-bail check
 	assert_failure
+	assert_equal "$status" 7
 	assert_output --partial "check-from-a"
 	assert_output --partial "check-from-b"
 }


### PR DESCRIPTION
## Summary
- Thread `--no-bail` into recursive run options
- Continue sequential recursive script fanout after non-zero child exits
- Return the first failing exit code after remaining matched packages run

## Validation
- `cargo build`
- `cargo fmt --check`
- `mise run test:bats test/yaml_only_root.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to sequential recursive `run` exit handling with default behavior unchanged; covered by a new integration test.
> 
> **Overview**
> **`aube run -r --no-bail`** now matches pnpm-style behavior for **sequential** recursive runs: a non-zero script or `.bin` fallback no longer stops the loop immediately; later matched packages still run, and the process exits with the **first** failing code once the fanout finishes.
> 
> The flag is threaded from `RunArgs` into `RecursiveOpts` (default `false`, so existing bail-on-first-failure behavior is unchanged). Parallel recursive runs were already finishing siblings and reporting the first failure; comments there are updated to reflect that `--no-bail` is wired for sequential paths.
> 
> `aube exec` only adds `no_bail: false` when building `RecursiveOpts` (the CLI flag is still ignored for filtered exec). A bats test asserts that after package `a` exits `7`, package `b` still runs and the command fails with status `7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5657573bfa83c6a9ae56a35279c497776f8564fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--no-bail` flag now works with recursive package operations, enabling continued execution across remaining packages when one fails instead of stopping at the first failure.

* **Tests**
  * Added test coverage for recursive `--no-bail` execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->