### PR TITLE
fix(install): persist computed tarball integrity

### DIFF
--- a/crates/aube-store/src/integrity.rs
+++ b/crates/aube-store/src/integrity.rs
@@ -197,6 +197,14 @@ pub fn sha512_integrity(data: &[u8]) -> String {
         hasher.update(data);
         hasher.finalize_reset()
     });
+    let mut digest_buf = [0u8; 64];
+    digest_buf.copy_from_slice(&digest);
+    sha512_integrity_from_digest(&digest_buf)
+}
+
+/// Return the npm Subresource Integrity string for a precomputed
+/// SHA-512 digest.
+pub fn sha512_integrity_from_digest(digest: &[u8; 64]) -> String {
     use base64::Engine;
     format!(
         "{SHA512_INTEGRITY_PREFIX}{}",

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -24,8 +24,9 @@ use git::{
 };
 pub use index::{PackageIndex, StoredFile, index_content_fingerprint};
 pub use integrity::{
-    SHA512_INTEGRITY_PREFIX, integrity_to_hex, sha512_integrity, validate_and_encode_name,
-    validate_pkg_content, validate_version, verify_integrity, verify_precomputed_sha512,
+    SHA512_INTEGRITY_PREFIX, integrity_to_hex, sha512_integrity, sha512_integrity_from_digest,
+    validate_and_encode_name, validate_pkg_content, validate_version, verify_integrity,
+    verify_precomputed_sha512,
 };
 #[cfg(test)]
 pub(crate) use tarball::normalize_tar_entry_path;

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -417,7 +417,7 @@ pub(in crate::commands) async fn fetch_packages(
     let strict_pkg_content_check = resolve_strict_store_pkg_content_check(&ctx);
     let virtual_store_dir_max_length = resolve_virtual_store_dir_max_length(&ctx);
     let aube_dir = resolve_virtual_store_dir(&ctx, &cwd);
-    fetch_packages_with_root(
+    let (indices, cached, fetched, _) = fetch_packages_with_root(
         packages,
         store,
         || client,
@@ -436,7 +436,8 @@ pub(in crate::commands) async fn fetch_packages(
         None,
         git_shallow_hosts,
     )
-    .await
+    .await?;
+    Ok((indices, cached, fetched))
 }
 
 // `network_concurrency`: override for the tarball-fetch semaphore.
@@ -490,7 +491,12 @@ pub(super) async fn fetch_packages_with_root<F>(
     git_prepare_depth: u32,
     inherited_build_policy: Option<std::sync::Arc<aube_scripts::BuildPolicy>>,
     git_shallow_hosts: Vec<String>,
-) -> miette::Result<(BTreeMap<String, aube_store::PackageIndex>, usize, usize)>
+) -> miette::Result<(
+    BTreeMap<String, aube_store::PackageIndex>,
+    usize,
+    usize,
+    BTreeMap<String, String>,
+)>
 where
     F: FnOnce() -> std::sync::Arc<aube_registry::client::RegistryClient>,
 {
@@ -700,6 +706,7 @@ where
     if let Some(p) = progress {
         p.inc_reused(cached_count);
     }
+    let mut computed_integrities: BTreeMap<String, String> = BTreeMap::new();
 
     // Critical-path fetch order: float likely-native-build packages
     // (sharp, esbuild, @swc/*, sqlite3, lmdb, bcrypt, etc) to the
@@ -767,8 +774,9 @@ where
         // instead of detaching them into the background. Detached
         // tasks keep writing to the CAS after the install command
         // has already errored out.
-        let mut handles: tokio::task::JoinSet<miette::Result<(String, aube_store::PackageIndex)>> =
-            tokio::task::JoinSet::new();
+        let mut handles: tokio::task::JoinSet<
+            miette::Result<(String, aube_store::PackageIndex, Option<String>)>,
+        > = tokio::task::JoinSet::new();
 
         for (dep_path, display_name, registry_name, version, tarball_url_override, integrity) in
             to_fetch
@@ -821,7 +829,7 @@ where
                         strict_pkg_content_check,
                     )
                     .await;
-                    let (index, bytes_len, _) = match streamed {
+                    let (index, bytes_len, computed_integrity) = match streamed {
                         Ok(v) => {
                             permit.record_success();
                             v
@@ -845,7 +853,7 @@ where
                         dl_time,
                         bytes_len
                     );
-                    return Ok::<_, miette::Report>((dep_path, index));
+                    return Ok::<_, miette::Report>((dep_path, index, computed_integrity));
                 }
 
                 // Buffered SHA-512 path. Streaming SHA-512 hashes
@@ -899,6 +907,12 @@ where
                 if let Some(p) = bytes_progress.as_ref() {
                     p.inc_downloaded_bytes(bytes.len() as u64);
                 }
+                let computed_integrity = integrity
+                    .is_none()
+                    .then(|| {
+                        streamed_digest.map(|digest| aube_store::sha512_integrity(&digest))
+                    })
+                    .flatten();
 
                 // Keep the semaphore permit through import, not just
                 // download. `import_tarball` fans out into gzip/tar
@@ -938,12 +952,12 @@ where
                     import_time
                 );
 
-                Ok::<_, miette::Report>((dep_path, index))
+                Ok::<_, miette::Report>((dep_path, index, computed_integrity))
             });
         }
 
         while let Some(joined) = handles.join_next().await {
-            let (dep_path, index) = joined.into_diagnostic()??;
+            let (dep_path, index, computed_integrity) = joined.into_diagnostic()??;
             if let Some(tx) = materialize_tx.as_ref() {
                 // Time channel send so back-pressure events show up in
                 // the trace. The materialize channel is bounded; if the
@@ -968,6 +982,9 @@ where
                     }
                 }
             }
+            if let Some(integrity) = computed_integrity {
+                computed_integrities.insert(dep_path.clone(), integrity);
+            }
             indices.insert(dep_path, index);
         }
     }
@@ -979,7 +996,7 @@ where
         sem.persist(&state, "tarball:default");
     }
 
-    Ok((indices, cached_count, fetch_count))
+    Ok((indices, cached_count, fetch_count, computed_integrities))
 }
 
 async fn verify_lockfile_tarball_url(

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -821,7 +821,7 @@ where
                         strict_pkg_content_check,
                     )
                     .await;
-                    let (index, bytes_len) = match streamed {
+                    let (index, bytes_len, _) = match streamed {
                         Ok(v) => {
                             permit.record_success();
                             v
@@ -1114,7 +1114,7 @@ pub(super) fn remap_indices_to_contextualized(
 /// coordinate. A `dep_path` with no suffix is returned unchanged — a
 /// bare `_<hex>` tail belongs to a `git+`/`url+`/`file+` source
 /// coordinate and is never a peer marker, so it is preserved.
-fn strip_peer_context_suffix(dep_path: &str) -> &str {
+pub(super) fn strip_peer_context_suffix(dep_path: &str) -> &str {
     dep_path.split('(').next().unwrap_or(dep_path)
 }
 

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -943,6 +943,15 @@ where
                     strict_pkg_content_check,
                 )
                 .await?;
+                if let Some(integrity) = computed_integrity.as_deref()
+                    && let Err(e) =
+                        store.save_index(&registry_name, &version, Some(integrity), &index)
+                {
+                    tracing::warn!(
+                        code = aube_codes::warnings::WARN_AUBE_CACHE_WRITE_FAILED,
+                        "Failed to cache index for {display_name}@{version} with computed integrity: {e}"
+                    );
+                }
 
                 tracing::trace!(
                     "fetch {display_name}@{version}: wait={:.0?} dl={:.0?} ({} bytes) import={:.0?}",

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -909,10 +909,10 @@ where
                 }
                 let computed_integrity = integrity
                     .is_none()
-                    .then(|| {
-                        streamed_digest.map(|digest| aube_store::sha512_integrity(&digest))
-                    })
-                    .flatten();
+                    .then(|| match streamed_digest.as_ref() {
+                        Some(digest) => aube_store::sha512_integrity_from_digest(digest),
+                        None => aube_store::sha512_integrity(&bytes),
+                    });
 
                 // Keep the semaphore permit through import, not just
                 // download. `import_tarball` fans out into gzip/tar
@@ -992,7 +992,8 @@ where
                 }
             }
             if let Some(integrity) = computed_integrity {
-                computed_integrities.insert(dep_path.clone(), integrity);
+                computed_integrities
+                    .insert(strip_peer_context_suffix(&dep_path).to_owned(), integrity);
             }
             indices.insert(dep_path, index);
         }

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -861,7 +861,7 @@ pub(super) async fn fetch_and_import_tarball_streaming(
     verify_integrity: bool,
     strict_integrity: bool,
     strict_pkg_content_check: bool,
-) -> Result<(aube_store::PackageIndex, u64), TarballStreamErr> {
+) -> Result<(aube_store::PackageIndex, u64, Option<String>), TarballStreamErr> {
     use sha2::Digest;
 
     // Local-error helper. Anything we observe past the response
@@ -978,6 +978,9 @@ pub(super) async fn fetch_and_import_tarball_streaming(
 
     let mut sha512 = [0u8; 64];
     sha512.copy_from_slice(&hasher.finalize()[..]);
+    let computed_integrity = integrity
+        .is_none()
+        .then(|| aube_store::sha512_integrity(&sha512));
 
     if verify_integrity {
         if let Some(expected) = integrity {
@@ -1020,14 +1023,15 @@ pub(super) async fn fetch_and_import_tarball_streaming(
         })?;
     }
 
-    if let Err(e) = store.save_index(registry_name, version, integrity, &index) {
+    let cache_integrity = integrity.or(computed_integrity.as_deref());
+    if let Err(e) = store.save_index(registry_name, version, cache_integrity, &index) {
         tracing::warn!(
             code = aube_codes::warnings::WARN_AUBE_CACHE_WRITE_FAILED,
             "Failed to cache index for {display_name}@{version}: {e}"
         );
     }
 
-    Ok((index, total))
+    Ok((index, total, computed_integrity))
 }
 
 pub(super) fn validate_required_scripts(

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -980,7 +980,7 @@ pub(super) async fn fetch_and_import_tarball_streaming(
     sha512.copy_from_slice(&hasher.finalize()[..]);
     let computed_integrity = integrity
         .is_none()
-        .then(|| aube_store::sha512_integrity(&sha512));
+        .then(|| aube_store::sha512_integrity_from_digest(&sha512));
 
     if verify_integrity {
         if let Some(expected) = integrity {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1456,18 +1456,29 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             })
                             .flatten();
                         let (index, _) = run_import_on_blocking(
-                            store,
+                            store.clone(),
                             bytes,
                             streamed_digest,
-                            pkg_display_name,
-                            pkg_registry_name,
-                            pkg_version,
-                            integrity,
+                            pkg_display_name.clone(),
+                            pkg_registry_name.clone(),
+                            pkg_version.clone(),
+                            integrity.clone(),
                             fetch_verify_integrity,
                             fetch_strict_integrity,
                             fetch_strict_pkg_content_check,
                         )
                         .await?;
+                        if let Some(integrity) = computed_integrity.as_deref()
+                            && let Err(e) =
+                                store.save_index(&pkg_registry_name, &pkg_version, Some(integrity), &index)
+                        {
+                            tracing::warn!(
+                                code = aube_codes::warnings::WARN_AUBE_CACHE_WRITE_FAILED,
+                                "Failed to cache index for {}@{} with computed integrity: {e}",
+                                pkg_display_name,
+                                pkg_version
+                            );
+                        }
 
                         Ok::<_, miette::Report>((dep_path, index, computed_integrity))
                     });

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -37,7 +37,7 @@ pub use dep_selection::DepSelection;
 pub(super) use fetch::fetch_packages;
 use fetch::{
     fetch_packages_with_root, import_local_source, remap_indices_to_contextualized,
-    version_from_dep_path,
+    strip_peer_context_suffix, version_from_dep_path,
 };
 pub use frozen::{FrozenMode, FrozenOverride, GlobalVirtualStoreFlags};
 pub(crate) use lifecycle::{
@@ -152,6 +152,70 @@ impl InstallPhaseTimings {
             }
             Err(e) => tracing::debug!("failed to write install phase timings: {e}"),
         }
+    }
+}
+
+fn apply_computed_integrities(
+    graph: &mut aube_lockfile::LockfileGraph,
+    computed: &BTreeMap<String, String>,
+) {
+    if computed.is_empty() {
+        return;
+    }
+    for pkg in graph.packages.values_mut() {
+        if pkg.integrity.is_some() || pkg.local_source.is_some() {
+            continue;
+        }
+        let canonical = strip_peer_context_suffix(&pkg.dep_path);
+        if let Some(integrity) = computed.get(canonical) {
+            pkg.integrity = Some(integrity.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod computed_integrity_tests {
+    use super::*;
+
+    #[test]
+    fn computed_integrity_updates_peer_variants() {
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.packages.insert(
+            "consumer@1.0.0(peer@2.0.0)".into(),
+            aube_lockfile::LockedPackage {
+                name: "consumer".into(),
+                version: "1.0.0".into(),
+                dep_path: "consumer@1.0.0(peer@2.0.0)".into(),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "already@1.0.0".into(),
+            aube_lockfile::LockedPackage {
+                name: "already".into(),
+                version: "1.0.0".into(),
+                dep_path: "already@1.0.0".into(),
+                integrity: Some("sha512-existing".into()),
+                ..Default::default()
+            },
+        );
+        let computed = BTreeMap::from([
+            ("consumer@1.0.0".into(), "sha512-computed".into()),
+            ("already@1.0.0".into(), "sha512-new".into()),
+        ]);
+
+        apply_computed_integrities(&mut graph, &computed);
+
+        assert_eq!(
+            graph.packages["consumer@1.0.0(peer@2.0.0)"]
+                .integrity
+                .as_deref(),
+            Some("sha512-computed")
+        );
+        assert_eq!(
+            graph.packages["already@1.0.0"].integrity.as_deref(),
+            Some("sha512-existing")
+        );
     }
 }
 
@@ -1094,7 +1158,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 // JoinSet aborts every outstanding task on drop,
                 // matches the pattern ensure_dep_scripts uses.
                 let mut handles: tokio::task::JoinSet<
-                    miette::Result<(String, aube_store::PackageIndex)>,
+                    miette::Result<(String, aube_store::PackageIndex, Option<String>)>,
                 > = tokio::task::JoinSet::new();
                 let mut indices: BTreeMap<String, aube_store::PackageIndex> = BTreeMap::new();
                 let mut cached_count = 0usize;
@@ -1312,7 +1376,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                                 fetch_strict_pkg_content_check,
                             )
                             .await;
-                            let (index, bytes_len) = match streamed {
+                            let (index, bytes_len, computed_integrity) = match streamed {
                                 Ok(v) => {
                                     permit.record_success();
                                     v
@@ -1329,7 +1393,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             if let Some(p) = bytes_progress.as_ref() {
                                 p.inc_downloaded_bytes(bytes_len);
                             }
-                            return Ok::<_, miette::Report>((dep_path, index));
+                            return Ok::<_, miette::Report>((
+                                dep_path,
+                                index,
+                                computed_integrity,
+                            ));
                         }
 
                         let fetch_outcome = if streaming_sha512_enabled {
@@ -1381,6 +1449,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                             p.inc_downloaded_bytes(bytes.len() as u64);
                         }
 
+                        let computed_integrity = integrity
+                            .is_none()
+                            .then(|| {
+                                streamed_digest.map(|digest| aube_store::sha512_integrity(&digest))
+                            })
+                            .flatten();
                         let (index, _) = run_import_on_blocking(
                             store,
                             bytes,
@@ -1395,19 +1469,23 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         )
                         .await?;
 
-                        Ok::<_, miette::Report>((dep_path, index))
+                        Ok::<_, miette::Report>((dep_path, index, computed_integrity))
                     });
                 }
 
                 // Collect all fetch results via JoinSet. Drop on
                 // error aborts outstanding siblings.
                 let fetch_count = handles.len();
+                let mut computed_integrities: BTreeMap<String, String> = BTreeMap::new();
                 while let Some(joined) = handles.join_next().await {
-                    let (dep_path, index) = joined.into_diagnostic()??;
+                    let (dep_path, index, computed_integrity) = joined.into_diagnostic()??;
                     materialize_tx
                         .send((dep_path.clone(), index.clone()))
                         .await
                         .map_err(|_| miette!("materializer task exited before fetch finished"))?;
+                    if let Some(integrity) = computed_integrity {
+                        computed_integrities.insert(dep_path.clone(), integrity);
+                    }
                     indices.insert(dep_path, index);
                 }
                 // Explicitly drop the materialize sender so the
@@ -1417,7 +1495,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 if let Some(state) = persistent_for_save.as_ref() {
                     semaphore_for_persist.persist(state, "tarball:default");
                 }
-                Ok::<_, miette::Report>((indices, cached_count, fetch_count))
+                Ok::<_, miette::Report>((indices, cached_count, fetch_count, computed_integrities))
             });
 
             // Run resolution (this streams packages to the fetch coordinator).
@@ -1581,7 +1659,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     return Err(combine_install_pipeline_errors(materialize_handle, e).await);
                 }
             };
-            let (canonical_indices, mut cached, mut fetched) = fetch_result;
+            let (canonical_indices, mut cached, mut fetched, computed_integrities) = fetch_result;
             tracing::debug!(
                 "phase:fetch {:.1?} ({fetched} packages, {cached} cached)",
                 fetch_phase_start.elapsed()
@@ -1623,6 +1701,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // same canonical package share a single set of files, so
             // cloning the PackageIndex is cheap relative to re-extraction.
             let mut indices = remap_indices_to_contextualized(&canonical_indices, &graph);
+            apply_computed_integrities(&mut graph, &computed_integrities);
 
             // Write the lockfile in whatever format the project was
             // already using. If no lockfile existed, create aube's

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -920,7 +920,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // closes and it exits naturally. Awaiting first lets a real
             // materializer error (the likely root cause of a generic
             // "materializer task exited..." fetch err) surface instead.
-            let (indices, cached, fetched) = match fetch_result {
+            let (indices, cached, fetched, _) = match fetch_result {
                 Ok(t) => t,
                 Err(e) => {
                     return Err(combine_install_pipeline_errors(lock_materialize_handle, e).await);
@@ -1707,6 +1707,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // already using. If no lockfile existed, create aube's
             // default `aube-lock.yaml`. Skipped entirely when
             // `lockfile=false`.
+            let write_kind = source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube);
             if lockfile_enabled {
                 // When `lockfileIncludeTarballUrl=true`, record the
                 // registry tarball URL on every registry-sourced
@@ -1735,7 +1736,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         }
                     }
                 }
-                let write_kind = source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube);
                 // Record/refresh the devEngines runtime pin before the
                 // graph hits disk (pnpm 10.14+ parity).
                 crate::runtime::refresh_lockfile_pin(
@@ -1801,6 +1801,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             } else {
                 tracing::debug!("lockfile=false: skipping lockfile write");
             }
+            let mut lockfile_graph_for_integrity_rewrite = lockfile_enabled.then(|| graph.clone());
 
             // Trim the in-memory graph down to host-installable optionals
             // before it reaches the linker. When the resolver widened its
@@ -1880,31 +1881,57 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 let catchup_start = std::time::Instant::now();
                 let cwd_for_catchup_client = cwd.clone();
                 let catchup_network_mode = opts.network_mode;
-                let (catchup_indices, catchup_cached, catchup_fetched) = fetch_packages_with_root(
-                    &missing_packages,
-                    &store,
-                    || {
-                        std::sync::Arc::new(
-                            make_client(&cwd_for_catchup_client)
-                                .with_network_mode(catchup_network_mode),
-                        )
-                    },
-                    prog_ref,
-                    &cwd,
-                    &aube_dir,
-                    /*materialize_tx=*/ None,
-                    /*skip_already_linked_shortcut=*/ has_workspace,
-                    virtual_store_dir_max_length,
-                    opts.ignore_scripts,
-                    network_concurrency_setting,
-                    verify_store_integrity_setting,
-                    strict_store_integrity_setting,
-                    strict_store_pkg_content_check_setting,
-                    opts.git_prepare_depth,
-                    inherited_build_policy_for_git_prepare.clone(),
-                    resolve_git_shallow_hosts(&settings_ctx),
-                )
-                .await?;
+                let (catchup_indices, catchup_cached, catchup_fetched, catchup_integrities) =
+                    fetch_packages_with_root(
+                        &missing_packages,
+                        &store,
+                        || {
+                            std::sync::Arc::new(
+                                make_client(&cwd_for_catchup_client)
+                                    .with_network_mode(catchup_network_mode),
+                            )
+                        },
+                        prog_ref,
+                        &cwd,
+                        &aube_dir,
+                        /*materialize_tx=*/ None,
+                        /*skip_already_linked_shortcut=*/ has_workspace,
+                        virtual_store_dir_max_length,
+                        opts.ignore_scripts,
+                        network_concurrency_setting,
+                        verify_store_integrity_setting,
+                        strict_store_integrity_setting,
+                        strict_store_pkg_content_check_setting,
+                        opts.git_prepare_depth,
+                        inherited_build_policy_for_git_prepare.clone(),
+                        resolve_git_shallow_hosts(&settings_ctx),
+                    )
+                    .await?;
+                if !catchup_integrities.is_empty() {
+                    apply_computed_integrities(&mut graph, &catchup_integrities);
+                    if let Some(lock_graph) = lockfile_graph_for_integrity_rewrite.as_mut() {
+                        apply_computed_integrities(lock_graph, &catchup_integrities);
+                        if shared_workspace_lockfile || !has_workspace {
+                            write_lockfile_dir_remapped(
+                                &lockfile_dir,
+                                &lockfile_importer_key,
+                                lock_graph,
+                                &manifest,
+                                write_kind,
+                            )
+                            .into_diagnostic()
+                            .wrap_err("failed to write lockfile with computed integrity")?;
+                        } else {
+                            write_per_project_lockfiles(
+                                &cwd,
+                                lock_graph,
+                                &manifests,
+                                write_kind,
+                                per_project_write_selection.as_ref(),
+                            )?;
+                        }
+                    }
+                }
                 indices.extend(catchup_indices);
                 cached += catchup_cached;
                 fetched += catchup_fetched;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1451,10 +1451,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
 
                         let computed_integrity = integrity
                             .is_none()
-                            .then(|| {
-                                streamed_digest.map(|digest| aube_store::sha512_integrity(&digest))
-                            })
-                            .flatten();
+                            .then(|| match streamed_digest.as_ref() {
+                                Some(digest) => aube_store::sha512_integrity_from_digest(digest),
+                                None => aube_store::sha512_integrity(&bytes),
+                            });
                         let (index, _) = run_import_on_blocking(
                             store.clone(),
                             bytes,
@@ -1495,7 +1495,8 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         .await
                         .map_err(|_| miette!("materializer task exited before fetch finished"))?;
                     if let Some(integrity) = computed_integrity {
-                        computed_integrities.insert(dep_path.clone(), integrity);
+                        computed_integrities
+                            .insert(strip_peer_context_suffix(&dep_path).to_owned(), integrity);
                     }
                     indices.insert(dep_path, index);
                 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the install fetch path and lockfile write behavior for packages missing integrity, but only fills absent fields and does not skip verification when integrity is already present.
> 
> **Overview**
> When registry packages are fetched **without** a lockfile `integrity` field, install now derives **SHA-512 SRI** from the tarball (streaming or buffered) and threads that value through the fetch pipeline.
> 
> **Store:** `sha512_integrity_from_digest` formats SRI from an already-computed digest so streaming paths do not re-hash bytes.
> 
> **Fetch:** Tarball tasks return an optional computed integrity; results are keyed by canonical `dep_path` (peer suffix stripped). Missing-integrity fetches also **cache the package index** under the computed integrity when possible.
> 
> **Lockfile:** `apply_computed_integrities` backfills `integrity` on registry packages in the in-memory graph (including peer-contextualized entries) before write. Catch-up fetches can trigger an extra lockfile rewrite when new integrities appear.
> 
> A unit test covers peer-variant mapping and skipping packages that already have integrity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78ead61f123f3c895351c923a209a6a2e000139e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package install command now automatically computes and stores missing integrity values in the lockfile, providing enhanced verification for all package dependencies.

* **Tests**
  * Added test to validate integrity computation behavior across different package context scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->