### PR TITLE
feat(resolver): support globs and version unions in minimumReleaseAgeExclude

### DIFF
--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -31,6 +31,8 @@ pub const WARN_AUBE_GVS_MODE_CHANGED: &str = "WARN_AUBE_GVS_MODE_CHANGED";
 // ── settings / config validation ────────────────────────────────────
 pub const WARN_AUBE_INVALID_CONCURRENCY: &str = "WARN_AUBE_INVALID_CONCURRENCY";
 pub const WARN_AUBE_INVALID_TRUST_POLICY: &str = "WARN_AUBE_INVALID_TRUST_POLICY";
+pub const WARN_AUBE_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE: &str =
+    "WARN_AUBE_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE";
 pub const WARN_AUBE_OVERRIDE_MISSING_DEP: &str = "WARN_AUBE_OVERRIDE_MISSING_DEP";
 pub const WARN_AUBE_OVERRIDE_DOLLAR_REF_DEPRECATED: &str =
     "WARN_AUBE_OVERRIDE_DOLLAR_REF_DEPRECATED";
@@ -250,6 +252,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_INVALID_TRUST_POLICY,
         category: category::SETTINGS_CONFIG,
         description: "A `trustPolicyExclude` entry was malformed and skipped.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE,
+        category: category::SETTINGS_CONFIG,
+        description: "A `minimumReleaseAgeExclude` entry was malformed and skipped.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -27,7 +27,7 @@ pub use trust::{
     MissingTimeDetails as MissingTrustTimeDetails, TrustCheckError, TrustDowngradeDetails,
     check_no_downgrade,
 };
-pub use trust::{TrustEvidence, TrustExcludeParseError, TrustExcludeRules};
+pub use trust::{PackageVersionPolicy, TrustEvidence, TrustExcludeParseError, TrustExcludeRules};
 pub use types::{
     DependencyPolicy, MinimumReleaseAge, PackageExtension, ReadPackageHook, ResolutionMode,
     ResolvedPackage, TrustPolicy,

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -101,6 +101,13 @@ pub(crate) struct ResolveDriver<'a> {
     /// from `minimum_release_age` for supply-chain mitigation;
     /// extended by the TimeBased cutoff once wave 0 resolves.
     published_by: Option<String>,
+    /// The TimeBased-resolution component of the cutoff, kept separate
+    /// from the merged `published_by`. `None` until wave 0 fires the
+    /// time-based wall (and stays `None` when time-based mode is off).
+    /// Acts as a hard floor that even `minimumReleaseAgeExclude`-exempt
+    /// versions must clear — the exclude relaxes only the
+    /// minimumReleaseAge age-gate, never the time-based wall.
+    time_cutoff: Option<String>,
     /// Direct deps still awaiting a terminal outcome (resolved,
     /// dropped, or filtered). Drops to zero once wave 0 completes and
     /// triggers the TimeBased cutoff computation.
@@ -223,6 +230,7 @@ impl<'a> ResolveDriver<'a> {
             catalog_picks: BTreeMap::new(),
             deferred_transitives: Vec::new(),
             published_by,
+            time_cutoff: None,
             direct_deps_pending,
             cutoff_pending,
             needs_time,
@@ -356,6 +364,7 @@ impl<'a> ResolveDriver<'a> {
                 }
                 if let Some(m) = max_time {
                     tracing::debug!("time-based resolution cutoff: {}", m);
+                    self.time_cutoff = Some(m.clone());
                     self.published_by = Some(match self.published_by.take() {
                         Some(existing) if existing.as_str() < m.as_str() => existing,
                         _ => m.clone(),
@@ -529,17 +538,19 @@ impl<'a> ResolveDriver<'a> {
         // and all picks in Highest mode) picks highest.
         let pick_lowest =
             self.resolver.resolution_mode == ResolutionMode::TimeBased && task.is_root;
-        // The cutoff itself is uniform; `minimumReleaseAgeExclude` is
-        // applied per-candidate-version inside `pick_version` via the
-        // `is_age_exempt` closure below. A name-only exclude rule
-        // matches every version, so the whole package skips the cutoff
-        // (the old package-level behavior); a `pkg@1.2.3`-style rule
-        // waves only those versions past it. The exclude is meant to
-        // suppress only the minimumReleaseAge leg, not the time-based
-        // leg, but since both collapse into one `published_by` here we
-        // exempt both — acceptable, as the two aren't expected to
-        // coexist in the wild.
+        // `minimumReleaseAgeExclude` is applied per-candidate-version
+        // inside `pick_version` via the `is_age_exempt` closure below. A
+        // name-only exclude rule matches every version; a `pkg@1.2.3`
+        // rule waves only those versions. The exclude relaxes ONLY the
+        // minimumReleaseAge age-gate — never the time-based hard wall —
+        // so exempt versions are still checked against `exempt_cutoff`
+        // (the time-based component alone) instead of being fully waved
+        // through. Non-exempt versions are checked against the merged
+        // `cutoff_for_pkg` = min(minimumReleaseAge, time-based). When
+        // time-based mode is off, `exempt_cutoff` is `None`, so exempt
+        // versions bypass the cutoff entirely (the prior behavior).
         let cutoff_for_pkg = self.published_by.as_deref();
+        let exempt_cutoff = self.time_cutoff.as_deref();
         // Strict semantics in two cases:
         //   - `minimumReleaseAgeStrict=true` (the user opted in
         //     to hard failures), or
@@ -555,9 +566,13 @@ impl<'a> ResolveDriver<'a> {
         };
         let registry_name = task.registry_name().to_string();
         // `minimumReleaseAgeExclude` exemption, shared by the version
-        // pick and the vulnerability re-pick below. Reuses an
-        // already-parsed version when the caller has one, falling back to
-        // a name-only match for unparseable versions.
+        // pick and the vulnerability re-pick below. Matches against the
+        // registry name (not `task.name`, the user-facing alias) so an
+        // `npm:real-pkg`-aliased dep is exempted by its real name — the
+        // same identity the age/publish-time data and the trust-policy
+        // sibling (`check_no_downgrade`) key on. Reuses an already-parsed
+        // version when the caller has one, falling back to a name-only
+        // match for unparseable versions.
         let mra_exclude = self
             .resolver
             .minimum_release_age
@@ -565,10 +580,10 @@ impl<'a> ResolveDriver<'a> {
             .map(|m| &m.exclude);
         let is_age_exempt = |ver: &str, parsed: Option<&node_semver::Version>| {
             mra_exclude.is_some_and(|ex| match parsed {
-                Some(v) => ex.matches(&task.name, v),
+                Some(v) => ex.matches(&registry_name, v),
                 None => match node_semver::Version::parse(ver) {
-                    Ok(v) => ex.matches(&task.name, &v),
-                    Err(_) => ex.matches_name_only(&task.name),
+                    Ok(v) => ex.matches(&registry_name, &v),
+                    Err(_) => ex.matches_name_only(&registry_name),
                 },
             })
         };
@@ -582,6 +597,7 @@ impl<'a> ResolveDriver<'a> {
                 locked_version,
                 pick_lowest,
                 cutoff_for_pkg,
+                exempt_cutoff,
                 strict,
                 is_age_exempt,
             );
@@ -658,6 +674,7 @@ impl<'a> ResolveDriver<'a> {
             &selected_pick,
             pick_lowest,
             cutoff_for_pkg,
+            exempt_cutoff,
             &self.resolver.vulnerable_ranges,
             is_age_exempt,
         );

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -529,18 +529,17 @@ impl<'a> ResolveDriver<'a> {
         // and all picks in Highest mode) picks highest.
         let pick_lowest =
             self.resolver.resolution_mode == ResolutionMode::TimeBased && task.is_root;
-        // Apply the cutoff unless this package is on the
-        // minimumReleaseAge exclude list. The exclude list only
-        // suppresses the *minimumReleaseAge* leg, not the
-        // time-based-mode leg — but since we collapse both
-        // into the same `published_by` string at this point,
-        // we have to skip the cutoff entirely for excluded
-        // names. Acceptable: time-based mode and exclude
-        // lists aren't expected to coexist in the wild.
-        let cutoff_for_pkg = match self.resolver.minimum_release_age.as_ref() {
-            Some(mra) if mra.exclude.contains(&task.name) => None,
-            _ => self.published_by.as_deref(),
-        };
+        // The cutoff itself is uniform; `minimumReleaseAgeExclude` is
+        // applied per-candidate-version inside `pick_version` via the
+        // `is_age_exempt` closure below. A name-only exclude rule
+        // matches every version, so the whole package skips the cutoff
+        // (the old package-level behavior); a `pkg@1.2.3`-style rule
+        // waves only those versions past it. The exclude is meant to
+        // suppress only the minimumReleaseAge leg, not the time-based
+        // leg, but since both collapse into one `published_by` here we
+        // exempt both — acceptable, as the two aren't expected to
+        // coexist in the wild.
+        let cutoff_for_pkg = self.published_by.as_deref();
         // Strict semantics in two cases:
         //   - `minimumReleaseAgeStrict=true` (the user opted in
         //     to hard failures), or
@@ -555,6 +554,24 @@ impl<'a> ResolveDriver<'a> {
             None => true,
         };
         let registry_name = task.registry_name().to_string();
+        // `minimumReleaseAgeExclude` exemption, shared by the version
+        // pick and the vulnerability re-pick below. Reuses an
+        // already-parsed version when the caller has one, falling back to
+        // a name-only match for unparseable versions.
+        let mra_exclude = self
+            .resolver
+            .minimum_release_age
+            .as_ref()
+            .map(|m| &m.exclude);
+        let is_age_exempt = |ver: &str, parsed: Option<&node_semver::Version>| {
+            mra_exclude.is_some_and(|ex| match parsed {
+                Some(v) => ex.matches(&task.name, v),
+                None => match node_semver::Version::parse(ver) {
+                    Ok(v) => ex.matches(&task.name, &v),
+                    Err(_) => ex.matches_name_only(&task.name),
+                },
+            })
+        };
         let selected_pick = loop {
             let packument = self.resolver.cache.get(&registry_name).ok_or_else(|| {
                 Error::Registry(registry_name.clone(), "packument not in cache".to_string())
@@ -566,6 +583,7 @@ impl<'a> ResolveDriver<'a> {
                 pick_lowest,
                 cutoff_for_pkg,
                 strict,
+                is_age_exempt,
             );
             match pick {
                 PickResult::Found(meta) => break meta.clone(),
@@ -641,6 +659,7 @@ impl<'a> ResolveDriver<'a> {
             pick_lowest,
             cutoff_for_pkg,
             &self.resolver.vulnerable_ranges,
+            is_age_exempt,
         );
         // Trust-policy enforcement runs *before* any other
         // post-pick processing (mirrors pnpm's placement

--- a/crates/aube-resolver/src/resolve/fetch.rs
+++ b/crates/aube-resolver/src/resolve/fetch.rs
@@ -2,7 +2,6 @@ use crate::{Error, FxHashSet, Resolver};
 use aube_registry::Packument;
 use aube_registry::client::RegistryClient;
 use aube_util::adaptive::AdaptiveLimit;
-use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::task::JoinSet;
@@ -28,7 +27,7 @@ pub(super) struct FetchScheduler {
     client: Arc<RegistryClient>,
     cache_dir: Option<PathBuf>,
     full_cache_dir: Option<PathBuf>,
-    mra_exclude: HashSet<String>,
+    mra_exclude: crate::trust::PackageVersionPolicy,
     force_metadata_primer: bool,
     needs_time: bool,
 }
@@ -50,7 +49,7 @@ impl FetchScheduler {
                 .minimum_release_age
                 .as_ref()
                 .map(|m| m.exclude.clone())
-                .unwrap_or_default(),
+                .unwrap_or_else(crate::trust::PackageVersionPolicy::empty),
             force_metadata_primer: resolver.force_metadata_primer,
             needs_time,
         }
@@ -70,7 +69,10 @@ impl FetchScheduler {
             return;
         }
         self.in_flight_names.insert(name.to_string());
-        let primer_covers_cutoff = self.mra_exclude.contains(name)
+        // Only a name-only exclude lets us skip the cutoff sight-unseen;
+        // a version-specific rule still needs publish times to tell which
+        // versions are exempt, so it falls through to the cutoff check.
+        let primer_covers_cutoff = self.mra_exclude.matches_name_only(name)
             || published_by.is_none_or(crate::primer::covers_cutoff);
         self.in_flight.spawn(fetch_one_packument(FetchInputs {
             name: name.to_string(),

--- a/crates/aube-resolver/src/resolve/vulnerable.rs
+++ b/crates/aube-resolver/src/resolve/vulnerable.rs
@@ -18,6 +18,7 @@ pub(super) fn is_vulnerable(
         .any(|range| version.satisfies(&range))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn prefer_non_vulnerable_pick<'a>(
     package_name: &str,
     packument: &'a Packument,
@@ -26,6 +27,7 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
     pick_lowest: bool,
     cutoff: Option<&str>,
     vulnerable_ranges: &BTreeMap<String, Vec<String>>,
+    is_age_exempt: impl Fn(&str, Option<&node_semver::Version>) -> bool,
 ) -> &'a aube_registry::VersionMetadata {
     if !is_vulnerable(package_name, &fallback.version, vulnerable_ranges) {
         return fallback;
@@ -34,8 +36,14 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
     else {
         return fallback;
     };
-    let passes_cutoff = |ver: &str| -> bool {
+    // Mirror `pick_version`'s cutoff: a `minimumReleaseAgeExclude` match
+    // waves a version past the age gate here too, otherwise the re-pick
+    // could discard the exempt safe version and keep the vulnerable one.
+    let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
         let Some(c) = cutoff else { return true };
+        if is_age_exempt(ver, parsed) {
+            return true;
+        }
         match packument.time.get(ver) {
             Some(t) => t.as_str() <= c,
             None => true,
@@ -47,7 +55,7 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
             continue;
         };
         if !version.satisfies(&range)
-            || !passes_cutoff(ver_str)
+            || !passes_cutoff(ver_str, Some(&version))
             || is_vulnerable(package_name, ver_str, vulnerable_ranges)
         {
             continue;

--- a/crates/aube-resolver/src/resolve/vulnerable.rs
+++ b/crates/aube-resolver/src/resolve/vulnerable.rs
@@ -26,6 +26,7 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
     fallback: &'a aube_registry::VersionMetadata,
     pick_lowest: bool,
     cutoff: Option<&str>,
+    exempt_cutoff: Option<&str>,
     vulnerable_ranges: &BTreeMap<String, Vec<String>>,
     is_age_exempt: impl Fn(&str, Option<&node_semver::Version>) -> bool,
 ) -> &'a aube_registry::VersionMetadata {
@@ -37,13 +38,17 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
         return fallback;
     };
     // Mirror `pick_version`'s cutoff: a `minimumReleaseAgeExclude` match
-    // waves a version past the age gate here too, otherwise the re-pick
-    // could discard the exempt safe version and keep the vulnerable one.
+    // waves a version past the minimumReleaseAge gate here too (still
+    // subject to `exempt_cutoff`, the time-based wall), otherwise the
+    // re-pick could discard the exempt safe version and keep the
+    // vulnerable one.
     let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
-        let Some(c) = cutoff else { return true };
-        if is_age_exempt(ver, parsed) {
-            return true;
-        }
+        let effective = if is_age_exempt(ver, parsed) {
+            exempt_cutoff
+        } else {
+            cutoff
+        };
+        let Some(c) = effective else { return true };
         match packument.time.get(ver) {
             Some(t) => t.as_str() <= c,
             None => true,

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -49,13 +49,21 @@ impl<'a> PickResult<'a> {
 /// hot-path call site here does, so the exemption check needn't reparse),
 /// and returns `true` to treat that version as if it cleared the cutoff.
 /// Pass `|_, _| false` when no exemptions apply.
+///
+/// `exempt_cutoff` is the time-based hard wall applied to exempt
+/// versions: a version waved past the age-gate by `is_age_exempt` must
+/// still clear `exempt_cutoff` (the time-based resolution cutoff). Pass
+/// `None` to fully bypass the cutoff for exempt versions (no time-based
+/// wall in effect).
 #[inline]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn pick_version<'a>(
     packument: &'a Packument,
     range_str: &str,
     locked: Option<&str>,
     pick_lowest: bool,
     cutoff: Option<&str>,
+    exempt_cutoff: Option<&str>,
     strict: bool,
     is_age_exempt: impl Fn(&str, Option<&node_semver::Version>) -> bool,
 ) -> PickResult<'a> {
@@ -101,11 +109,16 @@ pub(crate) fn pick_version<'a>(
         }
     };
 
+    // A version's effective cutoff: exempt versions answer to the
+    // time-based wall (`exempt_cutoff`) only; everyone else answers to
+    // the merged `cutoff`. `None` => no wall, keep the version.
     let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
-        let Some(c) = cutoff else { return true };
-        if is_age_exempt(ver, parsed) {
-            return true;
-        }
+        let effective = if is_age_exempt(ver, parsed) {
+            exempt_cutoff
+        } else {
+            cutoff
+        };
+        let Some(c) = effective else { return true };
         match packument.time.get(ver) {
             Some(t) => t.as_str() <= c,
             // Missing time: keep it — we'd rather risk a slightly newer

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -41,6 +41,14 @@ impl<'a> PickResult<'a> {
 /// cutoff. The lowest-satisfying fallback is pnpm's deliberate choice
 /// — the oldest version in the range is least likely to be the freshly
 /// pushed compromise that triggered the filter in the first place.
+///
+/// `is_age_exempt` lets the caller wave a specific version past the
+/// cutoff — used to honor `minimumReleaseAgeExclude` (bare names, name
+/// globs, and exact-version unions). It receives the candidate version
+/// string plus its already-parsed form when the caller has one (every
+/// hot-path call site here does, so the exemption check needn't reparse),
+/// and returns `true` to treat that version as if it cleared the cutoff.
+/// Pass `|_, _| false` when no exemptions apply.
 #[inline]
 pub(crate) fn pick_version<'a>(
     packument: &'a Packument,
@@ -49,6 +57,7 @@ pub(crate) fn pick_version<'a>(
     pick_lowest: bool,
     cutoff: Option<&str>,
     strict: bool,
+    is_age_exempt: impl Fn(&str, Option<&node_semver::Version>) -> bool,
 ) -> PickResult<'a> {
     // Handle dist-tag references. If the requested range is a tag
     // name and the packument has that tag, use the tagged version
@@ -92,8 +101,11 @@ pub(crate) fn pick_version<'a>(
         }
     };
 
-    let passes_cutoff = |ver: &str| -> bool {
+    let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
         let Some(c) = cutoff else { return true };
+        if is_age_exempt(ver, parsed) {
+            return true;
+        }
         match packument.time.get(ver) {
             Some(t) => t.as_str() <= c,
             // Missing time: keep it — we'd rather risk a slightly newer
@@ -106,7 +118,7 @@ pub(crate) fn pick_version<'a>(
     if let Some(locked_ver) = locked
         && let Ok(v) = node_semver::Version::parse(locked_ver)
         && v.satisfies(&range)
-        && passes_cutoff(locked_ver)
+        && passes_cutoff(locked_ver, Some(&v))
         && let Some(meta) = packument.versions.get(locked_ver)
     {
         return PickResult::Found(meta);
@@ -124,7 +136,7 @@ pub(crate) fn pick_version<'a>(
         && let Some(latest_ver) = packument.dist_tags.get("latest")
         && let Ok(v) = node_semver::Version::parse(latest_ver)
         && v.satisfies(&range)
-        && passes_cutoff(latest_ver)
+        && passes_cutoff(latest_ver, Some(&v))
         && let Some(meta) = packument.versions.get(latest_ver)
     {
         return PickResult::Found(meta);
@@ -151,7 +163,7 @@ pub(crate) fn pick_version<'a>(
             fallback_lowest = Some((v.clone(), meta));
         }
 
-        if passes_cutoff(ver_str) {
+        if passes_cutoff(ver_str, Some(&v)) {
             let replace = best
                 .as_ref()
                 .is_none_or(|(cur, _)| if pick_lowest { v < *cur } else { v > *cur });

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -109,22 +109,28 @@ pub(crate) fn pick_version<'a>(
         }
     };
 
+    // Does `ver` clear `effective` (the cutoff that applies to it)?
+    // `None` => no wall, keep the version. Missing time => keep it: we'd
+    // rather risk a slightly newer transitive than fail to resolve the
+    // range entirely.
+    let passes_effective_cutoff = |ver: &str, effective: Option<&str>| -> bool {
+        let Some(c) = effective else { return true };
+        match packument.time.get(ver) {
+            Some(t) => t.as_str() <= c,
+            None => true,
+        }
+    };
+
     // A version's effective cutoff: exempt versions answer to the
     // time-based wall (`exempt_cutoff`) only; everyone else answers to
-    // the merged `cutoff`. `None` => no wall, keep the version.
+    // the merged `cutoff`.
     let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
         let effective = if is_age_exempt(ver, parsed) {
             exempt_cutoff
         } else {
             cutoff
         };
-        let Some(c) = effective else { return true };
-        match packument.time.get(ver) {
-            Some(t) => t.as_str() <= c,
-            // Missing time: keep it — we'd rather risk a slightly newer
-            // transitive than fail to resolve the range entirely.
-            None => true,
-        }
+        passes_effective_cutoff(ver, effective)
     };
 
     // Prefer locked version if it satisfies and clears the cutoff.
@@ -172,7 +178,13 @@ pub(crate) fn pick_version<'a>(
             continue;
         }
 
-        if fallback_lowest.as_ref().is_none_or(|(cur, _)| v < *cur) {
+        // The lenient fallback drops the minimumReleaseAge gate but never
+        // the time-based hard wall, so only versions that clear
+        // `exempt_cutoff` are eligible (a no-op `None` when time-based
+        // mode is off).
+        if passes_effective_cutoff(ver_str, exempt_cutoff)
+            && fallback_lowest.as_ref().is_none_or(|(cur, _)| v < *cur)
+        {
             fallback_lowest = Some((v.clone(), meta));
         }
 
@@ -203,12 +215,21 @@ pub(crate) fn pick_version<'a>(
         };
     }
 
-    // Lenient fallback: pnpm's `pickPackageFromMetaUsingTime` ignores
-    // the cutoff and picks the *lowest* satisfying version.
+    // Lenient fallback: pnpm's `pickPackageFromMetaUsingTime` bypasses
+    // the minimumReleaseAge gate and picks the *lowest* satisfying
+    // version — the candidate already cleared the time-based wall above.
     if let Some((_, meta)) = fallback_lowest {
         return PickResult::Found(meta);
     }
-    PickResult::NoMatch
+    // Nothing left: either the range was unsatisfiable, or the
+    // time-based wall excluded every satisfying version. Report the age
+    // gate in the latter case so the caller surfaces a meaningful error
+    // rather than a bogus "no matching version".
+    if had_satisfying_but_age_gated {
+        PickResult::AgeGated
+    } else {
+        PickResult::NoMatch
+    }
 }
 
 /// Walk the packument's versions and return the highest non

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -678,7 +678,8 @@ fn test_pick_version_highest_match() {
     // dist-tag preference doesn't apply and we fall through to the
     // strictly-highest version inside the range — 1.2.0.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0", "2.0.0"], "2.0.0");
-    let result = pick_version(&packument, "^1.0.0", None, false, None, false).unwrap();
+    let result =
+        pick_version(&packument, "^1.0.0", None, false, None, false, |_, _| false).unwrap();
     assert_eq!(result.version, "1.2.0");
 }
 
@@ -695,7 +696,8 @@ fn test_pick_version_prefers_dist_tag_latest_when_in_range() {
     // -> aube add foo@^100.0.0` flow, which expects the lockfile to
     // pin 100.0.0 even though 100.1.0 is available.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0"], "1.0.0");
-    let result = pick_version(&packument, "^1.0.0", None, false, None, false).unwrap();
+    let result =
+        pick_version(&packument, "^1.0.0", None, false, None, false, |_, _| false).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -705,7 +707,8 @@ fn test_pick_version_falls_through_when_latest_outside_range() {
     // preference is a no-op; the strictly-highest matching version
     // (1.1.0) wins.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "2.0.0"], "2.0.0");
-    let result = pick_version(&packument, "^1.0.0", None, false, None, false).unwrap();
+    let result =
+        pick_version(&packument, "^1.0.0", None, false, None, false, |_, _| false).unwrap();
     assert_eq!(result.version, "1.1.0");
 }
 
@@ -715,21 +718,21 @@ fn test_pick_version_lowest_ignores_dist_tag_preference() {
     // range, not whatever the publisher tagged latest. Confirm the
     // dist-tag preference is suppressed when pick_lowest is set.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0"], "1.2.0");
-    let result = pick_version(&packument, "^1.0.0", None, true, None, false).unwrap();
+    let result = pick_version(&packument, "^1.0.0", None, true, None, false, |_, _| false).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
 #[test]
 fn test_pick_version_exact() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
-    let result = pick_version(&packument, "1.0.0", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "1.0.0", None, false, None, false, |_, _| false).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
 #[test]
 fn test_pick_version_no_match() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
-    let result = pick_version(&packument, "^2.0.0", None, false, None, false);
+    let result = pick_version(&packument, "^2.0.0", None, false, None, false, |_, _| false);
     assert!(matches!(result, PickResult::NoMatch));
 }
 
@@ -746,19 +749,44 @@ fn test_pick_version_strict_distinguishes_age_gate_from_no_match() {
         .time
         .insert("1.1.0".into(), "2024-06-01T00:00:00.000Z".into());
     let cutoff = "2020-01-01T00:00:00.000Z";
-    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), true);
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        Some(cutoff),
+        true,
+        |_, _| false,
+    );
     assert!(matches!(result, PickResult::AgeGated));
 
     // No version satisfies the range at all → still NoMatch even
     // in strict mode.
-    let result = pick_version(&packument, "^9.0.0", None, false, Some(cutoff), true);
+    let result = pick_version(
+        &packument,
+        "^9.0.0",
+        None,
+        false,
+        Some(cutoff),
+        true,
+        |_, _| false,
+    );
     assert!(matches!(result, PickResult::NoMatch));
 }
 
 #[test]
 fn test_pick_version_prefers_locked() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0"], "1.2.0");
-    let result = pick_version(&packument, "^1.0.0", Some("1.1.0"), false, None, false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        Some("1.1.0"),
+        false,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.1.0");
 }
 
@@ -766,21 +794,31 @@ fn test_pick_version_prefers_locked() {
 fn test_pick_version_locked_out_of_range() {
     let packument = make_packument("foo", &["1.0.0", "2.0.0"], "2.0.0");
     // Locked version doesn't satisfy range, should pick highest match
-    let result = pick_version(&packument, "^2.0.0", Some("1.0.0"), false, None, false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^2.0.0",
+        Some("1.0.0"),
+        false,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "2.0.0");
 }
 
 #[test]
 fn test_pick_version_dist_tag() {
     let packument = make_packument("foo", &["1.0.0", "2.0.0-beta.1"], "1.0.0");
-    let result = pick_version(&packument, "latest", None, false, None, false).unwrap();
+    let result =
+        pick_version(&packument, "latest", None, false, None, false, |_, _| false).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
 #[test]
 fn test_pick_version_lowest_picks_smallest_satisfying() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0", "2.0.0"], "2.0.0");
-    let result = pick_version(&packument, "^1.0.0", None, true, None, false).unwrap();
+    let result = pick_version(&packument, "^1.0.0", None, true, None, false, |_, _| false).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -798,7 +836,16 @@ fn test_pick_version_cutoff_filters_future_versions() {
         .insert("1.2.0".into(), "2023-01-01T00:00:00.000Z".into());
     // Highest pick, but cutoff forbids 1.2.0 → fall back to 1.1.0.
     let cutoff = "2022-06-01T00:00:00.000Z";
-    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        Some(cutoff),
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.1.0");
 }
 
@@ -818,7 +865,16 @@ fn test_pick_version_lenient_falls_back_to_lowest_when_cutoff_excludes_all() {
         .time
         .insert("1.2.0".into(), "2025-01-01T00:00:00.000Z".into());
     let cutoff = "2020-01-01T00:00:00.000Z";
-    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        Some(cutoff),
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -832,8 +888,40 @@ fn test_pick_version_strict_returns_age_gated_when_cutoff_excludes_all() {
         .time
         .insert("1.1.0".into(), "2024-06-01T00:00:00.000Z".into());
     let cutoff = "2020-01-01T00:00:00.000Z";
-    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), true);
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        Some(cutoff),
+        true,
+        |_, _| false,
+    );
     assert!(matches!(result, PickResult::AgeGated));
+}
+
+#[test]
+fn test_pick_version_age_exempt_waves_version_past_cutoff() {
+    let mut packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    packument
+        .time
+        .insert("1.0.0".into(), "2024-01-01T00:00:00.000Z".into());
+    packument
+        .time
+        .insert("1.1.0".into(), "2024-06-01T00:00:00.000Z".into());
+    let cutoff = "2020-01-01T00:00:00.000Z";
+    // Exempting every version (as a name-only / glob rule does) lets the
+    // otherwise age-gated highest version through instead of failing.
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        Some(cutoff),
+        true,
+        |_, _| true,
+    );
+    assert_eq!(result.unwrap().version, "1.1.0");
 }
 
 #[test]
@@ -1152,7 +1240,16 @@ fn test_pick_version_cutoff_allows_missing_time_entries() {
     // remove every candidate, or the resolver can never make
     // progress on abbreviated-packument registries.
     let cutoff = "2000-01-01T00:00:00.000Z";
-    let result = pick_version(&packument, "^1.0.0", None, false, Some(cutoff), false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        Some(cutoff),
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.1.0");
 }
 
@@ -1166,7 +1263,8 @@ fn test_pick_version_with_deps() {
         .dependencies
         .insert("bar".to_string(), "^2.0.0".to_string());
 
-    let result = pick_version(&packument, "^1.0.0", None, false, None, false).unwrap();
+    let result =
+        pick_version(&packument, "^1.0.0", None, false, None, false, |_, _| false).unwrap();
     assert_eq!(result.dependencies.get("bar").unwrap(), "^2.0.0");
 }
 
@@ -3571,7 +3669,7 @@ fn pick_version_exact_pin_not_hijacked_by_dist_tag() {
     packument
         .dist_tags
         .insert("1.0.0".to_string(), "1.5.0".to_string());
-    let result = pick_version(&packument, "1.0.0", None, false, None, false).unwrap();
+    let result = pick_version(&packument, "1.0.0", None, false, None, false, |_, _| false).unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -3580,7 +3678,7 @@ fn assert_protocol_hijack_blocked(spec: &str) {
     packument
         .dist_tags
         .insert(spec.to_string(), "1.0.0".to_string());
-    let result = pick_version(&packument, spec, None, false, None, false);
+    let result = pick_version(&packument, spec, None, false, None, false, |_, _| false);
     assert!(
         matches!(result, super::semver_util::PickResult::NoMatch),
         "protocol-prefixed range {spec:?} reached dist-tag fallback",

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -678,8 +678,17 @@ fn test_pick_version_highest_match() {
     // dist-tag preference doesn't apply and we fall through to the
     // strictly-highest version inside the range — 1.2.0.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0", "2.0.0"], "2.0.0");
-    let result =
-        pick_version(&packument, "^1.0.0", None, false, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.2.0");
 }
 
@@ -696,8 +705,17 @@ fn test_pick_version_prefers_dist_tag_latest_when_in_range() {
     // -> aube add foo@^100.0.0` flow, which expects the lockfile to
     // pin 100.0.0 even though 100.1.0 is available.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0"], "1.0.0");
-    let result =
-        pick_version(&packument, "^1.0.0", None, false, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -707,8 +725,17 @@ fn test_pick_version_falls_through_when_latest_outside_range() {
     // preference is a no-op; the strictly-highest matching version
     // (1.1.0) wins.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "2.0.0"], "2.0.0");
-    let result =
-        pick_version(&packument, "^1.0.0", None, false, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.1.0");
 }
 
@@ -718,21 +745,50 @@ fn test_pick_version_lowest_ignores_dist_tag_preference() {
     // range, not whatever the publisher tagged latest. Confirm the
     // dist-tag preference is suppressed when pick_lowest is set.
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0"], "1.2.0");
-    let result = pick_version(&packument, "^1.0.0", None, true, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        true,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
 #[test]
 fn test_pick_version_exact() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
-    let result = pick_version(&packument, "1.0.0", None, false, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "1.0.0",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
 #[test]
 fn test_pick_version_no_match() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
-    let result = pick_version(&packument, "^2.0.0", None, false, None, false, |_, _| false);
+    let result = pick_version(
+        &packument,
+        "^2.0.0",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    );
     assert!(matches!(result, PickResult::NoMatch));
 }
 
@@ -755,6 +811,7 @@ fn test_pick_version_strict_distinguishes_age_gate_from_no_match() {
         None,
         false,
         Some(cutoff),
+        None,
         true,
         |_, _| false,
     );
@@ -768,6 +825,7 @@ fn test_pick_version_strict_distinguishes_age_gate_from_no_match() {
         None,
         false,
         Some(cutoff),
+        None,
         true,
         |_, _| false,
     );
@@ -782,6 +840,7 @@ fn test_pick_version_prefers_locked() {
         "^1.0.0",
         Some("1.1.0"),
         false,
+        None,
         None,
         false,
         |_, _| false,
@@ -800,6 +859,7 @@ fn test_pick_version_locked_out_of_range() {
         Some("1.0.0"),
         false,
         None,
+        None,
         false,
         |_, _| false,
     )
@@ -810,15 +870,34 @@ fn test_pick_version_locked_out_of_range() {
 #[test]
 fn test_pick_version_dist_tag() {
     let packument = make_packument("foo", &["1.0.0", "2.0.0-beta.1"], "1.0.0");
-    let result =
-        pick_version(&packument, "latest", None, false, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "latest",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
 #[test]
 fn test_pick_version_lowest_picks_smallest_satisfying() {
     let packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0", "2.0.0"], "2.0.0");
-    let result = pick_version(&packument, "^1.0.0", None, true, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        true,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -842,6 +921,7 @@ fn test_pick_version_cutoff_filters_future_versions() {
         None,
         false,
         Some(cutoff),
+        None,
         false,
         |_, _| false,
     )
@@ -871,6 +951,7 @@ fn test_pick_version_lenient_falls_back_to_lowest_when_cutoff_excludes_all() {
         None,
         false,
         Some(cutoff),
+        None,
         false,
         |_, _| false,
     )
@@ -894,6 +975,7 @@ fn test_pick_version_strict_returns_age_gated_when_cutoff_excludes_all() {
         None,
         false,
         Some(cutoff),
+        None,
         true,
         |_, _| false,
     );
@@ -918,10 +1000,70 @@ fn test_pick_version_age_exempt_waves_version_past_cutoff() {
         None,
         false,
         Some(cutoff),
+        None,
         true,
         |_, _| true,
     );
     assert_eq!(result.unwrap().version, "1.1.0");
+}
+
+#[test]
+fn test_pick_version_age_exempt_still_blocked_by_time_cutoff() {
+    // `minimumReleaseAgeExclude` relaxes only the minimumReleaseAge
+    // age-gate, never the time-based resolution wall. Even with every
+    // version exempt, the time-based `exempt_cutoff` still forbids
+    // versions published after it — 1.1.0 (2024-06) is past the wall,
+    // so the pick falls back to 1.0.0 (2024-01).
+    let mut packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    packument
+        .time
+        .insert("1.0.0".into(), "2024-01-01T00:00:00.000Z".into());
+    packument
+        .time
+        .insert("1.1.0".into(), "2024-06-01T00:00:00.000Z".into());
+    // `cutoff` is the merged min(minimumReleaseAge, time-based); the
+    // exclude relaxes the minimumReleaseAge leg, but the time-based wall
+    // (`exempt_cutoff`) stays in force for exempt versions.
+    let cutoff = "2020-01-01T00:00:00.000Z";
+    let exempt_cutoff = "2024-03-01T00:00:00.000Z";
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        Some(cutoff),
+        Some(exempt_cutoff),
+        false,
+        |_, _| true,
+    );
+    assert_eq!(result.unwrap().version, "1.0.0");
+}
+
+#[test]
+fn test_pick_version_age_exempt_time_cutoff_age_gates_in_strict_mode() {
+    // When the time-based wall excludes every satisfying version, even a
+    // fully-exempt package hard-fails in strict mode — the exclude
+    // cannot punch through the time-based wall.
+    let mut packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    packument
+        .time
+        .insert("1.0.0".into(), "2024-01-01T00:00:00.000Z".into());
+    packument
+        .time
+        .insert("1.1.0".into(), "2024-06-01T00:00:00.000Z".into());
+    let cutoff = "2020-01-01T00:00:00.000Z";
+    let exempt_cutoff = "2023-01-01T00:00:00.000Z";
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        Some(cutoff),
+        Some(exempt_cutoff),
+        true,
+        |_, _| true,
+    );
+    assert!(matches!(result, PickResult::AgeGated));
 }
 
 #[test]
@@ -1246,6 +1388,7 @@ fn test_pick_version_cutoff_allows_missing_time_entries() {
         None,
         false,
         Some(cutoff),
+        None,
         false,
         |_, _| false,
     )
@@ -1263,8 +1406,17 @@ fn test_pick_version_with_deps() {
         .dependencies
         .insert("bar".to_string(), "^2.0.0".to_string());
 
-    let result =
-        pick_version(&packument, "^1.0.0", None, false, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.dependencies.get("bar").unwrap(), "^2.0.0");
 }
 
@@ -3669,7 +3821,17 @@ fn pick_version_exact_pin_not_hijacked_by_dist_tag() {
     packument
         .dist_tags
         .insert("1.0.0".to_string(), "1.5.0".to_string());
-    let result = pick_version(&packument, "1.0.0", None, false, None, false, |_, _| false).unwrap();
+    let result = pick_version(
+        &packument,
+        "1.0.0",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
     assert_eq!(result.version, "1.0.0");
 }
 
@@ -3678,7 +3840,9 @@ fn assert_protocol_hijack_blocked(spec: &str) {
     packument
         .dist_tags
         .insert(spec.to_string(), "1.0.0".to_string());
-    let result = pick_version(&packument, spec, None, false, None, false, |_, _| false);
+    let result = pick_version(&packument, spec, None, false, None, None, false, |_, _| {
+        false
+    });
     assert!(
         matches!(result, super::semver_util::PickResult::NoMatch),
         "protocol-prefixed range {spec:?} reached dist-tag fallback",

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -1067,6 +1067,35 @@ fn test_pick_version_age_exempt_time_cutoff_age_gates_in_strict_mode() {
 }
 
 #[test]
+fn test_pick_version_lenient_fallback_respects_time_cutoff() {
+    // The lenient (non-strict) fallback bypasses the minimumReleaseAge
+    // gate but must NOT bypass the time-based wall. With every
+    // satisfying version past `exempt_cutoff`, even non-strict mode
+    // age-gates instead of silently returning a walled-off version
+    // through the fallback path.
+    let mut packument = make_packument("foo", &["1.0.0", "1.1.0"], "1.1.0");
+    packument
+        .time
+        .insert("1.0.0".into(), "2024-01-01T00:00:00.000Z".into());
+    packument
+        .time
+        .insert("1.1.0".into(), "2024-06-01T00:00:00.000Z".into());
+    let cutoff = "2020-01-01T00:00:00.000Z";
+    let exempt_cutoff = "2023-01-01T00:00:00.000Z";
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        Some(cutoff),
+        Some(exempt_cutoff),
+        false,
+        |_, _| true,
+    );
+    assert!(matches!(result, PickResult::AgeGated));
+}
+
+#[test]
 fn test_minimum_release_age_cutoff_format() {
     let mra = MinimumReleaseAge {
         minutes: 60,

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -269,6 +269,16 @@ pub const DEFAULT_TRUST_POLICY_EXCLUDES: &[&str] = &[
 /// engine, so we do too — `TrustExcludeRules` is the neutral
 /// [`PackageVersionPolicy`] type seeded with the trust defaults, while
 /// `minimumReleaseAgeExclude` builds an empty one from user rules only.
+///
+/// # Warning
+///
+/// Because this is an alias for [`TrustExcludeRules`],
+/// `PackageVersionPolicy::default()` runs that type's [`Default`] impl,
+/// which seeds [`DEFAULT_TRUST_POLICY_EXCLUDES`] (40+ well-known
+/// packages). For the age gate that is wrong — it would silently exempt
+/// those packages from `minimumReleaseAge`. Age-gate call sites must use
+/// [`TrustExcludeRules::empty`]; never `default()`, `#[derive(Default)]`
+/// on a containing struct, or `unwrap_or_default()`.
 pub type PackageVersionPolicy = TrustExcludeRules;
 
 #[derive(Debug, Clone)]

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -263,6 +263,14 @@ pub const DEFAULT_TRUST_POLICY_EXCLUDES: &[&str] = &[
     "vite",
 ];
 
+/// A parsed package-version policy: a set of `<name>[@<exact-version>…]`
+/// rules with `*` name globs. pnpm backs both `trustPolicyExclude` and
+/// `minimumReleaseAgeExclude` with the same `createPackageVersionPolicy`
+/// engine, so we do too — `TrustExcludeRules` is the neutral
+/// [`PackageVersionPolicy`] type seeded with the trust defaults, while
+/// `minimumReleaseAgeExclude` builds an empty one from user rules only.
+pub type PackageVersionPolicy = TrustExcludeRules;
+
 #[derive(Debug, Clone)]
 pub struct TrustExcludeRules {
     rules: Vec<TrustExcludeRule>,
@@ -311,6 +319,22 @@ pub enum TrustExcludeParseError {
 }
 
 impl TrustExcludeRules {
+    /// A policy that matches nothing. Used as the
+    /// `minimumReleaseAgeExclude` default — unlike [`Default`], which
+    /// seeds the trust-specific exclude list, the age gate must start
+    /// with no exemptions.
+    pub fn empty() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+
     fn from_name_excludes(names: &[&str]) -> Self {
         Self {
             rules: names
@@ -371,7 +395,7 @@ impl TrustExcludeRules {
         (Self { rules }, errors)
     }
 
-    fn matches(&self, name: &str, version: &node_semver::Version) -> bool {
+    pub(crate) fn matches(&self, name: &str, version: &node_semver::Version) -> bool {
         for rule in &self.rules {
             if !rule.name_matcher.matches(name) {
                 continue;
@@ -392,7 +416,7 @@ impl TrustExcludeRules {
     /// no-version rule can match in that case (pnpm behavior:
     /// `evaluateVersionPolicy` returns `true` for name-only rules
     /// before the version array branch is taken).
-    fn matches_name_only(&self, name: &str) -> bool {
+    pub(crate) fn matches_name_only(&self, name: &str) -> bool {
         self.rules
             .iter()
             .any(|r| r.exact_versions.is_none() && r.name_matcher.matches(name))

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -314,15 +314,18 @@ struct GlobMatcher {
     trailing_wildcard: bool,
 }
 
+// Shared by both `trustPolicyExclude` and `minimumReleaseAgeExclude`, so
+// the message text stays setting-neutral — the caller's log line names
+// the specific setting the bad entry came from.
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum TrustExcludeParseError {
     #[error(
-        "invalid trustPolicyExclude pattern `{pattern}`: only exact versions are allowed in version unions, ranges (^/~/>=) are not supported"
+        "invalid exclude pattern `{pattern}`: only exact versions are allowed in version unions, ranges (^/~/>=) are not supported"
     )]
     #[diagnostic(code(ERR_AUBE_TRUST_EXCLUDE_INVALID_VERSION_UNION))]
     InvalidVersionUnion { pattern: String },
     #[error(
-        "invalid trustPolicyExclude pattern `{pattern}`: name patterns (`*`) cannot be combined with version unions"
+        "invalid exclude pattern `{pattern}`: name patterns (`*`) cannot be combined with version unions"
     )]
     #[diagnostic(code(ERR_AUBE_TRUST_EXCLUDE_NAME_GLOB_WITH_VERSIONS))]
     NameGlobWithVersions { pattern: String },

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -1,5 +1,5 @@
 use aube_lockfile::LocalSource;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -24,22 +24,37 @@ pub trait ReadPackageHook: Send {
     ) -> Pin<Box<dyn Future<Output = Result<aube_registry::VersionMetadata, String>> + Send + 'a>>;
 }
 
-/// Supply-chain mitigation: forbid versions younger than `min_age` for
-/// every package whose name isn't in `exclude`. Mirrors pnpm's
-/// `minimumReleaseAge` / `minimumReleaseAgeExclude` /
+/// Supply-chain mitigation: forbid versions younger than `min_age`
+/// unless the package (or specific version) is exempted by `exclude`.
+/// Mirrors pnpm's `minimumReleaseAge` / `minimumReleaseAgeExclude` /
 /// `minimumReleaseAgeStrict` triplet. Constructed by the install
 /// command, threaded into [`Resolver::with_minimum_release_age`].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct MinimumReleaseAge {
     /// Minutes a version must have aged in the registry. `0` disables.
     pub minutes: u64,
-    /// Package names skipped by the cutoff filter entirely.
-    pub exclude: HashSet<String>,
+    /// Packages exempt from the cutoff. Supports the same syntax pnpm's
+    /// `minimumReleaseAgeExclude` does: bare names, `*` name globs (e.g.
+    /// `@myorg/*`), and exact-version unions (`pkg@1.2.3 || 1.2.4`).
+    pub exclude: crate::trust::PackageVersionPolicy,
     /// When true, fail the install if no version satisfies the range
     /// without violating the cutoff. When false (the pnpm default), the
     /// resolver falls back to the lowest satisfying version, ignoring
     /// the cutoff for that pick only.
     pub strict: bool,
+}
+
+impl Default for MinimumReleaseAge {
+    fn default() -> Self {
+        // `PackageVersionPolicy::default()` carries the *trust* exclude
+        // list; the age gate must start with no exemptions, so use the
+        // explicitly-empty constructor.
+        Self {
+            minutes: 0,
+            exclude: crate::trust::PackageVersionPolicy::empty(),
+            strict: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -239,8 +239,11 @@ type = "list<string>"
 default = "undefined"
 docs = """
 Use for trusted internal packages that need to be rolled out immediately
-without waiting for the age gate. `pnpm audit --fix` (when implemented)
-will append patched versions to this list automatically.
+without waiting for the age gate. Each entry is a bare name (`react`), a
+`*` name glob (`@myorg/*`), or a name with an exact-version union
+(`nx@21.6.5`, `webpack@4.47.0 || 5.102.1`); ranges like `^1.0.0` are not
+allowed. `pnpm audit --fix` (when implemented) will append patched
+versions to this list automatically.
 """
 sources.cli = []
 sources.env = ["npm_config_minimum_release_age_exclude", "NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE", "AUBE_MINIMUM_RELEASE_AGE_EXCLUDE"]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -242,8 +242,8 @@ Use for trusted internal packages that need to be rolled out immediately
 without waiting for the age gate. Each entry is a bare name (`react`), a
 `*` name glob (`@myorg/*`), or a name with an exact-version union
 (`nx@21.6.5`, `webpack@4.47.0 || 5.102.1`); ranges like `^1.0.0` are not
-allowed. `pnpm audit --fix` (when implemented) will append patched
-versions to this list automatically.
+allowed. Once `aube audit --fix` learns to record patched versions, it
+will append them to this list automatically.
 """
 sources.cli = []
 sources.env = ["npm_config_minimum_release_age_exclude", "NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE", "AUBE_MINIMUM_RELEASE_AGE_EXCLUDE"]

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -82,11 +82,19 @@ fn resolve_minimum_release_age(
     if minutes == 0 {
         return None;
     }
-    let exclude: std::collections::HashSet<String> =
-        aube_settings::resolved::minimum_release_age_exclude(ctx)
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
+    // Parse pattern-by-pattern (bare names, `*` name globs, exact-version
+    // unions) so one malformed entry doesn't silently drop the rest and
+    // weaken the gate. Same engine pnpm uses for both exclude settings.
+    let (exclude, parse_errors) = aube_resolver::PackageVersionPolicy::parse_lossy(
+        aube_settings::resolved::minimum_release_age_exclude(ctx).unwrap_or_default(),
+    );
+    for err in parse_errors {
+        tracing::warn!(
+            code = aube_codes::warnings::WARN_AUBE_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE,
+            error = %err,
+            "ignoring malformed minimumReleaseAgeExclude entry"
+        );
+    }
     // `paranoid=true` forces the gate to be hard, not advisory.
     let strict = aube_settings::resolved::minimum_release_age_strict(ctx)
         || aube_settings::resolved::paranoid(ctx);
@@ -918,7 +926,7 @@ pub(crate) fn configure_resolver(
         resolve_minimum_release_age(settings_ctx, minimum_release_age_override);
     if let Some(ref mra) = minimum_release_age {
         tracing::debug!(
-            "minimumReleaseAge: {} min, {} excluded, strict={}",
+            "minimumReleaseAge: {} min, {} exclude rules, strict={}",
             mra.minutes,
             mra.exclude.len(),
             mra.strict

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -519,6 +519,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE",
+      "category": "Settings / config validation",
+      "description": "A `minimumReleaseAgeExclude` entry was malformed and skipped.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_OVERRIDE_MISSING_DEP",
       "category": "Settings / config validation",
       "description": "An `overrides` `$ref` pointed at a package not in any of the importer's dependency lists.",

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -329,8 +329,11 @@ Packages exempt from the minimumReleaseAge requirement.
 - Managed policy: `managedWins`
 
 Use for trusted internal packages that need to be rolled out immediately
-without waiting for the age gate. `pnpm audit --fix` (when implemented)
-will append patched versions to this list automatically.
+without waiting for the age gate. Each entry is a bare name (`react`), a
+`*` name glob (`@myorg/*`), or a name with an exact-version union
+(`nx@21.6.5`, `webpack@4.47.0 || 5.102.1`); ranges like `^1.0.0` are not
+allowed. `pnpm audit --fix` (when implemented) will append patched
+versions to this list automatically.
 
 ### `minimumReleaseAgeStrict` {#setting-minimumreleaseagestrict}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -332,8 +332,8 @@ Use for trusted internal packages that need to be rolled out immediately
 without waiting for the age gate. Each entry is a bare name (`react`), a
 `*` name glob (`@myorg/*`), or a name with an exact-version union
 (`nx@21.6.5`, `webpack@4.47.0 || 5.102.1`); ranges like `^1.0.0` are not
-allowed. `pnpm audit --fix` (when implemented) will append patched
-versions to this list automatically.
+allowed. Once `aube audit --fix` learns to record patched versions, it
+will append them to this list automatically.
 
 ### `minimumReleaseAgeStrict` {#setting-minimumreleaseagestrict}
 


### PR DESCRIPTION
## What

`minimumReleaseAgeExclude` previously matched package **names exactly**, so there was no way to exempt a whole scope (`@myorg/*`) or a specific version from the age gate. This backs it with the same `TrustExcludeRules` engine pnpm uses for *both* its exclude settings, so the syntax now matches pnpm:

- bare names - `react`
- `*` name globs - `@myorg/*`
- exact-version unions - `nx@21.6.5`, `webpack@4.47.0 || 5.102.1`

Ranges like `^1.0.0` are intentionally not allowed (matches pnpm).

## How

- `MinimumReleaseAge.exclude` changes from `HashSet<String>` to a `PackageVersionPolicy` (a neutral alias of `TrustExcludeRules`).
- The exemption is threaded **per-candidate-version** through `pick_version` via an `is_age_exempt` closure (reuses the already-parsed `node_semver::Version`, no double parse).
- The same closure now also feeds `prefer_non_vulnerable_pick`, so an exempt safe version can't be discarded in favor of a vulnerable one (a regression the name-only path would otherwise introduce).
- Malformed entries are parsed lossily and warn with the new `WARN_AUBE_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE` instead of silently dropping the rest of the list.
- Regenerated `error-codes.data.json` + settings docs; updated `settings.toml` docs.

## Verification

- `cargo test -p aube-resolver` - 221 pass (incl. new `test_pick_version_age_exempt_waves_version_past_cutoff`, `parse_lossy_keeps_valid_drops_invalid`)
- `cargo fmt --check` - clean

## Notes

- Rebased onto latest `main`.
- Depends conceptually on nothing, but #940 (a pre-existing clippy fix) is needed for `cargo clippy --all-targets` to be clean locally on this tree.

*This PR was generated by Claude.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Improved `minimumReleaseAgeExclude` handling with more precise, rule-based exemptions (including name-only exemption behavior and version-specific allow-listing).
  * Added a warning when a malformed `minimumReleaseAgeExclude` entry is skipped.

* **Bug Fixes**
  * Refined minimum-release-age gating during version selection to apply exemptions per candidate/version, while keeping time-based cutoff behavior consistent—especially in strict mode.

* **Documentation**
  * Expanded `minimumReleaseAgeExclude` docs to list supported formats (names, `*` globs, exact-version unions) and explicitly disallow semver range syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->