### PR TITLE
fix(install): move computed-integrity tests to end of module

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -173,52 +173,6 @@ fn apply_computed_integrities(
     }
 }
 
-#[cfg(test)]
-mod computed_integrity_tests {
-    use super::*;
-
-    #[test]
-    fn computed_integrity_updates_peer_variants() {
-        let mut graph = aube_lockfile::LockfileGraph::default();
-        graph.packages.insert(
-            "consumer@1.0.0(peer@2.0.0)".into(),
-            aube_lockfile::LockedPackage {
-                name: "consumer".into(),
-                version: "1.0.0".into(),
-                dep_path: "consumer@1.0.0(peer@2.0.0)".into(),
-                ..Default::default()
-            },
-        );
-        graph.packages.insert(
-            "already@1.0.0".into(),
-            aube_lockfile::LockedPackage {
-                name: "already".into(),
-                version: "1.0.0".into(),
-                dep_path: "already@1.0.0".into(),
-                integrity: Some("sha512-existing".into()),
-                ..Default::default()
-            },
-        );
-        let computed = BTreeMap::from([
-            ("consumer@1.0.0".into(), "sha512-computed".into()),
-            ("already@1.0.0".into(), "sha512-new".into()),
-        ]);
-
-        apply_computed_integrities(&mut graph, &computed);
-
-        assert_eq!(
-            graph.packages["consumer@1.0.0(peer@2.0.0)"]
-                .integrity
-                .as_deref(),
-            Some("sha512-computed")
-        );
-        assert_eq!(
-            graph.packages["already@1.0.0"].integrity.as_deref(),
-            Some("sha512-existing")
-        );
-    }
-}
-
 async fn validate_lockfile_trust_policy(
     cwd: &std::path::Path,
     graph: &aube_lockfile::LockfileGraph,
@@ -2161,4 +2115,50 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     })
     .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod computed_integrity_tests {
+    use super::*;
+
+    #[test]
+    fn computed_integrity_updates_peer_variants() {
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.packages.insert(
+            "consumer@1.0.0(peer@2.0.0)".into(),
+            aube_lockfile::LockedPackage {
+                name: "consumer".into(),
+                version: "1.0.0".into(),
+                dep_path: "consumer@1.0.0(peer@2.0.0)".into(),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "already@1.0.0".into(),
+            aube_lockfile::LockedPackage {
+                name: "already".into(),
+                version: "1.0.0".into(),
+                dep_path: "already@1.0.0".into(),
+                integrity: Some("sha512-existing".into()),
+                ..Default::default()
+            },
+        );
+        let computed = BTreeMap::from([
+            ("consumer@1.0.0".into(), "sha512-computed".into()),
+            ("already@1.0.0".into(), "sha512-new".into()),
+        ]);
+
+        apply_computed_integrities(&mut graph, &computed);
+
+        assert_eq!(
+            graph.packages["consumer@1.0.0(peer@2.0.0)"]
+                .integrity
+                .as_deref(),
+            Some("sha512-computed")
+        );
+        assert_eq!(
+            graph.packages["already@1.0.0"].integrity.as_deref(),
+            Some("sha512-existing")
+        );
+    }
 }


### PR DESCRIPTION
## What

Moves the `computed_integrity_tests` module in `crates/aube/src/commands/install/mod.rs` (added in #933) from the middle of the file to the end. Pure relocation - no behavior change.

## Why

With the test module mid-file, three production items follow it (`validate_lockfile_trust_policy`, `reachable_package_dep_paths`, `run`), which trips clippy's `items_after_test_module` lint under:

```
cargo clippy --all-targets -- -D warnings
```

which is the command the contributing guide tells contributors to run. CI's `hk` clippy step runs `cargo clippy --manifest-path … --quiet` **without** `--all-targets`, so test targets aren't compiled and the lint never fired in CI; that's how it landed. This change makes the documented gate pass.

## Verification

- `cargo clippy --all-targets -- -D warnings` - clean (was failing on `install/mod.rs`)
- `cargo fmt --check` - clean
- `cargo test -p aube --lib computed_integrity_updates_peer_variants` - passes

*This PR was generated by Claude.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal test placement for consistency; no user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->