### PR TITLE
feat(sbom): exclude peer-only components

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1603,6 +1603,7 @@ cmd runtime subcommand_required=#true help="Manage the project's Node.js runtime
 }
 cmd sbom help="Generate a Software Bill of Materials (CycloneDX or SPDX)" {
     flag "-D --dev" help="Show only devDependencies"
+    flag --exclude-peers help="Exclude peer dependencies from CycloneDX output"
     flag --format help="Output format: `cyclonedx` (default) or `spdx`" default=cyclonedx {
         arg <FORMAT> {
             choices cyclonedx spdx

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -58,8 +58,13 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
 
     let filter = DepFilter::from_flags(args.prod, args.dev);
     let closure = super::collect_dep_closure(&graph, filter, false);
-    let closure = if args.exclude_peers {
-        exclude_peer_only_packages(&graph, &closure)
+    if args.exclude_peers && args.format != SbomFormat::Cyclonedx {
+        return Err(miette::miette!(
+            "--exclude-peers is only supported with --format cyclonedx"
+        ));
+    }
+    let closure = if args.exclude_peers && args.format == SbomFormat::Cyclonedx {
+        exclude_peer_only_packages(&graph, &closure, &manifest.peer_dependencies)
     } else {
         closure
     };
@@ -188,12 +193,14 @@ fn url_is_http(url: &str) -> bool {
 fn exclude_peer_only_packages<'a>(
     graph: &'a LockfileGraph,
     closure: &BTreeMap<String, &'a LockedPackage>,
+    root_peer_dependencies: &BTreeMap<String, String>,
 ) -> BTreeMap<String, &'a LockedPackage> {
     let mut out = BTreeMap::new();
     let mut stack: Vec<String> = graph
         .root_deps()
         .iter()
         .filter(|dep| closure.contains_key(&dep.dep_path))
+        .filter(|dep| !root_peer_dependencies.contains_key(&dep.name))
         .map(|dep| dep.dep_path.clone())
         .collect();
 
@@ -617,12 +624,47 @@ mod tests {
             .iter()
             .map(|(dep_path, pkg)| (dep_path.clone(), pkg))
             .collect();
-        let pruned = exclude_peer_only_packages(&graph, &closure);
+        let pruned = exclude_peer_only_packages(&graph, &closure, &BTreeMap::new());
 
         assert!(pruned.contains_key("consumer@1.0.0"));
         assert!(pruned.contains_key("runtime@1.0.0"));
         assert!(pruned.contains_key("peer-child@1.0.0"));
         assert!(!pruned.contains_key("peer@1.0.0"));
+    }
+
+    #[test]
+    fn exclude_peer_only_packages_prunes_root_peer_deps() {
+        let mut graph = LockfileGraph::default();
+        graph.importers.insert(
+            ".".into(),
+            vec![DirectDep {
+                name: "react".into(),
+                dep_path: "react@18.2.0".into(),
+                dep_type: DepType::Dev,
+                specifier: None,
+            }],
+        );
+        graph.packages.insert(
+            "react@18.2.0".into(),
+            LockedPackage {
+                name: "react".into(),
+                version: "18.2.0".into(),
+                dep_path: "react@18.2.0".into(),
+                ..Default::default()
+            },
+        );
+        let closure: BTreeMap<_, _> = graph
+            .packages
+            .iter()
+            .map(|(dep_path, pkg)| (dep_path.clone(), pkg))
+            .collect();
+        let pruned = exclude_peer_only_packages(
+            &graph,
+            &closure,
+            &BTreeMap::from([("react".into(), "^18".into())]),
+        );
+
+        assert!(pruned.is_empty());
     }
 
     #[test]

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -18,6 +18,10 @@ pub struct SbomArgs {
     #[arg(short = 'D', long, conflicts_with = "prod")]
     pub dev: bool,
 
+    /// Exclude peer dependencies from CycloneDX output
+    #[arg(long)]
+    pub exclude_peers: bool,
+
     /// Output format: `cyclonedx` (default) or `spdx`
     #[arg(long, value_enum, default_value_t = SbomFormat::Cyclonedx)]
     pub format: SbomFormat,
@@ -54,11 +58,16 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
 
     let filter = DepFilter::from_flags(args.prod, args.dev);
     let closure = super::collect_dep_closure(&graph, filter, false);
+    let closure = if args.exclude_peers {
+        exclude_peer_only_packages(&graph, &closure)
+    } else {
+        closure
+    };
 
     let json = match args.format {
         SbomFormat::Cyclonedx => {
             let dev_only = collect_dev_only_packages(&graph, graph.importers.values().flatten());
-            render_cyclonedx(&manifest, &closure, &dev_only)?
+            render_cyclonedx(&manifest, &closure, &dev_only, args.exclude_peers)?
         }
         SbomFormat::Spdx => render_spdx(&manifest, &graph, filter, &closure)?,
     };
@@ -72,6 +81,7 @@ fn render_cyclonedx(
     manifest: &aube_manifest::PackageJson,
     closure: &BTreeMap<String, &LockedPackage>,
     dev_only: &BTreeMap<String, bool>,
+    exclude_peers: bool,
 ) -> miette::Result<String> {
     let root_name = manifest.name.clone().unwrap_or_else(|| "(unnamed)".into());
     let root_version = manifest.version.clone().unwrap_or_default();
@@ -85,6 +95,9 @@ fn render_cyclonedx(
         c.insert("name".into(), pkg.name.clone().into());
         c.insert("version".into(), pkg.version.clone().into());
         c.insert("purl".into(), purl(&pkg.name, &pkg.version).into());
+        if let Some(bugs_url) = bugs_url_from_extra(&pkg.extra_meta) {
+            c.insert("externalReferences".into(), external_references(bugs_url));
+        }
         if dev_only.get(dep_path).copied().unwrap_or(false) {
             c.insert("scope".into(), "excluded".into());
             c.insert(
@@ -104,6 +117,9 @@ fn render_cyclonedx(
     root_component.insert("name".into(), root_name.into());
     if !root_version.is_empty() {
         root_component.insert("version".into(), root_version.clone().into());
+    }
+    if let Some(bugs_url) = bugs_url_from_extra(&manifest.extra) {
+        root_component.insert("externalReferences".into(), external_references(bugs_url));
     }
 
     let mut metadata = serde_json::Map::new();
@@ -125,17 +141,82 @@ fn render_cyclonedx(
         serde_json::Value::Object(root_component),
     );
 
-    let bom = serde_json::json!({
-        "bomFormat": "CycloneDX",
-        "specVersion": "1.5",
-        "version": 1,
-        "metadata": metadata,
-        "components": components,
-    });
+    let mut bom = serde_json::Map::new();
+    bom.insert("bomFormat".into(), "CycloneDX".into());
+    bom.insert("specVersion".into(), "1.5".into());
+    bom.insert("version".into(), 1.into());
+    bom.insert("metadata".into(), metadata.into());
+    bom.insert("components".into(), components.into());
+    if exclude_peers {
+        bom.insert("properties".into(), cyclonedx_exclude_peers_property());
+    }
 
-    serde_json::to_string_pretty(&bom)
+    serde_json::to_string_pretty(&serde_json::Value::Object(bom))
         .into_diagnostic()
         .wrap_err("failed to serialize CycloneDX SBOM")
+}
+
+fn cyclonedx_exclude_peers_property() -> serde_json::Value {
+    serde_json::json!([{
+        "name": "cdx:npm:package:excludePeers",
+        "value": "true",
+    }])
+}
+
+fn external_references(url: &str) -> serde_json::Value {
+    serde_json::json!([{
+        "type": "issue-tracker",
+        "url": url,
+    }])
+}
+
+fn bugs_url_from_extra(extra: &BTreeMap<String, serde_json::Value>) -> Option<&str> {
+    match extra.get("bugs")? {
+        serde_json::Value::String(url) => url_is_http(url).then_some(url.as_str()),
+        serde_json::Value::Object(map) => map
+            .get("url")
+            .and_then(serde_json::Value::as_str)
+            .filter(|url| url_is_http(url)),
+        _ => None,
+    }
+}
+
+fn url_is_http(url: &str) -> bool {
+    url.starts_with("https://") || url.starts_with("http://")
+}
+
+fn exclude_peer_only_packages<'a>(
+    graph: &'a LockfileGraph,
+    closure: &BTreeMap<String, &'a LockedPackage>,
+) -> BTreeMap<String, &'a LockedPackage> {
+    let mut out = BTreeMap::new();
+    let mut stack: Vec<String> = graph
+        .root_deps()
+        .iter()
+        .filter(|dep| closure.contains_key(&dep.dep_path))
+        .map(|dep| dep.dep_path.clone())
+        .collect();
+
+    while let Some(dep_path) = stack.pop() {
+        let Some(pkg) = closure.get(&dep_path).copied() else {
+            continue;
+        };
+        if out.insert(dep_path.clone(), pkg).is_some() {
+            continue;
+        }
+        let peer_names = pkg.peer_dependencies_with_meta_defaults();
+        for (name, version) in &pkg.dependencies {
+            if peer_names.contains_key(name) {
+                continue;
+            }
+            let child_path = format!("{name}@{version}");
+            if closure.contains_key(&child_path) {
+                stack.push(child_path);
+            }
+        }
+    }
+
+    out
 }
 
 fn collect_dev_only_packages<'a>(
@@ -473,6 +554,93 @@ mod tests {
 
         let dev_only = collect_dev_only_packages(&graph, graph.importers.values().flatten());
         assert_eq!(dev_only.get("shared@1.0.0"), Some(&false));
+    }
+
+    #[test]
+    fn exclude_peer_only_packages_prunes_exclusive_peer_subtree() {
+        let mut graph = LockfileGraph::default();
+        graph.importers.insert(
+            ".".into(),
+            vec![DirectDep {
+                name: "consumer".into(),
+                dep_path: "consumer@1.0.0".into(),
+                dep_type: DepType::Production,
+                specifier: None,
+            }],
+        );
+        graph.packages.insert(
+            "consumer@1.0.0".into(),
+            LockedPackage {
+                name: "consumer".into(),
+                version: "1.0.0".into(),
+                dep_path: "consumer@1.0.0".into(),
+                dependencies: BTreeMap::from([
+                    ("peer".into(), "1.0.0".into()),
+                    ("runtime".into(), "1.0.0".into()),
+                ]),
+                peer_dependencies: BTreeMap::from([("peer".into(), "^1".into())]),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "peer@1.0.0".into(),
+            LockedPackage {
+                name: "peer".into(),
+                version: "1.0.0".into(),
+                dep_path: "peer@1.0.0".into(),
+                dependencies: BTreeMap::from([("peer-child".into(), "1.0.0".into())]),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "peer-child@1.0.0".into(),
+            LockedPackage {
+                name: "peer-child".into(),
+                version: "1.0.0".into(),
+                dep_path: "peer-child@1.0.0".into(),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "runtime@1.0.0".into(),
+            LockedPackage {
+                name: "runtime".into(),
+                version: "1.0.0".into(),
+                dep_path: "runtime@1.0.0".into(),
+                dependencies: BTreeMap::from([("peer-child".into(), "1.0.0".into())]),
+                ..Default::default()
+            },
+        );
+
+        let closure: BTreeMap<_, _> = graph
+            .packages
+            .iter()
+            .map(|(dep_path, pkg)| (dep_path.clone(), pkg))
+            .collect();
+        let pruned = exclude_peer_only_packages(&graph, &closure);
+
+        assert!(pruned.contains_key("consumer@1.0.0"));
+        assert!(pruned.contains_key("runtime@1.0.0"));
+        assert!(pruned.contains_key("peer-child@1.0.0"));
+        assert!(!pruned.contains_key("peer@1.0.0"));
+    }
+
+    #[test]
+    fn bugs_url_from_extra_accepts_url_shape_only() {
+        let object = BTreeMap::from([(
+            "bugs".into(),
+            serde_json::json!({"url": "https://github.com/acme/pkg/issues"}),
+        )]);
+        assert_eq!(
+            bugs_url_from_extra(&object),
+            Some("https://github.com/acme/pkg/issues")
+        );
+
+        let email = BTreeMap::from([(
+            "bugs".into(),
+            serde_json::json!({"email": "bugs@acme.test"}),
+        )]);
+        assert_eq!(bugs_url_from_extra(&email), None);
     }
 
     #[test]

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -64,7 +64,12 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
         ));
     }
     let closure = if args.exclude_peers && args.format == SbomFormat::Cyclonedx {
-        exclude_peer_only_packages(&graph, &closure, &manifest.peer_dependencies)
+        exclude_peer_only_packages(
+            &graph,
+            &closure,
+            &manifest.peer_dependencies,
+            &manifest.dependencies,
+        )
     } else {
         closure
     };
@@ -194,13 +199,17 @@ fn exclude_peer_only_packages<'a>(
     graph: &'a LockfileGraph,
     closure: &BTreeMap<String, &'a LockedPackage>,
     root_peer_dependencies: &BTreeMap<String, String>,
+    root_dependencies: &BTreeMap<String, String>,
 ) -> BTreeMap<String, &'a LockedPackage> {
     let mut out = BTreeMap::new();
     let mut stack: Vec<String> = graph
         .root_deps()
         .iter()
         .filter(|dep| closure.contains_key(&dep.dep_path))
-        .filter(|dep| !root_peer_dependencies.contains_key(&dep.name))
+        .filter(|dep| {
+            !root_peer_dependencies.contains_key(&dep.name)
+                || root_dependencies.contains_key(&dep.name)
+        })
         .map(|dep| dep.dep_path.clone())
         .collect();
 
@@ -624,7 +633,8 @@ mod tests {
             .iter()
             .map(|(dep_path, pkg)| (dep_path.clone(), pkg))
             .collect();
-        let pruned = exclude_peer_only_packages(&graph, &closure, &BTreeMap::new());
+        let pruned =
+            exclude_peer_only_packages(&graph, &closure, &BTreeMap::new(), &BTreeMap::new());
 
         assert!(pruned.contains_key("consumer@1.0.0"));
         assert!(pruned.contains_key("runtime@1.0.0"));
@@ -662,9 +672,46 @@ mod tests {
             &graph,
             &closure,
             &BTreeMap::from([("react".into(), "^18".into())]),
+            &BTreeMap::new(),
         );
 
         assert!(pruned.is_empty());
+    }
+
+    #[test]
+    fn exclude_peer_only_packages_keeps_root_prod_peer_deps() {
+        let mut graph = LockfileGraph::default();
+        graph.importers.insert(
+            ".".into(),
+            vec![DirectDep {
+                name: "react".into(),
+                dep_path: "react@18.2.0".into(),
+                dep_type: DepType::Production,
+                specifier: None,
+            }],
+        );
+        graph.packages.insert(
+            "react@18.2.0".into(),
+            LockedPackage {
+                name: "react".into(),
+                version: "18.2.0".into(),
+                dep_path: "react@18.2.0".into(),
+                ..Default::default()
+            },
+        );
+        let closure: BTreeMap<_, _> = graph
+            .packages
+            .iter()
+            .map(|(dep_path, pkg)| (dep_path.clone(), pkg))
+            .collect();
+        let pruned = exclude_peer_only_packages(
+            &graph,
+            &closure,
+            &BTreeMap::from([("react".into(), "^18".into())]),
+            &BTreeMap::from([("react".into(), "^18".into())]),
+        );
+
+        assert!(pruned.contains_key("react@18.2.0"));
     }
 
     #[test]

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -9208,6 +9208,18 @@
             "global": false
           },
           {
+            "name": "exclude-peers",
+            "usage": "--exclude-peers",
+            "help": "Exclude peer dependencies from CycloneDX output",
+            "help_first_line": "Exclude peer dependencies from CycloneDX output",
+            "short": [],
+            "long": [
+              "exclude-peers"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "format",
             "usage": "--format <FORMAT>",
             "help": "Output format: `cyclonedx` (default) or `spdx`",

--- a/docs/cli/sbom.md
+++ b/docs/cli/sbom.md
@@ -11,6 +11,10 @@ Generate a Software Bill of Materials (CycloneDX or SPDX)
 
 Show only devDependencies
 
+### `--exclude-peers`
+
+Exclude peer dependencies from CycloneDX output
+
 ### `--format <FORMAT>`
 
 Output format: `cyclonedx` (default) or `spdx`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> SBOM-only, read-only lockfile path; peer exclusion is opt-in and scoped to CycloneDX, with regression tests for pruning behavior.
> 
> **Overview**
> **`aube sbom`** gains **`--exclude-peers`** (CycloneDX only): it trims packages reachable only via peer edges from the component list, drops root direct deps that are peer-only unless they are also in `dependencies`, and records **`cdx:npm:package:excludePeers`** on the BOM. Using the flag with SPDX returns a clear error.
> 
> CycloneDX output also adds **`externalReferences`** (issue-tracker) for the root and each component when `package.json` / lockfile **`bugs`** is an `http`/`https` URL (string or `{ "url": "..." }`); email-only bugs are ignored.
> 
> CLI help and docs (`aube.usage.kdl`, `docs/cli/sbom.md`, `commands.json`) document the new flag. Unit tests cover peer pruning and bugs URL parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a5baab86be2a2ccc94797d24c32bbc94dd12a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->