### PR TITLE
fix(install): validate trust policy on lockfile reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,9 +2586,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3298,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4603,7 +4603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -23,7 +23,10 @@ pub use peer_context::{
 };
 pub use platform::{SupportedArchitectures, is_supported};
 pub use primer::{PruneStats as PrimerPruneStats, prune_cache as prune_primer_cache};
-pub use trust::{MissingTimeDetails as MissingTrustTimeDetails, TrustDowngradeDetails};
+pub use trust::{
+    MissingTimeDetails as MissingTrustTimeDetails, TrustCheckError, TrustDowngradeDetails,
+    check_no_downgrade,
+};
 pub use trust::{TrustEvidence, TrustExcludeParseError, TrustExcludeRules};
 pub use types::{
     DependencyPolicy, MinimumReleaseAge, PackageExtension, ReadPackageHook, ResolutionMode,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -58,11 +58,11 @@ pub(crate) use settings::{ResolverConfigInputs, configure_resolver, finalize_loc
 pub(crate) use side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root};
 
 use settings::{
-    check_unmet_peers, default_streaming_network_concurrency, maybe_cleanup_unused_catalogs,
-    resolve_git_shallow_hosts, resolve_link_concurrency, resolve_network_concurrency,
-    resolve_side_effects_cache, resolve_side_effects_cache_readonly,
-    resolve_strict_peer_dependencies, resolve_strict_store_pkg_content_check,
-    resolve_verify_store_integrity,
+    check_unmet_peers, default_lockfile_network_concurrency, default_streaming_network_concurrency,
+    maybe_cleanup_unused_catalogs, resolve_dependency_policy, resolve_git_shallow_hosts,
+    resolve_link_concurrency, resolve_network_concurrency, resolve_side_effects_cache,
+    resolve_side_effects_cache_readonly, resolve_strict_peer_dependencies,
+    resolve_strict_store_pkg_content_check, resolve_verify_store_integrity,
 };
 use startup::{
     apply_force_state_reset, merge_branch_lockfiles_if_needed, modules_cache_sweep_is_default,
@@ -153,6 +153,73 @@ impl InstallPhaseTimings {
             Err(e) => tracing::debug!("failed to write install phase timings: {e}"),
         }
     }
+}
+
+async fn validate_lockfile_trust_policy(
+    cwd: &std::path::Path,
+    graph: &aube_lockfile::LockfileGraph,
+    network_mode: aube_registry::NetworkMode,
+    policy: &aube_resolver::DependencyPolicy,
+) -> miette::Result<()> {
+    if policy.trust_policy != aube_resolver::TrustPolicy::NoDowngrade {
+        return Ok(());
+    }
+
+    let client = std::sync::Arc::new(make_client(cwd).with_network_mode(network_mode));
+    let full_cache_dir = super::packument_full_cache_dir();
+    let concurrency = default_lockfile_network_concurrency().max(1);
+    let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency));
+    let mut seen = std::collections::BTreeSet::new();
+    let mut checks: tokio::task::JoinSet<Result<(), aube_resolver::Error>> =
+        tokio::task::JoinSet::new();
+
+    for pkg in graph.packages.values() {
+        if pkg.local_source.is_some() {
+            continue;
+        }
+        let name = pkg.registry_name().to_string();
+        let version = pkg.version.clone();
+        if !seen.insert((name.clone(), version.clone())) {
+            continue;
+        }
+
+        let client = client.clone();
+        let full_cache_dir = full_cache_dir.clone();
+        let exclude = policy.trust_policy_exclude.clone();
+        let ignore_after = policy.trust_policy_ignore_after;
+        let semaphore = semaphore.clone();
+        checks.spawn(async move {
+            let _permit = semaphore.acquire_owned().await.map_err(|e| {
+                aube_resolver::Error::Registry(name.clone(), format!("trust check cancelled: {e}"))
+            })?;
+            let packument = client
+                .fetch_packument_with_time_cached(&name, &full_cache_dir)
+                .await
+                .map_err(|e| aube_resolver::Error::Registry(name.clone(), e.to_string()))?;
+            let picked = packument.versions.get(&version).ok_or_else(|| {
+                aube_resolver::Error::Registry(
+                    name.clone(),
+                    format!("registry packument has no metadata for {name}@{version}"),
+                )
+            })?;
+            aube_resolver::check_no_downgrade(&packument, &version, picked, &exclude, ignore_after)
+                .map_err(|e| match e {
+                    aube_resolver::TrustCheckError::Downgrade(d) => {
+                        aube_resolver::Error::TrustDowngrade(Box::new(d))
+                    }
+                    aube_resolver::TrustCheckError::MissingTime(d) => {
+                        aube_resolver::Error::TrustCheckMissingTime(Box::new(d))
+                    }
+                })
+        });
+    }
+
+    while let Some(result) = checks.join_next().await {
+        let result = result.map_err(|e| miette!("trust-policy validation task failed: {e}"))?;
+        result.map_err(miette::Report::new)?;
+    }
+
+    Ok(())
 }
 
 pub async fn run(opts: InstallOptions) -> miette::Result<()> {
@@ -578,6 +645,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         None;
     let (graph, package_indices, cached_count, fetch_count) = match lockfile_result {
         Ok((mut graph, kind)) => {
+            let dependency_policy = resolve_dependency_policy(&manifest, &settings_ctx);
+            validate_lockfile_trust_policy(&cwd, &graph, opts.network_mode, &dependency_policy)
+                .await?;
             // Under `sharedWorkspaceLockfile=false` the project's own
             // lockfile only carries the `.` importer, so the reuse path
             // would hand the linker a root-only graph and never relink

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -161,7 +161,9 @@ async fn validate_lockfile_trust_policy(
     network_mode: aube_registry::NetworkMode,
     policy: &aube_resolver::DependencyPolicy,
 ) -> miette::Result<()> {
-    if policy.trust_policy != aube_resolver::TrustPolicy::NoDowngrade {
+    if policy.trust_policy != aube_resolver::TrustPolicy::NoDowngrade
+        || matches!(network_mode, aube_registry::NetworkMode::Offline)
+    {
         return Ok(());
     }
 
@@ -173,7 +175,10 @@ async fn validate_lockfile_trust_policy(
     let mut checks: tokio::task::JoinSet<Result<(), aube_resolver::Error>> =
         tokio::task::JoinSet::new();
 
-    for pkg in graph.packages.values() {
+    for dep_path in reachable_package_dep_paths(graph) {
+        let Some(pkg) = graph.packages.get(&dep_path) else {
+            continue;
+        };
         if pkg.local_source.is_some() {
             continue;
         }
@@ -220,6 +225,35 @@ async fn validate_lockfile_trust_policy(
     }
 
     Ok(())
+}
+
+fn reachable_package_dep_paths(
+    graph: &aube_lockfile::LockfileGraph,
+) -> std::collections::BTreeSet<String> {
+    let mut reachable = std::collections::BTreeSet::new();
+    let mut stack = graph
+        .importers
+        .values()
+        .flat_map(|deps| deps.iter().map(|dep| dep.dep_path.clone()))
+        .collect::<Vec<_>>();
+
+    while let Some(dep_path) = stack.pop() {
+        if !reachable.insert(dep_path.clone()) {
+            continue;
+        }
+        let Some(pkg) = graph.packages.get(&dep_path) else {
+            continue;
+        };
+        for (name, tail) in &pkg.dependencies {
+            if let Some(child) =
+                aube_lockfile::resolve_dep_edge(name, tail, |k| graph.packages.contains_key(k))
+            {
+                stack.push(child);
+            }
+        }
+    }
+
+    reachable
 }
 
 pub async fn run(opts: InstallOptions) -> miette::Result<()> {
@@ -645,9 +679,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         None;
     let (graph, package_indices, cached_count, fetch_count) = match lockfile_result {
         Ok((mut graph, kind)) => {
-            let dependency_policy = resolve_dependency_policy(&manifest, &settings_ctx);
-            validate_lockfile_trust_policy(&cwd, &graph, opts.network_mode, &dependency_policy)
-                .await?;
             // Under `sharedWorkspaceLockfile=false` the project's own
             // lockfile only carries the `.` importer, so the reuse path
             // would hand the linker a root-only graph and never relink
@@ -660,6 +691,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             if !shared_workspace_lockfile && has_workspace {
                 merge_member_lockfile_graphs(&cwd, &mut graph, &manifests);
             }
+            let dependency_policy = resolve_dependency_policy(&manifest, &settings_ctx);
             let graph = resolve::apply_lockfile_graph_platform_rules(
                 graph,
                 kind,
@@ -667,6 +699,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 &ws_config_shared,
                 &settings_ctx,
             )?;
+            validate_lockfile_trust_policy(&cwd, &graph, opts.network_mode, &dependency_policy)
+                .await?;
             let source_label = resolve::lockfile_source_label(kind);
             tracing::debug!(
                 "{source_label}: {} packages for {project_name}",

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -34,11 +34,6 @@ pub(super) fn try_install_fast_path(
     mode: FrozenMode,
     modules_cache_sweep_default: bool,
 ) -> bool {
-    if restore_missing_lockfile_fast_path_eligible(cwd, opts, mode, modules_cache_sweep_default) {
-        emit_up_to_date(cwd);
-        return true;
-    }
-
     if !install_fast_path_eligible(cwd, opts, mode, modules_cache_sweep_default) {
         return false;
     }
@@ -64,7 +59,7 @@ fn install_fast_path_eligible(
     if !preconditions_met {
         return false;
     }
-    if trust_policy_requires_validation(cwd) {
+    if trust_policy_requires_validation(cwd, opts) {
         return false;
     }
     // Surface *why* the warm path was missed at debug level — the state
@@ -80,33 +75,18 @@ fn install_fast_path_eligible(
     }
 }
 
-fn restore_missing_lockfile_fast_path_eligible(
-    cwd: &Path,
-    opts: &InstallOptions,
-    mode: FrozenMode,
-    modules_cache_sweep_default: bool,
-) -> bool {
-    matches!(mode, FrozenMode::No)
-        && !opts.force
-        && !opts.lockfile_only
-        && !opts.dep_selection.is_filtered()
-        && !opts.merge_git_branch_lockfiles
-        && !opts.strict_no_lockfile
-        && !opts.dangerously_allow_all_builds
-        && opts.workspace_filter.is_empty()
-        && modules_cache_sweep_default
-        && !trust_policy_requires_validation(cwd)
-        && state::restore_missing_lockfile_if_fresh(cwd, &opts.cli_flags)
-}
-
-fn trust_policy_requires_validation(cwd: &Path) -> bool {
-    super::super::with_settings_ctx(cwd, |ctx| {
-        aube_settings::resolved::paranoid(ctx)
-            || matches!(
-                aube_settings::resolved::trust_policy(ctx),
-                aube_settings::resolved::TrustPolicy::NoDowngrade
-            )
-    })
+fn trust_policy_requires_validation(cwd: &Path, opts: &InstallOptions) -> bool {
+    if opts.network_mode == aube_registry::NetworkMode::Offline {
+        return false;
+    }
+    let files = crate::commands::FileSources::load(cwd);
+    let raw_workspace = aube_manifest::workspace::load_raw(cwd).unwrap_or_default();
+    let ctx = files.ctx(&raw_workspace, &opts.env_snapshot, &opts.cli_flags);
+    aube_settings::resolved::paranoid(&ctx)
+        || matches!(
+            aube_settings::resolved::trust_policy(&ctx),
+            aube_settings::resolved::TrustPolicy::NoDowngrade
+        )
 }
 
 fn emit_up_to_date(cwd: &Path) {

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -64,6 +64,9 @@ fn install_fast_path_eligible(
     if !preconditions_met {
         return false;
     }
+    if trust_policy_requires_validation(cwd) {
+        return false;
+    }
     // Surface *why* the warm path was missed at debug level — the state
     // freshness reason is otherwise discarded here (only `.is_none()` is
     // consulted), leaving `aube install -v` silent on repeat-install loops
@@ -92,7 +95,18 @@ fn restore_missing_lockfile_fast_path_eligible(
         && !opts.dangerously_allow_all_builds
         && opts.workspace_filter.is_empty()
         && modules_cache_sweep_default
+        && !trust_policy_requires_validation(cwd)
         && state::restore_missing_lockfile_if_fresh(cwd, &opts.cli_flags)
+}
+
+fn trust_policy_requires_validation(cwd: &Path) -> bool {
+    super::super::with_settings_ctx(cwd, |ctx| {
+        aube_settings::resolved::paranoid(ctx)
+            || matches!(
+                aube_settings::resolved::trust_policy(ctx),
+                aube_settings::resolved::TrustPolicy::NoDowngrade
+            )
+    })
 }
 
 fn emit_up_to_date(cwd: &Path) {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 const DEFAULT_STATE_DIR: &str = "node_modules";
 const INSTALL_STATE_FILE_NAME: &str = "state.json";
 const FRESH_STATE_FILE_NAME: &str = "fresh.json";
-const LOCKFILE_SNAPSHOT_FILE_NAME: &str = "lockfile";
 
 /// The install-state directory name, `.<name>-state`. Standalone aube:
 /// `.aube-state`.
@@ -405,28 +404,6 @@ fn check_needs_install_compute(
     None
 }
 
-pub fn restore_missing_lockfile_if_fresh(
-    project_dir: &Path,
-    cli_flags: &[(String, String)],
-) -> bool {
-    let (modules_dir, state_path) = resolve_paths(project_dir);
-    let (lockfile_name, lockfile_path) = active_lockfile(project_dir);
-    if lockfile_path.is_some() || !modules_dir.exists() {
-        return false;
-    }
-    let Some(state) = read_or_migrate_fresh_state(&state_path) else {
-        return false;
-    };
-    if package_jsons_stale(project_dir, &state).is_some()
-        || state.section_filtered
-        || verify_install_layout(project_dir, state.layout.as_ref()).is_some()
-        || hash_settings(project_dir, cli_flags) != state.settings_hash
-    {
-        return false;
-    }
-    restore_lockfile_snapshot(project_dir, &state_path, &state, &lockfile_name).is_some()
-}
-
 fn package_jsons_stale(project_dir: &Path, state: &FreshnessState) -> Option<String> {
     for (rel, stored_hash) in &state.package_json_hashes {
         let path = if rel == "." {
@@ -681,18 +658,15 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
 
 fn snapshot_active_lockfile(
     project_dir: &Path,
-    state_path: &Path,
+    _state_path: &Path,
 ) -> Result<(String, Option<String>), std::io::Error> {
     let (name, path) = active_lockfile(project_dir);
     let Some(path) = path else {
-        let _ = std::fs::remove_file(lockfile_snapshot_file(state_path));
         return Ok((String::new(), None));
     };
     let Ok(content) = std::fs::read(&path) else {
-        let _ = std::fs::remove_file(lockfile_snapshot_file(state_path));
         return Ok((String::new(), None));
     };
-    aube_util::fs_atomic::atomic_write(&lockfile_snapshot_file(state_path), &content)?;
     Ok((hash_bytes(&content), Some(name)))
 }
 
@@ -834,10 +808,6 @@ fn fresh_state_file(state_path: &Path) -> PathBuf {
     state_path.join(FRESH_STATE_FILE_NAME)
 }
 
-fn lockfile_snapshot_file(state_path: &Path) -> PathBuf {
-    state_path.join(LOCKFILE_SNAPSHOT_FILE_NAME)
-}
-
 fn read_fresh_state(state_path: &Path) -> Option<FreshnessState> {
     if state_path.is_file() {
         let _ = std::fs::remove_file(state_path);
@@ -859,46 +829,6 @@ fn read_or_migrate_fresh_state(state_path: &Path) -> Option<FreshnessState> {
 fn write_fresh_state(state_path: &Path, state: &FreshnessState) -> Result<(), std::io::Error> {
     let json = serde_json::to_string_pretty(state)?;
     aube_util::fs_atomic::atomic_write(&fresh_state_file(state_path), json.as_bytes())
-}
-
-fn restore_lockfile_snapshot(
-    project_dir: &Path,
-    state_path: &Path,
-    state: &FreshnessState,
-    expected_name: &str,
-) -> Option<PathBuf> {
-    let name = state.lockfile_snapshot_name.as_ref()?;
-    if !is_restorable_lockfile_name(name) {
-        return None;
-    }
-    if is_branch_lockfile_name(name) && name != expected_name {
-        return None;
-    }
-    let content = std::fs::read(lockfile_snapshot_file(state_path)).ok()?;
-    if hash_bytes(&content) != state.lockfile_hash {
-        return None;
-    }
-    let path = project_dir.join(name);
-    aube_util::fs_atomic::atomic_write(&path, &content).ok()?;
-    Some(path)
-}
-
-fn is_restorable_lockfile_name(name: &str) -> bool {
-    let basename = aube_util::embedder().lockfile_basename;
-    matches!(
-        name,
-        "pnpm-lock.yaml" | "bun.lock" | "yarn.lock" | "npm-shrinkwrap.json" | "package-lock.json"
-    ) || name == basename
-        || is_branch_lockfile_name(name)
-}
-
-fn is_branch_lockfile_name(name: &str) -> bool {
-    let basename = aube_util::embedder().lockfile_basename;
-    let stem = basename.rsplit_once('.').map_or(basename, |(s, _)| s);
-    (name.starts_with(&format!("{stem}.")) || name.starts_with("pnpm-lock."))
-        && name.ends_with(".yaml")
-        && name != basename
-        && name != "pnpm-lock.yaml"
 }
 
 fn remove_legacy_state_file(state_path: &Path) -> Result<(), std::io::Error> {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -399,9 +399,7 @@ fn check_needs_install_compute(
     // --node-linker=hoisted` writes a hash with cli_flags set, then
     // bare `aube run` reads without the flag, mismatches, and triggers
     // a spurious auto-install.
-    if lockfile_missing
-        && restore_lockfile_snapshot(project_dir, &state_path, &state, &lockfile_name).is_none()
-    {
+    if lockfile_missing {
         return Some("no lockfile found".into());
     }
     None

--- a/test/git_branch_lockfile.bats
+++ b/test/git_branch_lockfile.bats
@@ -107,7 +107,6 @@ teardown() {
 	run aube install --no-frozen-lockfile
 	assert_success
 	assert_file_exists aube-lock.main.yaml
-	assert_file_exists node_modules/.aube-state/lockfile
 
 	git checkout -q -b dev
 	rm aube-lock.main.yaml

--- a/test/install.bats
+++ b/test/install.bats
@@ -640,19 +640,16 @@ EOF
 	assert_output --partial "No lockfile found"
 }
 
-@test "aube install --no-frozen-lockfile restores missing lockfile from fresh state" {
+@test "aube install --no-frozen-lockfile re-resolves when lockfile is missing" {
 	_setup_basic_fixture
 	run aube install
 	assert_success
-	cp aube-lock.yaml aube-lock.yaml.expected
-	assert_file_exists node_modules/.aube-state/lockfile
 
 	rm aube-lock.yaml
 	run aube -v install --no-frozen-lockfile
 	assert_success
-	refute_output --partial "No lockfile found"
+	assert_output --partial "No lockfile found"
 	assert_file_exists aube-lock.yaml
-	assert_equal "$(cat aube-lock.yaml)" "$(cat aube-lock.yaml.expected)"
 }
 
 @test "aube install --fix-lockfile is a no-op on a fresh lockfile" {

--- a/test/pnpm_install_misc.bats
+++ b/test/pnpm_install_misc.bats
@@ -392,6 +392,34 @@ JSON
 	assert_file_exists node_modules/@pnpm/e2e.test-provenance/package.json
 }
 
+@test "trustPolicy=no-downgrade: lockfile reuse still validates trust evidence" {
+	cat >.npmrc <<EOF
+registry=${AUBE_TEST_REGISTRY}
+trust-policy=off
+EOF
+	cat >package.json <<'JSON'
+{
+  "name": "pnpm-misc-trust-lockfile-reuse-fail",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm/e2e.test-provenance": "0.0.5"
+  }
+}
+JSON
+
+	aube install
+	assert_file_exists aube-lock.yaml
+	assert_file_exists node_modules/@pnpm/e2e.test-provenance/package.json
+
+	cat >.npmrc <<EOF
+registry=${AUBE_TEST_REGISTRY}
+trust-policy=no-downgrade
+EOF
+	run aube install
+	assert_failure
+	assert_output --partial "trust downgrade for @pnpm/e2e.test-provenance@0.0.5"
+}
+
 @test "trustPolicyExclude with name@version: install succeeds for the listed version" {
 	# Ported from pnpm/test/install/misc.ts:600.
 	# pnpm: --trust-policy-exclude=@pnpm/e2e.test-provenance@0.0.5

--- a/test/resolve.bats
+++ b/test/resolve.bats
@@ -53,6 +53,18 @@ teardown() {
 	assert_output --partial "Lockfile:"
 }
 
+@test "deleting aube-lock.yaml makes install re-resolve instead of restoring stale state" {
+	echo '{"name":"test","version":"1.0.0","dependencies":{"is-odd":"^3.0.1"}}' >package.json
+	aube install
+	assert_file_exists aube-lock.yaml
+
+	rm aube-lock.yaml
+	run aube -v install
+	assert_success
+	assert_output --partial "No lockfile found"
+	assert_file_exists aube-lock.yaml
+}
+
 @test "generated lockfile contains integrity hashes" {
 	echo '{"name":"test","version":"1.0.0","dependencies":{"is-odd":"^3.0.1"}}' >package.json
 	aube install

--- a/test/shared_workspace_lockfile_warm_path.bats
+++ b/test/shared_workspace_lockfile_warm_path.bats
@@ -48,6 +48,7 @@ _setup_no_shared_workspace() {
 		packages:
 		  - packages/*
 		sharedWorkspaceLockfile: false
+		trustPolicy: off
 	YAML
 	mkdir -p packages/lib-a
 	cat >packages/lib-a/package.json <<-'JSON'
@@ -219,6 +220,7 @@ _setup_no_shared_workspace() {
 		packages:
 		  - packages/*
 		sharedWorkspaceLockfile: false
+		trustPolicy: off
 	YAML
 	mkdir -p packages/svc
 	cat >packages/svc/package.json <<-'JSON'
@@ -321,6 +323,7 @@ _setup_no_shared_workspace() {
 	cat >pnpm-workspace.yaml <<-'YAML'
 		packages:
 		  - packages/*
+		trustPolicy: off
 	YAML
 	mkdir -p packages/a
 	cat >packages/a/package.json <<-'JSON'

--- a/test/workspace_member_install_walks_up.bats
+++ b/test/workspace_member_install_walks_up.bats
@@ -39,6 +39,7 @@ _setup_minimal_workspace() {
 	cat >pnpm-workspace.yaml <<-'YAML'
 		packages:
 		  - packages/*
+		trustPolicy: off
 	YAML
 	mkdir -p packages/a
 	cat >packages/a/package.json <<-'JSON'


### PR DESCRIPTION
## Summary

- validate `trustPolicy=no-downgrade` when installs reuse an existing lockfile instead of re-resolving
- disable install fast paths that would skip trust validation when `trust-policy=no-downgrade` or `paranoid=true` is active
- treat a deleted lockfile as stale instead of restoring it from `.aube-state`

## Root Cause

`aube update` could write a lockfile and then later installs could reuse that lockfile or the warm install state without rechecking trust evidence. Separately, deleting `aube-lock.yaml` could be undone by the install state snapshot, which made `rm aube-lock.yaml` fail to behave like a reset.

## Validation

- `cargo fmt --check`
- `cargo check -q`
- `cargo build -q`
- `cargo test -q -p aube-resolver trust:: --lib`
- `mise run test:bats -- -f 'deleting aube-lock.yaml makes install re-resolve' test/resolve.bats`
- `mise run test:bats -- -f 'trustPolicy=no-downgrade: lockfile reuse still validates trust evidence' test/pnpm_install_misc.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install and freshness behavior (network on lockfile reuse, no lockfile snapshot restore) around supply-chain trust enforcement; offline mode skips validation.
> 
> **Overview**
> **Lockfile reuse now enforces `trust-policy=no-downgrade`** (and respects exclude/ignore-after the same way resolve does). After loading an existing lockfile, install walks reachable registry packages, fetches full packuments concurrently, and runs `check_no_downgrade` before fetch/link—so tightening trust settings cannot be bypassed by skipping re-resolve.
> 
> The **install warm/fast path is skipped** when `trust-policy=no-downgrade` or `paranoid=true` is active (unless offline), so those installs always run the full pipeline including trust validation.
> 
> **Deleted lockfiles are no longer restored** from `.aube-state`; a missing `aube-lock.yaml` is treated as stale and triggers a full re-resolve instead of silently copying a saved snapshot back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57eeaa785000c43900c8b6e3d8754e689a5a64e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * When `trust-policy=no-downgrade` (or paranoid mode) is enabled, installs that reuse `aube-lock.yaml` now re-validate trust evidence and fail on potential downgrades.

* **Improvements**
  * The warm/fast install path is disabled whenever trust validation is required.
  * If `aube-lock.yaml` is missing, it is no longer restored from a saved snapshot; it will be regenerated during install.

* **Bug Fixes**
  * Lockfile reuse under `no-downgrade` continues to enforce trust checks across reachable dependency paths.

* **Tests**
  * Added/updated Bats coverage for trust validation on lockfile reuse and for missing-lockfile regeneration behavior, including workspace fixtures with `trustPolicy: off`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->