### PR TITLE
fix(install): preserve npm optional natives

### DIFF
--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -833,21 +833,22 @@ pub(crate) fn configure_resolver(
     let force_metadata_primer = resolve_force_metadata_primer(settings_ctx);
     let (sup_os, sup_cpu, sup_libc) =
         aube_manifest::effective_supported_architectures(manifest, workspace_config);
-    // pnpm-lock.yaml, aube-lock.yaml, and bun.lock are all committed,
-    // cross-platform artifacts that carry per-package os/cpu metadata.
+    // pnpm-lock.yaml, aube-lock.yaml, bun.lock, package-lock.json, and
+    // npm-shrinkwrap.json are committed, cross-platform artifacts that
+    // carry per-package os/cpu metadata.
     // When the user hasn't declared `pnpm.supportedArchitectures`, record
     // EVERY optional-dep variant a package declares (`accept_all`) so the
     // committed lockfile installs cleanly on every contributor's platform
     // — withholding variants leaves teammates with "Cannot find native
-    // binding". This matches what pnpm AND bun both write verbatim (all 26
-    // `@esbuild/*` / `@rollup/rollup-*` natives, freebsd/ppc64/s390x and
-    // all), so a lockfile aube regenerates stays diff-clean against the
+    // binding". This matches what npm, pnpm, and bun write verbatim (all
+    // 26 `@esbuild/*` / `@rollup/rollup-*` natives, freebsd/ppc64/s390x
+    // and all), so a lockfile aube regenerates stays diff-clean against the
     // native tool. Install-time filtering (`filter_graph`) and the
     // streaming-fetch gate run against the unmodified host triple, so
     // `node_modules` and tarball downloads stay trimmed to the host — the
-    // wider lockfile costs only bytes, never extra installs. Yarn / npm
-    // lockfiles don't carry the same per-package os/cpu metadata, so
-    // widening there would only bloat them — keep pnpm's host-only default.
+    // wider lockfile costs only bytes, never extra installs. Yarn lockfiles
+    // don't carry the same per-package os/cpu metadata, so widening there
+    // would only bloat them — keep the host-only default.
     let manifest_set_supported_arch =
         !(sup_os.is_empty() && sup_cpu.is_empty() && sup_libc.is_empty());
     let writes_cross_platform_lock = matches!(
@@ -856,6 +857,8 @@ pub(crate) fn configure_resolver(
             aube_lockfile::LockfileKind::Pnpm
                 | aube_lockfile::LockfileKind::Aube
                 | aube_lockfile::LockfileKind::Bun
+                | aube_lockfile::LockfileKind::Npm
+                | aube_lockfile::LockfileKind::NpmShrinkwrap
         )
     );
     let supported_architectures = if manifest_set_supported_arch {

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -364,9 +364,9 @@ pub(crate) fn build_resolver(
     let ctx = files.ctx(&raw_workspace, env, &[]);
     // `aube update` and friends always rewrite a lockfile, so pick a
     // target kind. Detect the existing format to match install's
-    // cross-platform widening rules — a project on `pnpm-lock.yaml`
-    // keeps pnpm's host-only optional set, `aube-lock.yaml` gets the
-    // wide aube default.
+    // cross-platform widening rules — native package-manager lockfiles
+    // that record per-package platform metadata keep optional natives for
+    // every platform, while formats without that metadata stay host-only.
     let target_lockfile_kind = Some(
         aube_lockfile::detect_existing_lockfile_kind(cwd)
             .unwrap_or(aube_lockfile::LockfileKind::Aube),

--- a/test/optional_platform.bats
+++ b/test/optional_platform.bats
@@ -9,6 +9,50 @@ teardown() {
 	_common_teardown
 }
 
+assert_npm_lock_captures_cross_platform_optionals() {
+	local lockfile="$1"
+
+	case "$(uname -s)" in
+	MINGW* | MSYS* | CYGWIN* | Windows_NT)
+		skip "win32 host would install the win32 optional dependency"
+		;;
+	esac
+
+	cat >package.json <<-'JSON'
+		{
+		  "name": "npm-lock-cross-platform",
+		  "version": "0.0.0",
+		  "optionalDependencies": {
+		    "aube-test-optional-win32": "1.0.0"
+		  }
+		}
+	JSON
+	cat >"$lockfile" <<-'JSON'
+		{
+		  "name": "npm-lock-cross-platform",
+		  "version": "0.0.0",
+		  "lockfileVersion": 3,
+		  "requires": true,
+		  "packages": {
+		    "": {
+		      "name": "npm-lock-cross-platform",
+		      "version": "0.0.0"
+		    }
+		  }
+		}
+	JSON
+
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_exists "$lockfile"
+	assert_not_exists aube-lock.yaml
+	assert_not_exists node_modules/aube-test-optional-win32
+	run grep -F '"node_modules/aube-test-optional-win32"' "$lockfile"
+	assert_success
+	run grep -A8 -F '"node_modules/aube-test-optional-win32"' "$lockfile"
+	assert_output --partial '"optional": true'
+}
+
 # The fixture `aube-test-optional-win32` declares `os: ["win32"]` so on
 # Linux and macOS CI it must be skipped silently rather than failing
 # the install. This mirrors pnpm's "graceful failure" for optional deps
@@ -58,6 +102,14 @@ teardown() {
 	# `optional: true` in the snapshots block, exactly as pnpm marks it.
 	run grep -A1 -F 'aube-test-optional-win32@1.0.0:' aube-lock.yaml
 	assert_output --partial 'optional: true'
+}
+
+@test "package-lock.json captures cross-platform optionals like npm does" {
+	assert_npm_lock_captures_cross_platform_optionals package-lock.json
+}
+
+@test "npm-shrinkwrap.json captures cross-platform optionals like npm does" {
+	assert_npm_lock_captures_cross_platform_optionals npm-shrinkwrap.json
 }
 
 @test "required platform-mismatched dep still gets fetched and linked" {


### PR DESCRIPTION
## Summary
- treat npm package-lock.json as a cross-platform lockfile for optional native package resolution
- keep install/link filtering host-scoped so foreign native optionals stay out of node_modules
- add a package-lock regression test for non-host optional natives

## Tests
- PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check
- mise x cmake@latest -- bash -lc 'PATH="$HOME/.cargo/bin:$PATH" cargo build'\n- mise x node@24 -- ./test/bats/bin/bats test/optional_platform.bats\n\nDiscussion: #938\n\n*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resolver platform widening for all npm/shrinkwrap lockfile rewrites; behavior is constrained by existing host install filtering but affects lockfile contents teams commit and share.
> 
> **Overview**
> **npm lockfiles now use cross-platform optional resolution** when no explicit `supportedArchitectures` is set: `configure_resolver` widens `supportedArchitectures` with `accept_all: true` for `LockfileKind::Npm` and `NpmShrinkwrap`, matching pnpm/aube/bun behavior so regenerated locks keep foreign optional natives (e.g. win32-only optionals on Linux CI).
> 
> Install/link behavior is unchanged in intent—comments note host-scoped `filter_graph` and fetch gating so mismatched optionals stay out of `node_modules` while appearing in the committed lockfile. Comments in `settings_context.rs` were generalized away from pnpm-only wording.
> 
> **Tests:** `test/optional_platform.bats` adds shared coverage for `package-lock.json` and `npm-shrinkwrap.json` (optional entry present with `"optional": true`, package not linked on non-win32).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c14594023d0c4cbc28215d1ffa14eab1de09a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved installation handling for npm-style lockfiles (`package-lock.json` and `npm-shrinkwrap.json`) to better support cross-platform `optionalDependencies`.
  * Resolver now widens accepted architectures for these npm lockfile formats when no explicit architecture set is provided, while still avoiding platform-incompatible optional packages being linked.

* **Tests**
  * Added automated coverage to verify npm lockfiles capture cross-platform optional entries and that incompatible optional packages are not installed on non-matching hosts.

* **Documentation**
  * Updated guidance explaining cross-platform lockfile behavior across lockfile formats and package managers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->